### PR TITLE
feat(data-warehouse): migrate 3 sources to rest_source (batch 5)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/airops/airops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/airops/airops.py
@@ -1,151 +1,147 @@
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.airops.settings import AIROPS_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 AIROPS_BASE_URL = "https://api.airops.com"
+APPS_PATH = "public_api/airops_apps"
 # The executions endpoint caps `items` at 100.
 EXECUTIONS_PAGE_SIZE = 100
 
 
-class AirOpsRetryableError(Exception):
-    """Raised for AirOps responses that are safe to retry (429 / 5xx)."""
+class AirOpsCursorPaginator(JSONResponseCursorPaginator):
+    """Cursor pagination over `meta.cursor`, honoring an explicit `has_more: false`.
 
+    Pages while a cursor is present (a response with a cursor but no `has_more` flag must still
+    page), but stops when `meta.has_more` is explicitly false even if a cursor is returned, so the
+    final page isn't re-fetched.
+    """
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-    }
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if not self._has_next_page:
+            return
+        try:
+            body = response.json()
+        except Exception:
+            return
+        meta = body.get("meta") if isinstance(body, dict) else None
+        if isinstance(meta, dict) and meta.get("has_more") is False:
+            self._has_next_page = False
 
 
 def _make_session(api_key: str) -> requests.Session:
