### PR TITLE
fix(signals): resolve repo-qualified github schema names

### DIFF
--- a/products/signals/backend/emission/registry.py
+++ b/products/signals/backend/emission/registry.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import enum
 import dataclasses
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-if TYPE_CHECKING:
-    from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.sources import github_split_schema_name
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 
 class InternalSourceType(str, enum.Enum):
@@ -95,16 +95,24 @@ def register_signal_source(
     _SIGNAL_TABLE_CONFIGS[(source_type.value, schema_name)] = config
 
 
+def _registry_key(source_type: str, schema_name: str) -> tuple[str, str]:
+    """GitHub alone qualifies its schema rows (`owner/repo.issues`); emitters register the bare endpoint."""
+    if source_type == ExternalDataSourceType.GITHUB.value:
+        _, endpoint = github_split_schema_name(schema_name)
+        return (source_type, endpoint)
+    return (source_type, schema_name)
+
+
 def get_signal_config(source_type: str, schema_name: str) -> SignalSourceTableConfig | None:
-    return _SIGNAL_TABLE_CONFIGS.get((source_type, schema_name))
+    return _SIGNAL_TABLE_CONFIGS.get(_registry_key(source_type, schema_name))
 
 
 def is_signal_emission_registered(source_type: str, schema_name: str) -> bool:
-    return (source_type, schema_name) in _SIGNAL_TABLE_CONFIGS
+    return _registry_key(source_type, schema_name) in _SIGNAL_TABLE_CONFIGS
 
 
 def get_signal_source_identity(source_type: str, schema_name: str) -> tuple[str, str] | None:
-    config = _SIGNAL_TABLE_CONFIGS.get((source_type, schema_name))
+    config = get_signal_config(source_type, schema_name)
     return (config.source_product, config.source_type) if config else None
 
 
@@ -115,7 +123,6 @@ def _register_all_emitters() -> None:
     from products.signals.backend.emission.linear_issues import LINEAR_ISSUES_CONFIG
     from products.signals.backend.emission.pganalyze_issues import PGANALYZE_ISSUES_CONFIG
     from products.signals.backend.emission.zendesk_tickets import ZENDESK_TICKETS_CONFIG
-    from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
     register_signal_source(ExternalDataSourceType.ZENDESK, "tickets", ZENDESK_TICKETS_CONFIG)
     register_signal_source(ExternalDataSourceType.GITHUB, "issues", GITHUB_ISSUES_CONFIG)

--- a/products/signals/backend/emission/tests/test_registry.py
+++ b/products/signals/backend/emission/tests/test_registry.py
@@ -7,6 +7,7 @@ from products.signals.backend.emission.registry import (
     _SIGNAL_TABLE_CONFIGS,
     SignalSourceTableConfig,
     get_signal_config,
+    get_signal_source_identity,
     is_signal_emission_registered,
     register_signal_source,
 )
@@ -53,10 +54,27 @@ class TestGetSignalConfig:
             ("NonExistent", "tickets"),
             ("Zendesk", "nonexistent_table"),
             ("", ""),
+            ("Zendesk", "acme/support.tickets"),
+            ("Github", "posthog/posthog.pull_requests"),
         ],
     )
     def test_returns_none_for_unregistered(self, source_type, schema_name):
         assert get_signal_config(source_type, schema_name) is None
+
+
+class TestQualifiedGithubSchemaNames:
+    # The gate resolves through get_signal_source_identity and the activity through
+    # get_signal_config, so normalizing only one of them leaves emission silently dead.
+    @pytest.mark.parametrize(
+        "lookup",
+        [get_signal_config, is_signal_emission_registered, get_signal_source_identity],
+        ids=["get_signal_config", "is_signal_emission_registered", "get_signal_source_identity"],
+    )
+    def test_every_lookup_resolves_qualified_name(self, lookup):
+        assert lookup("Github", "posthog/posthog.issues")
+
+    def test_qualified_name_resolves_to_the_bare_registration(self):
+        assert get_signal_config("Github", "posthog/posthog.issues") is get_signal_config("Github", "issues")
 
 
 class TestIsSignalEmissionRegistered:

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -3,6 +3,8 @@ import logging
 from collections.abc import Mapping
 from typing import cast
 
+from django.db.models import Q
+
 from asgiref.sync import async_to_sync
 from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema_field
 from opentelemetry import trace
@@ -99,27 +101,26 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
     def _get_data_import_status(self, team_id: int, ext_source_type: str, schema_name: str) -> str | None:
         from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
