### PR TITLE
feat(data-warehouse): migrate 6 sources to rest_source (batch 3, fan-out + hydration)

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -11,13 +11,13 @@ Use this skill when building or updating Data warehouse sources in `products/war
 
 Before coding, read:
 
-- `products/warehouse_sources/backend/temporal/data_imports/sources/source.template` (use the top-of-file TODOs as a starting reference, but verify target files against the current source implementations — the template can drift, e.g. it currently still points at the old `posthog/warehouse/types.py` path instead of `products/warehouse_sources/backend/types.py`)
+- `products/warehouse_sources/backend/temporal/data_imports/sources/source.template` (the top-of-file TODOs are the bootstrap checklist; still verify target files against current source implementations, since the template can drift)
 - `products/warehouse_sources/backend/temporal/data_imports/sources/README.md`
 - `products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md` — inventory of every registered source with its communication method (HTTP / vendor SDK / gRPC / DB protocol / webhook) and tracked-transport state. Skim this first to see how similar sources are wired and what state today's source you're touching is in. **Keep it in sync** — see "Updating SOURCES.md" below.
 - `products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py` — base classes (`SimpleSource`, `ResumableSource`, `WebhookSource`) and the `FieldType` union
 - `products/warehouse_sources/backend/temporal/data_imports/sources/common/resumable.py` — `ResumableSourceManager`
 - `products/warehouse_sources/backend/temporal/data_imports/sources/common/webhook_s3.py` — `WebhookSourceManager`
-- 1 API source with `settings.py` + transport logic (e.g. klaviyo, github). For dependent-resource fan-out (parent→child with `type: "resolve"`), also read `products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py` and `config_setup.py` (e.g. `process_parent_data_item`, `make_parent_key_name`).
+- **`chargebee/` — the canonical reference for a new REST source.** It uses the shared `rest_source` framework (declarative `RESTAPIConfig` + `rest_api_resource`, framework auth + paginators, tracked+retrying transport) and is resumable — proof the framework covers the dominant "paginate a list endpoint and yield, resumably" shape. Read it first, alongside "Prefer the shared REST framework" below. Read `klaviyo/` or `github/` only as a _bespoke-transport_ fallback: they hand-roll their client for edge cases (custom query-string encoding, multi-level fan-out, JSON:API reshaping) that most sources don't have — don't copy that boilerplate into a source that doesn't need it. For dependent-resource fan-out (parent→child with `type: "resolve"`), also read `products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py` and `config_setup.py` (e.g. `process_parent_data_item`, `make_parent_key_name`).
 - For webhook-capable sources, read `products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py` as the reference implementation.
 
 ## Picking the right base class
@@ -47,6 +47,30 @@ Rule of thumb:
 
 Databases and file-transfer sources (SFTP, S3) stay on `SimpleSource` unless there's a clear reason otherwise.
 
+## Prefer the shared REST framework
+
+Most REST sources should be built on the shared `rest_source` framework
+(`common/rest_source/`), not a hand-rolled client. It already provides — so you write **none** of it:
+
+- **Tracked, retrying transport** — `RESTClient` defaults to `make_tracked_session()` and retries
+  `429` + transient `5xx` honoring `Retry-After`. No `tenacity`, no `RetryableError`, no fetch loop.
+- **Paginators** (`rest_source/paginators.py`, chosen by string/dict in the config, not hand-written):
+  `single_page`, `header_link`, `json_response` (next-URL in body), `cursor`, `offset`, `page_number`.
+- **Auth** (`rest_source/auth.py`): `bearer`, `api_key` (header/query/cookie), `http_basic`, `oauth2`
+  (customer-owned client-credentials/refresh). Each redacts its own secrets — no `_get_headers` builder.
+- **Incremental params, `data_selector`, response actions, resume** (`resume_hook` /
+  `initial_paginator_state`), and **parent/child fan-out** (`fanout.build_dependent_resource`).
+
+`chargebee/` is the canonical example (declarative endpoints + framework auth + resume). `zendesk/`
+shows multi-endpoint + `data_selector`; `attio/` shows cursor pagination.
+
+**When hand-rolling is justified** (read `klaviyo/` then): the API needs query strings the framework
+can't produce (literal brackets/operators, e.g. `filter=greater-than(...)`, `page[size]`);
+multi-level (2+ deep) fan-out; or per-item reshaping the `data_selector` can't express (e.g.
+flattening JSON:API `attributes` into the row root). Single-level fan-out and per-item maps are
+supported declaratively — don't hand-roll for those. If you must hand-roll, still ride
+`make_tracked_session()` and do **not** add a second status-code retry layer (see "Retry and throttling").
+
 ## End-to-end workflow for a new API source
 
 Follow this order. Each step maps to TODOs in `source.template`.
@@ -65,7 +89,7 @@ Follow this order. Each step maps to TODOs in `source.template`.
 
    Then update the two hand-edited files (the template still lists `posthog/schema.py` too, but that file is regenerated by `pnpm run schema:build` in step 12 — don't maintain it by hand):
    - `ExternalDataSourceType` at `products/warehouse_sources/backend/types.py` — follow the existing convention in that file: `ALL_CAPS` with **no underscores** between words (e.g. `ACTIVECAMPAIGN`, `APPLESEARCHADS`), value is `PascalCase`
-   - `externalDataSources` at `frontend/src/queries/schema/schema-general.ts` (`lower-kebab-case`)
+   - `externalDataSources` at `frontend/src/queries/schema/schema-general.ts` — **PascalCase, identical to the `ExternalDataSourceType` value** (e.g. `'ActiveCampaign'`, `'GoogleAds'`, `'CustomerIO'`). NOT kebab-case. (The only kebab-case identifier in the flow is the optional `featureFlag="dwh-{source_name}"`.)
 
 3. **Pick the base class** (see above) and rename the class / `source_type` return.
 4. **Define `get_source_config`** — name, **category** (required — see "Source category & keywords"), label, caption, docsUrl, iconPath, fields, and optional `keywords`. Use appropriate field types (see below).
@@ -74,7 +98,7 @@ Follow this order. Each step maps to TODOs in `source.template`.
 7. **Swap the generic `Config` type** in `source.py` for the generated `{Source}SourceConfig` class.
 8. **Implement**: `validate_credentials`, `get_schemas`, `source_for_pipeline` (plus `get_resumable_source_manager` / `get_webhook_source_manager` as needed).
 9. **Split transport logic.** Put API client, paginator, row normalization, and `SourceResponse` assembly in `{source}.py`. Keep endpoint catalog/incremental fields/primary keys/partition defaults in `settings.py`.
-10. **Add icon.** Place at `frontend/public/services/{source}.svg` (prefer SVG). If the logo isn't already committed, fetch from [Logo.dev](https://docs.logo.dev/introduction) — **ask the user for the Logo.dev API key**; do not hardcode one. Keep file size reasonable.
+10. **Add icon.** Place at `frontend/public/services/{source}.png` — **PNG is the repo convention** (~800 png vs ~58 svg, and `source.template` defaults to `.png`). SVG is accepted but not the norm; set `iconPath` to match whichever extension you commit. If the logo isn't already committed, fetch from [Logo.dev](https://docs.logo.dev/introduction) — **ask the user for the Logo.dev API key**; do not hardcode one. Logo.dev's image API returns PNG (not SVG). Keep file size reasonable.
 11. **Run migrations.** `DEBUG=1 python manage.py makemigrations && DEBUG=1 ./bin/migrate` (only needed if a new enum value triggers a Django migration).
 12. **Rebuild schema types**: `pnpm run schema:build`. This updates `posthog/schema.py` from `schema-general.ts` and makes the source appear in frontend dropdowns. Re-run whenever `schema-general.ts` changes.
 13. **Release status — a finished source has no `unreleasedSource` flag.** The default for the deliverable this skill produces is **no `unreleasedSource`** — a completed, working source ships visible and connectable. You don't need anyone's sign-off to ship it released; that's just the finished state. The scaffolded stub ships with `unreleasedSource=True` pre-set, so deleting that line is part of finishing the source — go ahead and remove it. (Why it matters: `unreleasedSource=True` **hides the connector from users entirely** — the frontend filters out every source where it's truthy; see `DataWarehouseQueryVariant.tsx`, `InlineSourceSetup.tsx`, and the "coming soon / Notify me" path in `nonHogFunctionTemplatesLogic.tsx`.)
@@ -246,7 +270,7 @@ Return a `SourceResponse` directly. **Do not** use `dlt_source_to_source_respons
 
 Prefer yielding data in the shape the API returns it. No custom dataclasses, no heavy parsing. Yield either `dict`, `list[dict]` (preferred when possible), or a `pyarrow.Table`. The pipeline buffers and batches for you.
 
-**Don't import or instantiate `Batcher` at the source layer.** The pipeline already runs one (`pipelines/pipeline/pipeline.py`) at the same 5000-row / 200 MiB thresholds. Yielding raw `dict` / `list[dict]` from your generator is the canonical path — reach for `pyarrow.Table` only when you already have arrow-shaped data (e.g., a ClickHouse adapter). Source-level batching results in double-buffering with no behavioral win.
+**Default to yielding raw `dict` / `list[dict]` and let the pipeline batch for you.** The pipeline already runs a `Batcher` (`pipelines/pipeline/pipeline.py`) at 5000-row / 200 MiB thresholds, so the common case needs no batcher of its own. Reach for `pyarrow.Table` only when you already have arrow-shaped data (e.g. a ClickHouse adapter). A source _may_ instantiate its own `Batcher` with **smaller** thresholds (e.g. `chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024`, as klaviyo and ~70 other sources do) when it deliberately wants a tighter memory footprint for large/wide rows — that's a valid choice, not the default. What to avoid is a second _full-size_ batcher, which just double-buffers with no win.
 
 For pyarrow tables, cap in-memory rows at ~200 MiB or ~5000 rows. Use helpers like `table_from_iterator()` / `table_from_py_list()` from `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py`.
 
@@ -329,6 +353,11 @@ log line and OTel metric, and participates in opt-in sample capture.
 
 - For raw `requests` usage: `make_tracked_session(headers=..., retry=...)` returns a `requests.Session`. Use
   `session.get/post/...` instead of the module-level `requests.get/...` shortcuts.
+- **Redact secrets from the captured samples.** Pass `redact_values=(api_key, token, ...)` to
+  `make_tracked_session(...)` so the tracked transport masks those literal values in logged URLs, headers,
+  and sampled bodies — important for keys that ride in a query param or an odd header name. `rest_source`
+  auth classes do this automatically (each implements `secret_values()`); only raw-session sources need to
+  pass `redact_values` themselves.
 - For sources that already go through `rest_source.RESTClient`: it defaults to a tracked session
   automatically; no change needed.
 - For vendor SDKs that accept a session/HTTP-client hook (Stripe `RequestsClient(session=...)`,
@@ -381,6 +410,25 @@ each, also alphabetical) so adding or removing a source only touches its own lin
 concurrent PRs — don't collapse it back into a comma-separated paragraph. If you add a partially-tracked
 source, also append a short "Notes on partially-tracked sources" entry explaining what blocks tracking
 (e.g. a vendor SDK with no session/interceptor seam).
+
+## Base-class capability flags & API versioning
+
+`common/base.py` exposes class-level flags most API sources leave at their defaults, but which matter
+when they apply:
+
+- `supports_column_selection` (default `False`; `SQLSource` sets `True`) — whether the source honors
+  `enabled_columns` via SELECT projection.
+- `supports_row_filters` (default `False`) — must be `True` for a source to apply saved `row_filters`;
+  otherwise filters are ignored.
+- `has_managed_hogql_schema` (default `False`; `True` for revenue-analytics sources like Stripe,
+  Paddle, Zendesk) — a fixed field set powers a managed HogQL schema, which disables column selection.
+  A new billing/revenue source that ignores this can break revenue analytics.
+- `cleanup_cdc_resources_on_deletion` — best-effort teardown hook for sources that provision CDC
+  resources; override only if your source creates such resources.
+
+For vendor **API versioning** (`supported_versions`, `default_version`, `api_docs_url`,
+`deprecated_versions`, `resolve_api_version()`), use the dedicated **`warehouse-source-new-version`**
+skill — don't hand-roll version handling.
 
 ## Required coding conventions
 
@@ -447,10 +495,9 @@ If undocumented, keep parsing/merge logic conservative and add a short code comm
 
 ## Retry and throttling strategy
 
-- Use `tenacity` instead of manual retry loops.
-- Retry transport failures and retryable status codes (`429`, transient `5xx`).
-- Prefer server-provided rate-limit reset headers on `429`; fall back to exponential backoff.
-- Bound and make deterministic (`stop_after_attempt`). Preserve clear terminal behavior.
+- **`make_tracked_session()` and `rest_source.RESTClient` already retry `429` + transient `5xx` at the transport layer**, honoring `Retry-After`. Do NOT wrap a second `tenacity` `@retry` around your fetch for status codes — it compounds (e.g. 3 transport attempts × 5 tenacity attempts) and is the single most-copied mistake across existing sources. If you use the framework or the tracked session, status-code retries are already handled; write none.
+- Only add `tenacity` for a condition the transport does **not** cover — e.g. an app-level "still processing" body that isn't a retryable HTTP status. If you do, disable transport retries so they don't compound: `make_tracked_session(retry=Retry(total=0))`.
+- Prefer server-provided rate-limit reset headers on `429` — the transport already honors `Retry-After`. Keep any custom retry bounded and deterministic (`stop_after_attempt`), with clear terminal behavior.
 - Keep timeout/retry settings near the top of the module for easy tuning.
 
 The backoff above is the right control when the **customer owns the credential** — their own PAT / API key / OAuth token on their own third-party account, which is nearly every source.
@@ -549,7 +596,7 @@ preserved (omitted) secret is reused — exfiltrating the credential. `host` and
 already handled separately, so only sources whose connection target lives in a differently named field (e.g.
 Okta's `okta_domain`) need to override this. The default is `[]` (no extra fields).
 
-Pair this with `_is_host_safe` (see `## Outbound HTTP must go through the tracked transport`) at both
+Pair this with `_is_host_safe` (`common/mixins.py`) at both
 source-create and sync time to block hosts resolving to internal/private IPs.
 
 ## Mixins
@@ -562,8 +609,8 @@ From `products/warehouse_sources/backend/temporal/data_imports/sources/common/mi
 
 ## Icons
 
-- Prefer SVG over PNG. Keep file size reasonable.
-- Place in `frontend/public/services/` and reference as `/static/services/{name}.svg` in `iconPath`.
+- PNG is the repo convention (`source.template` defaults to `.png`; ~800 png vs ~58 svg). SVG is accepted but not the norm. Keep file size reasonable.
+- Place in `frontend/public/services/` and reference as `/static/services/{name}.png` (or `.svg`) in `iconPath` — match the extension you commit.
 - If the source logo isn't already in the project, pull via [Logo.dev](https://docs.logo.dev/introduction). **Ask the user for the API key** — do not hardcode one. If the user hasn't provided one, surface that as a blocker rather than committing a placeholder.
 
 ## Testing expectations
@@ -599,7 +646,7 @@ Use parameterized tests for status codes and edge cases. Lean toward over-coveri
 ```text
 Bootstrapping:
 - [ ] Enum added to products/warehouse_sources/backend/types.py (ALL_CAPS, no underscores between words)
-- [ ] Entry added to frontend/src/queries/schema/schema-general.ts (kebab-case) — `pnpm run schema:build` regenerates posthog/schema.py from this; don't hand-edit posthog/schema.py
+- [ ] Entry added to frontend/src/queries/schema/schema-general.ts (PascalCase, matching the ExternalDataSourceType value — NOT kebab-case) — `pnpm run schema:build` regenerates posthog/schema.py from this; don't hand-edit posthog/schema.py
 - [ ] Source imported in products/warehouse_sources/backend/temporal/data_imports/sources/__init__.py + __all__
 - [ ] Class inherits from SimpleSource / ResumableSource / WebhookSource (or combo) — see "Picking the right base class"
 
@@ -621,7 +668,7 @@ Source implementation:
 - [ ] (Fixed-schema sources, static get_schemas only) Set lists_tables_without_credentials = True so public docs render the table catalog
 
 Tooling & assets:
-- [ ] Icon in frontend/public/services/ (SVG preferred — ask user for Logo.dev key if needed)
+- [ ] Icon in frontend/public/services/ (PNG is the convention; ask user for Logo.dev key if needed)
 - [ ] Run `pnpm run generate:source-configs`
 - [ ] Swap generic Config for generated {Source}SourceConfig in source.py
 - [ ] Run `pnpm run schema:build`

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/adroll.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/adroll.py
@@ -1,115 +1,155 @@
-from collections.abc import Iterator
-from typing import Any
+import dataclasses
+from typing import Any, Optional
 from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.adroll.settings import ADROLL_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 ADROLL_BASE_URL = "https://services.adroll.com"
-REQUEST_TIMEOUT_SECONDS = 60
 # Quota is requests/day (default 100), so retry sparingly.
 MAX_RETRY_ATTEMPTS = 3
 
-
-class AdRollRetryableError(Exception):
-    pass
-
-
-def _get_session(personal_access_token: str) -> requests.Session:
-    return make_tracked_session(
-        headers={"Authorization": f"Token {personal_access_token}"},
-        redact_values=(personal_access_token,),
-    )
+# Parent resource name in the fan-out config. With include_from_parent=["eid"] the framework
+# injects the parent advertisable EID into child rows as `_advertisable_eid` — the same key the
+# rows carried before the rest_source migration.
+_ADVERTISABLE_PARENT = "advertisable"
 
 
-def validate_credentials(client_id: str, personal_access_token: str) -> bool:
-    """Confirm the PAT + apikey pair is valid with a cheap organization probe."""
-    try:
-        response = _get_session(personal_access_token).get(
-            f"{ADROLL_BASE_URL}/api/v1/organization/get?{urlencode({'apikey': client_id})}",
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+@dataclasses.dataclass
+class AdRollResumeConfig:
+    # Framework fan-out checkpoint ({"completed": [...], "current": ..., "child_state": ...}).
+    # The plain advertisables list is a single request, so only fan-out endpoints checkpoint.
+    fanout_state: Optional[dict[str, Any]] = None
 
 
-def get_rows(
-    client_id: str,
-    personal_access_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = ADROLL_ENDPOINTS[endpoint]
-    session = _get_session(personal_access_token)
-
-    @retry(
-        retry=retry_if_exception_type((AdRollRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=5, max=120),
-        reraise=True,
-    )
-    def fetch(path: str, params: dict[str, Any]) -> dict[str, Any]:
-        # Every request needs the app's Client ID as the apikey param, even
-        # with PAT auth.
-        url = f"{ADROLL_BASE_URL}{path}?{urlencode({**params, 'apikey': client_id})}"
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise AdRollRetryableError(f"AdRoll API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"AdRoll API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    def advertisable_eids() -> list[str]:
-        data = fetch(ADROLL_ENDPOINTS["advertisables"].path, {})
-        results = data.get("results", []) or []
-        return [item["eid"] for item in results if item.get("eid")]
-
-    if not config.advertisable_scoped:
-        data = fetch(config.path, {})
-        items = data.get("results", []) or []
-        if items:
-            yield items
-        return
-
-    # advertisable_scoped endpoints always define a parent_key (enforced in
-    # AdRollEndpointConfig.__post_init__); narrow the Optional for the row build.
-    parent_key = config.parent_key
-    assert parent_key is not None
-    for eid in advertisable_eids():
-        data = fetch(config.path, {"advertisable": eid})
-        items = [{**item, parent_key: eid} for item in (data.get("results", []) or [])]
-        if items:
-            yield items
+def _client_config(client_id: str, personal_access_token: str) -> ClientConfig:
+    return {
+        "base_url": ADROLL_BASE_URL,
+        # The PAT travels on the Authorization header via framework auth so its value is
+        # redacted from logs. The app's Client ID is not a secret; it rides along as the
+        # `apikey` query param on every endpoint (see per-endpoint params).
+        "auth": {
+            "type": "api_key",
+            "api_key": f"Token {personal_access_token}",
+            "name": "Authorization",
+            "location": "header",
+        },
+        # AdRoll's get/get_all endpoints return everything in one response — no pagination.
+        "paginator": SinglePagePaginator(),
+        "max_retries": MAX_RETRY_ATTEMPTS,
+    }
 
 
 def adroll_source(
     client_id: str,
     personal_access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[AdRollResumeConfig],
 ) -> SourceResponse:
     config = ADROLL_ENDPOINTS[endpoint]
 
+    if not config.advertisable_scoped:
+        rest_config: RESTAPIConfig = {
+            "client": _client_config(client_id, personal_access_token),
+            "resources": [
+                {
+                    "name": endpoint,
+                    "endpoint": {
+                        "path": config.path,
+                        "params": {"apikey": client_id},
+                        "data_selector": "results",
+                    },
+                }
+            ],
+        }
+        # A single request — nothing to checkpoint.
+        resource = rest_api_resource(rest_config, team_id, job_id, None)
+    else:
+        initial_state: Optional[dict[str, Any]] = None
+        if resumable_source_manager.can_resume():
+            resume = resumable_source_manager.load_state()
+            if resume is not None and resume.fanout_state is not None:
+                initial_state = resume.fanout_state
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            if state is not None:
+                resumable_source_manager.save_state(AdRollResumeConfig(fanout_state=state))
+
+        rest_config = {
+            "client": _client_config(client_id, personal_access_token),
+            "resources": [
+                {
+                    "name": _ADVERTISABLE_PARENT,
+                    "endpoint": {
+                        "path": ADROLL_ENDPOINTS["advertisables"].path,
+                        "params": {"apikey": client_id},
+                        "data_selector": "results",
+                    },
+                },
+                {
+                    "name": endpoint,
+                    "endpoint": {
+                        # AdRoll scopes campaign/ad lists with an `advertisable` query param,
+                        # not a path segment; bind the resolve param inside the query string.
+                        "path": f"{config.path}?advertisable={{advertisable}}",
+                        "params": {
+                            "advertisable": {
+                                "type": "resolve",
+                                "resource": _ADVERTISABLE_PARENT,
+                                "field": "eid",
+                            },
+                            "apikey": client_id,
+                        },
+                        "data_selector": "results",
+                    },
+                    "include_from_parent": ["eid"],
+                },
+            ],
+        }
+        resources = {
+            resource.name: resource
+            for resource in rest_api_resources(
+                rest_config,
+                team_id,
+                job_id,
+                None,
+                resume_hook=save_checkpoint,
+                initial_paginator_state=initial_state,
+            )
+        }
+        # An advertisable without an EID can't scope a child request — skip it, as before.
+        resources[_ADVERTISABLE_PARENT].add_filter(lambda item: bool(item.get("eid")))
+        resource = resources[endpoint]
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            client_id=client_id,
-            personal_access_token=personal_access_token,
-            endpoint=endpoint,
-            logger=logger,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
         sort_mode="asc",
     )
+
+
+def validate_credentials(client_id: str, personal_access_token: str) -> bool:
+    """Confirm the PAT + apikey pair is valid with a cheap organization probe."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(personal_access_token,)),
+        f"{ADROLL_BASE_URL}/api/v1/organization/get?{urlencode({'apikey': client_id})}",
+        headers={"Authorization": f"Token {personal_access_token}"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/settings.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from products.warehouse_sources.backend.types import IncrementalField
+
 
 @dataclass
 class AdRollEndpointConfig:
@@ -41,3 +43,6 @@ ADROLL_ENDPOINTS: dict[str, AdRollEndpointConfig] = {
 }
 
 ENDPOINTS = tuple(ADROLL_ENDPOINTS.keys())
+
+# Entity endpoints have no updated_at filter — every endpoint is full refresh.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {name: [] for name in ADROLL_ENDPOINTS}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/source.py
@@ -14,22 +14,30 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     SourceResponse,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.adroll.adroll import (
+    AdRollResumeConfig,
     adroll_source,
     validate_credentials as validate_adroll_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.adroll.settings import ENDPOINTS
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.adroll.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AdRollSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class AdRollSource(SimpleSource[AdRollSourceConfig]):
+class AdRollSource(ResumableSource[AdRollSourceConfig, AdRollResumeConfig]):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 
     supported_versions = ("v1",)
@@ -99,21 +107,7 @@ Create a personal access token and an app in the [NextRoll developer console](ht
     ) -> list[SourceSchema]:
         # Entity endpoints have no updated_at filter — full refresh. Metrics
         # are GraphQL-only and a follow-up.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: AdRollSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -123,10 +117,20 @@ Create a personal access token and an app in the [NextRoll developer console](ht
 
         return False, "Invalid AdRoll credentials"
 
-    def source_for_pipeline(self, config: AdRollSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[AdRollResumeConfig]:
+        return ResumableSourceManager[AdRollResumeConfig](inputs, AdRollResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: AdRollSourceConfig,
+        resumable_source_manager: ResumableSourceManager[AdRollResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         return adroll_source(
             client_id=config.client_id,
             personal_access_token=config.personal_access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/tests/test_adroll.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/tests/test_adroll.py
@@ -1,35 +1,89 @@
+import json
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.adroll.adroll import (
     MAX_RETRY_ATTEMPTS,
-    AdRollRetryableError,
+    AdRollResumeConfig,
     adroll_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.adroll.settings import ADROLL_ENDPOINTS, ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.adroll.adroll"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the adroll module.
+ADROLL_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.adroll.adroll.make_tracked_session"
+)
+
+CAMPAIGNS_PATH = ADROLL_ENDPOINTS["campaigns"].path
+ADS_PATH = ADROLL_ENDPOINTS["ads"].path
 
 
-def _response(results: list[dict[str, Any]]) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {"results": results}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
-
-
-def _error_response(status_code: int) -> mock.MagicMock:
-    resp = mock.MagicMock()
+def _response(results: list[dict[str, Any]] | None, *, drop_results: bool = False, status_code: int = 200) -> Response:
+    body: dict[str, Any] = {}
+    if not drop_results:
+        body["results"] = results or []
+    resp = Response()
     resp.status_code = status_code
-    resp.ok = False
-    resp.text = "error"
+    resp._content = json.dumps(body).encode()
     return resp
+
+
+def _error_response(status_code: int) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = b'{"error": "boom"}'
+    return resp
+
+
+def _make_manager(resume_state: AdRollResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return snapshots of each request AT PREPARE TIME.
+
+    ``request.params`` dicts can be mutated/rebuilt across requests, so snapshot a copy
+    when each request is prepared instead of inspecting after the run.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None):
+    return adroll_source(
+        client_id="cid",
+        personal_access_token="pat",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+    )
 
 
 class TestValidateCredentials:
@@ -42,106 +96,210 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(ADROLL_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
-        response = mock.MagicMock()
-        response.status_code = status_code
-        mock_session.return_value.get.return_value = response
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         assert validate_credentials("cid", "pat") is expected
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(ADROLL_SESSION_PATCH)
     def test_validate_includes_apikey_and_token_header(self, mock_session):
-        response = mock.MagicMock()
-        response.status_code = 200
-        mock_session.return_value.get.return_value = response
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
         validate_credentials("cid", "pat")
 
         url = mock_session.return_value.get.call_args.args[0]
         assert parse_qs(urlparse(url).query)["apikey"] == ["cid"]
-        headers = mock_session.call_args.kwargs["headers"]
+        headers = mock_session.return_value.get.call_args.kwargs["headers"]
         assert headers["Authorization"] == "Token pat"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(ADROLL_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("cid", "pat") is False
 
 
-class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_advertisables_single_fetch(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"eid": "ADV1"}])
+class TestRows:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_advertisables_single_fetch(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"eid": "ADV1"}])])
 
-        batches = list(get_rows("cid", "pat", "advertisables", mock.MagicMock()))
+        rows = _rows(_source("advertisables"))
 
-        assert batches == [[{"eid": "ADV1"}]]
-        url = mock_session.return_value.get.call_args.args[0]
-        assert urlparse(url).path == "/api/v1/organization/get_advertisables"
-        assert parse_qs(urlparse(url).query)["apikey"] == ["cid"]
+        assert rows == [{"eid": "ADV1"}]
+        assert session.send.call_count == 1
+        assert urlparse(snapshots[0]["url"]).path == "/api/v1/organization/get_advertisables"
+        assert snapshots[0]["params"]["apikey"] == "cid"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_campaigns_fan_out_over_advertisables(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"eid": "ADV1"}, {"eid": "ADV2"}]),
-            _response([{"eid": "C1"}]),
-            _response([{"eid": "C2"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_requests_carry_token_auth_header(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"eid": "ADV1"}])])
 
-        batches = list(get_rows("cid", "pat", "campaigns", mock.MagicMock()))
+        _rows(_source("advertisables"))
 
-        flat = [item for batch in batches for item in batch]
-        assert [(c["eid"], c["_advertisable_eid"]) for c in flat] == [("C1", "ADV1"), ("C2", "ADV2")]
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert parse_qs(urlparse(urls[1]).query)["advertisable"] == ["ADV1"]
-        assert parse_qs(urlparse(urls[2]).query)["advertisable"] == ["ADV2"]
+        auth = snapshots[0]["auth"]
+        prepared = mock.MagicMock(headers={})
+        auth(prepared)
+        assert prepared.headers["Authorization"] == "Token pat"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_advertisables_without_eid_are_skipped(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"name": "broken"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_campaigns_fan_out_over_advertisables(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"eid": "ADV1"}, {"eid": "ADV2"}]),
+                _response([{"eid": "C1"}]),
+                _response([{"eid": "C2"}]),
+            ],
+        )
 
-        assert list(get_rows("cid", "pat", "ads", mock.MagicMock())) == []
-        assert mock_session.return_value.get.call_count == 1
+        rows = _rows(_source("campaigns"))
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_response_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+        assert [(c["eid"], c["_advertisable_eid"]) for c in rows] == [("C1", "ADV1"), ("C2", "ADV2")]
+        child_queries = [parse_qs(urlparse(s["url"]).query) for s in snapshots[1:]]
+        assert child_queries[0]["advertisable"] == ["ADV1"]
+        assert child_queries[1]["advertisable"] == ["ADV2"]
+        assert all(urlparse(s["url"]).path == CAMPAIGNS_PATH for s in snapshots[1:])
+        # The apikey param rides along on every request, parent and children alike.
+        assert all(s["params"]["apikey"] == "cid" for s in snapshots)
 
-        assert list(get_rows("cid", "pat", "advertisables", mock.MagicMock())) == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_advertisables_without_eid_are_skipped(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"name": "broken"}])])
+
+        assert _rows(_source("ads")) == []
+        assert session.send.call_count == 1
+
+    @pytest.mark.parametrize("endpoint", ["advertisables", "campaigns"])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_nothing(self, MockSession, endpoint):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        assert _rows(_source(endpoint)) == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_results_key_is_tolerated(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_results=True)])
+
+        assert _rows(_source("advertisables")) == []
 
     @mock.patch("time.sleep")
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_retries_retryable_status_then_succeeds(self, mock_session, _mock_sleep):
-        mock_session.return_value.get.side_effect = [
-            _error_response(500),
-            _error_response(429),
-            _response([{"eid": "ADV1"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_retryable_status_then_succeeds(self, MockSession, _mock_sleep):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _error_response(500),
+                _error_response(429),
+                _response([{"eid": "ADV1"}]),
+            ],
+        )
 
-        batches = list(get_rows("cid", "pat", "advertisables", mock.MagicMock()))
+        rows = _rows(_source("advertisables"))
 
-        assert batches == [[{"eid": "ADV1"}]]
-        assert mock_session.return_value.get.call_count == MAX_RETRY_ATTEMPTS
+        assert rows == [{"eid": "ADV1"}]
+        assert session.send.call_count == MAX_RETRY_ATTEMPTS
 
     @mock.patch("time.sleep")
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_retries_exhausted_raises(self, mock_session, _mock_sleep):
-        mock_session.return_value.get.return_value = _error_response(500)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_exhausted_raises(self, MockSession, _mock_sleep):
+        session = MockSession.return_value
+        _wire(session, [_error_response(500)] * MAX_RETRY_ATTEMPTS)
 
-        with pytest.raises(AdRollRetryableError):
-            list(get_rows("cid", "pat", "advertisables", mock.MagicMock()))
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source("advertisables"))
 
-        assert mock_session.return_value.get.call_count == MAX_RETRY_ATTEMPTS
+        assert session.send.call_count == MAX_RETRY_ATTEMPTS
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_retryable_client_error_raises(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_error_response(401)])
+
+        with pytest.raises(Exception, match="401"):
+            _rows(_source("advertisables"))
+
+        assert session.send.call_count == 1
+
+
+class TestFanOutResume:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_completed_advertisables(self, MockSession):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"eid": "ADV1"}, {"eid": "ADV2"}]),
+                _response([{"eid": "C1"}]),
+                _response([{"eid": "C2"}]),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("campaigns", manager))
+
+        final_state = manager.save_state.call_args.args[0]
+        assert final_state == AdRollResumeConfig(
+            fanout_state={
+                "completed": [
+                    f"{CAMPAIGNS_PATH}?advertisable=ADV1",
+                    f"{CAMPAIGNS_PATH}?advertisable=ADV2",
+                ],
+                "current": None,
+                "child_state": None,
+            }
+        )
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_advertisables(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"eid": "ADV1"}, {"eid": "ADV2"}]),
+                _response([{"eid": "C2"}]),
+            ],
+        )
+
+        manager = _make_manager(
+            AdRollResumeConfig(
+                fanout_state={
+                    "completed": [f"{CAMPAIGNS_PATH}?advertisable=ADV1"],
+                    "current": None,
+                    "child_state": None,
+                }
+            )
+        )
+        rows = _rows(_source("campaigns", manager))
+
+        # ADV1 was already synced — only the parent list and ADV2's campaigns are fetched.
+        assert [(c["eid"], c["_advertisable_eid"]) for c in rows] == [("C2", "ADV2")]
+        assert session.send.call_count == 2
+        assert parse_qs(urlparse(snapshots[1]["url"]).query)["advertisable"] == ["ADV2"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_resume_state_saved_for_plain_endpoint(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"eid": "ADV1"}])])
+
+        manager = _make_manager()
+        _rows(_source("advertisables", manager))
+
+        manager.save_state.assert_not_called()
 
 
 class TestAdRollSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = ADROLL_ENDPOINTS[endpoint]
-        response = adroll_source("cid", "pat", endpoint, mock.MagicMock())
+        response = _source(endpoint)
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/tests/test_adroll_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adroll/tests/test_adroll_source.py
@@ -100,11 +100,17 @@ class TestAdRollSource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_adroll_source):
         inputs = mock.MagicMock()
         inputs.schema_name = "campaigns"
+        inputs.team_id = self.team_id
+        inputs.job_id = "job-1"
+        manager = mock.MagicMock()
 
-        self.source.source_for_pipeline(self.config, inputs)
+        self.source.source_for_pipeline(self.config, manager, inputs)
 
         mock_adroll_source.assert_called_once()
         kwargs = mock_adroll_source.call_args.kwargs
         assert kwargs["client_id"] == "cid"
         assert kwargs["personal_access_token"] == "pat"
         assert kwargs["endpoint"] == "campaigns"
+        assert kwargs["team_id"] == self.team_id
+        assert kwargs["job_id"] == "job-1"
+        assert kwargs["resumable_source_manager"] is manager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/agilecrm/agilecrm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/agilecrm/agilecrm.py
@@ -1,31 +1,28 @@
 import re
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
+from requests.auth import HTTPBasicAuth
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.agilecrm.settings import (
     AGILECRM_ENDPOINTS,
     BASE_URL_TEMPLATE,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # A valid Agile CRM subdomain is a single DNS label: letters, digits and hyphens only. Constraining
 # the domain to this pattern stops a malicious value (e.g. `evil.com#`) from retargeting the basic-auth
 # credentials at an attacker-controlled host once it's interpolated into the base URL.
 _DOMAIN_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
-
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class AgileCRMRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -46,91 +43,120 @@ def base_url(domain: str) -> str:
     return BASE_URL_TEMPLATE.format(domain=_validate_domain(domain))
 
 
-def _make_session(email: str, api_key: str) -> requests.Session:
-    # Agile CRM authenticates with HTTP Basic: account email as username, API key as password.
-    session = make_tracked_session(headers={"Accept": "application/json"}, redact_values=(api_key,))
-    session.auth = (email, api_key)
-    return session
+class AgileCRMCursorPaginator(BasePaginator):
+    """Agile CRM signals the next page via a `cursor` field on the *last* item of the current page.
+
+    A missing cursor or a short page (fewer items than the requested page size) means the final page.
+    The cursor is stripped from the yielded rows by the endpoint's `data_map`, not here.
+    """
+
+    def __init__(self, page_size: int) -> None:
+        super().__init__()
+        self.page_size = page_size
+        self._cursor: Optional[str] = None
+
+    def _inject_cursor(self, request: Request) -> None:
+        if self._cursor is not None:
+            if request.params is None:
+                request.params = {}
+            request.params["cursor"] = self._cursor
+
+    def init_request(self, request: Request) -> None:
+        # Honour a seeded resume cursor on the first request.
+        self._inject_cursor(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
+        last_item = items[-1] if items else None
+        next_cursor = last_item.get("cursor") if isinstance(last_item, dict) else None
+        self._cursor = next_cursor
+        # No items, no cursor on the last item, or a short page all mean we've reached the end.
+        self._has_next_page = bool(next_cursor) and len(items) >= self.page_size
+
+    def update_request(self, request: Request) -> None:
+        self._inject_cursor(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        if self._has_next_page and self._cursor is not None:
+            return {"cursor": self._cursor}
+        return None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor = cursor
+            self._has_next_page = True
 
 
-@retry(
-    retry=retry_if_exception_type((AgileCRMRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, params: dict[str, Any], logger: FilteringBoundLogger
-) -> list[dict[str, Any]]:
-    response = session.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AgileCRMRetryableError(f"Agile CRM API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Agile CRM API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    # Known list endpoints return a bare JSON array. Tolerate an unexpected object by returning no rows
-    # rather than crashing the sync.
-    if isinstance(data, list):
-        return data
-    return []
+def _strip_cursor(item: dict[str, Any]) -> dict[str, Any]:
+    # The cursor is navigation metadata carried on the last item of each page, not data. Strip it so
+    # it isn't written to the warehouse as a sparse `cursor` column that only the final row of each
+    # page carries.
+    return {k: v for k, v in item.items() if k != "cursor"}
 
 
-def get_rows(
+def agilecrm_source(
     domain: str,
     email: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AgileCRMResumeConfig],
-) -> Iterator[Any]:
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
     config = AGILECRM_ENDPOINTS[endpoint]
-    url = f"{base_url(domain)}/{config.path}"
-    session = _make_session(email, api_key)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    cursor = resume.cursor if resume else None
-    if cursor:
-        logger.debug(f"Agile CRM: resuming {endpoint} from cursor={cursor}")
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url(domain),
+            "headers": {"Accept": "application/json"},
+            # Agile CRM authenticates with HTTP Basic: account email as username, API key as password.
+            "auth": {"type": "http_basic", "username": email, "password": api_key},
+            "paginator": AgileCRMCursorPaginator(page_size=config.page_size),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"page_size": config.page_size},
+                    "data_selector": config.data_selector,
+                    # Known list endpoints return a bare JSON array; a 200 object body means the
+                    # response shape changed — fail loud instead of silently mis-syncing.
+                    "data_selector_required": True,
+                },
+                "data_map": _strip_cursor,
+            }
+        ],
+    }
 
-    while True:
-        params: dict[str, Any] = {"page_size": config.page_size}
-        if cursor:
-            params["cursor"] = cursor
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.cursor:
+            initial_paginator_state = {"cursor": resume.cursor}
 
-        items = _fetch_page(session, url, params, logger)
-        if not items:
-            break
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; saved AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(AgileCRMResumeConfig(cursor=str(state["cursor"])))
 
-        # Agile CRM signals the next page via a `cursor` field on the *last* item of the current page.
-        last_item = items[-1]
-        next_cursor = last_item.get("cursor") if isinstance(last_item, dict) else None
-        # The cursor is navigation metadata, not data. Strip it from the last item so it isn't written
-        # to the warehouse as a sparse `cursor` column that only the final row of each page carries.
-        if isinstance(last_item, dict) and "cursor" in last_item:
-            items = [*items[:-1], {k: v for k, v in last_item.items() if k != "cursor"}]
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
-        for item in items:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save AFTER yielding so a crash re-yields the last page (merge dedupes on the primary
-                # key) rather than skipping it. Only persist when another page follows.
-                if next_cursor:
-                    resumable_source_manager.save_state(AgileCRMResumeConfig(cursor=next_cursor))
-
-        # No cursor, or a short page, means we've reached the end.
-        if not next_cursor or len(items) < config.page_size:
-            break
-
-        cursor = next_cursor
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+    )
 
 
 def validate_credentials(domain: str, email: str, api_key: str) -> bool:
@@ -139,32 +165,9 @@ def validate_credentials(domain: str, email: str, api_key: str) -> bool:
     except ValueError:
         return False
 
-    try:
-        response = _make_session(email, api_key).get(url, params={"page_size": 1}, timeout=REQUEST_TIMEOUT_SECONDS)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def agilecrm_source(
-    domain: str,
-    email: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AgileCRMResumeConfig],
-) -> SourceResponse:
-    endpoint_config = AGILECRM_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            domain=domain,
-            email=email,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=endpoint_config.primary_keys,
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(headers={"Accept": "application/json"}, redact_values=(api_key,)),
+        f"{url}?page_size=1",
+        auth=HTTPBasicAuth(email, api_key),
     )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/agilecrm/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/agilecrm/source.py
@@ -25,7 +25,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AgileCRMSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -116,19 +119,7 @@ Your domain is the subdomain of your Agile CRM URL — for `https://acme.agilecr
     ) -> list[SourceSchema]:
         # Agile CRM documents no server-side updated-since/created-after filter on any list endpoint,
         # so every table is full refresh only.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, {}, names)
 
     def validate_credentials(
         self, config: AgileCRMSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -152,6 +143,8 @@ Your domain is the subdomain of your Agile CRM URL — for `https://acme.agilecr
             email=config.email,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Agile CRM endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/agilecrm/tests/test_agilecrm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/agilecrm/tests/test_agilecrm.py
@@ -1,64 +1,77 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.agilecrm import agilecrm
 from products.warehouse_sources.backend.temporal.data_imports.sources.agilecrm.agilecrm import (
     AgileCRMResumeConfig,
+    agilecrm_source,
     base_url,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.agilecrm.settings import AGILECRM_ENDPOINTS
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the agilecrm module.
+AGILECRM_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.agilecrm.agilecrm.make_tracked_session"
+)
 
-class _FakeResumableManager:
-    def __init__(self, state: AgileCRMResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[AgileCRMResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> AgileCRMResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: AgileCRMResumeConfig) -> None:
-        self.saved.append(data)
+PAGE_SIZE = AGILECRM_ENDPOINTS["contacts"].page_size
 
 
-def _collect_rows(
-    monkeypatch: Any,
-    pages: list[list[dict[str, Any]]],
-    manager: _FakeResumableManager,
-    endpoint: str = "contacts",
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Drive get_rows against a queue of fake pages, returning (rows, recorded request params)."""
-    recorded_params: list[dict[str, Any]] = []
-    queue = list(pages)
+def _response(body: Any) -> Response:
+    # Agile CRM list endpoints return a bare JSON array as the body.
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
-    def fake_fetch(session: Any, url: str, params: dict[str, Any], logger: Any) -> list[dict[str, Any]]:
-        recorded_params.append(dict(params))
-        return queue.pop(0) if queue else []
 
-    monkeypatch.setattr(agilecrm, "_fetch_page", fake_fetch)
-    monkeypatch.setattr(agilecrm, "_make_session", lambda email, api_key: MagicMock())
+def _make_manager(resume_state: AgileCRMResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    rows: list[dict[str, Any]] = []
-    for table in get_rows(
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(manager: mock.MagicMock, endpoint: str = "contacts"):
+    return agilecrm_source(
         domain="acme",
         email="a@b.com",
         api_key="key",
         endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        rows.extend(table.to_pylist())
-    return rows, recorded_params
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
 
 
 class TestBaseUrl:
@@ -89,81 +102,103 @@ class TestBaseUrl:
 
 
 class TestPagination:
-    def test_paginates_until_short_page(self, monkeypatch: Any) -> None:
-        page_size = AGILECRM_ENDPOINTS["contacts"].page_size
-        first_page = [{"id": i} for i in range(page_size - 1)] + [{"id": page_size, "cursor": "CURSOR1"}]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        first_page = [{"id": i} for i in range(PAGE_SIZE - 1)] + [{"id": PAGE_SIZE, "cursor": "CURSOR1"}]
         second_page = [{"id": 9001}]  # short page -> terminal
-        manager = _FakeResumableManager()
+        params = _wire(session, [_response(first_page), _response(second_page)])
 
-        rows, params = _collect_rows(monkeypatch, [first_page, second_page], manager)
+        manager = _make_manager()
+        rows = _rows(_source(manager))
 
-        assert len(rows) == page_size + 1
+        assert len(rows) == PAGE_SIZE + 1
         # First request has no cursor; the second carries the cursor from the last item of page one.
         assert "cursor" not in params[0]
+        assert params[0]["page_size"] == PAGE_SIZE
         assert params[1]["cursor"] == "CURSOR1"
         # The cursor is navigation metadata and must never leak into the warehouse rows.
         assert all("cursor" not in row for row in rows)
+        # Checkpoint saved after the first page (points at the next page); the short page ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == AgileCRMResumeConfig(cursor="CURSOR1")
 
-    def test_stops_when_full_page_has_no_cursor(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_full_page_has_no_cursor(self, MockSession) -> None:
         # A full page whose last item carries no cursor must terminate rather than loop forever.
-        page_size = AGILECRM_ENDPOINTS["contacts"].page_size
-        full_page_no_cursor = [{"id": i} for i in range(page_size)]
-        manager = _FakeResumableManager()
+        session = MockSession.return_value
+        full_page_no_cursor = [{"id": i} for i in range(PAGE_SIZE)]
+        _wire(session, [_response(full_page_no_cursor), _response([{"id": 1}])])
 
-        rows, params = _collect_rows(monkeypatch, [full_page_no_cursor, [{"id": 1}]], manager)
+        manager = _make_manager()
+        rows = _rows(_source(manager))
 
-        assert len(rows) == page_size
-        assert len(params) == 1
+        assert len(rows) == PAGE_SIZE
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows, params = _collect_rows(monkeypatch, [[]], manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_short_page_even_with_cursor(self, MockSession) -> None:
+        # A short page is terminal even if its last item still carries a cursor.
+        session = MockSession.return_value
+        short_page = [{"id": 1}, {"id": 2, "cursor": "DANGLING"}]
+        _wire(session, [_response(short_page), _response([{"id": 3}])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert [r["id"] for r in rows] == [1, 2]
+        assert session.send.call_count == 1
+        assert all("cursor" not in row for row in rows)
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == []
-        assert len(params) == 1
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resume_uses_saved_cursor(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(AgileCRMResumeConfig(cursor="SAVED"))
-        rows, params = _collect_rows(monkeypatch, [[{"id": 1}]], manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_uses_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 1}])])
+
+        manager = _make_manager(AgileCRMResumeConfig(cursor="SAVED"))
+        rows = _rows(_source(manager))
 
         assert rows == [{"id": 1}]
         assert params[0]["cursor"] == "SAVED"
 
-    def test_saves_state_after_yielding_batch(self, monkeypatch: Any) -> None:
-        # The Batcher flushes once 2000 rows accumulate; state must be saved (with the next cursor)
-        # only after that batch is yielded, so a crash re-yields the last page rather than skipping it.
-        big_first_page = [{"id": i} for i in range(2499)] + [{"id": 2500, "cursor": "NEXT"}]
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "something went wrong"})])
 
-        rows, _ = _collect_rows(monkeypatch, [big_first_page, [{"id": 1}]], manager)
-
-        assert manager.saved
-        assert manager.saved[0].cursor == "NEXT"
-        # The cursor is navigation metadata and must never leak into the warehouse rows.
-        assert all("cursor" not in row for row in rows)
+        # A 200 object body means the response shape changed — fail loud, not silently mis-sync.
+        with pytest.raises(ValueError, match="Required a list response body"):
+            _rows(_source(_make_manager()))
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
     def test_status_maps_to_bool(self, _name: str, status_code: int, expected: bool) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-
-        with patch.object(agilecrm, "_make_session", lambda email, api_key: session):
+        with mock.patch(AGILECRM_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
             assert validate_credentials("acme", "a@b.com", "key") is expected
 
-    def test_invalid_domain_short_circuits_to_false(self, monkeypatch: Any) -> None:
+    def test_invalid_domain_short_circuits_to_false(self) -> None:
         # An invalid domain must fail before any request is attempted.
-        session = MagicMock()
-        monkeypatch.setattr(agilecrm, "_make_session", lambda email, api_key: session)
+        with mock.patch(AGILECRM_SESSION_PATCH) as mock_session:
+            assert validate_credentials("evil.com#", "a@b.com", "key") is False
+            mock_session.assert_not_called()
 
-        assert validate_credentials("evil.com#", "a@b.com", "key") is False
-        session.get.assert_not_called()
-
-    def test_network_error_is_false(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        monkeypatch.setattr(agilecrm, "_make_session", lambda email, api_key: session)
-
-        assert validate_credentials("acme", "a@b.com", "key") is False
+    def test_network_error_is_false(self) -> None:
+        with mock.patch(AGILECRM_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.side_effect = Exception("boom")
+            assert validate_credentials("acme", "a@b.com", "key") is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aha/aha.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aha/aha.py
@@ -1,15 +1,10 @@
 import re
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.aha.settings import (
     AHA_ENDPOINTS,
@@ -17,17 +12,24 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.aha.settin
     AhaEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.jsonpath_utils import (
+    find_values,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 AHA_API_PATH = "/api/v1"
 
 # A single DNS label: letters, digits, hyphens. Rejects anything that could retarget the host
 # (slashes, `@`, dots) so the stored API key is only ever sent to `<subdomain>.aha.io`.
 _SUBDOMAIN_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
-
-
-class AhaRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -58,10 +60,6 @@ def _base_url(subdomain: str) -> str:
     return f"https://{normalize_subdomain(subdomain)}.aha.io{AHA_API_PATH}"
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
-
-
 def _format_updated_since(value: Any) -> str:
     """Format an incremental cursor as the ISO8601 UTC string Aha! expects for `updated_since`."""
     if isinstance(value, datetime):
@@ -70,12 +68,6 @@ def _format_updated_since(value: Any) -> str:
     if isinstance(value, date):
         return datetime.combine(value, datetime.min.time(), tzinfo=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     return str(value)
-
-
-def _build_url(base_url: str, path: str, params: dict[str, Any]) -> str:
-    if not params:
-        return f"{base_url}{path}"
-    return f"{base_url}{path}?{urlencode(params)}"
 
 
 def _build_initial_params(
@@ -90,117 +82,98 @@ def _build_initial_params(
     return params
 
 
-@retry(
-    retry=retry_if_exception_type((AhaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, headers=headers, timeout=60)
+class AhaPageNumberPaginator(PageNumberPaginator):
+    """Page-number pagination with Aha!'s full-page fallback.
 
-    # Aha! enforces 300 req/min and 20 req/sec; 429 carries reset headers. Back off and retry rather
-    # than failing the sync. Transient 5xx are retryable too.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AhaRetryableError(f"Aha! API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Aha! API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _has_more_pages(pagination: dict[str, Any], page: int, item_count: int) -> bool:
-    """Decide whether to fetch another page.
-
-    Prefer Aha!'s `pagination.total_pages`; fall back to a full-page heuristic if the metadata is
-    ever absent (a full page implies there may be more).
+    Aha! reports `pagination.total_pages` (total number of PAGES), which the base paginator uses
+    to stop after the last page. If that metadata is ever absent, fall back to the full-page
+    heuristic: a short page means there are no more pages.
     """
-    total_pages = pagination.get("total_pages")
-    if isinstance(total_pages, int):
-        return page < total_pages
-    return item_count >= PER_PAGE
 
-
-def get_rows(
-    subdomain: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AhaResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = AHA_ENDPOINTS[endpoint]
-    base_url = _base_url(subdomain)
-    headers = _headers(api_key)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    session = make_tracked_session()
-
-    params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume is not None and resume.next_page else 1
-    if page > 1:
-        logger.debug(f"Aha!: resuming {endpoint} from page {page}")
-
-    while True:
-        data = _fetch_page(session, _build_url(base_url, config.path, {**params, "page": page}), headers, logger)
-        items = data.get(config.response_key, [])
-        if not items:
-            break
-
-        has_more = _has_more_pages(data.get("pagination", {}), page, len(items))
-
-        for item in items:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save AFTER yielding so a crash re-yields the last page rather than skipping it —
-                # merge dedupes on the primary key.
-                if has_more:
-                    resumable_source_manager.save_state(AhaResumeConfig(next_page=page + 1))
-
-        if not has_more:
-            break
-        page += 1
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if not self._has_next_page or data is None:
+            return
+        try:
+            values = find_values(self.total_path, response.json()) if self.total_path else []
+        except Exception:
+            values = []
+        has_total_metadata = bool(values) and isinstance(values[0], int)
+        if not has_total_metadata and len(data) < PER_PAGE:
+            self._has_next_page = False
 
 
 def aha_source(
     subdomain: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AhaResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
-    incremental_field: str | None = None,
 ) -> SourceResponse:
     config = AHA_ENDPOINTS[endpoint]
+    params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(subdomain),
+            # Auth (Bearer) goes through the framework auth config so its value is redacted from
+            # logs; only the non-secret accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": AhaPageNumberPaginator(
+                base_page=1,
+                page_param="page",
+                total_path="pagination.total_pages",
+            ),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # A 200 body without the root key yields an empty page and ends pagination —
+                    # same as the old implementation's `data.get(key, []) -> stop`.
+                    "data_selector": config.response_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_page:
+            initial_paginator_state = {"page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(AhaResumeConfig(next_page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            subdomain=subdomain,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
@@ -210,9 +183,9 @@ def validate_credentials(subdomain: str, api_key: str) -> tuple[bool, int | None
     Returns ``(ok, status_code)``. ``status_code`` is ``None`` on a transport error. Raises
     ``ValueError`` if the subdomain is malformed so the caller can surface a precise message.
     """
-    url = _build_url(_base_url(subdomain), "/me", {})
-    try:
-        response = make_tracked_session().get(url, headers=_headers(api_key), timeout=10)
-    except Exception:
-        return False, None
-    return response.status_code == 200, response.status_code
+    url = f"{_base_url(subdomain)}/me"
+    return validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        url,
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aha/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aha/source.py
@@ -18,18 +18,17 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.aha.aha im
     aha_source,
     validate_credentials as validate_aha_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.aha.settings import (
-    AHA_ENDPOINTS,
-    ENDPOINTS,
-    INCREMENTAL_FIELDS,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.aha.settings import ENDPOINTS, INCREMENTAL_FIELDS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AhaSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -95,7 +94,7 @@ Create an API key under **Settings → Personal → Developer → API keys** in 
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # 401/403 surface as a requests HTTPError when `_fetch_page` calls `raise_for_status()`.
+            # 401/403 surface as a requests HTTPError when the REST client calls `raise_for_status()`.
             # Retrying can never fix a credential/permission problem, so fail the sync. Match the
             # stable status text and `.aha.io` host, not the per-request path.
             "401 Client Error: Unauthorized": "Your Aha! API key is invalid or has been revoked. Create a new key in your Aha! account settings, then reconnect.",
@@ -110,21 +109,9 @@ Create an API key under **Settings → Personal → Developer → API keys** in 
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = AHA_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=endpoint_config.supports_incremental,
-                supports_append=endpoint_config.supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # `supports_incremental`/`supports_append` derive from the endpoint having incremental
+        # fields, which matches the per-endpoint `supports_incremental` flag in settings.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: AhaSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -153,11 +140,11 @@ Create an API key under **Settings → Personal → Developer → API keys** in 
             subdomain=config.subdomain,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,
-            incremental_field=inputs.incremental_field,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aha/tests/test_aha.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aha/tests/test_aha.py
@@ -1,23 +1,28 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.aha import aha
 from products.warehouse_sources.backend.temporal.data_imports.sources.aha.aha import (
-    PER_PAGE,
     AhaResumeConfig,
     _build_initial_params,
-    _build_url,
     _format_updated_since,
-    _has_more_pages,
-    get_rows,
+    aha_source,
     normalize_subdomain,
+    validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.aha.settings import AHA_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.aha.settings import AHA_ENDPOINTS, PER_PAGE
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import BearerTokenAuth
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the aha module.
+AHA_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.aha.aha.make_tracked_session"
 
 
 class TestNormalizeSubdomain:
@@ -89,176 +94,228 @@ class TestBuildInitialParams:
         assert params == {"per_page": PER_PAGE}
 
 
-class TestBuildUrl:
-    def test_no_params(self) -> None:
-        assert _build_url("https://acme.aha.io/api/v1", "/me", {}) == "https://acme.aha.io/api/v1/me"
-
-    def test_encodes_params(self) -> None:
-        url = _build_url(
-            "https://acme.aha.io/api/v1", "/features", {"page": 2, "updated_since": "2026-03-04T02:58:14Z"}
-        )
-        assert url == "https://acme.aha.io/api/v1/features?page=2&updated_since=2026-03-04T02%3A58%3A14Z"
-
-
-class TestHasMorePages:
-    @parameterized.expand(
-        [
-            ("more_pages", {"current_page": 1, "total_pages": 3}, 1, 200, True),
-            ("last_page", {"current_page": 3, "total_pages": 3}, 3, 50, False),
-            ("missing_meta_full_page", {}, 1, PER_PAGE, True),
-            ("missing_meta_partial_page", {}, 1, 5, False),
-        ]
-    )
-    def test_has_more(self, _name: str, pagination: dict, page: int, item_count: int, expected: bool) -> None:
-        assert _has_more_pages(pagination, page, item_count) is expected
+def _response(
+    response_key: str,
+    items: list[dict[str, Any]] | None,
+    *,
+    current_page: int | None = None,
+    total_pages: int | None = None,
+    drop_key: bool = False,
+) -> Response:
+    body: dict[str, Any] = {}
+    if not drop_key:
+        body[response_key] = items or []
+    if total_pages is not None:
+        body["pagination"] = {"current_page": current_page or 1, "total_pages": total_pages}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class _FakeResumableManager:
-    def __init__(self, state: AhaResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[AhaResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> AhaResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: AhaResumeConfig) -> None:
-        self.saved.append(data)
+def _make_manager(resume_state: AhaResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class _FakeBatcher:
-    """Yields one batch per item so save-after-yield behavior is observable without 2000+ rows."""
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request AT SEND TIME.
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._rows: list[dict] = []
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
 
-    def batch(self, row: dict) -> None:
-        self._rows.append(row)
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
 
-    def should_yield(self, include_incomplete_chunk: bool = False) -> bool:
-        return len(self._rows) > 0
-
-    def get_table(self) -> list[dict]:
-        rows = self._rows
-        self._rows = []
-        return rows
-
-
-def _patch_fetch(monkeypatch: Any, pages: dict[str, Any]) -> list[str]:
-    fetched: list[str] = []
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-        fetched.append(url)
-        return pages[url]
-
-    monkeypatch.setattr(aha, "_fetch_page", fake_fetch)
-    return fetched
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _collect(monkeypatch: Any, manager: _FakeResumableManager, **kwargs: Any) -> list[dict]:
-    monkeypatch.setattr(aha, "Batcher", _FakeBatcher)
-    rows: list[dict] = []
-    for batch in get_rows(
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return aha_source(
         subdomain="acme",
         api_key="key",
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
         **kwargs,
-    ):
-        rows.extend(batch)
-    return rows
+    )
 
 
-class TestGetRows:
-    def test_paginates_until_last_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://acme.aha.io/api/v1/features?per_page=200&page=1": {
-                "features": [{"id": "1"}, {"id": "2"}],
-                "pagination": {"current_page": 1, "total_pages": 2},
-            },
-            "https://acme.aha.io/api/v1/features?per_page=200&page=2": {
-                "features": [{"id": "3"}],
-                "pagination": {"current_page": 2, "total_pages": 2},
-            },
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(), endpoint="features")
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestAhaSource:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_total_pages(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response("features", [{"id": "1"}, {"id": "2"}], current_page=1, total_pages=2),
+                _response("features", [{"id": "3"}], current_page=2, total_pages=2),
+            ],
+        )
+
+        rows = _rows(_source("features", _make_manager()))
 
         assert [r["id"] for r in rows] == ["1", "2", "3"]
-        assert fetched == list(pages)
+        # total_pages=2 terminates after the last page — no extra empty-page request.
+        assert session.send.call_count == 2
+        assert snapshots[0]["url"] == "https://acme.aha.io/api/v1/features"
+        assert snapshots[0]["params"] == {"per_page": PER_PAGE, "page": 1}
+        assert snapshots[1]["params"] == {"per_page": PER_PAGE, "page": 2}
 
-    def test_saves_resume_state_after_each_yielded_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://acme.aha.io/api/v1/features?per_page=200&page=1": {
-                "features": [{"id": "1"}],
-                "pagination": {"current_page": 1, "total_pages": 2},
-            },
-            "https://acme.aha.io/api/v1/features?per_page=200&page=2": {
-                "features": [{"id": "2"}],
-                "pagination": {"current_page": 2, "total_pages": 2},
-            },
-        }
-        _patch_fetch(monkeypatch, pages)
-        manager = _FakeResumableManager()
-        _collect(monkeypatch, manager, endpoint="features")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_is_framework_bearer(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response("features", [{"id": "1"}], total_pages=1)])
+
+        _rows(_source("features", _make_manager()))
+
+        auth = snapshots[0]["auth"]
+        assert isinstance(auth, BearerTokenAuth)
+        assert auth.token == "key"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_resume_state_only_while_pages_remain(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response("features", [{"id": "1"}], current_page=1, total_pages=2),
+                _response("features", [{"id": "2"}], current_page=2, total_pages=2),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("features", manager))
 
         # State is saved only while more pages remain (page 1 -> next_page 2), never on the last page.
-        assert manager.saved == [AhaResumeConfig(next_page=2)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == AhaResumeConfig(next_page=2)
 
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://acme.aha.io/api/v1/features?per_page=200&page=2": {
-                "features": [{"id": "2"}],
-                "pagination": {"current_page": 2, "total_pages": 2},
-            },
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(AhaResumeConfig(next_page=2)), endpoint="features")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response("features", [{"id": "2"}], current_page=2, total_pages=2)])
+
+        rows = _rows(_source("features", _make_manager(AhaResumeConfig(next_page=2))))
 
         assert [r["id"] for r in rows] == ["2"]
-        assert fetched == ["https://acme.aha.io/api/v1/features?per_page=200&page=2"]
+        assert session.send.call_count == 1
+        assert snapshots[0]["params"]["page"] == 2
 
-    def test_incremental_cursor_added_to_request(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://acme.aha.io/api/v1/features?per_page=200&updated_since=2026-03-04T02%3A58%3A14Z&page=1": {
-                "features": [{"id": "1"}],
-                "pagination": {"current_page": 1, "total_pages": 1},
-            },
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        _collect(
-            monkeypatch,
-            _FakeResumableManager(),
-            endpoint="features",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_cursor_added_to_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response("features", [{"id": "1"}], total_pages=1)])
+
+        _rows(
+            _source(
+                "features",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            )
         )
-        assert "updated_since=2026-03-04T02%3A58%3A14Z" in fetched[0]
 
-    def test_uses_response_key_for_todos(self, monkeypatch: Any) -> None:
+        assert snapshots[0]["params"]["updated_since"] == "2026-03-04T02:58:14Z"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_uses_response_key_for_todos(self, MockSession) -> None:
         # to-dos live at /tasks with a `tasks` root key.
-        pages = {
-            "https://acme.aha.io/api/v1/tasks?per_page=200&page=1": {
-                "tasks": [{"id": "t1"}],
-                "pagination": {"current_page": 1, "total_pages": 1},
-            },
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(), endpoint="todos")
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response("tasks", [{"id": "t1"}], total_pages=1)])
+
+        rows = _rows(_source("todos", _make_manager()))
 
         assert [r["id"] for r in rows] == ["t1"]
-        assert fetched == ["https://acme.aha.io/api/v1/tasks?per_page=200&page=1"]
+        assert snapshots[0]["url"] == "https://acme.aha.io/api/v1/tasks"
 
-    def test_stops_on_empty_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://acme.aha.io/api/v1/goals?per_page=200&page=1": {
-                "goals": [],
-                "pagination": {"current_page": 1, "total_pages": 1},
-            },
-        }
-        _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(), endpoint="goals")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response("goals", [], total_pages=1)])
+
+        manager = _make_manager()
+        rows = _rows(_source("goals", manager))
 
         assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_response_key_stops_quietly(self, MockSession) -> None:
+        # A body without the root key is treated as an empty page (old `data.get(key, []) -> stop`).
+        session = MockSession.return_value
+        _wire(session, [_response("goals", None, drop_key=True)])
+
+        rows = _rows(_source("goals", _make_manager()))
+
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_metadata_partial_page_stops(self, MockSession) -> None:
+        # No pagination metadata + a short page -> no more pages (full-page fallback heuristic).
+        session = MockSession.return_value
+        _wire(session, [_response("features", [{"id": "1"}, {"id": "2"}])])
+
+        rows = _rows(_source("features", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["1", "2"]
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_metadata_full_page_continues(self, MockSession) -> None:
+        # No pagination metadata + a full page -> there may be more pages.
+        session = MockSession.return_value
+        full_page = [{"id": str(i)} for i in range(PER_PAGE)]
+        _wire(session, [_response("features", full_page), _response("features", [{"id": "last"}])])
+
+        rows = _rows(_source("features", _make_manager()))
+
+        assert len(rows) == PER_PAGE + 1
+        assert session.send.call_count == 2
+
+
+class TestValidateCredentials:
+    @mock.patch(AHA_SESSION_PATCH)
+    def test_ok(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("acme", "key") == (True, 200)
+
+    @mock.patch(AHA_SESSION_PATCH)
+    def test_unauthorized(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=401)
+        assert validate_credentials("acme", "key") == (False, 401)
+
+    @mock.patch(AHA_SESSION_PATCH)
+    def test_swallows_transport_errors(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("acme", "key") == (False, None)
+
+    @mock.patch(AHA_SESSION_PATCH)
+    def test_probes_me_endpoint_with_bearer_header(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("acme", "key")
+
+        call = mock_session.return_value.get.call_args
+        assert call.args[0] == "https://acme.aha.io/api/v1/me"
+        assert call.kwargs["headers"]["Authorization"] == "Bearer key"
+
+    @mock.patch(AHA_SESSION_PATCH)
+    def test_bad_subdomain_raises_before_probe(self, mock_session) -> None:
+        with pytest.raises(ValueError, match="Invalid Aha! account domain"):
+            validate_credentials("acme/../evil", "key")
+        mock_session.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/aircall.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/aircall.py
@@ -1,13 +1,10 @@
-import base64
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
+from requests.auth import HTTPBasicAuth
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.aircall.settings import (
@@ -15,33 +12,22 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.aircall.se
     AircallEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 AIRCALL_BASE_URL = "https://api.aircall.io/v1"
 # Aircall caps list pages at 50 items.
 PAGE_SIZE = 50
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-
-
-class AircallRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class AircallResumeConfig:
     next_url: str
-
-
-def _basic_auth_token(api_id: str, api_token: str) -> str:
-    return base64.b64encode(f"{api_id}:{api_token}".encode("ascii")).decode("ascii")
-
-
-def _get_headers(api_id: str, api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Basic {_basic_auth_token(api_id, api_token)}",
-        "Accept": "application/json",
-    }
 
 
 def _to_epoch(value: Any) -> Optional[int]:
@@ -87,110 +73,110 @@ def _build_params(config: AircallEndpointConfig, from_value: Optional[int]) -> d
     return params
 
 
-def validate_credentials(api_id: str, api_token: str) -> bool:
-    """Confirm the API key pair is valid. /v1/ping is a cheap authenticated probe."""
-    try:
-        response = make_tracked_session().get(
-            f"{AIRCALL_BASE_URL}/ping",
-            headers=_get_headers(api_id, api_token),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+class AircallPaginator(BasePaginator):
+    """Follows Aircall's `meta.next_page_link` chain, re-anchoring around the 10k cap.
 
+    When a page chain ends on a capped endpoint (calls/contacts), the paginator re-anchors
+    the `from` query param to the latest value of the cursor field seen so far and starts a
+    fresh chain, to fetch records beyond Aircall's hard 10k-record-per-query cap. The
+    strict-advance guard prevents an infinite loop when many records share the boundary
+    timestamp.
+    """
 
-def get_rows(
-    api_id: str,
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AircallResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = AIRCALL_ENDPOINTS[endpoint]
-    headers = _get_headers(api_id, api_token)
+    def __init__(
+        self,
+        config: AircallEndpointConfig,
+        cursor_field: Optional[str],
+        from_value: Optional[int],
+    ) -> None:
+        super().__init__()
+        self._config = config
+        self._cursor_field = cursor_field
+        self._from_value = from_value
+        # Latest value of the cursor field seen across the whole run.
+        self._max_cursor: Optional[int] = None
+        self._next_url: Optional[str] = None
 
-    cursor_field = incremental_field or config.reanchor_field
-    from_value = _to_epoch(db_incremental_field_last_value) if should_use_incremental_field else None
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume URL to the first request so a resumed run starts at the
+        # saved next-page link rather than the base path.
+        if self._next_url is not None:
+            request.url = self._next_url
+            request.params = {}
 
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url: str = resume_config.next_url
-        logger.debug(f"Aircall: resuming from URL: {url}")
-    else:
-        url = _build_url(config.path, _build_params(config, from_value))
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
+        if self._cursor_field is not None and items:
+            page_max = max(
+                (
+                    cursor
+                    for cursor in (_to_epoch(item.get(self._cursor_field)) for item in items)
+                    if cursor is not None
+                ),
+                default=None,
+            )
+            if page_max is not None and (self._max_cursor is None or page_max > self._max_cursor):
+                self._max_cursor = page_max
 
-    @retry(
-        retry=retry_if_exception_type((AircallRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # Aircall rate-limits at 120 req/min; 429s carry a reset header but exponential
-        # backoff is sufficient here.
-        if response.status_code == 429 or response.status_code >= 500:
-            raise AircallRetryableError(f"Aircall API error (retryable): status={response.status_code}, url={page_url}")
-
-        if not response.ok:
-            logger.error(f"Aircall API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    # Latest value of the re-anchor field seen across the whole run. Used to step `from`
-    # past Aircall's hard 10k-record-per-query cap on calls/contacts once a page chain ends.
-    max_cursor: Optional[int] = None
-
-    while True:
-        data = fetch_page(url)
-        items = data.get(config.data_key, []) or []
-
-        if items:
-            yield items
-
-            if cursor_field is not None:
-                page_max = max(
-                    (cursor for cursor in (_to_epoch(item.get(cursor_field)) for item in items) if cursor is not None),
-                    default=None,
-                )
-                if page_max is not None and (max_cursor is None or page_max > max_cursor):
-                    max_cursor = page_max
-
-        next_url = (data.get("meta") or {}).get("next_page_link")
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        next_url = ((body or {}).get("meta") or {}).get("next_page_link") if isinstance(body, dict) else None
 
         if next_url:
-            resumable_source_manager.save_state(AircallResumeConfig(next_url=next_url))
-            url = next_url
-            continue
+            self._next_url = next_url
+            self._has_next_page = True
+            return
 
         # Page chain ended. For capped endpoints, re-anchor on the latest cursor value to
-        # fetch records beyond the 10k window. The strict-advance guard prevents an infinite
-        # loop when many records share the boundary timestamp.
+        # fetch records beyond the 10k window.
         if (
-            config.reanchor_field is not None
-            and max_cursor is not None
-            and (from_value is None or max_cursor > from_value)
+            self._config.reanchor_field is not None
+            and self._max_cursor is not None
+            and (self._from_value is None or self._max_cursor > self._from_value)
         ):
-            from_value = max_cursor
-            url = _build_url(config.path, _build_params(config, from_value))
-            resumable_source_manager.save_state(AircallResumeConfig(next_url=url))
-            logger.debug(f"Aircall: re-anchoring {endpoint} from={from_value} to page around the 10k cap")
-            continue
+            self._from_value = self._max_cursor
+            self._next_url = _build_url(self._config.path, _build_params(self._config, self._from_value))
+            self._has_next_page = True
+            return
 
-        break
+        self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        if self._next_url is not None:
+            request.url = self._next_url
+            # The next-page URL is self-contained — it already carries every query param
+            # needed. Drop the original params so they aren't re-appended each page.
+            request.params = {}
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"next_url": self._next_url} if self._has_next_page and self._next_url is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_url = state.get("next_url")
+        if next_url is not None:
+            self._next_url = next_url
+            self._has_next_page = True
+
+
+def validate_credentials(api_id: str, api_token: str) -> bool:
+    """Confirm the API key pair is valid. /v1/ping is a cheap authenticated probe."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{AIRCALL_BASE_URL}/ping",
+        headers={"Accept": "application/json"},
+        auth=HTTPBasicAuth(api_id, api_token),
+    )
+    return ok
 
 
 def aircall_source(
     api_id: str,
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AircallResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -198,18 +184,55 @@ def aircall_source(
 ) -> SourceResponse:
     config = AIRCALL_ENDPOINTS[endpoint]
 
+    cursor_field = incremental_field or config.reanchor_field
+    from_value = _to_epoch(db_incremental_field_last_value) if should_use_incremental_field else None
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": AIRCALL_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Basic auth via the framework so the token is redacted from logs.
+            "auth": {"type": "http_basic", "username": api_id, "password": api_token},
+            "paginator": AircallPaginator(config, cursor_field, from_value),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # A missing data key is tolerated (treated as an empty page), matching
+                    # Aircall's occasional key-less bodies — so no data_selector_required.
+                    "data_selector": config.data_key,
+                    "params": _build_params(config, from_value),
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page (or re-anchored window) remains; save AFTER a page is
+        # yielded so a crash re-yields the last page (merge dedupes) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(AircallResumeConfig(next_url=str(state["next_url"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_id=api_id,
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         sort_mode="asc",
         partition_count=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AircallSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -101,21 +104,7 @@ You can create an API key (API ID + API token) in your [Aircall dashboard](https
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in list(ENDPOINTS)
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: AircallSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -138,7 +127,8 @@ You can create an API key (API ID + API token) in your [Aircall dashboard](https
             api_id=config.api_id,
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/tests/test_aircall.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/tests/test_aircall.py
@@ -1,8 +1,12 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
+
+from requests import Response
+from requests.auth import AuthBase
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall import (
     AircallResumeConfig,
@@ -10,13 +14,27 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.aircall.ai
     _build_url,
     _to_epoch,
     aircall_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.aircall.settings import (
     AIRCALL_ENDPOINTS,
     ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the aircall module.
+AIRCALL_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session"
+)
+
+
+def _response(items_key: str, items: list[dict[str, Any]], next_link: str | None) -> Response:
+    body = {"meta": {"next_page_link": next_link}, items_key: items}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: AircallResumeConfig | None = None) -> mock.MagicMock:
@@ -26,8 +44,30 @@ def _make_manager(resume_state: AircallResumeConfig | None = None) -> mock.Magic
     return manager
 
 
-def _page(items_key: str, items: list[dict[str, Any]], next_link: str | None) -> dict[str, Any]:
-    return {"meta": {"next_page_link": next_link}, items_key: items}
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request AT PREPARE TIME.
+
+    ``request.params``/``request.url`` are mutated in place across pages, so inspecting them
+    after the run shows only the final state — snapshot a copy when each request is prepared.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return aircall_source("id", "token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestToEpoch:
@@ -84,111 +124,153 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session")
+    @mock.patch(AIRCALL_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
-        response = mock.MagicMock()
-        response.status_code = status_code
-        mock_session.return_value.get.return_value = response
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         assert validate_credentials("id", "token") is expected
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session")
+    @mock.patch(AIRCALL_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("id", "token") is False
 
+    @mock.patch(AIRCALL_SESSION_PATCH)
+    def test_validate_credentials_probes_ping_with_basic_auth(self, mock_session):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
-class TestGetRows:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session")
-    def test_paginates_via_next_page_link(self, mock_session):
-        pages = [
-            _page("users", [{"id": 1}, {"id": 2}], "https://api.aircall.io/v1/users?page=2"),
-            _page("users", [{"id": 3}], None),
-        ]
-        responses = []
-        for page in pages:
-            resp = mock.MagicMock()
-            resp.json.return_value = page
-            resp.status_code = 200
-            resp.ok = True
-            responses.append(resp)
-        mock_session.return_value.get.side_effect = responses
+        validate_credentials("id", "token")
+
+        call = mock_session.return_value.get.call_args
+        assert call.args[0] == "https://api.aircall.io/v1/ping"
+        assert call.kwargs["auth"].username == "id"
+        assert call.kwargs["auth"].password == "token"
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_next_page_link(self, MockSession):
+        session = MockSession.return_value
+        requests_seen = _wire(
+            session,
+            [
+                _response("users", [{"id": 1}, {"id": 2}], "https://api.aircall.io/v1/users?page=2"),
+                _response("users", [{"id": 3}], None),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("id", "token", "users", mock.MagicMock(), manager))
+        rows = _rows(_source("users", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == [1, 2, 3]
+        assert [row["id"] for row in rows] == [1, 2, 3]
+        assert requests_seen[0]["url"] == "https://api.aircall.io/v1/users"
+        assert requests_seen[0]["params"] == {"per_page": 50}
+        # The next-page URL is self-contained; original params are dropped.
+        assert requests_seen[1]["url"] == "https://api.aircall.io/v1/users?page=2"
+        assert requests_seen[1]["params"] == {}
         # State is saved only while a next page exists.
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].next_url == "https://api.aircall.io/v1/users?page=2"
+        assert manager.save_state.call_args.args[0] == AircallResumeConfig(
+            next_url="https://api.aircall.io/v1/users?page=2"
+        )
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session")
-    def test_resumes_from_saved_state(self, mock_session):
-        resp = mock.MagicMock()
-        resp.json.return_value = _page("users", [{"id": 9}], None)
-        resp.status_code = 200
-        resp.ok = True
-        mock_session.return_value.get.return_value = resp
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_requests_carry_basic_auth(self, MockSession):
+        session = MockSession.return_value
+        requests_seen = _wire(session, [_response("teams", [{"id": 1}], None)])
+
+        _rows(_source("teams", _make_manager()))
+
+        auth = requests_seen[0]["auth"]
+        assert isinstance(auth, AuthBase)
+        assert auth.username == "id"
+        assert auth.password == "token"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession):
+        session = MockSession.return_value
+        requests_seen = _wire(session, [_response("users", [{"id": 9}], None)])
 
         resume_url = "https://api.aircall.io/v1/users?page=5"
         manager = _make_manager(AircallResumeConfig(next_url=resume_url))
 
-        list(get_rows("id", "token", "users", mock.MagicMock(), manager))
+        rows = _rows(_source("users", manager))
 
-        assert mock_session.return_value.get.call_args_list[0].args[0] == resume_url
+        assert [row["id"] for row in rows] == [9]
+        assert requests_seen[0]["url"] == resume_url
+        assert requests_seen[0]["params"] == {}
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session")
-    def test_reanchors_from_cursor_to_page_around_cap(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_reanchors_from_cursor_to_page_around_cap(self, MockSession):
         # First window ends without a next link; the latest started_at is used to issue a
         # fresh `from`-anchored request, then that window ends with no new advancement.
-        first_window = _page("calls", [{"id": 1, "started_at": 100}, {"id": 2, "started_at": 200}], None)
-        second_window = _page("calls", [{"id": 2, "started_at": 200}], None)
-
-        resp1 = mock.MagicMock(status_code=200, ok=True)
-        resp1.json.return_value = first_window
-        resp2 = mock.MagicMock(status_code=200, ok=True)
-        resp2.json.return_value = second_window
-        mock_session.return_value.get.side_effect = [resp1, resp2]
+        session = MockSession.return_value
+        requests_seen = _wire(
+            session,
+            [
+                _response("calls", [{"id": 1, "started_at": 100}, {"id": 2, "started_at": 200}], None),
+                _response("calls", [{"id": 2, "started_at": 200}], None),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("id", "token", "calls", mock.MagicMock(), manager))
+        rows = _rows(_source("calls", manager))
 
         # Two requests: original window + one re-anchored window.
-        assert mock_session.return_value.get.call_count == 2
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert "from=200" in second_url
+        assert len(requests_seen) == 2
+        assert "from=200" in requests_seen[1]["url"]
+        # The re-anchored window URL is checkpointed like a next-page link.
+        manager.save_state.assert_called_once()
+        assert "from=200" in manager.save_state.call_args.args[0].next_url
         # Boundary row re-emitted; merge on primary key dedupes downstream.
-        assert [item["id"] for batch in batches for item in batch] == [1, 2, 2]
+        assert [row["id"] for row in rows] == [1, 2, 2]
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session")
-    def test_no_reanchor_for_full_refresh_endpoint(self, mock_session):
-        resp = mock.MagicMock(status_code=200, ok=True)
-        resp.json.return_value = _page("teams", [{"id": 1}], None)
-        mock_session.return_value.get.return_value = resp
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_reanchor_for_full_refresh_endpoint(self, MockSession):
+        session = MockSession.return_value
+        requests_seen = _wire(session, [_response("teams", [{"id": 1}], None)])
 
-        manager = _make_manager()
-        list(get_rows("id", "token", "teams", mock.MagicMock(), manager))
+        _rows(_source("teams", _make_manager()))
 
-        assert mock_session.return_value.get.call_count == 1
+        assert len(requests_seen) == 1
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.aircall.aircall.make_tracked_session")
-    def test_empty_response_stops(self, mock_session):
-        resp = mock.MagicMock(status_code=200, ok=True)
-        resp.json.return_value = _page("calls", [], None)
-        mock_session.return_value.get.return_value = resp
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response("calls", [], None)])
 
         manager = _make_manager()
-        batches = list(get_rows("id", "token", "calls", mock.MagicMock(), manager))
+        rows = _rows(_source("calls", manager))
 
-        assert batches == []
+        assert rows == []
         manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_run_anchors_from_on_watermark(self, MockSession):
+        session = MockSession.return_value
+        requests_seen = _wire(session, [_response("calls", [{"id": 1, "started_at": 1700000000}], None)])
+
+        _rows(
+            _source(
+                "calls",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=1700000000,
+                incremental_field="started_at",
+            )
+        )
+
+        assert requests_seen[0]["params"] == {"per_page": 50, "order": "asc", "from": 1700000000}
+        # started_at did not advance past the watermark, so no re-anchored window is issued.
+        assert len(requests_seen) == 1
 
 
 class TestAircallSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata_per_endpoint(self, MockSession, endpoint):
         config = AIRCALL_ENDPOINTS[endpoint]
-        response = aircall_source("id", "token", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/tests/test_aircall_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aircall/tests/test_aircall_source.py
@@ -130,6 +130,8 @@ class TestAircallSource:
         assert kwargs["api_id"] == "api-id"
         assert kwargs["api_token"] == "api-token"
         assert kwargs["endpoint"] == "calls"
+        assert kwargs["team_id"] is inputs.team_id
+        assert kwargs["job_id"] is inputs.job_id
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == 1700000000

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/algolia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/algolia.py
@@ -1,14 +1,11 @@
 import re
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import quote
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.algolia.settings import (
     ALGOLIA_ENDPOINTS,
@@ -16,6 +13,15 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.algolia.se
     PaginationStyle,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    JSONResponseCursorPaginator,
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 # Algolia's REST API is served per-application. The main host handles both reads and the
@@ -47,10 +53,6 @@ class AlgoliaResumeConfig:
     page: int | None = None
 
 
-class AlgoliaRetryableError(Exception):
-    pass
-
-
 def _base_url(application_id: str) -> str:
     if not _APPLICATION_ID_RE.match(application_id):
         raise InvalidApplicationIdError("Algolia Application ID must be alphanumeric (letters and digits only)")
@@ -66,141 +68,136 @@ def _get_headers(application_id: str, api_key: str) -> dict[str, str]:
     }
 
 
-def _endpoint_url(application_id: str, config: AlgoliaEndpointConfig, index_name: str | None) -> str:
+def _endpoint_path(config: AlgoliaEndpointConfig, index_name: str | None) -> str:
     path = config.path
     if config.requires_index:
         if not index_name:
             raise ValueError(f"Algolia endpoint '{config.name}' requires an index name")
         path = path.format(index=quote(index_name, safe=""))
-    return f"{_base_url(application_id)}{path}"
+    return path
 
 
-@retry(
-    retry=retry_if_exception_type((AlgoliaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(
-    session: requests.Session,
-    method: str,
-    url: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    params: dict[str, Any] | None = None,
-    body: dict[str, Any] | None = None,
-) -> dict:
-    response = session.request(method, url, headers=headers, params=params, json=body, timeout=60)
-
-    # Algolia rate-limits the API and surfaces transient errors as 429 / 5xx; retry those.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AlgoliaRetryableError(f"Algolia API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Algolia API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+def _endpoint_url(application_id: str, config: AlgoliaEndpointConfig, index_name: str | None) -> str:
+    return f"{_base_url(application_id)}{_endpoint_path(config, index_name)}"
 
 
-def _iter_cursor(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    config: AlgoliaEndpointConfig,
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    manager: ResumableSourceManager[AlgoliaResumeConfig],
-    resume: AlgoliaResumeConfig | None,
-) -> Iterator[Any]:
-    """Page the browse endpoint via its opaque cursor; a missing cursor signals end of index."""
-    cursor = resume.cursor if resume else None
-    while True:
-        body: dict[str, Any] = {"hitsPerPage": config.page_size}
-        if cursor:
-            body["cursor"] = cursor
-        data = _fetch(session, "POST", url, headers, logger, body=body)
+class AlgoliaPageNumberPaginator(PageNumberPaginator):
+    """Page-number paginator matching Algolia's mixed termination rules.
 
-        next_cursor = data.get("cursor")
-        for item in data.get(config.data_selector, []):
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save after yielding so a crash re-yields the last batch (merge dedupes on
-                # the primary key) rather than skipping it.
-                if next_cursor:
-                    manager.save_state(AlgoliaResumeConfig(cursor=next_cursor))
+    `GET /1/indexes` reports the page count directly (`nbPages`, handled via `total_path`); the
+    synonyms/rules search endpoints don't, so when `nbPages` is absent a short final page (fewer
+    rows than requested) signals the end without paying an extra empty-page request.
+    """
 
-        if not next_cursor:
-            break
-        cursor = next_cursor
-        manager.save_state(AlgoliaResumeConfig(cursor=cursor))
+    def __init__(self, page_size: int, **kwargs: Any) -> None:
+        super().__init__(total_path="nbPages", **kwargs)
+        self.page_size = page_size
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if not self._has_next_page:
+            return
+        try:
+            body = response.json()
+            nb_pages = body.get("nbPages") if isinstance(body, dict) else None
+        except Exception:
+            nb_pages = None
+        if nb_pages is None and data is not None and len(data) < self.page_size:
+            self._has_next_page = False
 
 
-def _iter_pages(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    config: AlgoliaEndpointConfig,
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    manager: ResumableSourceManager[AlgoliaResumeConfig],
-    resume: AlgoliaResumeConfig | None,
-) -> Iterator[Any]:
-    """Page the search (synonyms/rules) and list (indices) endpoints via 0-based page numbers."""
-    page = resume.page if resume and resume.page is not None else 0
-    while True:
-        if config.method == "POST":
-            data = _fetch(session, "POST", url, headers, logger, body={"page": page, "hitsPerPage": config.page_size})
-        else:
-            data = _fetch(session, "GET", url, headers, logger, params={"page": page, "hitsPerPage": config.page_size})
-
-        items = data.get(config.data_selector, [])
-        next_page = page + 1
-        for item in items:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                manager.save_state(AlgoliaResumeConfig(page=next_page))
-
-        if not items:
-            break
-        # `indices` reports the page count directly; the search endpoints don't, so fall back to
-        # a short final page (fewer rows than requested) to detect the end.
-        nb_pages = data.get("nbPages")
-        if nb_pages is not None:
-            if next_page >= nb_pages:
-                break
-        elif len(items) < config.page_size:
-            break
-
-        page = next_page
-        manager.save_state(AlgoliaResumeConfig(page=page))
+def _build_paginator(config: AlgoliaEndpointConfig) -> BasePaginator:
+    if config.pagination == PaginationStyle.CURSOR:
+        # Browse pages via an opaque cursor carried in the POST body; a missing cursor in the
+        # response signals end of index.
+        return JSONResponseCursorPaginator(cursor_path="cursor", cursor_param="cursor", param_location="json")
+    # Search endpoints (synonyms/rules) page via a 0-based `page` in the POST body; the indices
+    # listing pages via `page` in the query string.
+    return AlgoliaPageNumberPaginator(
+        page_size=config.page_size,
+        base_page=0,
+        page_param="page",
+        param_location="json" if config.method == "POST" else "query",
+    )
 
 
-def get_rows(
+def algolia_source(
     endpoint: str,
     application_id: str,
     api_key: str,
     index_name: str | None,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     manager: ResumableSourceManager[AlgoliaResumeConfig],
-) -> Iterator[Any]:
+) -> SourceResponse:
     config = ALGOLIA_ENDPOINTS[endpoint]
-    headers = _get_headers(application_id, api_key)
-    url = _endpoint_url(application_id, config, index_name)
-    batcher = Batcher(logger=logger, chunk_size=5000, chunk_size_bytes=100 * 1024 * 1024)
-    session = make_tracked_session(redact_values=(api_key,))
+    is_cursor = config.pagination == PaginationStyle.CURSOR
 
-    resume = manager.load_state() if manager.can_resume() else None
-
-    if config.pagination == PaginationStyle.CURSOR:
-        yield from _iter_cursor(session, url, headers, config, logger, batcher, manager, resume)
+    endpoint_config: dict[str, Any] = {
+        "path": _endpoint_path(config, index_name),
+        "method": config.method,
+        "data_selector": config.data_selector,
+        "paginator": _build_paginator(config),
+    }
+    # Rows requested per page (`hitsPerPage`) travel where the page token does: in the POST body
+    # for browse/search, in the query string for the GET indices listing.
+    if config.method == "POST":
+        endpoint_config["json"] = {"hitsPerPage": config.page_size}
     else:
-        yield from _iter_pages(session, url, headers, config, logger, batcher, manager, resume)
+        endpoint_config["params"] = {"hitsPerPage": config.page_size}
 
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(application_id),
+            # The API key is supplied via the framework auth config so its value is redacted from
+            # logs; only the non-secret application ID / content headers are set here.
+            "headers": {
+                "X-Algolia-Application-Id": application_id,
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-Algolia-API-Key", "location": "header"},
+        },
+        "resources": [{"name": endpoint, "endpoint": endpoint_config}],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None:
+            if is_cursor and resume.cursor is not None:
+                initial_paginator_state = {"cursor": resume.cursor}
+            elif not is_cursor and resume.page is not None:
+                initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the hook fires AFTER a page is yielded so a crash
+        # re-yields the last page (merge dedupes on the primary key) rather than skipping it.
+        if not state:
+            return
+        if is_cursor:
+            if state.get("cursor") is not None:
+                manager.save_state(AlgoliaResumeConfig(cursor=state["cursor"]))
+        elif state.get("page") is not None:
+            manager.save_state(AlgoliaResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        # Full-refresh endpoints with no stable datetime field to partition on.
+        partition_count=1,
+        partition_size=1,
+    )
 
 
 def validate_credentials(
@@ -283,31 +280,4 @@ def validate_credentials(
         False,
         f"Algolia returned an unexpected status ({response.status_code}). Check your Application ID "
         "and API key, then try again.",
-    )
-
-
-def algolia_source(
-    endpoint: str,
-    application_id: str,
-    api_key: str,
-    index_name: str | None,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[AlgoliaResumeConfig],
-) -> SourceResponse:
-    config = ALGOLIA_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            endpoint=endpoint,
-            application_id=application_id,
-            api_key=api_key,
-            index_name=index_name,
-            logger=logger,
-            manager=manager,
-        ),
-        primary_keys=config.primary_keys,
-        # Full-refresh endpoints with no stable datetime field to partition on.
-        partition_count=1,
-        partition_size=1,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/source.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AlgoliaSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -118,23 +121,16 @@ The API key needs the ACLs for the data you want to sync:
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            return SourceSchema(
-                name=endpoint,
-                # No Algolia endpoint exposes a server-side "updated since" filter, so every table
-                # is full refresh; the cursor/page tokens still make each one resumable.
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=ALGOLIA_ENDPOINTS[endpoint].should_sync_default,
-                description=_ENDPOINT_DESCRIPTIONS.get(endpoint),
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # No Algolia endpoint exposes a server-side "updated since" filter, so every table is
+        # full refresh (no incremental fields); the cursor/page tokens still make each one
+        # resumable.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions=_ENDPOINT_DESCRIPTIONS,
+            should_sync_default={name: cfg.should_sync_default for name, cfg in ALGOLIA_ENDPOINTS.items()},
+        )
 
     def validate_credentials(
         self, config: AlgoliaSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -160,7 +156,8 @@ The API key needs the ACLs for the data you want to sync:
             application_id=config.application_id,
             api_key=config.api_key,
             index_name=config.index_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             manager=resumable_source_manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia.py
@@ -1,10 +1,11 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import pyarrow as pa
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.algolia.algolia import (
     AlgoliaResumeConfig,
@@ -12,28 +13,73 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.algolia.al
     _base_url,
     _endpoint_url,
     algolia_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.algolia.settings import ALGOLIA_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the algolia module.
+ALGOLIA_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.algolia.algolia.make_tracked_session"
+)
 
-def _response(body: dict[str, Any], status_code: int = 200) -> MagicMock:
-    resp = MagicMock()
+
+def _response(body: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
     resp.status_code = status_code
-    resp.ok = 200 <= status_code < 300
-    resp.json.return_value = body
-    resp.text = str(body)
+    resp._content = json.dumps(body).encode()
     return resp
 
 
-def _rows(tables: list[Any]) -> list[dict[str, Any]]:
-    out: list[dict[str, Any]] = []
-    for table in tables:
-        assert isinstance(table, pa.Table)
-        out.extend(table.to_pylist())
-    return out
+def _make_manager(resume_state: AlgoliaResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request AT PREPARE TIME.
+
+    ``request.params`` / ``request.json`` are single dicts mutated in place across pages, so
+    inspecting them after the run shows only the final state — snapshot copies when each request
+    is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append(
+            {
+                "method": request.method,
+                "url": request.url,
+                "params": dict(request.params or {}),
+                "json": dict(request.json) if request.json is not None else None,
+            }
+        )
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _build(endpoint: str, manager: mock.MagicMock, index_name: str | None = "idx") -> Any:
+    return algolia_source(
+        endpoint=endpoint,
+        application_id="APP",
+        api_key="key",
+        index_name=index_name,
+        team_id=1,
+        job_id="job",
+        manager=manager,
+    )
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestBaseUrl:
@@ -65,187 +111,169 @@ class TestEndpointUrl:
         assert _endpoint_url("APP", ALGOLIA_ENDPOINTS["indices"], None) == "https://APP.algolia.net/1/indexes"
 
 
-class _Driver:
-    """Drives get_rows against a fake tracked session, capturing every request."""
-
-    def __init__(self, responses: list[MagicMock]) -> None:
-        self.responses = iter(responses)
-        self.calls: list[dict[str, Any]] = []
-
-    def _request(self, method: str, url: str, **kwargs: Any) -> MagicMock:
-        self.calls.append({"method": method, "url": url, "json": kwargs.get("json"), "params": kwargs.get("params")})
-        return next(self.responses)
-
-    def run(self, endpoint: str, manager: MagicMock) -> list[dict[str, Any]]:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.algolia.algolia.make_tracked_session"
-        ) as mock_session_factory:
-            session = mock_session_factory.return_value
-            session.request.side_effect = self._request
-            tables = list(
-                get_rows(
-                    endpoint=endpoint,
-                    application_id="APP",
-                    api_key="key",
-                    index_name="idx",
-                    logger=MagicMock(),
-                    manager=manager,
-                )
-            )
-            return _rows(tables)
-
-
-def _fresh_manager() -> MagicMock:
-    manager = MagicMock(spec=ResumableSourceManager)
-    manager.can_resume.return_value = False
-    return manager
-
-
 class TestCursorPagination:
-    def test_pages_until_cursor_absent(self) -> None:
-        manager = _fresh_manager()
-        driver = _Driver(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pages_until_cursor_absent(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        manager = _make_manager()
+        calls = _wire(
+            session,
             [
                 _response({"hits": [{"objectID": "1"}], "cursor": "c1"}),
                 _response({"hits": [{"objectID": "2"}]}),
-            ]
+            ],
         )
 
-        rows = driver.run("records", manager)
+        rows = _rows(_build("records", manager))
 
         assert [r["objectID"] for r in rows] == ["1", "2"]
+        assert [c["method"] for c in calls] == ["POST", "POST"]
+        assert calls[0]["url"] == "https://APP.algolia.net/1/indexes/idx/browse"
         # First browse request carries no cursor; the second carries the cursor returned first.
-        assert driver.calls[0]["json"] == {"hitsPerPage": 1000}
-        assert driver.calls[1]["json"] == {"hitsPerPage": 1000, "cursor": "c1"}
+        assert calls[0]["json"] == {"hitsPerPage": 1000}
+        assert calls[1]["json"] == {"hitsPerPage": 1000, "cursor": "c1"}
 
-    def test_saves_cursor_after_non_terminal_page(self) -> None:
-        manager = _fresh_manager()
-        driver = _Driver(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_cursor_after_non_terminal_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        manager = _make_manager()
+        _wire(
+            session,
             [
                 _response({"hits": [{"objectID": "1"}], "cursor": "c1"}),
                 _response({"hits": [{"objectID": "2"}]}),
-            ]
+            ],
         )
 
-        driver.run("records", manager)
+        _rows(_build("records", manager))
 
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [AlgoliaResumeConfig(cursor="c1")]
 
-    def test_single_terminal_page_saves_nothing(self) -> None:
-        manager = _fresh_manager()
-        driver = _Driver([_response({"hits": [{"objectID": "only"}]})])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_terminal_page_saves_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        manager = _make_manager()
+        _wire(session, [_response({"hits": [{"objectID": "only"}]})])
 
-        rows = driver.run("records", manager)
+        rows = _rows(_build("records", manager))
 
         assert [r["objectID"] for r in rows] == ["only"]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_resume_seeds_cursor(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = AlgoliaResumeConfig(cursor="resumed")
-        driver = _Driver([_response({"hits": [{"objectID": "x"}]})])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_seeds_cursor(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        manager = _make_manager(AlgoliaResumeConfig(cursor="resumed"))
+        calls = _wire(session, [_response({"hits": [{"objectID": "x"}]})])
 
-        driver.run("records", manager)
+        _rows(_build("records", manager))
 
-        assert driver.calls[0]["json"] == {"hitsPerPage": 1000, "cursor": "resumed"}
+        assert calls[0]["json"] == {"hitsPerPage": 1000, "cursor": "resumed"}
 
 
 class TestPagePagination:
-    def test_search_endpoint_stops_on_short_page(self) -> None:
-        manager = _fresh_manager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_search_endpoint_stops_on_short_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        manager = _make_manager()
         # Fewer rows than the requested page size signals the last page for search endpoints.
-        driver = _Driver([_response({"hits": [{"objectID": "s1"}], "nbHits": 1})])
+        calls = _wire(session, [_response({"hits": [{"objectID": "s1"}], "nbHits": 1})])
 
-        rows = driver.run("synonyms", manager)
+        rows = _rows(_build("synonyms", manager))
 
         assert [r["objectID"] for r in rows] == ["s1"]
-        assert len(driver.calls) == 1
+        assert len(calls) == 1
         manager.save_state.assert_not_called()
 
-    def test_search_endpoint_walks_multiple_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        manager = _fresh_manager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_search_endpoint_walks_multiple_pages(
+        self, MockSession: mock.MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = MockSession.return_value
+        manager = _make_manager()
         monkeypatch.setattr(ALGOLIA_ENDPOINTS["synonyms"], "page_size", 2)
-        driver = _Driver(
+        calls = _wire(
+            session,
             [
                 _response({"hits": [{"objectID": "a"}, {"objectID": "b"}], "nbHits": 3}),
                 _response({"hits": [{"objectID": "c"}], "nbHits": 3}),
-            ]
+            ],
         )
 
-        rows = driver.run("synonyms", manager)
+        rows = _rows(_build("synonyms", manager))
 
         assert [r["objectID"] for r in rows] == ["a", "b", "c"]
-        assert [c["json"]["page"] for c in driver.calls] == [0, 1]
+        # Search endpoints page via the POST body.
+        assert [c["json"]["page"] for c in calls] == [0, 1]
+        assert all(c["json"]["hitsPerPage"] == 2 for c in calls)
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [AlgoliaResumeConfig(page=1)]
 
-    def test_indices_uses_nb_pages_to_terminate(self) -> None:
-        manager = _fresh_manager()
-        driver = _Driver(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_indices_uses_nb_pages_to_terminate(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        manager = _make_manager()
+        calls = _wire(
+            session,
             [
                 _response({"items": [{"name": "i1"}], "nbPages": 2}),
                 _response({"items": [{"name": "i2"}], "nbPages": 2}),
-            ]
+            ],
         )
 
-        rows = driver.run("indices", manager)
+        rows = _rows(_build("indices", manager, index_name=None))
 
         assert [r["name"] for r in rows] == ["i1", "i2"]
+        assert len(calls) == 2
         # GET endpoints page via query params, and must request the configured page size so the
         # listing doesn't fall back to Algolia's small server-side default.
-        assert [c["params"]["page"] for c in driver.calls] == [0, 1]
-        assert all(c["params"]["hitsPerPage"] == ALGOLIA_ENDPOINTS["indices"].page_size for c in driver.calls)
+        assert [c["method"] for c in calls] == ["GET", "GET"]
+        assert [c["params"]["page"] for c in calls] == [0, 1]
+        assert all(c["params"]["hitsPerPage"] == ALGOLIA_ENDPOINTS["indices"].page_size for c in calls)
 
-    def test_resume_seeds_page(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = AlgoliaResumeConfig(page=3)
-        driver = _Driver([_response({"items": [{"name": "i"}], "nbPages": 4})])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_seeds_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        manager = _make_manager(AlgoliaResumeConfig(page=3))
+        calls = _wire(session, [_response({"items": [{"name": "i"}], "nbPages": 4})])
 
-        driver.run("indices", manager)
+        _rows(_build("indices", manager, index_name=None))
 
-        assert driver.calls[0]["params"]["page"] == 3
+        assert calls[0]["params"]["page"] == 3
 
 
 class TestAlgoliaSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ALGOLIA_ENDPOINTS.keys()))
-    def test_primary_keys_match_settings(self, endpoint: str) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        response = algolia_source(
-            endpoint=endpoint,
-            application_id="APP",
-            api_key="key",
-            index_name="idx",
-            logger=MagicMock(),
-            manager=manager,
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_primary_keys_match_settings(self, MockSession: mock.MagicMock, endpoint: str) -> None:
+        MockSession.return_value.headers = {}
+        response = _build(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ALGOLIA_ENDPOINTS[endpoint].primary_keys
 
-    def test_items_is_lazy(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_items_is_lazy(self, MockSession: mock.MagicMock) -> None:
         # Building the SourceResponse must not issue any request; only iterating items should.
-        manager = MagicMock(spec=ResumableSourceManager)
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.algolia.algolia.make_tracked_session"
-        ) as factory:
-            algolia_source(
-                endpoint="records",
-                application_id="APP",
-                api_key="key",
-                index_name="idx",
-                logger=MagicMock(),
-                manager=manager,
-            )
-            factory.assert_not_called()
+        session = MockSession.return_value
+        session.headers = {}
+        _build("records", _make_manager())
+        session.send.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_application_id_header_is_set_on_session(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"hits": []})])
+
+        _rows(_build("records", _make_manager()))
+
+        assert session.headers.get("X-Algolia-Application-Id") == "APP"
 
 
 class TestValidateCredentials:
-    def _run(self, response: MagicMock, **kwargs: Any) -> tuple[bool, str | None]:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.algolia.algolia.make_tracked_session"
-        ) as factory:
+    def _run(self, response: Any, **kwargs: Any) -> tuple[bool, str | None]:
+        with mock.patch(ALGOLIA_SESSION_PATCH) as factory:
             session = factory.return_value
             session.get.return_value = response
             session.post.return_value = response
@@ -277,9 +305,7 @@ class TestValidateCredentials:
         assert error is not None
 
     def test_invalid_application_id_rejected_before_request(self) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.algolia.algolia.make_tracked_session"
-        ) as factory:
+        with mock.patch(ALGOLIA_SESSION_PATCH) as factory:
             valid, error = validate_credentials(application_id="evil.com/", api_key="key", index_name="idx")
         assert valid is False
         assert error is not None
@@ -287,9 +313,7 @@ class TestValidateCredentials:
         factory.return_value.post.assert_not_called()
 
     def test_network_error_returns_message(self) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.algolia.algolia.make_tracked_session"
-        ) as factory:
+        with mock.patch(ALGOLIA_SESSION_PATCH) as factory:
             factory.return_value.get.side_effect = requests.ConnectionError("boom")
             valid, error = validate_credentials(application_id="APP", api_key="key")
         assert valid is False
@@ -320,7 +344,9 @@ class TestValidateCredentials:
     def test_non_json_error_body_does_not_crash(self) -> None:
         # A non-JSON error body (e.g. an HTML 502 page) must not blow up validation; fall back to a
         # status-based message.
-        resp = _response({}, status_code=502)
+        resp = mock.MagicMock()
+        resp.status_code = 502
+        resp.ok = False
         resp.json.side_effect = ValueError("no json")
         valid, error = self._run(resp, index_name="idx")
         assert valid is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia_source.py
@@ -153,7 +153,8 @@ class TestAlgoliaSource:
             application_id="APPID",
             api_key="test-key",
             index_name="my_index",
-            logger=inputs.logger,
+            team_id=99,
+            job_id="job-xyz",
             manager=manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/alguna/alguna.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/alguna/alguna.py
@@ -1,144 +1,112 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from typing import Any, Optional
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.alguna.settings import ALGUNA_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 ALGUNA_BASE_URL = "https://api.alguna.io"
 # Alguna's API is date-versioned; every request must send this header or calls fail.
 ALGUNA_API_VERSION = "2026-04-01"
 PAGE_LIMIT = 100
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class AlgunaRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class AlgunaResumeConfig:
-    # Byte-for-byte deterministic restart point: list endpoints paginate with required
-    # limit/offset params, so the row offset of the next unfetched page is the full resume state.
+    # Row offset of the next unfetched page — Alguna list endpoints paginate with limit/offset.
     offset: int = 0
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Alguna-Version": ALGUNA_API_VERSION,
-        "Accept": "application/json",
-    }
-
-
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    return f"{ALGUNA_BASE_URL}{path}?{urlencode(params)}"
-
-
-def validate_credentials(api_key: str) -> bool:
-    url = _build_url("/customers", {"limit": 1, "offset": 0, "sort": "created_at:asc"})
-    try:
-        session = make_tracked_session(redact_values=(api_key,))
-        response = session.get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            AlgunaRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AlgunaRetryableError(f"Alguna API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Alguna API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AlgunaResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = ALGUNA_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    session = make_tracked_session(redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume is not None else 0
-    if offset:
-        logger.debug(f"Alguna: resuming {endpoint} from offset={offset}")
-
-    while True:
-        params: dict[str, Any] = {"limit": PAGE_LIMIT, "offset": offset}
-        if config.sort is not None:
-            params["sort"] = config.sort
-
-        data = _fetch_page(session, _build_url(config.path, params), headers, logger)
-        # Direct access: a 200 body without "data" means the response shape changed — fail the
-        # sync loudly instead of silently reporting 0 rows.
-        items = data["data"]
-        if not items:
-            break
-
-        yield items
-
-        offset += len(items)
-        # A short page means we've reached the end; don't save state for a finished sync.
-        if len(items) < PAGE_LIMIT:
-            break
-
-        # Save AFTER yielding so a crash re-yields the last page rather than skipping it —
-        # merge dedupes on the primary key.
-        resumable_source_manager.save_state(AlgunaResumeConfig(offset=offset))
+def _version_headers() -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs;
+    # only the non-secret version/accept headers are set here.
+    return {"Alguna-Version": ALGUNA_API_VERSION, "Accept": "application/json"}
 
 
 def alguna_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AlgunaResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = ALGUNA_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {"limit": PAGE_LIMIT}
+    if config.sort is not None:
+        params["sort"] = config.sort
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ALGUNA_BASE_URL,
+            "headers": _version_headers(),
+            "auth": {"type": "bearer", "token": api_key},
+            # Alguna has no top-level `total`; termination is short/empty page (OffsetPaginator default).
+            "paginator": OffsetPaginator(limit=PAGE_LIMIT, total_path=None),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    "data_selector": "data",
+                    # A 200 body without `data` means the response shape changed — fail loud
+                    # instead of silently syncing 0 rows.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(AlgunaResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime",
         partition_format="month",
         partition_keys=[config.partition_key],
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{ALGUNA_BASE_URL}/customers?limit=1&offset=0&sort=created_at:asc",
+        headers={"Authorization": f"Bearer {api_key}", **_version_headers()},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/alguna/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/alguna/source.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AlgunaSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -92,19 +95,7 @@ You can create an API key in your Alguna dashboard under Settings > Credentials.
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: AlgunaSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -126,6 +117,8 @@ You can create an API key in your Alguna dashboard under Settings > Credentials.
         return alguna_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Alguna endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/alguna/tests/test_alguna.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/alguna/tests/test_alguna.py
@@ -1,24 +1,34 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
-import requests
-from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.alguna.alguna import (
     ALGUNA_API_VERSION,
     AlgunaResumeConfig,
     alguna_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.alguna.settings import ALGUNA_ENDPOINTS, ENDPOINTS
 
-SESSION_PATCH_TARGET = (
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the alguna module.
+ALGUNA_SESSION_PATCH = (
     "products.warehouse_sources.backend.temporal.data_imports.sources.alguna.alguna.make_tracked_session"
 )
+
+
+def _response(items: list[dict[str, Any]] | None, *, drop_data: bool = False) -> Response:
+    body: dict[str, Any] = {"pagination": {"per_page": 100}}
+    if not drop_data:
+        body["data"] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: AlgunaResumeConfig | None = None) -> mock.MagicMock:
@@ -28,153 +38,114 @@ def _make_manager(resume_state: AlgunaResumeConfig | None = None) -> mock.MagicM
     return manager
 
 
-def _response(items: list[dict[str, Any]], status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.status_code = status_code
-    resp.ok = status_code < 400
-    resp.json.return_value = {"data": items, "pagination": {"per_page": 100, "total_pages": 1}}
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-def _query(call: mock._Call) -> dict[str, list[str]]:
-    return parse_qs(urlparse(call.args[0]).query)
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_progresses_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": f"c_{i}"} for i in range(100)]
+        params = _wire(session, [_response(full_page), _response([{"id": "c_last"}])])
+
+        manager = _make_manager()
+        rows = _rows(alguna_source("key", "customers", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert [r["id"] for r in rows] == [*(f"c_{i}" for i in range(100)), "c_last"]
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == 100
+        assert params[1]["offset"] == 100
+        # Checkpoint saved after the first full page (points at the next page); short page ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == AlgunaResumeConfig(offset=100)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "a"}, {"id": "b"}])])
+
+        manager = _make_manager()
+        rows = _rows(alguna_source("key", "customers", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert [r["id"] for r in rows] == ["a", "b"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "c_201"}])])
+
+        manager = _make_manager(AlgunaResumeConfig(offset=200))
+        _rows(alguna_source("key", "customers", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert params[0]["offset"] == 200
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_version_header_is_set_on_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "a"}])])
+
+        _rows(alguna_source("key", "customers", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert session.headers.get("Alguna-Version") == ALGUNA_API_VERSION
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sort_param_present_for_sortable_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "a"}])])
+
+        _rows(alguna_source("key", "customers", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert params[0]["sort"] == "created_at:asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_sort_param_for_unsortable_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "a"}])])
+
+        _rows(alguna_source("key", "payments", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert "sort" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_data=True)])
+
+        # A 200 body without "data" means the response shape changed — fail loud, not silently 0 rows.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(alguna_source("key", "customers", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
 
 class TestValidateCredentials:
-    @parameterized.expand(
-        [
-            ("ok", 200, True),
-            ("unauthorized", 401, False),
-            ("forbidden", 403, False),
-            ("server_error", 500, False),
-        ]
-    )
-    def test_validate_credentials_status_mapping(self, _name: str, status_code: int, expected: bool) -> None:
-        response = mock.MagicMock()
-        response.status_code = status_code
+    @mock.patch(ALGUNA_SESSION_PATCH)
+    def test_ok(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("key") is True
 
-        with mock.patch(SESSION_PATCH_TARGET) as mock_session:
-            mock_session.return_value.get.return_value = response
-            assert validate_credentials("key") is expected
+    @mock.patch(ALGUNA_SESSION_PATCH)
+    def test_unauthorized(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=401)
+        assert validate_credentials("key") is False
 
-    def test_validate_credentials_swallows_exceptions(self):
-        with mock.patch(SESSION_PATCH_TARGET) as mock_session:
-            mock_session.return_value.get.side_effect = Exception("boom")
-            assert validate_credentials("key") is False
-
-
-class TestGetRows:
-    @mock.patch(SESSION_PATCH_TARGET)
-    def test_paginates_with_limit_offset(self, mock_session):
-        full_page = [{"id": f"cust_{i}"} for i in range(100)]
-        last_page = [{"id": "cust_last"}]
-        mock_session.return_value.get.side_effect = [_response(full_page), _response(last_page)]
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "customers", mock.MagicMock(), manager))
-
-        assert [item["id"] for batch in batches for item in batch] == [*(f"cust_{i}" for i in range(100)), "cust_last"]
-
-        calls = mock_session.return_value.get.call_args_list
-        assert _query(calls[0])["offset"] == ["0"]
-        assert _query(calls[0])["limit"] == ["100"]
-        assert _query(calls[0])["sort"] == ["created_at:asc"]
-        assert _query(calls[1])["offset"] == ["100"]
-
-        # State is saved only after a full page has been yielded, so a crash re-yields
-        # the last page instead of skipping it.
-        manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].offset == 100
-
-    @mock.patch(SESSION_PATCH_TARGET)
-    def test_requests_send_auth_and_version_headers(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "cust_1"}])
-
-        list(get_rows("key", "customers", mock.MagicMock(), _make_manager()))
-
-        headers = mock_session.return_value.get.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer key"
-        # Alguna rejects any request without the date-based version header.
-        assert headers["Alguna-Version"] == ALGUNA_API_VERSION
-
-    @parameterized.expand([("payments",), ("products",)])
-    def test_no_sort_param_for_endpoints_without_sort(self, endpoint: str) -> None:
-        with mock.patch(SESSION_PATCH_TARGET) as mock_session:
-            mock_session.return_value.get.return_value = _response([{"id": "x"}])
-
-            list(get_rows("key", endpoint, mock.MagicMock(), _make_manager()))
-
-            assert "sort" not in _query(mock_session.return_value.get.call_args)
-
-    @mock.patch(SESSION_PATCH_TARGET)
-    def test_resumes_from_saved_offset(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "cust_201"}])
-
-        manager = _make_manager(AlgunaResumeConfig(offset=200))
-        list(get_rows("key", "customers", mock.MagicMock(), manager))
-
-        assert _query(mock_session.return_value.get.call_args_list[0])["offset"] == ["200"]
-
-    @mock.patch(SESSION_PATCH_TARGET)
-    def test_empty_first_page_stops_without_yield(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "customers", mock.MagicMock(), manager))
-
-        assert batches == []
-        manager.save_state.assert_not_called()
-
-    @mock.patch(SESSION_PATCH_TARGET)
-    def test_short_page_terminates_without_saving_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "cust_1"}, {"id": "cust_2"}])
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "customers", mock.MagicMock(), manager))
-
-        assert len(batches) == 1
-        assert mock_session.return_value.get.call_count == 1
-        manager.save_state.assert_not_called()
-
-    @mock.patch(SESSION_PATCH_TARGET)
-    def test_missing_data_key_raises(self, mock_session):
-        resp = mock.MagicMock()
-        resp.status_code = 200
-        resp.ok = True
-        resp.json.return_value = {"unexpected": "envelope"}
-        mock_session.return_value.get.return_value = resp
-
-        # A 200 body without "data" means the response shape changed — the sync must fail
-        # loudly instead of silently reporting 0 rows.
-        with pytest.raises(KeyError):
-            list(get_rows("key", "customers", mock.MagicMock(), _make_manager()))
-
-    @mock.patch(SESSION_PATCH_TARGET)
-    def test_auth_error_raises_without_retry(self, mock_session):
-        resp = mock.MagicMock()
-        resp.status_code = 401
-        resp.ok = False
-        resp.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=resp)
-        mock_session.return_value.get.return_value = resp
-
-        with pytest.raises(requests.HTTPError):
-            list(get_rows("key", "customers", mock.MagicMock(), _make_manager()))
-
-        # Credential failures must not burn retry attempts before surfacing.
-        assert mock_session.return_value.get.call_count == 1
-
-
-class TestAlgunaSourceResponse:
-    @parameterized.expand([(endpoint,) for endpoint in ENDPOINTS])
-    def test_response_metadata_per_endpoint(self, endpoint: str) -> None:
-        config = ALGUNA_ENDPOINTS[endpoint]
-        response = alguna_source("key", endpoint, mock.MagicMock(), _make_manager())
-
-        assert response.name == endpoint
-        assert response.primary_keys == config.primary_keys
-        assert response.partition_mode == "datetime"
-        assert response.partition_keys == [config.partition_key]
-
-    @parameterized.expand([(name, config) for name, config in ALGUNA_ENDPOINTS.items()])
-    def test_partition_keys_are_stable_creation_fields(self, _name: str, config) -> None:
-        assert config.partition_key == "created_at"
+    @mock.patch(ALGUNA_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key") is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/apify_dataset.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/apify_dataset.py
@@ -1,28 +1,28 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import quote, urlencode
+from typing import Any, Optional
+from urllib.parse import quote
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.apify_dataset.settings import (
     APIFY_BASE_URL,
     PRIMARY_KEYS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # One request to /datasets/{id}/items returns this many rows. The dataset endpoints carry a high
 # rate limit (~400 req/s), so a large page keeps the round-trip count down on big datasets.
 PAGE_SIZE = 1000
-
-
-class ApifyRetryableError(Exception):
-    pass
+# Apify reports the dataset's total item count in this response header (the body is a bare JSON array).
+APIFY_TOTAL_HEADER = "X-Apify-Pagination-Total"
 
 
 @dataclasses.dataclass
@@ -32,135 +32,82 @@ class ApifyResumeConfig:
     offset: int = 0
 
 
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_token}",
-        "Accept": "application/json",
-    }
-
-
-def _items_url(dataset_id: str, offset: int, limit: int) -> str:
-    # `format=json` returns a JSON array of the raw rows; offset/limit drive the pagination.
-    params = {"offset": offset, "limit": limit, "format": "json"}
+def _items_path(dataset_id: str) -> str:
     # Encode the dataset_id as a single path segment so a crafted value can't inject extra path
-    # segments or query params (e.g. dropping the enforced offset/limit).
-    return f"{APIFY_BASE_URL}/datasets/{quote(dataset_id, safe='')}/items?{urlencode(params)}"
-
-
-def validate_credentials(api_token: str, dataset_id: str) -> tuple[bool, str | None]:
-    """Probe the dataset itself so a bad token (401) and a wrong/inaccessible dataset (404) are both caught."""
-    # Encode the dataset_id as a single path segment so a crafted value can't escape the path.
-    url = f"{APIFY_BASE_URL}/datasets/{quote(dataset_id, safe='')}"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_token), timeout=10)
-    except Exception:
-        return False, "Could not reach the Apify API. Please try again."
-
-    if response.status_code == 200:
-        return True, None
-    if response.status_code in (401, 403):
-        return False, "Invalid Apify API token, or the token cannot access this dataset."
-    if response.status_code == 404:
-        return False, "Dataset not found. Check the dataset ID and that the token can access it."
-    return False, f"Unexpected response from Apify (status {response.status_code})."
-
-
-@retry(
-    retry=retry_if_exception_type((ApifyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> tuple[list[dict[str, Any]], int]:
-    """Fetch one page of dataset items. Returns the rows plus the dataset's total item count.
-
-    Apify reports the total via the ``X-Apify-Pagination-Total`` response header rather than in the body
-    (the body is a bare JSON array), so we read it from there to know when to stop paging.
-    """
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ApifyRetryableError(f"Apify API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Apify API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    items = response.json()
-    if not isinstance(items, list):
-        # The items endpoint always returns a JSON array for format=json; anything else means the
-        # request was misrouted (e.g. an error object). That's a permanent contract violation, so raise
-        # a non-retryable error to fail loudly rather than waiting through every retry attempt.
-        raise ValueError(f"Unexpected Apify response shape (not a list), url={url}")
-
-    total_header = response.headers.get("X-Apify-Pagination-Total")
-    try:
-        total = int(total_header) if total_header is not None else len(items)
-    except (TypeError, ValueError):
-        total = len(items)
-    return items, total
-
-
-def get_rows(
-    api_token: str,
-    dataset_id: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ApifyResumeConfig],
-) -> Iterator[Any]:
-    headers = _get_headers(api_token)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # One session reused across every page so urllib3 keeps the connection alive between requests.
-    session = make_tracked_session()
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume else 0
-    if resume:
-        logger.debug(f"Apify: resuming dataset {dataset_id} from offset {offset}")
-
-    while True:
-        url = _items_url(dataset_id, offset, PAGE_SIZE)
-        items, total = _fetch_page(session, url, headers, logger)
-
-        if not items:
-            break
-
-        offset += len(items)
-        more_pages = offset < total
-
-        for item in items:
-            batcher.batch(item)
-
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save AFTER yielding (and only when more rows remain) so a crash re-yields the last
-                # page rather than skipping it. The dataset is append-only, so the re-pulled rows are
-                # identical; full refresh tolerates the rare resume-window overlap.
-                if more_pages:
-                    resumable_source_manager.save_state(ApifyResumeConfig(offset=offset))
-
-        if not more_pages:
-            break
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    # segments or query params.
+    return f"/datasets/{quote(dataset_id, safe='')}/items"
 
 
 def apify_dataset_source(
     api_token: str,
     dataset_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ApifyResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": APIFY_BASE_URL,
+            "auth": {"type": "bearer", "token": api_token},
+            # Total lives in a response header, not the body; the bare JSON array is the row list.
+            "paginator": OffsetPaginator(limit=PAGE_SIZE, total_path=None, total_header=APIFY_TOTAL_HEADER),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": _items_path(dataset_id),
+                    "params": {"format": "json"},
+                    # The body is a bare JSON array; require it to be a list so a misrouted request
+                    # returning an error object fails loud instead of syncing the object as a row.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(ApifyResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            dataset_id=dataset_id,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=PRIMARY_KEYS.get(endpoint),
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_token: str, dataset_id: str) -> tuple[bool, str | None]:
+    """Probe the dataset itself so a bad token (401/403) and a wrong/inaccessible dataset (404) are both caught."""
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{APIFY_BASE_URL}/datasets/{quote(dataset_id, safe='')}",
+        headers={"Authorization": f"Bearer {api_token}", "Accept": "application/json"},
+    )
+    if ok:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid Apify API token, or the token cannot access this dataset."
+    if status == 404:
+        return False, "Dataset not found. Check the dataset ID and that the token can access it."
+    if status is None:
+        return False, "Could not reach the Apify API. Please try again."
+    return False, f"Unexpected response from Apify (status {status})."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/source.py
@@ -19,14 +19,17 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.apify_data
     validate_credentials as validate_apify_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.apify_dataset.settings import (
+    DATASET_ITEMS_ENDPOINT,
     ENDPOINTS,
     INCREMENTAL_FIELDS,
-    PRIMARY_KEYS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ApifyDatasetSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -106,21 +109,14 @@ The token needs read access to the dataset's storage.""",
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                detected_primary_keys=PRIMARY_KEYS.get(endpoint),
-                description="The rows produced by the Apify dataset. Columns are defined by the Actor that produced them. Full refresh only — the whole dataset is re-imported on every sync.",
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions={
+                DATASET_ITEMS_ENDPOINT: "The rows produced by the Apify dataset. Columns are defined by the Actor that produced them. Full refresh only — the whole dataset is re-imported on every sync."
+            },
+        )
 
     def validate_credentials(
         self, config: ApifyDatasetSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -140,6 +136,8 @@ The token needs read access to the dataset's storage.""",
             api_token=config.api_token,
             dataset_id=config.dataset_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # full refresh only
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/tests/test_apify_dataset.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/tests/test_apify_dataset.py
@@ -1,252 +1,145 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
 
-import pyarrow as pa
-import requests
-from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.sources.apify_dataset import apify_dataset
 from products.warehouse_sources.backend.temporal.data_imports.sources.apify_dataset.apify_dataset import (
     ApifyResumeConfig,
-    ApifyRetryableError,
-    _fetch_page,
-    _items_url,
     apify_dataset_source,
-    get_rows,
     validate_credentials,
 )
 
-
-def _response(status_code: int, *, json_body: Any = None, headers: dict[str, str] | None = None) -> mock.Mock:
-    response = mock.Mock(spec=requests.Response)
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    response.text = ""
-    response.headers = headers or {}
-    response.json.return_value = json_body
-    response.raise_for_status.side_effect = (
-        None if response.ok else requests.HTTPError(f"{status_code} Client Error", response=response)
-    )
-    return response
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+APIFY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.apify_dataset.apify_dataset.make_tracked_session"
+)
 
 
-def _small_batcher(**kwargs: Any) -> Batcher:
-    # Force a tiny chunk so a yield fires after a couple of rows without building thousands of dicts.
-    return Batcher(logger=kwargs["logger"], chunk_size=2, chunk_size_bytes=kwargs["chunk_size_bytes"])
+def _response(body: Any, *, total: int | None = None) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    if total is not None:
+        resp.headers["X-Apify-Pagination-Total"] = str(total)
+    return resp
 
 
-@pytest.fixture(autouse=True)
-def _no_sleep():
-    # The tenacity retry decorator sleeps between attempts; zero it so retry tests stay instant.
-    with mock.patch("time.sleep", return_value=None):
-        yield
-
-
-class TestItemsUrl:
-    @parameterized.expand(
-        [
-            ("first_page", "ds1", 0, 1000),
-            ("offset_page", "ds1", 2000, 500),
-        ]
-    )
-    def test_items_url_contains_pagination_params(self, _name: str, dataset_id: str, offset: int, limit: int) -> None:
-        url = _items_url(dataset_id, offset, limit)
-        assert url.startswith(f"https://api.apify.com/v2/datasets/{dataset_id}/items?")
-        assert f"offset={offset}" in url
-        assert f"limit={limit}" in url
-        assert "format=json" in url
-
-    def test_items_url_encodes_dataset_id_as_path_segment(self) -> None:
-        # A crafted dataset_id must not be able to inject extra path segments or query params
-        # (e.g. dropping the enforced offset/limit); it has to stay a single encoded path segment.
-        url = _items_url("evil/items?format=json#", 0, 1000)
-        assert url.startswith("https://api.apify.com/v2/datasets/evil%2Fitems%3Fformat%3Djson%23/items?")
-        assert "offset=0" in url
-        assert "limit=1000" in url
-
-
-class TestValidateCredentials:
-    @parameterized.expand(
-        [
-            ("ok", 200, True),
-            ("unauthorized", 401, False),
-            ("forbidden", 403, False),
-            ("not_found", 404, False),
-            ("unexpected", 500, False),
-        ]
-    )
-    def test_status_code_mapping(self, _name: str, status_code: int, expected_ok: bool) -> None:
-        session = mock.Mock()
-        session.get.return_value = _response(status_code)
-        with mock.patch.object(apify_dataset, "make_tracked_session", return_value=session):
-            ok, error = validate_credentials("token", "ds1")
-        assert ok is expected_ok
-        assert (error is None) is expected_ok
-
-    def test_network_error_is_not_valid(self) -> None:
-        session = mock.Mock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with mock.patch.object(apify_dataset, "make_tracked_session", return_value=session):
-            ok, error = validate_credentials("token", "ds1")
-        assert ok is False
-        assert error is not None
-
-
-class TestFetchPage:
-    def test_reads_total_from_pagination_header(self) -> None:
-        session = mock.Mock()
-        session.get.return_value = _response(200, json_body=[{"a": 1}], headers={"X-Apify-Pagination-Total": "42"})
-        items, total = _fetch_page(session, "https://api.apify.com/v2/datasets/ds1/items", {}, mock.Mock())
-        assert items == [{"a": 1}]
-        assert total == 42
-
-    def test_total_falls_back_to_item_count_without_header(self) -> None:
-        session = mock.Mock()
-        session.get.return_value = _response(200, json_body=[{"a": 1}, {"a": 2}], headers={})
-        items, total = _fetch_page(session, "https://api.apify.com/v2/datasets/ds1/items", {}, mock.Mock())
-        assert total == 2
-
-    @parameterized.expand([("empty", ""), ("non_numeric", "abc")])
-    def test_total_falls_back_to_item_count_for_malformed_header(self, _name: str, header_value: str) -> None:
-        session = mock.Mock()
-        session.get.return_value = _response(
-            200, json_body=[{"a": 1}, {"a": 2}], headers={"X-Apify-Pagination-Total": header_value}
-        )
-        items, total = _fetch_page(session, "https://api.apify.com/v2/datasets/ds1/items", {}, mock.Mock())
-        assert total == 2
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_eventually_reraise(self, _name: str, status_code: int) -> None:
-        session = mock.Mock()
-        session.get.return_value = _response(status_code)
-        with pytest.raises(ApifyRetryableError):
-            _fetch_page(session, "https://api.apify.com/v2/datasets/ds1/items", {}, mock.Mock())
-        assert session.get.call_count == 5
-
-    def test_retries_then_succeeds(self) -> None:
-        session = mock.Mock()
-        session.get.side_effect = [
-            _response(503),
-            _response(200, json_body=[{"a": 1}], headers={"X-Apify-Pagination-Total": "1"}),
-        ]
-        items, total = _fetch_page(session, "https://api.apify.com/v2/datasets/ds1/items", {}, mock.Mock())
-        assert items == [{"a": 1}]
-        assert session.get.call_count == 2
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_immediately(self, _name: str, status_code: int) -> None:
-        session = mock.Mock()
-        session.get.return_value = _response(status_code)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page(session, "https://api.apify.com/v2/datasets/ds1/items", {}, mock.Mock())
-        assert session.get.call_count == 1
-
-    def test_non_list_body_raises_without_retrying(self) -> None:
-        session = mock.Mock()
-        session.get.return_value = _response(200, json_body={"error": "nope"})
-        # A non-list 200 body is a permanent contract violation, so it raises ValueError (not a
-        # retryable error) and exits immediately rather than waiting through all retry attempts.
-        with pytest.raises(ValueError):
-            _fetch_page(session, "https://api.apify.com/v2/datasets/ds1/items", {}, mock.Mock())
-        assert session.get.call_count == 1
-
-
-def _resume_manager(saved: ApifyResumeConfig | None = None) -> mock.Mock:
-    manager = mock.Mock()
-    manager.can_resume.return_value = saved is not None
-    manager.load_state.return_value = saved
+def _make_manager(resume_state: ApifyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-def _collect_rows(tables: list[pa.Table]) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
-    for table in tables:
-        rows.extend(table.to_pylist())
-    return rows
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    session.headers = {}
+    params: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        params.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return params
 
 
-class TestGetRows:
-    def test_paginates_until_offset_reaches_total(self) -> None:
-        manager = _resume_manager()
-        pages = [
-            ([{"i": 0}, {"i": 1}], 5),
-            ([{"i": 2}, {"i": 3}], 5),
-            ([{"i": 4}], 5),
-        ]
-        with (
-            mock.patch.object(apify_dataset, "make_tracked_session", return_value=mock.Mock()),
-            mock.patch.object(apify_dataset, "PAGE_SIZE", 2),
-            mock.patch.object(apify_dataset, "_fetch_page", side_effect=pages) as fetch,
-        ):
-            rows = _collect_rows(list(get_rows("token", "ds1", mock.Mock(), manager)))
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
-        assert fetch.call_count == 3
-        assert [r["i"] for r in rows] == [0, 1, 2, 3, 4]
-        # The offset advances on each request: 0 -> 2 -> 4.
-        offsets = [call.args[1] for call in fetch.call_args_list]
-        assert "offset=0" in offsets[0]
-        assert "offset=2" in offsets[1]
-        assert "offset=4" in offsets[2]
 
-    def test_resumes_from_saved_offset(self) -> None:
-        manager = _resume_manager(ApifyResumeConfig(offset=2))
-        with (
-            mock.patch.object(apify_dataset, "make_tracked_session", return_value=mock.Mock()),
-            mock.patch.object(apify_dataset, "PAGE_SIZE", 2),
-            mock.patch.object(apify_dataset, "_fetch_page", side_effect=[([{"i": 2}], 3)]) as fetch,
-        ):
-            list(get_rows("token", "ds1", mock.Mock(), manager))
+def _run(manager, responses):
+    return apify_dataset_source(
+        api_token="tok",
+        dataset_id="ds1",
+        endpoint="dataset_items",
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
 
-        assert "offset=2" in fetch.call_args_list[0].args[1]
 
-    def test_saves_state_after_yield_with_next_offset(self) -> None:
-        manager = _resume_manager()
-        pages = [
-            ([{"i": 0}, {"i": 1}], 4),
-            ([{"i": 2}, {"i": 3}], 4),
-        ]
-        with (
-            mock.patch.object(apify_dataset, "make_tracked_session", return_value=mock.Mock()),
-            mock.patch.object(apify_dataset, "PAGE_SIZE", 2),
-            mock.patch.object(apify_dataset, "Batcher", _small_batcher),
-            mock.patch.object(apify_dataset, "_fetch_page", side_effect=pages),
-        ):
-            list(get_rows("token", "ds1", mock.Mock(), manager))
+class TestPagination:
+    @mock.patch.object(apify_dataset, "PAGE_SIZE", 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_progresses_offset_and_terminates_on_header_total(self, MockSession) -> None:
+        session = MockSession.return_value
+        # total=3: page 1 (2 rows, full) -> continue; page 2 (offset 2, 1 row) -> offset 4 >= 3 -> stop.
+        params = _wire(session, [_response([{"i": 0}, {"i": 1}], total=3), _response([{"i": 2}], total=3)])
 
-        # After the first page (offset advanced to 2) more rows remain, so state is saved at offset 2.
-        saved_offsets = [call.args[0].offset for call in manager.save_state.call_args_list]
-        assert 2 in saved_offsets
+        manager = _make_manager()
+        rows = _rows(_run(manager, None))
 
-    def test_does_not_save_state_on_final_page(self) -> None:
-        manager = _resume_manager()
-        with (
-            mock.patch.object(apify_dataset, "make_tracked_session", return_value=mock.Mock()),
-            mock.patch.object(apify_dataset, "PAGE_SIZE", 2),
-            mock.patch.object(apify_dataset, "Batcher", _small_batcher),
-            mock.patch.object(apify_dataset, "_fetch_page", side_effect=[([{"i": 0}, {"i": 1}], 2)]),
-        ):
-            list(get_rows("token", "ds1", mock.Mock(), manager))
+        assert [r["i"] for r in rows] == [0, 1, 2]
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == 2
+        assert params[0]["format"] == "json"
+        assert params[1]["offset"] == 2
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == ApifyResumeConfig(offset=2)
 
+    @mock.patch.object(apify_dataset, "PAGE_SIZE", 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_page_terminates(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"i": 0}], total=1)])
+
+        manager = _make_manager()
+        rows = _rows(_run(manager, None))
+
+        assert [r["i"] for r in rows] == [0]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_empty_dataset_yields_nothing(self) -> None:
-        manager = _resume_manager()
-        with (
-            mock.patch.object(apify_dataset, "make_tracked_session", return_value=mock.Mock()),
-            mock.patch.object(apify_dataset, "_fetch_page", side_effect=[([], 0)]),
-        ):
-            tables = list(get_rows("token", "ds1", mock.Mock(), manager))
+    @mock.patch.object(apify_dataset, "PAGE_SIZE", 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"i": 200}], total=201)])
 
-        assert tables == []
+        manager = _make_manager(ApifyResumeConfig(offset=200))
+        _rows(_run(manager, None))
+
+        assert params[0]["offset"] == 200
+
+    @mock.patch.object(apify_dataset, "PAGE_SIZE", 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "wrong shape"}, total=0)])
+
+        # A misrouted request returning an error object (not a list) must fail loud, not sync it as a row.
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_run(_make_manager(), None))
 
 
-class TestApifyDatasetSource:
-    def test_source_response_shape(self) -> None:
-        response = apify_dataset_source("token", "ds1", "dataset_items", mock.Mock(), _resume_manager())
-        assert response.name == "dataset_items"
-        # Arbitrary dataset rows have no unique key, so the table is full-refresh only.
-        assert response.primary_keys is None
-        assert response.sort_mode == "asc"
+class TestValidateCredentials:
+    @mock.patch(APIFY_SESSION_PATCH)
+    def test_ok(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("tok", "ds1") == (True, None)
+
+    @mock.patch(APIFY_SESSION_PATCH)
+    def test_unauthorized_message(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=401)
+        ok, msg = validate_credentials("tok", "ds1")
+        assert ok is False
+        assert "token" in (msg or "")
+
+    @mock.patch(APIFY_SESSION_PATCH)
+    def test_not_found_message(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=404)
+        ok, msg = validate_credentials("tok", "ds1")
+        assert ok is False
+        assert "Dataset not found" in (msg or "")
+
+    @mock.patch(APIFY_SESSION_PATCH)
+    def test_network_error_message(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        ok, msg = validate_credentials("tok", "ds1")
+        assert ok is False
+        assert "reach the Apify API" in (msg or "")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/tests/test_apify_dataset_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apify_dataset/tests/test_apify_dataset_source.py
@@ -92,7 +92,8 @@ class TestApifyDatasetSource:
     def test_source_for_pipeline_plumbs_arguments(self) -> None:
         inputs = mock.Mock()
         inputs.schema_name = "dataset_items"
-        inputs.logger = mock.Mock()
+        inputs.team_id = 7
+        inputs.job_id = "job-1"
         manager = mock.Mock()
         with mock.patch.object(source_module, "apify_dataset_source", return_value="sentinel") as build:
             result = self.source.source_for_pipeline(_config(), manager, inputs)
@@ -101,6 +102,8 @@ class TestApifyDatasetSource:
             api_token="apify_api_token",
             dataset_id="ds1",
             endpoint="dataset_items",
-            logger=inputs.logger,
+            team_id=7,
+            job_id="job-1",
             resumable_source_manager=manager,
+            db_incremental_field_last_value=None,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/ashby.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/ashby.py
@@ -1,27 +1,26 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.ashby.settings import ASHBY_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 ASHBY_BASE_URL = "https://api.ashbyhq.com"
 PAGE_SIZE = 100  # Ashby's documented max (and default).
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint to confirm a key is genuine when no specific schema is being validated.
 DEFAULT_PROBE_PATH = "department.list"
 
 AUTH_ERROR_HINT = "Ashby API authentication or permission error"
-
-
-class AshbyRetryableError(Exception):
-    pass
 
 
 class AshbyAPIError(Exception):
@@ -31,11 +30,6 @@ class AshbyAPIError(Exception):
 @dataclasses.dataclass
 class AshbyResumeConfig:
     cursor: str
-
-
-def _auth(api_key: str) -> tuple[str, str]:
-    # Ashby uses HTTP Basic auth: API key as username, empty password.
-    return (api_key, "")
 
 
 def _headers() -> dict[str, str]:
@@ -66,94 +60,87 @@ def _errors_from_payload(data: dict[str, Any]) -> list[Any]:
     return []
 
 
-@retry(
-    retry=retry_if_exception_type((AshbyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    api_key: str,
-    path: str,
-    body: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.post(
-        f"{ASHBY_BASE_URL}/{path}", json=body, auth=_auth(api_key), headers=_headers(), timeout=REQUEST_TIMEOUT_SECONDS
-    )
+class AshbyCursorPaginator(JSONResponseCursorPaginator):
+    """Cursor-in-JSON-body pagination plus Ashby's HTTP-200 error envelope.
 
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AshbyRetryableError(f"Ashby API error (retryable): status={response.status_code}, path={path}")
+    Ashby reports many failures as HTTP 200 with ``success: false`` and an ``errors``
+    array — raise on those (auth-ish messages carry ``AUTH_ERROR_HINT`` so the job-level
+    classifier treats them as non-retryable). Termination honors ``moreDataAvailable``,
+    which can be false even when a ``nextCursor`` is present.
+    """
 
-    if response.status_code in (401, 403):
-        raise AshbyAPIError(f"{response.status_code} Client Error: {AUTH_ERROR_HINT} for path {path}")
+    def __init__(self, path: str) -> None:
+        super().__init__(cursor_path="nextCursor", cursor_param="cursor", param_location="json")
+        self._path = path
 
-    if not response.ok:
-        logger.error(f"Ashby API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        payload = response.json()
+        if not payload.get("success", False):
+            is_auth, message = _classify_failure_message(_errors_from_payload(payload))
+            if is_auth:
+                raise AshbyAPIError(f"{AUTH_ERROR_HINT} for path {self._path}: {message}")
+            raise AshbyAPIError(f"Ashby API error for path {self._path}: {message}")
 
-    data = response.json()
-    if not data.get("success", False):
-        is_auth, message = _classify_failure_message(_errors_from_payload(data))
-        if is_auth:
-            raise AshbyAPIError(f"{AUTH_ERROR_HINT} for path {path}: {message}")
-        raise AshbyAPIError(f"Ashby API error for path {path}: {message}")
-
-    return data
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AshbyResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = ASHBY_ENDPOINTS[endpoint]
-    session = make_tracked_session()
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    cursor: Optional[str] = resume.cursor if resume else None
-    if cursor:
-        logger.debug(f"Ashby: resuming {endpoint} from cursor")
-
-    while True:
-        body: dict[str, Any] = {"limit": PAGE_SIZE}
-        if cursor:
-            body["cursor"] = cursor
-
-        data = _fetch_page(session, api_key, config.path, body, logger)
-
-        results = data.get("results") or []
-        if results:
-            yield results
-
-        next_cursor = data.get("nextCursor")
-        if not data.get("moreDataAvailable", False) or not next_cursor:
-            break
-
-        cursor = next_cursor
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages
-        # are persisted); merge/replace dedupes on the primary key.
-        resumable_source_manager.save_state(AshbyResumeConfig(cursor=cursor))
+        super().update_state(response, data)
+        if not payload.get("moreDataAvailable", False):
+            self._has_next_page = False
 
 
 def ashby_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AshbyResumeConfig],
 ) -> SourceResponse:
     config = ASHBY_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ASHBY_BASE_URL,
+            "headers": _headers(),
+            # Ashby uses HTTP Basic auth: API key as username, empty password.
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            "paginator": AshbyCursorPaginator(config.path),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "method": "post",
+                    "json": {"limit": PAGE_SIZE},
+                    "data_selector": "results",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint fires AFTER a page is yielded so a
+        # crash re-fetches from the next page (already-yielded pages are persisted); merge/replace
+        # dedupes on the primary key.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(AshbyResumeConfig(cursor=str(state["cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # every Ashby endpoint is full refresh
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_key,
         partition_count=1,
         partition_size=1,
@@ -166,14 +153,15 @@ def ashby_source(
 def check_access(api_key: str, path: str) -> tuple[int, Optional[str]]:
     """Probe a single endpoint to validate credentials.
 
-    Returns a normalized ``(status, message)`` where status mimics HTTP semantics even when
-    Ashby reports the failure as HTTP 200 + ``success: false``:
+    Ashby's RPC endpoints are POST-only and report many failures as HTTP 200 with
+    ``success: false``, so the generic GET-based ``validate_via_probe`` can't express this
+    check. Returns a normalized ``(status, message)`` where status mimics HTTP semantics:
       200 = reachable, 401 = bad key, 403 = valid key without scope, other = unexpected.
     """
-    session = make_tracked_session()
+    session = make_tracked_session(redact_values=(api_key,))
     try:
         response = session.post(
-            f"{ASHBY_BASE_URL}/{path}", json={"limit": 1}, auth=_auth(api_key), headers=_headers(), timeout=15
+            f"{ASHBY_BASE_URL}/{path}", json={"limit": 1}, auth=(api_key, ""), headers=_headers(), timeout=15
         )
     except Exception as e:
         return 0, f"Could not connect to Ashby: {e}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/source.py
@@ -27,7 +27,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AshbySourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -89,19 +92,7 @@ You can create an API key under **Admin → API Keys** in Ashby. Grant read perm
         # Ashby exposes incremental sync only via an opaque syncToken and an unordered
         # `createdAfter` filter — neither maps safely onto PostHog's timestamp-watermark
         # model — so every endpoint is full refresh for now.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, {}, names)
 
     def validate_credentials(
         self, config: AshbySourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -144,6 +135,7 @@ You can create an API key under **Admin → API Keys** in Ashby. Grant read perm
         return ashby_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/tests/test_ashby.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/tests/test_ashby.py
@@ -1,7 +1,11 @@
+import json
 from typing import Any, Optional
 
 import pytest
 from unittest import mock
+
+import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.ashby.ashby import (
     ASHBY_BASE_URL,
@@ -12,51 +16,80 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.ashby.ashb
     _errors_from_payload,
     ashby_source,
     check_access,
-    get_rows,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.ashby.settings import ENDPOINTS
 
-SESSION_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.ashby.ashby.make_tracked_session"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# check_access builds its own tracked session in the ashby module.
+ASHBY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.ashby.ashby.make_tracked_session"
+)
 
 
-class FakeResponse:
-    def __init__(
-        self, status_code: int = 200, json_data: Optional[dict[str, Any]] = None, raise_json: bool = False
-    ) -> None:
-        self.status_code = status_code
-        self._json = json_data if json_data is not None else {}
-        self.text = str(self._json)
-        self._raise_json = raise_json
-
-    @property
-    def ok(self) -> bool:
-        return 200 <= self.status_code < 300
-
-    def json(self) -> dict[str, Any]:
-        if self._raise_json:
-            raise ValueError("no json")
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            raise Exception(f"{self.status_code} Client Error")
+def _response(body: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class FakeSession:
-    def __init__(self, responses: list[FakeResponse]) -> None:
-        self._responses = list(responses)
-        self.calls: list[dict[str, Any]] = []
+def _page(
+    items: list[dict[str, Any]],
+    *,
+    more: bool = False,
+    next_cursor: Optional[str] = None,
+) -> Response:
+    body: dict[str, Any] = {"success": True, "results": items, "moreDataAvailable": more}
+    if next_cursor is not None:
+        body["nextCursor"] = next_cursor
+    return _response(body)
 
-    def post(self, url: str, json: Any = None, auth: Any = None, headers: Any = None, timeout: Any = None):
-        self.calls.append({"url": url, "json": json, "auth": auth, "headers": headers})
-        return self._responses[0] if len(self._responses) == 1 else self._responses.pop(0)
 
-
-def _manager(can_resume: bool = False, state: Optional[AshbyResumeConfig] = None) -> mock.MagicMock:
+def _make_manager(resume_state: AshbyResumeConfig | None = None) -> mock.MagicMock:
     manager = mock.MagicMock()
-    manager.can_resume.return_value = can_resume
-    manager.load_state.return_value = state
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return snapshots of each request AT SEND TIME.
+
+    ``request.json`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append(
+            {
+                "url": request.url,
+                "method": request.method,
+                "json": dict(request.json or {}),
+                "auth": request.auth,
+            }
+        )
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str = "candidates", manager: Optional[mock.MagicMock] = None, api_key: str = "dummy-key"):
+    return ashby_source(
+        api_key=api_key,
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+    )
 
 
 class TestClassifyFailureMessage:
@@ -92,80 +125,126 @@ class TestErrorsFromPayload:
         assert _errors_from_payload(payload) == expected
 
 
-class TestGetRows:
-    def test_paginates_until_no_more_data(self) -> None:
-        responses = [
-            FakeResponse(
-                json_data={"success": True, "results": [{"id": "1"}], "moreDataAvailable": True, "nextCursor": "c1"}
-            ),
-            FakeResponse(json_data={"success": True, "results": [{"id": "2"}], "moreDataAvailable": False}),
-        ]
-        session = FakeSession(responses)
-        manager = _manager()
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_no_more_data(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _page([{"id": "1"}], more=True, next_cursor="c1"),
+                _page([{"id": "2"}], more=False),
+            ],
+        )
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("dummy-key", "candidates", mock.MagicMock(), manager))
+        rows = _rows(_source("candidates"))
 
-        assert batches == [[{"id": "1"}], [{"id": "2"}]]
-        # First call has no cursor, second forwards nextCursor.
-        assert "cursor" not in session.calls[0]["json"]
-        assert session.calls[1]["json"]["cursor"] == "c1"
-        assert session.calls[0]["json"]["limit"] == 100
-        assert session.calls[0]["auth"] == ("dummy-key", "")
-        assert session.calls[0]["url"] == f"{ASHBY_BASE_URL}/candidate.list"
+        assert rows == [{"id": "1"}, {"id": "2"}]
+        # First call has no cursor, second forwards nextCursor; limit is sent in the JSON body.
+        assert "cursor" not in snapshots[0]["json"]
+        assert snapshots[1]["json"]["cursor"] == "c1"
+        assert snapshots[0]["json"]["limit"] == 100
+        assert snapshots[0]["url"] == f"{ASHBY_BASE_URL}/candidate.list"
+        assert snapshots[0]["method"] == "POST"
+        # Ashby authenticates via HTTP Basic: API key as username, empty password.
+        assert snapshots[0]["auth"].username == "dummy-key"
+        assert snapshots[0]["auth"].password == ""
 
-    def test_saves_state_after_yielding_each_page(self) -> None:
-        responses = [
-            FakeResponse(
-                json_data={"success": True, "results": [{"id": "1"}], "moreDataAvailable": True, "nextCursor": "c1"}
-            ),
-            FakeResponse(json_data={"success": True, "results": [{"id": "2"}], "moreDataAvailable": False}),
-        ]
-        manager = _manager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_yielding_each_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page([{"id": "1"}], more=True, next_cursor="c1"),
+                _page([{"id": "2"}], more=False),
+            ],
+        )
+        manager = _make_manager()
 
-        with mock.patch(SESSION_PATH, return_value=FakeSession(responses)):
-            list(get_rows("k", "candidates", mock.MagicMock(), manager))
+        _rows(_source("candidates", manager))
 
         manager.save_state.assert_called_once_with(AshbyResumeConfig(cursor="c1"))
 
-    def test_resumes_from_saved_cursor(self) -> None:
-        responses = [FakeResponse(json_data={"success": True, "results": [{"id": "9"}], "moreDataAvailable": False})]
-        session = FakeSession(responses)
-        manager = _manager(can_resume=True, state=AshbyResumeConfig(cursor="resume-cursor"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_page([{"id": "9"}], more=False)])
+        manager = _make_manager(AshbyResumeConfig(cursor="resume-cursor"))
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("k", "candidates", mock.MagicMock(), manager))
+        rows = _rows(_source("candidates", manager))
 
-        assert batches == [[{"id": "9"}]]
-        assert session.calls[0]["json"]["cursor"] == "resume-cursor"
+        assert rows == [{"id": "9"}]
+        assert snapshots[0]["json"]["cursor"] == "resume-cursor"
 
-    def test_empty_results_yield_nothing(self) -> None:
-        responses = [FakeResponse(json_data={"success": True, "results": [], "moreDataAvailable": False})]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_results_yield_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([], more=False)])
 
-        with mock.patch(SESSION_PATH, return_value=FakeSession(responses)):
-            batches = list(get_rows("k", "users", mock.MagicMock(), _manager()))
+        assert _rows(_source("users")) == []
 
-        assert batches == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_more_data_unavailable_even_with_cursor(self, MockSession) -> None:
+        # Ashby can return a nextCursor alongside moreDataAvailable=false — that must terminate.
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "1"}], more=False, next_cursor="c9")])
+        manager = _make_manager()
 
-    @pytest.mark.parametrize(
-        "response",
-        [
-            FakeResponse(status_code=401),
-            FakeResponse(status_code=403),
-        ],
-    )
-    def test_http_auth_errors_raise_matchable_api_error(self, response: FakeResponse) -> None:
-        with mock.patch(SESSION_PATH, return_value=FakeSession([response])):
-            with pytest.raises(AshbyAPIError) as exc:
-                list(get_rows("k", "candidates", mock.MagicMock(), _manager()))
-        assert f"{response.status_code} Client Error" in str(exc.value)
+        rows = _rows(_source("candidates", manager))
 
-    def test_success_false_auth_error_raises_matchable_api_error(self) -> None:
-        response = FakeResponse(json_data={"success": False, "errors": ["Missing permission: candidatesRead"]})
-        with mock.patch(SESSION_PATH, return_value=FakeSession([response])):
-            with pytest.raises(AshbyAPIError) as exc:
-                list(get_rows("k", "candidates", mock.MagicMock(), _manager()))
+        assert rows == [{"id": "1"}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_http_auth_errors_raise_matchable_error(self, MockSession, status_code: int) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=status_code)])
+
+        with pytest.raises(requests.HTTPError) as exc:
+            _rows(_source("candidates"))
+        assert f"{status_code} Client Error" in str(exc.value)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_success_false_auth_error_raises_matchable_api_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"success": False, "errors": ["Missing permission: candidatesRead"]})])
+
+        with pytest.raises(AshbyAPIError) as exc:
+            _rows(_source("candidates"))
         assert AUTH_ERROR_HINT in str(exc.value)
+        assert "Missing permission: candidatesRead" in str(exc.value)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_success_false_non_auth_error_raises_without_auth_hint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"success": False, "errors": ["validation failed"]})])
+
+        with pytest.raises(AshbyAPIError) as exc:
+            _rows(_source("candidates"))
+        assert AUTH_ERROR_HINT not in str(exc.value)
+        assert "validation failed" in str(exc.value)
+
+
+class FakeResponse:
+    def __init__(
+        self, status_code: int = 200, json_data: Optional[dict[str, Any]] = None, raise_json: bool = False
+    ) -> None:
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {}
+        self.text = str(self._json)
+        self._raise_json = raise_json
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 300
+
+    def json(self) -> dict[str, Any]:
+        if self._raise_json:
+            raise ValueError("no json")
+        return self._json
 
 
 class TestCheckAccess:
@@ -182,34 +261,51 @@ class TestCheckAccess:
         ],
     )
     def test_status_mapping(self, response: FakeResponse, expected_status: int) -> None:
-        with mock.patch(SESSION_PATH, return_value=FakeSession([response])):
+        session = mock.MagicMock()
+        session.post.return_value = response
+        with mock.patch(ASHBY_SESSION_PATCH, return_value=session):
             status, _message = check_access("k", "department.list")
         assert status == expected_status
+
+    def test_probes_endpoint_with_basic_auth(self) -> None:
+        session = mock.MagicMock()
+        session.post.return_value = FakeResponse(json_data={"success": True, "results": []})
+        with mock.patch(ASHBY_SESSION_PATCH, return_value=session):
+            check_access("k", "department.list")
+        call = session.post.call_args
+        assert call.args[0] == f"{ASHBY_BASE_URL}/department.list"
+        assert call.kwargs["auth"] == ("k", "")
+        assert call.kwargs["json"] == {"limit": 1}
 
     def test_connection_error_returns_zero(self) -> None:
         session = mock.MagicMock()
         session.post.side_effect = Exception("boom")
-        with mock.patch(SESSION_PATH, return_value=session):
+        with mock.patch(ASHBY_SESSION_PATCH, return_value=session):
             status, message = check_access("k", "department.list")
         assert status == 0
         assert message is not None
 
 
-class TestAshbySource:
-    def test_candidates_partitioned_by_created_at(self) -> None:
-        response = ashby_source("k", "candidates", mock.MagicMock(), _manager())
+class TestAshbySourceResponse:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_candidates_partitioned_by_created_at(self, MockSession) -> None:
+        response = _source("candidates")
         assert response.name == "candidates"
         assert response.primary_keys == ["id"]
         assert response.partition_mode == "datetime"
+        assert response.partition_format == "month"
         assert response.partition_keys == ["createdAt"]
 
-    def test_reference_endpoint_is_unpartitioned(self) -> None:
-        response = ashby_source("k", "users", mock.MagicMock(), _manager())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_reference_endpoint_is_unpartitioned(self, MockSession) -> None:
+        response = _source("users")
         assert response.partition_mode is None
+        assert response.partition_format is None
         assert response.partition_keys is None
         assert response.primary_keys == ["id"]
 
-    def test_all_endpoints_buildable(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_all_endpoints_buildable(self, MockSession) -> None:
         for endpoint in ENDPOINTS:
-            response = ashby_source("k", endpoint, mock.MagicMock(), _manager())
+            response = _source(endpoint)
             assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/tests/test_ashby_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/tests/test_ashby_source.py
@@ -131,6 +131,8 @@ class TestAshbySource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_ashby_source: mock.MagicMock) -> None:
         inputs = mock.MagicMock()
         inputs.schema_name = "candidates"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         manager = mock.MagicMock()
 
         self.source.source_for_pipeline(self.config, manager, inputs)
@@ -139,4 +141,6 @@ class TestAshbySource:
         kwargs = mock_ashby_source.call_args.kwargs
         assert kwargs["api_key"] == "ashby-key"
         assert kwargs["endpoint"] == "candidates"
+        assert kwargs["team_id"] == 123
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/assemblyai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/assemblyai.py
@@ -1,16 +1,25 @@
 import dataclasses
 from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode, urljoin, urlsplit
+from typing import Any, Optional
+from urllib.parse import urljoin, urlsplit
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.settings import ASSEMBLYAI_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # AssemblyAI offers a US base URL and an EU data-residency variant. The Authorization header is the
 # raw API key (no "Bearer" prefix).
@@ -23,12 +32,6 @@ DEFAULT_REGION = "us"
 # List endpoint max page size is 200.
 PAGE_SIZE = 200
 
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class AssemblyAIRetryableError(Exception):
-    pass
-
 
 @dataclasses.dataclass
 class AssemblyAIResumeConfig:
@@ -39,13 +42,6 @@ class AssemblyAIResumeConfig:
 
 def base_url_for_region(region: str | None) -> str:
     return BASE_URLS.get((region or DEFAULT_REGION).lower(), BASE_URLS[DEFAULT_REGION])
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": api_key,
-        "Accept": "application/json",
-    }
 
 
 def _pinned_url(base_url: str, url: str) -> str:
@@ -62,120 +58,127 @@ def _pinned_url(base_url: str, url: str) -> str:
     return resolved
 
 
-@retry(
-    retry=retry_if_exception_type(
-        (AssemblyAIRetryableError, requests.ReadTimeout, requests.ConnectionError),
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+class AssemblyAINextUrlPaginator(JSONResponsePaginator):
+    """Follows page_details.next_url, pinned to the selected regional host.
 
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AssemblyAIRetryableError(f"AssemblyAI API error (retryable): status={response.status_code}, url={url}")
+    Also stops as soon as a page carries no items — the transcript list is finite and
+    newest-first, so an empty page means the walk is done regardless of any next_url.
+    """
 
-    if not response.ok:
-        logger.error(f"AssemblyAI API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
+    def __init__(self, base_url: str) -> None:
+        super().__init__(next_url_path="page_details.next_url")
+        self._base_url = base_url
 
-    return response.json()
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+        super().update_state(response, data)
+        if self._has_next_page and self._next_url is not None:
+            self._next_url = _pinned_url(self._base_url, self._next_url)
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        super().set_resume_state(state)
+        if self._next_url is not None:
+            # Persisted state is still untrusted input — pin it to the selected host before fetching.
+            self._next_url = _pinned_url(self._base_url, self._next_url)
 
 
 def validate_credentials(api_key: str, region: str | None) -> bool:
     # Cheapest probe that exercises the token: list a single transcript.
     base_url = base_url_for_region(region)
-    url = f"{base_url}/v2/transcript?{urlencode({'limit': 1})}"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{base_url}/v2/transcript?limit=1",
+        headers={"Authorization": api_key, "Accept": "application/json"},
+    )
+    return ok
 
 
-def _hydrate_transcript(
-    session: requests.Session,
-    base_url: str,
-    transcript_id: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    """Fetch the full transcript object for a single id."""
-    url = f"{base_url}/v2/transcript/{transcript_id}"
-    return _fetch(session, url, headers, logger)
-
-
-def get_rows(
-    api_key: str,
-    region: str | None,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AssemblyAIResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = ASSEMBLYAI_ENDPOINTS[endpoint]
-    base_url = base_url_for_region(region)
-    headers = _get_headers(api_key)
-    # One session reused across every list page and hydration request so urllib3 keeps the
-    # connection alive instead of re-handshaking per request.
-    session = make_tracked_session()
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None and resume.next_url:
-        # Persisted state is still untrusted input — pin it to the selected host before fetching.
-        url = _pinned_url(base_url, resume.next_url)
-        logger.debug(f"AssemblyAI: resuming from URL: {url}")
-    else:
-        url = f"{base_url}{config.path}?{urlencode({'limit': PAGE_SIZE})}"
-
-    while True:
-        data = _fetch(session, url, headers, logger)
-
-        items = data.get(endpoint, [])
-        if not items:
-            break
-
-        if config.hydrate:
-            rows = [_hydrate_transcript(session, base_url, item["id"], headers, logger) for item in items]
-        else:
-            rows = items
-
-        yield rows
-
-        next_url = data.get("page_details", {}).get("next_url")
-        if not next_url:
-            break
-
-        # Save AFTER yielding the page so a crash re-yields the just-finished page rather than
-        # skipping it — merge dedupes on the primary key. Resume picks up at the next page.
-        url = _pinned_url(base_url, next_url)
-        resumable_source_manager.save_state(AssemblyAIResumeConfig(next_url=url))
+def _hydrate_transcript(client: RESTClient, transcript_id: str) -> dict[str, Any]:
+    """Fetch the full transcript object for a single id (the list rows are summaries)."""
+    for page in client.paginate(path=f"/v2/transcript/{transcript_id}", paginator=SinglePagePaginator()):
+        if page:
+            return page[0]
+    raise ValueError(f"AssemblyAI returned an empty body for transcript {transcript_id}")
 
 
 def assemblyai_source(
     api_key: str,
     region: str | None,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AssemblyAIResumeConfig],
 ) -> SourceResponse:
-    endpoint_config = ASSEMBLYAI_ENDPOINTS[endpoint]
+    config = ASSEMBLYAI_ENDPOINTS[endpoint]
+    base_url = base_url_for_region(region)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            "headers": {"Accept": "application/json"},
+            # AssemblyAI expects the raw API key in Authorization (no "Bearer" prefix).
+            "auth": {"type": "api_key", "api_key": api_key, "name": "Authorization", "location": "header"},
+            "paginator": AssemblyAINextUrlPaginator(base_url),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": PAGE_SIZE},
+                    "data_selector": endpoint,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_url:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the hook fires AFTER a page is yielded so a crash
+        # re-yields the just-finished page (merge dedupes) rather than skipping it. Resume picks up
+        # at the saved next page — earlier list pages are never re-fetched.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(AssemblyAIResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # full refresh only — no server-side watermark filter exists (see settings.py)
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    def items() -> Iterator[list[dict[str, Any]]]:
+        if not config.hydrate:
+            yield from resource
+            return
+        # One client (and session) reused for every hydration request so urllib3 keeps the
+        # connection alive instead of re-handshaking per transcript.
+        hydration_client = RESTClient(
+            base_url=base_url,
+            headers={"Accept": "application/json"},
+            auth=APIKeyAuth(api_key=api_key, name="Authorization", location="header"),
+        )
+        for page in resource:
+            yield [_hydrate_transcript(hydration_client, item["id"]) for item in page]
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            region=region,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=endpoint_config.primary_keys,
+        items=items,
+        primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="week" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
         # The list endpoint returns transcripts newest-first and exposes no ascending sort, so rows
         # arrive in descending creation order. Full refresh only, so this never drives a watermark.
         sort_mode="desc",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/source.py
@@ -32,7 +32,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AssemblyAISourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -112,23 +115,24 @@ class AssemblyAISource(ResumableSource[AssemblyAISourceConfig, AssemblyAIResumeC
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            return SourceSchema(
-                name=endpoint,
-                # No server-side `created >= X` filter exists, so an "incremental" sync would still
-                # walk the whole list every run — ship full refresh only. See settings.py.
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=ASSEMBLYAI_ENDPOINTS[endpoint].should_sync_default,
-                description="Lists transcripts and hydrates each with its full text, words, and audio-intelligence results. AssemblyAI retains only the last 90 days. Full refresh only.",
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # No server-side `created >= X` filter exists, so an "incremental" sync would still walk the
+        # whole list every run — ship full refresh only (every endpoint is in both append_only and
+        # merge_only, forcing both capability flags off while keeping `created` listed for the UI).
+        # See settings.py.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            append_only=ENDPOINTS,
+            merge_only=ENDPOINTS,
+            descriptions=dict.fromkeys(
+                ENDPOINTS,
+                "Lists transcripts and hydrates each with its full text, words, and audio-intelligence results. AssemblyAI retains only the last 90 days. Full refresh only.",
+            ),
+            should_sync_default={
+                endpoint: ASSEMBLYAI_ENDPOINTS[endpoint].should_sync_default for endpoint in ENDPOINTS
+            },
+        )
 
     def validate_credentials(
         self, config: AssemblyAISourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -151,6 +155,7 @@ class AssemblyAISource(ResumableSource[AssemblyAISourceConfig, AssemblyAIResumeC
             api_key=config.api_key,
             region=config.region,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
@@ -1,17 +1,28 @@
+import json
 from typing import Any
+from urllib.parse import urlencode
 
 import pytest
 from unittest import mock
+
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai import (
     AssemblyAIResumeConfig,
     _pinned_url,
     assemblyai_source,
     base_url_for_region,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.settings import ENDPOINTS
+
+# RESTClient (list pagination and per-transcript hydration) builds its session via
+# make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the assemblyai module.
+ASSEMBLYAI_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+)
 
 US_LIST_URL = "https://api.assemblyai.com/v2/transcript?limit=200"
 
@@ -23,25 +34,43 @@ def _make_manager(resume_state: AssemblyAIResumeConfig | None = None) -> mock.Ma
     return manager
 
 
-def _resp(json_body: Any, status: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = json_body
-    resp.status_code = status
-    resp.ok = status < 400
-    return resp
-
-
 def _list_page(items: list[dict[str, Any]], next_url: str | None) -> dict[str, Any]:
     return {"transcripts": items, "page_details": {"next_url": next_url}}
 
 
-def _url_router(responses: dict[str, dict[str, Any]]) -> Any:
-    """Return a session.get side_effect that maps each requested URL to a mocked response."""
+def _wire(session: mock.MagicMock, responses: dict[str, dict[str, Any]]) -> list[str]:
+    """Wire a mock session that routes each request to a response body by its full URL.
 
-    def fake_get(url: str, headers: Any = None, timeout: Any = None) -> mock.MagicMock:
-        return _resp(responses[url])
+    URLs are snapshotted at prepare_request time (the params dict is mutated in place across
+    pages, so inspecting it after the run would only show the final state).
+    """
+    session.headers = {}
+    requested: list[str] = []
 
-    return fake_get
+    def _prepare(request: Any) -> mock.MagicMock:
+        url = request.url
+        if request.params:
+            url = f"{url}?{urlencode(request.params)}"
+        requested.append(url)
+        prepared = mock.MagicMock()
+        prepared.url = url
+        return prepared
+
+    def _send(prepared: Any) -> Response:
+        resp = Response()
+        resp.status_code = 200
+        resp.url = prepared.url
+        resp._content = json.dumps(responses[prepared.url]).encode()
+        return resp
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = _send
+    return requested
+
+
+def _batches(api_key: str, region: str | None, endpoint: str, manager: mock.MagicMock) -> list[list[dict[str, Any]]]:
+    response = assemblyai_source(api_key, region, endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+    return list(response.items())
 
 
 class TestBaseUrlForRegion:
@@ -89,105 +118,134 @@ class TestPinnedUrl:
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
-    )
+    @mock.patch(ASSEMBLYAI_SESSION_PATCH)
     def test_status_mapping(self, mock_session: mock.MagicMock, status_code: int, expected: bool) -> None:
-        mock_session.return_value.get.return_value = _resp({}, status=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("key", "us") is expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
-    )
+    @mock.patch(ASSEMBLYAI_SESSION_PATCH)
     def test_swallows_exceptions(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("key", "us") is False
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
-    )
-    def test_eu_region_probes_eu_host(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _resp({}, status=200)
+    @mock.patch(ASSEMBLYAI_SESSION_PATCH)
+    def test_eu_region_probes_eu_host_with_raw_key(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("key", "eu")
-        called_url = mock_session.return_value.get.call_args.args[0]
-        assert called_url.startswith("https://api.eu.assemblyai.com/v2/transcript")
+        call = mock_session.return_value.get.call_args
+        assert call.args[0].startswith("https://api.eu.assemblyai.com/v2/transcript")
+        # AssemblyAI takes the raw API key in Authorization — no "Bearer" prefix.
+        assert call.kwargs["headers"]["Authorization"] == "key"
 
 
-class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
-    )
-    def test_lists_then_hydrates_each_transcript(self, mock_session: mock.MagicMock) -> None:
+class TestAssemblyAIRows:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_lists_then_hydrates_each_transcript(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         next_url = "https://api.assemblyai.com/v2/transcript?limit=200&before_id=t2"
-        responses = {
-            US_LIST_URL: _list_page([{"id": "t1"}, {"id": "t2"}], next_url),
-            "https://api.assemblyai.com/v2/transcript/t1": {"id": "t1", "text": "hello", "status": "completed"},
-            "https://api.assemblyai.com/v2/transcript/t2": {"id": "t2", "text": "world", "status": "completed"},
-            next_url: _list_page([{"id": "t3"}], None),
-            "https://api.assemblyai.com/v2/transcript/t3": {"id": "t3", "text": "again", "status": "completed"},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+        requested = _wire(
+            session,
+            {
+                US_LIST_URL: _list_page([{"id": "t1"}, {"id": "t2"}], next_url),
+                "https://api.assemblyai.com/v2/transcript/t1": {"id": "t1", "text": "hello", "status": "completed"},
+                "https://api.assemblyai.com/v2/transcript/t2": {"id": "t2", "text": "world", "status": "completed"},
+                next_url: _list_page([{"id": "t3"}], None),
+                "https://api.assemblyai.com/v2/transcript/t3": {"id": "t3", "text": "again", "status": "completed"},
+            },
+        )
 
-        manager = _make_manager()
-        batches = list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
+        batches = _batches("key", "us", "transcripts", _make_manager())
 
         rows = [row for batch in batches for row in batch]
         # Rows are the hydrated full objects, not the list summaries.
         assert [r["id"] for r in rows] == ["t1", "t2", "t3"]
         assert all("text" in r for r in rows)
+        assert requested[0] == US_LIST_URL
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
-    )
-    def test_saves_state_after_each_page_only_when_more_remain(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_each_page_only_when_more_remain(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         next_url = "https://api.assemblyai.com/v2/transcript?limit=200&before_id=t1"
-        responses = {
-            US_LIST_URL: _list_page([{"id": "t1"}], next_url),
-            "https://api.assemblyai.com/v2/transcript/t1": {"id": "t1", "text": "hello"},
-            next_url: _list_page([{"id": "t2"}], None),
-            "https://api.assemblyai.com/v2/transcript/t2": {"id": "t2", "text": "world"},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+        _wire(
+            session,
+            {
+                US_LIST_URL: _list_page([{"id": "t1"}], next_url),
+                "https://api.assemblyai.com/v2/transcript/t1": {"id": "t1", "text": "hello"},
+                next_url: _list_page([{"id": "t2"}], None),
+                "https://api.assemblyai.com/v2/transcript/t2": {"id": "t2", "text": "world"},
+            },
+        )
 
         manager = _make_manager()
-        list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
+        _batches("key", "us", "transcripts", manager)
 
         # Only the first page has a next_url, so state is saved exactly once, pointing at page two.
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].next_url == next_url
+        assert manager.save_state.call_args.args[0] == AssemblyAIResumeConfig(next_url=next_url)
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
-    )
-    def test_resumes_from_saved_state(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         resume_url = "https://api.assemblyai.com/v2/transcript?limit=200&before_id=resume"
-        responses = {
-            resume_url: _list_page([{"id": "r1"}], None),
-            "https://api.assemblyai.com/v2/transcript/r1": {"id": "r1", "text": "resumed"},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+        requested = _wire(
+            session,
+            {
+                resume_url: _list_page([{"id": "r1"}], None),
+                "https://api.assemblyai.com/v2/transcript/r1": {"id": "r1", "text": "resumed"},
+            },
+        )
 
         manager = _make_manager(AssemblyAIResumeConfig(next_url=resume_url))
-        batches = list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
+        batches = _batches("key", "us", "transcripts", manager)
 
         rows = [row for batch in batches for row in batch]
         assert [r["id"] for r in rows] == ["r1"]
         # The initial list URL must never be requested when resuming.
-        requested = [call.args[0] for call in mock_session.return_value.get.call_args_list]
         assert US_LIST_URL not in requested
+        assert requested[0] == resume_url
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
-    )
-    def test_empty_list_yields_nothing(self, mock_session: mock.MagicMock) -> None:
-        responses = {US_LIST_URL: _list_page([], None)}
-        mock_session.return_value.get.side_effect = _url_router(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_list_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, {US_LIST_URL: _list_page([], None)})
 
         manager = _make_manager()
-        batches = list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
-
-        assert batches == []
+        assert _batches("key", "us", "transcripts", manager) == []
         manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_stops_even_with_next_url(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, {US_LIST_URL: _list_page([], "https://api.assemblyai.com/v2/transcript?before_id=x")})
+
+        manager = _make_manager()
+        assert _batches("key", "us", "transcripts", manager) == []
+        # The walk ends on the empty page — the advertised next page is never fetched.
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tampered_next_url_is_rejected(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            {
+                US_LIST_URL: _list_page([{"id": "t1"}], "https://evil.example.com/v2/transcript"),
+                "https://api.assemblyai.com/v2/transcript/t1": {"id": "t1", "text": "hello"},
+            },
+        )
+
+        with pytest.raises(ValueError, match="not on the selected host"):
+            _batches("key", "us", "transcripts", _make_manager())
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tampered_saved_state_is_rejected(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, {})
+
+        manager = _make_manager(AssemblyAIResumeConfig(next_url="https://evil.example.com/v2/transcript"))
+        with pytest.raises(ValueError, match="not on the selected host"):
+            _batches("key", "us", "transcripts", manager)
 
 
 class TestAssemblyAISource:
@@ -195,7 +253,9 @@ class TestAssemblyAISource:
         assert ENDPOINTS == ("transcripts",)
 
     def test_source_response_shape(self) -> None:
-        response = assemblyai_source("key", "us", "transcripts", mock.MagicMock(), _make_manager())
+        response = assemblyai_source(
+            "key", "us", "transcripts", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
         assert response.name == "transcripts"
         assert response.primary_keys == ["id"]
         assert response.partition_mode == "datetime"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai_source.py
@@ -142,6 +142,8 @@ class TestAssemblyAISource:
         assert kwargs["api_key"] == "key"
         assert kwargs["region"] == "us"
         assert kwargs["endpoint"] == "transcripts"
+        assert kwargs["team_id"] is inputs.team_id
+        assert kwargs["job_id"] is inputs.job_id
         assert kwargs["resumable_source_manager"] is manager
 
     def test_canonical_descriptions_keyed_by_endpoint(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/beamer/beamer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/beamer/beamer.py
@@ -1,24 +1,32 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.beamer.settings import (
     BEAMER_ENDPOINTS,
     BeamerEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    AuthConfig,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BEAMER_BASE_URL = "https://api.getbeamer.com/v0"
-REQUEST_TIMEOUT = 60
 # Beamer's `page` query param is documented as paginating alongside `maxResults` but the docs don't
 # state whether it's 0- or 1-based. We could not curl-verify against the live API without a paid key,
 # so we assume the common convention (page 1 = first page). If a real key shows it's 0-based, change
@@ -26,22 +34,41 @@ REQUEST_TIMEOUT = 60
 FIRST_PAGE = 1
 
 
-class BeamerRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class BeamerResumeConfig:
-    # Next page to fetch (1-based, see FIRST_PAGE).
+    # Next page to fetch (1-based, see FIRST_PAGE). Used by the top-level (non-fan-out) endpoints.
     page: int = FIRST_PAGE
-    # Fan-out bookmark: id of the parent currently being processed. A stable parent-id bookmark (not a
-    # positional index) so parents added/removed between a crash and the retry can't resume us into the
-    # wrong parent. None for the top-level (non-fan-out) endpoints.
+    # Legacy fan-out bookmark (id of the parent being processed). Kept only so previously saved
+    # state still parses (`ResumableSourceManager._load_json` does `dataclass(**saved)`); the
+    # framework fan-out now checkpoints into `fanout_state`, and an old-shape bookmark restarts
+    # the fan-out from scratch (merge dedupes the re-pulled rows).
     parent_id: str | None = None
+    # Framework fan-out checkpoint: {"completed": [child_path, ...], "current": child_path | None,
+    # "child_state": {"page": N} | None}.
+    fanout_state: dict | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {"Beamer-Api-Key": api_key, "Accept": "application/json"}
+class BeamerPageNumberPaginator(PageNumberPaginator):
+    """Page-number paginator that also stops on a short page.
+
+    Beamer list endpoints expose no total count (header or body); a page with fewer than
+    `maxResults` rows is the last one, so stopping there saves the extra empty-page request
+    the base paginator would otherwise pay.
+    """
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(base_page=FIRST_PAGE)
+        self.limit = limit
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and data is not None and len(data) < self.limit:
+            self._has_next_page = False
+
+
+def _auth_config(api_key: str) -> AuthConfig:
+    # Framework auth (not a hand-built header) so the key is redacted from logs/captured samples.
+    return {"type": "api_key", "api_key": api_key, "name": "Beamer-Api-Key", "location": "header"}
 
 
 def _format_datetime(value: Any) -> str:
@@ -54,39 +81,6 @@ def _format_datetime(value: Any) -> str:
     return str(value)
 
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    query = {key: value for key, value in params.items() if value is not None}
-    base = f"{BEAMER_BASE_URL}{path}"
-    return f"{base}?{urlencode(query)}" if query else base
-
-
-@retry(
-    retry=retry_if_exception_type((BeamerRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[dict[str, Any]]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
-
-    # 429 (rate limit) and 5xx are transient — back off and retry. Beamer allows 30 req/sec on paid
-    # plans plus a monthly quota, both of which surface as 429.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BeamerRetryableError(f"Beamer API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # 404 happens when a parent is deleted mid fan-out; the caller handles it. Everything else is
-        # a hard error (e.g. 401/403 bad-or-unscoped key) raised for `get_non_retryable_errors`.
-        log = logger.warning if response.status_code == 404 else logger.error
-        log(f"Beamer API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    # Beamer list endpoints return a bare JSON array.
-    return response.json()
-
-
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
     # A bad key 401s; a valid-but-unscoped key 403s (the 'Read posts' permission is optional). Both
     # mean the key is genuine, so only a 401 fails source-create — per-endpoint scope is surfaced
@@ -94,179 +88,161 @@ def validate_credentials(api_key: str) -> tuple[bool, str | None]:
     # statuses are inconclusive: reporting them as an invalid key would push users to needlessly
     # rotate a working credential (and re-enter it into a possibly-degraded environment), so they
     # get a generic retry message instead. `redact_values` masks the key from any captured sample.
-    url = _build_url("/posts", {"maxResults": 1})
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(url, headers=_get_headers(api_key), timeout=10)
-    except requests.RequestException:
-        return False, "Could not reach Beamer to validate the API key. Please try again."
-    if response.status_code in (200, 403):
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BEAMER_BASE_URL}/posts?maxResults=1",
+        headers={"Beamer-Api-Key": api_key, "Accept": "application/json"},
+        ok_statuses=(200, 403),
+    )
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status == 401:
         return False, "Invalid Beamer API key"
-    return False, f"Beamer could not validate the API key right now (status {response.status_code}). Please try again."
+    if status is None:
+        return False, "Could not reach Beamer to validate the API key. Please try again."
+    return False, f"Beamer could not validate the API key right now (status {status}). Please try again."
 
 
-def _iter_parent_ids(
-    session: requests.Session,
-    parent_config: BeamerEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-) -> Iterator[str]:
-    """Page through a parent collection (posts / feature requests) yielding each row's id."""
-    page = FIRST_PAGE
-    while True:
-        url = _build_url(parent_config.path, {"maxResults": parent_config.max_results, "page": page})
-        items = _fetch_page(session, url, headers, logger)
-        if not items:
-            break
-        for item in items:
-            # `id` is the required primary key on every parent row; direct access so a missing
-            # field fails loudly rather than silently dropping the parent's children.
-            yield str(item["id"])
-        if len(items) < parent_config.max_results:
-            break
-        page += 1
-
-
-def _iter_top_level_rows(
-    session: requests.Session,
+def _top_level_resource(
     config: BeamerEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    manager: ResumableSourceManager[BeamerResumeConfig],
-    base_params: dict[str, Any],
-    start_page: int,
-) -> Iterator[Any]:
-    page = start_page
-    while True:
-        url = _build_url(config.path, {**base_params, "page": page})
-        items = _fetch_page(session, url, headers, logger)
-        if not items:
-            break
-
-        has_more = len(items) >= config.max_results
-        last_index = len(items) - 1
-        for index, item in enumerate(items):
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # The batcher just flushed everything buffered up to this item, so checkpoint here.
-                # Advance to the next page only on the page's last item; a mid-page flush (the bytes
-                # cap firing before the count cap) leaves this page's tail un-batched, so resume from
-                # this same page and let merge dedupe the rows already flushed. Saving page+1 mid-page
-                # would skip those trailing items on a crash.
-                resume_page = page + 1 if index == last_index and has_more else page
-                manager.save_state(BeamerResumeConfig(page=resume_page))
-
-        if not has_more:
-            break
-        page += 1
-
-
-def _iter_fan_out_rows(
-    session: requests.Session,
-    config: BeamerEndpointConfig,
-    parent_config: BeamerEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    manager: ResumableSourceManager[BeamerResumeConfig],
-) -> Iterator[Any]:
-    assert config.parent_key is not None  # set on every fan-out endpoint in settings.py
-    parent_ids = list(_iter_parent_ids(session, parent_config, headers, logger))
-
-    # Resolve the saved parent-id bookmark to the slice of parents still to process. If the bookmarked
-    # parent no longer exists (deleted between runs), start over — merge dedupes the re-pulled rows.
-    resume = manager.load_state() if manager.can_resume() else None
-    remaining = parent_ids
-    resume_page = FIRST_PAGE
-    if resume is not None and resume.parent_id is not None and resume.parent_id in parent_ids:
-        remaining = parent_ids[parent_ids.index(resume.parent_id) :]
-        resume_page = resume.page
-        logger.debug(f"Beamer: resuming {config.name} from parent_id={resume.parent_id}, page={resume_page}")
-
-    for index, parent_id in enumerate(remaining):
-        page = resume_page if index == 0 else FIRST_PAGE
-        child_path = config.path.replace("{parent_id}", parent_id)
-        try:
-            while True:
-                url = _build_url(child_path, {"maxResults": config.max_results, "page": page})
-                items = _fetch_page(session, url, headers, logger)
-                if not items:
-                    break
-
-                has_more = len(items) >= config.max_results
-                last_index = len(items) - 1
-                for item_index, item in enumerate(items):
-                    batcher.batch({**item, config.parent_key: parent_id})
-                    if batcher.should_yield():
-                        yield batcher.get_table()
-                        # Same checkpoint rule as the top-level path: only advance the page on the
-                        # page's last item, otherwise resume from this page (merge dedupes).
-                        checkpoint_page = page + 1 if item_index == last_index and has_more else page
-                        manager.save_state(BeamerResumeConfig(page=checkpoint_page, parent_id=parent_id))
-
-                if not has_more:
-                    break
-                page += 1
-        except requests.HTTPError as exc:
-            # A parent deleted between enumeration and this fetch 404s. Skip it rather than failing the
-            # whole sync — the children are genuinely gone. Any other HTTP error is re-raised.
-            if exc.response is not None and exc.response.status_code == 404:
-                logger.warning(f"Beamer: {parent_config.name} {parent_id} not found while fetching {config.name}")
-            else:
-                raise
-
-        # Advance the bookmark to the next parent so a crash between parents resumes correctly — but
-        # only when the batcher holds no unflushed rows. If this parent's tail is still buffered,
-        # advancing past it would skip those rows on resume; we leave the last on-yield checkpoint in
-        # place instead (a crash re-fetches from there and merge dedupes).
-        if index + 1 < len(remaining) and not batcher.should_yield(include_incomplete_chunk=True):
-            manager.save_state(BeamerResumeConfig(page=FIRST_PAGE, parent_id=remaining[index + 1]))
-
-
-def get_rows(
     api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BeamerResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = BEAMER_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # One session reused across every page (and, for fan-out, every parent) so urllib3 keeps the
-    # connection alive instead of re-handshaking per request. `redact_values` masks the API key
-    # (sent in the `Beamer-Api-Key` header) from any captured HTTP samples or logged requests.
-    session = make_tracked_session(redact_values=(api_key,))
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[BeamerResumeConfig],
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Optional[Any],
+) -> Resource:
+    params: dict[str, Any] = {"maxResults": config.max_results}
+    if config.supports_incremental and should_use_incremental_field and db_incremental_field_last_value is not None:
+        params["dateFrom"] = _format_datetime(db_incremental_field_last_value)
 
-    if config.parent is not None:
-        parent_config = BEAMER_ENDPOINTS[config.parent]
-        yield from _iter_fan_out_rows(
-            session, config, parent_config, headers, logger, batcher, resumable_source_manager
-        )
-    else:
-        base_params: dict[str, Any] = {"maxResults": config.max_results}
-        if config.supports_incremental and should_use_incremental_field and db_incremental_field_last_value is not None:
-            base_params["dateFrom"] = _format_datetime(db_incremental_field_last_value)
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BEAMER_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": _auth_config(api_key),
+            "paginator": BeamerPageNumberPaginator(limit=config.max_results),
+        },
+        "resources": [
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Beamer list endpoints return a bare JSON array; a 200 with a non-list body
+                    # means the response shape changed — fail loud instead of syncing 0 rows.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
 
-        resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-        start_page = resume.page if resume is not None and resume.parent_id is None else FIRST_PAGE
-        yield from _iter_top_level_rows(
-            session, config, headers, logger, batcher, resumable_source_manager, base_params, start_page
-        )
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        # Only a top-level checkpoint (no fan-out bookmark of either shape) seeds the paginator.
+        if resume is not None and resume.parent_id is None and resume.fanout_state is None:
+            initial_paginator_state = {"page": resume.page}
 
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the hook fires AFTER a page is yielded, so a crash
+        # re-fetches the last checkpointed page (merge dedupes) rather than skipping rows.
+        if state and state.get("page") is not None:
+            manager.save_state(BeamerResumeConfig(page=int(state["page"])))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _fan_out_resource(
+    config: BeamerEndpointConfig,
+    parent_config: BeamerEndpointConfig,
+    api_key: str,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[BeamerResumeConfig],
+) -> Resource:
+    assert config.parent_key is not None  # set on every fan-out endpoint in settings.py
+    parent_key = config.parent_key
+    # include_from_parent injects the parent's id under `_{parent}_id`; rename it to the composite
+    # primary-key column and str-cast so child rows keep the exact shape the hand-rolled source
+    # produced (`{**item, parent_key: str(parent_id)}`).
+    prefixed_parent_id = f"_{parent_config.name}_id"
+
+    def _inject_parent_id(row: dict[str, Any]) -> dict[str, Any]:
+        row[parent_key] = str(row.pop(prefixed_parent_id))
+        return row
+
+    parent_resource: EndpointResource = {
+        "name": parent_config.name,
+        "endpoint": {
+            "path": parent_config.path,
+            "params": {"maxResults": parent_config.max_results},
+            "paginator": BeamerPageNumberPaginator(limit=parent_config.max_results),
+            "data_selector_required": True,
+        },
+    }
+    child_resource: EndpointResource = {
+        "name": config.name,
+        "include_from_parent": ["id"],
+        "data_map": _inject_parent_id,
+        "endpoint": {
+            "path": config.path,
+            "params": {
+                "parent_id": {"type": "resolve", "resource": parent_config.name, "field": "id"},
+                "maxResults": config.max_results,
+            },
+            "paginator": BeamerPageNumberPaginator(limit=config.max_results),
+            "data_selector_required": True,
+            # A parent deleted between enumeration and this fetch 404s. Skip it rather than failing
+            # the whole sync — the children are genuinely gone. Any other HTTP error still raises.
+            "response_actions": [{"status_code": 404, "action": "ignore"}],
+        },
+    }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BEAMER_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": _auth_config(api_key),
+        },
+        "resources": [parent_resource, child_resource],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        # An old-shape bookmark (`parent_id`) can't seed the framework fan-out — start that part
+        # fresh and let merge dedupe the re-pulled rows.
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state is not None:
+            manager.save_state(BeamerResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(resource for resource in resources if resource.name == config.name)
 
 
 def beamer_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BeamerResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -274,17 +250,24 @@ def beamer_source(
 ) -> SourceResponse:
     config = BEAMER_ENDPOINTS[endpoint]
 
+    if config.parent is not None:
+        resource = _fan_out_resource(
+            config, BEAMER_ENDPOINTS[config.parent], api_key, team_id, job_id, resumable_source_manager
+        )
+    else:
+        resource = _top_level_resource(
+            config,
+            api_key,
+            team_id,
+            job_id,
+            resumable_source_manager,
+            should_use_incremental_field,
+            db_incremental_field_last_value,
+        )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/beamer/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/beamer/source.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BeamerSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -85,7 +88,7 @@ Notes:
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # 401/403 surface as a requests HTTPError when `_fetch_page` calls `raise_for_status()`.
+            # 401/403 surface as a requests HTTPError when the rest_source client calls `raise_for_status()`.
             # Retrying can never satisfy a credential/permission problem, so fail the sync. Match the
             # stable status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://api.getbeamer.com": "Your Beamer API key is invalid or has been revoked. Generate a new key in your Beamer account settings, then reconnect.",
@@ -100,29 +103,23 @@ Notes:
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _description(endpoint: str) -> str | None:
-            if endpoint == "users":
-                return "Requires a Beamer Scale plan. Full refresh only"
-            if BEAMER_ENDPOINTS[endpoint].parent is not None:
-                return "Full refresh only (fanned out over every parent record)"
-            return None
-
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = BEAMER_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=endpoint_config.supports_incremental,
-                supports_append=endpoint_config.supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-                description=_description(endpoint),
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        descriptions = {
+            "users": "Requires a Beamer Scale plan. Full refresh only",
+            **{
+                endpoint: "Full refresh only (fanned out over every parent record)"
+                for endpoint, endpoint_config in BEAMER_ENDPOINTS.items()
+                if endpoint_config.parent is not None
+            },
+        }
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions=descriptions,
+            should_sync_default={
+                endpoint: endpoint_config.should_sync_default for endpoint, endpoint_config in BEAMER_ENDPOINTS.items()
+            },
+        )
 
     def validate_credentials(
         self, config: BeamerSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -141,7 +138,8 @@ Notes:
         return beamer_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/beamer/tests/test_beamer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/beamer/tests/test_beamer.py
@@ -1,23 +1,77 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
-from products.warehouse_sources.backend.temporal.data_imports.sources.beamer import beamer
 from products.warehouse_sources.backend.temporal.data_imports.sources.beamer.beamer import (
     BeamerResumeConfig,
-    _build_url,
     _format_datetime,
     beamer_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.beamer.settings import BEAMER_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the beamer module.
+BEAMER_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.beamer.beamer.make_tracked_session"
+)
+
+
+def _response(body: Any, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = "https://api.getbeamer.com/v0/mock"
+    resp.reason = "Error" if status >= 400 else "OK"
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: BeamerResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session, returning (url, params) snapshots captured AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[tuple[str, dict[str, Any]]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append((request.url, dict(request.params or {})))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None, **kwargs: Any):
+    return beamer_source(
+        api_key="key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job",
+        resumable_source_manager=manager or _make_manager(),
+        **kwargs,
+    )
 
 
 class TestFormatDatetime:
@@ -36,15 +90,6 @@ class TestFormatDatetime:
         assert "+00:00" not in _format_datetime(datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC))
 
 
-class TestBuildUrl:
-    def test_drops_none_params(self) -> None:
-        url = _build_url("/posts", {"maxResults": 10, "page": 1, "dateFrom": None})
-        assert url == "https://api.getbeamer.com/v0/posts?maxResults=10&page=1"
-
-    def test_no_params_has_no_query_string(self) -> None:
-        assert _build_url("/posts", {}) == "https://api.getbeamer.com/v0/posts"
-
-
 class TestValidateCredentials:
     @parameterized.expand(
         [
@@ -57,11 +102,9 @@ class TestValidateCredentials:
         ]
     )
     def test_status_mapping(self, _name: str, status_code: int, expected_ok: bool, expected_msg: str | None) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(beamer, "make_tracked_session", return_value=session):
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=status_code)
+        with mock.patch(BEAMER_SESSION_PATCH, return_value=session):
             ok, message = validate_credentials("key")
         assert ok is expected_ok
         if expected_msg is None:
@@ -71,195 +114,286 @@ class TestValidateCredentials:
 
     def test_network_error_is_inconclusive_not_invalid(self) -> None:
         # A transport failure must not be reported as an invalid key.
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = requests.ConnectionError()
-        with patch.object(beamer, "make_tracked_session", return_value=session):
+        with mock.patch(BEAMER_SESSION_PATCH, return_value=session):
             ok, message = validate_credentials("key")
         assert ok is False
         assert message is not None and "Could not reach Beamer" in message
 
-
-class _FakeResumableManager:
-    def __init__(self, state: BeamerResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BeamerResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> BeamerResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: BeamerResumeConfig) -> None:
-        self.saved.append(data)
-
-
-def _collect(
-    monkeypatch: Any,
-    endpoint: str,
-    pages: dict[str, Any],
-    manager: _FakeResumableManager | None = None,
-    **kwargs: Any,
-) -> tuple[list[dict], list[str]]:
-    """Run get_rows against a fake page map keyed by URL, returning (rows, fetched_urls)."""
-    fetched: list[str] = []
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> Any:
-        fetched.append(url)
-        result = pages[url]
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    monkeypatch.setattr(beamer, "_fetch_page", fake_fetch)
-    monkeypatch.setattr(beamer, "make_tracked_session", lambda *args, **kwargs: MagicMock())
-
-    rows: list[dict] = []
-    for table in get_rows(
-        api_key="key",
-        endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager or _FakeResumableManager(),  # type: ignore[arg-type]
-        **kwargs,
-    ):
-        rows.extend(table.to_pylist())
-    return rows, fetched
+    def test_probe_sends_api_key_header(self) -> None:
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=200)
+        with mock.patch(BEAMER_SESSION_PATCH, return_value=session):
+            validate_credentials("key")
+        _, kwargs = session.get.call_args
+        assert kwargs["headers"]["Beamer-Api-Key"] == "key"
 
 
 class TestTopLevelPagination:
-    def test_paginates_until_short_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.getbeamer.com/v0/posts?maxResults=10&page=1": [
-                {"id": i, "date": "2026-01-01"} for i in range(10)
-            ],
-            "https://api.getbeamer.com/v0/posts?maxResults=10&page=2": [{"id": 10, "date": "2026-01-02"}],
-        }
-        rows, fetched = _collect(monkeypatch, "posts", pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": i, "date": "2026-01-01"} for i in range(10)]
+        snapshots = _wire(session, [_response(full_page), _response([{"id": 10, "date": "2026-01-02"}])])
+
+        rows = _rows(_source("posts"))
+
         assert [r["id"] for r in rows] == list(range(11))
         # Stops after the short second page; never requests page 3.
-        assert fetched == [
-            "https://api.getbeamer.com/v0/posts?maxResults=10&page=1",
-            "https://api.getbeamer.com/v0/posts?maxResults=10&page=2",
-        ]
+        assert session.send.call_count == 2
+        assert snapshots[0][0] == "https://api.getbeamer.com/v0/posts"
+        assert snapshots[0][1] == {"maxResults": 10, "page": 1}
+        assert snapshots[1][1] == {"maxResults": 10, "page": 2}
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        pages: dict[str, list[dict[str, Any]]] = {"https://api.getbeamer.com/v0/posts?maxResults=10&page=1": []}
-        rows, fetched = _collect(monkeypatch, "posts", pages)
-        assert rows == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
-    def test_incremental_adds_datefrom(self, monkeypatch: Any) -> None:
-        url = "https://api.getbeamer.com/v0/posts?maxResults=10&dateFrom=2026-03-04T02%3A58%3A14Z&page=1"
-        pages = {url: [{"id": 1, "date": "2026-03-05"}]}
-        rows, fetched = _collect(
-            monkeypatch,
-            "posts",
-            pages,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
-            incremental_field="date",
+        assert _rows(_source("posts")) == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_adds_datefrom(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 1, "date": "2026-03-05"}])])
+
+        rows = _rows(
+            _source(
+                "posts",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+                incremental_field="date",
+            )
         )
+
         assert rows == [{"id": 1, "date": "2026-03-05"}]
-        assert "dateFrom=2026-03-04T02%3A58%3A14Z" in fetched[0]
+        assert snapshots[0][1]["dateFrom"] == "2026-03-04T02:58:14Z"
 
-    def test_nps_uses_larger_page_size(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.getbeamer.com/v0/nps?maxResults=100&page=1": [{"id": 1, "date": "2026-01-01", "score": 9}]
-        }
-        rows, fetched = _collect(monkeypatch, "nps", pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_datefrom_without_incremental(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 1, "date": "2026-01-01"}])])
+
+        _rows(_source("posts"))
+        assert "dateFrom" not in snapshots[0][1]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_nps_uses_larger_page_size(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 1, "date": "2026-01-01", "score": 9}])])
+
+        rows = _rows(_source("nps"))
         assert rows[0]["score"] == 9
-        assert "maxResults=100" in fetched[0]
+        assert snapshots[0][0] == "https://api.getbeamer.com/v0/nps"
+        assert snapshots[0][1]["maxResults"] == 100
 
-    def test_resume_starts_from_saved_page(self, monkeypatch: Any) -> None:
-        pages = {"https://api.getbeamer.com/v0/posts?maxResults=10&page=3": [{"id": 99, "date": "2026-01-01"}]}
-        manager = _FakeResumableManager(BeamerResumeConfig(page=3, parent_id=None))
-        rows, fetched = _collect(monkeypatch, "posts", pages, manager=manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_starts_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 99, "date": "2026-01-01"}])])
+
+        manager = _make_manager(BeamerResumeConfig(page=3, parent_id=None))
+        rows = _rows(_source("posts", manager=manager))
+
         assert rows == [{"id": 99, "date": "2026-01-01"}]
-        assert fetched == ["https://api.getbeamer.com/v0/posts?maxResults=10&page=3"]
+        assert snapshots[0][1]["page"] == 3
 
-    def test_mid_page_yield_checkpoints_current_page_not_next(self, monkeypatch: Any) -> None:
-        # Force a flush on every item (chunk_size=1) so we can observe the per-item checkpoint. A
-        # mid-page flush must save the current page, not page+1 — saving page+1 mid-page would skip
-        # the page's un-batched tail on a crash. Only the page's final item advances the checkpoint.
-        monkeypatch.setattr(beamer, "Batcher", lambda **kwargs: Batcher(logger=MagicMock(), chunk_size=1))
-        pages = {
-            "https://api.getbeamer.com/v0/posts?maxResults=10&page=1": [
-                {"id": i, "date": "2026-01-01"} for i in range(10)
-            ],
-            "https://api.getbeamer.com/v0/posts?maxResults=10&page=2": [{"id": 10, "date": "2026-01-02"}],
-        }
-        manager = _FakeResumableManager()
-        _collect(monkeypatch, "posts", pages, manager=manager)
-        saved_pages = [state.page for state in manager.saved]
-        # Page 1 is full: its first nine items checkpoint page 1, its last item advances to page 2.
-        # Page 2 is short (no further pages): its lone item checkpoints page 2, never page 3.
-        assert saved_pages == [1] * 9 + [2, 2]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_checkpoints_next_page_and_short_page_does_not(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": i, "date": "2026-01-01"} for i in range(10)]
+        _wire(session, [_response(full_page), _response([{"id": 10, "date": "2026-01-02"}])])
+
+        manager = _make_manager()
+        _rows(_source("posts", manager=manager))
+
+        # The checkpoint fires AFTER a page is yielded and points at the next page, so a crash
+        # re-fetches the last checkpointed page (merge dedupes) rather than skipping rows. The
+        # short final page leaves no checkpoint behind.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BeamerResumeConfig(page=2)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unexpected"})])
+
+        # A 200 body that isn't a bare array means the response shape changed — fail loud, not 0 rows.
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source("posts"))
 
 
 class TestFanOut:
-    def _post_pages(self, extra: dict[str, Any]) -> dict[str, Any]:
-        pages = {
-            "https://api.getbeamer.com/v0/posts?maxResults=10&page=1": [{"id": "P1"}, {"id": "P2"}],
-        }
-        pages.update(extra)
-        return pages
-
-    def test_injects_parent_id_into_child_rows(self, monkeypatch: Any) -> None:
-        pages = self._post_pages(
-            {
-                "https://api.getbeamer.com/v0/posts/P1/comments?maxResults=10&page=1": [
-                    {"id": "C1", "date": "2026-01-01", "text": "hi"}
-                ],
-                "https://api.getbeamer.com/v0/posts/P2/comments?maxResults=10&page=1": [
-                    {"id": "C2", "date": "2026-01-02", "text": "yo"}
-                ],
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_injects_parent_id_into_child_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "P1"}, {"id": "P2"}]),
+                _response([{"id": "C1", "date": "2026-01-01", "text": "hi"}]),
+                _response([{"id": "C2", "date": "2026-01-02", "text": "yo"}]),
+            ],
         )
-        rows, _ = _collect(monkeypatch, "post_comments", pages)
+
+        rows = _rows(_source("post_comments"))
+
         assert rows == [
             {"id": "C1", "date": "2026-01-01", "text": "hi", "post_id": "P1"},
             {"id": "C2", "date": "2026-01-02", "text": "yo", "post_id": "P2"},
         ]
+        assert [url for url, _ in snapshots] == [
+            "https://api.getbeamer.com/v0/posts",
+            "https://api.getbeamer.com/v0/posts/P1/comments",
+            "https://api.getbeamer.com/v0/posts/P2/comments",
+        ]
+        # Child pages use the child's page size, not the parent's.
+        assert snapshots[1][1] == {"maxResults": 10, "page": 1}
 
-    def test_feature_request_votes_inject_feature_request_id(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.getbeamer.com/v0/requests?maxResults=10&page=1": [{"id": "R1"}],
-            "https://api.getbeamer.com/v0/requests/R1/votes?maxResults=10&page=1": [{"id": "V1", "date": "2026-01-01"}],
-        }
-        rows, _ = _collect(monkeypatch, "feature_request_votes", pages)
-        assert rows == [{"id": "V1", "date": "2026-01-01", "feature_request_id": "R1"}]
-
-    def test_deleted_parent_404_is_skipped(self, monkeypatch: Any) -> None:
-        not_found = requests.HTTPError(response=MagicMock(status_code=404))
-        pages = self._post_pages(
-            {
-                "https://api.getbeamer.com/v0/posts/P1/comments?maxResults=10&page=1": not_found,
-                "https://api.getbeamer.com/v0/posts/P2/comments?maxResults=10&page=1": [
-                    {"id": "C2", "date": "2026-01-02"}
-                ],
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_numeric_parent_id_is_stringified(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": 42}]),
+                _response([{"id": "C1", "date": "2026-01-01"}]),
+            ],
         )
-        rows, _ = _collect(monkeypatch, "post_comments", pages)
+
+        rows = _rows(_source("post_comments"))
+        # The composite primary key column keeps the string shape the hand-rolled source produced.
+        assert rows == [{"id": "C1", "date": "2026-01-01", "post_id": "42"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_feature_request_votes_inject_feature_request_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "R1"}]),
+                _response([{"id": "V1", "date": "2026-01-01"}]),
+            ],
+        )
+
+        rows = _rows(_source("feature_request_votes"))
+        assert rows == [{"id": "V1", "date": "2026-01-01", "feature_request_id": "R1"}]
+        assert snapshots[1][0] == "https://api.getbeamer.com/v0/requests/R1/votes"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_deleted_parent_404_is_skipped(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "P1"}, {"id": "P2"}]),
+                _response({"error": "not found"}, status=404),
+                _response([{"id": "C2", "date": "2026-01-02"}]),
+            ],
+        )
+
+        # A parent deleted between enumeration and the child fetch 404s — skip it rather than
+        # failing the whole sync; the remaining parents still sync.
+        rows = _rows(_source("post_comments"))
         assert rows == [{"id": "C2", "date": "2026-01-02", "post_id": "P2"}]
 
-    def test_non_404_error_propagates(self, monkeypatch: Any) -> None:
-        server_error = requests.HTTPError(response=MagicMock(status_code=500))
-        pages = self._post_pages({"https://api.getbeamer.com/v0/posts/P1/comments?maxResults=10&page=1": server_error})
-        with pytest.raises(requests.HTTPError):
-            _collect(monkeypatch, "post_comments", pages)
-
-    def test_resume_from_bookmarked_parent(self, monkeypatch: Any) -> None:
-        # Bookmarked at P2 — P1 is skipped, P2 resumed at page 2.
-        pages = self._post_pages(
-            {
-                "https://api.getbeamer.com/v0/posts/P2/comments?maxResults=10&page=2": [
-                    {"id": "C9", "date": "2026-01-09"}
-                ],
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_404_error_propagates(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "P1"}]),
+                _response({"error": "forbidden"}, status=403),
+            ],
         )
-        manager = _FakeResumableManager(BeamerResumeConfig(page=2, parent_id="P2"))
-        rows, fetched = _collect(monkeypatch, "post_comments", pages, manager=manager)
+
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("post_comments"))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_parents_and_resumes_child_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "P1"}, {"id": "P2"}]),
+                _response([{"id": "C9", "date": "2026-01-09"}]),
+            ],
+        )
+
+        manager = _make_manager(
+            BeamerResumeConfig(
+                fanout_state={
+                    "completed": ["/posts/P1/comments"],
+                    "current": "/posts/P2/comments",
+                    "child_state": {"page": 2},
+                }
+            )
+        )
+        rows = _rows(_source("post_comments", manager=manager))
+
         assert rows == [{"id": "C9", "date": "2026-01-09", "post_id": "P2"}]
-        assert "https://api.getbeamer.com/v0/posts/P1/comments?maxResults=10&page=1" not in fetched
+        assert [url for url, _ in snapshots] == [
+            "https://api.getbeamer.com/v0/posts",
+            "https://api.getbeamer.com/v0/posts/P2/comments",
+        ]
+        assert snapshots[1][1]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_fanout_state_as_parents_complete(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "P1"}, {"id": "P2"}]),
+                _response([{"id": "C1", "date": "2026-01-01"}]),
+                _response([{"id": "C2", "date": "2026-01-02"}]),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("post_comments", manager=manager))
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert all(isinstance(state, BeamerResumeConfig) and state.fanout_state is not None for state in saved)
+        # The final checkpoint records both parents as fully synced with no child mid-stream.
+        final = saved[-1].fanout_state
+        assert final == {
+            "completed": ["/posts/P1/comments", "/posts/P2/comments"],
+            "current": None,
+            "child_state": None,
+        }
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_old_shape_resume_state_restarts_fanout(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "P1"}, {"id": "P2"}]),
+                _response([{"id": "C1", "date": "2026-01-01"}]),
+                _response([{"id": "C2", "date": "2026-01-02"}]),
+            ],
+        )
+
+        # A pre-migration bookmark (parent_id) can't seed the framework fan-out — the sync starts
+        # that part fresh and merge dedupes the re-pulled rows.
+        manager = _make_manager(BeamerResumeConfig(page=2, parent_id="P2"))
+        rows = _rows(_source("post_comments", manager=manager))
+
+        assert [r["post_id"] for r in rows] == ["P1", "P2"]
+        assert snapshots[1][1]["page"] == 1
+
+    def test_old_shape_saved_state_still_parses(self) -> None:
+        # ResumableSourceManager._load_json does dataclass(**saved) — state saved before the
+        # migration must still construct.
+        state = BeamerResumeConfig(**{"page": 3, "parent_id": "P2"})
+        assert state.page == 3
+        assert state.parent_id == "P2"
+        assert state.fanout_state is None
 
 
 class TestBeamerSourceResponse:
@@ -273,27 +407,22 @@ class TestBeamerSourceResponse:
             ("feature_request_votes", ["feature_request_id", "id"], "date", "asc"),
         ]
     )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_source_response_shape(
-        self, endpoint: str, primary_keys: list[str], partition_key: str, sort_mode: str
+        self, endpoint: str, primary_keys: list[str], partition_key: str, sort_mode: str, MockSession
     ) -> None:
-        response = beamer_source(
-            api_key="key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        response = _source(endpoint)
         assert response.name == endpoint
         assert response.primary_keys == primary_keys
         assert response.partition_keys == [partition_key]
         assert response.partition_mode == "datetime"
         assert response.sort_mode == sort_mode
 
-    def test_incremental_endpoints_sort_desc(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_endpoints_sort_desc(self, MockSession) -> None:
         # Endpoints with a server-side dateFrom filter must use "desc" so the watermark is only
         # persisted at the end of a successful sync (we can't verify the API's default sort order).
         for name, config in BEAMER_ENDPOINTS.items():
-            response = beamer_source(
-                api_key="key", endpoint=name, logger=MagicMock(), resumable_source_manager=MagicMock()
-            )
+            response = _source(name)
             expected = "desc" if config.supports_incremental else "asc"
             assert response.sort_mode == expected, name

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/bigmailer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/bigmailer.py
@@ -1,10 +1,9 @@
 import dataclasses
 from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
+from requests import Response
+from requests.exceptions import HTTPError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigmailer.settings import (
@@ -12,13 +11,23 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigmailer.
     BigMailerEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BIGMAILER_BASE_URL = "https://api.bigmailer.io/v1"
 # The API caps list responses at 100 objects per page; request the max to minimise round trips
 # against the 10 req/s account rate limit.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
 
 # Stable substring matched by BigMailerSource.get_non_retryable_errors to permanently fail the sync
 # on a credential problem instead of retrying. Kept identical to the raised exception text.
@@ -35,174 +44,212 @@ class BigMailerAuthError(Exception):
 
 @dataclasses.dataclass
 class BigMailerResumeConfig:
-    # Cursor for the next page to fetch. None starts a list at its first page.
+    # Cursor for the next page to fetch on a top-level (account-wide) endpoint. None starts a list
+    # at its first page.
     cursor: str | None = None
-    # The brand currently being processed. A stable brand-ID bookmark (not a positional index) so a
-    # brand added or removed between a crash and the retry can't resume us into the wrong brand. None
-    # for the account-level endpoints (brands, users).
+    # Pre-framework brand bookmark. Kept (with a default) so previously saved state still parses;
+    # no longer written — brand-scoped resume now lives in fanout_state.
     brand_id: str | None = None
+    # Framework fan-out resume state for brand-scoped endpoints:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: dict | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {"X-API-Key": api_key, "Accept": "application/json"}
+class BigMailerCursorPaginator(JSONResponseCursorPaginator):
+    """BigMailer always echoes a `cursor` in list bodies, even on the last page; only `has_more`
+    signals that another page exists, so advancing is gated on it rather than on cursor presence."""
+
+    def __init__(self) -> None:
+        super().__init__(cursor_path="cursor", cursor_param="cursor")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        next_cursor = body.get("cursor") if isinstance(body, dict) and body.get("has_more") else None
+        if next_cursor:
+            self._cursor_value = next_cursor
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
 
 
-def _build_url(path: str, cursor: str | None) -> str:
-    params: dict[str, Any] = {"limit": PAGE_SIZE}
-    if cursor:
-        params["cursor"] = cursor
-    return f"{BIGMAILER_BASE_URL}{path}?{urlencode(params)}"
+def _client_config(api_key: str) -> ClientConfig:
+    # Framework auth (not a hand-built header) so the key is redacted from logged URLs/headers/samples.
+    return {
+        "base_url": BIGMAILER_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "api_key", "name": "X-API-Key", "api_key": api_key, "location": "header"},
+        "paginator": BigMailerCursorPaginator(),
+    }
 
 
-def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> dict:
-    """Fetch a single list page. The tracked session retries 429/5xx with backoff, so by the time we
-    inspect the response any transient errors are already exhausted."""
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+def _raise_auth_errors(resource: Resource) -> Iterator[list[dict[str, Any]]]:
+    """Convert HTTP credential failures into the stable non-retryable auth error.
 
-    # An invalid key returns 400 with `{"type": "invalid_request_error", "message": "Invalid api key"}`;
-    # insufficient permissions surface as 401/403. None of these are retryable.
-    if response.status_code in (401, 403) or (response.status_code == 400 and "api key" in response.text.lower()):
-        raise BigMailerAuthError(AUTH_ERROR_MESSAGE)
-
-    if not response.ok:
-        logger.error(f"BigMailer API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _iter_pages(
-    session: requests.Session,
-    path: str,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[BigMailerResumeConfig],
-    start_cursor: str | None,
-    brand_id: str | None,
-) -> Iterator[list[dict]]:
-    """Page through a list endpoint, yielding one page of raw rows at a time.
-
-    Saves resume state AFTER yielding each page (pointing at the next page) so a crash re-fetches the
-    in-flight page rather than skipping it — the merge dedupes the re-pulled rows on the primary key.
+    An invalid key returns 400 with `{"type": "invalid_request_error", "message": "Invalid api key"}`;
+    insufficient permissions surface as 401/403. None of these are retryable. Any other HTTP error
+    (e.g. a non-auth 400 or a 404) propagates unchanged so a transient request bug isn't misreported
+    as a credential problem.
     """
-    cursor = start_cursor
-    while True:
-        data = _fetch_page(session, _build_url(path, cursor), logger)
-        items = data.get("data", []) or []
-
-        if items:
-            yield items
-
-        # The API always returns a `cursor`, but only `has_more` tells us another page exists.
-        next_cursor = data.get("cursor") if data.get("has_more") else None
-        if not next_cursor:
-            break
-        manager.save_state(BigMailerResumeConfig(cursor=next_cursor, brand_id=brand_id))
-        cursor = next_cursor
-
-
-def _iter_brand_ids(session: requests.Session, logger: FilteringBoundLogger) -> Iterator[str]:
-    """Page through /brands and yield each brand id, for fanning out brand-scoped endpoints."""
-    cursor: str | None = None
-    while True:
-        data = _fetch_page(session, _build_url("/brands", cursor), logger)
-        for item in data.get("data", []) or []:
-            yield item["id"]
-        cursor = data.get("cursor") if data.get("has_more") else None
-        if not cursor:
-            break
-
-
-def _get_top_level_rows(
-    session: requests.Session,
-    config: BigMailerEndpointConfig,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[BigMailerResumeConfig],
-) -> Iterator[list[dict]]:
-    resume = manager.load_state() if manager.can_resume() else None
-    start_cursor = resume.cursor if resume else None
-    yield from _iter_pages(session, config.path, logger, manager, start_cursor, brand_id=None)
-
-
-def _get_brand_scoped_rows(
-    session: requests.Session,
-    config: BigMailerEndpointConfig,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[BigMailerResumeConfig],
-) -> Iterator[list[dict]]:
-    """Fan out a brand-scoped endpoint over every brand, injecting `brand_id` into each row.
-
-    Child objects (lists, segments, campaigns, …) don't carry their brand id in the response, so we
-    add it here to keep the composite ["brand_id", "id"] key unique across the whole table.
-    """
-    brand_ids = list(_iter_brand_ids(session, logger))
-
-    # Resolve the saved brand-ID bookmark to the slice of brands still to process. If the bookmarked
-    # brand no longer exists (deleted between runs), start over — merge dedupes the re-pulled rows.
-    resume = manager.load_state() if manager.can_resume() else None
-    remaining = brand_ids
-    resume_cursor: str | None = None
-    if resume is not None and resume.brand_id is not None and resume.brand_id in brand_ids:
-        remaining = brand_ids[brand_ids.index(resume.brand_id) :]
-        resume_cursor = resume.cursor
-        logger.debug(f"BigMailer: resuming {config.name} from brand_id={resume.brand_id}, cursor={resume_cursor}")
-
-    for index, brand_id in enumerate(remaining):
-        path = config.path.format(brand_id=brand_id)
-        start_cursor = resume_cursor  # only the resumed-into brand uses the saved cursor
-        resume_cursor = None
-
-        for items in _iter_pages(session, path, logger, manager, start_cursor, brand_id=brand_id):
-            yield [{**item, "brand_id": brand_id} for item in items]
-
-        # Advance the bookmark to the next brand so a crash between brands resumes correctly. Its first
-        # page is fetched fresh (cursor=None).
-        if index + 1 < len(remaining):
-            manager.save_state(BigMailerResumeConfig(cursor=None, brand_id=remaining[index + 1]))
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[BigMailerResumeConfig],
-) -> Iterator[list[dict]]:
-    config = BIGMAILER_ENDPOINTS[endpoint]
-    # One session reused across every page (and every brand, for fan-out) so urllib3 keeps the
-    # connection alive instead of re-handshaking per request. The api key is redacted from logged URLs.
-    session = make_tracked_session(headers=_get_headers(api_key), redact_values=(api_key,))
-
-    if config.brand_scoped:
-        yield from _get_brand_scoped_rows(session, config, logger, manager)
-    else:
-        yield from _get_top_level_rows(session, config, logger, manager)
-
-
-def validate_credentials(api_key: str) -> bool:
-    """Cheap probe that the key is genuine. /brands is account-wide and always reachable for a valid
-    key, so a 200 confirms the credential without needing any specific brand or scope."""
     try:
-        session = make_tracked_session(headers=_get_headers(api_key), redact_values=(api_key,))
-        response = session.get(_build_url("/brands", cursor=None), timeout=REQUEST_TIMEOUT_SECONDS)
-        return response.status_code == 200
-    except Exception:
-        return False
+        yield from resource
+    except HTTPError as e:
+        response = e.response
+        if response is not None and (
+            response.status_code in (401, 403) or (response.status_code == 400 and "api key" in response.text.lower())
+        ):
+            raise BigMailerAuthError(AUTH_ERROR_MESSAGE) from e
+        raise
+
+
+def _top_level_resource(
+    api_key: str,
+    config: BigMailerEndpointConfig,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[BigMailerResumeConfig],
+) -> Resource:
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": PAGE_SIZE},
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None and resume.cursor is not None:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint is saved AFTER a page is yielded so a
+        # crash re-fetches the in-flight page (the merge dedupes re-pulled rows) rather than skipping it.
+        if state and state.get("cursor"):
+            manager.save_state(BigMailerResumeConfig(cursor=str(state["cursor"])))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _inject_brand_id(row: dict[str, Any]) -> dict[str, Any]:
+    # include_from_parent lands the parent brand's id as `_brands_id`; rename it to the `brand_id`
+    # column the composite ["brand_id", "id"] key expects. Child objects (lists, segments,
+    # campaigns, …) don't carry their brand id in the response, so this keeps the key unique
+    # across the whole table.
+    if "_brands_id" in row:
+        row["brand_id"] = row.pop("_brands_id")
+    return row
+
+
+def _brand_scoped_resource(
+    api_key: str,
+    config: BigMailerEndpointConfig,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[BigMailerResumeConfig],
+) -> Resource:
+    """Fan out a brand-scoped endpoint over every brand via a dependent resource: the framework
+    lists /brands and pages each brand's child list, injecting `brand_id` into every row."""
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": "brands",
+                "endpoint": {
+                    "path": "/brands",
+                    "params": {"limit": PAGE_SIZE},
+                    "data_selector": "data",
+                },
+            },
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {
+                        "limit": PAGE_SIZE,
+                        "brand_id": {"type": "resolve", "resource": "brands", "field": "id"},
+                    },
+                    "data_selector": "data",
+                },
+                "include_from_parent": ["id"],
+                "data_map": _inject_brand_id,
+            },
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        # Only framework-shaped fan-out state is resumable. A pre-migration bookmark (cursor/brand_id)
+        # can't be translated into the completed/current path map, so such a sync restarts fresh —
+        # safe, because the merge dedupes re-pulled rows on the primary key.
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state:
+            manager.save_state(BigMailerResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(r for r in resources if r.name == config.name)
 
 
 def bigmailer_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[BigMailerResumeConfig],
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[BigMailerResumeConfig],
 ) -> SourceResponse:
     config = BIGMAILER_ENDPOINTS[endpoint]
 
+    if config.brand_scoped:
+        resource = _brand_scoped_resource(api_key, config, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _top_level_resource(api_key, config, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_key=api_key, endpoint=endpoint, logger=logger, manager=manager),
+        items=lambda: _raise_auth_errors(resource),
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime",
         partition_format="month",
         partition_keys=[config.partition_key],
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Cheap probe that the key is genuine. /brands is account-wide and always reachable for a valid
+    key, so a 200 confirms the credential without needing any specific brand or scope."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BIGMAILER_BASE_URL}/brands?limit=1",
+        headers={"X-API-Key": api_key, "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/source.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BigMailerSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -95,22 +98,16 @@ Create an API key in your BigMailer console under **Account Settings → API Key
     ) -> list[SourceSchema]:
         # BigMailer has no server-side timestamp filter on any list endpoint, and cursor pagination
         # doesn't accept a sort param — an "incremental" sync would still page through everything, so
-        # every table is full refresh only.
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = BIGMAILER_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # every table is full refresh only (no incremental fields declared).
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            {},
+            names,
+            should_sync_default={
+                endpoint: endpoint_config.should_sync_default
+                for endpoint, endpoint_config in BIGMAILER_ENDPOINTS.items()
+            },
+        )
 
     def validate_credentials(
         self, config: BigMailerSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -132,6 +129,7 @@ Create an API key in your BigMailer console under **Account Settings → API Key
         return bigmailer_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
-            manager=resumable_source_manager,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/tests/test_bigmailer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/tests/test_bigmailer.py
@@ -1,79 +1,274 @@
+import json
+from typing import Any
+
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.bigmailer import bigmailer
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigmailer.bigmailer import (
     AUTH_ERROR_MESSAGE,
     BigMailerAuthError,
     BigMailerResumeConfig,
-    _build_url,
-    _fetch_page,
     bigmailer_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the bigmailer module.
+BIGMAILER_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.bigmailer.bigmailer.make_tracked_session"
+)
 
 
-def _resp(status: int = 200, body: dict | None = None, text: str = "") -> MagicMock:
-    response = MagicMock(spec=requests.Response)
-    response.status_code = status
-    response.ok = 200 <= status < 400
-    response.json.return_value = body if body is not None else {}
-    response.text = text
-
-    def raise_for_status() -> None:
-        if not response.ok:
-            raise requests.HTTPError(f"{status} error", response=response)
-
-    response.raise_for_status.side_effect = raise_for_status
-    return response
+def _response(body: dict[str, Any] | None = None, *, status: int = 200, text: str | None = None) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = text.encode() if text is not None else json.dumps(body if body is not None else {}).encode()
+    return resp
 
 
-class FakeManager(ResumableSourceManager[BigMailerResumeConfig]):
-    """Stand-in for ResumableSourceManager: records saved state and replays a seeded resume state.
+def _page(items: list[dict[str, Any]], *, has_more: bool = False, cursor: str | None = None) -> Response:
+    # The API always returns a `cursor`; only `has_more` tells us another page exists.
+    return _response({"data": items, "has_more": has_more, "cursor": cursor if cursor is not None else "ignored"})
 
-    Overrides every method `get_rows` touches, so the Redis-bound base `__init__` is skipped.
+
+def _make_manager(resume_state: BigMailerResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session and return (url, params) snapshots captured AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
     """
+    session.headers = {}
+    snapshots: list[tuple[str, dict[str, Any]]] = []
 
-    def __init__(self, state: BigMailerResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BigMailerResumeConfig] = []
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append((request.url, dict(request.params or {})))
+        return mock.MagicMock()
 
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> BigMailerResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: BigMailerResumeConfig) -> None:
-        self.saved.append(data)
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _session_returning(*responses: MagicMock) -> MagicMock:
-    session = MagicMock()
-    session.get.side_effect = list(responses)
-    return session
+def _source(endpoint: str, manager: mock.MagicMock | None = None) -> SourceResponse:
+    return bigmailer_source(
+        api_key="key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+    )
 
 
-def _requested_urls(session: MagicMock) -> list[str]:
-    return [call.args[0] for call in session.get.call_args_list]
+def _rows(source_response: SourceResponse) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
-class TestBuildUrl:
-    def test_includes_limit_and_no_cursor(self) -> None:
-        assert _build_url("/brands", None) == "https://api.bigmailer.io/v1/brands?limit=100"
+class TestTopLevelPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_cursor_until_has_more_false(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _page([{"id": "b1", "created": 1}], has_more=True, cursor="C2=="),
+                _page([{"id": "b2", "created": 2}], has_more=False, cursor="ignored"),
+            ],
+        )
 
-    def test_cursor_is_percent_encoded(self) -> None:
-        # BigMailer cursors are base64 and contain `==`; leaving them raw would corrupt the query string.
-        url = _build_url("/brands/b1/contacts", "K5pwIGH3hgYrhytbDUY5eQ==")
-        assert "cursor=K5pwIGH3hgYrhytbDUY5eQ%3D%3D" in url
+        rows = _rows(_source("brands"))
+
+        assert [r["id"] for r in rows] == ["b1", "b2"]
+        assert snapshots[0][1] == {"limit": 100}
+        # second request must carry the cursor from page one
+        assert snapshots[1][1] == {"limit": 100, "cursor": "C2=="}
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_does_not_inject_brand_id_for_top_level(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "b1", "created": 1}])])
+
+        rows = _rows(_source("brands"))
+        assert "brand_id" not in rows[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_cursor_after_yielding_each_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "b1"}], has_more=True, cursor="C2=="), _page([{"id": "b2"}])])
+
+        manager = _make_manager()
+        _rows(_source("brands", manager))
+
+        # one save (for the single page boundary that had a next page); none after the terminal page
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BigMailerResumeConfig(cursor="C2==")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_page([{"id": "b2"}])])
+
+        manager = _make_manager(BigMailerResumeConfig(cursor="RESUME==", brand_id=None))
+        _rows(_source("brands", manager))
+
+        assert snapshots[0][1]["cursor"] == "RESUME=="
 
 
-class TestFetchPage:
+class TestBrandFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_iterates_every_brand_and_injects_brand_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _page([{"id": "b1"}, {"id": "b2"}]),  # /brands
+                _page([{"id": "c1", "created": 1}]),  # b1 contacts
+                _page([{"id": "c2", "created": 2}]),  # b2 contacts
+            ],
+        )
+
+        rows = _rows(_source("contacts"))
+
+        assert [(r["id"], r["brand_id"]) for r in rows] == [("c1", "b1"), ("c2", "b2")]
+        # the injected brand id must be the plain `brand_id` column, not the prefixed parent key
+        assert rows[0] == {"id": "c1", "created": 1, "brand_id": "b1"}
+        assert snapshots[1][0].endswith("/brands/b1/contacts")
+        assert snapshots[2][0].endswith("/brands/b2/contacts")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_within_a_brand(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _page([{"id": "b1"}]),  # /brands
+                _page([{"id": "c1"}], has_more=True, cursor="P2=="),  # b1 contacts page 1
+                _page([{"id": "c2"}]),  # b1 contacts page 2
+            ],
+        )
+
+        rows = _rows(_source("contacts"))
+
+        assert [r["id"] for r in rows] == ["c1", "c2"]
+        assert snapshots[2][0].endswith("/brands/b1/contacts")
+        assert snapshots[2][1]["cursor"] == "P2=="
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_the_brand_list_itself(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page([{"id": "b1"}], has_more=True, cursor="B2=="),  # /brands page 1
+                _page([{"id": "c1"}]),  # b1 contacts
+                _page([{"id": "b2"}]),  # /brands page 2
+                _page([{"id": "c2"}]),  # b2 contacts
+            ],
+        )
+
+        rows = _rows(_source("contacts"))
+        assert [(r["id"], r["brand_id"]) for r in rows] == [("c1", "b1"), ("c2", "b2")]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_brands_and_resumes_cursor(self, MockSession) -> None:
+        # Resuming mid-fan-out must not re-request brands completed before the crash, and must start
+        # the in-progress brand from its saved cursor.
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _page([{"id": "b1"}, {"id": "b2"}, {"id": "b3"}]),  # /brands
+                _page([{"id": "c2"}]),  # b2 contacts (resumed)
+                _page([{"id": "c3"}]),  # b3 contacts (fresh)
+            ],
+        )
+
+        manager = _make_manager(
+            BigMailerResumeConfig(
+                fanout_state={
+                    "completed": ["/brands/b1/contacts"],
+                    "current": "/brands/b2/contacts",
+                    "child_state": {"cursor": "MID=="},
+                }
+            )
+        )
+        rows = _rows(_source("contacts", manager))
+
+        urls = [url for url, _params in snapshots]
+        assert not any("/brands/b1/contacts" in url for url in urls)
+        assert snapshots[1][0].endswith("/brands/b2/contacts")
+        assert snapshots[1][1]["cursor"] == "MID=="
+        assert snapshots[2][0].endswith("/brands/b3/contacts")
+        assert "cursor" not in snapshots[2][1]
+        assert [r["id"] for r in rows] == ["c2", "c3"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pre_migration_resume_state_starts_fresh(self, MockSession) -> None:
+        # An old-shape bookmark (cursor + brand_id, no fanout_state) can't be translated into the
+        # framework's completed/current map — the fan-out restarts from the first brand instead.
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _page([{"id": "b1"}, {"id": "b2"}]),  # /brands
+                _page([{"id": "c1"}]),  # b1 contacts
+                _page([{"id": "c2"}]),  # b2 contacts
+            ],
+        )
+
+        manager = _make_manager(BigMailerResumeConfig(cursor="MID==", brand_id="b2"))
+        rows = _rows(_source("contacts", manager))
+
+        assert [(r["id"], r["brand_id"]) for r in rows] == [("c1", "b1"), ("c2", "b2")]
+        assert all("cursor" not in params for _url, params in snapshots)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_completed_brands(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page([{"id": "b1"}, {"id": "b2"}]),
+                _page([{"id": "c1"}]),
+                _page([{"id": "c2"}]),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("contacts", manager))
+
+        # after finishing b1 a checkpoint marks it completed, so a crash resumes on b2, not b1
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert any(
+            state.fanout_state is not None and "/brands/b1/contacts" in state.fanout_state["completed"]
+            for state in saved
+        )
+
+
+class TestResumeConfigCompatibility:
+    def test_old_saved_state_still_parses(self) -> None:
+        # ResumableSourceManager._load_json does dataclass(**saved) — state saved by the
+        # pre-framework implementation must keep loading after the migration.
+        state = BigMailerResumeConfig(**{"cursor": "C2==", "brand_id": "b1"})
+        assert state.cursor == "C2=="
+        assert state.brand_id == "b1"
+        assert state.fanout_state is None
+
+
+class TestAuthErrors:
     @parameterized.expand(
         [
             ("invalid_key_400", 400, '{"message":"Invalid api key"}'),
@@ -81,133 +276,53 @@ class TestFetchPage:
             ("forbidden_403", 403, ""),
         ]
     )
-    def test_auth_failures_raise_non_retryable(self, _name: str, status: int, text: str) -> None:
-        session = _session_returning(_resp(status=status, text=text))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_failures_raise_non_retryable(self, _name: str, status: int, text: str, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status=status, text=text)])
+
         with pytest.raises(BigMailerAuthError) as exc:
-            _fetch_page(session, "https://api.bigmailer.io/v1/brands?limit=100", MagicMock())
+            _rows(_source("brands"))
         assert str(exc.value) == AUTH_ERROR_MESSAGE
 
-    def test_non_auth_400_raises_http_error_not_auth_error(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_failure_on_a_brand_child_list_raises_non_retryable(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "b1"}]), _response(status=401, text="")])
+
+        with pytest.raises(BigMailerAuthError):
+            _rows(_source("contacts"))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_auth_400_raises_http_error_not_auth_error(self, MockSession) -> None:
         # A 400 that isn't about the api key (e.g. a malformed param) must not be misreported as a
         # credential problem — otherwise a transient request bug would permanently disable the source.
-        session = _session_returning(_resp(status=400, text='{"message":"bad cursor"}'))
+        session = MockSession.return_value
+        _wire(session, [_response(status=400, text='{"message":"bad cursor"}')])
+
         with pytest.raises(requests.HTTPError):
-            _fetch_page(session, "https://api.bigmailer.io/v1/brands?limit=100", MagicMock())
+            _rows(_source("brands"))
 
-    def test_404_raises_http_error(self) -> None:
-        session = _session_returning(_resp(status=404, text="not found"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_404_raises_http_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status=404, text="not found")])
+
         with pytest.raises(requests.HTTPError):
-            _fetch_page(session, "https://api.bigmailer.io/v1/brands?limit=100", MagicMock())
-
-    def test_200_returns_parsed_body(self) -> None:
-        session = _session_returning(_resp(status=200, body={"data": [{"id": "x"}], "has_more": False}))
-        assert _fetch_page(session, "https://api.bigmailer.io/v1/brands?limit=100", MagicMock()) == {
-            "data": [{"id": "x"}],
-            "has_more": False,
-        }
-
-
-def _run(endpoint: str, session: MagicMock, manager: FakeManager) -> list[dict]:
-    with patch.object(bigmailer, "make_tracked_session", return_value=session):
-        rows: list[dict] = []
-        for page in get_rows(api_key="key", endpoint=endpoint, logger=MagicMock(), manager=manager):
-            rows.extend(page)
-        return rows
-
-
-class TestTopLevelPagination:
-    def test_follows_cursor_until_has_more_false(self) -> None:
-        session = _session_returning(
-            _resp(body={"data": [{"id": "b1", "created": 1}], "has_more": True, "cursor": "C2=="}),
-            _resp(body={"data": [{"id": "b2", "created": 2}], "has_more": False, "cursor": "ignored"}),
-        )
-        rows = _run("brands", session, FakeManager())
-        assert [r["id"] for r in rows] == ["b1", "b2"]
-        # second request must carry the encoded cursor from page one
-        assert "cursor=C2%3D%3D" in _requested_urls(session)[1]
-
-    def test_does_not_inject_brand_id_for_top_level(self) -> None:
-        session = _session_returning(_resp(body={"data": [{"id": "b1", "created": 1}], "has_more": False}))
-        rows = _run("brands", session, FakeManager())
-        assert "brand_id" not in rows[0]
-
-    def test_saves_next_cursor_after_yielding_each_page(self) -> None:
-        manager = FakeManager()
-        session = _session_returning(
-            _resp(body={"data": [{"id": "b1"}], "has_more": True, "cursor": "C2=="}),
-            _resp(body={"data": [{"id": "b2"}], "has_more": False}),
-        )
-        _run("brands", session, manager)
-        # one save (for the single page boundary that had a next page); none after the terminal page
-        assert [(s.cursor, s.brand_id) for s in manager.saved] == [("C2==", None)]
-
-    def test_resumes_from_saved_cursor(self) -> None:
-        manager = FakeManager(BigMailerResumeConfig(cursor="RESUME==", brand_id=None))
-        session = _session_returning(_resp(body={"data": [{"id": "b2"}], "has_more": False}))
-        _run("brands", session, manager)
-        assert "cursor=RESUME%3D%3D" in _requested_urls(session)[0]
-
-
-class TestBrandFanOut:
-    def test_iterates_every_brand_and_injects_brand_id(self) -> None:
-        session = _session_returning(
-            _resp(body={"data": [{"id": "b1"}, {"id": "b2"}], "has_more": False}),  # /brands
-            _resp(body={"data": [{"id": "c1", "created": 1}], "has_more": False}),  # b1 contacts
-            _resp(body={"data": [{"id": "c2", "created": 2}], "has_more": False}),  # b2 contacts
-        )
-        rows = _run("contacts", session, FakeManager())
-        assert [(r["id"], r["brand_id"]) for r in rows] == [("c1", "b1"), ("c2", "b2")]
-
-    def test_paginates_within_a_brand(self) -> None:
-        session = _session_returning(
-            _resp(body={"data": [{"id": "b1"}], "has_more": False}),  # /brands
-            _resp(body={"data": [{"id": "c1"}], "has_more": True, "cursor": "P2=="}),  # b1 contacts page 1
-            _resp(body={"data": [{"id": "c2"}], "has_more": False}),  # b1 contacts page 2
-        )
-        rows = _run("contacts", session, FakeManager())
-        assert [r["id"] for r in rows] == ["c1", "c2"]
-        assert "cursor=P2%3D%3D" in _requested_urls(session)[2]
-
-    def test_resume_skips_already_processed_brands(self) -> None:
-        # Resuming mid-fan-out must not re-request brands processed before the crash, and must start the
-        # bookmarked brand from its saved cursor.
-        manager = FakeManager(BigMailerResumeConfig(cursor="MID==", brand_id="b2"))
-        session = _session_returning(
-            _resp(body={"data": [{"id": "b1"}, {"id": "b2"}, {"id": "b3"}], "has_more": False}),  # /brands
-            _resp(body={"data": [{"id": "c2"}], "has_more": False}),  # b2 contacts (resumed)
-            _resp(body={"data": [{"id": "c3"}], "has_more": False}),  # b3 contacts (fresh)
-        )
-        rows = _run("contacts", session, manager)
-        urls = _requested_urls(session)
-        assert not any("/brands/b1/contacts" in u for u in urls)
-        assert "/brands/b2/contacts" in urls[1] and "cursor=MID%3D%3D" in urls[1]
-        assert "/brands/b3/contacts" in urls[2] and "cursor=" not in urls[2]
-        assert [r["id"] for r in rows] == ["c2", "c3"]
-
-    def test_advances_bookmark_between_brands(self) -> None:
-        manager = FakeManager()
-        session = _session_returning(
-            _resp(body={"data": [{"id": "b1"}, {"id": "b2"}], "has_more": False}),
-            _resp(body={"data": [{"id": "c1"}], "has_more": False}),
-            _resp(body={"data": [{"id": "c2"}], "has_more": False}),
-        )
-        _run("contacts", session, manager)
-        # after finishing b1 we bookmark b2 at its first page so a crash resumes on b2, not b1
-        assert BigMailerResumeConfig(cursor=None, brand_id="b2") in manager.saved
+            _rows(_source("brands"))
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("invalid", 400, False), ("forbidden", 403, False)])
-    def test_status_maps_to_bool(self, _name: str, status: int, expected: bool) -> None:
-        session = _session_returning(_resp(status=status))
-        with patch.object(bigmailer, "make_tracked_session", return_value=session):
-            assert validate_credentials("key") is expected
+    @mock.patch(BIGMAILER_SESSION_PATCH)
+    def test_status_maps_to_bool(self, _name: str, status: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("key") is expected
 
-    def test_network_error_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(bigmailer, "make_tracked_session", return_value=session):
-            assert validate_credentials("key") is False
+    @mock.patch(BIGMAILER_SESSION_PATCH)
+    def test_network_error_is_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("key") is False
 
 
 class TestSourceResponse:
@@ -221,12 +336,12 @@ class TestSourceResponse:
         ]
     )
     def test_primary_keys_per_endpoint(self, endpoint: str, expected_keys: list[str]) -> None:
-        response = bigmailer_source(api_key="key", endpoint=endpoint, logger=MagicMock(), manager=MagicMock())
+        response = _source(endpoint)
         assert response.name == endpoint
         assert response.primary_keys == expected_keys
 
     def test_partitions_on_created_by_month(self) -> None:
-        response = bigmailer_source(api_key="key", endpoint="contacts", logger=MagicMock(), manager=MagicMock())
+        response = _source("contacts")
         assert response.partition_mode == "datetime"
         assert response.partition_format == "month"
         assert response.partition_keys == ["created"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/tests/test_bigmailer_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigmailer/tests/test_bigmailer_source.py
@@ -118,6 +118,9 @@ class TestPipelineHandoff:
     def test_source_for_pipeline_builds_response(self, endpoint: str, expected_keys: list[str]) -> None:
         src = BigMailerSource()
         inputs = _inputs(endpoint)
-        response = src.source_for_pipeline(_config(), src.get_resumable_source_manager(inputs), inputs)
+        # the transport reads resume state while building the resource, so a Redis-free stand-in is used
+        manager = MagicMock()
+        manager.can_resume.return_value = False
+        response = src.source_for_pipeline(_config(), manager, inputs)
         assert response.name == endpoint
         assert response.primary_keys == expected_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bland_ai/bland_ai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bland_ai/bland_ai.py
@@ -1,29 +1,30 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from jsonpath_ng import DatumInContext, JSONPath
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.settings import BLAND_AI_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
-# The authorization header is the raw API key (no "Bearer" prefix).
 BASE_URL = "https://api.bland.ai"
 
 # GET /v1/calls default (and documented maximum) page size.
 PAGE_SIZE = 1000
-
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class BlandAIRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -33,48 +34,24 @@ class BlandAIResumeConfig:
     # The exact `start_date` filter the interrupted run used. The pipeline checkpoints the
     # incremental watermark per batch, so on resume `db_incremental_field_last_value` may already
     # have advanced past the value we filtered by — reusing the original filter keeps the saved
-    # offset pointing into the same result set.
+    # cursor pointing into the same result set.
     start_date: str | None = None
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "authorization": api_key,
-        "Accept": "application/json",
-    }
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (BlandAIRetryableError, requests.ReadTimeout, requests.ConnectionError),
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Bland's read-endpoint rate limits aren't documented, so back off politely on 429 and 5xx.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BlandAIRetryableError(f"Bland AI API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Bland AI API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+    # Framework fan-out checkpoint for call_transcripts (completed/current child paths plus the
+    # in-progress child paginator state). Optional so state saved before this field existed
+    # (offset-only) still parses; such state restarts the fan-out fresh under the saved filter.
+    fanout_state: dict[str, Any] | None = None
 
 
 def validate_credentials(api_key: str) -> bool:
     # Cheapest probe that exercises the token: list a single call. A bad key returns
     # 401 {"errors": [{"error": "AUTH_FAILURE", ...}]}.
-    url = f"{BASE_URL}/v1/calls?{urlencode({'limit': 1})}"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BASE_URL}/v1/calls?limit=1",
+        # Bland expects the raw key in the authorization header (no "Bearer" prefix).
+        headers={"authorization": api_key, "Accept": "application/json"},
+    )
+    return ok
 
 
 def _format_start_date(value: Any) -> str | None:
@@ -94,84 +71,100 @@ def _format_start_date(value: Any) -> str | None:
     return str(value)
 
 
-def _get_pathway_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    data = _fetch(session, f"{BASE_URL}/v1/pathway", headers, logger)
+class _PathwaysBodySelector(JSONPath):
+    """Data selector normalizing GET /v1/pathway's response body.
 
-    # The docs' response example shows a single pathway object without an explicit list wrapper,
-    # and we couldn't verify the live shape without account credentials — accept a bare list,
-    # common list wrappers, or a single object.
-    if isinstance(data, list):
-        rows = data
-    elif isinstance(data, dict):
-        wrapped = next((data[key] for key in ("pathways", "data") if isinstance(data.get(key), list)), None)
-        rows = wrapped if wrapped is not None else [data]
-    else:
-        rows = []
+    The docs' response example shows a single pathway object without an explicit list wrapper,
+    and we couldn't verify the live shape without account credentials — accept a bare list,
+    common list wrappers, or a single object.
+    """
 
-    if rows:
-        yield rows
+    def find(self, data: Any) -> list[DatumInContext]:
+        if isinstance(data, list):
+            rows = data
+        elif isinstance(data, dict):
+            wrapped = next((data[key] for key in ("pathways", "data") if isinstance(data.get(key), list)), None)
+            rows = wrapped if wrapped is not None else [data]
+        else:
+            rows = []
+        return [DatumInContext(rows)]
 
 
-def _transcript_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    calls: list[dict[str, Any]],
-    logger: FilteringBoundLogger,
-) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
-    for call in calls:
-        detail = _fetch(session, f"{BASE_URL}/v1/calls/{call['call_id']}", headers, logger)
-        for utterance in detail.get("transcripts") or []:
-            rows.append(
-                {
-                    **utterance,
-                    "call_id": call["call_id"],
-                    # The parent call's creation time. Utterance `created_at`s aren't monotonic
-                    # across calls (a long call's utterances postdate the next call's creation),
-                    # so this is the field the incremental cursor and partitioning key off.
-                    # Direct access on purpose: a silent None here would corrupt partitions and
-                    # stall the incremental watermark.
-                    "call_created_at": call["created_at"],
-                }
-            )
-    return rows
+def _adopt_parent_call_fields(row: dict[str, Any]) -> dict[str, Any]:
+    # Rename the injected parent fields onto the utterance row: `call_id` (part of the composite
+    # primary key) and `call_created_at`, the parent call's creation time. Utterance `created_at`s
+    # aren't monotonic across calls (a long call's utterances postdate the next call's creation),
+    # so `call_created_at` is the field the incremental cursor and partitioning key off.
+    # `pop` without a default on purpose: a silent None here would corrupt partitions and stall
+    # the incremental watermark.
+    row["call_id"] = row.pop("_calls_call_id")
+    row["call_created_at"] = row.pop("_calls_created_at")
+    return row
 
 
-def get_rows(
+def _calls_list_resource(params: dict[str, Any]) -> EndpointResource:
+    return {
+        "name": "calls",
+        "endpoint": {
+            "path": "v1/calls",
+            "params": params,
+            "data_selector": "calls",
+            # Index-offset pagination (`from` + `limit`) with `total_count` in the response body.
+            "paginator": OffsetPaginator(
+                limit=PAGE_SIZE,
+                offset_param="from",
+                limit_param="limit",
+                total_path="total_count",
+            ),
+        },
+    }
+
+
+def bland_ai_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BlandAIResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = BLAND_AI_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every list page and hydration request so urllib3 keeps the
-    # connection alive instead of re-handshaking per request.
-    session = make_tracked_session()
+) -> SourceResponse:
+    endpoint_config = BLAND_AI_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BASE_URL,
+            # Auth is supplied via the framework auth config so its value is redacted from logs;
+            # Bland expects the raw API key (no "Bearer" prefix) in the authorization header.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "authorization", "location": "header"},
+            "headers": {"Accept": "application/json"},
+        },
+        "resources": [],
+    }
+
+    resource: Resource
     if endpoint == "pathways":
-        yield from _get_pathway_rows(session, headers, logger)
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None:
-        offset = resume.offset
-        start_date = resume.start_date
-        logger.debug(f"Bland AI: resuming {endpoint} from offset {offset} (start_date={start_date})")
+        # Small (name/description/nodes/edges per pathway), no timestamp filters — a single
+        # unordered page on a full-refresh-only endpoint.
+        rest_config["resources"] = [
+            {
+                "name": "pathways",
+                "endpoint": {
+                    "path": "v1/pathway",
+                    "data_selector": _PathwaysBodySelector(),
+                    "paginator": SinglePagePaginator(),
+                },
+            }
+        ]
+        resource = rest_api_resource(rest_config, team_id, job_id, None)
     else:
-        offset = 0
-        start_date = _format_start_date(db_incremental_field_last_value) if should_use_incremental_field else None
+        resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+        if resume is not None:
+            start_date = resume.start_date
+        else:
+            start_date = _format_start_date(db_incremental_field_last_value) if should_use_incremental_field else None
 
-    while True:
-        params: dict[str, Any] = {
-            "from": offset,
-            "limit": PAGE_SIZE,
+        list_params: dict[str, Any] = {
             # Ascending creation order so the pipeline's incremental watermark can checkpoint
             # after every batch, and so index offsets stay stable while new calls append.
             "ascending": "true",
@@ -179,47 +172,65 @@ def get_rows(
         }
         if start_date:
             # `start_date` is inclusive; the boundary row is re-fetched and deduped by merge.
-            params["start_date"] = start_date
-        data = _fetch(session, f"{BASE_URL}/v1/calls?{urlencode(params)}", headers, logger)
+            list_params["start_date"] = start_date
 
-        calls = data.get("calls") or []
-        if not calls:
-            break
+        if endpoint == "calls":
+            initial_paginator_state = {"offset": resume.offset} if resume is not None else None
 
-        rows = _transcript_rows(session, headers, calls, logger) if config.hydrate_transcripts else calls
-        if rows:
-            yield rows
+            def save_calls_checkpoint(state: Optional[dict[str, Any]]) -> None:
+                # Persist only when a next page remains; the hook fires AFTER a page is yielded so
+                # a crash re-yields the last page (merge dedupes) rather than skipping it. The
+                # exact filter is saved alongside so a resume continues the same result set.
+                if state and state.get("offset") is not None:
+                    resumable_source_manager.save_state(
+                        BlandAIResumeConfig(offset=int(state["offset"]), start_date=start_date)
+                    )
 
-        offset += len(calls)
-        total_count = data.get("total_count")
-        if isinstance(total_count, int) and offset >= total_count:
-            break
+            rest_config["resources"] = [_calls_list_resource(list_params)]
+            resource = rest_api_resource(
+                rest_config,
+                team_id,
+                job_id,
+                None,
+                resume_hook=save_calls_checkpoint,
+                initial_paginator_state=initial_paginator_state,
+            )
+        else:  # call_transcripts
+            # Transcripts are excluded from the list endpoint for size reasons, so this endpoint
+            # lists calls (same pagination/filtering as `calls`) and hydrates each via
+            # GET /v1/calls/{call_id}, emitting one row per transcript utterance.
+            def save_transcripts_checkpoint(state: Optional[dict[str, Any]]) -> None:
+                if state is not None:
+                    resumable_source_manager.save_state(BlandAIResumeConfig(start_date=start_date, fanout_state=state))
 
-        # Save AFTER yielding the page so a crash re-yields the just-finished page rather than
-        # skipping it — merge dedupes on the primary key. Resume picks up at the next offset.
-        resumable_source_manager.save_state(BlandAIResumeConfig(offset=offset, start_date=start_date))
-
-
-def bland_ai_source(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BlandAIResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Optional[Any] = None,
-) -> SourceResponse:
-    endpoint_config = BLAND_AI_ENDPOINTS[endpoint]
+            rest_config["resources"] = [
+                _calls_list_resource(list_params),
+                {
+                    "name": "call_transcripts",
+                    "include_from_parent": ["call_id", "created_at"],
+                    "data_map": _adopt_parent_call_fields,
+                    "endpoint": {
+                        "path": "v1/calls/{call_id}",
+                        "params": {"call_id": {"type": "resolve", "resource": "calls", "field": "call_id"}},
+                        # A call with no transcripts (e.g. unanswered) is a legit zero-row detail.
+                        "data_selector": "transcripts",
+                        "paginator": SinglePagePaginator(),
+                    },
+                },
+            ]
+            resources = rest_api_resources(
+                rest_config,
+                team_id,
+                job_id,
+                None,
+                resume_hook=save_transcripts_checkpoint,
+                initial_paginator_state=resume.fanout_state if resume is not None else None,
+            )
+            resource = next(r for r in resources if r.name == "call_transcripts")
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=endpoint_config.primary_keys,
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bland_ai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bland_ai/source.py
@@ -19,14 +19,21 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.b
     bland_ai_source,
     validate_credentials as validate_bland_ai_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.settings import BLAND_AI_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.settings import (
+    BLAND_AI_ENDPOINTS,
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BlandAISourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -94,21 +101,13 @@ class BlandAISource(ResumableSource[BlandAISourceConfig, BlandAIResumeConfig]):
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint_config.name,
-                supports_incremental=endpoint_config.supports_incremental,
-                supports_append=endpoint_config.supports_incremental,
-                incremental_fields=endpoint_config.incremental_fields,
-                should_sync_default=endpoint_config.should_sync_default,
-                description=endpoint_config.description,
-            )
-            for endpoint_config in BLAND_AI_ENDPOINTS.values()
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions={name: config.description for name, config in BLAND_AI_ENDPOINTS.items()},
+            should_sync_default={name: config.should_sync_default for name, config in BLAND_AI_ENDPOINTS.items()},
+        )
 
     def validate_credentials(
         self, config: BlandAISourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -130,7 +129,8 @@ class BlandAISource(ResumableSource[BlandAISourceConfig, BlandAIResumeConfig]):
         return bland_ai_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bland_ai/tests/test_bland_ai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bland_ai/tests/test_bland_ai.py
@@ -1,10 +1,11 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import urlencode
 
 from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.bland_ai import (
     BASE_URL,
@@ -12,19 +13,23 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.b
     BlandAIResumeConfig,
     _format_start_date,
     bland_ai_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.settings import ENDPOINTS
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.bland_ai"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the bland_ai module.
+BLAND_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.bland_ai.bland_ai.make_tracked_session"
+)
 
 
-def _calls_url(offset: int, start_date: str | None = None) -> str:
-    params: dict[str, Any] = {"from": offset, "limit": PAGE_SIZE, "ascending": "true", "sort_by": "created_at"}
-    if start_date:
-        params["start_date"] = start_date
-    return f"{BASE_URL}/v1/calls?{urlencode(params)}"
+def _response(body: Any, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: BlandAIResumeConfig | None = None) -> mock.MagicMock:
@@ -34,21 +39,43 @@ def _make_manager(resume_state: BlandAIResumeConfig | None = None) -> mock.Magic
     return manager
 
 
-def _resp(json_body: Any, status: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = json_body
-    resp.status_code = status
-    resp.ok = status < 400
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's url/params/auth AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _url_router(responses: dict[str, Any]) -> Any:
-    """Return a session.get side_effect that maps each requested URL to a mocked response."""
+def _source(
+    endpoint: str,
+    manager: mock.MagicMock,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+):
+    return bland_ai_source(
+        api_key="key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
 
-    def fake_get(url: str, headers: Any = None, timeout: Any = None) -> mock.MagicMock:
-        return _resp(responses[url])
 
-    return fake_get
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatStartDate:
@@ -71,93 +98,111 @@ class TestValidateCredentials:
         [("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False), ("error", 500, False)]
     )
     def test_status_mapping(self, _name: str, status_code: int, expected: bool) -> None:
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _resp({}, status=status_code)
+        with mock.patch(BLAND_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
             assert validate_credentials("key") is expected
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
+    @mock.patch(BLAND_SESSION_PATCH)
     def test_swallows_exceptions(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("key") is False
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
+    @mock.patch(BLAND_SESSION_PATCH)
     def test_sends_raw_api_key_in_authorization_header(self, mock_session: mock.MagicMock) -> None:
         # Bland expects the raw key, not a "Bearer "-prefixed value.
-        mock_session.return_value.get.return_value = _resp({}, status=200)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("sk-raw-key")
         headers = mock_session.return_value.get.call_args.kwargs["headers"]
         assert headers["authorization"] == "sk-raw-key"
 
 
-class TestGetCallRows:
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_paginates_by_offset_until_total_count(self, mock_session: mock.MagicMock) -> None:
+class TestCallsPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_by_offset_until_total_count(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         page_one = [{"call_id": f"c{i}", "created_at": "2026-01-01T00:00:00+00:00"} for i in range(PAGE_SIZE)]
         page_two = [{"call_id": "clast", "created_at": "2026-01-02T00:00:00+00:00"}]
-        responses = {
-            _calls_url(0): {"total_count": PAGE_SIZE + 1, "count": PAGE_SIZE, "calls": page_one},
-            _calls_url(PAGE_SIZE): {"total_count": PAGE_SIZE + 1, "count": 1, "calls": page_two},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+        snapshots = _wire(
+            session,
+            [
+                _response({"total_count": PAGE_SIZE + 1, "count": PAGE_SIZE, "calls": page_one}),
+                _response({"total_count": PAGE_SIZE + 1, "count": 1, "calls": page_two}),
+            ],
+        )
 
-        manager = _make_manager()
-        batches = list(get_rows("key", "calls", mock.MagicMock(), manager))
+        rows = _rows(_source("calls", _make_manager()))
 
-        assert [len(b) for b in batches] == [PAGE_SIZE, 1]
-        assert batches[1][0]["call_id"] == "clast"
+        assert len(rows) == PAGE_SIZE + 1
+        assert rows[-1]["call_id"] == "clast"
         # Reaching total_count terminates without requesting a third page.
-        assert mock_session.return_value.get.call_count == 2
+        assert session.send.call_count == 2
+        assert snapshots[0]["url"] == f"{BASE_URL}/v1/calls"
+        assert snapshots[0]["params"]["from"] == 0
+        assert snapshots[0]["params"]["limit"] == PAGE_SIZE
+        # Ascending creation order so index offsets stay stable while new calls append.
+        assert snapshots[0]["params"]["ascending"] == "true"
+        assert snapshots[0]["params"]["sort_by"] == "created_at"
+        assert snapshots[1]["params"]["from"] == PAGE_SIZE
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_stops_on_empty_page_when_total_count_overcounts(self, mock_session: mock.MagicMock) -> None:
-        # total_count can drift from what's actually returned; an empty page must still terminate.
-        responses = {
-            _calls_url(0): {"total_count": 50, "count": 2, "calls": [{"call_id": "c1"}, {"call_id": "c2"}]},
-            _calls_url(2): {"total_count": 50, "count": 0, "calls": []},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_short_page_when_total_count_overcounts(self, MockSession: mock.MagicMock) -> None:
+        # total_count can drift from what's actually returned; a short page must still terminate.
+        session = MockSession.return_value
+        _wire(session, [_response({"total_count": 50, "count": 2, "calls": [{"call_id": "c1"}, {"call_id": "c2"}]})])
 
-        batches = list(get_rows("key", "calls", mock.MagicMock(), _make_manager()))
+        rows = _rows(_source("calls", _make_manager()))
 
-        assert [len(b) for b in batches] == [2]
+        assert [r["call_id"] for r in rows] == ["c1", "c2"]
+        assert session.send.call_count == 1
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_incremental_watermark_becomes_start_date_filter(self, mock_session: mock.MagicMock) -> None:
-        watermark = datetime(2026, 1, 5, tzinfo=UTC)
-        url = _calls_url(0, start_date="2026-01-05T00:00:00+00:00")
-        responses = {url: {"total_count": 1, "count": 1, "calls": [{"call_id": "c1"}]}}
-        mock_session.return_value.get.side_effect = _url_router(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sends_raw_api_key_auth(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"total_count": 1, "count": 1, "calls": [{"call_id": "c1"}]})])
 
-        batches = list(
-            get_rows(
-                "key",
+        _rows(_source("calls", _make_manager()))
+
+        # The framework auth injects the raw key (no "Bearer" prefix) into the authorization header.
+        auth = snapshots[0]["auth"]
+        assert auth.api_key == "key"
+        assert auth.name == "authorization"
+        assert auth.location == "header"
+        assert session.headers.get("Accept") == "application/json"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_watermark_becomes_start_date_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"total_count": 1, "count": 1, "calls": [{"call_id": "c1"}]})])
+
+        rows = _rows(
+            _source(
                 "calls",
-                mock.MagicMock(),
                 _make_manager(),
                 should_use_incremental_field=True,
-                db_incremental_field_last_value=watermark,
+                db_incremental_field_last_value=datetime(2026, 1, 5, tzinfo=UTC),
             )
         )
 
-        # The router KeyErrors on any URL without the start_date filter, so reaching here proves
-        # the watermark was sent server-side.
-        assert [r["call_id"] for b in batches for r in b] == ["c1"]
+        assert [r["call_id"] for r in rows] == ["c1"]
+        # The watermark is sent server-side as the inclusive `start_date` filter.
+        assert snapshots[0]["params"]["start_date"] == "2026-01-05T00:00:00+00:00"
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_saves_state_after_each_page_with_filter(self, mock_session: mock.MagicMock) -> None:
-        start_date = "2026-01-05T00:00:00+00:00"
-        responses = {
-            _calls_url(0, start_date): {"total_count": 3, "count": 2, "calls": [{"call_id": "c1"}, {"call_id": "c2"}]},
-            _calls_url(2, start_date): {"total_count": 3, "count": 1, "calls": [{"call_id": "c3"}]},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_each_page_with_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        page_one = [{"call_id": f"c{i}"} for i in range(PAGE_SIZE)]
+        _wire(
+            session,
+            [
+                _response({"total_count": PAGE_SIZE + 1, "count": PAGE_SIZE, "calls": page_one}),
+                _response({"total_count": PAGE_SIZE + 1, "count": 1, "calls": [{"call_id": "clast"}]}),
+            ],
+        )
 
         manager = _make_manager()
-        list(
-            get_rows(
-                "key",
+        _rows(
+            _source(
                 "calls",
-                mock.MagicMock(),
                 manager,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2026, 1, 5, tzinfo=UTC),
@@ -168,23 +213,20 @@ class TestGetCallRows:
         # offset and the exact filter, so a resume continues the same result set.
         manager.save_state.assert_called_once()
         saved = manager.save_state.call_args.args[0]
-        assert saved.offset == 2
-        assert saved.start_date == start_date
+        assert saved.offset == PAGE_SIZE
+        assert saved.start_date == "2026-01-05T00:00:00+00:00"
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_resumes_from_saved_offset_and_filter(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset_and_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         saved_filter = "2026-01-05T00:00:00+00:00"
-        responses = {
-            _calls_url(2, saved_filter): {"total_count": 3, "count": 1, "calls": [{"call_id": "c3"}]},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+        snapshots = _wire(session, [_response({"total_count": 3, "count": 1, "calls": [{"call_id": "c3"}]})])
 
+        # Old-format state (no fanout_state) must still seed the paginator.
         manager = _make_manager(BlandAIResumeConfig(offset=2, start_date=saved_filter))
-        batches = list(
-            get_rows(
-                "key",
+        rows = _rows(
+            _source(
                 "calls",
-                mock.MagicMock(),
                 manager,
                 should_use_incremental_field=True,
                 # The checkpointed watermark has advanced past the interrupted run's filter; the
@@ -193,44 +235,52 @@ class TestGetCallRows:
             )
         )
 
-        assert [r["call_id"] for b in batches for r in b] == ["c3"]
+        assert [r["call_id"] for r in rows] == ["c3"]
+        assert snapshots[0]["params"]["from"] == 2
+        assert snapshots[0]["params"]["start_date"] == saved_filter
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_empty_account_yields_nothing(self, mock_session: mock.MagicMock) -> None:
-        responses = {_calls_url(0): {"total_count": 0, "count": 0, "calls": []}}
-        mock_session.return_value.get.side_effect = _url_router(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_account_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"total_count": 0, "count": 0, "calls": []})])
 
         manager = _make_manager()
-        assert list(get_rows("key", "calls", mock.MagicMock(), manager)) == []
+        assert _rows(_source("calls", manager)) == []
         manager.save_state.assert_not_called()
 
 
-class TestGetCallTranscriptRows:
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_hydrates_each_call_and_injects_parent_keys(self, mock_session: mock.MagicMock) -> None:
-        responses = {
-            _calls_url(0): {
-                "total_count": 2,
-                "count": 2,
-                "calls": [
-                    {"call_id": "c1", "created_at": "2026-01-01T00:00:00+00:00"},
-                    {"call_id": "c2", "created_at": "2026-01-02T00:00:00+00:00"},
-                ],
-            },
-            f"{BASE_URL}/v1/calls/c1": {
-                "call_id": "c1",
-                "transcripts": [
-                    {"id": 1, "text": "hello", "user": "assistant", "created_at": "2026-01-01T00:00:01+00:00"},
-                    {"id": 2, "text": "hi", "user": "user", "created_at": "2026-01-01T00:00:05+00:00"},
-                ],
-            },
-            # A call with no transcripts (e.g. unanswered) must not break the batch.
-            f"{BASE_URL}/v1/calls/c2": {"call_id": "c2", "transcripts": None},
-        }
-        mock_session.return_value.get.side_effect = _url_router(responses)
+class TestCallTranscripts:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_hydrates_each_call_and_injects_parent_keys(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(
+                    {
+                        "total_count": 2,
+                        "count": 2,
+                        "calls": [
+                            {"call_id": "c1", "created_at": "2026-01-01T00:00:00+00:00"},
+                            {"call_id": "c2", "created_at": "2026-01-02T00:00:00+00:00"},
+                        ],
+                    }
+                ),
+                _response(
+                    {
+                        "call_id": "c1",
+                        "transcripts": [
+                            {"id": 1, "text": "hello", "user": "assistant", "created_at": "2026-01-01T00:00:01+00:00"},
+                            {"id": 2, "text": "hi", "user": "user", "created_at": "2026-01-01T00:00:05+00:00"},
+                        ],
+                    }
+                ),
+                # A call with no transcripts (e.g. unanswered) must not break the batch.
+                _response({"call_id": "c2", "transcripts": None}),
+            ],
+        )
 
-        batches = list(get_rows("key", "call_transcripts", mock.MagicMock(), _make_manager()))
-        rows = [row for batch in batches for row in batch]
+        rows = _rows(_source("call_transcripts", _make_manager()))
 
         assert [r["id"] for r in rows] == [1, 2]
         # Rows carry the parent call id (composite primary key) and the parent's creation time
@@ -238,9 +288,117 @@ class TestGetCallTranscriptRows:
         assert all(r["call_id"] == "c1" for r in rows)
         assert all(r["call_created_at"] == "2026-01-01T00:00:00+00:00" for r in rows)
         assert rows[0]["text"] == "hello"
+        # One list request plus one hydration request per listed call.
+        assert [s["url"] for s in snapshots] == [
+            f"{BASE_URL}/v1/calls",
+            f"{BASE_URL}/v1/calls/c1",
+            f"{BASE_URL}/v1/calls/c2",
+        ]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_fanout_state_with_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(
+                    {
+                        "total_count": 1,
+                        "count": 1,
+                        "calls": [{"call_id": "c1", "created_at": "2026-01-05T00:00:00+00:00"}],
+                    }
+                ),
+                _response({"call_id": "c1", "transcripts": [{"id": 1}]}),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(
+            _source(
+                "call_transcripts",
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 5, tzinfo=UTC),
+            )
+        )
+
+        assert manager.save_state.call_count > 0
+        saved = manager.save_state.call_args.args[0]
+        # The final checkpoint records the fully-hydrated call and keeps the exact filter so a
+        # resume walks the same parent result set.
+        assert saved.fanout_state["completed"] == ["v1/calls/c1"]
+        assert saved.fanout_state["current"] is None
+        assert saved.start_date == "2026-01-05T00:00:00+00:00"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_already_hydrated_calls(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(
+                    {
+                        "total_count": 2,
+                        "count": 2,
+                        "calls": [
+                            {"call_id": "c1", "created_at": "2026-01-01T00:00:00+00:00"},
+                            {"call_id": "c2", "created_at": "2026-01-02T00:00:00+00:00"},
+                        ],
+                    }
+                ),
+                _response({"call_id": "c2", "transcripts": [{"id": 7, "text": "yo"}]}),
+            ],
+        )
+
+        manager = _make_manager(
+            BlandAIResumeConfig(
+                start_date=None,
+                fanout_state={"completed": ["v1/calls/c1"], "current": None, "child_state": None},
+            )
+        )
+        rows = _rows(_source("call_transcripts", manager))
+
+        # c1 was fully hydrated before the interruption — only c2 is fetched again.
+        assert [r["id"] for r in rows] == [7]
+        assert all(r["call_id"] == "c2" for r in rows)
+        assert [s["url"] for s in snapshots] == [f"{BASE_URL}/v1/calls", f"{BASE_URL}/v1/calls/c2"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_old_format_resume_state_restarts_fanout_under_saved_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        saved_filter = "2026-01-05T00:00:00+00:00"
+        snapshots = _wire(
+            session,
+            [
+                _response(
+                    {
+                        "total_count": 1,
+                        "count": 1,
+                        "calls": [{"call_id": "c1", "created_at": "2026-01-05T00:00:00+00:00"}],
+                    }
+                ),
+                _response({"call_id": "c1", "transcripts": [{"id": 1}]}),
+            ],
+        )
+
+        # State saved before fanout_state existed (offset-only): the fan-out restarts from the top
+        # but keeps the frozen filter so it walks the same result set (merge dedupes re-yields).
+        manager = _make_manager(BlandAIResumeConfig(offset=5, start_date=saved_filter))
+        rows = _rows(
+            _source(
+                "call_transcripts",
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 7, tzinfo=UTC),
+            )
+        )
+
+        assert [r["id"] for r in rows] == [1]
+        assert snapshots[0]["params"]["from"] == 0
+        assert snapshots[0]["params"]["start_date"] == saved_filter
 
 
-class TestGetPathwayRows:
+class TestPathways:
     @parameterized.expand(
         [
             # Bare list of pathway objects.
@@ -253,21 +411,23 @@ class TestGetPathwayRows:
         ]
     )
     def test_normalizes_response_shapes(self, _name: str, api_response: Any, expected_ids: list[str]) -> None:
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            responses = {f"{BASE_URL}/v1/pathway": api_response}
-            mock_session.return_value.get.side_effect = _url_router(responses)
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            snapshots = _wire(session, [_response(api_response)])
 
-            batches = list(get_rows("key", "pathways", mock.MagicMock(), _make_manager()))
-            rows = [row for batch in batches for row in batch]
+            rows = _rows(_source("pathways", _make_manager()))
 
             assert [r["id"] for r in rows] == expected_ids
+            # A single unordered page on a full-refresh-only endpoint.
+            assert session.send.call_count == 1
+            assert snapshots[0]["url"] == f"{BASE_URL}/v1/pathway"
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_empty_pathway_list_yields_nothing(self, mock_session: mock.MagicMock) -> None:
-        responses: dict[str, Any] = {f"{BASE_URL}/v1/pathway": []}
-        mock_session.return_value.get.side_effect = _url_router(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_pathway_list_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
-        assert list(get_rows("key", "pathways", mock.MagicMock(), _make_manager())) == []
+        assert _rows(_source("pathways", _make_manager())) == []
 
 
 class TestBlandAISourceResponse:
@@ -283,8 +443,10 @@ class TestBlandAISourceResponse:
             ("pathways", ["id"], None),
         ]
     )
-    def test_source_response_shape(self, endpoint: str, primary_keys: list[str], partition_keys: list[str]) -> None:
-        response = bland_ai_source("key", endpoint, mock.MagicMock(), _make_manager())
+    def test_source_response_shape(
+        self, endpoint: str, primary_keys: list[str], partition_keys: list[str] | None
+    ) -> None:
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == primary_keys
         assert response.partition_keys == partition_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/blogger.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/blogger.py
@@ -1,29 +1,29 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
-from typing import Any
-from urllib.parse import urlencode, urlsplit
+from typing import Any, Optional
+from urllib.parse import urlsplit
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.blogger.settings import (
-    BLOGGER_ENDPOINTS,
-    BloggerEndpointConfig,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.blogger.settings import BLOGGER_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import Endpoint
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BLOGGER_BASE_URL = "https://www.googleapis.com/blogger/v3"
 # Blogger caps `maxResults` per resource; 100 is comfortably within the limits for posts/comments/pages.
 DEFAULT_PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class BloggerRetryableError(Exception):
-    """Raised for transient Blogger API failures (429 / 5xx) that tenacity should retry."""
 
 
 @dataclasses.dataclass
@@ -43,161 +43,140 @@ def _format_rfc3339(value: Any) -> str:
     return str(value)
 
 
-def _headers() -> dict[str, str]:
-    return {"Accept": "application/json"}
+class BloggerPageTokenPaginator(JSONResponseCursorPaginator):
+    """Blogger's opaque `pageToken` cursor, with one twist: never checkpoint an empty page. An empty
+    page yields no rows, so persisting its continuation token would let a crash skip past pages we
+    never surfaced — re-walking the (cheap) empty pages on resume is the safe choice."""
+
+    def __init__(self) -> None:
+        super().__init__(cursor_path="nextPageToken", cursor_param="pageToken")
+        self._last_page_had_items = True
+
+    def update_state(self, response: requests.Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        self._last_page_had_items = bool(data)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        if not self._last_page_had_items:
+            return None
+        return super().get_resume_state()
 
 
-def _raise_sanitized_for_status(response: requests.Response) -> None:
-    """Mirror `requests.Response.raise_for_status()` but strip the URL's query string before it lands
-    in an exception message. Blogger carries the API key in `?key=...`, and these import errors are
-    logged and captured by the shared non-retryable error handler — so the raw `raise_for_status()`
-    message would leak the key. The sanitized URL keeps the stable `.../blogger/v3` prefix that
-    `BloggerSource.get_non_retryable_errors()` matches on, so error classification is unaffected."""
-    if response.ok:
-        return
-    kind = "Client Error" if response.status_code < 500 else "Server Error"
-    safe_url = urlsplit(response.url)._replace(query="").geturl()
-    raise requests.HTTPError(f"{response.status_code} {kind}: {response.reason} for url: {safe_url}", response=response)
+def _make_sanitized_session(api_key: str) -> requests.Session:
+    """Tracked session that strips the query string from the final response URL. Blogger carries the
+    API key in `?key=...`, and both `raise_for_status()` and the client's retryable-error messages
+    embed `response.url` — which the shared non-retryable error handler logs and surfaces. Stripping
+    the query keeps the stable `.../blogger/v3` prefix that `BloggerSource.get_non_retryable_errors()`
+    matches on, so error classification is unaffected while the key never leaks."""
+    session = make_tracked_session(redact_values=(api_key,))
+    original_send = session.send
 
+    def send_with_sanitized_url(request: Any, **kwargs: Any) -> requests.Response:
+        response = original_send(request, **kwargs)
+        if response.url:
+            response.url = urlsplit(response.url)._replace(query="").geturl()
+        return response
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    return f"{BLOGGER_BASE_URL}{path}?{urlencode(params)}"
-
-
-def _build_params(
-    config: BloggerEndpointConfig,
-    api_key: str,
-    page_token: str | None,
-    start_date: str | None,
-) -> dict[str, Any]:
-    # The Google API key always rides as the `key` query param (Blogger has no header form for it).
-    params: dict[str, Any] = {"key": api_key}
-    if config.is_single_object:
-        return params
-
-    params["maxResults"] = DEFAULT_PAGE_SIZE
-    if config.order_by:
-        params["orderBy"] = config.order_by
-    if start_date:
-        params["startDate"] = start_date
-    if page_token:
-        params["pageToken"] = page_token
-    return params
-
-
-@retry(
-    retry=retry_if_exception_type((BloggerRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BloggerRetryableError(f"Blogger API error (retryable): status={response.status_code}")
-
-    if not response.ok:
-        logger.error(f"Blogger API error: status={response.status_code}, body={response.text}")
-        _raise_sanitized_for_status(response)
-
-    return response.json()
+    session.send = send_with_sanitized_url  # type: ignore[method-assign]
+    return session
 
 
 def validate_credentials(api_key: str, blog_id: str) -> tuple[bool, str | None]:
     """Probe `blogs.get` for the configured blog. This confirms both the API key and that the key can
     read the target blog in a single cheap request."""
-    url = _build_url(f"/blogs/{blog_id}", {"key": api_key})
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(url, headers=_headers(), timeout=10)
-    except Exception:
-        return False, "Could not reach the Blogger API. Please try again."
-
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BLOGGER_BASE_URL}/blogs/{blog_id}",
+        headers={"Accept": "application/json"},
+        auth=APIKeyAuth(api_key=api_key, name="key", location="query"),
+    )
+    if ok:
         return True, None
-    if response.status_code in (400, 401, 403):
+    if status is None:
+        return False, "Could not reach the Blogger API. Please try again."
+    if status in (400, 401, 403):
         return False, "Your Blogger API key is invalid or does not have access to this blog."
-    if response.status_code == 404:
+    if status == 404:
         return False, "No Blogger blog was found for that blog ID."
-    return False, f"The Blogger API returned an unexpected error (status {response.status_code})."
-
-
-def get_rows(
-    api_key: str,
-    blog_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BloggerResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = BLOGGER_ENDPOINTS[endpoint]
-    # One session reused across every page so urllib3 keeps the connection alive. The API key is in the
-    # query string, so register it for redaction in logged URLs and captured samples.
-    session = make_tracked_session(redact_values=(api_key,))
-    headers = _headers()
-
-    if config.is_single_object:
-        data = _fetch_page(session, _build_url(config.path.format(blog_id=blog_id), {"key": api_key}), headers, logger)
-        yield [data]
-        return
-
-    # `startDate` is the only server-side filter Blogger offers; map the user's incremental cursor
-    # (always `published`) onto it. On first sync there's no last value, so we pull full history.
-    start_date: str | None = None
-    if config.supports_incremental and should_use_incremental_field and db_incremental_field_last_value:
-        start_date = _format_rfc3339(db_incremental_field_last_value)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page_token = resume.page_token if resume is not None else None
-
-    base_path = config.path.format(blog_id=blog_id)
-    while True:
-        url = _build_url(base_path, _build_params(config, api_key, page_token, start_date))
-        data = _fetch_page(session, url, headers, logger)
-
-        items = data.get("items", [])
-        next_token = data.get("nextPageToken")
-
-        if items:
-            yield items
-            # Save AFTER yielding (and only when more pages remain) so a crash re-yields the last page
-            # rather than skipping it — merge dedupes on the primary key.
-            if next_token:
-                resumable_source_manager.save_state(BloggerResumeConfig(page_token=next_token))
-
-        if not next_token:
-            break
-        page_token = next_token
+    return False, f"The Blogger API returned an unexpected error (status {status})."
 
 
 def blogger_source(
     api_key: str,
     blog_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BloggerResumeConfig],
     should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = BLOGGER_ENDPOINTS[endpoint]
 
+    endpoint_def: Endpoint
+    if config.is_single_object:
+        # `blogs.get` returns a single blog object rather than a paginated `items` list.
+        endpoint_def = {
+            "path": config.path.format(blog_id=blog_id),
+            "data_selector": "$",
+            "paginator": SinglePagePaginator(),
+        }
+    else:
+        params: dict[str, Any] = {"maxResults": DEFAULT_PAGE_SIZE}
+        if config.order_by:
+            params["orderBy"] = config.order_by
+        # A body without `items` is a legit zero-row page (Blogger omits the key when empty), so the
+        # selector is deliberately not required.
+        endpoint_def = {
+            "path": config.path.format(blog_id=blog_id),
+            "params": params,
+            "data_selector": "items",
+            "paginator": BloggerPageTokenPaginator(),
+        }
+        # `startDate` is the only server-side filter Blogger offers; map the user's incremental cursor
+        # (always `published`) onto it. On first sync there's no last value, so we pull full history.
+        if config.supports_incremental and should_use_incremental_field and db_incremental_field_last_value:
+            endpoint_def["incremental"] = {
+                "start_param": "startDate",
+                "cursor_path": "published",
+                "convert": _format_rfc3339,
+            }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BLOGGER_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # The Google API key always rides as the `key` query param (Blogger has no header form).
+            "auth": {"type": "api_key", "name": "key", "api_key": api_key, "location": "query"},
+            "session": _make_sanitized_session(api_key),
+        },
+        "resources": [{"name": endpoint, "endpoint": endpoint_def}],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.page_token:
+            initial_paginator_state = {"cursor": resume.page_token}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint fires AFTER a page is yielded so a
+        # crash re-yields the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(BloggerResumeConfig(page_token=state["cursor"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            blog_id=blog_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # Blogger only returns list results newest-first (its sort-direction param is unavailable), so
         # incremental endpoints scroll descending. Full-refresh endpoints don't care about order.
@@ -207,4 +186,5 @@ def blogger_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/source.py
@@ -142,11 +142,11 @@ The API key reads publicly visible content (live posts, pages, and comments). Dr
             api_key=config.api_key,
             blog_id=config.blog_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,
-            incremental_field=inputs.incremental_field,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/tests/test_blogger.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/tests/test_blogger.py
@@ -1,109 +1,76 @@
+import json
 from datetime import UTC, date, datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.blogger import blogger
 from products.warehouse_sources.backend.temporal.data_imports.sources.blogger.blogger import (
     BloggerResumeConfig,
-    _build_params,
     _format_rfc3339,
     blogger_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.blogger.settings import BLOGGER_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
+
+# blogger builds its (sanitized) tracked session itself, so both the pipeline transport and
+# validate_credentials patch the blogger module's make_tracked_session.
+BLOGGER_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.blogger.blogger.make_tracked_session"
+)
 
 
-class _FakeResponse:
-    def __init__(
-        self,
-        status_code: int,
-        json_data: dict | None = None,
-        *,
-        url: str = "https://www.googleapis.com/blogger/v3",
-        reason: str = "OK",
-        text: str = "",
-    ) -> None:
-        self.status_code = status_code
-        self._json = json_data or {}
-        self.text = text
-        self.url = url
-        self.reason = reason
-        self.ok = 200 <= status_code < 300
-
-    def json(self) -> dict:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            raise requests.HTTPError(
-                f"{self.status_code} error for url: {self.url}", response=cast(requests.Response, self)
-            )
+def _response(body: dict[str, Any], *, status_code: int = 200, url: str = "", reason: str = "OK") -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp.reason = reason
+    resp.url = url or "https://www.googleapis.com/blogger/v3/x"
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class _FakeSession:
-    def __init__(self, response: _FakeResponse) -> None:
-        self._response = response
-        self.requested_urls: list[str] = []
-
-    def get(self, url: str, headers: dict | None = None, timeout: int | None = None) -> _FakeResponse:
-        self.requested_urls.append(url)
-        return self._response
+def _make_manager(resume_state: BloggerResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class _FakeResumableManager:
-    def __init__(self, state: BloggerResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BloggerResumeConfig] = []
+def _wire(session: mock.MagicMock, responses: list[requests.Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return snapshots of each request AT PREPARE TIME.
 
-    def can_resume(self) -> bool:
-        return self._state is not None
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
 
-    def load_state(self) -> BloggerResumeConfig | None:
-        return self._state
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"params": dict(request.params or {}), "url": request.url, "auth": request.auth})
+        return mock.MagicMock()
 
-    def save_state(self, data: BloggerResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class _SequentialFetch:
-    """Stand-in for `_fetch_page` that returns canned responses in order and records request URLs."""
-
-    def __init__(self, responses: list[dict]) -> None:
-        self._responses = list(responses)
-        self.urls: list[str] = []
-
-    def __call__(self, session: Any, url: str, headers: dict, logger: Any) -> dict:
-        self.urls.append(url)
-        return self._responses.pop(0)
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _collect(
-    endpoint: str,
-    manager: _FakeResumableManager,
-    fetch: _SequentialFetch,
-    **kwargs: Any,
-) -> list[dict]:
-    rows: list[dict] = []
-    with (
-        patch.object(blogger, "_fetch_page", fetch),
-        patch.object(blogger, "make_tracked_session", lambda **_: MagicMock()),
-    ):
-        for batch in get_rows(
-            api_key="K",
-            blog_id="BID",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(batch)
-    return rows
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any) -> Any:
+    return blogger_source(
+        api_key="K",
+        blog_id="BID",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
 
 
 class TestFormatRfc3339:
@@ -127,30 +94,6 @@ class TestFormatRfc3339:
         assert "+00:00" not in _format_rfc3339(datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC))
 
 
-class TestBuildParams:
-    def test_single_object_sends_only_key(self) -> None:
-        params = _build_params(BLOGGER_ENDPOINTS["blogs"], "K", page_token=None, start_date=None)
-        assert params == {"key": "K"}
-
-    def test_posts_sends_max_results_and_order_by(self) -> None:
-        params = _build_params(BLOGGER_ENDPOINTS["posts"], "K", page_token=None, start_date=None)
-        assert params["key"] == "K"
-        assert params["maxResults"] == 100
-        assert params["orderBy"] == "published"
-        assert "startDate" not in params
-        assert "pageToken" not in params
-
-    def test_comments_has_no_order_by(self) -> None:
-        # comments.listByBlog rejects ordering params, so we never send orderBy for it.
-        params = _build_params(BLOGGER_ENDPOINTS["comments"], "K", page_token=None, start_date=None)
-        assert "orderBy" not in params
-
-    def test_start_date_and_page_token_included(self) -> None:
-        params = _build_params(BLOGGER_ENDPOINTS["posts"], "K", page_token="TOK", start_date="2026-03-04T00:00:00Z")
-        assert params["startDate"] == "2026-03-04T00:00:00Z"
-        assert params["pageToken"] == "TOK"
-
-
 class TestValidateCredentials:
     @parameterized.expand(
         [
@@ -162,84 +105,144 @@ class TestValidateCredentials:
             ("server_error", 500, False),
         ]
     )
-    def test_status_mapping(self, _name: str, status: int, expected_ok: bool) -> None:
-        session = _FakeSession(_FakeResponse(status))
-        with patch.object(blogger, "make_tracked_session", lambda **_: session):
-            ok, error = validate_credentials("K", "BID")
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_status_mapping(self, _name: str, status: int, expected_ok: bool, MockSession: mock.MagicMock) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=status)
+        ok, error = validate_credentials("K", "BID")
         assert ok is expected_ok
         if not expected_ok:
             assert error
 
-    def test_network_error_returns_false(self) -> None:
-        class _Boom:
-            def get(self, *args: Any, **kwargs: Any) -> Any:
-                raise requests.ConnectionError("boom")
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_probe_sends_key_as_query_auth(self, MockSession: mock.MagicMock) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("K", "BID")
+        call = MockSession.return_value.get.call_args
+        assert call.args[0].endswith("/blogs/BID")
+        auth = call.kwargs["auth"]
+        assert isinstance(auth, APIKeyAuth)
+        assert (auth.api_key, auth.name, auth.location) == ("K", "key", "query")
 
-        with patch.object(blogger, "make_tracked_session", lambda **_: _Boom()):
-            ok, error = validate_credentials("K", "BID")
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_network_error_returns_false(self, MockSession: mock.MagicMock) -> None:
+        MockSession.return_value.get.side_effect = requests.ConnectionError("boom")
+        ok, error = validate_credentials("K", "BID")
         assert ok is False
         assert error
 
 
 class TestGetRows:
-    def test_single_object_yields_one_row(self) -> None:
-        fetch = _SequentialFetch([{"id": "B1", "name": "My blog"}])
-        manager = _FakeResumableManager()
-        rows = _collect("blogs", manager, fetch)
-        assert rows == [{"id": "B1", "name": "My blog"}]
-        assert manager.saved == []
-        assert "/blogs/BID?key=K" in fetch.urls[0]
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_single_object_yields_one_row(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"id": "B1", "name": "My blog"})])
 
-    def test_list_paginates_and_saves_state_only_when_more_pages(self) -> None:
-        fetch = _SequentialFetch(
+        manager = _make_manager()
+        rows = _rows(_source("blogs", manager))
+
+        assert rows == [{"id": "B1", "name": "My blog"}]
+        manager.save_state.assert_not_called()
+        assert snapshots[0]["url"].endswith("/blogs/BID")
+        # `blogs.get` sends no list params; the key rides via the framework's query-param auth.
+        assert snapshots[0]["params"] == {}
+
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_api_key_rides_as_query_param_auth(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"items": [{"id": "p1"}]})])
+
+        _rows(_source("posts", _make_manager()))
+
+        auth = snapshots[0]["auth"]
+        assert isinstance(auth, APIKeyAuth)
+        assert (auth.api_key, auth.name, auth.location) == ("K", "key", "query")
+
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_list_paginates_and_saves_state_only_when_more_pages(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
             [
-                {"items": [{"id": "p1"}, {"id": "p2"}], "nextPageToken": "T2"},
-                {"items": [{"id": "p3"}], "nextPageToken": None},
-            ]
+                _response({"items": [{"id": "p1"}, {"id": "p2"}], "nextPageToken": "T2"}),
+                _response({"items": [{"id": "p3"}], "nextPageToken": None}),
+            ],
         )
-        manager = _FakeResumableManager()
-        rows = _collect("posts", manager, fetch)
+
+        manager = _make_manager()
+        rows = _rows(_source("posts", manager))
+
         assert [r["id"] for r in rows] == ["p1", "p2", "p3"]
         # State is saved once — after the first page (which had a next token), not after the last.
-        assert manager.saved == [BloggerResumeConfig(page_token="T2")]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BloggerResumeConfig(page_token="T2")
         # The second request carries the page token from the first response.
-        assert "pageToken=T2" in fetch.urls[1]
+        assert snapshots[0]["params"].get("pageToken") is None
+        assert snapshots[1]["params"]["pageToken"] == "T2"
         # Full refresh sends no startDate.
-        assert all("startDate" not in url for url in fetch.urls)
+        assert all("startDate" not in s["params"] for s in snapshots)
 
-    def test_incremental_maps_last_value_to_start_date(self) -> None:
-        fetch = _SequentialFetch([{"items": [{"id": "p1"}], "nextPageToken": None}])
-        manager = _FakeResumableManager()
-        _collect(
-            "posts",
-            manager,
-            fetch,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
-            incremental_field="published",
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_posts_sends_max_results_and_order_by(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"items": [{"id": "p1"}]})])
+
+        _rows(_source("posts", _make_manager()))
+
+        assert snapshots[0]["params"]["maxResults"] == 100
+        assert snapshots[0]["params"]["orderBy"] == "published"
+
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_comments_has_no_order_by(self, MockSession: mock.MagicMock) -> None:
+        # comments.listByBlog rejects ordering params, so we never send orderBy for it.
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"items": [{"id": "c1"}]})])
+
+        _rows(_source("comments", _make_manager()))
+
+        assert "orderBy" not in snapshots[0]["params"]
+
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_incremental_maps_last_value_to_start_date(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"items": [{"id": "p1"}], "nextPageToken": None})])
+
+        _rows(
+            _source(
+                "posts",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            )
         )
-        # Colons are percent-encoded by urlencode.
-        assert "startDate=2026-03-04T02%3A58%3A14Z" in fetch.urls[0]
 
-    def test_first_sync_without_last_value_sends_no_start_date(self) -> None:
-        fetch = _SequentialFetch([{"items": [{"id": "p1"}], "nextPageToken": None}])
-        manager = _FakeResumableManager()
-        _collect(
-            "posts",
-            manager,
-            fetch,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=None,
-            incremental_field="published",
+        assert snapshots[0]["params"]["startDate"] == "2026-03-04T02:58:14Z"
+
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_first_sync_without_last_value_sends_no_start_date(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"items": [{"id": "p1"}], "nextPageToken": None})])
+
+        _rows(
+            _source(
+                "posts",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=None,
+            )
         )
-        assert "startDate" not in fetch.urls[0]
 
-    def test_resume_starts_from_saved_page_token(self) -> None:
-        fetch = _SequentialFetch([{"items": [{"id": "p9"}], "nextPageToken": None}])
-        manager = _FakeResumableManager(BloggerResumeConfig(page_token="RESUME"))
-        rows = _collect("posts", manager, fetch)
+        assert "startDate" not in snapshots[0]["params"]
+
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_resume_starts_from_saved_page_token(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"items": [{"id": "p9"}], "nextPageToken": None})])
+
+        manager = _make_manager(BloggerResumeConfig(page_token="RESUME"))
+        rows = _rows(_source("posts", manager))
+
         assert [r["id"] for r in rows] == ["p9"]
-        assert "pageToken=RESUME" in fetch.urls[0]
+        assert snapshots[0]["params"]["pageToken"] == "RESUME"
 
     @parameterized.expand(
         [
@@ -254,27 +257,48 @@ class TestGetRows:
             ),
         ]
     )
-    def test_empty_items_never_save_state(self, _name: str, responses: list[dict], expected_requests: int) -> None:
-        fetch = _SequentialFetch(responses)
-        manager = _FakeResumableManager()
-        rows = _collect("posts", manager, fetch)
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_empty_items_never_save_state(
+        self, _name: str, responses: list[dict], expected_requests: int, MockSession: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(body) for body in responses])
+
+        manager = _make_manager()
+        rows = _rows(_source("posts", manager))
+
         assert rows == []
         # Empty pages never persist a resume token: a crash mid-sequence re-walks the empty pages
         # rather than skipping past them, so no unseen data is missed on resume.
-        assert manager.saved == []
-        assert len(fetch.urls) == expected_requests
+        manager.save_state.assert_not_called()
+        assert len(snapshots) == expected_requests
         if expected_requests > 1:
             # The continuation token from the empty page still drives the follow-up request.
-            assert "pageToken=T2" in fetch.urls[1]
+            assert snapshots[1]["params"]["pageToken"] == "T2"
+
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_missing_items_key_is_a_zero_row_page(self, MockSession: mock.MagicMock) -> None:
+        # Blogger omits `items` entirely when there is nothing to return — that's a legit empty
+        # page, not a changed response shape, so it must not raise.
+        session = MockSession.return_value
+        _wire(session, [_response({"kind": "blogger#postList"})])
+
+        rows = _rows(_source("posts", _make_manager()))
+
+        assert rows == []
 
 
-class TestFetchPageErrorSanitization:
-    def test_client_error_strips_api_key_but_keeps_matchable_prefix(self) -> None:
+class TestErrorSanitization:
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_client_error_strips_api_key_but_keeps_matchable_prefix(self, MockSession: mock.MagicMock) -> None:
         # The real URL carries the key in the query string; the raised error must not leak it.
         leaky_url = "https://www.googleapis.com/blogger/v3/blogs/BID/posts?key=SECRETKEY&maxResults=100"
-        session = _FakeSession(_FakeResponse(400, url=leaky_url, reason="Bad Request"))
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=400, url=leaky_url, reason="Bad Request")])
+
         with pytest.raises(requests.HTTPError) as exc_info:
-            blogger._fetch_page(session, leaky_url, {}, MagicMock())  # type: ignore[arg-type]
+            _rows(_source("posts", _make_manager()))
+
         message = str(exc_info.value)
         assert "SECRETKEY" not in message
         # The non-retryable matcher keys are prefixes of this message, so error classification still works.
@@ -283,39 +307,24 @@ class TestFetchPageErrorSanitization:
 
 class TestBloggerSourceResponse:
     @parameterized.expand([("posts", "desc"), ("comments", "desc"), ("blogs", "asc"), ("pages", "asc")])
-    def test_sort_mode_matches_incremental(self, endpoint: str, expected: str) -> None:
-        response = blogger_source(
-            api_key="K",
-            blog_id="BID",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_sort_mode_matches_incremental(self, endpoint: str, expected: str, MockSession: mock.MagicMock) -> None:
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         assert response.sort_mode == expected
 
     @parameterized.expand([("posts",), ("comments",)])
-    def test_incremental_endpoints_partition_by_published(self, endpoint: str) -> None:
-        response = blogger_source(
-            api_key="K",
-            blog_id="BID",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_incremental_endpoints_partition_by_published(self, endpoint: str, MockSession: mock.MagicMock) -> None:
+        response = _source(endpoint, _make_manager())
         assert response.partition_mode == "datetime"
         assert response.partition_keys == ["published"]
         assert response.partition_format == "month"
 
     @parameterized.expand([("blogs",), ("pages",)])
-    def test_full_refresh_endpoints_have_no_partition(self, endpoint: str) -> None:
-        response = blogger_source(
-            api_key="K",
-            blog_id="BID",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(BLOGGER_SESSION_PATCH)
+    def test_full_refresh_endpoints_have_no_partition(self, endpoint: str, MockSession: mock.MagicMock) -> None:
+        response = _source(endpoint, _make_manager())
         assert response.partition_mode is None
         assert response.partition_keys is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/tests/test_blogger_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/blogger/tests/test_blogger_source.py
@@ -172,9 +172,10 @@ class TestBloggerPipelinePlumbing:
         assert captured["api_key"] == "K"
         assert captured["blog_id"] == "BID"
         assert captured["endpoint"] == "comments"
+        assert captured["team_id"] == 1
+        assert captured["job_id"] == "job-id"
         assert captured["should_use_incremental_field"] is True
         assert captured["db_incremental_field_last_value"] == "2026-01-01T00:00:00Z"
-        assert captured["incremental_field"] == "published"
 
     def test_source_for_pipeline_clears_last_value_when_not_incremental(self) -> None:
         captured: dict[str, Any] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ChargebeeSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -65,21 +68,7 @@ class ChargebeeSource(ResumableSource[ChargebeeSourceConfig, ChargebeeResumeConf
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in list(ENDPOINTS)
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: ChargebeeSourceConfig, team_id: int, schema_name: Optional[str] = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/errors.py
@@ -20,8 +20,7 @@ def auth_non_retryable_errors(host: str | None = None, *, service: str | None = 
     svc = f"{service} " if service else ""
     unauthorized = f"Your {svc}API key or token is invalid or expired. Please reconnect with valid credentials."
     forbidden = (
-        f"Your {svc}credentials don't have permission to access this resource. "
-        "Check the key's scopes and reconnect."
+        f"Your {svc}credentials don't have permission to access this resource. Check the key's scopes and reconnect."
     )
     if host:
         return {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/errors.py
@@ -1,0 +1,35 @@
+"""Shared non-retryable-error helpers for warehouse sources.
+
+`get_non_retryable_errors()` returns a dict mapping a substring of the stringified exception to a
+friendly message; the pipeline fails the job (instead of retrying) when a raised error contains one
+of these substrings. Nearly every source hand-writes the same 401/403 pair, so centralize it here.
+"""
+
+
+def auth_non_retryable_errors(host: str | None = None, *, service: str | None = None) -> dict[str, str | None]:
+    """Standard 401/403 -> friendly-message map for `get_non_retryable_errors()`.
+
+    A bad or unscoped credential is permanent, not transient, so the job should fail fast rather than
+    retry. Keys match the stable ``requests`` ``raise_for_status()`` text as a substring.
+
+    Pass ``host`` (the source's base URL) to scope the match to this source's requests — e.g.
+    ``"401 Client Error: Unauthorized for url: https://api.example.com"`` — so an unrelated 401 from a
+    different host in the same job can't match. Omit it for a host-agnostic match. ``service`` names
+    the vendor in the message. Sources with provider-specific copy should still hand-write their own.
+    """
+    svc = f"{service} " if service else ""
+    unauthorized = f"Your {svc}API key or token is invalid or expired. Please reconnect with valid credentials."
+    forbidden = (
+        f"Your {svc}credentials don't have permission to access this resource. "
+        "Check the key's scopes and reconnect."
+    )
+    if host:
+        return {
+            f"401 Client Error: Unauthorized for url: {host}": unauthorized,
+            f"403 Client Error: Forbidden for url: {host}": forbidden,
+        }
+    return {"401 Client Error": unauthorized, "403 Client Error": forbidden}
+
+
+# Host-agnostic default, for sources that just want the common pair with no service name.
+AUTH_401_403_ERRORS: dict[str, str | None] = auth_non_retryable_errors()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -127,8 +127,27 @@ def _make_paginate_dependent_resource(
     incremental_param: Optional[IncrementalParam],
     incremental_cursor_transform: Optional[Callable[..., Any]],
     db_incremental_field_last_value: Optional[Any],
+    resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
+    initial_state: Optional[dict[str, Any]] = None,
 ) -> Callable[..., Iterator[list[Any]]]:
-    """Build the generator for a dependent (child) resource."""
+    """Build the generator for a dependent (child) resource.
+
+    When ``resume_hook`` is set the fan-out is resumable: each parent's child pagination is
+    checkpointed under that parent's resolved child path, so a restart skips parents already fully
+    synced and resumes the one that was in progress. Parent pagination itself is not resumed — the
+    (usually small) parent list is re-fetched each run and already-completed parents are skipped by
+    path. Resume state shape:
+    ``{"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}``.
+    """
+    # Closure state persists across parent-page invocations within a single run.
+    seed: dict[str, Any] = dict(initial_state) if initial_state else {}
+    completed: set[str] = set(seed.get("completed") or [])
+    current_path: Optional[str] = seed.get("current")
+    current_child_state: Optional[dict[str, Any]] = seed.get("child_state")
+
+    def checkpoint(current: Optional[str], child_state: Optional[dict[str, Any]]) -> None:
+        # resume_hook is non-None here (only called from the resumable path).
+        resume_hook({"completed": sorted(completed), "current": current, "child_state": child_state})  # type: ignore[misc]
 
     def paginate_dependent_resource(
         items: list[dict[str, Any]],
@@ -140,6 +159,7 @@ def _make_paginate_dependent_resource(
         hooks: Optional[dict[str, Any]],
         columns_config: Optional[Any] = None,
     ) -> Iterator[list[Any]]:
+        nonlocal current_path, current_child_state
         effective_columns_config = columns_config if columns_config is not None else default_columns_config
 
         if incremental_object:
@@ -154,6 +174,20 @@ def _make_paginate_dependent_resource(
         for item in items:
             formatted_path, parent_record = process_parent_data_item(path, item, resolved_param, include_from_parent)
 
+            if resume_hook is not None and formatted_path in completed:
+                continue
+
+            # Resume this parent's child cursor only if it's the one we were mid-way through.
+            child_initial = (
+                current_child_state if (resume_hook is not None and current_path == formatted_path) else None
+            )
+
+            def child_resume_hook(paginator_state: Optional[dict[str, Any]], _path: str = formatted_path) -> None:
+                nonlocal current_path, current_child_state
+                current_path = _path
+                current_child_state = paginator_state
+                checkpoint(_path, paginator_state)
+
             for child_page in client.paginate(
                 method=method,
                 path=formatted_path,
@@ -161,12 +195,20 @@ def _make_paginate_dependent_resource(
                 paginator=paginator,
                 data_selector=data_selector,
                 hooks=hooks,
+                resume_hook=child_resume_hook if resume_hook is not None else None,
+                initial_paginator_state=child_initial,
             ):
                 if parent_record:
                     for child_record in child_page:
                         child_record.update(parent_record)
 
                 yield list(convert_types(child_page, effective_columns_config))
+
+            if resume_hook is not None:
+                completed.add(formatted_path)
+                current_path = None
+                current_child_state = None
+                checkpoint(None, None)
 
     return paginate_dependent_resource
 
@@ -183,6 +225,11 @@ def create_resources(
     initial_paginator_state: Optional[dict[str, Any]] = None,
 ) -> dict[str, Resource]:
     resources: dict[str, Resource] = {}
+
+    # Resume is routed to the dependent (child) resource in a fan-out; the parent list is re-fetched
+    # each run (see _make_paginate_dependent_resource). So when any resource is dependent, the
+    # non-dependent resources in the same config don't consume the resume hook.
+    has_dependent_resource = any(rp is not None for rp in resolved_param_map.values())
 
     for resource_name in dependency_graph.static_order():
         resource_name = cast(str, resource_name)
@@ -217,7 +264,7 @@ def create_resources(
 
         hooks = create_response_hooks(endpoint_config.get("response_actions"))
 
-        resource_kwargs = exclude_keys(endpoint_resource, {"endpoint", "include_from_parent"})
+        resource_kwargs = exclude_keys(endpoint_resource, {"endpoint", "include_from_parent", "data_map"})
 
         columns_config = endpoint_resource.get("columns")
 
@@ -250,8 +297,12 @@ def create_resources(
                 incremental_object: Optional[Incremental] = incremental_object,
                 incremental_param: Optional[IncrementalParam] = incremental_param,
                 incremental_cursor_transform: Optional[Callable[..., Any]] = incremental_cursor_transform,
-                resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = resume_hook,
-                initial_paginator_state: Optional[dict[str, Any]] = initial_paginator_state,
+                resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = (
+                    None if has_dependent_resource else resume_hook
+                ),
+                initial_paginator_state: Optional[dict[str, Any]] = (
+                    None if has_dependent_resource else initial_paginator_state
+                ),
             ) -> Iterator[list[Any]]:
                 if incremental_object:
                     params = _set_incremental_params(
@@ -292,10 +343,6 @@ def create_resources(
             )
 
         else:
-            if resume_hook is not None or initial_paginator_state is not None:
-                raise NotImplementedError(
-                    f"Resume is not supported for dependent REST resources (resource={resource_name!r})"
-                )
             predecessor = resources[resolved_param.resolve_config["resource"]]
 
             base_params = exclude_keys(request_params, {resolved_param.param_name})
@@ -309,6 +356,8 @@ def create_resources(
                 incremental_param=incremental_param,
                 incremental_cursor_transform=incremental_cursor_transform,
                 db_incremental_field_last_value=db_incremental_field_last_value,
+                resume_hook=resume_hook,
+                initial_state=initial_paginator_state,
             )
 
             resources[resource_name] = Resource(
@@ -328,6 +377,12 @@ def create_resources(
                 },
                 data_from=predecessor,
             )
+
+        # Declarative per-item transform (e.g. flatten JSON:API attributes), applied after
+        # type coercion during iteration. dict -> dict; use data_selector for extraction first.
+        data_map = endpoint_resource.get("data_map")
+        if data_map is not None:
+            resources[resource_name].add_map(data_map)
 
     return resources
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -129,6 +129,7 @@ def _make_paginate_dependent_resource(
     db_incremental_field_last_value: Optional[Any],
     resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
     initial_state: Optional[dict[str, Any]] = None,
+    data_selector_required: bool = False,
 ) -> Callable[..., Iterator[list[Any]]]:
     """Build the generator for a dependent (child) resource.
 
@@ -197,6 +198,7 @@ def _make_paginate_dependent_resource(
                 hooks=hooks,
                 resume_hook=child_resume_hook if resume_hook is not None else None,
                 initial_paginator_state=child_initial,
+                data_selector_required=data_selector_required,
             ):
                 if parent_record:
                     for child_record in child_page:
@@ -303,6 +305,7 @@ def create_resources(
                 initial_paginator_state: Optional[dict[str, Any]] = (
                     None if has_dependent_resource else initial_paginator_state
                 ),
+                data_selector_required: bool = bool(endpoint_config.get("data_selector_required")),
             ) -> Iterator[list[Any]]:
                 if incremental_object:
                     params = _set_incremental_params(
@@ -323,6 +326,7 @@ def create_resources(
                     hooks=hooks,
                     resume_hook=resume_hook,
                     initial_paginator_state=initial_paginator_state,
+                    data_selector_required=data_selector_required,
                 ):
                     yield list(convert_types(page, columns_config))
 
@@ -358,6 +362,7 @@ def create_resources(
                 db_incremental_field_last_value=db_incremental_field_last_value,
                 resume_hook=resume_hook,
                 initial_state=initial_paginator_state,
+                data_selector_required=bool(endpoint_config.get("data_selector_required")),
             )
 
             resources[resource_name] = Resource(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
@@ -50,6 +50,13 @@ class BaseNextUrlPaginator(BasePaginator):
         super().__init__()
         self._next_url: Optional[str] = None
 
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume URL to the first request so a resumed run starts at the
+        # saved next-page link rather than the base path.
+        if self._next_url is not None:
+            request.url = self._next_url
+            request.params = {}
+
     def update_request(self, request: Request) -> None:
         if self._next_url is not None:
             request.url = self._next_url
@@ -59,6 +66,15 @@ class BaseNextUrlPaginator(BasePaginator):
             # back into their next link, so re-appending compounds one copy per page
             # until the URL grows large enough for the server to reject it.
             request.params = {}
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"next_url": self._next_url} if self._has_next_page and self._next_url is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_url = state.get("next_url")
+        if next_url is not None:
+            self._next_url = next_url
+            self._has_next_page = True
 
 
 class HeaderLinkPaginator(BaseNextUrlPaginator):
@@ -116,6 +132,13 @@ class JSONResponseCursorPaginator(BasePaginator):
         self.cursor_param = cursor_param
         self._cursor_value: Optional[str] = None
 
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume cursor to the first request.
+        if self._cursor_value is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._cursor_value
+
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         try:
             values = find_values(self.cursor_path, response.json())
@@ -132,6 +155,15 @@ class JSONResponseCursorPaginator(BasePaginator):
             if request.params is None:
                 request.params = {}
             request.params[self.cursor_param] = self._cursor_value
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor_value} if self._has_next_page and self._cursor_value is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor_value = cursor
+            self._has_next_page = True
 
     def __str__(self) -> str:
         return f"JSONResponseCursorPaginator(cursor_path={self.cursor_path})"
@@ -196,6 +228,16 @@ class OffsetPaginator(BasePaginator):
             request.params = {}
         request.params[self.offset_param] = self.offset
 
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.offset already points at the next page to fetch (update_state incremented it).
+        return {"offset": self.offset} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        offset = state.get("offset")
+        if offset is not None:
+            self.offset = int(offset)
+            self._has_next_page = True
+
     def __str__(self) -> str:
         return f"OffsetPaginator(offset={self.offset}, limit={self.limit})"
 
@@ -240,6 +282,16 @@ class PageNumberPaginator(BasePaginator):
         if request.params is None:
             request.params = {}
         request.params[self.page_param] = self.page
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page already points at the next page to fetch (update_state incremented it).
+        return {"page": self.page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._has_next_page = True
 
     def __str__(self) -> str:
         return f"PageNumberPaginator(page={self.page})"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
@@ -177,6 +177,7 @@ class OffsetPaginator(BasePaginator):
         offset_param: str = "offset",
         limit_param: str = "limit",
         total_path: Optional[TJsonPath] = "total",
+        total_header: Optional[str] = None,
         maximum_offset: Optional[int] = None,
         stop_after_empty_page: bool = True,
     ) -> None:
@@ -186,6 +187,9 @@ class OffsetPaginator(BasePaginator):
         self.offset_param = offset_param
         self.limit_param = limit_param
         self.total_path = total_path
+        # Some APIs report the grand total in a response header (e.g. X-*-Total) rather than the body;
+        # when set, this takes precedence over total_path for the stop check.
+        self.total_header = total_header
         self.maximum_offset = maximum_offset
         self.stop_after_empty_page = stop_after_empty_page
 
@@ -205,6 +209,16 @@ class OffsetPaginator(BasePaginator):
         if self.maximum_offset is not None and self.offset >= self.maximum_offset:
             self._has_next_page = False
             return
+
+        if self.total_header:
+            raw_total = response.headers.get(self.total_header)
+            if raw_total is not None:
+                try:
+                    if self.offset >= int(raw_total):
+                        self._has_next_page = False
+                        return
+                except (TypeError, ValueError):
+                    pass
 
         if self.total_path:
             try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
@@ -1,10 +1,25 @@
 import re
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from requests import Request, Response
 
 from .jsonpath_utils import TJsonPath, find_values
+
+# Where a paginator writes its pagination fields. "query" (default) mutates request.params;
+# "json" mutates the POST body — for APIs that carry page/cursor/limit inside the JSON payload.
+ParamLocation = Literal["query", "json"]
+
+
+def _inject_param(request: Request, location: ParamLocation, name: str, value: Any) -> None:
+    if location == "json":
+        if request.json is None:
+            request.json = {}
+        request.json[name] = value
+    else:
+        if request.params is None:
+            request.params = {}
+        request.params[name] = value
 
 
 class BasePaginator(ABC):
@@ -126,18 +141,18 @@ class JSONResponseCursorPaginator(BasePaginator):
         self,
         cursor_path: TJsonPath = "cursors.next",
         cursor_param: str = "cursor",
+        param_location: ParamLocation = "query",
     ) -> None:
         super().__init__()
         self.cursor_path = cursor_path
         self.cursor_param = cursor_param
+        self.param_location = param_location
         self._cursor_value: Optional[str] = None
 
     def init_request(self, request: Request) -> None:
         # Apply a seeded resume cursor to the first request.
         if self._cursor_value is not None:
-            if request.params is None:
-                request.params = {}
-            request.params[self.cursor_param] = self._cursor_value
+            _inject_param(request, self.param_location, self.cursor_param, self._cursor_value)
 
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         try:
@@ -152,9 +167,7 @@ class JSONResponseCursorPaginator(BasePaginator):
 
     def update_request(self, request: Request) -> None:
         if self._cursor_value is not None:
-            if request.params is None:
-                request.params = {}
-            request.params[self.cursor_param] = self._cursor_value
+            _inject_param(request, self.param_location, self.cursor_param, self._cursor_value)
 
     def get_resume_state(self) -> Optional[dict[str, Any]]:
         return {"cursor": self._cursor_value} if self._has_next_page and self._cursor_value is not None else None
@@ -180,6 +193,7 @@ class OffsetPaginator(BasePaginator):
         total_header: Optional[str] = None,
         maximum_offset: Optional[int] = None,
         stop_after_empty_page: bool = True,
+        param_location: ParamLocation = "query",
     ) -> None:
         super().__init__()
         self.limit = limit
@@ -192,12 +206,11 @@ class OffsetPaginator(BasePaginator):
         self.total_header = total_header
         self.maximum_offset = maximum_offset
         self.stop_after_empty_page = stop_after_empty_page
+        self.param_location = param_location
 
     def init_request(self, request: Request) -> None:
-        if request.params is None:
-            request.params = {}
-        request.params[self.offset_param] = self.offset
-        request.params[self.limit_param] = self.limit
+        _inject_param(request, self.param_location, self.offset_param, self.offset)
+        _inject_param(request, self.param_location, self.limit_param, self.limit)
 
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         if self.stop_after_empty_page and (data is None or len(data) == 0):
@@ -238,9 +251,7 @@ class OffsetPaginator(BasePaginator):
         self._has_next_page = True
 
     def update_request(self, request: Request) -> None:
-        if request.params is None:
-            request.params = {}
-        request.params[self.offset_param] = self.offset
+        _inject_param(request, self.param_location, self.offset_param, self.offset)
 
     def get_resume_state(self) -> Optional[dict[str, Any]]:
         # self.offset already points at the next page to fetch (update_state incremented it).
@@ -262,22 +273,24 @@ class PageNumberPaginator(BasePaginator):
         base_page: int = 0,
         page: Optional[int] = None,
         page_param: str = "page",
-        total_path: Optional[TJsonPath] = "total",
+        total_path: Optional[TJsonPath] = None,
         maximum_page: Optional[int] = None,
         stop_after_empty_page: bool = True,
+        param_location: ParamLocation = "query",
     ) -> None:
         super().__init__()
         self.base_page = base_page
         self.page = page if page is not None else base_page
         self.page_param = page_param
+        # jsonpath to the TOTAL NUMBER OF PAGES in the response body (e.g. "pagination.total_pages").
+        # When set, pagination stops after the last page instead of paying one extra empty-page request.
         self.total_path = total_path
         self.maximum_page = maximum_page
         self.stop_after_empty_page = stop_after_empty_page
+        self.param_location = param_location
 
     def init_request(self, request: Request) -> None:
-        if request.params is None:
-            request.params = {}
-        request.params[self.page_param] = self.page
+        _inject_param(request, self.param_location, self.page_param, self.page)
 
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         if self.stop_after_empty_page and (data is None or len(data) == 0):
@@ -290,12 +303,23 @@ class PageNumberPaginator(BasePaginator):
             self._has_next_page = False
             return
 
+        if self.total_path:
+            try:
+                values = find_values(self.total_path, response.json())
+                if values:
+                    total_pages = values[0]
+                    # self.page now points at the NEXT page; the last valid page is
+                    # base_page + total_pages - 1.
+                    if isinstance(total_pages, int) and self.page > self.base_page + total_pages - 1:
+                        self._has_next_page = False
+                        return
+            except Exception:
+                pass
+
         self._has_next_page = True
 
     def update_request(self, request: Request) -> None:
-        if request.params is None:
-            request.params = {}
-        request.params[self.page_param] = self.page
+        _inject_param(request, self.param_location, self.page_param, self.page)
 
     def get_resume_state(self) -> Optional[dict[str, Any]]:
         # self.page already points at the next page to fetch (update_state incremented it).

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -136,6 +136,7 @@ class RESTClient:
         hooks: Optional[Hooks] = None,
         resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
         initial_paginator_state: Optional[dict[str, Any]] = None,
+        data_selector_required: bool = False,
     ) -> Iterator[list[Any]]:
         paginator = copy.deepcopy(paginator) if paginator else copy.deepcopy(self.paginator)
         hooks = hooks or {}
@@ -164,7 +165,7 @@ class RESTClient:
             except IgnoreResponseException:
                 break
 
-            data = self._extract_response(body, data_selector)
+            data = self._extract_response(body, data_selector, required=data_selector_required)
 
             if paginator is not None:
                 paginator.update_state(response, data)
@@ -222,9 +223,20 @@ class RESTClient:
 
         return response, body
 
-    def _extract_response(self, body: Any, data_selector: Optional[TJsonPath]) -> list[Any]:
+    def _extract_response(self, body: Any, data_selector: Optional[TJsonPath], *, required: bool = False) -> list[Any]:
         if data_selector:
-            data: Any = find_values(data_selector, body)
+            matches: Any = find_values(data_selector, body)
+            # ``required`` distinguishes "the selector key is absent" (no matches -> the response
+            # shape changed, fail loud) from "the key is present but the list is empty" (a legit
+            # zero-row page, which yields one match whose value is []). Sources that treat a missing
+            # data key as an error set data_selector_required=True instead of silently syncing 0 rows.
+            if required and not matches:
+                keys = sorted(body.keys())[:20] if isinstance(body, dict) else type(body).__name__
+                raise ValueError(
+                    f"Required data_selector {data_selector!r} matched nothing in the response "
+                    f"(body keys: {keys}). The API response shape may have changed."
+                )
+            data: Any = matches
             # unwrap single-item list from jsonpath
             if isinstance(data, list) and len(data) == 1:
                 data = data[0]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -241,6 +241,14 @@ class RESTClient:
             if isinstance(data, list) and len(data) == 1:
                 data = data[0]
         else:
+            # No selector: the whole body is the row list. With ``required``, a non-list body means
+            # the response shape changed (e.g. an error object on a 200) — fail loud rather than
+            # wrapping the stray object as a single row.
+            if required and not isinstance(body, list):
+                raise ValueError(
+                    f"Required a list response body, got {type(body).__name__}. "
+                    "The API response shape may have changed."
+                )
             data = body
 
         if data is None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_data_map.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_data_map.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from unittest.mock import patch
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import rest_api_resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
+
+
+def test_data_map_reshapes_rows_declaratively() -> None:
+    config: dict[str, Any] = {
+        "client": {"base_url": "https://api.example.com"},
+        "resources": [
+            {
+                "name": "things",
+                "endpoint": {"path": "/things"},
+                # flatten a JSON:API-style ``attributes`` block into the row root
+                "data_map": lambda row: {"id": row["id"], **row.get("attributes", {})},
+            }
+        ],
+    }
+    raw_page = [{"id": 1, "attributes": {"name": "x", "active": True}}]
+    with patch.object(RESTClient, "paginate", return_value=iter([raw_page])):
+        resource = rest_api_resource(config, team_id=1, job_id="j", db_incremental_field_last_value=None)
+        rows = [row for page in resource for row in page]
+
+    assert rows == [{"id": 1, "name": "x", "active": True}]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
@@ -232,7 +232,17 @@ class _FakeResumableClient:
         self.pages_by_path = pages_by_path
 
     def paginate(
-        self, *, method, path, params, paginator, data_selector, hooks, resume_hook=None, initial_paginator_state=None
+        self,
+        *,
+        method,
+        path,
+        params,
+        paginator,
+        data_selector,
+        hooks,
+        resume_hook=None,
+        initial_paginator_state=None,
+        data_selector_required=False,
     ):
         pages = self.pages_by_path[path]
         start = initial_paginator_state["page"] if initial_paginator_state else 0

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
@@ -223,3 +223,105 @@ def test_paginate_dependent_resource_does_not_leak_params_across_parents() -> No
         assert params_snapshot["since"] == "2026-01-01"
         assert params_snapshot["until"] == "2026-03-01"
         assert "before" not in params_snapshot
+
+
+class _FakeResumableClient:
+    # paginate() simulates page-by-page pagination with resume: it honors
+    # initial_paginator_state["page"] as the start index and calls resume_hook after each page.
+    def __init__(self, pages_by_path: dict[str, list[list[dict[str, Any]]]]) -> None:
+        self.pages_by_path = pages_by_path
+
+    def paginate(
+        self, *, method, path, params, paginator, data_selector, hooks, resume_hook=None, initial_paginator_state=None
+    ):
+        pages = self.pages_by_path[path]
+        start = initial_paginator_state["page"] if initial_paginator_state else 0
+        for i in range(start, len(pages)):
+            yield pages[i]
+            if resume_hook is not None:
+                resume_hook({"page": i + 1} if i < len(pages) - 1 else None)
+
+
+_RESOLVED_PARAM = ResolvedParam(
+    param_name="parent_id",
+    resolve_config={"type": "resolve", "resource": "parents", "field": "id"},
+)
+
+
+def _dependent_fn(client, resume_hook=None, initial_state=None):
+    return _make_paginate_dependent_resource(
+        client=client,
+        resolved_param=_RESOLVED_PARAM,
+        include_from_parent=[],
+        default_columns_config=None,
+        incremental_object=None,
+        incremental_param=None,
+        incremental_cursor_transform=None,
+        db_incremental_field_last_value=None,
+        resume_hook=resume_hook,
+        initial_state=initial_state,
+    )
+
+
+def _drive(paginate_fn) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for page in paginate_fn(
+        items=[{"id": "a"}, {"id": "b"}],
+        method="get",
+        path="/parents/{parent_id}/children",
+        params={},
+        paginator=None,
+        data_selector=None,
+        hooks=None,
+    ):
+        rows.extend(page)
+    return rows
+
+
+def test_dependent_resume_checkpoints_completed_parents() -> None:
+    client = _FakeResumableClient(
+        {
+            "/parents/a/children": [[{"id": "a1"}], [{"id": "a2"}]],
+            "/parents/b/children": [[{"id": "b1"}]],
+        }
+    )
+    checkpoints: list[Any] = []
+    rows = _drive(_dependent_fn(client, resume_hook=checkpoints.append))
+
+    assert [r["id"] for r in rows] == ["a1", "a2", "b1"]
+    # Final checkpoint records both parents fully synced, nothing in progress.
+    assert checkpoints[-1] == {
+        "completed": ["/parents/a/children", "/parents/b/children"],
+        "current": None,
+        "child_state": None,
+    }
+
+
+def test_dependent_resume_skips_completed_and_resumes_current() -> None:
+    client = _FakeResumableClient(
+        {
+            "/parents/a/children": [[{"id": "a1"}], [{"id": "a2"}]],
+            "/parents/b/children": [[{"id": "b1"}], [{"id": "b2"}]],
+        }
+    )
+    # Parent a already fully synced; parent b was mid-way (its child cursor is at page index 1).
+    initial_state = {
+        "completed": ["/parents/a/children"],
+        "current": "/parents/b/children",
+        "child_state": {"page": 1},
+    }
+    rows = _drive(_dependent_fn(client, resume_hook=lambda _s: None, initial_state=initial_state))
+
+    # a is skipped entirely (no re-yield); b resumes from page 1, so only b2 (b1 already synced).
+    assert [r["id"] for r in rows] == ["b2"]
+
+
+def test_dependent_resume_disabled_without_hook_processes_all() -> None:
+    client = _FakeResumableClient(
+        {
+            "/parents/a/children": [[{"id": "a1"}]],
+            "/parents/b/children": [[{"id": "b1"}]],
+        }
+    )
+    rows = _drive(_dependent_fn(client, resume_hook=None))
+    assert [r["id"] for r in rows] == ["a1", "b1"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -190,3 +190,59 @@ class TestSingleEntityPath:
     )
     def test_detection(self, path: str, expected: bool) -> None:
         assert single_entity_path(path) == expected
+
+
+class TestPaginatorResume:
+    def test_offset_paginator_round_trips_resume_state(self) -> None:
+        p = OffsetPaginator(limit=100, total_path=None)
+        p.update_state(_make_response(), data=[{} for _ in range(100)])  # full page -> more
+        assert p.has_next_page is True
+        state = p.get_resume_state()
+        assert state == {"offset": 100}
+
+        resumed = OffsetPaginator(limit=100, total_path=None)
+        resumed.set_resume_state(state)
+        req = Request(method="GET", url="https://api.example.com/x")
+        resumed.init_request(req)
+        assert req.params["offset"] == 100
+
+    def test_offset_paginator_no_resume_state_when_done(self) -> None:
+        p = OffsetPaginator(limit=100, total_path=None)
+        p.update_state(_make_response(), data=[{}])  # short page -> done
+        assert p.get_resume_state() is None
+
+    def test_page_number_paginator_round_trips_resume_state(self) -> None:
+        p = PageNumberPaginator(page=1)
+        p.update_state(_make_response(), data=[{} for _ in range(50)])
+        state = p.get_resume_state()
+        assert state == {"page": 2}
+
+        resumed = PageNumberPaginator(page=1)
+        resumed.set_resume_state(state)
+        req = Request(method="GET", url="https://api.example.com/x")
+        resumed.init_request(req)
+        assert req.params["page"] == 2
+
+    def test_cursor_paginator_round_trips_resume_state(self) -> None:
+        p = JSONResponseCursorPaginator(cursor_path="cursors.next", cursor_param="cursor")
+        p.update_state(_make_response({"cursors": {"next": "abc"}}))
+        state = p.get_resume_state()
+        assert state == {"cursor": "abc"}
+
+        resumed = JSONResponseCursorPaginator(cursor_param="cursor")
+        resumed.set_resume_state(state)
+        req = Request(method="GET", url="https://api.example.com/x")
+        resumed.init_request(req)
+        assert req.params["cursor"] == "abc"
+
+    def test_next_url_paginator_round_trips_resume_state(self) -> None:
+        p = JSONResponsePaginator(next_url_path="next")
+        p.update_state(_make_response({"next": "https://api.example.com/page2"}))
+        state = p.get_resume_state()
+        assert state == {"next_url": "https://api.example.com/page2"}
+
+        resumed = JSONResponsePaginator()
+        resumed.set_resume_state(state)
+        req = Request(method="GET", url="https://api.example.com/page1")
+        resumed.init_request(req)
+        assert req.url == "https://api.example.com/page2"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -246,3 +246,17 @@ class TestPaginatorResume:
         req = Request(method="GET", url="https://api.example.com/page1")
         resumed.init_request(req)
         assert req.url == "https://api.example.com/page2"
+
+
+class TestOffsetPaginatorTotalHeader:
+    def test_stops_when_offset_reaches_header_total(self) -> None:
+        p = OffsetPaginator(limit=2, total_path=None, total_header="X-Total")
+        resp = _make_response({}, headers={"X-Total": "2"})
+        p.update_state(resp, data=[{}, {}])  # full page, offset -> 2, total 2 -> stop
+        assert p.has_next_page is False
+
+    def test_continues_when_below_header_total(self) -> None:
+        p = OffsetPaginator(limit=2, total_path=None, total_header="X-Total")
+        resp = _make_response({}, headers={"X-Total": "5"})
+        p.update_state(resp, data=[{}, {}])  # offset -> 2, below 5 -> continue
+        assert p.has_next_page is True

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -260,3 +260,52 @@ class TestOffsetPaginatorTotalHeader:
         resp = _make_response({}, headers={"X-Total": "5"})
         p.update_state(resp, data=[{}, {}])  # offset -> 2, below 5 -> continue
         assert p.has_next_page is True
+
+
+class TestJsonBodyPagination:
+    def test_offset_paginator_injects_into_json_body(self) -> None:
+        p = OffsetPaginator(limit=50, total_path=None, param_location="json")
+        req = Request(method="POST", url="https://api.example.com/search", json=None)
+        p.init_request(req)
+        assert req.json == {"offset": 0, "limit": 50}
+        assert not req.params
+
+        p.update_state(_make_response(), data=[{} for _ in range(50)])
+        p.update_request(req)
+        assert req.json["offset"] == 50
+
+    def test_page_number_paginator_injects_into_json_body(self) -> None:
+        p = PageNumberPaginator(base_page=0, page_param="page", param_location="json")
+        req = Request(method="POST", url="https://api.example.com/search", json={"query": ""})
+        p.init_request(req)
+        assert req.json == {"query": "", "page": 0}
+
+    def test_cursor_paginator_injects_into_json_body(self) -> None:
+        p = JSONResponseCursorPaginator(cursor_path="cursor", cursor_param="cursor", param_location="json")
+        p.update_state(_make_response({"cursor": "abc"}))
+        req = Request(method="POST", url="https://api.example.com/browse", json={"hitsPerPage": 1000})
+        p.update_request(req)
+        assert req.json == {"hitsPerPage": 1000, "cursor": "abc"}
+
+
+class TestPageNumberTotalPages:
+    def test_stops_after_last_page_per_total_pages(self) -> None:
+        p = PageNumberPaginator(base_page=1, total_path="pagination.total_pages")
+        resp = _make_response({"pagination": {"total_pages": 2}})
+        p.update_state(resp, data=[{}])  # fetched page 1 of 2 -> continue
+        assert p.has_next_page is True
+        p.update_state(resp, data=[{}])  # fetched page 2 of 2 -> stop, no extra request
+        assert p.has_next_page is False
+
+    def test_zero_based_pages_respect_total(self) -> None:
+        p = PageNumberPaginator(base_page=0, total_path="pages")
+        resp = _make_response({"pages": 1})
+        p.update_state(resp, data=[{}])  # fetched page 0, total 1 page -> stop
+        assert p.has_next_page is False
+
+    def test_missing_total_falls_back_to_empty_page_stop(self) -> None:
+        p = PageNumberPaginator(base_page=1, total_path="pagination.total_pages")
+        p.update_state(_make_response({}), data=[{}])
+        assert p.has_next_page is True
+        p.update_state(_make_response({}), data=[])
+        assert p.has_next_page is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_required_selector.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_required_selector.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import Mock
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
+
+
+def _client() -> RESTClient:
+    return RESTClient(base_url="https://api.example.com", session=Mock())
+
+
+class TestRequiredDataSelector:
+    def test_absent_key_raises_when_required(self) -> None:
+        # The selector key is missing entirely -> response shape changed -> fail loud.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _client()._extract_response({"unexpected": "envelope"}, "data", required=True)
+
+    def test_present_empty_list_is_valid_zero_rows_when_required(self) -> None:
+        # Key present, list empty -> a legit zero-row page, NOT a shape change -> no raise.
+        assert _client()._extract_response({"data": []}, "data", required=True) == []
+
+    def test_present_with_rows_when_required(self) -> None:
+        assert _client()._extract_response({"data": [{"id": 1}]}, "data", required=True) == [{"id": 1}]
+
+    def test_absent_key_is_silent_when_not_required(self) -> None:
+        # Backward compatible: without required, a missing key still silently yields nothing.
+        assert _client()._extract_response({"unexpected": "envelope"}, "data", required=False) == []

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_required_selector.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_required_selector.py
@@ -24,3 +24,12 @@ class TestRequiredDataSelector:
     def test_absent_key_is_silent_when_not_required(self) -> None:
         # Backward compatible: without required, a missing key still silently yields nothing.
         assert _client()._extract_response({"unexpected": "envelope"}, "data", required=False) == []
+
+
+class TestRequiredListBody:
+    def test_non_list_body_raises_when_required_and_no_selector(self) -> None:
+        with pytest.raises(ValueError, match="list response body"):
+            _client()._extract_response({"error": "x"}, None, required=True)
+
+    def test_list_body_ok_when_required_and_no_selector(self) -> None:
+        assert _client()._extract_response([{"id": 1}], None, required=True) == [{"id": 1}]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -55,6 +55,7 @@ class PageNumberPaginatorConfig(PaginatorTypeConfig, total=False):
     page_param: Optional[str]
     total_path: Optional[TJsonPath]
     maximum_page: Optional[int]
+    param_location: Optional[str]  # "query" (default) or "json" (POST-body pagination)
 
 
 class OffsetPaginatorConfig(PaginatorTypeConfig, total=False):
@@ -63,7 +64,9 @@ class OffsetPaginatorConfig(PaginatorTypeConfig, total=False):
     offset_param: Optional[str]
     limit_param: Optional[str]
     total_path: Optional[TJsonPath]
+    total_header: Optional[str]
     maximum_offset: Optional[int]
+    param_location: Optional[str]  # "query" (default) or "json" (POST-body pagination)
 
 
 class HeaderLinkPaginatorConfig(PaginatorTypeConfig, total=False):
@@ -77,6 +80,7 @@ class JSONResponsePaginatorConfig(PaginatorTypeConfig, total=False):
 class JSONResponseCursorPaginatorConfig(PaginatorTypeConfig, total=False):
     cursor_path: Optional[TJsonPath]
     cursor_param: Optional[str]
+    param_location: Optional[str]  # "query" (default) or "json" (POST-body pagination)
 
 
 PaginatorConfig = (

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -221,6 +221,10 @@ class Endpoint(TypedDict, total=False):
     json: Optional[dict[str, Any]]
     paginator: Optional[PaginatorConfig]
     data_selector: Optional[TJsonPath]
+    # When True, a response whose ``data_selector`` matches nothing (the key is absent) raises
+    # instead of yielding an empty page — fail-loud on an unexpected/changed API response shape,
+    # rather than silently syncing 0 rows. A present-but-empty list is still a valid 0-row page.
+    data_selector_required: Optional[bool]
     response_actions: Optional[list[ResponseAction]]
     incremental: Optional[IncrementalConfig]
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -242,6 +242,10 @@ class ResourceBase(TypedDict, total=False):
 class EndpointResourceBase(ResourceBase, total=False):
     endpoint: Optional[str | Endpoint]
     include_from_parent: Optional[list[str]]
+    # Per-item transform applied after ``data_selector`` and before type coercion, for reshaping
+    # a row the selector can't express (e.g. flattening JSON:API ``attributes`` into the row root).
+    # Wired through to ``Resource.add_map``; must be dict -> dict (1:1).
+    data_map: Optional[Callable[[dict[str, Any]], dict[str, Any]]]
 
 
 class EndpointResource(EndpointResourceBase, total=False):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/schema.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/schema.py
@@ -1,6 +1,7 @@
+from collections.abc import Collection, Iterable, Mapping
 from dataclasses import dataclass, field
 
-from products.warehouse_sources.backend.types import IncrementalField
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
 
 # Preference order (lowercased) for auto-selecting an incremental field. Columns that
 # advance on every write (`updated_at`) catch late-arriving updates that creation-only
@@ -99,4 +100,66 @@ def build_default_schemas(source_schemas: list[SourceSchema]) -> list[dict]:
         if source_schema.detected_primary_keys:
             entry["primary_key_columns"] = source_schema.detected_primary_keys
         schemas.append(entry)
+    return schemas
+
+
+def incremental_field(
+    field: str,
+    field_type: IncrementalFieldType = IncrementalFieldType.DateTime,
+    label: str | None = None,
+) -> IncrementalField:
+    """Build an ``IncrementalField`` for a settings.py endpoint catalog.
+
+    Replaces the hand-written 4-key dict (``label``/``type``/``field``/``field_type``) that most
+    sources repeat per endpoint, where ``type`` and ``field_type`` are almost always the same value
+    and ``label`` defaults to the field name — a frequent copy-paste bug source.
+    """
+    return {"label": label or field, "type": field_type, "field": field, "field_type": field_type}
+
+
+def build_endpoint_schemas(
+    endpoints: Iterable[str],
+    incremental_fields: Mapping[str, list[IncrementalField]],
+    names: list[str] | None = None,
+    *,
+    append_only: Collection[str] = (),
+    merge_only: Collection[str] = (),
+    descriptions: Mapping[str, str] | None = None,
+    should_sync_default: Mapping[str, bool] | None = None,
+    supports_webhooks: Collection[str] = (),
+) -> list[SourceSchema]:
+    """Build the ``SourceSchema`` list for a static endpoint-catalog source's ``get_schemas``.
+
+    Collapses the near-universal ``for endpoint in ENDPOINTS: SourceSchema(...)`` loop plus the
+    identical ``names`` filter tail. An endpoint with incremental fields defaults to
+    ``supports_incremental=True`` and ``supports_append=True`` (the dominant pattern). Overrides:
+
+    - ``append_only``: endpoints that support append but not incremental merge.
+    - ``merge_only``: endpoints that support incremental merge but not append.
+    - ``descriptions`` / ``should_sync_default`` / ``supports_webhooks``: per-endpoint metadata.
+
+    ``names`` (the schema-picker filter) keeps only the requested endpoints when set.
+    """
+    descriptions = descriptions or {}
+    should_sync_default = should_sync_default or {}
+    schemas = []
+    for name in endpoints:
+        fields = incremental_fields.get(name) or []
+        has_incremental = bool(fields)
+        schemas.append(
+            SourceSchema(
+                name=name,
+                supports_incremental=has_incremental and name not in append_only,
+                supports_append=has_incremental and name not in merge_only,
+                incremental_fields=fields,
+                description=descriptions.get(name),
+                should_sync_default=should_sync_default.get(name, True),
+                supports_webhooks=name in supports_webhooks,
+            )
+        )
+
+    if names is not None:
+        names_set = set(names)
+        schemas = [s for s in schemas if s.name in names_set]
+
     return schemas

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/source_helpers.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/source_helpers.py
@@ -22,16 +22,19 @@ def validate_via_probe(
 ) -> tuple[bool, int | None]:
     """Probe ``url`` with a GET and report ``(is_valid, status_code)``.
 
-    ``session_factory`` should return a tracked session (``make_tracked_session``). Transport failures
-    (DNS, connection, timeout) map to ``(False, None)``; any HTTP response maps to
-    ``(status in ok_statuses, status)`` so the caller can distinguish 401 (bad token) from 403
-    (valid token, missing scope) — accept 403 at source-create when ``schema_name`` is None, per the
-    skill. The caller wraps the result into the ``(bool, message)`` its ``validate_credentials``
-    returns.
+    ``session_factory`` should return a tracked session (``make_tracked_session``). ANY failure
+    building the session or making the request (transport error, and defensively anything else) maps
+    to ``(False, None)`` — a credential probe should never raise out of ``validate_credentials`` and
+    fail source creation; an unreachable/erroring probe just means "not validated". This matches the
+    broad ``except Exception`` the hand-rolled probes across ~all sources use, so it's a drop-in.
+    Any HTTP response maps to ``(status in ok_statuses, status)`` so the caller can distinguish 401
+    (bad token) from 403 (valid token, missing scope) — accept 403 at source-create when
+    ``schema_name`` is None, per the skill. The caller wraps the result into the ``(bool, message)``
+    its ``validate_credentials`` returns.
     """
     try:
         session = session_factory()
         response = session.get(url, headers=dict(headers) if headers else None, auth=auth, timeout=timeout)
-    except requests.RequestException:
+    except Exception:  # noqa: BLE001 — a credential probe must never raise; any failure means "not validated"
         return False, None
     return response.status_code in ok_statuses, response.status_code

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/source_helpers.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/source_helpers.py
@@ -1,0 +1,37 @@
+"""Shared helpers for source credential validation.
+
+Most API sources implement `validate_credentials` by probing one cheap endpoint and mapping the HTTP
+status to a bool. Centralize that probe so sources don't each re-implement the try/except + status
+check (and so the 401-vs-403 distinction the skill describes is handled consistently).
+"""
+
+from collections.abc import Callable, Mapping
+
+import requests
+from requests.auth import AuthBase
+
+
+def validate_via_probe(
+    session_factory: Callable[[], requests.Session],
+    url: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+    auth: AuthBase | None = None,
+    ok_statuses: tuple[int, ...] = (200,),
+    timeout: float = 10.0,
+) -> tuple[bool, int | None]:
+    """Probe ``url`` with a GET and report ``(is_valid, status_code)``.
+
+    ``session_factory`` should return a tracked session (``make_tracked_session``). Transport failures
+    (DNS, connection, timeout) map to ``(False, None)``; any HTTP response maps to
+    ``(status in ok_statuses, status)`` so the caller can distinguish 401 (bad token) from 403
+    (valid token, missing scope) — accept 403 at source-create when ``schema_name`` is None, per the
+    skill. The caller wraps the result into the ``(bool, message)`` its ``validate_credentials``
+    returns.
+    """
+    try:
+        session = session_factory()
+        response = session.get(url, headers=dict(headers) if headers else None, auth=auth, timeout=timeout)
+    except requests.RequestException:
+        return False, None
+    return response.status_code in ok_statuses, response.status_code

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_source_helpers.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_source_helpers.py
@@ -1,0 +1,138 @@
+from unittest.mock import Mock
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.types import IncrementalFieldType
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.errors import (
+    auth_non_retryable_errors,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+    incremental_field,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import (
+    validate_via_probe,
+)
+
+ENDPOINTS = ("charges", "invoices", "events")
+INCREMENTAL_FIELDS = {
+    "charges": [incremental_field("updated_at")],
+    "invoices": [incremental_field("created", IncrementalFieldType.Date)],
+    # "events" intentionally has no incremental fields (full-refresh only)
+}
+
+
+class TestIncrementalField:
+    def test_defaults_type_and_label_from_field(self) -> None:
+        assert incremental_field("updated_at") == {
+            "label": "updated_at",
+            "type": IncrementalFieldType.DateTime,
+            "field": "updated_at",
+            "field_type": IncrementalFieldType.DateTime,
+        }
+
+    def test_type_and_field_type_stay_in_sync(self) -> None:
+        # The whole point of the helper: type == field_type, so they can't drift apart.
+        f = incremental_field("created", IncrementalFieldType.Date, label="Created")
+        assert f["label"] == "Created"
+        assert f["type"] == f["field_type"] == IncrementalFieldType.Date
+
+
+class TestBuildEndpointSchemas:
+    def test_matches_the_hand_written_loop(self) -> None:
+        # Equivalent to the loop copy-pasted across ~421 sources — output must be identical.
+        expected = [
+            SourceSchema(
+                name=e,
+                supports_incremental=INCREMENTAL_FIELDS.get(e) is not None,
+                supports_append=INCREMENTAL_FIELDS.get(e) is not None,
+                incremental_fields=INCREMENTAL_FIELDS.get(e, []),
+            )
+            for e in ENDPOINTS
+        ]
+        assert build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS) == expected
+
+    def test_endpoint_without_incremental_fields_is_full_refresh(self) -> None:
+        events = next(s for s in build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS) if s.name == "events")
+        assert events.supports_incremental is False
+        assert events.supports_append is False
+        assert events.incremental_fields == []
+
+    def test_names_filter_keeps_only_requested(self) -> None:
+        schemas = build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names=["invoices"])
+        assert [s.name for s in schemas] == ["invoices"]
+
+    def test_names_none_returns_all(self) -> None:
+        assert len(build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names=None)) == len(ENDPOINTS)
+
+    def test_append_only_disables_incremental_but_keeps_append(self) -> None:
+        charges = next(
+            s
+            for s in build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, append_only={"charges"})
+            if s.name == "charges"
+        )
+        assert charges.supports_incremental is False
+        assert charges.supports_append is True
+
+    def test_merge_only_disables_append_but_keeps_incremental(self) -> None:
+        charges = next(
+            s
+            for s in build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, merge_only={"charges"})
+            if s.name == "charges"
+        )
+        assert charges.supports_incremental is True
+        assert charges.supports_append is False
+
+    def test_per_endpoint_metadata_overrides(self) -> None:
+        schemas = build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            descriptions={"charges": "A charge"},
+            should_sync_default={"events": False},
+            supports_webhooks={"invoices"},
+        )
+        by_name = {s.name: s for s in schemas}
+        assert by_name["charges"].description == "A charge"
+        assert by_name["events"].should_sync_default is False
+        assert by_name["invoices"].supports_webhooks is True
+        # unspecified endpoints keep the defaults
+        assert by_name["charges"].should_sync_default is True
+        assert by_name["charges"].supports_webhooks is False
+
+
+class TestAuthNonRetryableErrors:
+    def test_host_scoped_keys_match_requests_error_text(self) -> None:
+        # Keys must be substrings of the real `raise_for_status()` message, or non-retryable
+        # matching silently fails and bad-credential jobs retry forever.
+        host = "https://api.example.com"
+        errors = auth_non_retryable_errors(host, service="Example")
+        assert f"401 Client Error: Unauthorized for url: {host}" in errors
+        assert f"403 Client Error: Forbidden for url: {host}" in errors
+        assert "Example" in errors[f"401 Client Error: Unauthorized for url: {host}"]
+
+    def test_host_agnostic_default(self) -> None:
+        errors = auth_non_retryable_errors()
+        assert set(errors) == {"401 Client Error", "403 Client Error"}
+
+
+class TestValidateViaProbe:
+    @parameterized.expand([(200, True), (204, False), (401, False), (403, False), (500, False)])
+    def test_status_mapping(self, status: int, expected_valid: bool) -> None:
+        response = Mock(status_code=status)
+        session = Mock()
+        session.get.return_value = response
+        valid, code = validate_via_probe(lambda: session, "https://api.example.com/ping")
+        assert (valid, code) == (expected_valid, status)
+
+    def test_custom_ok_statuses(self) -> None:
+        session = Mock()
+        session.get.return_value = Mock(status_code=204)
+        valid, code = validate_via_probe(lambda: session, "https://x", ok_statuses=(200, 204))
+        assert (valid, code) == (True, 204)
+
+    def test_transport_error_maps_to_false_none(self) -> None:
+        session = Mock()
+        session.get.side_effect = requests.ConnectionError("boom")
+        assert validate_via_probe(lambda: session, "https://x") == (False, None)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_source_helpers.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_source_helpers.py
@@ -3,18 +3,14 @@ from unittest.mock import Mock
 import requests
 from parameterized import parameterized
 
-from products.warehouse_sources.backend.types import IncrementalFieldType
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.errors import (
-    auth_non_retryable_errors,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.errors import auth_non_retryable_errors
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
     SourceSchema,
     build_endpoint_schemas,
     incremental_field,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import (
-    validate_via_probe,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.types import IncrementalFieldType
 
 ENDPOINTS = ("charges", "invoices", "events")
 INCREMENTAL_FIELDS = {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_source_helpers.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_source_helpers.py
@@ -132,3 +132,11 @@ class TestValidateViaProbe:
         session = Mock()
         session.get.side_effect = requests.ConnectionError("boom")
         assert validate_via_probe(lambda: session, "https://x") == (False, None)
+
+    def test_any_exception_maps_to_false_none(self) -> None:
+        # A credential probe must never raise out of validate_credentials — matches the broad
+        # `except Exception` the hand-rolled source probes use, so the helper is a drop-in.
+        def boom() -> Mock:
+            raise ValueError("session build failed")
+
+        assert validate_via_probe(boom, "https://x") == (False, None)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/source.template
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/source.template
@@ -1,17 +1,17 @@
-# 1. TODO: add a new value for your source in the following three places:
-#       - ExternalDataSourceType at `posthog/warehouse/types.py`
-#       - ExternalDataSourceType at `posthog/schema.py`. this is only needed so type checking doesn't initially fail
+# 1. TODO: add a new value for your source in these TWO hand-edited places:
+#       - ExternalDataSourceType at `products/warehouse_sources/backend/types.py`
+#         (models.TextChoices: `KEY = "PascalValue", "PascalValue"`, KEY is ALL_CAPS with NO underscores)
 #       - externalDataSources at `frontend/src/queries/schema/schema-general.ts`
-#
-#       following the casing conventions for each file whether ALL_CAPS_WITH_UNDERS, PascalCase, or
-#       lower-kebab-case
+#         (PascalCase string, identical to the types.py value — NOT kebab-case)
+#       Do NOT hand-edit `posthog/schema.py` / `posthog/schema_enums.py` — `pnpm run schema:build`
+#       (step 12) regenerates the ExternalDataSourceType enum there from schema-general.ts.
 # 2. TODO: run django migrations with `DEBUG=1 python manage.py makemigrations && DEBUG=1 ./bin/migrate`
 # 3. TODO: change the name of your source class from TemplateSource
 # 4. TODO: update the return value of source_type to match the ExternalDataSourceType you created in step one
-# 5. TODO: update ExternalDataSourceType in `posthog/schema.py` to include your
-#       source type as an enum value again, the key should be ALL_CAPS_WITH_UNDERS
-#       and the value should be PascalCase
-# 6. TODO: update get_source_config(). update the name to match the SchemaExternalDataSourceType from step 5.
+# 5. NOTE: you do NOT hand-edit posthog/schema.py — `pnpm run schema:build` (step 12) regenerates the
+#       SchemaExternalDataSourceType enum from your schema-general.ts entry (step 1). The member key is
+#       derived automatically (PascalCase value -> ALL_CAPS_WITH_UNDERS key, e.g. GoogleAds -> GOOGLE_ADS).
+# 6. TODO: update get_source_config(). set the name to SchemaExternalDataSourceType.<YOUR_KEY> (generated in step 12).
 #       also add any config fields users will need to connect the source. see other sources for examples.
 #       set `category` to the closest DataWarehouseSourceCategory bucket (required — it groups the source in
 #       the new-source wizard catalog) and optionally `keywords` (search aliases). see other sources for examples.


### PR DESCRIPTION
## Problem

Third batch of hand-rolled source → `rest_source` migrations, stacked on #71540. This batch proves the **fan-out and hydration patterns** on the framework's dependent resources (with resume), which previous batches had deferred.

## Changes

**Six sources migrated to `rest_source`**, each behavior-preserving with its full suite green:

| Source | Shape | Tests |
|---|---|---|
| `aircall` | offset/page lists + resume | 54 |
| `assemblyai` | list → per-id transcript hydration (dependent resource) | 42 |
| `beamer` | page lists + resume | 60 |
| `adroll` | advertisable-scoped fan-out (dependent resources, `include_from_parent`) | 35 |
| `bigmailer` | /brands → per-brand child lists fan-out + resume | 40 |
| `bland_ai` | calls list → per-call transcript hydration | 50 |

All fan-out/hydration migrations keep the yielded row shape identical (parent ids injected as before) and follow the resume-state compatibility rule (existing ResumeConfig fields kept so previously saved Redis state still parses).

**Vetted and skipped** (still hand-rolled, need future framework features): `airtable` (two-level fan-out: bases → tables → records), `baserow` (still an unimplemented stub — not a migration target).

> [!NOTE]
> Stacked on #71540 → #71524 → #71520 → #71481/#71477. Review the commits above the batch-2 head.

## How did you test this code?

- Merged verification: **418 tests pass** across the 6 migrated sources + the full `rest_source` suite.
- Each source's suite passed in isolation first (counts above); coverage preserved per the migration rule — pagination progression, fan-out parent/child behavior, resume round-trips, termination, fail-loud paths, `validate_credentials` mapping.
- Each migration produced in an isolated worktree touching only its own `sources/<name>/` dir (verified before merge). `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