-    """Session for all AirOps traffic. The bearer token is set once on the session (so its redaction
-    policy applies to every request and captured sample) and redirects are pinned off so a credentialed
+    """Session for all AirOps traffic. The bearer token is registered for value-based redaction (so
+    it can't leak into logged URLs or samples) and redirects are pinned off so a credentialed
     request can't be replayed against another host. Response capture is disabled because executions
     carry free-form `inputs`/`output` under arbitrary keys — a user can place credentials or other
     secrets there, and the name-based sample scrubbers can't reliably recognise them."""
     return make_tracked_session(
-        headers=_get_headers(api_key),
+        headers={"Accept": "application/json"},
         redact_values=(api_key,),
         allow_redirects=False,
         capture=False,
     )
 
 
-@retry(
-    retry=retry_if_exception_type(
-        (
-            AirOpsRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_json(session: requests.Session, url: str, logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AirOpsRetryableError(f"AirOps API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"AirOps API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+def _stamp_app_id(row: dict[str, Any]) -> dict[str, Any]:
+    # Keep the legacy row shape: the parent app id is exposed as `airops_app_id` (part of the
+    # composite primary key, so two apps' executions that share an id stay distinct rows) rather
+    # than the framework's `_apps_id` parent-key name.
+    row["airops_app_id"] = row.pop("_apps_id")
+    return row
 
 
-def _iter_apps(session: requests.Session, logger: FilteringBoundLogger) -> Iterator[dict]:
-    """List every app. The apps endpoint returns a plain (unwrapped) JSON array with no pagination."""
-    data = _fetch_json(session, f"{AIROPS_BASE_URL}/public_api/airops_apps", logger)
-    if not isinstance(data, list):
-        # Defensive: the docs describe a bare array, but tolerate a `{data: [...]}` envelope if the
-        # beta API ever wraps it, rather than crashing the sync.
-        data = data.get("data", []) if isinstance(data, dict) else []
-    yield from data
-
-
-def _get_apps(session: requests.Session, logger: FilteringBoundLogger) -> Iterator[list[dict]]:
-    apps = list(_iter_apps(session, logger))
-    if apps:
-        yield apps
-
-
-def _get_executions(session: requests.Session, logger: FilteringBoundLogger) -> Iterator[list[dict]]:
-    """Fan out over every app and page through its executions.
-
-    Executions can only be listed per app, so we enumerate apps first and follow each app's
-    cursor-paginated executions endpoint. Each row is stamped with `airops_app_id` so the flattened
-    table can be joined back to its parent app (and so the primary key stays meaningful table-wide).
-    """
-    for app in _iter_apps(session, logger):
-        # The app id is required to reach the child endpoint; a missing id means we'd silently drop an
-        # app's executions, so fail loudly rather than sync partial data.
-        app_id = app["id"]
-
-        cursor: str | None = None
-        while True:
-            params: dict[str, Any] = {"airops_app_id": app_id, "items": EXECUTIONS_PAGE_SIZE}
-            if cursor:
-                params["cursor"] = cursor
-            url = f"{AIROPS_BASE_URL}/public_api/airops_apps/{app_id}/executions?{urlencode(params)}"
-
-            data = _fetch_json(session, url, logger)
-            records = data.get("data", []) if isinstance(data, dict) else []
-            for record in records:
-                record["airops_app_id"] = app_id
-            if records:
-                yield records
-
-            meta = data.get("meta", {}) if isinstance(data, dict) else {}
-            cursor = meta.get("cursor")
-            # Keep paging while a cursor is present. Only stop when the cursor runs out or `has_more`
-            # is explicitly false, so a response that returns a cursor without `has_more` isn't dropped.
-            if not cursor or meta.get("has_more") is False:
-                break
-
-
-def get_rows(api_key: str, endpoint: str, logger: FilteringBoundLogger) -> Iterator[list[dict]]:
-    session = _make_session(api_key)
-
-    if endpoint == "apps":
-        yield from _get_apps(session, logger)
-    elif endpoint == "executions":
-        yield from _get_executions(session, logger)
-    else:
+def airops_source(api_key: str, endpoint: str, team_id: int, job_id: str) -> SourceResponse:
+    if endpoint not in AIROPS_ENDPOINTS:
         raise ValueError(f"Unknown AirOps endpoint: {endpoint}")
-
-
-def airops_source(api_key: str, endpoint: str, logger: FilteringBoundLogger) -> SourceResponse:
     endpoint_config = AIROPS_ENDPOINTS[endpoint]
+
+    # The apps endpoint returns a plain (unwrapped) JSON array with no pagination. A non-list 200
+    # body means the response shape changed — fail loud instead of silently syncing 0 rows.
+    apps_resource: EndpointResource = {
+        "name": "apps",
+        "endpoint": {
+            "path": APPS_PATH,
+            "paginator": SinglePagePaginator(),
+            "data_selector_required": True,
+        },
+    }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": AIROPS_BASE_URL,
+            # Auth goes through the framework so the Authorization header is built per request and
+            # the token is redacted from tracked telemetry.
+            "auth": {"type": "bearer", "token": api_key},
+            "session": _make_session(api_key),
+        },
+        "resource_defaults": None,
+        "resources": [],
+    }
+
+    if endpoint == "executions":
+        # Executions can only be listed per app, so enumerate apps first and follow each app's
+        # cursor-paginated executions endpoint, stamping every row with its parent app id.
+        rest_config["resources"] = [
+            apps_resource,
+            {
+                "name": "executions",
+                "endpoint": {
+                    "path": f"{APPS_PATH}/{{airops_app_id}}/executions",
+                    # A parent app without an `id` fails loudly (in the framework's parent-field
+                    # resolution) rather than silently dropping that app's executions.
+                    "params": {
+                        "airops_app_id": {"type": "resolve", "resource": "apps", "field": "id"},
+                        "items": EXECUTIONS_PAGE_SIZE,
+                    },
+                    # A page without `data` is tolerated as a 0-row page; the cursor still advances.
+                    "data_selector": "data",
+                    "paginator": AirOpsCursorPaginator(cursor_path="meta.cursor", cursor_param="cursor"),
+                },
+                "include_from_parent": ["id"],
+                "data_map": _stamp_app_id,
+            },
+        ]
+        resources = rest_api_resources(rest_config, team_id, job_id, None)
+        resource = next(r for r in resources if r.name == "executions")
+    else:
+        rest_config["resources"] = [apps_resource]
+        resource = rest_api_resource(rest_config, team_id, job_id, None)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_key=api_key, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=endpoint_config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if endpoint_config.partition_key else None,
         partition_format="month" if endpoint_config.partition_key else None,
         partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
 def validate_credentials(api_key: str) -> bool:
     """Cheapest probe that confirms the workspace API key is genuine: list apps and check for a 200."""
-    try:
-        response = _make_session(api_key).get(f"{AIROPS_BASE_URL}/public_api/airops_apps", timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+    ok, _status = validate_via_probe(
+        lambda: _make_session(api_key),
+        f"{AIROPS_BASE_URL}/{APPS_PATH}",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/airops/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/airops/source.py
@@ -26,7 +26,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AirOpsSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -91,20 +94,8 @@ You can create a workspace API key in your [AirOps workspace settings](https://a
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # AirOps has no server-side timestamp filter and executions mutate after creation, so every
-        # table is full refresh only (no incremental / append support).
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # table is full refresh only (no incremental / append support — INCREMENTAL_FIELDS is empty).
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: AirOpsSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -117,5 +108,6 @@ You can create a workspace API key in your [AirOps workspace settings](https://a
         return airops_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/airops/tests/test_airops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/airops/tests/test_airops.py
@@ -2,39 +2,72 @@ import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from requests import Response
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.airops.airops import (
-    AirOpsRetryableError,
-    _fetch_json,
+    AIROPS_BASE_URL,
     _make_session,
     airops_source,
-    get_rows,
     validate_credentials,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
+
+# All AirOps traffic (sync + credential probe) flows through _make_session, which builds its
+# tracked session in the airops module — so one patch point covers every request.
+SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.airops.airops.make_tracked_session"
+
+APPS_URL = f"{AIROPS_BASE_URL}/public_api/airops_apps"
 
 
-def _response(body: Any, status: int = 200, url: str = "https://api.airops.com/public_api/airops_apps") -> Response:
+def _response(body: Any, status: int = 200, reason: str | None = None, url: str = APPS_URL) -> Response:
     resp = Response()
     resp.status_code = status
     resp._content = json.dumps(body).encode()
+    resp.reason = reason
     resp.url = url
     resp.headers["Content-Type"] = "application/json"
     return resp
 
 
-def _run(endpoint: str, responses: list[Response]) -> tuple[list[list[dict]], MagicMock]:
-    session = MagicMock()
-    session.get.side_effect = responses
-    with patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.airops.airops.make_tracked_session",
-        return_value=session,
-    ):
-        batches = list(get_rows(api_key="k", endpoint=endpoint, logger=MagicMock()))
-    return batches, session
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request's URL, params, and auth headers AT PREPARE
+    TIME — the paginator mutates the params dict in place between pages, so a later look at the
+    same dict would show the final page's params for every request."""
+    session.headers = {}
+    seen: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        prepared = mock.MagicMock()
+        prepared.headers = {}
+        if request.auth is not None:
+            request.auth(prepared)
+        seen.append(
+            {
+                "url": request.url,
+                "params": dict(request.params or {}),
+                "auth_headers": dict(prepared.headers),
+            }
+        )
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return seen
+
+
+def _source(endpoint: str) -> SourceResponse:
+    return airops_source(api_key="k", endpoint=endpoint, team_id=1, job_id="j")
+
+
+def _batches(source_response: SourceResponse) -> list[list[dict[str, Any]]]:
+    return [list(page) for page in source_response.items()]
 
 
 class TestMakeSession:
@@ -42,40 +75,58 @@ class TestMakeSession:
         # Executions carry free-form inputs/output that can hold user secrets the name-based
         # scrubbers can't recognise, so response capture must stay off; redirects stay pinned off
         # so a credentialed request can't be replayed against another host.
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.airops.airops.make_tracked_session"
-        ) as make_session:
+        with mock.patch(SESSION_PATCH) as make_session:
             _make_session("secret-key")
         assert make_session.call_args.kwargs["capture"] is False
         assert make_session.call_args.kwargs["allow_redirects"] is False
         assert make_session.call_args.kwargs["redact_values"] == ("secret-key",)
+        assert make_session.call_args.kwargs["headers"] == {"Accept": "application/json"}
 
 
-class TestGetApps:
-    def test_yields_the_unwrapped_array(self) -> None:
-        batches, session = _run("apps", [_response([{"id": 1, "name": "A"}, {"id": 2, "name": "B"}])])
+class TestApps:
+    @mock.patch(SESSION_PATCH)
+    def test_yields_the_unwrapped_array(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        seen = _wire(session, [_response([{"id": 1, "name": "A"}, {"id": 2, "name": "B"}])])
+
+        batches = _batches(_source("apps"))
+
         assert batches == [[{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]]
-        assert session.get.call_count == 1
+        # The apps endpoint has no pagination — exactly one request.
+        assert session.send.call_count == 1
+        assert seen[0]["url"] == APPS_URL
+        # The bearer token is applied by the framework auth at prepare time (so it's redacted).
+        assert seen[0]["auth_headers"]["Authorization"] == "Bearer k"
 
-    def test_tolerates_data_envelope(self) -> None:
-        # Defensive fallback: the docs describe a bare array, but a beta API could wrap it.
-        batches, _ = _run("apps", [_response({"data": [{"id": 1}]})])
-        assert batches == [[{"id": 1}]]
+    @mock.patch(SESSION_PATCH)
+    def test_empty_apps_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        _wire(MockSession.return_value, [_response([])])
+        assert _batches(_source("apps")) == []
 
-    def test_empty_apps_yields_nothing(self) -> None:
-        batches, _ = _run("apps", [_response([])])
-        assert batches == []
+    @mock.patch(SESSION_PATCH)
+    def test_non_list_body_fails_loud(self, MockSession: mock.MagicMock) -> None:
+        # The documented shape is a bare array; a 200 with anything else means the response shape
+        # changed — fail loud rather than silently syncing 0 (or garbage) rows.
+        _wire(MockSession.return_value, [_response({"data": [{"id": 1}]})])
+        with pytest.raises(ValueError, match="list response body"):
+            _batches(_source("apps"))
 
 
-class TestGetExecutions:
-    def test_fans_out_over_apps_and_paginates(self) -> None:
-        responses = [
-            _response([{"id": 10}, {"id": 20}]),  # apps
-            _response({"data": [{"id": "e1"}], "meta": {"has_more": True, "cursor": "c1"}}),  # app 10 page 1
-            _response({"data": [{"id": "e2"}], "meta": {"has_more": False, "cursor": None}}),  # app 10 page 2
-            _response({"data": [{"id": "e3"}], "meta": {"has_more": False}}),  # app 20 page 1
-        ]
-        batches, session = _run("executions", responses)
+class TestExecutions:
+    @mock.patch(SESSION_PATCH)
+    def test_fans_out_over_apps_and_paginates(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        seen = _wire(
+            session,
+            [
+                _response([{"id": 10}, {"id": 20}]),  # apps
+                _response({"data": [{"id": "e1"}], "meta": {"has_more": True, "cursor": "c1"}}),  # app 10 page 1
+                _response({"data": [{"id": "e2"}], "meta": {"has_more": False, "cursor": None}}),  # app 10 page 2
+                _response({"data": [{"id": "e3"}], "meta": {"has_more": False}}),  # app 20 page 1
+            ],
+        )
+
+        batches = _batches(_source("executions"))
 
         rows = [row for batch in batches for row in batch]
         # Every execution row is stamped with its parent app id so the flattened table can be joined
@@ -86,86 +137,146 @@ class TestGetExecutions:
             {"id": "e3", "airops_app_id": 20},
         ]
         # 1 apps call + 2 pages for app 10 + 1 page for app 20.
-        assert session.get.call_count == 4
-        # The second page carries the cursor returned by the first.
-        page_two_url = session.get.call_args_list[2].args[0]
-        assert "cursor=c1" in page_two_url
+        assert session.send.call_count == 4
+        assert [s["url"] for s in seen] == [
+            APPS_URL,
+            f"{APPS_URL}/10/executions",
+            f"{APPS_URL}/10/executions",
+            f"{APPS_URL}/20/executions",
+        ]
+        # Page size is pinned to the endpoint's cap; the second page carries the cursor returned by
+        # the first, and a fresh parent starts without one.
+        assert seen[1]["params"] == {"items": 100}
+        assert seen[2]["params"] == {"items": 100, "cursor": "c1"}
+        assert seen[3]["params"] == {"items": 100}
 
-    def test_stops_when_cursor_missing_even_if_has_more_true(self) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_stops_when_cursor_missing_even_if_has_more_true(self, MockSession: mock.MagicMock) -> None:
         # A truthy has_more with no cursor would otherwise loop forever re-fetching page one.
-        responses = [
-            _response([{"id": 10}]),
-            _response({"data": [{"id": "e1"}], "meta": {"has_more": True}}),
-        ]
-        batches, session = _run("executions", responses)
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": 10}]),
+                _response({"data": [{"id": "e1"}], "meta": {"has_more": True}}),
+            ],
+        )
+
+        batches = _batches(_source("executions"))
+
         assert [row for batch in batches for row in batch] == [{"id": "e1", "airops_app_id": 10}]
-        assert session.get.call_count == 2
+        assert session.send.call_count == 2
 
-    def test_fails_when_app_missing_id(self) -> None:
-        # A missing app id must fail loudly rather than silently dropping that app's executions.
-        responses = [_response([{"name": "no id"}])]
-        with pytest.raises(KeyError):
-            _run("executions", responses)
+    @mock.patch(SESSION_PATCH)
+    def test_stops_when_has_more_false_even_if_cursor_present(self, MockSession: mock.MagicMock) -> None:
+        # An explicit has_more=false ends the app's pagination even when a cursor is echoed back,
+        # so the last page isn't paid for twice.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": 10}]),
+                _response({"data": [{"id": "e1"}], "meta": {"has_more": False, "cursor": "c1"}}),
+            ],
+        )
 
-    def test_paginates_when_cursor_present_without_has_more(self) -> None:
+        batches = _batches(_source("executions"))
+
+        assert [row for batch in batches for row in batch] == [{"id": "e1", "airops_app_id": 10}]
+        assert session.send.call_count == 2
+
+    @mock.patch(SESSION_PATCH)
+    def test_paginates_when_cursor_present_without_has_more(self, MockSession: mock.MagicMock) -> None:
         # A response with a cursor but no has_more flag must still page to the next cursor.
-        responses = [
-            _response([{"id": 10}]),
-            _response({"data": [{"id": "e1"}], "meta": {"cursor": "c1"}}),
-            _response({"data": [{"id": "e2"}], "meta": {"has_more": False}}),
-        ]
-        batches, session = _run("executions", responses)
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": 10}]),
+                _response({"data": [{"id": "e1"}], "meta": {"cursor": "c1"}}),
+                _response({"data": [{"id": "e2"}], "meta": {"has_more": False}}),
+            ],
+        )
+
+        batches = _batches(_source("executions"))
+
         assert [row for batch in batches for row in batch] == [
             {"id": "e1", "airops_app_id": 10},
             {"id": "e2", "airops_app_id": 10},
         ]
-        assert session.get.call_count == 3
+        assert session.send.call_count == 3
+
+    @mock.patch(SESSION_PATCH)
+    def test_fails_when_app_missing_id(self, MockSession: mock.MagicMock) -> None:
+        # A missing app id must fail loudly rather than silently dropping that app's executions.
+        _wire(MockSession.return_value, [_response([{"name": "no id"}])])
+        with pytest.raises(ValueError, match="field 'id'"):
+            _batches(_source("executions"))
+
+    @mock.patch(SESSION_PATCH)
+    def test_no_apps_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+        assert _batches(_source("executions")) == []
+        assert session.send.call_count == 1
 
 
-class TestGetRowsUnknownEndpoint:
+class TestUnknownEndpoint:
     def test_raises_for_unknown_endpoint(self) -> None:
         with pytest.raises(ValueError, match="Unknown AirOps endpoint"):
-            list(get_rows(api_key="k", endpoint="nope", logger=MagicMock()))
+            airops_source(api_key="k", endpoint="nope", team_id=1, job_id="j")
 
 
-class TestFetchJsonStatusHandling:
+class TestErrorHandling:
     @pytest.mark.parametrize("status", [429, 500, 503])
-    def test_retryable_statuses_raise_retryable_error(self, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response({}, status=status)
-        # Call the undecorated function so tenacity's retry/backoff doesn't sleep in the test.
-        with pytest.raises(AirOpsRetryableError):
-            _fetch_json.__wrapped__(session, "https://api.airops.com/x", MagicMock())  # type: ignore[attr-defined]
+    @mock.patch(SESSION_PATCH)
+    def test_retryable_statuses_retry_then_raise(self, MockSession: mock.MagicMock, status: int) -> None:
+        # 429/5xx are retried by the framework client; once attempts are exhausted the last
+        # retryable error is reraised. Patch tenacity's sleep so the retries don't actually wait.
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status) for _ in range(5)])
 
-    @pytest.mark.parametrize("status", [400, 401, 403, 404])
-    def test_client_errors_propagate_as_httperror(self, status: int) -> None:
+        with (
+            mock.patch.object(RESTClient._send_request.retry, "sleep"),  # type: ignore[attr-defined]
+            pytest.raises(RESTClientRetryableError),
+        ):
+            _batches(_source("apps"))
+        assert session.send.call_count == 5
+
+    @pytest.mark.parametrize(
+        "status, reason",
+        [(400, "Bad Request"), (401, "Unauthorized"), (403, "Forbidden"), (404, "Not Found")],
+    )
+    @mock.patch(SESSION_PATCH)
+    def test_client_errors_propagate_as_httperror(self, MockSession: mock.MagicMock, status: int, reason: str) -> None:
         # 4xx (bad/expired credentials, missing app) must surface as HTTPError so
         # get_non_retryable_errors can match and permanently fail the sync.
-        session = MagicMock()
-        session.get.return_value = _response({"error": "nope"}, status=status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_json.__wrapped__(session, "https://api.airops.com/x", MagicMock())  # type: ignore[attr-defined]
+        _wire(MockSession.return_value, [_response({"error": "nope"}, status=status, reason=reason)])
+        with pytest.raises(requests.HTTPError, match=f"{status} Client Error"):
+            _batches(_source("apps"))
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize(("status", "expected"), [(200, True), (401, False), (403, False)])
-    def test_maps_status_to_bool(self, status: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = _response({}, status=status)
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.airops.airops.make_tracked_session",
-            return_value=session,
-        ):
-            assert validate_credentials("key") is expected
+    @mock.patch(SESSION_PATCH)
+    def test_maps_status_to_bool(self, MockSession: mock.MagicMock, status: int, expected: bool) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("key") is expected
 
-    def test_network_failure_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.airops.airops.make_tracked_session",
-            return_value=session,
-        ):
-            assert validate_credentials("key") is False
+    @mock.patch(SESSION_PATCH)
+    def test_network_failure_is_false(self, MockSession: mock.MagicMock) -> None:
+        MockSession.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("key") is False
+
+    @mock.patch(SESSION_PATCH)
+    def test_probes_apps_endpoint_with_bearer_header(self, MockSession: mock.MagicMock) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("key")
+
+        call = MockSession.return_value.get.call_args
+        called_url = call.args[0] if call.args else call.kwargs["url"]
+        assert called_url == APPS_URL
+        assert call.kwargs["headers"]["Authorization"] == "Bearer key"
 
 
 class TestAirOpsSourceResponse:
@@ -179,7 +290,7 @@ class TestAirOpsSourceResponse:
     )
     def test_partition_and_primary_keys(self, endpoint: str, partition_key: str, primary_keys: list[str]) -> None:
         # Partition on a STABLE creation timestamp (never updated_at), which differs per endpoint.
