### PR TITLE
feat(tasks): widen send_followup_message signal handler arity

### DIFF
--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1777,7 +1777,21 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         self._last_active_time = workflow.now()
 
     @temporalio.workflow.signal
-    async def send_followup_message(self, message: str | None = None, artifact_ids: Optional[list[str]] = None) -> None:
+    async def send_followup_message(
+        self,
+        message: str | None = None,
+        artifact_ids: Optional[list[str]] = None,
+        message_id: Optional[str] = None,
+        actor_user_id: Optional[int] = None,
+        message_context: Optional[dict[str, Any]] = None,
+    ) -> None:
+        # The handler declares the full positional arg list even though only
+        # ``message`` and ``artifact_ids`` are read here. Temporal passes every
+        # positional arg a caller sends to the handler, and a handler that
+        # declares fewer params than were sent raises and fails the workflow
+        # task — so the arity must stay a superset of every caller's. Widening it
+        # here, ahead of any caller that populates the extra fields, lets this
+        # handler roll out to all workers before those callers ship.
         # Log signal arrival so we can correlate it with the adapter's "begin dispatch"
         # log below — gaps between the two point at workflow-loop backpressure.
         context = self._context


### PR DESCRIPTION
## Problem

Temporal delivers every positional arg a caller sends straight to the signal handler, and a handler declaring fewer params than were sent raises and fails the workflow task. The follow-up queue stack widens `send_followup_message` from 2 args to 5 (`message_id`, `actor_user_id`, `message_context`). If a new sender reaches an old worker mid-rollout, that workflow gets stuck until the worker upgrades.

## Change

Widen the handler signature to the full 5-param arg list now, with defaults and the body unchanged (the extra fields are accepted and ignored here). Deploying this to every worker first makes them tolerant of both the old and new call shapes, so the senders in the rest of the stack can ship safely.

**Deploy this first and let it fully roll out before the sender changes (#70806 → #70762) deploy.**

## How did you test this code?

Signature-only change, body identical to before; existing follow-up signal tests pass. Base of the follow-up queue stack.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