-        schema = (
+        statuses = set(
             ExternalDataSchema.objects.filter(
+                Q(name=schema_name) | Q(name__endswith=f".{schema_name}"),
                 team_id=team_id,
                 source__source_type=ext_source_type,
-                name=schema_name,
             )
             .exclude(source__deleted=True)
-            .first()
+            .values_list("status", flat=True)
         )
-        if schema is None:
-            return None
-        if schema.status == ExternalDataSchema.Status.RUNNING:
+        if ExternalDataSchema.Status.RUNNING in statuses:
             return "running"
-        if schema.status == ExternalDataSchema.Status.COMPLETED:
-            return "completed"
-        if schema.status in (
+        # One failing repo outranks its siblings' success, so a broken repo is never hidden.
+        if statuses & {
             ExternalDataSchema.Status.FAILED,
             ExternalDataSchema.Status.BILLING_LIMIT_REACHED,
             ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW,
-        ):
+        }:
             return "failed"
+        if ExternalDataSchema.Status.COMPLETED in statuses:
+            return "completed"
         return None
 
     def validate(self, attrs: dict) -> dict:

--- a/products/signals/backend/test/test_source_config_status.py
+++ b/products/signals/backend/test/test_source_config_status.py
@@ -1,0 +1,62 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.signals.backend.enums import SignalSourceProduct, SignalSourceType
+from products.signals.backend.models import SignalSourceConfig
+from products.signals.backend.serializers import SignalSourceConfigSerializer
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
+
+RUNNING = ExternalDataSchema.Status.RUNNING
+COMPLETED = ExternalDataSchema.Status.COMPLETED
+FAILED = ExternalDataSchema.Status.FAILED
+
+
+class TestSignalSourceConfigStatus(BaseTest):
+    def _github_source_with_schemas(self, *schemas: tuple[str, str]) -> None:
+        source = ExternalDataSource.objects.create(
+            team=self.team, source_type="Github", status="Running", prefix="github_"
+        )
+        for name, status in schemas:
+            ExternalDataSchema.objects.create(team=self.team, source=source, name=name, status=status)
+
+    def _status(self) -> str | None:
+        config = SignalSourceConfig.objects.create(
+            team=self.team,
+            source_product=SignalSourceProduct.GITHUB,
+            source_type=SignalSourceType.ISSUE,
+            enabled=True,
+        )
+        return SignalSourceConfigSerializer(config).data["status"]
+
+    @parameterized.expand(
+        [
+            ("legacy_bare_row", [("issues", RUNNING)], "running"),
+            ("qualified_row", [("posthog/posthog.issues", RUNNING)], "running"),
+            ("repo_name_with_dots", [("posthog/some.repo.issues", COMPLETED)], "completed"),
+            (
+                "failing_repo_outranks_completed_sibling",
+                [("posthog/a.issues", COMPLETED), ("posthog/b.issues", FAILED)],
+                "failed",
+            ),
+            (
+                "running_outranks_everything",
+                [("posthog/a.issues", FAILED), ("posthog/b.issues", RUNNING)],
+                "running",
+            ),
+            ("only_other_endpoints", [("posthog/posthog.pull_requests", RUNNING)], None),
+            ("no_rows", [], None),
+        ]
+    )
+    def test_status_across_repo_rows(self, _name: str, schemas: list[tuple[str, str]], expected: str | None) -> None:
+        self._github_source_with_schemas(*schemas)
+
+        assert self._status() == expected
+
+    def test_ignores_deleted_sources(self) -> None:
+        source = ExternalDataSource.objects.create(
+            team=self.team, source_type="Github", status="Running", prefix="github_", deleted=True
+        )
+        ExternalDataSchema.objects.create(team=self.team, source=source, name="posthog/posthog.issues", status=RUNNING)
+
+        assert self._status() is None

--- a/products/warehouse_sources/backend/facade/sources.py
+++ b/products/warehouse_sources/backend/facade/sources.py
@@ -10,6 +10,9 @@ facade import path doesn't drag in DB drivers or the Google client libraries.
 """
 
 from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
+from products.warehouse_sources.backend.temporal.data_imports.sources.github.naming import (
+    split_schema_name as github_split_schema_name,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.constants import (
     CHARGE_RESOURCE_NAME,
     CUSTOMER_RESOURCE_NAME,
@@ -25,4 +28,5 @@ __all__ = [
     "NamingConvention",
     "PRODUCT_RESOURCE_NAME",
     "SUBSCRIPTION_RESOURCE_NAME",
+    "github_split_schema_name",
 ]


### PR DESCRIPTION
## Problem

**GitHub Issues signals are dead for every GitHub source connected since [multi-repo GitHub](https://github.com/PostHog/posthog/pull/71274) merged.** Silently: no signal, no error, nothing in the inbox. Single-repo connections included, since new sources qualify their schema rows from day one.

Those rows are named `owner/repo.issues`. Signals only ever matched the bare `issues`, so:

- The emission gate misses, so the signals child workflow never spawns.
- The status chip in the sources modal reads blank.

## Changes

- Normalize the registry lookup key once, so both the gate and the emit activity resolve qualified rows to the single bare registration. Fixing only `get_signal_config` would leave the gate dead.
- Status matches bare and qualified rows, and reports across repos. A failing repo outranks a sibling's success (the old `.first()` was unordered, so arbitrary once a source has N rows).
- Expose the GitHub name parser on the warehouse_sources facade. The gate has only a schema name and no metadata, so name parsing is the only option there.

> [!NOTE]
> The frontend half of this bug is in [the inbox source setup PR](https://github.com/PostHog/posthog/pull/70830). Independent of this one, no file overlap, either can merge first.

## How did you test this code?

I (actually Claude Code) ran the automated tests below. No manual testing against a live GitHub sync.

- Reverted the fix with the new tests in place: 8 failures on exactly the qualified-name cases, while legacy-bare and negative cases stayed green.
- `test_registry.py` catches normalizing only one of the three lookups, which silently leaves the gate dead. Nothing covered qualified names before.
- `test_source_config_status.py` catches the blank status chip on a qualified source, and a failing repo hiding behind a sibling.
- Full emission suite (315 tests), ruff, `tach check`, `hogli ci:preflight`, and the startup import budget guard (this moves two imports to module level).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code found this while tracing what [the multi-repo PR](https://github.com/PostHog/posthog/pull/71274) broke downstream. [The engineering analytics PR](https://github.com/PostHog/posthog/pull/71450) fixes the same bug class for that product. This is the signals equivalent, kept independent rather than stacked since there is no file overlap and it is urgent on its own.

Used `split_schema_name` rather than the richer metadata-aware `schema_repo_endpoint` that the engineering analytics PR adds, because the gate signature carries no metadata to consult. Those two facade exports may want collapsing once it lands.

Not covered: `emit_signals_from_warehouse` looks its schema row up by exact bare name separately from the registry, so that dev command still errors on a qualified source. Out of scope here; the emission path is what matters.

Skills invoked: `/writing-tests`, `/simplify`.