-        response = airops_source(api_key="k", endpoint=endpoint, logger=MagicMock())
+        response = _source(endpoint)
         assert response.name == endpoint
         assert response.primary_keys == primary_keys
         assert response.partition_keys == [partition_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/airops/tests/test_airops_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/airops/tests/test_airops_source.py
@@ -93,7 +93,7 @@ class TestAirOpsSource:
             result = AirOpsSource().source_for_pipeline(_config("key-123"), inputs)
 
         assert result is sentinel
-        mock_source.assert_called_once_with(api_key="key-123", endpoint="executions", logger=inputs.logger)
+        mock_source.assert_called_once_with(api_key="key-123", endpoint="executions", team_id=1, job_id="job-1")
 
     def test_documented_tables_render_without_credentials(self) -> None:
         # `lists_tables_without_credentials=True` powers the public docs table catalog; it must resolve

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/bamboohr.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/bamboohr.py
@@ -1,13 +1,9 @@
 import re
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
-from typing import Any, Optional, cast
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.bamboohr.settings import (
@@ -15,14 +11,22 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bamboohr.s
     BambooHREndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BaseNextUrlPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # BambooHR's API is served through a single gateway host; the company subdomain is a path segment.
 # Confirmed live: the gateway returns 401 (not 404) for the v1 paths below, so the route shape is correct.
 BAMBOOHR_API_HOST = "https://api.bamboohr.com/api/gateway.php"
 # Basic auth uses the API key as the username and any non-empty string as the password.
 BAMBOOHR_BASIC_AUTH_PASSWORD = "x"
-REQUEST_TIMEOUT_SECONDS = 60
 # Credential validation is a single cheap probe; keep it snappy so source creation doesn't feel hung.
 VALIDATE_TIMEOUT_SECONDS = 10
 # Time-off endpoints require an explicit window; widen it enough to capture all history and pending future requests.
@@ -41,10 +45,6 @@ INVALID_SUBDOMAIN_MESSAGE = (
 )
 
 
-class BambooHRRetryableError(Exception):
-    pass
-
-
 def _validate_subdomain(subdomain: str) -> None:
     if not SUBDOMAIN_PATTERN.fullmatch(subdomain):
         raise ValueError(f"Invalid BambooHR subdomain: {subdomain!r}")
@@ -60,38 +60,11 @@ def _base_url(subdomain: str) -> str:
     return f"{BAMBOOHR_API_HOST}/{subdomain}/v1"
 
 
-def _headers() -> dict[str, str]:
-    return {"Accept": "application/json"}
+class BambooHRBasicAuth(HttpBasicAuth):
+    """Basic auth where the *username* is the secret (the API key), so redact it instead of the password."""
 
-
-def _auth(api_key: str) -> tuple[str, str]:
-    return (api_key, BAMBOOHR_BASIC_AUTH_PASSWORD)
-
-
-def _build_url(subdomain: str, config: BambooHREndpointConfig) -> str:
-    url = f"{_base_url(subdomain)}/{config.path}"
-    params: dict[str, str] = {}
-    if config.requires_date_window:
-        end = (datetime.now(UTC) + timedelta(days=TIME_OFF_FUTURE_DAYS)).strftime("%Y-%m-%d")
-        params["start"] = TIME_OFF_WINDOW_START
-        params["end"] = end
-    if params:
-        return f"{url}?{urlencode(params)}"
-    return url
-
-
-def _extract_records(payload: Any, config: BambooHREndpointConfig) -> list[dict[str, Any]]:
-    records: Any = payload
-    if config.data_key is not None and isinstance(payload, dict):
-        # Direct key access so a missing envelope key (e.g. an API change) fails loudly
-        # rather than silently syncing zero rows.
-        records = payload[config.data_key]
-
-    if config.data_shape == "dict":
-        # e.g. meta/users returns ``{"<id>": {...}}`` — flatten to the list of records.
-        return cast(list[dict[str, Any]], list(records.values())) if isinstance(records, dict) else []
-
-    return cast(list[dict[str, Any]], records) if isinstance(records, list) else []
+    def secret_values(self) -> tuple[str, ...]:
+        return (self.username,) if self.username else ()
 
 
 def _next_url(payload: Any) -> str | None:
@@ -116,6 +89,115 @@ def _next_url(payload: Any) -> str | None:
     return None
 
 
+class BambooHRPaginator(BaseNextUrlPaginator):
+    """Follows the full next-page URL BambooHR returns under ``_links.next`` (or ``links.next``),
+    pinned to the gateway host via ``_next_url``."""
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            payload = response.json()
+        except Exception:
+            payload = None
+        next_url = _next_url(payload)
+        if next_url:
+            self._next_url = next_url
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def __str__(self) -> str:
+        return "BambooHRPaginator(_links.next|links.next)"
+
+
+def _selector_for(config: BambooHREndpointConfig) -> tuple[str | None, bool]:
+    """Map an endpoint's response layout to a (data_selector, data_selector_required) pair.
+
+    - "dict" shape (e.g. ``meta/users`` — ``{"<id>": {...}}``): the ``*`` wildcard flattens the
+      object to its values; not required so an empty account (empty object) is a legit 0-row page.
+    - Enveloped list (``data_key``): select the key and fail loudly when it's absent (an API
+      change) rather than silently syncing zero rows.
+    - Bare list body: no selector; require a list so an unexpected 200 envelope fails loudly
+      instead of being wrapped as a garbage row.
+    """
+    if config.data_shape == "dict":
+        return "*", False
+    if config.data_key is not None:
+        return config.data_key, True
+    return None, True
+
+
+def bamboohr_source(
+    subdomain: str,
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[BambooHRResumeConfig],
+) -> SourceResponse:
+    config = BAMBOOHR_ENDPOINTS[endpoint]
+    base_url = _base_url(subdomain)
+
+    params: dict[str, Any] = {}
+    if config.requires_date_window:
+        end = (datetime.now(UTC) + timedelta(days=TIME_OFF_FUTURE_DAYS)).strftime("%Y-%m-%d")
+        params = {"start": TIME_OFF_WINDOW_START, "end": end}
+
+    data_selector, data_selector_required = _selector_for(config)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            "headers": {"Accept": "application/json"},
+            # Auth goes through the framework config so the API key is redacted from logs;
+            # only the non-secret Accept header is set on the session.
+            "auth": BambooHRBasicAuth(username=api_key, password=BAMBOOHR_BASIC_AUTH_PASSWORD),
+            "paginator": BambooHRPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    "data_selector": data_selector,
+                    "data_selector_required": data_selector_required,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            # Guard the persisted resume URL too — only ever saved from _next_url (host-pinned),
+            # but re-check so a tampered Redis state can't redirect our authenticated request.
+            if not resume.next_url.startswith(BAMBOOHR_API_HOST):
+                raise ValueError(f"BambooHR resume state contains an unexpected URL: {resume.next_url!r}")
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; the hook fires AFTER a page is yielded so a
+        # crash re-yields the last page (merge dedupes on PK) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(BambooHRResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # every BambooHR stream is full-refresh (see settings.py)
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+    )
+
+
 def validate_credentials(subdomain: str, api_key: str, schema_name: Optional[str] = None) -> tuple[bool, str | None]:
     """Cheap probe against ``meta/fields`` to confirm the subdomain + API key are genuine.
 
@@ -126,103 +208,25 @@ def validate_credentials(subdomain: str, api_key: str, schema_name: Optional[str
         url = f"{_base_url(subdomain)}/meta/fields"
     except ValueError:
         return False, INVALID_SUBDOMAIN_MESSAGE
-    try:
-        response = make_tracked_session().get(
-            url, auth=_auth(api_key), headers=_headers(), timeout=VALIDATE_TIMEOUT_SECONDS
-        )
-    except Exception:
-        return False, "Could not connect to BambooHR. Check the company subdomain and try again."
 
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        url,
+        headers={"Accept": "application/json"},
+        auth=BambooHRBasicAuth(username=api_key, password=BAMBOOHR_BASIC_AUTH_PASSWORD),
+        timeout=VALIDATE_TIMEOUT_SECONDS,
+    )
+
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status is None:
+        return False, "Could not connect to BambooHR. Check the company subdomain and try again."
+    if status == 401:
         return False, "Invalid BambooHR API key."
-    if response.status_code == 404:
+    if status == 404:
         return False, "BambooHR company subdomain not found. Use the subdomain from your BambooHR URL."
-    if response.status_code == 403:
+    if status == 403:
         if schema_name is None:
             return True, None
         return False, "Your BambooHR API key does not have permission to access this data."
-    return False, f"BambooHR API returned an unexpected status code: {response.status_code}"
-
-
-def get_rows(
-    subdomain: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BambooHRResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = BAMBOOHR_ENDPOINTS[endpoint]
-    headers = _headers()
-    auth = _auth(api_key)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url = resume_config.next_url
-        # Guard the persisted resume URL too — only ever saved from _next_url (host-pinned),
-        # but re-check so a tampered Redis state can't redirect our authenticated request.
-        if not url.startswith(BAMBOOHR_API_HOST):
-            raise ValueError(f"BambooHR resume state contains an unexpected URL: {url!r}")
-        logger.debug(f"BambooHR: resuming {endpoint} from URL: {url}")
-    else:
-        url = _build_url(subdomain, config)
-
-    @retry(
-        retry=retry_if_exception_type((BambooHRRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> Any:
-        response = make_tracked_session().get(page_url, auth=auth, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise BambooHRRetryableError(
-                f"BambooHR API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"BambooHR API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        payload = fetch_page(url)
-        records = _extract_records(payload, config)
-        next_url = _next_url(payload)
-
-        if records:
-            yield records
-            # Save state only after yielding so a crash re-yields the last batch (merge dedupes on PK)
-            # rather than skipping it.
-            if next_url:
-                resumable_source_manager.save_state(BambooHRResumeConfig(next_url=next_url))
-
-        if not next_url:
-            break
-
-        url = next_url
-
-
-def bamboohr_source(
-    subdomain: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BambooHRResumeConfig],
-) -> SourceResponse:
-    config = BAMBOOHR_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            subdomain=subdomain,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=config.primary_keys,
-    )
+    return False, f"BambooHR API returned an unexpected status code: {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BambooHRSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -97,19 +100,7 @@ Make sure your API key has access to the data you want to sync (employee, time o
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in list(ENDPOINTS)
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: BambooHRSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -135,6 +126,7 @@ Make sure your API key has access to the data you want to sync (employee, time o
             subdomain=config.subdomain,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/tests/test_bamboohr.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/tests/test_bamboohr.py
@@ -1,47 +1,84 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.bamboohr.bamboohr import (
+    BAMBOOHR_API_HOST,
     INVALID_SUBDOMAIN_MESSAGE,
+    BambooHRBasicAuth,
     BambooHRResumeConfig,
     _base_url,
-    _build_url,
-    _extract_records,
     _next_url,
     bamboohr_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.bamboohr.settings import BAMBOOHR_ENDPOINTS
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.bamboohr.bamboohr"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
 
 
-def _mock_response(status_code: int = 200, payload: Any = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    response.json.return_value = payload if payload is not None else {}
-    response.text = ""
-    return response
+def _response(payload: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(payload).encode()
+    return resp
 
 
-def _mock_session_returning(*responses: MagicMock) -> MagicMock:
-    session = MagicMock()
-    session.get.side_effect = list(responses)
-    return session
+def _make_manager(resume_state: BambooHRResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class TestExtractRecords:
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request (url/params/auth) AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    request_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        request_snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return request_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(
+    endpoint: str,
+    responses: list[Response],
+    MockSession: mock.MagicMock,
+    manager: mock.MagicMock | None = None,
+    subdomain: str = "acme",
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], mock.MagicMock]:
+    session = MockSession.return_value
+    requests_made = _wire(session, responses)
+    manager = manager if manager is not None else _make_manager()
+    rows = _rows(bamboohr_source(subdomain, "key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager))
+    return rows, requests_made, manager
+
+
+class TestRows:
     @parameterized.expand(
         [
             (
-                "employees_directory",
+                "employees_directory_envelope",
                 "employees",
                 {"fields": [{"id": "displayName"}], "employees": [{"id": "1"}, {"id": "2"}]},
                 [{"id": "1"}, {"id": "2"}],
@@ -64,16 +101,127 @@ class TestExtractRecords:
                 {"7": {"id": "7", "employeeId": "1"}, "8": {"id": "8", "employeeId": "2"}},
                 [{"id": "7", "employeeId": "1"}, {"id": "8", "employeeId": "2"}],
             ),
-            ("non_list_returns_empty", "meta_fields", {"id": "1"}, []),
+            (
+                "dict_with_single_entry",
+                "meta_users",
+                {"7": {"id": "7", "employeeId": "1"}},
+                [{"id": "7", "employeeId": "1"}],
+            ),
+            ("empty_dict_yields_no_rows", "meta_users", {}, []),
+            ("empty_wrapped_list_yields_no_rows", "time_off_types", {"timeOffTypes": []}, []),
         ]
     )
-    def test_extract_records(self, _name: str, endpoint: str, payload: Any, expected: list[dict[str, Any]]) -> None:
-        assert _extract_records(payload, BAMBOOHR_ENDPOINTS[endpoint]) == expected
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rows_per_response_shape(
+        self, _name: str, endpoint: str, payload: Any, expected: list[dict[str, Any]], MockSession
+    ) -> None:
+        rows, _requests, _manager = _run(endpoint, [_response(payload)], MockSession)
+        assert rows == expected
 
-    def test_missing_data_key_raises(self) -> None:
-        # A missing envelope key should fail loudly rather than silently sync zero rows.
-        with pytest.raises(KeyError):
-            _extract_records({"somethingElse": []}, BAMBOOHR_ENDPOINTS["time_off_types"])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_fails_loudly(self, MockSession) -> None:
+        # A 200 body without the envelope key means the response shape changed — fail loud
+        # rather than silently syncing zero rows.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _run("time_off_types", [_response({"somethingElse": []})], MockSession)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_for_bare_list_endpoint_fails_loudly(self, MockSession) -> None:
+        # meta/fields returns a bare JSON array; an object body is an unexpected shape change.
+        with pytest.raises(ValueError, match="list response body"):
+            _run("meta_fields", [_response({"id": "1"})], MockSession)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_employees_url_and_no_params(self, MockSession) -> None:
+        _rows_, requests_made, _manager = _run("employees", [_response({"employees": [{"id": "1"}]})], MockSession)
+        assert requests_made[0]["url"] == "https://api.bamboohr.com/api/gateway.php/acme/v1/employees/directory"
+        assert requests_made[0]["params"] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_time_off_requests_sends_date_window(self, MockSession) -> None:
+        _rows_, requests_made, _manager = _run("time_off_requests", [_response([{"id": "1"}])], MockSession)
+        assert requests_made[0]["url"] == "https://api.bamboohr.com/api/gateway.php/acme/v1/time_off/requests"
+        assert requests_made[0]["params"]["start"] == "2000-01-01"
+        # End of the window is now + 730 days, formatted as a date.
+        assert len(requests_made[0]["params"]["end"]) == 10
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_invalid_subdomain_rejected_before_any_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        with pytest.raises(ValueError):
+            bamboohr_source(
+                "acme/v1/employees/123?",
+                "key",
+                "employees",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
+            )
+        session.send.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_basic_auth_uses_api_key_as_username_and_redacts_it(self, MockSession) -> None:
+        _rows_, requests_made, _manager = _run("employees", [_response({"employees": [{"id": "1"}]})], MockSession)
+        auth = requests_made[0]["auth"]
+        assert isinstance(auth, BambooHRBasicAuth)
+        assert auth.username == "key"
+        assert auth.password == "x"
+        # The API key is the Basic auth *username* — it must be the redacted secret.
+        assert auth.secret_values() == ("key",)
+        assert "key" in (MockSession.call_args.kwargs.get("redact_values") or ())
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_saves_state_after_each_yield(self, MockSession) -> None:
+        next_url = "https://api.bamboohr.com/api/gateway.php/acme/v1/p2"
+        page1 = {"employees": [{"id": "1"}], "_links": {"next": next_url}}
+        page2 = {"employees": [{"id": "2"}]}
+
+        rows, requests_made, manager = _run("employees", [_response(page1), _response(page2)], MockSession)
+
+        assert [r["id"] for r in rows] == ["1", "2"]
+        assert requests_made[1]["url"] == next_url
+        # Checkpoint saved once (after page 1, pointing at page 2); the last page saves nothing.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BambooHRResumeConfig(next_url=next_url)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        rows, requests_made, manager = _run("employees", [_response({"employees": [{"id": "1"}]})], MockSession)
+
+        assert [r["id"] for r in rows] == ["1"]
+        assert len(requests_made) == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_off_host_next_link_is_not_followed(self, MockSession) -> None:
+        page = {"employees": [{"id": "1"}], "_links": {"next": "http://169.254.169.254/latest/meta-data/"}}
+
+        rows, requests_made, manager = _run("employees", [_response(page)], MockSession)
+
+        assert [r["id"] for r in rows] == ["1"]
+        assert len(requests_made) == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession) -> None:
+        resume_url = "https://api.bamboohr.com/api/gateway.php/acme/v1/resume"
+        manager = _make_manager(BambooHRResumeConfig(next_url=resume_url))
+
+        rows, requests_made, _manager = _run(
+            "employees", [_response({"employees": [{"id": "9"}]})], MockSession, manager=manager
+        )
+
+        assert [r["id"] for r in rows] == ["9"]
+        assert requests_made[0]["url"] == resume_url
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tampered_resume_state_raises(self, MockSession) -> None:
+        manager = _make_manager(BambooHRResumeConfig(next_url="http://169.254.169.254/latest/meta-data/"))
+
+        with pytest.raises(ValueError, match="unexpected URL"):
+            bamboohr_source("acme", "key", "employees", team_id=1, job_id="j", resumable_source_manager=manager)
 
 
 class TestNextUrl:
@@ -110,7 +258,7 @@ class TestValidateSubdomain:
         ]
     )
     def test_valid_subdomains_build_urls(self, _name: str, subdomain: str) -> None:
-        assert _base_url(subdomain) == f"https://api.bamboohr.com/api/gateway.php/{subdomain}/v1"
+        assert _base_url(subdomain) == f"{BAMBOOHR_API_HOST}/{subdomain}/v1"
 
     @parameterized.expand(
         [
@@ -129,18 +277,6 @@ class TestValidateSubdomain:
             _base_url(subdomain)
 
 
-class TestBuildUrl:
-    def test_employees_directory_has_no_params(self) -> None:
-        url = _build_url("acme", BAMBOOHR_ENDPOINTS["employees"])
-        assert url == "https://api.bamboohr.com/api/gateway.php/acme/v1/employees/directory"
-
-    def test_time_off_requests_includes_date_window(self) -> None:
-        url = _build_url("acme", BAMBOOHR_ENDPOINTS["time_off_requests"])
-        assert url.startswith("https://api.bamboohr.com/api/gateway.php/acme/v1/time_off/requests?")
-        assert "start=2000-01-01" in url
-        assert "end=" in url
-
-
 class TestValidateCredentials:
     @parameterized.expand(
         [
@@ -155,23 +291,25 @@ class TestValidateCredentials:
     def test_validate_credentials_status_mapping(
         self, _name: str, status_code: int, schema_name: str | None, expected_valid: bool
     ) -> None:
-        with patch(f"{MODULE}.make_tracked_session", return_value=_mock_session_returning(_mock_response(status_code))):
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=status_code)
+        with mock.patch(f"{MODULE}.make_tracked_session", return_value=session):
             valid, message = validate_credentials("acme", "key", schema_name)
         assert valid is expected_valid
         if not expected_valid:
             assert message is not None
 
     def test_validate_credentials_connection_error(self) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = Exception("boom")
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
+        with mock.patch(f"{MODULE}.make_tracked_session", return_value=session):
             valid, message = validate_credentials("acme", "key")
         assert valid is False
         assert message is not None
 
     def test_invalid_subdomain_rejected_before_request(self) -> None:
-        session = MagicMock()
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
+        session = mock.MagicMock()
+        with mock.patch(f"{MODULE}.make_tracked_session", return_value=session):
             valid, message = validate_credentials("acme/v1/employees/123?", "key")
         assert valid is False
         assert message == INVALID_SUBDOMAIN_MESSAGE
@@ -180,71 +318,11 @@ class TestValidateCredentials:
 
 class TestBambooHRSource:
     @parameterized.expand([(endpoint,) for endpoint in BAMBOOHR_ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        response = bamboohr_source("acme", "key", endpoint, MagicMock(), manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, MockSession) -> None:
+        _wire(MockSession.return_value, [])
+        response = bamboohr_source(
+            "acme", "key", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
         assert response.name == endpoint
         assert response.primary_keys == BAMBOOHR_ENDPOINTS[endpoint].primary_keys
-
-
-class TestGetRows:
-    def _run(
-        self, manager: MagicMock, *responses: MagicMock, endpoint: str = "employees"
-    ) -> list[list[dict[str, Any]]]:
-        with patch(f"{MODULE}.make_tracked_session", return_value=_mock_session_returning(*responses)):
-            return list(
-                get_rows(
-                    subdomain="acme",
-                    api_key="key",
-                    endpoint=endpoint,
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,
-                )
-            )
-
-    def test_single_page_yields_once_and_does_not_save_state(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        payload = {"fields": [], "employees": [{"id": "1"}, {"id": "2"}]}
-
-        batches = self._run(manager, _mock_response(200, payload))
-
-        assert batches == [[{"id": "1"}, {"id": "2"}]]
-        manager.save_state.assert_not_called()
-
-    def test_paginates_and_saves_state_after_each_yield(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        page1 = {"employees": [{"id": "1"}], "_links": {"next": "https://api.bamboohr.com/api/gateway.php/acme/v1/p2"}}
-        page2 = {"employees": [{"id": "2"}]}
-
-        batches = self._run(manager, _mock_response(200, page1), _mock_response(200, page2))
-
-        assert batches == [[{"id": "1"}], [{"id": "2"}]]
-        manager.save_state.assert_called_once()
-        saved = manager.save_state.call_args[0][0]
-        assert isinstance(saved, BambooHRResumeConfig)
-        assert saved.next_url == "https://api.bamboohr.com/api/gateway.php/acme/v1/p2"
-
-    def test_resumes_from_saved_state(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = BambooHRResumeConfig(
-            next_url="https://api.bamboohr.com/api/gateway.php/acme/v1/resume"
-        )
-        session = _mock_session_returning(_mock_response(200, {"employees": [{"id": "9"}]}))
-
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            batches = list(
-                get_rows(
-                    subdomain="acme",
-                    api_key="key",
-                    endpoint="employees",
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,
-                )
-            )
-
-        assert batches == [[{"id": "9"}]]
-        called_url = session.get.call_args[0][0]
-        assert called_url == "https://api.bamboohr.com/api/gateway.php/acme/v1/resume"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/tests/test_bamboohr_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bamboohr/tests/test_bamboohr_source.py
@@ -75,6 +75,7 @@ class TestBambooHRSource:
             subdomain="acme",
             api_key="key",
             endpoint="employees",
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/better_stack/better_stack.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/better_stack/better_stack.py
@@ -1,13 +1,9 @@
-import time
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import urlsplit
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.better_stack.settings import (
@@ -16,15 +12,15 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.better_sta
     BetterStackEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-
-REQUEST_TIMEOUT_SECONDS = 60
-# Better Stack publishes no fixed quota — 429s carry a Retry-After header; cap how long we honor it.
-MAX_RETRY_AFTER_SECONDS = 60
-
-
-class BetterStackRetryableError(Exception):
-    pass
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 
 class BetterStackUntrustedURLError(Exception):
@@ -46,22 +42,30 @@ def _validate_pagination_url(url: str) -> str:
     return url
 
 
+class BetterStackPaginator(JSONResponsePaginator):
+    """Follows the response's `pagination.next` URL, refusing any URL off the Better Stack origin —
+    whether it arrived in a response body or was seeded from saved resume state."""
+
+    def __init__(self) -> None:
+        super().__init__(next_url_path="pagination.next")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._next_url is not None:
+            _validate_pagination_url(self._next_url)
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        super().set_resume_state(state)
+        if self._next_url is not None:
+            _validate_pagination_url(self._next_url)
+
+
 @dataclasses.dataclass
 class BetterStackResumeConfig:
     # Full next-page URL from the response's `pagination.next` field (null on the last page). It
     # carries the page, per_page, and any `from` filter, so following it preserves the incremental
     # window on every page.
     next_url: str | None = None
-
-
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_token}"}
-
-
-def _build_url(base_url: str, params: dict[str, Any]) -> str:
-    if not params:
-        return base_url
-    return f"{base_url}?{urlencode(params)}"
 
 
 def _format_from_date(value: Any) -> str:
@@ -111,124 +115,82 @@ def _flatten_item(item: dict[str, Any]) -> dict[str, Any]:
     return flattened
 
 
-def _fetch_page_once(
-    session: requests.Session, page_url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict:
-    response = session.get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429:
-        # Better Stack signals rate limiting with a Retry-After header; honor it before tenacity's
-        # exponential backoff kicks in.
-        retry_after = response.headers.get("Retry-After")
-        if retry_after is not None:
-            try:
-                sleep_seconds = int(retry_after)
-            except ValueError:
-                # Per RFC 7231, Retry-After may be an HTTP-date instead of a seconds count. We don't
-                # parse the date; fall back to the cap so we still back off rather than hammering.
-                sleep_seconds = MAX_RETRY_AFTER_SECONDS
-            time.sleep(min(sleep_seconds, MAX_RETRY_AFTER_SECONDS))
-        raise BetterStackRetryableError(f"Better Stack API rate limited: status=429, url={page_url}")
-
-    if response.status_code >= 500:
-        raise BetterStackRetryableError(
-            f"Better Stack API error (retryable): status={response.status_code}, url={page_url}"
-        )
-
-    if not response.ok:
-        logger.error(f"Better Stack API error: status={response.status_code}, body={response.text}, url={page_url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-# Kept separate from `_fetch_page_once` so tests can exercise the request handling without
-# tenacity's retry waits.
-_fetch_page = retry(
-    retry=retry_if_exception_type((BetterStackRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)(_fetch_page_once)
-
-
 def probe_credentials(api_token: str, endpoint: str | None = None) -> int | None:
     """Cheap probe of a Better Stack collection. Returns the HTTP status code, or None on a
     connection failure. Probes the given endpoint's path when set, else the monitors collection."""
     config = BETTER_STACK_ENDPOINTS.get(endpoint) if endpoint else None
     path = config.path if config else "/v2/monitors"
-    url = _build_url(f"{BETTER_STACK_BASE_URL}{path}", {"per_page": 1})
-    try:
-        response = make_tracked_session(capture=False).get(url, headers=_get_headers(api_token), timeout=10)
-    except Exception:
-        return None
-    return response.status_code
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BetterStackResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[Any]:
-    config = BETTER_STACK_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-    # One session reused across pages so urllib3 keeps the connection alive.
-    # capture=False: incident `response_content` and monitor URLs can carry arbitrary
-    # secrets the name-based scrubbers can't recognise, so keep them out of HTTP samples.
-    session = make_tracked_session(capture=False)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None and resume.next_url:
-        url = _validate_pagination_url(resume.next_url)
-        logger.debug(f"Better Stack: resuming {endpoint} from URL: {url}")
-    else:
-        params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
-        url = _build_url(f"{BETTER_STACK_BASE_URL}{config.path}", params)
-
-    while True:
-        data = _fetch_page(session, url, headers, logger)
-
-        items = data.get("data", [])
-        next_url = data.get("pagination", {}).get("next")
-        if next_url:
-            next_url = _validate_pagination_url(next_url)
-
-        if items:
-            # Yield one page at a time as a list[dict]; the pipeline buffers and batches for us.
-            yield [_flatten_item(item) for item in items]
-
-        if not next_url:
-            break
-
-        # Save AFTER yielding so a crash re-yields the last page rather than skipping it — merge
-        # dedupes on the primary key. Advance the URL before the next fetch to avoid re-looping it.
-        resumable_source_manager.save_state(BetterStackResumeConfig(next_url=next_url))
-        url = next_url
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(capture=False, redact_values=(api_token,)),
+        f"{BETTER_STACK_BASE_URL}{path}?per_page=1",
+        headers={"Authorization": f"Bearer {api_token}"},
+    )
+    return status
 
 
 def better_stack_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BetterStackResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = BETTER_STACK_ENDPOINTS[endpoint]
 
