### PR TITLE
fix(conversations): show teams thread reply authors correctly

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -1860,14 +1860,45 @@ class TestTicketMessagesAPI(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("customer_with_name", {"name": "Bob", "email": "bob@example.com"}, "customer", "Bob"),
-            ("customer_email_fallback", {"email": "bob@example.com"}, "customer", "bob@example.com"),
-            ("customer_default", {}, "customer", "Customer"),
-            ("ai_author", {}, "AI", "PostHog Assistant"),
-            ("support_without_user", {}, "support", "Support"),
+            ("customer_with_name", {"name": "Bob", "email": "bob@example.com"}, "customer", {}, "Bob"),
+            ("customer_email_fallback", {"email": "bob@example.com"}, "customer", {}, "bob@example.com"),
+            ("customer_default", {}, "customer", {}, "Customer"),
+            ("ai_author", {}, "AI", {}, "PostHog Assistant"),
+            ("support_without_user", {}, "support", {}, "Support"),
+            # Per-comment author overrides the ticket requester (thread replies from other participants)
+            (
+                "teams_thread_reply_author",
+                {"name": "Mark"},
+                "customer",
+                {"teams_author_name": "Chris"},
+                "Chris",
+            ),
+            (
+                "slack_thread_reply_author",
+                {"name": "Mark"},
+                "customer",
+                {"slack_author_name": "Chris"},
+                "Chris",
+            ),
+            (
+                "zendesk_import_author",
+                {"name": "Mark"},
+                "customer",
+                {"author_name": "Chris"},
+                "Chris",
+            ),
+            (
+                "context_author_on_support_comment",
+                {},
+                "support",
+                {"teams_author_name": "Chris"},
+                "Chris",
+            ),
         ]
     )
-    def test_messages_author_name_resolution(self, mock_on_commit, _name, traits, author_type, expected_name):
+    def test_messages_author_name_resolution(
+        self, mock_on_commit, _name, traits, author_type, extra_context, expected_name
+    ):
         self.ticket.anonymous_traits = traits
         self.ticket.save(update_fields=["anonymous_traits"])
         Comment.objects.create(
@@ -1875,7 +1906,7 @@ class TestTicketMessagesAPI(APIBaseTest):
             scope="conversations_ticket",
             item_id=str(self.ticket.id),
             content="msg",
-            item_context={"author_type": author_type},
+            item_context={"author_type": author_type, **extra_context},
         )
 
         response = self.client.get(self.url)

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1079,13 +1079,27 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
         item_context = comment.item_context or {}
         author_type = item_context.get("author_type", "customer")
 
+        # Per-message author identity (Slack/Teams/Zendesk store each comment's own
+        # author) takes precedence over the ticket-level requester, so a thread reply
+        # from a second participant doesn't show as the ticket owner.
+        context_author_name = (
+            item_context.get("author_name")
+            or item_context.get("author_email")
+            or item_context.get("slack_author_name")
+            or item_context.get("teams_author_name")
+            or item_context.get("teams_author_email")
+            or item_context.get("email_from_name")
+        )
+
         if comment.created_by:
             author_name = comment.created_by.first_name or comment.created_by.email
+        elif author_type == "AI":
+            author_name = "PostHog Assistant"
+        elif context_author_name:
+            author_name = context_author_name
         elif author_type == "customer":
             traits = ticket.anonymous_traits or {}
             author_name = traits.get("name") or traits.get("email") or "Customer"
-        elif author_type == "AI":
-            author_name = "PostHog Assistant"
         else:
             author_name = "Support"
 

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -143,6 +143,40 @@ describe('supportTicketSceneLogic ai reply feedback', () => {
     })
 })
 
+function makeCustomerComment(id: string, itemContext: Record<string, any>): CommentType {
+    return {
+        id,
+        content: 'reply body',
+        scope: 'conversations_ticket',
+        item_id: 'ticket-1',
+        item_context: { author_type: 'customer', ...itemContext },
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: null,
+    } as unknown as CommentType
+}
+
+describe('supportTicketSceneLogic chatMessages author attribution', () => {
+    let logic: ReturnType<typeof supportTicketSceneLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = supportTicketSceneLogic({ id: 'new' })
+        logic.mount()
+        logic.actions.setTicket({ ...makeTicket(), anonymous_traits: { name: 'Mark' } } as Ticket)
+    })
+
+    // A thread reply from a second Teams/Slack participant must show its own author,
+    // not fall back to the ticket requester's name.
+    test.each<[string, Record<string, any>, string]>([
+        ['teams thread reply author', { teams_author_name: 'Chris' }, 'Chris'],
+        ['slack thread reply author', { slack_author_name: 'Chris' }, 'Chris'],
+        ['requester fallback without per-message author', {}, 'Mark'],
+    ])('%s', (_name, itemContext, expectedName) => {
+        logic.actions.setMessages([makeCustomerComment('msg-1', itemContext)])
+        expect(logic.values.chatMessages[0].authorName).toBe(expectedName)
+    })
+})
+
 type GateTicket = Pick<Ticket, 'channel_source' | 'email_from' | 'email_to'>
 
 const emailTicket = (overrides: Partial<GateTicket> = {}): GateTicket => ({

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -476,6 +476,8 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                             message.item_context?.author_name ||
                             message.item_context?.author_email ||
                             message.item_context?.slack_author_name ||
+                            message.item_context?.teams_author_name ||
+                            message.item_context?.teams_author_email ||
                             message.item_context?.email_from_name
                         if (messageAuthorName) {
                             displayName = messageAuthorName


### PR DESCRIPTION
## Problem

Teams thread replies from a second participant (e.g. someone other than the ticket requester) all showed as the requester in the support ticket UI.

Ingestion already stored the real author in `item_context.teams_author_name`. The ticket scene and messages API ignored that field and fell back to `anonymous_traits`, so every customer-authored Teams comment looked like it came from the person who opened the ticket.

Same gap existed for Slack on the messages API path (side panel / MCP).

## Changes

- Ticket scene `chatMessages` selector now reads `teams_author_name` / `teams_author_email` in the per-message author fallback chain (alongside Slack / Zendesk / email).
- `_serialize_message` prefers per-comment `item_context` authors before falling back to ticket traits.


## How did you test this code?

- Extended `test_messages_author_name_resolution` with Teams / Slack / Zendesk per-comment author cases (guards the API falling back to the ticket requester for thread replies).
- Added `chatMessages` attribution cases in `supportTicketSceneLogic.test.ts` (guards the ticket UI ignoring `teams_author_name`).