### PR TITLE
feat(data-warehouse): migrate 5 sources to rest_source (batch 4)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/bluetally.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/bluetally.py
@@ -1,26 +1,24 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.bluetally.settings import BLUETALLY_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BLUETALLY_BASE_URL = "https://app.bluetallyapp.com/api/v1"
 # BlueTally caps a single response at 1000 rows; using the max minimizes requests against the
 # 10,000-requests-per-hour budget.
 PAGE_SIZE = 1000
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class BluetallyRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -30,120 +28,72 @@ class BluetallyResumeConfig:
     offset: int = 0
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-    }
-
-
-def _make_session(api_key: str) -> requests.Session:
-    # `redact_values` masks the bearer token in logged URLs and captured HTTP samples so a failed or
-    # sampled request can never persist the raw BlueTally credential in PostHog's HTTP telemetry.
-    return make_tracked_session(headers=_get_headers(api_key), redact_values=(api_key,))
-
-
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    query = {key: value for key, value in params.items() if value is not None and value != ""}
-    return f"{BLUETALLY_BASE_URL}{path}?{urlencode(query)}"
-
-
-@retry(
-    retry=retry_if_exception_type((BluetallyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> list[dict[str, Any]]:
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BluetallyRetryableError(f"BlueTally API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Don't log the response body: it can echo back the Authorization header or other secrets.
-        logger.error(f"BlueTally API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    # Every list endpoint returns a bare JSON array. A non-list 200 is a permanent API-contract
-    # violation (wrapped payload, proxy HTML, …), not a transient failure — raise a plain ValueError
-    # so it surfaces immediately instead of burning the retry budget on something retries can't fix.
-    if not isinstance(data, list):
-        raise ValueError(f"BlueTally API returned a non-list response: url={url}")
-    return data
-
-
-def validate_credentials(api_key: str, tenant_id: str | None = None, path: str = "/assets") -> bool:
-    url = _build_url(path, {"limit": 1, "tenant_id": tenant_id})
-    try:
-        response = _make_session(api_key).get(url, timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BluetallyResumeConfig],
-    tenant_id: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = BLUETALLY_ENDPOINTS[endpoint]
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = _make_session(api_key)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume else 0
-    if resume:
-        logger.debug(f"BlueTally: resuming {endpoint} from offset={offset}")
-
-    while True:
-        url = _build_url(
-            config.path,
-            {
-                "limit": PAGE_SIZE,
-                "offset": offset,
-                "sort": config.sort,
-                "order": "asc",
-                "tenant_id": tenant_id,
-            },
-        )
-        page = _fetch_page(session, url, logger)
-        if not page:
-            break
-
-        yield page
-
-        # A short page means we've reached the end of the resource.
-        if len(page) < PAGE_SIZE:
-            break
-
-        offset += len(page)
-        # Save AFTER yielding so a crash re-runs from the last persisted offset rather than skipping
-        # ahead; the merge dedupes any re-pulled rows on the primary key.
-        resumable_source_manager.save_state(BluetallyResumeConfig(offset=offset))
-
-
 def bluetally_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BluetallyResumeConfig],
     tenant_id: Optional[str] = None,
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = BLUETALLY_ENDPOINTS[endpoint]
 
+    # Sorting on `created_at` ascending keeps offset pagination stable even as new rows are
+    # appended mid-sync.
+    params: dict[str, Any] = {"sort": config.sort, "order": "asc"}
+    if tenant_id:
+        params["tenant_id"] = tenant_id
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BLUETALLY_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted from
+            # logged URLs and captured HTTP samples; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            # BlueTally reports no total anywhere; termination is short/empty page (OffsetPaginator default).
+            "paginator": OffsetPaginator(limit=PAGE_SIZE, total_path=None),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Every list endpoint returns a bare JSON array. A non-list 200 (wrapped payload,
+                    # proxy HTML, …) is a permanent API-contract violation — fail loud instead of
+                    # syncing the stray object as a row.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; saved AFTER a page is yielded so a crash re-runs
+        # from the last persisted offset rather than skipping ahead (merge dedupes re-pulled rows).
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(BluetallyResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            tenant_id=tenant_id,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -152,4 +102,17 @@ def bluetally_source(
         partition_keys=[config.partition_key] if config.partition_key else None,
         # We request `sort=created_at&order=asc`, so rows arrive oldest-first.
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str, tenant_id: str | None = None, path: str = "/assets") -> bool:
+    query: dict[str, Any] = {"limit": 1}
+    if tenant_id:
+        query["tenant_id"] = tenant_id
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BLUETALLY_BASE_URL}{path}?{urlencode(query)}",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/source.py
@@ -96,7 +96,7 @@ If your account has multi-tenancy enabled, also enter the tenant ID the key shou
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # An invalid or expired API key surfaces as a requests HTTPError when `_fetch_page`
+            # An invalid or expired API key surfaces as a requests HTTPError when the REST client
             # calls `raise_for_status()`. Retrying can never satisfy a credential problem, so stop
             # the sync. Match the stable status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://app.bluetallyapp.com": "Your BlueTally API key is invalid or has expired. Create a new key under Settings → API Keys in BlueTally, then reconnect.",
@@ -149,7 +149,8 @@ If your account has multi-tenancy enabled, also enter the tenant ID the key shou
         return bluetally_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             tenant_id=config.tenant_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/test_bluetally.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/test_bluetally.py
@@ -1,185 +1,225 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.bluetally import bluetally
 from products.warehouse_sources.backend.temporal.data_imports.sources.bluetally.bluetally import (
     PAGE_SIZE,
     BluetallyResumeConfig,
-    BluetallyRetryableError,
-    _build_url,
     bluetally_source,
-    get_rows,
+    validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.bluetally.settings import (
     BLUETALLY_ENDPOINTS,
     ENDPOINTS,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    DEFAULT_RETRY_ATTEMPTS,
+    RESTClientRetryableError,
+)
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the bluetally module.
+BLUETALLY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.bluetally.bluetally.make_tracked_session"
+)
 
 
-class _FakeResumableManager:
-    def __init__(self, state: BluetallyResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BluetallyResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> BluetallyResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: BluetallyResumeConfig) -> None:
-        self.saved.append(data)
+def _response(items: list[dict[str, Any]], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(items).encode()
+    return resp
 
 
-def _response_with_status(status_code: int, body: Any = None) -> requests.Response:
-    response = requests.Response()
-    response.status_code = status_code
-    response._content = b"" if body is None else str(body).encode()
-    return response
+def _error_response(status_code: int) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.url = "https://app.bluetallyapp.com/api/v1/assets"
+    resp._content = b""
+    return resp
 
 
-class TestBuildUrl:
-    def test_includes_all_pagination_params(self) -> None:
-        url = _build_url("/assets", {"limit": 1000, "offset": 0, "sort": "created_at", "order": "asc"})
-        assert url == "https://app.bluetallyapp.com/api/v1/assets?limit=1000&offset=0&sort=created_at&order=asc"
+def _non_list_response() -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp.url = "https://app.bluetallyapp.com/api/v1/assets"
+    resp._content = b'{"error": "unexpected"}'
+    return resp
 
-    def test_omits_none_tenant_id(self) -> None:
-        url = _build_url("/employees", {"limit": 50, "offset": 0, "tenant_id": None})
-        assert "tenant_id" not in url
 
-    def test_includes_tenant_id_when_set(self) -> None:
-        url = _build_url("/employees", {"offset": 0, "tenant_id": "42"})
-        assert "tenant_id=42" in url
+def _make_manager(resume_state: BluetallyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def test_offset_zero_is_kept(self) -> None:
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(
+    endpoint: str = "assets",
+    manager: mock.MagicMock | None = None,
+    tenant_id: str | None = None,
+):
+    return bluetally_source(
+        api_key="key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        tenant_id=tenant_id,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_first_request_params(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 1}])])
+
+        _rows(_source())
+
         # offset=0 is the first page; it must not be dropped as a falsy value.
-        url = _build_url("/assets", {"offset": 0})
-        assert "offset=0" in url
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == PAGE_SIZE
+        assert params[0]["sort"] == "created_at"
+        assert params[0]["order"] == "asc"
+        assert "tenant_id" not in params[0]
 
-
-class TestFetchPage:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response_with_status(status)
-        # No-op the backoff sleep so the 5 attempts run instantly.
-        with patch.object(bluetally._fetch_page.retry, "sleep", lambda *a, **k: None):  # type: ignore[attr-defined]
-            with pytest.raises(BluetallyRetryableError):
-                bluetally._fetch_page(session, "https://app.bluetallyapp.com/api/v1/assets", MagicMock())
-        assert session.get.call_count == 5
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_http_error(self, _name: str, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response_with_status(status)
-        with pytest.raises(requests.HTTPError):
-            bluetally._fetch_page(session, "https://app.bluetallyapp.com/api/v1/assets", MagicMock())
-
-    def test_returns_list_payload(self) -> None:
-        response = _response_with_status(200)
-        response._content = b'[{"id": 1}, {"id": 2}]'
-        session = MagicMock()
-        session.get.return_value = response
-        rows = bluetally._fetch_page(session, "https://app.bluetallyapp.com/api/v1/assets", MagicMock())
-        assert rows == [{"id": 1}, {"id": 2}]
-
-    def test_non_list_payload_raises_value_error(self) -> None:
-        # A non-list 200 is a permanent contract violation, so it must bypass the retry decorator.
-        response = _response_with_status(200)
-        response._content = b'{"error": "unexpected"}'
-        session = MagicMock()
-        session.get.return_value = response
-        with pytest.raises(ValueError):
-            bluetally._fetch_page(session, "https://app.bluetallyapp.com/api/v1/assets", MagicMock())
-        assert session.get.call_count == 1
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        pages: list[list[dict]],
-        tenant_id: str | None = None,
-    ) -> tuple[list[dict], list[str]]:
-        fetched_urls: list[str] = []
-
-        def fake_fetch(session: Any, url: str, logger: Any) -> list[dict]:
-            fetched_urls.append(url)
-            # Map the requested offset to the corresponding canned page.
-            offset = int(url.split("offset=")[1].split("&")[0])
-            index = offset // PAGE_SIZE
-            return pages[index] if index < len(pages) else []
-
-        monkeypatch.setattr(bluetally, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(bluetally, "make_tracked_session", lambda **kwargs: MagicMock())
-
-        rows: list[dict] = []
-        for page in get_rows(
-            api_key="key",
-            endpoint="assets",
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            tenant_id=tenant_id,
-        ):
-            rows.extend(page)
-        return rows, fetched_urls
-
-    def test_single_short_page_stops_without_saving_state(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows, urls = self._collect(manager, monkeypatch, [[{"id": 1}, {"id": 2}]])
-        assert rows == [{"id": 1}, {"id": 2}]
-        assert len(urls) == 1
-        # A short first page never advances the offset, so no resume state is persisted.
-        assert manager.saved == []
-
-    def test_paginates_until_short_page(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_threads_tenant_id_into_requests(self, MockSession) -> None:
+        session = MockSession.return_value
         full_page = [{"id": i} for i in range(PAGE_SIZE)]
-        last_page = [{"id": PAGE_SIZE}]
-        manager = _FakeResumableManager()
-        rows, urls = self._collect(manager, monkeypatch, [full_page, last_page])
+        params = _wire(session, [_response(full_page), _response([{"id": PAGE_SIZE}])])
+
+        _rows(_source(tenant_id="99"))
+
+        assert all(p["tenant_id"] == "99" for p in params)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": i} for i in range(PAGE_SIZE)]
+        params = _wire(session, [_response(full_page), _response([{"id": PAGE_SIZE}])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
+
         assert len(rows) == PAGE_SIZE + 1
-        assert len(urls) == 2
+        assert params[0]["offset"] == 0
+        assert params[1]["offset"] == PAGE_SIZE
         # State is saved after the full page (pointing at the next offset), then we stop on the short page.
-        assert manager.saved == [BluetallyResumeConfig(offset=PAGE_SIZE)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BluetallyResumeConfig(offset=PAGE_SIZE)
 
-    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
-        full_page = [{"id": i} for i in range(PAGE_SIZE)]
-        last_page = [{"id": PAGE_SIZE}]
-        manager = _FakeResumableManager(BluetallyResumeConfig(offset=PAGE_SIZE))
-        rows, urls = self._collect(manager, monkeypatch, [full_page, last_page])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_stops_without_saving_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}, {"id": 2}])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 1
+        # A short first page never advances the offset, so no resume state is persisted.
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": PAGE_SIZE}])])
+
+        manager = _make_manager(BluetallyResumeConfig(offset=PAGE_SIZE))
+        rows = _rows(_source(manager=manager))
+
         # Resuming at offset=PAGE_SIZE skips the already-synced first page.
         assert rows == [{"id": PAGE_SIZE}]
-        assert urls == [
-            f"https://app.bluetallyapp.com/api/v1/assets?limit={PAGE_SIZE}&offset={PAGE_SIZE}&sort=created_at&order=asc"
-        ]
+        assert params[0]["offset"] == PAGE_SIZE
 
-    def test_threads_tenant_id_into_requests(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        _, urls = self._collect(manager, monkeypatch, [[{"id": 1}]], tenant_id="99")
-        assert all("tenant_id=99" in url for url in urls)
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows, urls = self._collect(manager, monkeypatch, [[]])
-        assert rows == []
-        assert len(urls) == 1
+class TestErrors:
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    @mock.patch("time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_exhaust_retries(self, _name: str, status: int, MockSession, _mock_sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_error_response(status)] * DEFAULT_RETRY_ATTEMPTS)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source())
+
+        assert session.send.call_count == DEFAULT_RETRY_ATTEMPTS
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_http_error(self, _name: str, status: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_error_response(status)])
+
+        with pytest.raises(requests.HTTPError):
+            _rows(_source())
+
+        # Client errors are permanent — no retries.
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_payload_raises_value_error(self, MockSession) -> None:
+        # A non-list 200 is a permanent contract violation (wrapped payload, proxy HTML, …) — it must
+        # fail loud without burning the retry budget on something retries can't fix.
+        session = MockSession.return_value
+        _wire(session, [_non_list_response()])
+
+        with pytest.raises(ValueError, match="list"):
+            _rows(_source())
+
+        assert session.send.call_count == 1
 
 
 class TestBluetallySourceResponse:
     @parameterized.expand([(name,) for name in ENDPOINTS])
-    def test_source_response_shape(self, name: str) -> None:
-        response = bluetally_source(
-            api_key="key",
-            endpoint=name,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, name: str, MockSession) -> None:
+        response = _source(endpoint=name)
         assert response.name == name
         assert response.primary_keys == ["id"]
         assert response.sort_mode == "asc"
@@ -190,3 +230,36 @@ class TestBluetallySourceResponse:
     def test_every_endpoint_partitions_on_created_at(self) -> None:
         # Guards against accidentally partitioning on a churning field like updated_at.
         assert all(cfg.partition_key == "created_at" for cfg in BLUETALLY_ENDPOINTS.values())
+
+
+class TestValidateCredentials:
+    @mock.patch(BLUETALLY_SESSION_PATCH)
+    def test_ok(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("key") is True
+
+    @mock.patch(BLUETALLY_SESSION_PATCH)
+    def test_unauthorized(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=401)
+        assert validate_credentials("key") is False
+
+    @mock.patch(BLUETALLY_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key") is False
+
+    @mock.patch(BLUETALLY_SESSION_PATCH)
+    def test_probes_given_path_with_tenant_id(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("key", tenant_id="42", path="/employees") is True
+        url = mock_session.return_value.get.call_args.args[0]
+        assert url.startswith("https://app.bluetallyapp.com/api/v1/employees?")
+        assert "limit=1" in url
+        assert "tenant_id=42" in url
+
+    @mock.patch(BLUETALLY_SESSION_PATCH)
+    def test_omits_unset_tenant_id(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("key")
+        url = mock_session.return_value.get.call_args.args[0]
+        assert "tenant_id" not in url

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/test_bluetally_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bluetally/test_bluetally_source.py
@@ -114,7 +114,8 @@ class TestResumableWiring:
     def test_source_for_pipeline_plumbs_arguments(self) -> None:
         inputs = MagicMock()
         inputs.schema_name = "licenses"
-        inputs.logger = MagicMock()
+        inputs.team_id = 1
+        inputs.job_id = "j"
         manager = MagicMock()
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.bluetally.source.bluetally_source"
@@ -123,7 +124,8 @@ class TestResumableWiring:
         mocked.assert_called_once_with(
             api_key="key",
             endpoint="licenses",
-            logger=inputs.logger,
+            team_id=1,
+            job_id="j",
             resumable_source_manager=manager,
             tenant_id="3",
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/calendly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/calendly.py
@@ -2,11 +2,6 @@ import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.calendly.settings import (
@@ -14,15 +9,19 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.calendly.s
     CalendlyEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CALENDLY_BASE_URL = "https://api.calendly.com"
 PAGE_SIZE = 100
 REQUEST_TIMEOUT = 60
-
-
-class CalendlyRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -48,11 +47,12 @@ def _get_headers(token: str) -> dict[str, str]:
 
 
 def validate_credentials(token: str) -> bool:
-    try:
-        response = make_tracked_session().get(f"{CALENDLY_BASE_URL}/users/me", headers=_get_headers(token), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(token,)),
+        f"{CALENDLY_BASE_URL}/users/me",
+        headers=_get_headers(token),
+    )
+    return ok
 
 
 def get_current_organization(token: str) -> str:
@@ -61,7 +61,7 @@ def get_current_organization(token: str) -> str:
     Every list endpoint we sync is scoped by this URI, so we access it directly and let a
     malformed response surface immediately as a KeyError rather than degrading to None.
     """
-    response = make_tracked_session().get(
+    response = make_tracked_session(redact_values=(token,)).get(
         f"{CALENDLY_BASE_URL}/users/me", headers=_get_headers(token), timeout=REQUEST_TIMEOUT
     )
     response.raise_for_status()
@@ -88,88 +88,72 @@ def _build_initial_params(
     return params
 
 
-def get_rows(
-    token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CalendlyResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[Any]:
-    config = CALENDLY_ENDPOINTS[endpoint]
-    headers = _get_headers(token)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if resume_config is not None:
-        url = resume_config.next_url
-        logger.debug(f"Calendly: resuming from URL: {url}")
-    else:
-        organization = get_current_organization(token) if config.scope_param == "organization" else None
-        params = _build_initial_params(
-            config, organization, should_use_incremental_field, db_incremental_field_last_value
-        )
-        url = f"{CALENDLY_BASE_URL}{config.path}?{urlencode(params)}"
-
-    @retry(
-        retry=retry_if_exception_type((CalendlyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise CalendlyRetryableError(
-                f"Calendly API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Calendly API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-
-        items = data.get("collection", [])
-        if items:
-            yield items
-
-        # Keep paginating until the API signals completion with a null next_page, even if an
-        # individual page came back empty.
-        next_url = data.get("pagination", {}).get("next_page")
-        if not next_url:
-            break
-
-        # Save state after yielding so a crash re-yields the last page (merge dedupes on `uri`)
-        # rather than skipping it.
-        resumable_source_manager.save_state(CalendlyResumeConfig(next_url=next_url))
-        url = next_url
-
-
 def calendly_source(
     token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CalendlyResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = CALENDLY_ENDPOINTS[endpoint]
 
+    def get_rows() -> Iterator[Any]:
+        resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+        initial_paginator_state: Optional[dict[str, Any]] = None
+        organization: str | None = None
+        if resume_config is not None:
+            # The saved next-page URL is self-contained, so the `/users/me` bootstrap is skipped.
+            initial_paginator_state = {"next_url": resume_config.next_url}
+        elif config.scope_param == "organization":
+            organization = get_current_organization(token)
+
+        params = _build_initial_params(
+            config, organization, should_use_incremental_field, db_incremental_field_last_value
+        )
+
+        rest_config: RESTAPIConfig = {
+            "client": {
+                "base_url": CALENDLY_BASE_URL,
+                "headers": {"Content-Type": "application/json"},
+                "auth": {"type": "bearer", "token": token},
+                "paginator": JSONResponsePaginator(next_url_path="pagination.next_page"),
+            },
+            "resources": [
+                {
+                    "name": endpoint,
+                    "endpoint": {
+                        "path": config.path,
+                        "params": params,
+                        # A missing `collection` key is treated as an empty page (matching the API's
+                        # tolerant contract); pagination keeps following `next_page` until it's null,
+                        # even across empty pages.
+                        "data_selector": "collection",
+                    },
+                }
+            ],
+        }
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only when a next page remains; saved AFTER a page is yielded so a crash
+            # re-yields the last page (merge dedupes on `uri`) rather than skipping it.
+            if state and state.get("next_url"):
+                resumable_source_manager.save_state(CalendlyResumeConfig(next_url=state["next_url"]))
+
+        yield from rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            token=token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=get_rows,
         primary_keys=["uri"],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CalendlySourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -84,19 +87,7 @@ You can create a personal access token in Calendly under **Integrations → API 
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
-                supports_append=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CalendlySourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -124,7 +115,8 @@ You can create a personal access token in Calendly under **Integrations → API 
         return calendly_source(
             token=config.personal_access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/tests/test_calendly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/calendly/tests/test_calendly.py
@@ -1,77 +1,96 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
+import pytest
 from unittest import mock
 
 from parameterized import parameterized
+from requests import HTTPError, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.calendly.calendly import (
     CALENDLY_BASE_URL,
     CalendlyResumeConfig,
-    _build_initial_params,
     _format_datetime,
     calendly_source,
     get_current_organization,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.calendly.settings import (
-    CALENDLY_ENDPOINTS,
-    ENDPOINTS,
+from products.warehouse_sources.backend.temporal.data_imports.sources.calendly.settings import ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# The /users/me bootstrap and validate_credentials build their own tracked session in the calendly module.
+CALENDLY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.calendly.calendly.make_tracked_session"
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 ORG_URI = "https://api.calendly.com/organizations/ABC123"
 
 
-class FakeResponse:
-    def __init__(self, status_code: int = 200, json_data: Optional[dict] = None):
-        self.status_code = status_code
-        self._json = json_data or {}
-        self.text = str(self._json)
-
-    @property
-    def ok(self) -> bool:
-        return self.status_code < 400
-
-    def json(self) -> dict:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if self.status_code >= 400:
-            raise Exception(f"{self.status_code} Client Error for url: {CALENDLY_BASE_URL}")
-
-
-class FakeSession:
-    """Returns queued responses in order for each .get() call."""
-
-    def __init__(self, responses: list[FakeResponse]):
-        self._responses = list(responses)
-        self.requested_urls: list[str] = []
-
-    def get(self, url: str, **_kwargs: Any) -> FakeResponse:
-        self.requested_urls.append(url)
-        return self._responses.pop(0)
+def _response(
+    collection: Optional[list[dict[str, Any]]],
+    next_page: Optional[str] = None,
+    *,
+    status: int = 200,
+    drop_collection: bool = False,
+) -> Response:
+    body: dict[str, Any] = {"pagination": {"next_page": next_page}}
+    if not drop_collection:
+        body["collection"] = collection or []
+    resp = Response()
+    resp.status_code = status
+    resp.url = f"{CALENDLY_BASE_URL}/event_types?count=100"
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class StubResumeManager(ResumableSourceManager[CalendlyResumeConfig]):
-    # Overrides every method `get_rows` touches, so the Redis-bound base `__init__` is skipped.
-    def __init__(self, resume_state: Optional[CalendlyResumeConfig] = None):
-        self._resume_state = resume_state
-        self.saved_states: list[CalendlyResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._resume_state is not None
-
-    def load_state(self) -> Optional[CalendlyResumeConfig]:
-        return self._resume_state
-
-    def save_state(self, data: CalendlyResumeConfig) -> None:
-        self.saved_states.append(data)
+def _users_me_response(status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = f"{CALENDLY_BASE_URL}/users/me"
+    resp._content = json.dumps({"resource": {"current_organization": ORG_URI}}).encode()
+    return resp
 
 
-def _users_me_response() -> FakeResponse:
-    return FakeResponse(200, {"resource": {"current_organization": ORG_URI}})
+def _make_manager(resume_state: Optional[CalendlyResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request's url/params AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(manager: mock.MagicMock, endpoint: str = "event_types", **kwargs):
+    return calendly_source(
+        token="token",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
 
 
 class TestFormatDatetime:
@@ -90,152 +109,194 @@ class TestFormatDatetime:
         assert "+00:00" not in _format_datetime(datetime(2026, 3, 4, tzinfo=UTC))
 
 
-class TestBuildInitialParams:
-    def test_scope_param_and_count_present(self) -> None:
-        params = _build_initial_params(CALENDLY_ENDPOINTS["event_types"], ORG_URI, False, None)
-
-        assert params["organization"] == ORG_URI
-        assert params["count"] == 100
-        assert "min_start_time" not in params
-
-    def test_scheduled_events_adds_sort_and_no_filter_without_incremental(self) -> None:
-        params = _build_initial_params(CALENDLY_ENDPOINTS["scheduled_events"], ORG_URI, False, None)
-
-        assert params["sort"] == "start_time:asc"
-        assert "min_start_time" not in params
-
-    def test_scheduled_events_adds_min_start_time_when_incremental(self) -> None:
-        params = _build_initial_params(
-            CALENDLY_ENDPOINTS["scheduled_events"],
-            ORG_URI,
-            True,
-            datetime(2026, 1, 1, tzinfo=UTC),
-        )
-
-        assert params["min_start_time"] == "2026-01-01T00:00:00.000000Z"
-
-    def test_non_incremental_endpoint_never_adds_filter(self) -> None:
-        params = _build_initial_params(
-            CALENDLY_ENDPOINTS["event_types"], ORG_URI, True, datetime(2026, 1, 1, tzinfo=UTC)
-        )
-
-        assert "min_start_time" not in params
-
-
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    def test_validate_credentials_status_mapping(self, _name: str, status_code: int, expected: bool) -> None:
-        session = FakeSession([FakeResponse(status_code)])
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.calendly.calendly.make_tracked_session",
-            return_value=session,
-        ):
-            assert validate_credentials("token") is expected
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    def test_validate_credentials_status_mapping(
+        self, _name: str, status_code: int, expected: bool, mock_session: mock.MagicMock
+    ) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("token") is expected
 
-    def test_validate_credentials_swallows_exceptions(self) -> None:
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.calendly.calendly.make_tracked_session",
-            side_effect=Exception("network down"),
-        ):
-            assert validate_credentials("token") is False
+    @mock.patch(CALENDLY_SESSION_PATCH, side_effect=Exception("network down"))
+    def test_validate_credentials_swallows_exceptions(self, _mock_session: mock.MagicMock) -> None:
+        assert validate_credentials("token") is False
 
 
 class TestGetCurrentOrganization:
-    def test_parses_org_uri(self) -> None:
-        session = FakeSession([_users_me_response()])
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.calendly.calendly.make_tracked_session",
-            return_value=session,
-        ):
-            assert get_current_organization("token") == ORG_URI
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    def test_parses_org_uri(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = _users_me_response()
+        assert get_current_organization("token") == ORG_URI
 
 
-class TestGetRows:
-    def _run(self, session: FakeSession, manager: StubResumeManager, endpoint: str = "event_types", **kwargs):
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.calendly.calendly.make_tracked_session",
-            return_value=session,
-        ):
-            return list(
-                get_rows(
-                    token="token",
-                    endpoint=endpoint,
-                    logger=mock.MagicMock(),
-                    resumable_source_manager=manager,
-                    **kwargs,
-                )
-            )
-
-    def test_paginates_across_pages_following_next_page(self) -> None:
-        page1 = FakeResponse(
-            200,
-            {
-                "collection": [{"uri": "a"}, {"uri": "b"}],
-                "pagination": {"next_page": f"{CALENDLY_BASE_URL}/event_types?page=2"},
-            },
+class TestPagination:
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_across_pages_following_next_page(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        next_url = f"{CALENDLY_BASE_URL}/event_types?page=2"
+        snapshots = _wire(
+            MockClientSession.return_value,
+            [_response([{"uri": "a"}, {"uri": "b"}], next_page=next_url), _response([{"uri": "c"}])],
         )
-        page2 = FakeResponse(200, {"collection": [{"uri": "c"}], "pagination": {"next_page": None}})
-        session = FakeSession([_users_me_response(), page1, page2])
-        manager = StubResumeManager()
+        manager = _make_manager()
 
-        batches = self._run(session, manager)
+        rows = _rows(_source(manager))
 
-        assert batches == [[{"uri": "a"}, {"uri": "b"}], [{"uri": "c"}]]
-        # State saved after the first page yielded, pointing at page 2.
-        assert len(manager.saved_states) == 1
-        assert manager.saved_states[0].next_url == f"{CALENDLY_BASE_URL}/event_types?page=2"
+        assert [r["uri"] for r in rows] == ["a", "b", "c"]
+        # First request is the org-scoped list; second follows the self-contained next_page URL.
+        assert snapshots[0]["params"]["count"] == 100
+        assert snapshots[0]["params"]["organization"] == ORG_URI
+        assert snapshots[1]["url"] == next_url
+        assert snapshots[1]["params"] == {}
+        # State saved after the first page yielded, pointing at page 2; no save at the end.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == CalendlyResumeConfig(next_url=next_url)
 
-    def test_empty_collection_yields_nothing(self) -> None:
-        session = FakeSession([_users_me_response(), FakeResponse(200, {"collection": [], "pagination": {}})])
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_collection_yields_nothing(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        _wire(MockClientSession.return_value, [_response([])])
 
-        batches = self._run(session, StubResumeManager())
+        rows = _rows(_source(_make_manager()))
 
-        assert batches == []
+        assert rows == []
 
-    def test_empty_page_mid_pagination_does_not_terminate_early(self) -> None:
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_collection_key_treated_as_empty(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        _wire(MockClientSession.return_value, [_response(None, drop_collection=True)])
+
+        rows = _rows(_source(_make_manager()))
+
+        assert rows == []
+
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_mid_pagination_does_not_terminate_early(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
         # An empty page that still advertises a next_page must not end the sync.
-        empty_page = FakeResponse(
-            200, {"collection": [], "pagination": {"next_page": f"{CALENDLY_BASE_URL}/event_types?page=2"}}
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        _wire(
+            MockClientSession.return_value,
+            [_response([], next_page=f"{CALENDLY_BASE_URL}/event_types?page=2"), _response([{"uri": "a"}])],
         )
-        last_page = FakeResponse(200, {"collection": [{"uri": "a"}], "pagination": {"next_page": None}})
-        session = FakeSession([_users_me_response(), empty_page, last_page])
 
-        batches = self._run(session, StubResumeManager())
+        rows = _rows(_source(_make_manager()))
 
-        assert batches == [[{"uri": "a"}]]
+        assert [r["uri"] for r in rows] == ["a"]
 
-    def test_resume_skips_users_me_and_starts_from_saved_url(self) -> None:
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_users_me_and_starts_from_saved_url(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
         resume_url = f"{CALENDLY_BASE_URL}/event_types?page=5"
-        session = FakeSession([FakeResponse(200, {"collection": [{"uri": "z"}], "pagination": {"next_page": None}})])
-        manager = StubResumeManager(resume_state=CalendlyResumeConfig(next_url=resume_url))
+        snapshots = _wire(MockClientSession.return_value, [_response([{"uri": "z"}])])
+        manager = _make_manager(resume_state=CalendlyResumeConfig(next_url=resume_url))
 
-        batches = self._run(session, manager)
+        rows = _rows(_source(manager))
 
-        assert batches == [[{"uri": "z"}]]
+        assert [r["uri"] for r in rows] == ["z"]
         # No /users/me bootstrap call on resume; first request is the saved URL.
-        assert session.requested_urls == [resume_url]
+        mock_calendly_session.assert_not_called()
+        assert snapshots[0]["url"] == resume_url
+        assert snapshots[0]["params"] == {}
 
-    def test_first_request_scopes_to_organization(self) -> None:
-        session = FakeSession(
-            [_users_me_response(), FakeResponse(200, {"collection": [{"uri": "a"}], "pagination": {}})]
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_first_request_scopes_to_organization(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        snapshots = _wire(MockClientSession.return_value, [_response([{"uri": "a"}])])
+
+        _rows(_source(_make_manager()))
+
+        # users/me bootstrap first, then the scoped list request carrying the org URI.
+        users_me_call = mock_calendly_session.return_value.get.call_args
+        assert users_me_call.args[0] == f"{CALENDLY_BASE_URL}/users/me"
+        assert snapshots[0]["params"]["organization"] == ORG_URI
+
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_http_4xx_fails_loudly(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        _wire(MockClientSession.return_value, [_response([], status=401)])
+
+        with pytest.raises(HTTPError, match="401 Client Error"):
+            _rows(_source(_make_manager()))
+
+
+class TestRequestParams:
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_scheduled_events_adds_sort_and_no_filter_without_incremental(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        snapshots = _wire(MockClientSession.return_value, [_response([{"uri": "a"}])])
+
+        _rows(_source(_make_manager(), endpoint="scheduled_events"))
+
+        assert snapshots[0]["params"]["sort"] == "start_time:asc"
+        assert "min_start_time" not in snapshots[0]["params"]
+
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_scheduled_events_adds_min_start_time_when_incremental(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        snapshots = _wire(MockClientSession.return_value, [_response([{"uri": "a"}])])
+
+        _rows(
+            _source(
+                _make_manager(),
+                endpoint="scheduled_events",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            )
         )
 
-        self._run(session, StubResumeManager())
+        assert snapshots[0]["params"]["min_start_time"] == "2026-01-01T00:00:00.000000Z"
 
-        # users/me first, then the scoped list request carrying the org URI.
-        assert session.requested_urls[0] == f"{CALENDLY_BASE_URL}/users/me"
-        assert "organization=" in session.requested_urls[1]
+    @mock.patch(CALENDLY_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_incremental_endpoint_never_adds_filter(
+        self, MockClientSession: mock.MagicMock, mock_calendly_session: mock.MagicMock
+    ) -> None:
+        mock_calendly_session.return_value.get.return_value = _users_me_response()
+        snapshots = _wire(MockClientSession.return_value, [_response([{"uri": "a"}])])
+
+        _rows(
+            _source(
+                _make_manager(),
+                endpoint="event_types",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+
+        assert "min_start_time" not in snapshots[0]["params"]
 
 
 class TestCalendlySource:
     @parameterized.expand([(name,) for name in ENDPOINTS])
     def test_source_response_shape(self, endpoint: str) -> None:
-        response = calendly_source(
-            token="token",
-            endpoint=endpoint,
-            logger=mock.MagicMock(),
-            resumable_source_manager=StubResumeManager(),
-        )
+        response = _source(_make_manager(), endpoint=endpoint)
 
         assert response.name == endpoint
         assert response.primary_keys == ["uri"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/campayn.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/campayn.py
@@ -1,27 +1,21 @@
 import re
-from collections.abc import Iterator
 from typing import Any
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.campayn.settings import (
-    CAMPAYN_ENDPOINTS,
-    CampaynEndpointConfig,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.campayn.settings import CAMPAYN_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ApiKeyAuthConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CAMPAYN_API_PATH = "/api/v1"
-REQUEST_TIMEOUT_SECONDS = 60
 # Per-account host: requests go to {subdomain}.campayn.com. The label is validated against this
 # pattern at source-create so a pasted URL or injection can't retarget the credential elsewhere.
 _SUBDOMAIN_PATTERN = re.compile(r"^[a-zA-Z0-9-]+$")
-
-
-class CampaynRetryableError(Exception):
-    pass
 
 
 def normalize_subdomain(subdomain: str) -> str:
@@ -48,121 +42,76 @@ def base_url(subdomain: str) -> str:
     return f"https://{normalize_subdomain(subdomain)}.campayn.com{CAMPAYN_API_PATH}"
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    # Campayn's custom auth scheme: "Authorization: TRUEREST apikey={key}".
-    return {"Authorization": f"TRUEREST apikey={api_key}", "Accept": "application/json"}
+def _auth_config(api_key: str) -> ApiKeyAuthConfig:
+    # Campayn's custom auth scheme: "Authorization: TRUEREST apikey={key}". Sent through the
+    # framework's api_key auth so the whole credential-bearing value is registered for value-based
+    # redaction in tracked HTTP logs — the custom scheme isn't recognised by name-based scrubbers.
+    return {
+        "type": "api_key",
+        "name": "Authorization",
+        "api_key": f"TRUEREST apikey={api_key}",
+        "location": "header",
+    }
 
 
-@retry(
-    retry=retry_if_exception_type((CampaynRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CampaynRetryableError(f"Campayn API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Campayn API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _as_rows(payload: Any) -> list[dict[str, Any]]:
-    """Coerce a Campayn list response into a list of row dicts.
-
-    Every documented list endpoint returns a bare JSON array. We couldn't curl-verify the live API
-    (it needs a per-account subdomain + key), so we also tolerate a single object or a ``{data: [...]}``
-    wrapper defensively rather than crashing the sync if the shape differs from the docs.
-    """
-    if isinstance(payload, list):
-        return [item for item in payload if isinstance(item, dict)]
-    if isinstance(payload, dict):
-        data = payload.get("data")
-        if isinstance(data, list):
-            return [item for item in data if isinstance(item, dict)]
-        return [payload]
-    return []
-
-
-def _iter_list_ids(
-    session: requests.Session, subdomain: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> Iterator[str]:
-    payload = _fetch(session, f"{base_url(subdomain)}/lists.json", headers, logger)
-    for item in _as_rows(payload):
-        # `id` drives all fan-out, so fail fast on a malformed list record rather than silently
-        # dropping its contacts/forms.
-        yield str(item["id"])
-
-
-def get_rows(
-    subdomain: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CAMPAYN_ENDPOINTS[endpoint]
-    headers = _headers(api_key)
-    # One session reused across every request (and, for fan-out, every list) so urllib3 keeps the
-    # connection alive instead of re-handshaking per request. `redact_values` masks the API key
-    # everywhere the tracked adapter records request headers/URLs/samples — the custom
-    # `TRUEREST apikey=...` header isn't recognised by the name-based scrubbers.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    if config.fan_out_over_lists:
-        yield from _get_fan_out_rows(session, subdomain, headers, logger, config)
-        return
-
-    payload = _fetch(session, f"{base_url(subdomain)}{config.path}", headers, logger)
-    rows = _as_rows(payload)
-    if rows:
-        yield rows
-
-
-def _get_fan_out_rows(
-    session: requests.Session,
-    subdomain: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    config: CampaynEndpointConfig,
-) -> Iterator[list[dict[str, Any]]]:
-    """Fetch a child resource (contacts/forms) per list, stamping each row with its parent ``list_id``.
-
-    Full refresh only — these endpoints expose no incremental filter. The parent ``list_id`` is part of
-    the composite primary key, so the same contact appearing under multiple lists stays a distinct row.
-    """
-    for list_id in _iter_list_ids(session, subdomain, headers, logger):
-        url = f"{base_url(subdomain)}{config.path.format(list_id=list_id)}"
-        try:
-            payload = _fetch(session, url, headers, logger)
-        except requests.HTTPError as exc:
-            # A list deleted between enumeration and this fetch 404s. Skip it rather than failing the
-            # whole sync; any other HTTP error is re-raised.
-            if exc.response is not None and exc.response.status_code == 404:
-                logger.warning(f"Campayn: list {list_id} not found while fetching {config.name}, skipping")
-                continue
-            raise
-
-        rows = [{**row, "list_id": list_id} for row in _as_rows(payload)]
-        if rows:
-            yield rows
+def _stamp_list_id(row: dict[str, Any]) -> dict[str, Any]:
+    # Keep the legacy row shape: the parent list id is exposed as a string `list_id` column (part
+    # of the composite primary key, so the same contact under multiple lists stays a distinct row)
+    # rather than the framework's `_lists_id` parent-key name.
+    row["list_id"] = str(row.pop("_lists_id"))
+    return row
 
 
 def campayn_source(
     subdomain: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     config = CAMPAYN_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url(subdomain),
+            "headers": {"Accept": "application/json"},
+            "auth": _auth_config(api_key),
+            # Campayn's public API exposes no pagination on any list endpoint — every table is a
+            # single bare-array page, full refresh only.
+            "paginator": "single_page",
+        },
+        "resource_defaults": None,
+        "resources": [],
+    }
+
+    if config.fan_out_over_lists:
+        # Contacts/forms are nested under a list: enumerate /lists.json, then fetch the child
+        # resource per list, stamping each row with its parent list_id. Full refresh only —
+        # these endpoints expose no incremental filter.
+        rest_config["resources"] = [
+            {"name": "lists", "endpoint": {"path": CAMPAYN_ENDPOINTS["lists"].path}},
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"list_id": {"type": "resolve", "resource": "lists", "field": "id"}},
+                    # A list deleted between enumeration and this fetch 404s. Skip it rather than
+                    # failing the whole sync; any other HTTP error still raises.
+                    "response_actions": [{"status_code": 404, "action": "ignore"}],
+                },
+                "include_from_parent": ["id"],
+                "data_map": _stamp_list_id,
+            },
+        ]
+        resources = rest_api_resources(rest_config, team_id, job_id, None)
+        resource = next(r for r in resources if r.name == endpoint)
+    else:
+        rest_config["resources"] = [{"name": endpoint, "endpoint": {"path": config.path}}]
+        resource = rest_api_resource(rest_config, team_id, job_id, None)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(subdomain=subdomain, api_key=api_key, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # No stable creation-time field is exposed on any Campayn resource, so partitioning is disabled.
         partition_mode=None,
@@ -170,13 +119,12 @@ def campayn_source(
 
 
 def validate_credentials(subdomain: str, api_key: str) -> bool:
-    # /lists.json is the cheapest read and the entry point every fan-out depends on.
-    try:
-        # `redact_values` masks the API key in tracked telemetry — the credential check runs before
-        # the source is saved, so the raw key must not leak into HTTP logs/samples here either.
-        response = make_tracked_session(redact_values=(api_key,)).get(
-            f"{base_url(subdomain)}/lists.json", headers=_headers(api_key), timeout=15
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+    # /lists.json is the cheapest read and the entry point every fan-out depends on. The probe runs
+    # before the source is saved, so `redact_values` masks the API key in tracked telemetry here too.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{base_url(subdomain)}{CAMPAYN_ENDPOINTS['lists'].path}",
+        headers={"Authorization": f"TRUEREST apikey={api_key}", "Accept": "application/json"},
+        timeout=15,
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/source.py
@@ -24,7 +24,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CampaynSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -103,19 +106,7 @@ Your subdomain is the first part of your account host — for `acme.campayn.com`
     ) -> list[SourceSchema]:
         # Campayn's API exposes no pagination, cursors, or timestamp filters, so every table is full
         # refresh only.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, {}, names)
 
     def validate_credentials(
         self, config: CampaynSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -133,5 +124,6 @@ Your subdomain is the first part of your account host — for `acme.campayn.com`
             subdomain=config.subdomain,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/tests/test_campayn.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/tests/test_campayn.py
@@ -1,17 +1,15 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.campayn.campayn import (
-    CampaynRetryableError,
-    _as_rows,
-    _fetch,
     base_url,
     campayn_source,
-    get_rows,
     is_subdomain_valid,
     normalize_subdomain,
     validate_credentials,
@@ -20,42 +18,56 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.campayn.se
     CAMPAYN_ENDPOINTS,
     ENDPOINTS,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
 
-SESSION_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.campayn.campayn.make_tracked_session"
-
-
-class FakeResponse:
-    def __init__(self, status_code: int = 200, json_data: Any = None) -> None:
-        self.status_code = status_code
-        self._json = json_data if json_data is not None else []
-        self.text = str(self._json)
-
-    @property
-    def ok(self) -> bool:
-        return 200 <= self.status_code < 300
-
-    def json(self) -> Any:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            raise requests.HTTPError(
-                f"{self.status_code} Client Error", response=mock.MagicMock(status_code=self.status_code)
-            )
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the campayn module.
+CAMPAYN_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.campayn.campayn.make_tracked_session"
+)
 
 
-class FakeSession:
-    def __init__(self, responses_by_url: dict[str, FakeResponse]) -> None:
-        self._responses_by_url = responses_by_url
-        self.calls: list[dict[str, Any]] = []
+def _response(body: Any, status: int = 200, reason: str | None = None, url: str | None = None) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.reason = reason
+    resp.url = url  # type: ignore[assignment]
+    return resp
 
-    def get(self, url: str, headers: Any = None, timeout: Any = None) -> FakeResponse:
-        self.calls.append({"url": url, "headers": headers})
-        # Match by suffix so tests don't have to spell out the full subdomain host every time.
-        for suffix, response in self._responses_by_url.items():
-            if url.endswith(suffix):
-                return response
-        raise AssertionError(f"unexpected URL: {url}")
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request's URL + auth headers AT PREPARE TIME.
+
+    The framework auth object only runs against the prepared request, so we apply it to a stand-in
+    with a real headers dict to observe the Authorization header it would send.
+    """
+    session.headers = {}
+    seen: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        prepared = mock.MagicMock()
+        prepared.headers = {}
+        if request.auth is not None:
+            request.auth(prepared)
+        seen.append({"url": request.url, "auth_headers": dict(prepared.headers)})
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return seen
+
+
+def _source(endpoint: str):
+    return campayn_source("acme", "k", endpoint, team_id=1, job_id="j")
+
+
+def _batches(source_response) -> list[list[dict[str, Any]]]:
+    return [list(page) for page in source_response.items()]
 
 
 class TestNormalizeSubdomain:
@@ -94,112 +106,166 @@ class TestIsSubdomainValid:
         assert is_subdomain_valid(raw) is expected
 
 
-class TestAsRows:
-    @pytest.mark.parametrize(
-        "payload, expected",
-        [
-            ([{"id": "1"}, {"id": "2"}], [{"id": "1"}, {"id": "2"}]),
-            ([{"id": "1"}, "junk"], [{"id": "1"}]),
-            ({"data": [{"id": "1"}]}, [{"id": "1"}]),
-            ({"id": "1"}, [{"id": "1"}]),
-            ("nope", []),
-            ([], []),
-        ],
-    )
-    def test_coercion(self, payload: Any, expected: list[dict[str, Any]]) -> None:
-        assert _as_rows(payload) == expected
+class TestTopLevelEndpoints:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_lists_yields_single_batch(self, MockSession) -> None:
+        session = MockSession.return_value
+        seen = _wire(session, [_response([{"id": "1"}, {"id": "2"}])])
 
+        batches = _batches(_source("lists"))
 
-class TestGetRowsTopLevel:
-    def test_lists_yields_single_batch(self) -> None:
-        session = FakeSession({"/lists.json": FakeResponse(json_data=[{"id": "1"}, {"id": "2"}])})
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("acme", "k", "lists", mock.MagicMock()))
         assert batches == [[{"id": "1"}, {"id": "2"}]]
-        assert session.calls[0]["url"] == f"{base_url('acme')}/lists.json"
-        assert session.calls[0]["headers"]["Authorization"] == "TRUEREST apikey=k"
+        # No pagination anywhere on Campayn's API — exactly one request per endpoint.
+        assert session.send.call_count == 1
+        assert seen[0]["url"] == f"{base_url('acme')}/lists.json"
+        assert seen[0]["auth_headers"]["Authorization"] == "TRUEREST apikey=k"
+        assert session.headers.get("Accept") == "application/json"
 
-    def test_empty_response_yields_nothing(self) -> None:
-        session = FakeSession({"/emails.json": FakeResponse(json_data=[])})
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("acme", "k", "emails", mock.MagicMock()))
-        assert batches == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        assert _batches(_source("emails")) == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_object_body_is_wrapped_as_one_row(self, MockSession) -> None:
+        # Defensive: the docs say list endpoints return bare arrays, but a single-object body is
+        # tolerated as one row rather than crashing the sync.
+        session = MockSession.return_value
+        _wire(session, [_response({"id": "1"})])
+
+        assert _batches(_source("reports")) == [[{"id": "1"}]]
 
 
-class TestGetRowsFanOut:
-    def test_contacts_fan_out_injects_list_id(self) -> None:
-        session = FakeSession(
-            {
-                "/lists.json": FakeResponse(json_data=[{"id": "10"}, {"id": "20"}]),
-                "/lists/10/contacts.json": FakeResponse(json_data=[{"id": "1", "email": "a@x.com"}]),
-                "/lists/20/contacts.json": FakeResponse(json_data=[{"id": "2", "email": "b@x.com"}]),
-            }
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_contacts_fan_out_injects_list_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        seen = _wire(
+            session,
+            [
+                _response([{"id": "10"}, {"id": "20"}]),
+                _response([{"id": "1", "email": "a@x.com"}]),
+                _response([{"id": "2", "email": "b@x.com"}]),
+            ],
         )
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("acme", "k", "contacts", mock.MagicMock()))
+
+        batches = _batches(_source("contacts"))
 
         assert batches == [
             [{"id": "1", "email": "a@x.com", "list_id": "10"}],
             [{"id": "2", "email": "b@x.com", "list_id": "20"}],
         ]
+        assert [s["url"] for s in seen] == [
+            f"{base_url('acme')}/lists.json",
+            f"{base_url('acme')}/lists/10/contacts.json",
+            f"{base_url('acme')}/lists/20/contacts.json",
+        ]
 
-    def test_fan_out_skips_list_deleted_mid_sync(self) -> None:
-        session = FakeSession(
-            {
-                "/lists.json": FakeResponse(json_data=[{"id": "10"}, {"id": "20"}]),
-                "/lists/10/contacts.json": FakeResponse(status_code=404),
-                "/lists/20/contacts.json": FakeResponse(json_data=[{"id": "2"}]),
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_stringifies_numeric_parent_id(self, MockSession) -> None:
+        # The composite primary key expects list_id as a string, whatever JSON type the API returns.
+        session = MockSession.return_value
+        seen = _wire(session, [_response([{"id": 10}]), _response([{"id": "1"}])])
+
+        batches = _batches(_source("contacts"))
+
+        assert batches == [[{"id": "1", "list_id": "10"}]]
+        assert seen[1]["url"] == f"{base_url('acme')}/lists/10/contacts.json"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_with_no_lists_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        assert _batches(_source("forms")) == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_skips_list_deleted_mid_sync(self, MockSession) -> None:
+        # A list deleted between enumeration and the child fetch 404s — skip it, keep syncing.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "10"}, {"id": "20"}]),
+                _response({"error": "not found"}, status=404),
+                _response([{"id": "2"}]),
+            ],
         )
-        logger = mock.MagicMock()
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("acme", "k", "contacts", logger))
+
+        batches = _batches(_source("contacts"))
 
         assert batches == [[{"id": "2", "list_id": "20"}]]
-        logger.warning.assert_called_once()
 
-    def test_fan_out_reraises_non_404_http_error(self) -> None:
-        session = FakeSession(
-            {
-                "/lists.json": FakeResponse(json_data=[{"id": "10"}]),
-                "/lists/10/forms.json": FakeResponse(status_code=403),
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_reraises_non_404_http_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "10"}]),
+                _response({"error": "forbidden"}, status=403, reason="Forbidden", url="https://x"),
+            ],
         )
-        with mock.patch(SESSION_PATH, return_value=session):
-            with pytest.raises(requests.HTTPError):
-                list(get_rows("acme", "k", "forms", mock.MagicMock()))
+
+        with pytest.raises(requests.HTTPError, match="403 Client Error"):
+            _batches(_source("forms"))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_fails_loudly_on_parent_row_missing_id(self, MockSession) -> None:
+        # `id` drives all fan-out, so a malformed list record must fail rather than silently
+        # dropping its contacts/forms.
+        session = MockSession.return_value
+        _wire(session, [_response([{"name": "no id here"}])])
+
+        with pytest.raises(ValueError, match="field 'id'"):
+            _batches(_source("contacts"))
 
 
-class TestFetchRetry:
+class TestErrorHandling:
     @pytest.mark.parametrize("status", [429, 500, 503])
-    def test_retryable_statuses_raise_retryable_error(self, status: int) -> None:
-        # Override tenacity's backoff sleep so the 5 retries don't actually wait; the decorator
-        # reraises the last CampaynRetryableError once attempts are exhausted.
-        session = FakeSession({"/lists.json": FakeResponse(status_code=status)})
-        with mock.patch(SESSION_PATH, return_value=session), mock.patch.object(_fetch.retry, "sleep"):  # type: ignore[attr-defined]
-            with pytest.raises(CampaynRetryableError):
-                list(get_rows("acme", "k", "lists", mock.MagicMock()))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_raise_retryable_error(self, MockSession, status: int) -> None:
+        # Override tenacity's backoff sleep so the 5 retries don't actually wait; the client
+        # reraises the last retryable error once attempts are exhausted.
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status) for _ in range(5)])
 
-    @pytest.mark.parametrize("status", [401, 403, 404])
-    def test_client_errors_raise_http_error(self, status: int) -> None:
-        session = FakeSession({"/lists.json": FakeResponse(status_code=status)})
-        with mock.patch(SESSION_PATH, return_value=session):
-            with pytest.raises(requests.HTTPError):
-                list(get_rows("acme", "k", "lists", mock.MagicMock()))
+        with (
+            mock.patch.object(RESTClient._send_request.retry, "sleep"),  # type: ignore[attr-defined]
+            pytest.raises(RESTClientRetryableError),
+        ):
+            _batches(_source("lists"))
+        assert session.send.call_count == 5
+
+    @pytest.mark.parametrize(
+        "status, reason",
+        [(401, "Unauthorized"), (403, "Forbidden"), (404, "Not Found")],
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_http_error(self, MockSession, status: int, reason: str) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status, reason=reason, url="https://x")])
+
+        # The "<status> Client Error" prefix is what get_non_retryable_errors matches on.
+        with pytest.raises(requests.HTTPError, match=f"{status} Client Error"):
+            _batches(_source("lists"))
 
 
 class TestCampaynSource:
     def test_all_endpoints_buildable_with_correct_primary_keys(self) -> None:
         for endpoint in ENDPOINTS:
-            response = campayn_source("acme", "k", endpoint, mock.MagicMock())
+            response = _source(endpoint)
             assert response.name == endpoint
             assert response.primary_keys == CAMPAYN_ENDPOINTS[endpoint].primary_keys
             # No stable creation-time field exists, so nothing is partitioned.
             assert response.partition_mode is None
 
     def test_fan_out_endpoints_key_includes_parent_list_id(self) -> None:
-        assert campayn_source("acme", "k", "contacts", mock.MagicMock()).primary_keys == ["list_id", "id"]
-        assert campayn_source("acme", "k", "forms", mock.MagicMock()).primary_keys == ["list_id", "id"]
+        assert _source("contacts").primary_keys == ["list_id", "id"]
+        assert _source("forms").primary_keys == ["list_id", "id"]
 
 
 class TestValidateCredentials:
@@ -207,24 +273,22 @@ class TestValidateCredentials:
         "status, expected",
         [(200, True), (401, False), (403, False), (500, False)],
     )
-    def test_status_mapping(self, status: int, expected: bool) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = FakeResponse(status_code=status)
-        with mock.patch(SESSION_PATH, return_value=session):
-            assert validate_credentials("acme", "k") is expected
+    @mock.patch(CAMPAYN_SESSION_PATCH)
+    def test_status_mapping(self, mock_session: mock.MagicMock, status: int, expected: bool) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("acme", "k") is expected
 
-    def test_connection_error_returns_false(self) -> None:
-        session = mock.MagicMock()
-        session.get.side_effect = Exception("boom")
-        with mock.patch(SESSION_PATH, return_value=session):
-            assert validate_credentials("acme", "k") is False
+    @mock.patch(CAMPAYN_SESSION_PATCH)
+    def test_connection_error_returns_false(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("acme", "k") is False
 
-    def test_probes_lists_endpoint(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = FakeResponse(status_code=200)
-        with mock.patch(SESSION_PATH, return_value=session):
-            validate_credentials("acme", "k")
-        called_url = (
-            session.get.call_args.args[0] if session.get.call_args.args else session.get.call_args.kwargs["url"]
-        )
+    @mock.patch(CAMPAYN_SESSION_PATCH)
+    def test_probes_lists_endpoint_with_auth_header(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("acme", "k")
+
+        call = mock_session.return_value.get.call_args
+        called_url = call.args[0] if call.args else call.kwargs["url"]
         assert called_url == f"{base_url('acme')}/lists.json"
+        assert call.kwargs["headers"]["Authorization"] == "TRUEREST apikey=k"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/tests/test_campayn_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campayn/tests/test_campayn_source.py
@@ -139,3 +139,5 @@ class TestCampaynSource:
         assert kwargs["subdomain"] == "acme"
         assert kwargs["api_key"] == "campayn-key"
         assert kwargs["endpoint"] == "contacts"
+        assert kwargs["team_id"] is inputs.team_id
+        assert kwargs["job_id"] is inputs.job_id

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/chartmogul.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/chartmogul.py
@@ -1,29 +1,26 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
+from requests.auth import HTTPBasicAuth
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.settings import (
-    CHARTMOGUL_ENDPOINTS,
-    ChartMogulEndpointConfig,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.settings import CHARTMOGUL_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CHARTMOGUL_BASE_URL = "https://api.chartmogul.com"
 DEFAULT_PAGE_SIZE = 200
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
-
-
-class ChartMogulRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -35,10 +32,55 @@ class ChartMogulResumeConfig:
     cursor: str
 
 
-def _get_session(api_key: str) -> requests.Session:
-    # ChartMogul uses HTTP Basic auth with the API key as the username and an
-    # empty password. Redact the key from logged URLs / captured samples.
-    return make_tracked_session(redact_values=(api_key,))
+class ChartMogulPaginator(BasePaginator):
+    """Cursor pagination gated on ChartMogul's `has_more` flag.
+
+    ChartMogul returns both `cursor` and `has_more` on every page; a next page
+    exists only when `has_more` is true AND a cursor is present, so the
+    built-in cursor paginator (cursor presence alone) can't be used.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cursor: Optional[str] = None
+
+    def init_request(self, request: Request) -> None:
+        # Honour a seeded resume cursor on the first request.
+        if self._cursor is not None:
+            if request.params is None:
+                request.params = {}
+            request.params["cursor"] = self._cursor
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+
+        if not isinstance(body, dict):
+            self._has_next_page = False
+            return
+
+        cursor = body.get("cursor")
+        if body.get("has_more", False) and cursor:
+            self._cursor = cursor
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["cursor"] = self._cursor
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor} if self._has_next_page and self._cursor is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor = str(cursor)
+            self._has_next_page = True
 
 
 def _format_start_date(value: Any) -> str:
@@ -52,111 +94,81 @@ def _format_start_date(value: Any) -> str:
 
 
 def validate_credentials(api_key: str) -> bool:
-    url = f"{CHARTMOGUL_BASE_URL}/v1/data_sources"
-    try:
-        response = _get_session(api_key).get(url, auth=(api_key, ""), timeout=REQUEST_TIMEOUT_SECONDS)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _build_initial_params(
-    config: ChartMogulEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {}
-
-    if config.paginated:
-        params["per_page"] = DEFAULT_PAGE_SIZE
-
-    if config.incremental_param and should_use_incremental_field and db_incremental_field_last_value:
-        params[config.incremental_param] = _format_start_date(db_incremental_field_last_value)
-
-    return params
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ChartMogulResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CHARTMOGUL_ENDPOINTS[endpoint]
-    session = _get_session(api_key)
-    base_url = f"{CHARTMOGUL_BASE_URL}{config.path}"
-
-    params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        params["cursor"] = resume_config.cursor
-        logger.debug(f"ChartMogul: resuming {endpoint} from cursor: {resume_config.cursor}")
-
-    @retry(
-        retry=retry_if_exception_type((ChartMogulRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
+    # ChartMogul uses HTTP Basic auth with the API key as the username and an
+    # empty password.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CHARTMOGUL_BASE_URL}/v1/data_sources",
+        auth=HTTPBasicAuth(api_key, ""),
+        timeout=60.0,
     )
-    def fetch_page(page_params: dict[str, Any]) -> dict[str, Any]:
-        url = f"{base_url}?{urlencode(page_params)}" if page_params else base_url
-        response = session.get(url, auth=(api_key, ""), timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise ChartMogulRetryableError(
-                f"ChartMogul API error (retryable): status={response.status_code}, url={base_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"ChartMogul API error: status={response.status_code}, body={response.text}, url={base_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(params)
-
-        items = data.get(config.data_key, [])
-        if items:
-            yield items
-
-        if not config.paginated:
-            break
-
-        has_more = data.get("has_more", False)
-        cursor = data.get("cursor")
-        if not has_more or not cursor:
-            break
-
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(ChartMogulResumeConfig(cursor=cursor))
-        params["cursor"] = cursor
+    return ok
 
 
 def chartmogul_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ChartMogulResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = CHARTMOGUL_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {}
+    if config.paginated:
+        params["per_page"] = DEFAULT_PAGE_SIZE
+    if config.incremental_param and should_use_incremental_field and db_incremental_field_last_value:
+        params[config.incremental_param] = _format_start_date(db_incremental_field_last_value)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CHARTMOGUL_BASE_URL,
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            # Some endpoints (data_sources) return the full list without pagination.
+            "paginator": ChartMogulPaginator() if config.paginated else SinglePagePaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # ChartMogul wraps results per resource (customers/activities
+                    # use "entries", plans use "plans", etc.); a missing key is
+                    # treated as an empty page, matching the historical behavior.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume_config = resumable_source_manager.load_state()
+        if resume_config is not None:
+            initial_paginator_state = {"cursor": resume_config.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint is saved AFTER
+        # the page is yielded so a crash re-yields the last page (merge dedupes
+        # on primary key) rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(ChartMogulResumeConfig(cursor=str(state["cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ChartMogulSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -87,19 +90,7 @@ You can find your API key in your [ChartMogul admin settings](https://app.chartm
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
-                supports_append=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in list(ENDPOINTS)
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: ChartMogulSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -127,7 +118,8 @@ You can find your API key in your [ChartMogul admin settings](https://app.chartm
         return chartmogul_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/tests/test_chartmogul.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/tests/test_chartmogul.py
@@ -1,49 +1,88 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
+
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul import (
     ChartMogulResumeConfig,
-    _build_initial_params,
     _format_start_date,
     chartmogul_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.settings import CHARTMOGUL_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the chartmogul module.
+CHARTMOGUL_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul.make_tracked_session"
+)
 
 
-class _FakeResponse:
-    def __init__(self, status_code: int, body: dict[str, Any] | None = None, text: str = "") -> None:
-        self.status_code = status_code
-        self._body = body or {}
-        self.text = text
-
-    @property
-    def ok(self) -> bool:
-        return self.status_code < 400
-
-    def json(self) -> dict[str, Any]:
-        return self._body
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            raise AssertionError(f"HTTP {self.status_code}")
+def _response(body: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _fake_session(responses: list[_FakeResponse]) -> MagicMock:
-    session = MagicMock()
-    session.get.side_effect = list(responses)
-    return session
+def _page(
+    data_key: str,
+    items: list[dict[str, Any]],
+    *,
+    has_more: bool = False,
+    cursor: str | None = None,
+) -> Response:
+    return _response({data_key: items, "has_more": has_more, "cursor": cursor})
 
 
-def _manager(can_resume: bool = False, resume_state: ChartMogulResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock()
-    manager.can_resume.return_value = can_resume
+def _make_manager(resume_state: ChartMogulResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
     manager.load_state.return_value = resume_state
     return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(
+    endpoint: str,
+    manager: mock.MagicMock,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+):
+    return chartmogul_source(
+        "key",
+        endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
 
 
 class TestFormatStartDate:
@@ -63,146 +102,151 @@ class TestFormatStartDate:
         assert "+00:00" not in _format_start_date(datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC))
 
 
-class TestBuildInitialParams:
-    def test_paginated_endpoint_sets_per_page(self) -> None:
-        params = _build_initial_params(CHARTMOGUL_ENDPOINTS["customers"], False, None)
-        assert params["per_page"] == 200
-        assert "start-date" not in params
-
-    def test_non_paginated_endpoint_omits_per_page(self) -> None:
-        params = _build_initial_params(CHARTMOGUL_ENDPOINTS["data_sources"], False, None)
-        assert "per_page" not in params
-
-    def test_activities_incremental_sets_start_date(self) -> None:
-        params = _build_initial_params(
-            CHARTMOGUL_ENDPOINTS["activities"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_across_cursors(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _page("entries", [{"uuid": "a"}], has_more=True, cursor="c1"),
+                _page("entries", [{"uuid": "b"}]),
+            ],
         )
-        assert params["start-date"] == "2026-01-01T00:00:00"
 
-    def test_no_start_date_when_incremental_disabled(self) -> None:
-        params = _build_initial_params(
-            CHARTMOGUL_ENDPOINTS["activities"],
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
-        )
-        assert "start-date" not in params
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
 
-    def test_non_incremental_endpoint_never_sets_start_date(self) -> None:
-        params = _build_initial_params(
-            CHARTMOGUL_ENDPOINTS["customers"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
-        )
-        assert "start-date" not in params
-
-
-class TestGetRows:
-    def test_paginates_across_cursors(self) -> None:
-        responses = [
-            _FakeResponse(200, {"entries": [{"uuid": "a"}], "has_more": True, "cursor": "c1"}),
-            _FakeResponse(200, {"entries": [{"uuid": "b"}], "has_more": False, "cursor": None}),
-        ]
-        manager = _manager()
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=_fake_session(responses),
-        ):
-            batches = list(get_rows("key", "customers", MagicMock(), manager))
-
-        assert batches == [[{"uuid": "a"}], [{"uuid": "b"}]]
-
-    def test_saves_state_after_each_page(self) -> None:
-        responses = [
-            _FakeResponse(200, {"entries": [{"uuid": "a"}], "has_more": True, "cursor": "c1"}),
-            _FakeResponse(200, {"entries": [{"uuid": "b"}], "has_more": False, "cursor": None}),
-        ]
-        manager = _manager()
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=_fake_session(responses),
-        ):
-            list(get_rows("key", "customers", MagicMock(), manager))
-
+        assert [r["uuid"] for r in rows] == ["a", "b"]
+        assert params[0]["per_page"] == 200
+        assert "cursor" not in params[0]
+        assert params[1]["cursor"] == "c1"
+        # Checkpoint saved after the first page (points at the next page); final page ends it.
         manager.save_state.assert_called_once_with(ChartMogulResumeConfig(cursor="c1"))
 
-    def test_resumes_from_saved_cursor(self) -> None:
-        session = _fake_session([_FakeResponse(200, {"entries": [{"uuid": "b"}], "has_more": False, "cursor": None})])
-        manager = _manager(can_resume=True, resume_state=ChartMogulResumeConfig(cursor="resume-cursor"))
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=session,
-        ):
-            list(get_rows("key", "customers", MagicMock(), manager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_has_more_false_even_with_cursor(self, MockSession) -> None:
+        # ChartMogul may still return a cursor on the last page; termination is
+        # gated on has_more, not cursor presence.
+        session = MockSession.return_value
+        _wire(session, [_page("entries", [{"uuid": "a"}], has_more=False, cursor="c9")])
 
-        called_url = session.get.call_args_list[0].args[0]
-        assert "cursor=resume-cursor" in called_url
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
 
-    def test_non_paginated_endpoint_fetches_once(self) -> None:
-        session = _fake_session(
-            [_FakeResponse(200, {"data_sources": [{"uuid": "ds1"}], "has_more": True, "cursor": "ignored"})]
-        )
-        manager = _manager()
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=session,
-        ):
-            batches = list(get_rows("key", "data_sources", MagicMock(), manager))
-
-        assert batches == [[{"uuid": "ds1"}]]
-        assert session.get.call_count == 1
+        assert [r["uuid"] for r in rows] == ["a"]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_empty_page_is_not_yielded(self) -> None:
-        session = _fake_session([_FakeResponse(200, {"plans": [], "has_more": False, "cursor": None})])
-        manager = _manager()
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=session,
-        ):
-            batches = list(get_rows("key", "plans", MagicMock(), manager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("entries", [{"uuid": "b"}])])
 
-        assert batches == []
+        manager = _make_manager(ChartMogulResumeConfig(cursor="resume-cursor"))
+        _rows(_source("customers", manager))
+
+        assert params[0]["cursor"] == "resume-cursor"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_endpoint_fetches_once(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("data_sources", [{"uuid": "ds1"}], has_more=True, cursor="ignored")])
+
+        manager = _make_manager()
+        rows = _rows(_source("data_sources", manager))
+
+        assert [r["uuid"] for r in rows] == ["ds1"]
+        assert session.send.call_count == 1
+        assert "per_page" not in params[0]
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("plans", [])])
+
+        rows = _rows(_source("plans", _make_manager()))
+
+        assert rows == []
 
     @pytest.mark.parametrize("status", [429, 503])
-    @patch("tenacity.nap.time.sleep", return_value=None)
-    def test_retryable_status_codes_recover(self, _mock_sleep: MagicMock, status: int) -> None:
-        # A single retryable response then success: the tenacity retry should
-        # recover and still yield the data. tenacity's backoff sleep is patched
-        # out to keep the test fast and deterministic.
-        responses = [
-            _FakeResponse(status, {}),
-            _FakeResponse(200, {"plans": [{"uuid": "p1"}], "has_more": False, "cursor": None}),
-        ]
-        manager = _manager()
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=_fake_session(responses),
-        ):
-            batches = list(get_rows("key", "plans", MagicMock(), manager))
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_codes_recover(self, MockSession, _mock_sleep, status: int) -> None:
+        # A single retryable response then success: the client retry should
+        # recover and still yield the data. The backoff sleep is patched out to
+        # keep the test fast and deterministic.
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=status), _page("plans", [{"uuid": "p1"}])])
 
-        assert batches == [[{"uuid": "p1"}]]
+        rows = _rows(_source("plans", _make_manager()))
+
+        assert [r["uuid"] for r in rows] == ["p1"]
+
+
+class TestIncrementalParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_activities_incremental_sets_start_date(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("entries", [{"uuid": "a"}])])
+
+        _rows(
+            _source(
+                "activities",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+            )
+        )
+
+        assert params[0]["start-date"] == "2026-01-01T00:00:00"
+        assert params[0]["per_page"] == 200
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_start_date_when_incremental_disabled(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("entries", [{"uuid": "a"}])])
+
+        _rows(
+            _source(
+                "activities",
+                _make_manager(),
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+
+        assert "start-date" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_incremental_endpoint_never_sets_start_date(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("entries", [{"uuid": "a"}])])
+
+        _rows(
+            _source(
+                "customers",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+
+        assert "start-date" not in params[0]
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status,expected", [(200, True), (401, False), (403, False)])
-    def test_status_mapping(self, status: int, expected: bool) -> None:
-        session = _fake_session([_FakeResponse(status, {})])
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=session,
-        ):
-            assert validate_credentials("key") is expected
+    @mock.patch(CHARTMOGUL_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status: int, expected: bool) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("key") is expected
 
-    def test_exception_returns_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.chartmogul.chartmogul._get_session",
-            return_value=session,
-        ):
-            assert validate_credentials("key") is False
+    @mock.patch(CHARTMOGUL_SESSION_PATCH)
+    def test_exception_returns_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key") is False
 
 
 class TestChartmogulSource:
@@ -217,8 +261,11 @@ class TestChartmogulSource:
             ("data_sources", ["uuid"], "created_at"),
         ],
     )
-    def test_source_response_shape(self, endpoint: str, primary_keys: list[str], partition_key: str | None) -> None:
-        response = chartmogul_source("key", endpoint, MagicMock(), _manager())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(
+        self, MockSession, endpoint: str, primary_keys: list[str], partition_key: str | None
+    ) -> None:
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/churnkey/churnkey.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/churnkey/churnkey.py
@@ -1,11 +1,5 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.settings import (
@@ -13,11 +7,15 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.s
     CHURNKEY_ENDPOINTS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-
-
-class ChurnkeyRetryableError(Exception):
-    pass
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 
 @dataclasses.dataclass
@@ -27,38 +25,14 @@ class ChurnkeyResumeConfig:
     skip: int = 0
 
 
-def _get_headers(api_key: str, app_id: str) -> dict[str, str]:
+def _non_secret_headers(app_id: str) -> dict[str, str]:
+    # The API key is supplied via the framework auth config so its value is redacted from logs;
+    # only the non-secret app id / content negotiation headers are set here.
     return {
-        "x-ck-api-key": api_key,
         "x-ck-app": app_id,
         "content-type": "application/json",
         "accept": "application/json",
     }
-
-
-@retry(
-    retry=retry_if_exception_type((ChurnkeyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[dict[str, Any]]:
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ChurnkeyRetryableError(f"Churnkey API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Churnkey API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    # The sessions endpoint returns a bare JSON array, not a `{"data": [...]}` envelope.
-    if not isinstance(data, list):
-        return []
-    return data
 
 
 def validate_credentials(api_key: str, app_id: str) -> tuple[bool, Optional[int]]:
@@ -66,73 +40,73 @@ def validate_credentials(api_key: str, app_id: str) -> tuple[bool, Optional[int]
 
     Returns ``(is_valid, status_code)``. A network failure surfaces as ``(False, None)``.
     """
-    url = f"{CHURNKEY_BASE_URL}/sessions?{urlencode({'limit': 1})}"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key, app_id), timeout=10)
-        return response.status_code == 200, response.status_code
-    except Exception:
-        return False, None
-
-
-def get_rows(
-    api_key: str,
-    app_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ChurnkeyResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = CHURNKEY_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key, app_id)
-    # One session reused across every page so urllib3 keeps the connection alive instead of
-    # re-handshaking per request.
-    session = make_tracked_session()
-    limit = config.page_size
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    skip = resume.skip if resume else 0
-    if resume:
-        logger.debug(f"Churnkey: resuming {endpoint} from skip={skip}")
-
-    while True:
-        url = f"{CHURNKEY_BASE_URL}{config.path}?{urlencode({'limit': limit, 'skip': skip})}"
-        page = _fetch_page(session, url, headers, logger)
-        if not page:
-            break
-
-        yield page
-
-        skip += limit
-        # A short page means we've reached the end — stop without checkpointing further.
-        if len(page) < limit:
-            break
-
-        # Save AFTER yielding so a crash resumes at the next page rather than skipping the
-        # one we just emitted prematurely; merge dedupes any re-pulled rows on `_id`.
-        resumable_source_manager.save_state(ChurnkeyResumeConfig(skip=skip))
+    return validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CHURNKEY_BASE_URL}/sessions?limit=1",
+        headers={"x-ck-api-key": api_key, **_non_secret_headers(app_id)},
+    )
 
 
 def churnkey_source(
     api_key: str,
     app_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ChurnkeyResumeConfig],
 ) -> SourceResponse:
     config = CHURNKEY_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CHURNKEY_BASE_URL,
+            "headers": _non_secret_headers(app_id),
+            "auth": {"type": "api_key", "api_key": api_key, "name": "x-ck-api-key", "location": "header"},
+            # No total count anywhere in the response; termination is short/empty page.
+            "paginator": OffsetPaginator(limit=config.page_size, offset_param="skip", total_path=None),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # The endpoint returns a bare JSON array — a non-list 200 body means the
+                    # response shape changed, so fail loud instead of syncing garbage.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.skip}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on `_id`) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(ChurnkeyResumeConfig(skip=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            app_id=app_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/churnkey/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/churnkey/source.py
@@ -151,6 +151,7 @@ The Data API key is distinct from your Cancel Flow API key — request one from 
             api_key=config.api_key,
             app_id=config.app_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/churnkey/tests/test_churnkey.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/churnkey/tests/test_churnkey.py
@@ -1,38 +1,69 @@
-from collections.abc import Iterable
-from typing import Any, cast
+import json
+from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
+
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.churnkey import (
     ChurnkeyResumeConfig,
-    _get_headers,
     churnkey_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.settings import (
     CHURNKEY_ENDPOINTS,
     DEFAULT_PAGE_SIZE,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
-_FETCH = "products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.churnkey._fetch_page"
-
-
-def _logger() -> MagicMock:
-    log = MagicMock()
-    log.debug = MagicMock()
-    log.error = MagicMock()
-    return log
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the churnkey module.
+CHURNKEY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.churnkey.make_tracked_session"
+)
 
 
-class TestHeaders:
-    def test_get_headers(self) -> None:
-        headers = _get_headers("data_abc", "app_123")
-        assert headers["x-ck-api-key"] == "data_abc"
-        assert headers["x-ck-app"] == "app_123"
-        assert headers["content-type"] == "application/json"
+def _response(body: Any) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: ChurnkeyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Wire a mock session; return (param snapshots, auth snapshots) captured AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    auth_snapshots: list[Any] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        auth_snapshots.append(request.auth)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, auth_snapshots
+
+
+def _source(manager: mock.MagicMock):
+    return churnkey_source("data_key", "app_123", "Sessions", team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestValidateCredentials:
@@ -47,101 +78,114 @@ class TestValidateCredentials:
         ],
     )
     def test_status_mapping(self, status_code: int, expected: tuple[bool, int]) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.churnkey.make_tracked_session"
-        ) as mock_session:
-            response = MagicMock()
-            response.status_code = status_code
-            mock_session.return_value.get.return_value = response
-
+        with mock.patch(CHURNKEY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
             assert validate_credentials("key", "app") == expected
 
     def test_network_failure_returns_none_status(self) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.churnkey.make_tracked_session"
-        ) as mock_session:
+        with mock.patch(CHURNKEY_SESSION_PATCH) as mock_session:
             mock_session.return_value.get.side_effect = Exception("boom")
             assert validate_credentials("key", "app") == (False, None)
 
-
-def _drive_rows(manager: MagicMock, pages: list[list[dict[str, Any]]]) -> tuple[list[list[dict[str, Any]]], list[str]]:
-    """Run ``get_rows`` against ``pages`` (returned in order) with page size forced to 2.
-
-    Returns ``(yielded_pages, requested_urls)``.
-    """
-    urls: list[str] = []
-    page_iter = iter(pages)
-
-    def fake_fetch(_session: Any, url: str, _headers: Any, _logger: Any) -> list[dict[str, Any]]:
-        urls.append(url)
-        return next(page_iter, [])
-
-    with (
-        patch.object(CHURNKEY_ENDPOINTS["Sessions"], "page_size", 2),
-        patch(_FETCH, side_effect=fake_fetch),
-        patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.churnkey.churnkey.make_tracked_session"
-        ),
-    ):
-        yielded = list(get_rows("key", "app", "Sessions", _logger(), manager))
-    return yielded, urls
+    def test_probe_sends_both_auth_headers(self) -> None:
+        with mock.patch(CHURNKEY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+            validate_credentials("data_abc", "app_123")
+            headers = mock_session.return_value.get.call_args.kwargs["headers"]
+            assert headers["x-ck-api-key"] == "data_abc"
+            assert headers["x-ck-app"] == "app_123"
 
 
-class TestGetRows:
-    def test_fresh_run_pages_and_saves_after_each_non_terminal_page(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fresh_run_pages_and_saves_after_each_non_terminal_page(self, MockSession) -> None:
+        session = MockSession.return_value
         pages = [
             [{"_id": "1"}, {"_id": "2"}],
             [{"_id": "3"}, {"_id": "4"}],
             [{"_id": "5"}],  # short page → terminal
         ]
-        yielded, urls = _drive_rows(manager, pages)
+        with mock.patch.object(CHURNKEY_ENDPOINTS["Sessions"], "page_size", 2):
+            params, _ = _wire(session, [_response(p) for p in pages])
+            manager = _make_manager()
+            rows = _rows(_source(manager))
 
-        assert yielded == pages
+        assert [r["_id"] for r in rows] == ["1", "2", "3", "4", "5"]
         # skip advances by the page size (2) each request, starting at 0.
-        assert [u.split("?", 1)[1] for u in urls] == ["limit=2&skip=0", "limit=2&skip=2", "limit=2&skip=4"]
+        assert [(p["skip"], p["limit"]) for p in params] == [(0, 2), (2, 2), (4, 2)]
         # State saved only after the two full (non-terminal) pages, never after the short one.
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [ChurnkeyResumeConfig(skip=2), ChurnkeyResumeConfig(skip=4)]
         manager.load_state.assert_not_called()
 
-    def test_resume_starts_from_saved_skip(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = ChurnkeyResumeConfig(skip=4)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_starts_from_saved_skip(self, MockSession) -> None:
+        session = MockSession.return_value
+        with mock.patch.object(CHURNKEY_ENDPOINTS["Sessions"], "page_size", 2):
+            params, _ = _wire(session, [_response([{"_id": "5"}])])
+            manager = _make_manager(ChurnkeyResumeConfig(skip=4))
+            rows = _rows(_source(manager))
 
-        yielded, urls = _drive_rows(manager, [[{"_id": "5"}]])
-
-        assert yielded == [[{"_id": "5"}]]
-        assert urls[0].split("?", 1)[1] == "limit=2&skip=4"
+        assert [r["_id"] for r in rows] == ["5"]
+        assert params[0]["skip"] == 4
         manager.load_state.assert_called_once()
 
-    def test_terminal_single_page_does_not_save_state(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_terminal_single_page_does_not_save_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        with mock.patch.object(CHURNKEY_ENDPOINTS["Sessions"], "page_size", 2):
+            _wire(session, [_response([{"_id": "only"}])])
+            manager = _make_manager()
+            rows = _rows(_source(manager))
 
-        yielded, _ = _drive_rows(manager, [[{"_id": "only"}]])
-
-        assert yielded == [[{"_id": "only"}]]
+        assert [r["_id"] for r in rows] == ["only"]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_empty_first_page_yields_nothing(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+        manager = _make_manager()
+        rows = _rows(_source(manager))
 
-        yielded, urls = _drive_rows(manager, [[]])
-
-        assert yielded == []
-        assert len(urls) == 1
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unexpected envelope"})])
+
+        # The endpoint returns a bare array — a non-list 200 body means the response shape
+        # changed, so fail loud instead of syncing garbage.
+        with pytest.raises(ValueError, match="Required a list response body"):
+            _rows(_source(_make_manager()))
+
+
+class TestAuthAndHeaders:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_api_key_auth_and_app_header(self, MockSession) -> None:
+        session = MockSession.return_value
+        _, auths = _wire(session, [_response([{"_id": "a"}])])
+        _rows(_source(_make_manager()))
+
+        # Non-secret headers live on the session; the API key goes through framework auth so it
+        # gets redacted from logs.
+        assert session.headers["x-ck-app"] == "app_123"
+        assert session.headers["content-type"] == "application/json"
+        auth = auths[0]
+        assert auth.name == "x-ck-api-key"
+        assert auth.api_key == "data_key"
+        assert auth.location == "header"
 
 
 class TestChurnkeySource:
-    def test_source_response_shape(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        response = churnkey_source("key", "app", "Sessions", _logger(), manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, MockSession) -> None:
+        _wire(MockSession.return_value, [])
+        response = _source(_make_manager())
 
         assert response.name == "Sessions"
         assert response.primary_keys == ["_id"]
@@ -149,17 +193,16 @@ class TestChurnkeySource:
         assert response.partition_format == "month"
         assert response.partition_keys == ["createdAt"]
 
-    def test_items_is_lazy(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_items_is_lazy(self, MockSession) -> None:
         # Building the SourceResponse must not perform any HTTP — items is a thunk.
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        with patch(_FETCH) as mock_fetch:
-            response = churnkey_source("key", "app", "Sessions", _logger(), manager)
-            mock_fetch.assert_not_called()
-            # Draining the iterator (one empty page) then triggers a fetch.
-            mock_fetch.return_value = []
-            list(cast(Iterable[Any], response.items()))
-            assert mock_fetch.called
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+        response = _source(_make_manager())
+        assert session.send.call_count == 0
+
+        list(response.items())
+        assert session.send.call_count == 1
 
     def test_default_page_size_within_api_cap(self) -> None:
         # The API rejects limit > 10,000.


### PR DESCRIPTION
## Problem

Fourth batch of hand-rolled source → `rest_source` migrations, stacked on #71552.

## Changes

**Five sources migrated to `rest_source`**, each behavior-preserving with its full suite green:

| Source | Tests |
|---|---|
| `bluetally` | 54 |
| `calendly` | 40 |
| `campayn` | 59 |
| `chartmogul` | 41 |
| `churnkey` | 34 |

**Vetted and skipped**: `buildbetter` (GraphQL with body-level error classification), `bugsnag` (two-level fan-out: orgs → projects → resources with cross-parent resume).

> [!NOTE]
> Stacked on #71552 → #71540 → #71524 → #71520 → #71481/#71477. Review the commits above the batch-3 head.

## How did you test this code?

- Merged verification: **365 tests pass** across the 5 migrated sources + the full `rest_source` suite.
- Each source's suite passed in isolation first; coverage preserved (pagination progression, resume round-trips, termination, fail-loud paths, `validate_credentials` mapping).
- Each migration produced in an isolated worktree touching only its own `sources/<name>/` dir (verified before merge). `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