+    params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BETTER_STACK_BASE_URL,
+            # Auth (Bearer) goes through the framework auth config so its value is redacted from logs.
+            "auth": {"type": "bearer", "token": api_token},
+            # capture=False: incident `response_content` and monitor URLs can carry arbitrary
+            # secrets the name-based scrubbers can't recognise, so keep them out of HTTP samples.
+            "session": make_tracked_session(capture=False, redact_values=(api_token,)),
+            "paginator": BetterStackPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # A missing `data` key is treated as an empty page (matching the API's
+                    # envelope, which always carries `data`), so no data_selector_required here.
+                    "data_selector": "data",
+                },
+                # Better Stack is JSON:API — hoist each item's `attributes` into the row root.
+                "data_map": _flatten_item,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_url:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; the checkpoint lands AFTER a page is yielded so a
+        # crash re-yields the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(BetterStackResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/better_stack/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/better_stack/source.py
@@ -31,7 +31,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BetterStackSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -92,21 +95,14 @@ You can create an Uptime API token in your [Better Stack dashboard](https://upti
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = BETTER_STACK_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=endpoint_config.supports_incremental,
-                supports_append=endpoint_config.supports_incremental,
-                incremental_fields=endpoint_config.incremental_fields,
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            {name: endpoint_config.incremental_fields for name, endpoint_config in BETTER_STACK_ENDPOINTS.items()},
+            names,
+            should_sync_default={
+                name: endpoint_config.should_sync_default for name, endpoint_config in BETTER_STACK_ENDPOINTS.items()
+            },
+        )
 
     def validate_credentials(
         self, config: BetterStackSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -137,7 +133,8 @@ You can create an Uptime API token in your [Better Stack dashboard](https://upti
         return better_stack_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/better_stack/tests/test_better_stack.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/better_stack/tests/test_better_stack.py
@@ -1,26 +1,84 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
+import pytest
 from freezegun import freeze_time
 from unittest import mock
-from unittest.mock import MagicMock
 
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.better_stack import better_stack
 from products.warehouse_sources.backend.temporal.data_imports.sources.better_stack.better_stack import (
+    BETTER_STACK_BASE_URL,
     BetterStackResumeConfig,
     BetterStackUntrustedURLError,
-    _build_initial_params,
-    _fetch_page_once,
     _flatten_item,
     _format_from_date,
     _validate_pagination_url,
-    get_rows,
+    better_stack_source,
+    probe_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.better_stack.settings import (
-    BETTER_STACK_ENDPOINTS,
+
+# better_stack builds its own capture=False session and passes it into the RESTClient.
+SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.better_stack.better_stack.make_tracked_session"
 )
+
+
+def _response(items: list[dict[str, Any]] | None, next_url: str | None = None, *, drop_data: bool = False) -> Response:
+    body: dict[str, Any] = {"pagination": {"next": next_url}}
+    if not drop_data:
+        body["data"] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: BetterStackResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's url/params AT SEND TIME.
+
+    ``request.params`` is mutated in place across pages and the next-URL paginator rewrites
+    ``request.url``, so inspecting the request after the run shows only the final state —
+    snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(
+    endpoint: str = "incidents",
+    manager: mock.MagicMock | None = None,
+    **kwargs: Any,
+):
+    return better_stack_source(
+        api_token="bs_test",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        **kwargs,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatFromDate:
@@ -35,41 +93,6 @@ class TestFormatFromDate:
     def test_formats_as_date_only(self, _name: str, value: object, expected: str) -> None:
         # Better Stack's `from` filter takes YYYY-MM-DD, not a full timestamp.
         assert _format_from_date(value) == expected
-
-
-class TestBuildInitialParams:
-    def test_incremental_endpoint_filters_from_watermark_date(self) -> None:
-        params = _build_initial_params(
-            BETTER_STACK_ENDPOINTS["incidents"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
-        )
-        assert params == {"per_page": 50, "from": "2026-03-04"}
-
-    def test_incremental_first_sync_has_no_filter(self) -> None:
-        params = _build_initial_params(
-            BETTER_STACK_ENDPOINTS["incidents"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=None,
-        )
-        assert params == {"per_page": 50}
-
-    @freeze_time("2026-06-15T12:00:00Z")
-    def test_future_cursor_is_clamped(self) -> None:
-        params = _build_initial_params(
-            BETTER_STACK_ENDPOINTS["incidents"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2027, 2, 5, tzinfo=UTC),
-        )
-        assert params["from"] == "2026-06-15"
-
-    def test_full_refresh_endpoint_never_filters(self) -> None:
-        params = _build_initial_params(
-            BETTER_STACK_ENDPOINTS["monitors"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
-        )
-        assert params == {"per_page": 250}
 
 
 class TestFlattenItem:
@@ -91,46 +114,6 @@ class TestFlattenItem:
         assert _flatten_item({"id": "123", "type": "incident"}) == {"id": "123", "type": "incident"}
 
 
-class TestFetchPage:
-    def test_429_honors_retry_after_and_raises_retryable(self) -> None:
-        response = MagicMock(status_code=429, headers={"Retry-After": "7"})
-        session = MagicMock()
-        session.get.return_value = response
-        with mock.patch.object(better_stack.time, "sleep") as sleep:
-            try:
-                # Call the undecorated function so tenacity doesn't retry 5 times in the test.
-                _fetch_page_once(session, "https://uptime.betterstack.com/api/v2/monitors", {}, MagicMock())
-                raise AssertionError("expected BetterStackRetryableError")
-            except better_stack.BetterStackRetryableError:
-                pass
-        sleep.assert_called_once_with(7)
-
-    def test_429_retry_after_is_capped(self) -> None:
-        response = MagicMock(status_code=429, headers={"Retry-After": "3600"})
-        session = MagicMock()
-        session.get.return_value = response
-        with mock.patch.object(better_stack.time, "sleep") as sleep:
-            try:
-                _fetch_page_once(session, "https://uptime.betterstack.com/api/v2/monitors", {}, MagicMock())
-                raise AssertionError("expected BetterStackRetryableError")
-            except better_stack.BetterStackRetryableError:
-                pass
-        sleep.assert_called_once_with(better_stack.MAX_RETRY_AFTER_SECONDS)
-
-    def test_429_http_date_retry_after_falls_back_to_cap(self) -> None:
-        # RFC 7231 allows Retry-After to be an HTTP-date; we can't int() it, so we still back off.
-        response = MagicMock(status_code=429, headers={"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"})
-        session = MagicMock()
-        session.get.return_value = response
-        with mock.patch.object(better_stack.time, "sleep") as sleep:
-            try:
-                _fetch_page_once(session, "https://uptime.betterstack.com/api/v2/monitors", {}, MagicMock())
-                raise AssertionError("expected BetterStackRetryableError")
-            except better_stack.BetterStackRetryableError:
-                pass
-        sleep.assert_called_once_with(better_stack.MAX_RETRY_AFTER_SECONDS)
-
-
 class TestValidatePaginationUrl:
     def test_api_origin_url_is_returned_unchanged(self) -> None:
         url = "https://uptime.betterstack.com/api/v3/incidents?page=2&per_page=50"
@@ -146,126 +129,221 @@ class TestValidatePaginationUrl:
     )
     def test_off_origin_urls_are_refused(self, _name: str, url: str) -> None:
         # A poisoned resume state or hostile response must not retarget the bearer-token request.
-        try:
+        with pytest.raises(BetterStackUntrustedURLError):
             _validate_pagination_url(url)
-            raise AssertionError("expected BetterStackUntrustedURLError")
-        except BetterStackUntrustedURLError:
-            pass
 
 
-class _FakeResumableManager:
-    def __init__(self, state: BetterStackResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BetterStackResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> BetterStackResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: BetterStackResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(manager: _FakeResumableManager, monkeypatch: Any, pages: dict[str, Any], **kwargs: Any) -> list[dict]:
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            return pages[url]
-
-        monkeypatch.setattr(better_stack, "_fetch_page", fake_fetch)
-
-        rows: list[dict] = []
-        for page in get_rows(
-            api_token="bs_test",
-            endpoint="incidents",
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(page)
-        return rows
-
-    def test_follows_pagination_next_and_flattens(self, monkeypatch: Any) -> None:
-        first = "https://uptime.betterstack.com/api/v3/incidents?per_page=50"
+class TestPagination:
+    @mock.patch(SESSION_PATCH)
+    def test_follows_pagination_next_and_flattens(self, MockSession) -> None:
+        session = MockSession.return_value
         second = "https://uptime.betterstack.com/api/v3/incidents?page=2&per_page=50"
-        pages = {
-            first: {
-                "data": [{"id": "1", "type": "incident", "attributes": {"cause": "Timeout"}}],
-                "pagination": {"next": second},
-            },
-            second: {
-                "data": [{"id": "2", "type": "incident", "attributes": {"cause": "Status 500"}}],
-                "pagination": {"next": None},
-            },
-        }
-        rows = self._collect(_FakeResumableManager(), monkeypatch, pages)
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "1", "type": "incident", "attributes": {"cause": "Timeout"}}], next_url=second),
+                _response([{"id": "2", "type": "incident", "attributes": {"cause": "Status 500"}}]),
+            ],
+        )
+
+        rows = _rows(_source())
+
         assert rows == [
             {"id": "1", "type": "incident", "cause": "Timeout"},
             {"id": "2", "type": "incident", "cause": "Status 500"},
         ]
+        assert snapshots[0]["url"] == f"{BETTER_STACK_BASE_URL}/v3/incidents"
+        assert snapshots[0]["params"] == {"per_page": 50}
+        # The next-page URL is self-contained; the original params must not be re-appended.
+        assert snapshots[1]["url"] == second
+        assert snapshots[1]["params"] == {}
 
-    def test_saves_state_after_each_page_except_the_last(self, monkeypatch: Any) -> None:
-        first = "https://uptime.betterstack.com/api/v3/incidents?per_page=50"
+    @mock.patch(SESSION_PATCH)
+    def test_saves_state_after_each_page_except_the_last(self, MockSession) -> None:
+        session = MockSession.return_value
         second = "https://uptime.betterstack.com/api/v3/incidents?page=2&per_page=50"
-        pages = {
-            first: {"data": [{"id": "1", "attributes": {}}], "pagination": {"next": second}},
-            second: {"data": [{"id": "2", "attributes": {}}], "pagination": {"next": None}},
-        }
-        manager = _FakeResumableManager()
-        self._collect(manager, monkeypatch, pages)
+        _wire(
+            session,
+            [
+                _response([{"id": "1", "attributes": {}}], next_url=second),
+                _response([{"id": "2", "attributes": {}}]),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source(manager=manager))
+
         # State saved once (pointing at the second page) so a crash re-yields that page; nothing
         # is saved after the final page (no next link).
-        assert [s.next_url for s in manager.saved] == [second]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BetterStackResumeConfig(next_url=second)
 
-    def test_resumes_from_saved_next_url(self, monkeypatch: Any) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_from_saved_next_url(self, MockSession) -> None:
+        session = MockSession.return_value
         resume_url = "https://uptime.betterstack.com/api/v3/incidents?page=3&per_page=50"
-        pages = {resume_url: {"data": [{"id": "9", "attributes": {"cause": "Z"}}], "pagination": {"next": None}}}
-        manager = _FakeResumableManager(BetterStackResumeConfig(next_url=resume_url))
-        rows = self._collect(manager, monkeypatch, pages)
+        snapshots = _wire(session, [_response([{"id": "9", "attributes": {"cause": "Z"}}])])
+
+        manager = _make_manager(BetterStackResumeConfig(next_url=resume_url))
+        rows = _rows(_source(manager=manager))
+
         # Starts at the resumed URL, not the freshly-built first page.
         assert rows == [{"id": "9", "cause": "Z"}]
+        assert snapshots[0]["url"] == resume_url
+        assert snapshots[0]["params"] == {}
 
-    def test_empty_collection_yields_nothing(self, monkeypatch: Any) -> None:
-        first = "https://uptime.betterstack.com/api/v3/incidents?per_page=50"
-        pages = {first: {"data": [], "pagination": {"next": None}}}
-        rows = self._collect(_FakeResumableManager(), monkeypatch, pages)
-        assert rows == []
+    @parameterized.expand(
+        [
+            ("empty_collection", False),
+            # Old envelope always carries `data`; a body without it is treated as an empty page.
+            ("missing_data_key", True),
+        ]
+    )
+    @mock.patch(SESSION_PATCH)
+    def test_empty_collection_yields_nothing(self, _name: str, drop_data: bool, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], drop_data=drop_data)])
 
-    def test_off_origin_next_url_is_refused(self, monkeypatch: Any) -> None:
-        first = "https://uptime.betterstack.com/api/v3/incidents?per_page=50"
-        pages = {
-            first: {
-                "data": [{"id": "1", "attributes": {}}],
-                "pagination": {"next": "https://evil.example.com/api/v3/incidents?page=2"},
-            }
-        }
-        try:
-            self._collect(_FakeResumableManager(), monkeypatch, pages)
-            raise AssertionError("expected BetterStackUntrustedURLError")
-        except BetterStackUntrustedURLError:
-            pass
+        manager = _make_manager()
+        assert _rows(_source(manager=manager)) == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_poisoned_resume_url_is_refused(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(BetterStackResumeConfig(next_url="https://evil.example.com/api/v3/incidents"))
-        try:
-            self._collect(manager, monkeypatch, pages={})
-            raise AssertionError("expected BetterStackUntrustedURLError")
-        except BetterStackUntrustedURLError:
-            pass
+    @mock.patch(SESSION_PATCH)
+    def test_off_origin_next_url_is_refused(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response([{"id": "1", "attributes": {}}], next_url="https://evil.example.com/api/v3/incidents?page=2")],
+        )
+
+        with pytest.raises(BetterStackUntrustedURLError):
+            _rows(_source())
+
+    @mock.patch(SESSION_PATCH)
+    def test_poisoned_resume_url_is_refused(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [])
+
+        manager = _make_manager(BetterStackResumeConfig(next_url="https://evil.example.com/api/v3/incidents"))
+        with pytest.raises(BetterStackUntrustedURLError):
+            _rows(_source(manager=manager))
+        # Refused before any request carries the bearer token off-origin.
+        assert session.send.call_count == 0
+
+
+class TestIncrementalParams:
+    @parameterized.expand(
+        [
+            (
+                "incremental_endpoint_filters_from_watermark_date",
+                "incidents",
+                True,
+                datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+                {"per_page": 50, "from": "2026-03-04"},
+            ),
+            ("incremental_first_sync_has_no_filter", "incidents", True, None, {"per_page": 50}),
+            ("incremental_disabled_has_no_filter", "incidents", False, datetime(2026, 3, 4), {"per_page": 50}),
+            (
+                "full_refresh_endpoint_never_filters",
+                "monitors",
+                True,
+                datetime(2026, 3, 4, tzinfo=UTC),
+                {"per_page": 250},
+            ),
+        ]
+    )
+    @mock.patch(SESSION_PATCH)
+    def test_initial_request_params(
+        self,
+        _name: str,
+        endpoint: str,
+        should_use_incremental_field: bool,
+        last_value: Any,
+        expected_params: dict[str, Any],
+        MockSession,
+    ) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": "1", "attributes": {}}])])
+
+        _rows(
+            _source(
+                endpoint=endpoint,
+                should_use_incremental_field=should_use_incremental_field,
+                db_incremental_field_last_value=last_value,
+            )
+        )
+
+        assert snapshots[0]["params"] == expected_params
+
+    @freeze_time("2026-06-15T12:00:00Z")
+    @mock.patch(SESSION_PATCH)
+    def test_future_cursor_is_clamped(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": "1", "attributes": {}}])])
+
+        _rows(
+            _source(
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2027, 2, 5, tzinfo=UTC),
+            )
+        )
+
+        assert snapshots[0]["params"]["from"] == "2026-06-15"
 
 
 class TestProbeCredentials:
     @parameterized.expand([("ok", 200), ("unauthorized", 401), ("forbidden", 403)])
-    def test_returns_status_code(self, _name: str, status_code: int) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status_code)
-        with mock.patch.object(better_stack, "make_tracked_session", return_value=session):
-            assert better_stack.probe_credentials("bs_test", "incidents") == status_code
+    @mock.patch(SESSION_PATCH)
+    def test_returns_status_code(self, _name: str, status_code: int, MockSession) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert probe_credentials("bs_test", "incidents") == status_code
 
-    def test_connection_failure_returns_none(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        with mock.patch.object(better_stack, "make_tracked_session", return_value=session):
-            assert better_stack.probe_credentials("bs_test") is None
+    @mock.patch(SESSION_PATCH)
+    def test_connection_failure_returns_none(self, MockSession) -> None:
+        MockSession.return_value.get.side_effect = Exception("boom")
+        assert probe_credentials("bs_test") is None
+
+    @mock.patch(SESSION_PATCH)
+    def test_probes_endpoint_path_with_bearer_token(self, MockSession) -> None:
+        session = MockSession.return_value
+        session.get.return_value = mock.MagicMock(status_code=200)
+
+        probe_credentials("bs_test", "incidents")
+
+        url = session.get.call_args.args[0]
+        assert url == f"{BETTER_STACK_BASE_URL}/v3/incidents?per_page=1"
+        assert session.get.call_args.kwargs["headers"]["Authorization"] == "Bearer bs_test"
+
+    @mock.patch(SESSION_PATCH)
+    def test_defaults_to_monitors_probe(self, MockSession) -> None:
+        session = MockSession.return_value
+        session.get.return_value = mock.MagicMock(status_code=200)
+
+        probe_credentials("bs_test")
+
+        assert session.get.call_args.args[0] == f"{BETTER_STACK_BASE_URL}/v2/monitors?per_page=1"
+
+
+class TestBearerAuth:
+    @mock.patch(SESSION_PATCH)
+    def test_request_auth_is_framework_bearer(self, MockSession) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        auths: list[Any] = []
+
+        def _prepare(request: Any) -> mock.MagicMock:
+            auths.append(request.auth)
+            return mock.MagicMock()
+
+        session.prepare_request.side_effect = _prepare
+        session.send.side_effect = [_response([{"id": "1", "attributes": {}}])]
+
+        _rows(_source())
+
+        # The token flows through the framework auth (so it's redacted from logs), not a
+        # hand-built Authorization header.
+        prepared = mock.MagicMock()
+        prepared.headers = {}
+        auths[0](prepared)
+        assert prepared.headers["Authorization"] == "Bearer bs_test"


### PR DESCRIPTION
## Problem

Fifth batch of hand-rolled source → `rest_source` migrations, stacked on #71559.

## Changes

**Three sources migrated** (each behavior-preserving, full suite green): `bamboohr` (58 tests), `better_stack` (64), `airops` (35).

**Vetted and skipped** (each names a concrete framework gap for future work): `amplitude` (zip/gzip export transport), `appsflyer` (CSV report downloads), `aviator` (multi-mode + cross-series pivot), `amazon_ads` (parent-resolved per-request header — dependent resources only bind path params), `anthropic` (needs 1-to-many `data_map` explode; currently strict 1:1).

> [!NOTE]
> Stacked on #71559 → #71552 → #71540 → #71524 → #71520 → #71481/#71477.

## How did you test this code?

- Merged verification: **294 tests pass** across the 3 migrated sources + the full `rest_source` suite.
- Each source's suite passed in isolation first; coverage preserved. Worktree isolation verified before merge. `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
