### PR TITLE
feat(data-warehouse): migrate 3 sources to rest_source (batch 6) + 1-to-many data_map

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/anthropic.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/anthropic.py
@@ -1,23 +1,30 @@
 import hashlib
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic.settings import (
     ANTHROPIC_ENDPOINTS,
-    AnthropicEndpointConfig,
     PaginationType,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ApiKeyAuthConfig,
+    ClientConfig,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 ANTHROPIC_VERSION = "2023-06-01"
@@ -29,57 +36,84 @@ ENTITY_PAGE_SIZE = 1000
 DEFAULT_STARTING_AT = datetime(2023, 1, 1, tzinfo=UTC)
 
 
-class AnthropicRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        # Seconds the server asked us to wait (from a 429 `Retry-After`), or None to back off blindly.
-        self.retry_after = retry_after
-
-
-# The report endpoints (usage_report/cost_report) are strictly rate limited and return a `Retry-After`
-# on 429. Cap the honored value so a pathological header can't pin the worker; the pipeline retries the
-# activity above us if the window is genuinely longer.
-_MAX_RETRY_AFTER_SECONDS = 60
-_fallback_wait = wait_exponential_jitter(initial=1, max=30)
-
-
-def _parse_retry_after(value: str | None) -> float | None:
-    """Parse a `Retry-After` header expressed as delta-seconds (Anthropic's form). Returns None for a
-    missing, non-numeric, or negative value so the caller falls back to exponential backoff."""
-    if value is None:
-        return None
-    try:
-        seconds = float(value)
-    except (TypeError, ValueError):
-        return None
-    return seconds if seconds >= 0 else None
-
-
-def _wait_anthropic(retry_state: RetryCallState) -> float:
-    """Honor the server's `Retry-After` on 429s (capped), else fall back to exponential jitter."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, AnthropicRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, _MAX_RETRY_AFTER_SECONDS)
-    return _fallback_wait(retry_state)
-
-
 @dataclasses.dataclass
 class AnthropicResumeConfig:
     # Opaque pagination cursor: an `after_id` for CURSOR endpoints or a `next_page` token for PAGE
     # endpoints. None means "start at the first page".
     cursor: str | None = None
-    # workspace_members fan-out only: the workspace whose members we were paging when we saved state.
-    # A stable id (not a positional index) so workspaces added/removed between a crash and the retry
-    # can't resume us into the wrong workspace.
+    # Legacy workspace_members resume field (pre-framework): the workspace whose members we were
+    # paging when we saved state. Kept so previously-saved state still parses; the framework's
+    # fan-out checkpoint below supersedes it, and an old-shape state restarts the fan-out fresh.
     workspace_id: str | None = None
+    # workspace_members fan-out checkpoint from the framework:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: dict | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "x-api-key": api_key,
-        "anthropic-version": ANTHROPIC_VERSION,
-        "accept": "application/json",
-    }
+class AnthropicCursorPaginator(BasePaginator):
+    """Token-plus-flag pagination shared by every Anthropic endpoint.
+
+    Entity lists page with `after_id` and echo `last_id`; the report endpoints page with `page` and
+    echo `next_page`. Both signal continuation via `has_more`. The built-in cursor paginator stops
+    only on a missing token, but the entity endpoints return `last_id` on the final page too —
+    `has_more` is the authoritative stop signal, so both are honored here.
+    """
+
+    def __init__(self, cursor_path: str, cursor_param: str) -> None:
+        super().__init__()
+        self.cursor_path = cursor_path
+        self.cursor_param = cursor_param
+        self._cursor_value: Optional[str] = None
+
+    def _apply(self, request: Request) -> None:
+        if self._cursor_value is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._cursor_value
+
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume cursor to the first request.
+        self._apply(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        if not isinstance(body, dict):
+            self._has_next_page = False
+            return
+        token = body.get(self.cursor_path)
+        if body.get("has_more") and token:
+            self._cursor_value = token
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        self._apply(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor_value} if self._has_next_page and self._cursor_value is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor_value = cursor
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"AnthropicCursorPaginator(cursor_path={self.cursor_path}, cursor_param={self.cursor_param})"
+
+
+def _version_headers() -> dict[str, str]:
+    # Auth (x-api-key) is supplied via the framework auth config so its value is redacted from
+    # logs; only the non-secret version/accept headers are set here.
+    return {"anthropic-version": ANTHROPIC_VERSION, "accept": "application/json"}
+
+
+def _auth_config(api_key: str) -> ApiKeyAuthConfig:
+    return {"type": "api_key", "name": "x-api-key", "api_key": api_key, "location": "header"}
 
 
 def _format_rfc3339(value: Any) -> str:
@@ -93,57 +127,17 @@ def _format_rfc3339(value: Any) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _build_url(path: str, params: dict[str, Any], multi_params: dict[str, list[str]] | None = None) -> str:
-    """Build a fully-encoded URL. `multi_params` values are repeated (e.g. group_by[]=a&group_by[]=b)."""
-    query: list[tuple[str, str]] = [(k, str(v)) for k, v in params.items() if v is not None]
-    if multi_params:
-        for key, values in multi_params.items():
-            query.extend((key, v) for v in values)
-    encoded = urlencode(query)
-    url = f"{ANTHROPIC_BASE_URL}{path}"
-    return f"{url}?{encoded}" if encoded else url
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            AnthropicRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=_wait_anthropic,
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        retry_after = _parse_retry_after(response.headers.get("retry-after")) if response.status_code == 429 else None
-        raise AnthropicRetryableError(
-            f"Anthropic API error (retryable): status={response.status_code}, url={url}",
-            retry_after=retry_after,
-        )
-
-    if not response.ok:
-        logger.error(f"Anthropic API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
 def validate_credentials(api_key: str) -> bool:
     # A single cheap probe against the smallest list endpoint confirms the admin key is genuine.
-    url = _build_url("/v1/organizations/users", {"limit": 1})
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-    except Exception:
-        return False
-    # 200 => valid. 403 => valid key without a scope we probed here; still a real key, so accept it at
-    # create time (sync-time 403s are caught by get_non_retryable_errors). 401 => bad key.
-    return response.status_code in (200, 403)
+    # 200 => valid. 403 => valid key without a scope we probed here; still a real key, so accept it
+    # at create time (sync-time 403s are caught by get_non_retryable_errors). 401 => bad key.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{ANTHROPIC_BASE_URL}/v1/organizations/users?limit=1",
+        headers={"x-api-key": api_key, **_version_headers()},
+        ok_statuses=(200, 403),
+    )
+    return ok
 
 
 def _flatten_created_by(item: dict[str, Any]) -> dict[str, Any]:
@@ -154,12 +148,6 @@ def _flatten_created_by(item: dict[str, Any]) -> dict[str, Any]:
         item.pop("created_by")
         item["created_by_id"] = created_by.get("id")
         item["created_by_type"] = created_by.get("type")
-    return item
-
-
-def _normalize_entity(endpoint: str, item: dict[str, Any]) -> dict[str, Any]:
-    if endpoint == "api_keys":
-        return _flatten_created_by(item)
     return item
 
 
@@ -238,221 +226,162 @@ def _flatten_cost_result(bucket: dict[str, Any], result: dict[str, Any]) -> dict
     }
 
 
-def _report_params(
-    config: AnthropicEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> tuple[dict[str, Any], dict[str, list[str]]]:
-    params: dict[str, Any] = {"bucket_width": config.bucket_width}
-    if config.limit is not None:
-        params["limit"] = config.limit
-
-    # `starting_at` is required. On an incremental run start from the watermark (already shifted back
-    # by the pipeline's lookback); otherwise fall back to the Anthropic launch date to pull all history.
-    if should_use_incremental_field and db_incremental_field_last_value:
-        params["starting_at"] = _format_rfc3339(db_incremental_field_last_value)
-    else:
-        params["starting_at"] = _format_rfc3339(DEFAULT_STARTING_AT)
-
-    multi_params = {"group_by[]": config.group_by} if config.group_by else {}
-    return params, multi_params
+def _explode_usage_bucket(bucket: dict[str, Any]) -> list[dict[str, Any]]:
+    # One report page is a list of time buckets, each carrying grouped results — flatten to one row
+    # per result with the bucket window merged in. An empty bucket yields no rows.
+    return [_flatten_usage_result(bucket, result) for result in bucket.get("results") or []]
 
 
-def _iter_report_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[AnthropicResumeConfig],
-    config: AnthropicEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> Iterator[Any]:
-    params, multi_params = _report_params(config, should_use_incremental_field, db_incremental_field_last_value)
-    flatten = _flatten_usage_result if config.name == "usage_report" else _flatten_cost_result
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None and resume.cursor:
-        params["page"] = resume.cursor
-        logger.debug(f"Anthropic: resuming {config.name} from page cursor")
-
-    while True:
-        url = _build_url(config.path, params, multi_params)
-        data = _fetch_page(session, url, headers, logger)
-        next_page = data.get("next_page")
-        has_more = bool(data.get("has_more"))
-
-        for bucket in data.get("data", []):
-            for result in bucket.get("results", []):
-                batcher.batch(flatten(bucket, result))
-                # A single batch can split into several ready chunks, so drain them all before
-                # the next batch() call (which raises if `_ready` is still populated).
-                while batcher.should_yield():
-                    yield batcher.get_table()
-                    # Save only when a batch is actually committed, pointing at the next page. A crash
-                    # then resumes from a page whose predecessors are all in the yielded batch, so no
-                    # buffered rows are skipped; the overlap merge dedupes on the primary key.
-                    if has_more and next_page:
-                        resumable_source_manager.save_state(AnthropicResumeConfig(cursor=next_page))
-
-        if not has_more or not next_page:
-            break
-        params["page"] = next_page
+def _explode_cost_bucket(bucket: dict[str, Any]) -> list[dict[str, Any]]:
+    return [_flatten_cost_result(bucket, result) for result in bucket.get("results") or []]
 
 
-def _iter_cursor_pages(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    path: str,
-    base_params: dict[str, Any],
-    start_after_id: str | None = None,
-) -> Iterator[tuple[list[dict[str, Any]], str | None]]:
-    """Yield (items, last_id) for each page of a cursor-paginated entity endpoint."""
-    after_id = start_after_id
-    while True:
-        params = {**base_params, "limit": ENTITY_PAGE_SIZE}
-        if after_id:
-            params["after_id"] = after_id
-        url = _build_url(path, params)
-        data = _fetch_page(session, url, headers, logger)
-
-        items = data.get("data", [])
-        last_id = data.get("last_id")
-        yield items, last_id
-
-        if not data.get("has_more") or not last_id:
-            break
-        after_id = last_id
+def _stamp_workspace_id(row: dict[str, Any]) -> dict[str, Any]:
+    # The member object already carries workspace_id, but fall back to the parent workspace's id
+    # (injected by the fan-out as `_workspaces_id`) so the composite primary key is always populated.
+    parent_id = row.pop("_workspaces_id", None)
+    row["workspace_id"] = row.get("workspace_id") or parent_id
+    return row
 
 
-def _iter_entity_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[AnthropicResumeConfig],
-    config: AnthropicEndpointConfig,
-) -> Iterator[Any]:
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_after_id = resume.cursor if resume is not None else None
-
-    for items, last_id in _iter_cursor_pages(
-        session, headers, logger, config.path, config.extra_params, start_after_id
-    ):
-        for item in items:
-            batcher.batch(_normalize_entity(config.name, item))
-            while batcher.should_yield():
-                yield batcher.get_table()
-                if last_id:
-                    resumable_source_manager.save_state(AnthropicResumeConfig(cursor=last_id))
-
-
-def _iter_workspace_member_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[AnthropicResumeConfig],
-    config: AnthropicEndpointConfig,
-) -> Iterator[Any]:
-    """Fan out over every workspace, emitting one row per (workspace_id, user_id) membership."""
-    workspace_ids = _list_all_workspace_ids(session, headers, logger)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    remaining = workspace_ids
-    resume_after_id: str | None = None
-    if resume is not None and resume.workspace_id and resume.workspace_id in workspace_ids:
-        remaining = workspace_ids[workspace_ids.index(resume.workspace_id) :]
-        resume_after_id = resume.cursor
-        logger.debug(f"Anthropic: resuming workspace_members from workspace_id={resume.workspace_id}")
-
-    for index, workspace_id in enumerate(remaining):
-        path = config.path.format(workspace_id=workspace_id)
-        after_id = resume_after_id
-        resume_after_id = None  # only the resumed-into workspace uses the saved cursor
-
-        for items, last_id in _iter_cursor_pages(session, headers, logger, path, {}, after_id):
-            for item in items:
-                # The member object already carries workspace_id, but set it defensively so the
-                # composite primary key is always populated.
-                row = {**item, "workspace_id": item.get("workspace_id") or workspace_id}
-                batcher.batch(row)
-                while batcher.should_yield():
-                    yield batcher.get_table()
-                    if last_id:
-                        resumable_source_manager.save_state(
-                            AnthropicResumeConfig(cursor=last_id, workspace_id=workspace_id)
-                        )
-
-        if index + 1 < len(remaining):
-            resumable_source_manager.save_state(AnthropicResumeConfig(cursor=None, workspace_id=remaining[index + 1]))
-
-
-def _list_all_workspace_ids(
-    session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[str]:
-    workspace_ids: list[str] = []
-    for items, _ in _iter_cursor_pages(
-        session, headers, logger, "/v1/organizations/workspaces", {"include_archived": "true"}
-    ):
-        workspace_ids.extend(item["id"] for item in items if item.get("id"))
-    return workspace_ids
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AnthropicResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[Any]:
-    config = ANTHROPIC_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    batcher = Batcher(logger=logger, chunk_size=5000, chunk_size_bytes=100 * 1024 * 1024)
-    session = make_tracked_session()
-
-    if config.pagination == PaginationType.PAGE:
-        yield from _iter_report_rows(
-            session,
-            headers,
-            logger,
-            batcher,
-            resumable_source_manager,
-            config,
-            should_use_incremental_field,
-            db_incremental_field_last_value,
-        )
-    elif config.fan_out_over_workspaces:
-        yield from _iter_workspace_member_rows(session, headers, logger, batcher, resumable_source_manager, config)
-    else:
-        yield from _iter_entity_rows(session, headers, logger, batcher, resumable_source_manager, config)
-
-    while batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+def _entity_paginator() -> AnthropicCursorPaginator:
+    return AnthropicCursorPaginator(cursor_path="last_id", cursor_param="after_id")
 
 
 def anthropic_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AnthropicResumeConfig],
-    should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = ANTHROPIC_ENDPOINTS[endpoint]
 
+    client_config: ClientConfig = {
+        "base_url": ANTHROPIC_BASE_URL,
+        "headers": _version_headers(),
+        "auth": _auth_config(api_key),
+    }
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    if config.fan_out_over_workspaces:
+        # No org-wide member list exists; enumerate every workspace (archived included, since they
+        # are still referenced by historical usage/cost rows) and fetch its /members per workspace.
+        workspaces_config = ANTHROPIC_ENDPOINTS["workspaces"]
+        rest_config: RESTAPIConfig = {
+            "client": client_config,
+            "resource_defaults": None,
+            "resources": [
+                {
+                    "name": "workspaces",
+                    "endpoint": {
+                        "path": workspaces_config.path,
+                        "params": {"limit": ENTITY_PAGE_SIZE, **workspaces_config.extra_params},
+                        "data_selector": "data",
+                        "paginator": _entity_paginator(),
+                    },
+                },
+                {
+                    "name": endpoint,
+                    "endpoint": {
+                        "path": config.path,
+                        "params": {
+                            "limit": ENTITY_PAGE_SIZE,
+                            "workspace_id": {"type": "resolve", "resource": "workspaces", "field": "id"},
+                        },
+                        "data_selector": "data",
+                        "paginator": _entity_paginator(),
+                    },
+                    "include_from_parent": ["id"],
+                    "data_map": _stamp_workspace_id,
+                },
+            ],
+        }
+
+        # Only a framework-shaped checkpoint can seed the fan-out; a legacy (cursor, workspace_id)
+        # state restarts the fan-out fresh — the overlap merge dedupes on the composite key.
+        initial_fanout_state = resume.fanout_state if resume is not None else None
+
+        def save_fanout_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            if state:
+                resumable_source_manager.save_state(AnthropicResumeConfig(fanout_state=state))
+
+        resources = rest_api_resources(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_fanout_checkpoint,
+            initial_paginator_state=initial_fanout_state,
+        )
+        resource = next(r for r in resources if r.name == endpoint)
+    else:
+        data_map: Optional[Callable[[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]]
+        if config.pagination == PaginationType.PAGE:
+            # Report endpoints: `starting_at` is required. On an incremental run start from the
+            # watermark (already shifted back by the pipeline's lookback); otherwise fall back to
+            # the Anthropic launch date to pull all history.
+            params: dict[str, Any] = {"bucket_width": config.bucket_width}
+            if config.limit is not None:
+                params["limit"] = config.limit
+            if config.group_by:
+                # requests encodes a list value as one repeated query param per element.
+                params["group_by[]"] = config.group_by
+            params["starting_at"] = {
+                "type": "incremental",
+                "cursor_path": "starting_at",
+                "initial_value": DEFAULT_STARTING_AT,
+                "convert": _format_rfc3339,
+            }
+            paginator = AnthropicCursorPaginator(cursor_path="next_page", cursor_param="page")
+            data_map = _explode_usage_bucket if endpoint == "usage_report" else _explode_cost_bucket
+        else:
+            params = {"limit": ENTITY_PAGE_SIZE, **config.extra_params}
+            paginator = _entity_paginator()
+            data_map = _flatten_created_by if endpoint == "api_keys" else None
+
+        endpoint_resource: EndpointResource = {
+            "name": endpoint,
+            "endpoint": {
+                "path": config.path,
+                "params": params,
+                "data_selector": "data",
+                "paginator": paginator,
+            },
+            "data_map": data_map,
+        }
+
+        rest_config = {
+            "client": client_config,
+            "resource_defaults": None,
+            "resources": [endpoint_resource],
+        }
+
+        initial_paginator_state: Optional[dict[str, Any]] = None
+        if resume is not None and resume.cursor:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only while a next page remains; the checkpoint is saved AFTER a page is
+            # yielded, pointing at the next page, so a crash resumes from a page whose predecessors
+            # were all yielded — the overlap merge dedupes on the primary key.
+            if state and state.get("cursor"):
+                resumable_source_manager.save_state(AnthropicResumeConfig(cursor=state["cursor"]))
+
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # Report buckets return oldest-first from `starting_at`, and entity cursors page forward, so
         # rows arrive in ascending order — the pipeline checkpoints the watermark after each batch.
@@ -462,4 +391,5 @@ def anthropic_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/source.py
@@ -128,9 +128,9 @@ Create an Admin API key (prefixed `sk-ant-admin...`) in your [Anthropic Console]
         return anthropic_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/tests/test_anthropic.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/tests/test_anthropic.py
@@ -1,68 +1,92 @@
+import json
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
-from tenacity import RetryCallState
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic import anthropic
 from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic.anthropic import (
-    _MAX_RETRY_AFTER_SECONDS,
+    ANTHROPIC_VERSION,
     AnthropicResumeConfig,
-    AnthropicRetryableError,
-    _build_url,
     _flatten_cost_result,
     _flatten_usage_result,
-    _parse_retry_after,
-    _report_params,
     _row_id,
-    _wait_anthropic,
-    get_rows,
+    anthropic_source,
     validate_credentials,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic.settings import ANTHROPIC_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic.source import AnthropicSource
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the anthropic module.
+ANTHROPIC_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.anthropic.anthropic.make_tracked_session"
+)
 
-class _FakeResumableManager:
-    def __init__(self, state: AnthropicResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[AnthropicResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> AnthropicResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: AnthropicResumeConfig) -> None:
-        self.saved.append(data)
+MEMBERS_PATH = "/v1/organizations/workspaces/{workspace_id}/members"
 
 
-def _collect(
-    manager: _FakeResumableManager, monkeypatch: Any, responses: list[dict], endpoint: str, **kw: Any
-) -> list[dict]:
-    calls: list[str] = []
+def _response(body: dict[str, Any], status: int = 200, headers: dict[str, str] | None = None) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://api.anthropic.com/v1/organizations/users"
+    if headers:
+        resp.headers.update(headers)
+    return resp
 
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-        calls.append(url)
-        return responses[len(calls) - 1]
 
-    monkeypatch.setattr(anthropic, "_fetch_page", fake_fetch)
+def _entity_page(items: list[dict[str, Any]], *, has_more: bool, last_id: str | None) -> Response:
+    return _response({"data": items, "has_more": has_more, "first_id": None, "last_id": last_id})
 
-    rows: list[dict] = []
-    for table in get_rows(
+
+def _report_page(buckets: list[dict[str, Any]], *, has_more: bool, next_page: str | None) -> Response:
+    return _response({"data": buckets, "has_more": has_more, "next_page": next_page})
+
+
+def _make_manager(resume_state: AnthropicResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, last_value: Any = None):
+    return anthropic_source(
         api_key="sk-ant-admin-test",
         endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-        **kw,
-    ):
-        rows.extend(table.to_pylist())
-    manager._captured_calls = calls  # type: ignore[attr-defined]
-    return rows
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        db_incremental_field_last_value=last_value,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestRowId:
@@ -83,49 +107,6 @@ class TestRowId:
         # and positions stay aligned so distinct dimension tuples never collide either.
         assert _row_id(None, "x") != _row_id("", "x")
         assert _row_id(None, "x") != _row_id("x", None)
-
-
-class TestBuildUrl:
-    def test_repeats_multi_params(self) -> None:
-        url = _build_url(
-            "/v1/organizations/usage_report/messages", {"limit": 31}, {"group_by[]": ["model", "workspace_id"]}
-        )
-        assert url.count("group_by") == 2
-        assert "limit=31" in url
-
-    def test_drops_none_values(self) -> None:
-        url = _build_url("/v1/organizations/users", {"limit": 1000, "after_id": None})
-        assert "after_id" not in url
-
-
-class TestReportParams:
-    def test_incremental_uses_watermark_as_starting_at(self) -> None:
-        config = anthropic.ANTHROPIC_ENDPOINTS["usage_report"]
-        params, multi = _report_params(
-            config,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 0, 0, 0, tzinfo=UTC),
-        )
-        assert params["starting_at"] == "2026-03-04T00:00:00Z"
-        assert params["bucket_width"] == "1d"
-        assert params["limit"] == 7
-        assert multi == {"group_by[]": config.group_by}
-
-    def test_usage_report_page_size_stays_below_bucket_max(self) -> None:
-        # Grouping by every dimension multiplies the results per bucket, so requesting the 31-bucket
-        # max overflows the per-response result cap and the API 400s. Keep the page small while still
-        # grouping by the full set; pagination walks the rest.
-        config = anthropic.ANTHROPIC_ENDPOINTS["usage_report"]
-        params, _ = _report_params(config, should_use_incremental_field=False, db_incremental_field_last_value=None)
-        assert len(config.group_by) == 8
-        assert params["limit"] <= 7
-
-    def test_full_refresh_falls_back_to_launch_date(self) -> None:
-        # Without a watermark we must still send the required starting_at; the Anthropic launch date
-        # pulls all available history without requesting decades of empty pre-launch buckets.
-        config = anthropic.ANTHROPIC_ENDPOINTS["cost_report"]
-        params, _ = _report_params(config, should_use_incremental_field=False, db_incremental_field_last_value=None)
-        assert params["starting_at"] == "2023-01-01T00:00:00Z"
 
 
 class TestFlattenUsage:
@@ -164,120 +145,381 @@ class TestFlattenCost:
         assert row["id"]
 
 
+class TestReportParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_uses_watermark_as_starting_at(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_report_page([], has_more=False, next_page=None)])
+
+        _rows(_source("usage_report", _make_manager(), last_value=datetime(2026, 3, 4, 0, 0, 0, tzinfo=UTC)))
+
+        config = ANTHROPIC_ENDPOINTS["usage_report"]
+        assert params[0]["params"]["starting_at"] == "2026-03-04T00:00:00Z"
+        assert params[0]["params"]["bucket_width"] == "1d"
+        assert params[0]["params"]["limit"] == 7
+        # requests encodes the list as one repeated group_by[] query param per dimension.
+        assert params[0]["params"]["group_by[]"] == config.group_by
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_falls_back_to_launch_date(self, MockSession) -> None:
+        # Without a watermark we must still send the required starting_at; the Anthropic launch date
+        # pulls all available history without requesting decades of empty pre-launch buckets.
+        session = MockSession.return_value
+        params = _wire(session, [_report_page([], has_more=False, next_page=None)])
+
+        _rows(_source("cost_report", _make_manager()))
+
+        assert params[0]["params"]["starting_at"] == "2023-01-01T00:00:00Z"
+
+    def test_usage_report_page_size_stays_below_bucket_max(self) -> None:
+        # Grouping by every dimension multiplies the results per bucket, so requesting the 31-bucket
+        # max overflows the per-response result cap and the API 400s. Keep the page small while still
+        # grouping by the full set; pagination walks the rest.
+        config = ANTHROPIC_ENDPOINTS["usage_report"]
+        assert len(config.group_by) == 8
+        assert config.limit is not None and config.limit <= 7
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_version_header_is_set_on_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_entity_page([{"id": "user_1"}], has_more=False, last_id="user_1")])
+
+        _rows(_source("users", _make_manager()))
+        assert session.headers.get("anthropic-version") == ANTHROPIC_VERSION
+
+
 class TestReportPagination:
-    def test_follows_next_page_until_has_more_false(self, monkeypatch: Any) -> None:
-        responses = [
-            {
-                "data": [{"starting_at": "d1", "ending_at": "d2", "results": [{"model": "a"}]}],
-                "has_more": True,
-                "next_page": "PAGE2",
-            },
-            {
-                "data": [{"starting_at": "d2", "ending_at": "d3", "results": [{"model": "b"}]}],
-                "has_more": False,
-                "next_page": None,
-            },
-        ]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, responses, "usage_report")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_next_page_until_has_more_false(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _report_page(
+                    [{"starting_at": "d1", "ending_at": "d2", "results": [{"model": "a"}]}],
+                    has_more=True,
+                    next_page="PAGE2",
+                ),
+                _report_page(
+                    [{"starting_at": "d2", "ending_at": "d3", "results": [{"model": "b"}]}],
+                    has_more=False,
+                    next_page=None,
+                ),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("usage_report", manager))
+
         assert [r["model"] for r in rows] == ["a", "b"]
-        # Second request must carry the page token from the first response.
-        assert "page=PAGE2" in manager._captured_calls[1]  # type: ignore[attr-defined]
+        # Second request must carry the page token from the first response; the first must not.
+        assert "page" not in params[0]["params"]
+        assert params[1]["params"]["page"] == "PAGE2"
+        # Checkpoint saved after the first page was yielded, pointing at the next page.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == AnthropicResumeConfig(cursor="PAGE2")
 
-    def test_resumes_from_saved_page_cursor(self, monkeypatch: Any) -> None:
-        responses = [
-            {
-                "data": [{"starting_at": "d2", "ending_at": "d3", "results": [{"model": "b"}]}],
-                "has_more": False,
-                "next_page": None,
-            },
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_explodes_every_result_in_a_bucket(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _report_page(
+                    [
+                        {
+                            "starting_at": "d1",
+                            "ending_at": "d2",
+                            "results": [{"model": "a"}, {"model": "b"}],
+                        },
+                        {"starting_at": "d2", "ending_at": "d3", "results": []},
+                    ],
+                    has_more=False,
+                    next_page=None,
+                ),
+            ],
+        )
+
+        rows = _rows(_source("usage_report", _make_manager()))
+
+        # Two rows from the first bucket (bucket window merged into each), none from the empty one.
+        assert [(r["model"], r["starting_at"], r["ending_at"]) for r in rows] == [
+            ("a", "d1", "d2"),
+            ("b", "d1", "d2"),
         ]
-        manager = _FakeResumableManager(AnthropicResumeConfig(cursor="PAGE2"))
-        rows = _collect(manager, monkeypatch, responses, "usage_report")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _report_page(
+                    [{"starting_at": "d2", "ending_at": "d3", "results": [{"model": "b"}]}],
+                    has_more=False,
+                    next_page=None,
+                ),
+            ],
+        )
+
+        manager = _make_manager(AnthropicResumeConfig(cursor="PAGE2"))
+        rows = _rows(_source("usage_report", manager))
+
         assert [r["model"] for r in rows] == ["b"]
-        assert "page=PAGE2" in manager._captured_calls[0]  # type: ignore[attr-defined]
+        assert params[0]["params"]["page"] == "PAGE2"
 
-    def test_drains_every_chunk_when_a_batch_splits(self, monkeypatch: Any) -> None:
-        # A batch can split into several ready chunks (byte/offset caps). Force it with tiny limits:
-        # if the loop only pops one chunk per batch, the next batch() raises and rows go missing.
-        real_batcher = anthropic.Batcher
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_has_more_false_even_with_next_page_token(self, MockSession) -> None:
+        # `has_more` is the authoritative stop signal — a stray token on the final page must not
+        # trigger an extra request.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _report_page(
+                    [{"starting_at": "d1", "ending_at": "d2", "results": [{"model": "a"}]}],
+                    has_more=False,
+                    next_page="STRAY",
+                ),
+            ],
+        )
 
-        def tiny_batcher(**_: Any) -> anthropic.Batcher:
-            return real_batcher(logger=MagicMock(), chunk_size=4, chunk_size_bytes=10**12, max_table_bytes=1)
+        manager = _make_manager()
+        rows = _rows(_source("cost_report", manager))
 
-        monkeypatch.setattr(anthropic, "Batcher", tiny_batcher)
-
-        results = [{"model": f"m{i}"} for i in range(8)]
-        responses = [
-            {
-                "data": [{"starting_at": "d1", "ending_at": "d2", "results": results}],
-                "has_more": False,
-                "next_page": None,
-            }
-        ]
-        rows = _collect(_FakeResumableManager(), monkeypatch, responses, "usage_report")
-        assert sorted(r["model"] for r in rows) == [f"m{i}" for i in range(8)]
+        assert len(rows) == 1
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
 
 class TestEntityPagination:
-    def test_cursor_pagination_uses_last_id_and_stops(self, monkeypatch: Any) -> None:
-        responses = [
-            {"data": [{"id": "user_1"}], "has_more": True, "last_id": "user_1"},
-            {"data": [{"id": "user_2"}], "has_more": False, "last_id": "user_2"},
-        ]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, responses, "users")
-        assert [r["id"] for r in rows] == ["user_1", "user_2"]
-        assert "after_id=user_1" in manager._captured_calls[1]  # type: ignore[attr-defined]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_cursor_pagination_uses_last_id_and_stops_on_has_more_false(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _entity_page([{"id": "user_1"}], has_more=True, last_id="user_1"),
+                # Final page still carries a last_id — has_more must stop the walk with no extra call.
+                _entity_page([{"id": "user_2"}], has_more=False, last_id="user_2"),
+            ],
+        )
 
-    def test_api_keys_flatten_created_by(self, monkeypatch: Any) -> None:
-        responses = [
-            {
-                "data": [{"id": "apikey_1", "created_by": {"id": "user_1", "type": "user"}}],
-                "has_more": False,
-                "last_id": "apikey_1",
-            }
-        ]
-        rows = _collect(_FakeResumableManager(), monkeypatch, responses, "api_keys")
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
+        assert [r["id"] for r in rows] == ["user_1", "user_2"]
+        assert "after_id" not in params[0]["params"]
+        assert params[0]["params"]["limit"] == 1000
+        assert params[1]["params"]["after_id"] == "user_1"
+        assert session.send.call_count == 2
+        # Checkpoint saved after the first page, pointing past it; nothing saved on the final page.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == AnthropicResumeConfig(cursor="user_1")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_after_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_entity_page([{"id": "user_6"}], has_more=False, last_id="user_6")])
+
+        _rows(_source("users", _make_manager(AnthropicResumeConfig(cursor="user_5"))))
+
+        assert params[0]["params"]["after_id"] == "user_5"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_api_keys_flatten_created_by(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _entity_page(
+                    [{"id": "apikey_1", "created_by": {"id": "user_1", "type": "user"}}],
+                    has_more=False,
+                    last_id="apikey_1",
+                )
+            ],
+        )
+
+        rows = _rows(_source("api_keys", _make_manager()))
+
         assert rows[0]["created_by_id"] == "user_1"
         assert rows[0]["created_by_type"] == "user"
         assert "created_by" not in rows[0]
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_workspaces_include_archived(self, MockSession) -> None:
+        # Archived workspaces are still referenced by historical usage/cost rows, so the dimension
+        # table must stay complete.
+        session = MockSession.return_value
+        params = _wire(session, [_entity_page([{"id": "wrkspc_1"}], has_more=False, last_id="wrkspc_1")])
+
+        _rows(_source("workspaces", _make_manager()))
+
+        assert params[0]["params"]["include_archived"] == "true"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows(self, MockSession) -> None:
+        # The legacy implementation tolerated a body without `data` (0 rows); preserve that.
+        session = MockSession.return_value
+        _wire(session, [_response({"has_more": False, "last_id": None})])
+
+        assert _rows(_source("users", _make_manager())) == []
+
 
 class TestWorkspaceMembersFanOut:
-    def test_emits_one_row_per_workspace_member_with_composite_key(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_emits_one_row_per_workspace_member_with_composite_key(self, MockSession) -> None:
         # First response lists workspaces, then one members page per workspace.
-        responses = [
-            {"data": [{"id": "wrkspc_1"}, {"id": "wrkspc_2"}], "has_more": False, "last_id": "wrkspc_2"},
-            {
-                "data": [{"type": "workspace_member", "user_id": "u1", "workspace_id": "wrkspc_1"}],
-                "has_more": False,
-                "last_id": "u1",
-            },
-            {
-                "data": [{"type": "workspace_member", "user_id": "u2", "workspace_id": "wrkspc_2"}],
-                "has_more": False,
-                "last_id": "u2",
-            },
-        ]
-        rows = _collect(_FakeResumableManager(), monkeypatch, responses, "workspace_members")
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _entity_page([{"id": "wrkspc_1"}, {"id": "wrkspc_2"}], has_more=False, last_id="wrkspc_2"),
+                _entity_page(
+                    [{"type": "workspace_member", "user_id": "u1", "workspace_id": "wrkspc_1"}],
+                    has_more=False,
+                    last_id="u1",
+                ),
+                _entity_page(
+                    # The API always sends workspace_id, but stamp it from the parent defensively
+                    # so the composite primary key is populated even if it goes missing.
+                    [{"type": "workspace_member", "user_id": "u2"}],
+                    has_more=False,
+                    last_id="u2",
+                ),
+            ],
+        )
+
+        rows = _rows(_source("workspace_members", _make_manager()))
+
         assert [(r["workspace_id"], r["user_id"]) for r in rows] == [("wrkspc_1", "u1"), ("wrkspc_2", "u2")]
+        # The framework's parent-key column must not leak into the row shape.
+        assert all("_workspaces_id" not in r for r in rows)
+        assert params[0]["url"].endswith("/v1/organizations/workspaces")
+        assert params[0]["params"]["include_archived"] == "true"
+        assert params[1]["url"].endswith("/v1/organizations/workspaces/wrkspc_1/members")
+        assert params[2]["url"].endswith("/v1/organizations/workspaces/wrkspc_2/members")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_completed_workspaces(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _entity_page([{"id": "wrkspc_1"}, {"id": "wrkspc_2"}], has_more=False, last_id="wrkspc_2"),
+                _entity_page([{"user_id": "u1", "workspace_id": "wrkspc_1"}], has_more=False, last_id="u1"),
+                _entity_page([{"user_id": "u2", "workspace_id": "wrkspc_2"}], has_more=False, last_id="u2"),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("workspace_members", manager))
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved, "fan-out must checkpoint progress"
+        assert all(isinstance(state, AnthropicResumeConfig) and state.fanout_state for state in saved)
+        final = saved[-1].fanout_state
+        assert final["completed"] == [
+            MEMBERS_PATH.format(workspace_id="wrkspc_1"),
+            MEMBERS_PATH.format(workspace_id="wrkspc_2"),
+        ]
+        assert final["current"] is None
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_skipping_completed_workspaces(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _entity_page([{"id": "wrkspc_1"}, {"id": "wrkspc_2"}], has_more=False, last_id="wrkspc_2"),
+                # Only wrkspc_2's members are fetched — wrkspc_1 completed before the crash.
+                _entity_page([{"user_id": "u2", "workspace_id": "wrkspc_2"}], has_more=False, last_id="u2"),
+            ],
+        )
+
+        resume = AnthropicResumeConfig(
+            fanout_state={
+                "completed": [MEMBERS_PATH.format(workspace_id="wrkspc_1")],
+                "current": None,
+                "child_state": None,
+            }
+        )
+        rows = _rows(_source("workspace_members", _make_manager(resume)))
+
+        assert [(r["workspace_id"], r["user_id"]) for r in rows] == [("wrkspc_2", "u2")]
+        assert session.send.call_count == 2
+        assert params[1]["url"].endswith("/v1/organizations/workspaces/wrkspc_2/members")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_resume_state_restarts_fan_out_fresh(self, MockSession) -> None:
+        # Pre-framework state carried (cursor, workspace_id). It still parses, but the fan-out
+        # restarts from scratch — the overlap merge dedupes on the composite key.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _entity_page([{"id": "wrkspc_1"}], has_more=False, last_id="wrkspc_1"),
+                _entity_page([{"user_id": "u1", "workspace_id": "wrkspc_1"}], has_more=False, last_id="u1"),
+            ],
+        )
+
+        resume = AnthropicResumeConfig(cursor="u0", workspace_id="wrkspc_1")
+        rows = _rows(_source("workspace_members", _make_manager(resume)))
+
+        assert [(r["workspace_id"], r["user_id"]) for r in rows] == [("wrkspc_1", "u1")]
+
+    def test_saved_state_shapes_still_parse(self) -> None:
+        # ResumableSourceManager._load_json does dataclass(**saved) — every historical shape must
+        # keep parsing after the migration.
+        assert AnthropicResumeConfig(**{"cursor": "PAGE2", "workspace_id": None}) == AnthropicResumeConfig(
+            cursor="PAGE2"
+        )
+        assert AnthropicResumeConfig(**{"cursor": "u1", "workspace_id": "wrkspc_2"}).workspace_id == "wrkspc_2"
+        assert AnthropicResumeConfig(**{"fanout_state": {"completed": []}}).fanout_state == {"completed": []}
+
+
+class TestRetries:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rate_limited_request_is_retried_honoring_retry_after(self, MockSession) -> None:
+        # The report endpoints are strictly rate limited and return Retry-After on 429; the request
+        # must be reissued (Retry-After: 0 keeps the test instant) and the rows still delivered.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status=429, headers={"Retry-After": "0"}),
+                _entity_page([{"id": "user_1"}], has_more=False, last_id="user_1"),
+            ],
+        )
+
+        rows = _rows(_source("users", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["user_1"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises_without_retry(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unauthorized"}, status=401)])
+
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("users", _make_manager()))
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("forbidden_scope", 403, True), ("unauthorized", 401, False)])
     def test_status_mapping(self, _name: str, status: int, expected: bool) -> None:
         # 403 is accepted at create time (real key, unprobed scope); 401 means a bad key.
-        response = MagicMock(status_code=status)
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(anthropic, "make_tracked_session", return_value=session):
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=status)
+        with mock.patch(ANTHROPIC_SESSION_PATCH, return_value=session):
             assert validate_credentials("sk-ant-admin-test") is expected
 
     def test_network_error_is_invalid(self) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(anthropic, "make_tracked_session", return_value=session):
+        with mock.patch(ANTHROPIC_SESSION_PATCH, return_value=session):
             assert validate_credentials("sk-ant-admin-test") is False
 
 
@@ -310,72 +552,3 @@ class TestNonRetryableErrors:
     def test_transient_errors_remain_retryable(self, _name: str, other_error: str) -> None:
         non_retryable = AnthropicSource().get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable)
-
-
-class TestFetchPage:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        response = MagicMock(status_code=status, ok=False)
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(anthropic._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(anthropic.AnthropicRetryableError):
-                anthropic._fetch_page(session, "https://api.anthropic.com/v1/organizations/users", {}, MagicMock())
-        assert session.get.call_count == 5  # exhausts the retry budget
-
-    def test_client_error_raises_for_status_without_retry(self) -> None:
-        response = MagicMock(status_code=401, ok=False, text="unauthorized")
-        response.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=response)
-        session = MagicMock()
-        session.get.return_value = response
-        with pytest.raises(requests.HTTPError):
-            anthropic._fetch_page(session, "https://api.anthropic.com/v1/organizations/users", {}, MagicMock())
-        assert session.get.call_count == 1
-
-
-class _FakeRetryState:
-    def __init__(self, exc: Exception | None, attempt_number: int = 1) -> None:
-        self.outcome = MagicMock()
-        self.outcome.exception.return_value = exc
-        self.attempt_number = attempt_number
-
-
-class TestRetryAfter:
-    @parameterized.expand(
-        [
-            ("delta_seconds", "45", 45.0),
-            ("zero", "0", 0.0),
-            ("missing", None, None),
-            ("non_numeric", "in a while", None),
-            ("negative", "-5", None),
-        ]
-    )
-    def test_parse_retry_after(self, _name: str, header: str | None, expected: float | None) -> None:
-        assert _parse_retry_after(header) == expected
-
-    def test_fetch_page_attaches_retry_after_from_header(self) -> None:
-        # The rate-limited report endpoints tell us exactly when the window resets; that value must
-        # survive onto the exception so the wait strategy can honor it instead of guessing.
-        response = MagicMock(status_code=429, ok=False, headers={"retry-after": "45"})
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(anthropic._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(AnthropicRetryableError) as exc_info:
-                anthropic._fetch_page(
-                    session, "https://api.anthropic.com/v1/organizations/cost_report", {}, MagicMock()
-                )
-        assert exc_info.value.retry_after == 45.0
-
-    def test_wait_honors_retry_after_capped(self) -> None:
-        state = _FakeRetryState(AnthropicRetryableError("rate limited", retry_after=45.0))
-        assert _wait_anthropic(cast(RetryCallState, state)) == 45.0
-        # A server asking for longer than the cap is clamped so it can't wedge the worker.
-        capped = _FakeRetryState(AnthropicRetryableError("rate limited", retry_after=6000.0))
-        assert _wait_anthropic(cast(RetryCallState, capped)) == _MAX_RETRY_AFTER_SECONDS
-
-    def test_wait_falls_back_when_no_retry_after(self) -> None:
-        # No header (e.g. a 5xx) → blind exponential backoff, never a crash on the missing value.
-        state = _FakeRetryState(AnthropicRetryableError("server error"), attempt_number=1)
-        wait = _wait_anthropic(cast(RetryCallState, state))
-        assert isinstance(wait, float)
-        assert wait >= 0

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/baseten.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/baseten.py
@@ -1,10 +1,8 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.baseten.settings import (
@@ -12,254 +10,288 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.baseten.se
     BasetenEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BASETEN_BASE_URL = "https://api.baseten.co"
 # Cursor-paginated endpoints (users, model_apis) accept a `limit`; the entity endpoints ignore it.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT = 60
-
-
-class BasetenRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class BasetenResumeConfig:
     # Cursor for the current page of a cursor-paginated endpoint (users, model_apis).
     cursor: str | None = None
-    # For fan-out endpoints: the next parent id to process. A stable id (not a positional index) so
-    # parents added/removed between a crash and the retry can't resume us into the wrong parent.
+    # Legacy fan-out bookmark (next parent id) from the pre-rest_source implementation. Kept so
+    # previously saved states still parse; no longer written. A legacy bookmark can't be translated
+    # into `fanout_state`, so such a resume restarts the fan-out from the top — these are
+    # full-refresh tables, so at worst rows are re-appended once.
     parent_id: str | None = None
+    # Framework fan-out checkpoint: {"completed": [child_path, ...], "current": ..., "child_state": ...}.
+    fanout_state: dict[str, Any] | None = None
 
 
-def _headers(api_key: str) -> dict[str, str]:
+class BasetenCursorPaginator(BasePaginator):
+    """Cursor+limit pagination: {"items": [...], "pagination": {"has_more": bool, "cursor": str}}.
+
+    `has_more` is authoritative — the API may still echo a cursor on the terminal page, so a plain
+    cursor-path paginator could loop; only follow the cursor while `has_more` is true.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cursor: Optional[str] = None
+
+    def _inject(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["cursor"] = self._cursor
+
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume cursor to the first request.
+        if self._cursor is not None:
+            self._inject(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            pagination = response.json().get("pagination") or {}
+        except Exception:
+            pagination = {}
+        next_cursor = pagination.get("cursor") if pagination.get("has_more") else None
+        if next_cursor:
+            self._cursor = next_cursor
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        if self._cursor is not None:
+            self._inject(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor} if self._has_next_page and self._cursor is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor = cursor
+            self._has_next_page = True
+
+
+def _client_config(api_key: str) -> ClientConfig:
+    # Auth (Bearer) goes through the framework auth config so the key is redacted from logs and
+    # captured samples; only the non-secret Accept header is set here.
     return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
+        "base_url": BASETEN_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_key},
     }
 
 
-def _get_session(api_key: str) -> requests.Session:
-    # Redact the key everywhere the tracked transport might surface it (logged URLs, captured
-    # samples). The `Authorization` header is already dropped wholesale by the sampler, but masking
-    # the literal value is cheap defense-in-depth in case it ever lands in an error body or URL.
-    return make_tracked_session(redact_values=(api_key,))
+def _flatten_map(flatten_key: str) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Lift a nested object (e.g. instance_type_prices' `instance_type`) up into the root."""
+
+    def _map(row: dict[str, Any]) -> dict[str, Any]:
+        if isinstance(row.get(flatten_key), dict):
+            nested = row.pop(flatten_key)
+            # Root-level siblings (e.g. `price`) take precedence over nested keys on collision.
+            return {**nested, **row}
+        return row
+
+    return _map
 
 
-@retry(
-    retry=retry_if_exception_type(
-        (
-            BasetenRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    params: dict[str, Any] | None,
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT)
+def _rename_parent_fields_map(
+    parent_name: str, include_from_parent_fields: dict[str, str]
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Rename the framework's `_<parent>_<field>` injected columns to the original child columns."""
+    key_map = {f"_{parent_name}_{src}": dst for src, dst in include_from_parent_fields.items()}
 
-    # 429 responses carry a `retry_after` seconds hint; exponential backoff subsumes it without us
-    # having to sleep here. 5xx are transient too.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BasetenRetryableError(f"Baseten API error (retryable): status={response.status_code}, url={url}")
+    def _map(row: dict[str, Any]) -> dict[str, Any]:
+        for prefixed_key, target_key in key_map.items():
+            if prefixed_key in row:
+                row[target_key] = row.pop(prefixed_key)
+        return row
 
-    if not response.ok:
-        # 404 is expected during fan-out when a parent resource is deleted mid-sync; caller handles it.
-        # Log only status + url — upstream error bodies can echo workspace metadata or secret-adjacent
-        # data, so we never persist `response.text`.
-        log = logger.warning if response.status_code == 404 else logger.error
-        log(f"Baseten API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
+    return _map
 
-    return response.json()
+
+def _build_flat_resource(
+    api_key: str,
+    config: BasetenEndpointConfig,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[BasetenResumeConfig],
+) -> Resource:
+    """Top-level endpoint: either a single unpaginated request or cursor+limit pagination."""
+    endpoint: Endpoint = {
+        "path": config.path,
+        # Missing data key yields 0 rows (matching the API contract that the key is always present
+        # on success); an empty array is a legit zero-row response either way.
+        "data_selector": config.data_key,
+    }
+
+    resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None
+    initial_paginator_state: Optional[dict[str, Any]] = None
+
+    if config.paginated:
+        endpoint["params"] = {"limit": PAGE_SIZE}
+        endpoint["paginator"] = BasetenCursorPaginator()
+
+        if resumable_source_manager.can_resume():
+            resume = resumable_source_manager.load_state()
+            if resume is not None and resume.cursor is not None:
+                initial_paginator_state = {"cursor": resume.cursor}
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only when a next page remains; saved AFTER a page is yielded so a crash
+            # re-yields the last page rather than skipping it. These are full-refresh tables
+            # (append writes, no primary-key merge), so a resumed run can re-append at most the
+            # one in-flight page — bounded, and cleared by the next clean full refresh.
+            if state and state.get("cursor"):
+                resumable_source_manager.save_state(BasetenResumeConfig(cursor=state["cursor"]))
+
+        resume_hook = save_checkpoint
+    else:
+        endpoint["paginator"] = SinglePagePaginator()
+
+    resource_config: EndpointResource = {"name": config.name, "endpoint": endpoint}
+    if config.flatten_key:
+        resource_config["data_map"] = _flatten_map(config.flatten_key)
+
+    rest_config: RESTAPIConfig = {"client": _client_config(api_key), "resources": [resource_config]}
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=resume_hook,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _build_fan_out_resource(
+    api_key: str,
+    config: BasetenEndpointConfig,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[BasetenResumeConfig],
+) -> Resource:
+    """Iterate an unpaginated parent list and fetch this child endpoint once per parent row."""
+    assert config.fan_out_parent is not None
+    parent_config = BASETEN_ENDPOINTS[config.fan_out_parent]
+    include_from_parent_fields = config.fan_out_include_parent_fields or {}
+
+    parent_resource: EndpointResource = {
+        "name": parent_config.name,
+        "endpoint": {
+            "path": parent_config.path,
+            "data_selector": parent_config.data_key,
+            "paginator": SinglePagePaginator(),
+        },
+    }
+    child_resource: EndpointResource = {
+        "name": config.name,
+        "endpoint": {
+            "path": config.path,
+            "data_selector": config.data_key,
+            "paginator": SinglePagePaginator(),
+            "params": {
+                config.fan_out_path_param: {
+                    "type": "resolve",
+                    "resource": parent_config.name,
+                    "field": config.fan_out_parent_field,
+                },
+            },
+            # A parent deleted between enumeration and the child fetch 404s — skip it rather than
+            # fail the whole sync. 429/5xx are retried by the client before hooks run, and any
+            # other 4xx still raises.
+            "response_actions": [{"status_code": 404, "action": "ignore"}],
+        },
+        # Copies parent context onto each child row so the linkage column is always present (and
+        # the composite primary key stays unique table-wide).
+        "include_from_parent": list(include_from_parent_fields),
+        "data_map": _rename_parent_fields_map(parent_config.name, include_from_parent_fields),
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # The framework checkpoints after each parent completes; a resumed run re-fetches the
+        # (small) parent list and skips parents already fully synced. Full-refresh tables, so a
+        # crash mid-parent can at most re-append that parent's children — bounded, and cleared by
+        # the next clean full refresh.
+        if state:
+            resumable_source_manager.save_state(BasetenResumeConfig(fanout_state=state))
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [parent_resource, child_resource],
+    }
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    parent = next(r for r in resources if r.name == parent_config.name)
+    child = next(r for r in resources if r.name == config.name)
+
+    # Drop parents missing the fan-out id. Stringifying a missing id would build a bogus child path
+    # (e.g. `/v1/models/None/deployments`) and could sync child rows keyed to a literal "None".
+    parent.add_filter(lambda item: item.get(config.fan_out_parent_field) not in (None, ""))
+
+    return child
 
 
 def validate_credentials(api_key: str) -> bool:
     # /v1/users/me is the cheapest workspace-scoped probe and doesn't depend on any resource existing.
-    url = f"{BASETEN_BASE_URL}/v1/users/me"
-    try:
-        response = _get_session(api_key).get(url, headers=_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _flatten_row(item: dict[str, Any], flatten_key: str | None) -> dict[str, Any]:
-    """Lift a nested object (e.g. instance_type_prices' `instance_type`) up into the root."""
-    if flatten_key and isinstance(item.get(flatten_key), dict):
-        nested = item.pop(flatten_key)
-        # Root-level siblings (e.g. `price`) take precedence over nested keys on collision.
-        return {**nested, **item}
-    return item
-
-
-def _top_level_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    config: BasetenEndpointConfig,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    """Single unpaginated request returning a full array under `config.data_key`."""
-    data = _fetch(session, f"{BASETEN_BASE_URL}{config.path}", headers, None, logger)
-    rows = [_flatten_row(item, config.flatten_key) for item in data.get(config.data_key, [])]
-    if rows:
-        yield rows
-
-
-def _paginated_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    config: BasetenEndpointConfig,
-    manager: ResumableSourceManager[BasetenResumeConfig],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    """Cursor+limit pagination: {"items": [...], "pagination": {"has_more": bool, "cursor": str}}."""
-    resume = manager.load_state() if manager.can_resume() else None
-    cursor = resume.cursor if resume else None
-
-    url = f"{BASETEN_BASE_URL}{config.path}"
-    while True:
-        params: dict[str, Any] = {"limit": PAGE_SIZE}
-        if cursor:
-            params["cursor"] = cursor
-
-        data = _fetch(session, url, headers, params, logger)
-        rows = data.get(config.data_key, [])
-        if rows:
-            yield rows
-
-        pagination = data.get("pagination") or {}
-        next_cursor = pagination.get("cursor") if pagination.get("has_more") else None
-        if not next_cursor:
-            break
-
-        # Save AFTER yielding so a crash re-yields the last page rather than skipping it. These are
-        # full-refresh tables (append writes, no primary-key merge), so a resumed run can re-append
-        # at most the one in-flight page — bounded, and cleared by the next clean full refresh. We
-        # prefer that transient duplicate over the alternative (save-before-yield), which would drop
-        # a page entirely on a crash in the same window.
-        manager.save_state(BasetenResumeConfig(cursor=next_cursor))
-        cursor = next_cursor
-
-
-def _iter_parents(
-    session: requests.Session,
-    headers: dict[str, str],
-    parent_config: BasetenEndpointConfig,
-    logger: FilteringBoundLogger,
-) -> list[dict[str, Any]]:
-    """Fetch the (unpaginated) parent list for a fan-out."""
-    data = _fetch(session, f"{BASETEN_BASE_URL}{parent_config.path}", headers, None, logger)
-    return list(data.get(parent_config.data_key, []))
-
-
-def _fan_out_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    config: BasetenEndpointConfig,
-    manager: ResumableSourceManager[BasetenResumeConfig],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    """Iterate a parent resource and fetch this child endpoint once per parent row."""
-    assert config.fan_out_parent is not None
-    parent_config = BASETEN_ENDPOINTS[config.fan_out_parent]
-    parents = _iter_parents(session, headers, parent_config, logger)
-
-    # Drop parents missing the fan-out id. Stringifying a missing id would build a bogus child path
-    # (e.g. `/v1/models/None/deployments`) and could sync child rows keyed to a literal "None".
-    parented: list[tuple[str, dict[str, Any]]] = []
-    for parent in parents:
-        raw_id = parent.get(config.fan_out_parent_field)
-        if raw_id is None or raw_id == "":
-            logger.warning(f"Baseten: skipping {config.fan_out_parent} without {config.fan_out_parent_field}")
-            continue
-        parented.append((str(raw_id), parent))
-    parent_ids = [pid for pid, _ in parented]
-
-    # Resolve the saved parent bookmark to the slice still to process. If the bookmarked parent no
-    # longer exists (deleted between runs), start over. These are full-refresh tables, so re-pulling
-    # a parent's children can at most re-append them (bounded, cleared by the next clean full refresh).
-    resume = manager.load_state() if manager.can_resume() else None
-    remaining = parented
-    if resume is not None and resume.parent_id is not None and resume.parent_id in parent_ids:
-        start = parent_ids.index(resume.parent_id)
-        remaining = remaining[start:]
-        logger.debug(f"Baseten: resuming {config.name} from parent_id={resume.parent_id}")
-
-    for index, (parent_id, parent) in enumerate(remaining):
-        child_path = config.path.replace(f"{{{config.fan_out_path_param}}}", parent_id)
-        try:
-            data = _fetch(session, f"{BASETEN_BASE_URL}{child_path}", headers, None, logger)
-        except requests.HTTPError as exc:
-            # A parent deleted between enumeration and this fetch 404s. Skip it rather than failing
-            # the whole sync. Any other HTTP error is re-raised.
-            if exc.response is not None and exc.response.status_code == 404:
-                logger.warning(f"Baseten: {config.fan_out_parent} {parent_id} not found for {config.name}, skipping")
-                continue
-            raise
-
-        rows = []
-        for item in data.get(config.data_key, []):
-            row = _flatten_row(item, config.flatten_key)
-            if config.fan_out_include_parent_fields:
-                for parent_field, child_column in config.fan_out_include_parent_fields.items():
-                    row[child_column] = parent.get(parent_field)
-            rows.append(row)
-
-        if rows:
-            yield rows
-
-        # Advance the bookmark to the next parent so a crash between parents resumes correctly.
-        if index + 1 < len(remaining):
-            manager.save_state(BasetenResumeConfig(parent_id=remaining[index + 1][0]))
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BasetenResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = BASETEN_ENDPOINTS[endpoint]
-    headers = _headers(api_key)
-    # One session reused across every page/parent so urllib3 keeps the connection alive.
-    session = _get_session(api_key)
-
-    if config.paginated:
-        yield from _paginated_rows(session, headers, config, resumable_source_manager, logger)
-    elif config.fan_out_parent:
-        yield from _fan_out_rows(session, headers, config, resumable_source_manager, logger)
-    else:
-        yield from _top_level_rows(session, headers, config, logger)
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BASETEN_BASE_URL}/v1/users/me",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    return ok
 
 
 def baseten_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BasetenResumeConfig],
 ) -> SourceResponse:
     config = BASETEN_ENDPOINTS[endpoint]
 
+    if config.fan_out_parent:
+        resource = _build_fan_out_resource(api_key, config, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _build_flat_resource(api_key, config, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         sort_mode="asc",
         partition_count=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BasetenSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -95,21 +98,13 @@ Create an API key in your [Baseten workspace settings](https://app.baseten.co/se
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Baseten exposes no server-side "updated since" filter on any entity list endpoint, so every
-        # table syncs as a full refresh.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-                should_sync_default=BASETEN_ENDPOINTS[endpoint].should_sync_default,
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # table syncs as a full refresh (no incremental fields).
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            {},
+            names,
+            should_sync_default={endpoint: BASETEN_ENDPOINTS[endpoint].should_sync_default for endpoint in ENDPOINTS},
+        )
 
     def validate_credentials(
         self, config: BasetenSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -131,6 +126,7 @@ Create an API key in your [Baseten workspace settings](https://app.baseten.co/se
         return baseten_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/tests/test_baseten.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/tests/test_baseten.py
@@ -1,17 +1,14 @@
 import json
-from collections.abc import Iterator
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.baseten.baseten import (
     BasetenResumeConfig,
-    _flatten_row,
     baseten_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.baseten.settings import (
@@ -20,7 +17,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.baseten.se
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.baseten.baseten"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the baseten module.
+BASETEN_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.baseten.baseten.make_tracked_session"
+)
 
 
 def _response(body: dict[str, Any], status_code: int = 200) -> Response:
@@ -28,188 +30,263 @@ def _response(body: dict[str, Any], status_code: int = 200) -> Response:
     resp.status_code = status_code
     resp._content = json.dumps(body).encode()
     resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://api.baseten.co/v1/test"
     return resp
 
 
-def _drive(endpoint: str, manager: MagicMock, responses: list[Response]) -> tuple[list[list[dict]], list[dict]]:
-    """Run ``get_rows`` against a mocked HTTP session; return (yielded batches, captured get kwargs)."""
-    captured: list[dict[str, Any]] = []
-    response_iter = iter(responses)
-
-    def fake_get(url: str, **kwargs: Any) -> Response:
-        captured.append({"url": url, "params": kwargs.get("params")})
-        return next(response_iter)
-
-    with patch(f"{MODULE}.make_tracked_session") as mock_factory:
-        session = mock_factory.return_value
-        session.get.side_effect = fake_get
-        batches = list(get_rows("test-key", endpoint, MagicMock(), manager))
-    return batches, captured
+def _make_manager(resume_state: BasetenResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class TestFlattenRow:
-    def test_lifts_nested_object_into_root(self) -> None:
-        row = _flatten_row({"instance_type": {"id": "gpu-1", "name": "A100"}, "price": 0.5}, "instance_type")
-        assert row == {"id": "gpu-1", "name": "A100", "price": 0.5}
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session; return snapshots of each request's url/params/auth AT PREPARE TIME.
 
-    def test_root_keys_win_on_collision(self) -> None:
-        # A sibling `price` (or any root key) must survive a nested key of the same name.
-        row = _flatten_row({"instance_type": {"id": "gpu-1", "price": 999}, "price": 0.5}, "instance_type")
-        assert row["price"] == 0.5
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
 
-    def test_noop_without_flatten_key(self) -> None:
-        row = _flatten_row({"id": "1"}, None)
-        assert row == {"id": "1"}
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append(
+            {
+                "url": request.url,
+                "params": dict(request.params or {}),
+                "bearer_token": getattr(request.auth, "token", None),
+            }
+        )
+        return mock.MagicMock()
 
-    def test_noop_when_key_absent(self) -> None:
-        row = _flatten_row({"id": "1"}, "instance_type")
-        assert row == {"id": "1"}
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(
+    endpoint: str, manager: mock.MagicMock, session: mock.MagicMock, responses: list[Response]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    snapshots = _wire(session, responses)
+    rows = _rows(baseten_source("test-key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager))
+    return rows, snapshots
 
 
 class TestTopLevelEndpoints:
-    def test_yields_rows_under_data_key(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        batches, captured = _drive("models", manager, [_response({"models": [{"id": "m1"}, {"id": "m2"}]})])
-        assert batches == [[{"id": "m1"}, {"id": "m2"}]]
-        assert captured[0]["url"].endswith("/v1/models")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_yields_rows_under_data_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows, snapshots = _run(
+            "models", _make_manager(), session, [_response({"models": [{"id": "m1"}, {"id": "m2"}]})]
+        )
+        assert rows == [{"id": "m1"}, {"id": "m2"}]
+        assert snapshots[0]["url"] == "https://api.baseten.co/v1/models"
+        assert session.send.call_count == 1
 
-    def test_empty_array_yields_nothing(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        batches, _ = _drive("models", manager, [_response({"models": []})])
-        assert batches == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_goes_through_framework_bearer(self, MockSession) -> None:
+        session = MockSession.return_value
+        _, snapshots = _run("models", _make_manager(), session, [_response({"models": [{"id": "m1"}]})])
+        assert snapshots[0]["bearer_token"] == "test-key"
 
-    def test_instance_type_prices_flattened(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        body = {"instance_types": [{"instance_type": {"id": "gpu-1", "name": "A100"}, "price": 0.5}]}
-        batches, _ = _drive("instance_type_prices", manager, [_response(body)])
-        assert batches == [[{"id": "gpu-1", "name": "A100", "price": 0.5}]]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_array_yields_nothing(self, MockSession) -> None:
+        rows, _ = _run("models", _make_manager(), MockSession.return_value, [_response({"models": []})])
+        assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_nothing(self, MockSession) -> None:
+        # The Baseten client has always treated a missing data key as zero rows, not an error.
+        rows, _ = _run("models", _make_manager(), MockSession.return_value, [_response({"unexpected": True})])
+        assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_instance_type_prices_flattened(self, MockSession) -> None:
+        body = {
+            "instance_types": [
+                # Nested object lifts into the root; root-level siblings win on collision.
+                {"instance_type": {"id": "gpu-1", "name": "A100", "price": 999}, "price": 0.5},
+                # Rows without the nested key pass through untouched.
+                {"id": "plain"},
+            ]
+        }
+        rows, _ = _run("instance_type_prices", _make_manager(), MockSession.return_value, [_response(body)])
+        assert rows == [{"id": "gpu-1", "name": "A100", "price": 0.5}, {"id": "plain"}]
 
 
 class TestCursorPagination:
-    def test_saves_cursor_after_each_non_terminal_page(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pages_until_has_more_false_and_saves_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        manager = _make_manager()
         responses = [
             _response({"items": [{"user_id": "u1"}], "pagination": {"has_more": True, "cursor": "c1"}}),
             _response({"items": [{"user_id": "u2"}], "pagination": {"has_more": True, "cursor": "c2"}}),
             _response({"items": [{"user_id": "u3"}], "pagination": {"has_more": False, "cursor": None}}),
         ]
-        batches, captured = _drive("users", manager, responses)
+        rows, snapshots = _run("users", manager, session, responses)
 
-        assert batches == [[{"user_id": "u1"}], [{"user_id": "u2"}], [{"user_id": "u3"}]]
+        assert rows == [{"user_id": "u1"}, {"user_id": "u2"}, {"user_id": "u3"}]
         # First request has no cursor; later requests carry the prior page's cursor.
-        assert [p["params"].get("cursor") for p in captured] == [None, "c1", "c2"]
+        assert [s["params"].get("cursor") for s in snapshots] == [None, "c1", "c2"]
+        assert all(s["params"]["limit"] == 100 for s in snapshots)
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [BasetenResumeConfig(cursor="c1"), BasetenResumeConfig(cursor="c2")]
 
-    def test_single_terminal_page_does_not_save(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        _drive("users", manager, [_response({"items": [{"user_id": "u1"}], "pagination": {"has_more": False}})])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_terminal_page_does_not_save(self, MockSession) -> None:
+        manager = _make_manager()
+        _run(
+            "users",
+            manager,
+            MockSession.return_value,
+            [_response({"items": [{"user_id": "u1"}], "pagination": {"has_more": False}})],
+        )
         manager.save_state.assert_not_called()
 
-    def test_resume_seeds_saved_cursor(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = BasetenResumeConfig(cursor="resumed-cursor")
-        _, captured = _drive("users", manager, [_response({"items": [{"user_id": "u9"}], "pagination": {}})])
-        assert captured[0]["params"].get("cursor") == "resumed-cursor"
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_has_more_false_stops_even_if_cursor_echoed(self, MockSession) -> None:
+        # `has_more` is authoritative — a cursor echoed on the terminal page must not cause a loop.
+        session = MockSession.return_value
+        rows, _ = _run(
+            "users",
+            _make_manager(),
+            session,
+            [_response({"items": [{"user_id": "u1"}], "pagination": {"has_more": False, "cursor": "stale"}})],
+        )
+        assert rows == [{"user_id": "u1"}]
+        assert session.send.call_count == 1
 
-    def test_does_not_load_state_when_cannot_resume(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        _drive("users", manager, [_response({"items": [], "pagination": {}})])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_seeds_saved_cursor(self, MockSession) -> None:
+        manager = _make_manager(BasetenResumeConfig(cursor="resumed-cursor"))
+        _, snapshots = _run(
+            "users", manager, MockSession.return_value, [_response({"items": [{"user_id": "u9"}], "pagination": {}})]
+        )
+        assert snapshots[0]["params"].get("cursor") == "resumed-cursor"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_does_not_load_state_when_cannot_resume(self, MockSession) -> None:
+        manager = _make_manager()
+        _run("users", manager, MockSession.return_value, [_response({"items": [], "pagination": {}})])
         manager.load_state.assert_not_called()
 
 
 class TestFanOut:
-    def test_injects_parent_id_and_yields_per_parent(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_injects_parent_id_and_yields_per_parent(self, MockSession) -> None:
+        manager = _make_manager()
         responses = [
             _response({"models": [{"id": "m1"}, {"id": "m2"}]}),  # parent list
             _response({"deployments": [{"id": "d1"}]}),  # m1 children
             _response({"deployments": [{"id": "d2"}]}),  # m2 children
         ]
-        batches, captured = _drive("deployments", manager, responses)
+        rows, snapshots = _run("deployments", manager, MockSession.return_value, responses)
 
-        assert batches == [[{"id": "d1", "model_id": "m1"}], [{"id": "d2", "model_id": "m2"}]]
-        assert captured[1]["url"].endswith("/v1/models/m1/deployments")
-        assert captured[2]["url"].endswith("/v1/models/m2/deployments")
-        # Bookmark advances to the next parent after finishing the first one.
+        assert rows == [{"id": "d1", "model_id": "m1"}, {"id": "d2", "model_id": "m2"}]
+        assert snapshots[1]["url"] == "https://api.baseten.co/v1/models/m1/deployments"
+        assert snapshots[2]["url"] == "https://api.baseten.co/v1/models/m2/deployments"
+        # The resolve param binds into the path, not the query string.
+        assert "model_id" not in snapshots[1]["params"]
+        # A checkpoint marking m1 complete is saved before m2 is processed.
         saved = [call.args[0] for call in manager.save_state.call_args_list]
-        assert saved == [BasetenResumeConfig(parent_id="m2")]
+        assert (
+            BasetenResumeConfig(
+                fanout_state={"completed": ["/v1/models/m1/deployments"], "current": None, "child_state": None}
+            )
+            in saved
+        )
+        # Every checkpoint stays parseable as the resume dataclass (cursor/parent_id untouched).
+        assert all(s.cursor is None and s.parent_id is None and isinstance(s.fanout_state, dict) for s in saved)
 
-    def test_composite_key_column_present_for_environments(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_composite_key_column_present_for_environments(self, MockSession) -> None:
         responses = [
             _response({"models": [{"id": "m1"}]}),
             _response({"environments": [{"name": "production"}]}),
         ]
-        batches, _ = _drive("model_environments", manager, responses)
+        rows, _ = _run("model_environments", _make_manager(), MockSession.return_value, responses)
         # model_id is injected so [model_id, name] stays unique table-wide.
-        assert batches == [[{"name": "production", "model_id": "m1"}]]
+        assert rows == [{"name": "production", "model_id": "m1"}]
 
-    def test_404_child_is_skipped(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_404_child_is_skipped(self, MockSession) -> None:
         responses = [
             _response({"models": [{"id": "gone"}, {"id": "m2"}]}),
             _response({"code": "NOT_FOUND"}, status_code=404),  # parent deleted mid-sync
             _response({"deployments": [{"id": "d2"}]}),
         ]
-        batches, _ = _drive("deployments", manager, responses)
-        assert batches == [[{"id": "d2", "model_id": "m2"}]]
+        rows, _ = _run("deployments", _make_manager(), MockSession.return_value, responses)
+        assert rows == [{"id": "d2", "model_id": "m2"}]
 
-    def test_parent_without_id_is_skipped(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_parent_without_id_is_skipped(self, MockSession) -> None:
         responses = [
             _response({"models": [{"id": "m1"}, {"name": "orphan"}]}),  # second parent has no id
             _response({"deployments": [{"id": "d1"}]}),  # only m1's children are fetched
         ]
-        batches, captured = _drive("deployments", manager, responses)
-        assert batches == [[{"id": "d1", "model_id": "m1"}]]
+        rows, snapshots = _run("deployments", _make_manager(), MockSession.return_value, responses)
+        assert rows == [{"id": "d1", "model_id": "m1"}]
         # The id-less parent must not produce a request against a stringified "None" id.
-        assert not any("/models/None/" in c["url"] for c in captured)
+        assert not any("/models/None/" in s["url"] for s in snapshots)
 
-    def test_resume_starts_from_bookmarked_parent(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = BasetenResumeConfig(parent_id="m2")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_parents(self, MockSession) -> None:
+        manager = _make_manager(
+            BasetenResumeConfig(
+                fanout_state={"completed": ["/v1/models/m1/deployments"], "current": None, "child_state": None}
+            )
+        )
         responses = [
             _response({"models": [{"id": "m1"}, {"id": "m2"}]}),
             _response({"deployments": [{"id": "d2"}]}),  # only m2 is fetched
         ]
-        batches, captured = _drive("deployments", manager, responses)
-        assert batches == [[{"id": "d2", "model_id": "m2"}]]
-        child_urls = [c["url"] for c in captured if "/deployments" in c["url"]]
+        rows, snapshots = _run("deployments", manager, MockSession.return_value, responses)
+        assert rows == [{"id": "d2", "model_id": "m2"}]
+        child_urls = [s["url"] for s in snapshots if s["url"].endswith("/deployments") and "/models/" in s["url"]]
         assert child_urls == ["https://api.baseten.co/v1/models/m2/deployments"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_parent_id_state_restarts_fan_out(self, MockSession) -> None:
+        # Pre-migration states bookmarked the next parent id; they still parse but the fan-out
+        # restarts from the top (full-refresh tables, so re-appending is bounded).
+        manager = _make_manager(BasetenResumeConfig(parent_id="m2"))
+        responses = [
+            _response({"models": [{"id": "m1"}, {"id": "m2"}]}),
+            _response({"deployments": [{"id": "d1"}]}),
+            _response({"deployments": [{"id": "d2"}]}),
+        ]
+        rows, _ = _run("deployments", manager, MockSession.return_value, responses)
+        assert rows == [{"id": "d1", "model_id": "m1"}, {"id": "d2", "model_id": "m2"}]
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize(("status", "expected"), [(200, True), (403, False), (401, False), (500, False)])
     def test_status_maps_to_bool(self, status: int, expected: bool) -> None:
-        with patch(f"{MODULE}.make_tracked_session") as mock_factory:
+        with mock.patch(BASETEN_SESSION_PATCH) as mock_factory:
             session = mock_factory.return_value
             session.get.return_value = _response({}, status_code=status)
             assert validate_credentials("key") is expected
+            _, kwargs = session.get.call_args
+            assert kwargs["headers"]["Authorization"] == "Bearer key"
 
     def test_network_error_is_false(self) -> None:
-        with patch(f"{MODULE}.make_tracked_session") as mock_factory:
+        with mock.patch(BASETEN_SESSION_PATCH) as mock_factory:
             mock_factory.return_value.get.side_effect = Exception("boom")
             assert validate_credentials("key") is False
 
 
 class TestSourceResponseShape:
     @pytest.mark.parametrize("endpoint", ENDPOINTS)
-    def test_partition_and_primary_keys_match_config(self, endpoint: str) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_partition_and_primary_keys_match_config(self, MockSession, endpoint: str) -> None:
         config = BASETEN_ENDPOINTS[endpoint]
-        response = baseten_source("k", endpoint, MagicMock(), MagicMock(spec=ResumableSourceManager))
+        response = baseten_source("k", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -220,8 +297,11 @@ class TestSourceResponseShape:
             assert response.partition_mode is None
             assert response.partition_keys is None
 
-    def test_items_is_lazy(self) -> None:
-        # Building the SourceResponse must not perform any I/O; items is a deferred callable.
-        response = baseten_source("k", "models", MagicMock(), MagicMock(spec=ResumableSourceManager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_items_is_lazy(self, MockSession) -> None:
+        # Building the SourceResponse must not perform any I/O; requests only fire on iteration.
+        session = MockSession.return_value
+        session.headers = {}
+        response = baseten_source("k", "deployments", team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert callable(response.items)
-        assert isinstance(response.items(), Iterator)
+        session.send.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/tests/test_baseten_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/baseten/tests/test_baseten_source.py
@@ -101,6 +101,7 @@ class TestBasetenPipelineWiring:
         mock_source.assert_called_once_with(
             api_key="secret",
             endpoint="deployments",
-            logger=inputs.logger,
+            team_id=1,
+            job_id="job-1",
             resumable_source_manager=manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brex/brex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brex/brex.py
@@ -1,13 +1,6 @@
-import time
 import dataclasses
-from collections.abc import Callable, Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.brex.settings import (
@@ -15,39 +8,47 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.brex.setti
     BrexEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BREX_BASE_URL = "https://api.brex.com"
 # Expenses caps `limit` at 100; other endpoints don't document a max, so 100 is used uniformly.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-MAX_RETRY_AFTER_SECONDS = 60
 
 CASH_ACCOUNTS_PATH = "/v2/accounts/cash"
 # Injected into cash transaction rows so rows from different cash accounts stay distinguishable.
 CASH_ACCOUNT_ID_KEY = "account_id"
-
-
-class BrexRetryableError(Exception):
-    pass
+# Parent resource name in the cash-transactions fan-out config. With include_from_parent=["id"]
+# the framework injects the parent account id into child rows as `_cash_accounts_id`; a data_map
+# renames it to the `account_id` key the rows carried before the rest_source migration.
+_CASH_ACCOUNTS_PARENT = "cash_accounts"
+_PARENT_ACCOUNT_ID_KEY = f"_{_CASH_ACCOUNTS_PARENT}_id"
 
 
 @dataclasses.dataclass
 class BrexResumeConfig:
+    # Pre-framework fields, kept so previously saved state still parses (dataclass(**saved)).
     # `next_cursor` of the last fully-yielded page for the endpoint (or current cash account).
     cursor: Optional[str] = None
     # Cash account currently being paged; None for top-level endpoints.
     account_id: Optional[str] = None
     # Cash accounts already fully synced in this run.
     completed_account_ids: list[str] = dataclasses.field(default_factory=list)
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-    }
+    # Framework fan-out checkpoint for cash_transactions
+    # ({"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}).
+    fanout_state: Optional[dict[str, Any]] = None
 
 
 def _to_rfc3339(value: Any) -> Optional[str]:
@@ -69,211 +70,157 @@ def _to_rfc3339(value: Any) -> Optional[str]:
     return None
 
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    clean_params = {key: value for key, value in params.items() if value is not None}
-    if not clean_params:
-        return f"{BREX_BASE_URL}{path}"
-    return f"{BREX_BASE_URL}{path}?{urlencode(clean_params)}"
+def _paginator() -> JSONResponseCursorPaginator:
+    # All Brex sub-APIs paginate with `cursor` + `limit` params and `next_cursor` +
+    # `items` in the response body.
+    return JSONResponseCursorPaginator(cursor_path="next_cursor", cursor_param="cursor")
 
 
-def _build_params(
-    config: BrexEndpointConfig,
-    cursor: Optional[str],
-    incremental_value: Optional[str],
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE}
-    if cursor is not None:
-        params["cursor"] = cursor
-    # Brex docs don't state whether the cursor re-encodes the original filters, so the
-    # timestamp filter is re-sent on every page to be safe.
-    if config.incremental_param is not None and incremental_value is not None:
-        params[config.incremental_param] = incremental_value
-    return params
+def _client_config(api_key: str) -> ClientConfig:
+    return {
+        "base_url": BREX_BASE_URL,
+        # Bearer auth via the framework auth config so the token is redacted from logs;
+        # only the non-secret accept header is set here. Brex rate-limits at 1,000
+        # requests per 60s — the client retries 429/5xx and honors Retry-After.
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_key},
+        "paginator": _paginator(),
+    }
 
 
-def validate_credentials(api_key: str) -> bool:
-    """Confirm the API user token is genuine. /v2/users/me is a cheap authenticated probe.
-
-    A 403 means the token is valid but wasn't granted the Team scope — users may
-    legitimately scope tokens to only the endpoints they want to sync, so it's accepted.
-    """
-    try:
-        response = make_tracked_session().get(
-            f"{BREX_BASE_URL}/v2/users/me",
-            headers=_get_headers(api_key),
-            timeout=10,
-        )
-        return response.status_code in (200, 403)
-    except Exception:
-        return False
+def _endpoint_config(config: BrexEndpointConfig, path: str, should_use_incremental_field: bool) -> Endpoint:
+    endpoint: Endpoint = {
+        "path": path,
+        "params": {"limit": PAGE_SIZE},
+        "data_selector": "items",
+    }
+    if should_use_incremental_field and config.incremental_param is not None:
+        # Brex docs don't state whether the cursor re-encodes the original filters, so the
+        # timestamp filter is re-sent on every page to be safe.
+        endpoint["incremental"] = {"start_param": config.incremental_param, "convert": _to_rfc3339}
+    return endpoint
 
 
-PageFetcher = Callable[[str], dict[str, Any]]
+def _inject_account_id(row: dict[str, Any]) -> dict[str, Any]:
+    row[CASH_ACCOUNT_ID_KEY] = row.pop(_PARENT_ACCOUNT_ID_KEY)
+    return row
 
 
-def _make_page_fetcher(api_key: str, logger: FilteringBoundLogger) -> PageFetcher:
-    headers = _get_headers(api_key)
-
-    @retry(
-        retry=retry_if_exception_type((BrexRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # Brex rate-limits at 1,000 requests per 60s. Honor Retry-After when present,
-        # otherwise tenacity's exponential backoff covers it.
-        if response.status_code == 429:
-            retry_after = response.headers.get("Retry-After")
-            if retry_after is not None:
-                try:
-                    time.sleep(min(int(retry_after), MAX_RETRY_AFTER_SECONDS))
-                except ValueError:
-                    pass
-            raise BrexRetryableError(f"Brex API rate limited: status=429, url={page_url}")
-
-        if response.status_code >= 500:
-            raise BrexRetryableError(f"Brex API error (retryable): status={response.status_code}, url={page_url}")
-
-        if not response.ok:
-            logger.error(f"Brex API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    return fetch_page
-
-
-def _list_cash_account_ids(fetch_page: PageFetcher, logger: FilteringBoundLogger) -> list[str]:
-    account_ids: list[str] = []
-    cursor: Optional[str] = None
-
-    while True:
-        url = _build_url(CASH_ACCOUNTS_PATH, {"limit": PAGE_SIZE, "cursor": cursor})
-        data = fetch_page(url)
-        items = data.get("items", []) or []
-        account_ids.extend(item["id"] for item in items)
-
-        cursor = data.get("next_cursor")
-        if not cursor:
-            break
-
-    logger.debug(f"Brex: found {len(account_ids)} cash accounts")
-    return account_ids
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrexResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = BREX_ENDPOINTS[endpoint]
-    fetch_page = _make_page_fetcher(api_key, logger)
-
-    incremental_value = _to_rfc3339(db_incremental_field_last_value) if should_use_incremental_field else None
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        logger.debug(
-            f"Brex: resuming {endpoint}. cursor={resume_config.cursor}, account_id={resume_config.account_id}, "
-            f"completed_account_ids={resume_config.completed_account_ids}"
-        )
-
-    if config.fan_out_cash_accounts:
-        yield from _get_fan_out_rows(
-            config, fetch_page, logger, resumable_source_manager, resume_config, incremental_value
-        )
-        return
-
-    cursor = resume_config.cursor if resume_config is not None else None
-
-    while True:
-        url = _build_url(config.path, _build_params(config, cursor, incremental_value))
-        data = fetch_page(url)
-        items = data.get("items", []) or []
-
-        if items:
-            yield items
-
-        cursor = data.get("next_cursor")
-        if not cursor:
-            break
-
-        # Save after yielding so a crash re-yields the last batch (merge dedupes on
-        # primary key) rather than skipping it.
-        resumable_source_manager.save_state(BrexResumeConfig(cursor=cursor))
-
-
-def _get_fan_out_rows(
-    config: BrexEndpointConfig,
-    fetch_page: PageFetcher,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrexResumeConfig],
-    resume_config: Optional[BrexResumeConfig],
-    incremental_value: Optional[str],
-) -> Iterator[list[dict[str, Any]]]:
-    account_ids = _list_cash_account_ids(fetch_page, logger)
-
-    completed_account_ids = list(resume_config.completed_account_ids) if resume_config is not None else []
-    completed_set = set(completed_account_ids)
-
-    for account_id in account_ids:
-        if account_id in completed_set:
-            continue
-
-        cursor = resume_config.cursor if resume_config is not None and resume_config.account_id == account_id else None
-        path = config.path.format(account_id=account_id)
-
-        while True:
-            url = _build_url(path, _build_params(config, cursor, incremental_value))
-            data = fetch_page(url)
-            items = data.get("items", []) or []
-
-            if items:
-                yield [{**item, CASH_ACCOUNT_ID_KEY: account_id} for item in items]
-
-            cursor = data.get("next_cursor")
-            if not cursor:
-                break
-
-            resumable_source_manager.save_state(
-                BrexResumeConfig(
-                    cursor=cursor,
-                    account_id=account_id,
-                    completed_account_ids=list(completed_account_ids),
-                )
-            )
-
-        completed_account_ids.append(account_id)
-        completed_set.add(account_id)
-        resumable_source_manager.save_state(BrexResumeConfig(completed_account_ids=list(completed_account_ids)))
+def _fanout_initial_state(config: BrexEndpointConfig, resume: BrexResumeConfig) -> Optional[dict[str, Any]]:
+    if resume.fanout_state is not None:
+        return resume.fanout_state
+    # Translate pre-framework resume state (account ids + cursor) into the framework's
+    # fan-out checkpoint shape (resolved child paths).
+    if not (resume.completed_account_ids or resume.account_id):
+        return None
+    current = config.path.format(account_id=resume.account_id) if resume.account_id else None
+    return {
+        "completed": [config.path.format(account_id=account_id) for account_id in resume.completed_account_ids],
+        "current": current,
+        "child_state": {"cursor": resume.cursor} if resume.cursor is not None and current is not None else None,
+    }
 
 
 def brex_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BrexResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = BREX_ENDPOINTS[endpoint]
 
+    resume: Optional[BrexResumeConfig] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+
+    if config.fan_out_cash_accounts:
+        initial_state = _fanout_initial_state(config, resume) if resume is not None else None
+
+        def save_fanout_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            if state is not None:
+                resumable_source_manager.save_state(BrexResumeConfig(fanout_state=state))
+
+        rest_config: RESTAPIConfig = {
+            "client": _client_config(api_key),
+            "resources": [
+                {
+                    "name": _CASH_ACCOUNTS_PARENT,
+                    "endpoint": {
+                        "path": CASH_ACCOUNTS_PATH,
+                        "params": {"limit": PAGE_SIZE},
+                        "data_selector": "items",
+                    },
+                },
+                {
+                    "name": endpoint,
+                    "endpoint": {
+                        **_endpoint_config(config, config.path, should_use_incremental_field),
+                        "params": {
+                            "limit": PAGE_SIZE,
+                            "account_id": {
+                                "type": "resolve",
+                                "resource": _CASH_ACCOUNTS_PARENT,
+                                "field": "id",
+                            },
+                        },
+                        # The path ends in `{account_id}`, which the framework would otherwise
+                        # treat as a single-entity endpoint (SinglePagePaginator) — each
+                        # account's transaction list is cursor-paged like everything else.
+                        "paginator": _paginator(),
+                    },
+                    "include_from_parent": ["id"],
+                    "data_map": _inject_account_id,
+                },
+            ],
+        }
+        resources = {
+            res.name: res
+            for res in rest_api_resources(
+                rest_config,
+                team_id,
+                job_id,
+                db_incremental_field_last_value,
+                resume_hook=save_fanout_checkpoint,
+                initial_paginator_state=initial_state,
+            )
+        }
+        resource = resources[endpoint]
+    else:
+        initial_paginator_state: Optional[dict[str, Any]] = None
+        if resume is not None and resume.cursor is not None:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only while a next page remains; the framework calls the hook AFTER a page
+            # is yielded, so a crash re-yields the last batch (merge dedupes on primary key)
+            # rather than skipping it.
+            if state is not None and state.get("cursor") is not None:
+                resumable_source_manager.save_state(BrexResumeConfig(cursor=state["cursor"]))
+
+        rest_config = {
+            "client": _client_config(api_key),
+            "resources": [
+                {
+                    "name": endpoint,
+                    "endpoint": _endpoint_config(config, config.path, should_use_incremental_field),
+                }
+            ],
+        }
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # Brex doesn't expose a sort param and doesn't document list ordering. "desc" makes the
         # pipeline commit the incremental watermark only after a fully successful run, which is
@@ -285,3 +232,18 @@ def brex_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Confirm the API user token is genuine. /v2/users/me is a cheap authenticated probe.
+
+    A 403 means the token is valid but wasn't granted the Team scope — users may
+    legitimately scope tokens to only the endpoints they want to sync, so it's accepted.
+    """
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BREX_BASE_URL}/v2/users/me",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+        ok_statuses=(200, 403),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brex/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brex/source.py
@@ -25,7 +25,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BrexSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -89,23 +92,7 @@ Note: Brex tokens expire after 90 days without API activity, so a token that has
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = []
-        for endpoint in ENDPOINTS:
-            incremental_fields = INCREMENTAL_FIELDS.get(endpoint)
-            schemas.append(
-                SourceSchema(
-                    name=endpoint,
-                    supports_incremental=incremental_fields is not None,
-                    supports_append=incremental_fields is not None,
-                    incremental_fields=incremental_fields or [],
-                )
-            )
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: BrexSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -127,7 +114,8 @@ Note: Brex tokens expire after 90 days without API activity, so a token that has
         return brex_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brex/tests/test_brex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brex/tests/test_brex.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
@@ -5,14 +6,12 @@ import pytest
 from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex import (
     BrexResumeConfig,
-    _build_params,
-    _build_url,
     _to_rfc3339,
     brex_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.brex.settings import (
@@ -20,6 +19,31 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.brex.setti
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the brex module.
+BREX_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session"
+
+CASH_TX_PATH = BREX_ENDPOINTS["cash_transactions"].path
+
+
+def _response(
+    payload: dict[str, Any],
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(payload).encode()
+    resp.url = "https://api.brex.com/test"
+    if headers:
+        resp.headers.update(headers)
+    return resp
+
+
+def _page(items: list[dict[str, Any]], next_cursor: str | None) -> dict[str, Any]:
+    return {"items": items, "next_cursor": next_cursor}
 
 
 def _make_manager(resume_state: BrexResumeConfig | None = None) -> mock.MagicMock:
@@ -29,17 +53,44 @@ def _make_manager(resume_state: BrexResumeConfig | None = None) -> mock.MagicMoc
     return manager
 
 
-def _page(items: list[dict[str, Any]], next_cursor: str | None) -> dict[str, Any]:
-    return {"items": items, "next_cursor": next_cursor}
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's url + params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _response(payload: dict[str, Any], status_code: int = 200, headers: dict[str, str] | None = None) -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.json.return_value = payload
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.headers = headers or {}
-    return response
+def _source(
+    endpoint: str,
+    manager: mock.MagicMock,
+    *,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+):
+    return brex_source(
+        "bxt_token",
+        endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestToRfc3339:
@@ -59,46 +110,6 @@ class TestToRfc3339:
         assert _to_rfc3339(value) == expected
 
 
-class TestBuildParams:
-    def test_always_includes_limit(self):
-        params = _build_params(BREX_ENDPOINTS["users"], cursor=None, incremental_value=None)
-        assert params == {"limit": 100}
-
-    def test_includes_cursor_when_set(self):
-        params = _build_params(BREX_ENDPOINTS["users"], cursor="abc", incremental_value=None)
-        assert params["cursor"] == "abc"
-
-    @pytest.mark.parametrize(
-        "endpoint, expected_param",
-        [
-            ("card_transactions", "posted_at_start"),
-            ("cash_transactions", "posted_at_start"),
-            ("expenses", "updated_at_start"),
-        ],
-    )
-    def test_incremental_param_included_for_incremental_endpoints(self, endpoint, expected_param):
-        params = _build_params(BREX_ENDPOINTS[endpoint], cursor=None, incremental_value="2024-01-02T00:00:00Z")
-        assert params[expected_param] == "2024-01-02T00:00:00Z"
-
-    @pytest.mark.parametrize("endpoint", ["users", "departments", "locations", "vendors", "budgets"])
-    def test_incremental_value_ignored_for_full_refresh_endpoints(self, endpoint):
-        params = _build_params(BREX_ENDPOINTS[endpoint], cursor=None, incremental_value="2024-01-02T00:00:00Z")
-        assert params == {"limit": 100}
-
-    def test_incremental_param_omitted_without_value(self):
-        params = _build_params(BREX_ENDPOINTS["expenses"], cursor=None, incremental_value=None)
-        assert "updated_at_start" not in params
-
-
-class TestBuildUrl:
-    def test_no_params(self):
-        assert _build_url("/v2/users", {}) == "https://api.brex.com/v2/users"
-
-    def test_drops_none_values_and_encodes(self):
-        url = _build_url("/v1/expenses", {"limit": 100, "cursor": None, "updated_at_start": "2024-01-02T00:00:00Z"})
-        assert url == "https://api.brex.com/v1/expenses?limit=100&updated_at_start=2024-01-02T00%3A00%3A00Z"
-
-
 class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected",
@@ -110,18 +121,18 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
+    @mock.patch(BREX_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
         mock_session.return_value.get.return_value = _response({}, status_code=status_code)
 
         assert validate_credentials("bxt_token") is expected
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
+    @mock.patch(BREX_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("bxt_token") is False
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
+    @mock.patch(BREX_SESSION_PATCH)
     def test_validate_credentials_sends_bearer_header(self, mock_session):
         mock_session.return_value.get.return_value = _response({}, status_code=200)
 
@@ -132,254 +143,367 @@ class TestValidateCredentials:
 
 
 class TestGetRows:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_paginates_via_next_cursor(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "u1"}, {"id": "u2"}], "cursor-2")),
-            _response(_page([{"id": "u3"}], None)),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_next_cursor(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "u1"}, {"id": "u2"}], "cursor-2")),
+                _response(_page([{"id": "u3"}], None)),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("bxt_token", "users", mock.MagicMock(), manager))
+        rows = _rows(_source("users", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["u1", "u2", "u3"]
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert first_url == "https://api.brex.com/v2/users?limit=100"
-        assert "cursor=cursor-2" in second_url
+        assert [row["id"] for row in rows] == ["u1", "u2", "u3"]
+        assert snapshots[0]["url"] == "https://api.brex.com/v2/users"
+        assert snapshots[0]["params"] == {"limit": 100}
+        assert snapshots[1]["params"] == {"limit": 100, "cursor": "cursor-2"}
         # State is saved only while a next page exists, after the batch has been yielded.
         manager.save_state.assert_called_once()
         assert manager.save_state.call_args.args[0] == BrexResumeConfig(cursor="cursor-2")
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_resumes_from_saved_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_page([{"id": "u9"}], None))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page([{"id": "u9"}], None))])
 
         manager = _make_manager(BrexResumeConfig(cursor="cursor-5"))
-        list(get_rows("bxt_token", "users", mock.MagicMock(), manager))
+        _rows(_source("users", manager))
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "cursor=cursor-5" in first_url
+        assert snapshots[0]["params"]["cursor"] == "cursor-5"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_empty_response_stops_without_saving_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_page([], None))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops_without_saving_state(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response(_page([], None))])
 
         manager = _make_manager()
-        batches = list(get_rows("bxt_token", "expenses", mock.MagicMock(), manager))
+        rows = _rows(_source("expenses", manager))
 
-        assert batches == []
+        assert rows == []
         manager.save_state.assert_not_called()
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_incremental_run_passes_server_side_filter(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_page([{"id": "e1"}], None))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_run_passes_server_side_filter(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page([{"id": "e1"}], None))])
 
         manager = _make_manager()
-        list(
-            get_rows(
-                "bxt_token",
+        _rows(
+            _source(
                 "expenses",
-                mock.MagicMock(),
                 manager,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
             )
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert "updated_at_start=2024-01-02T00%3A00%3A00Z" in url
+        assert snapshots[0]["params"]["updated_at_start"] == "2024-01-02T00:00:00Z"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_full_refresh_run_has_no_filter(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_page([{"id": "e1"}], None))
-
-        manager = _make_manager()
-        list(get_rows("bxt_token", "expenses", mock.MagicMock(), manager))
-
-        url = mock_session.return_value.get.call_args.args[0]
-        assert "updated_at_start" not in url
-
-    @mock.patch("tenacity.nap.time.sleep")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.time")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_429_honors_retry_after_then_retries(self, mock_session, mock_time, mock_nap):
-        mock_session.return_value.get.side_effect = [
-            _response({}, status_code=429, headers={"Retry-After": "7"}),
-            _response(_page([{"id": "u1"}], None)),
-        ]
-
-        manager = _make_manager()
-        batches = list(get_rows("bxt_token", "users", mock.MagicMock(), manager))
-
-        assert [item["id"] for batch in batches for item in batch] == ["u1"]
-        mock_time.sleep.assert_called_once_with(7)
-
-    @mock.patch("tenacity.nap.time.sleep")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.time")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_429_with_unparseable_retry_after_still_retries(self, mock_session, mock_time, mock_nap):
-        mock_session.return_value.get.side_effect = [
-            _response({}, status_code=429, headers={"Retry-After": "not-a-number"}),
-            _response(_page([{"id": "u1"}], None)),
-        ]
-
-        manager = _make_manager()
-        batches = list(get_rows("bxt_token", "users", mock.MagicMock(), manager))
-
-        assert [item["id"] for batch in batches for item in batch] == ["u1"]
-        mock_time.sleep.assert_not_called()
-
-    @mock.patch("tenacity.nap.time.sleep")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_5xx_is_retried(self, mock_session, mock_nap):
-        mock_session.return_value.get.side_effect = [
-            _response({}, status_code=502),
-            _response(_page([{"id": "u1"}], None)),
-        ]
-
-        manager = _make_manager()
-        batches = list(get_rows("bxt_token", "users", mock.MagicMock(), manager))
-
-        assert [item["id"] for batch in batches for item in batch] == ["u1"]
-        assert mock_session.return_value.get.call_count == 2
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_4xx_raises_immediately(self, mock_session):
-        response = _response({}, status_code=401)
-        response.raise_for_status.side_effect = requests.HTTPError(
-            "401 Client Error: Unauthorized for url: https://api.brex.com/v2/users", response=response
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_resent_on_every_page(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}], "cursor-2")),
+                _response(_page([{"id": "e2"}], None)),
+            ],
         )
-        response.text = "unauthorized"
-        mock_session.return_value.get.return_value = response
 
         manager = _make_manager()
-        with pytest.raises(requests.HTTPError):
-            list(get_rows("bxt_token", "users", mock.MagicMock(), manager))
-
-        assert mock_session.return_value.get.call_count == 1
-
-
-class TestGetRowsCashFanOut:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_fans_out_over_cash_accounts_and_injects_account_id(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "acc_1"}, {"id": "acc_2"}], None)),
-            _response(_page([{"id": "tx_1", "posted_at_date": "2024-01-01"}], None)),
-            _response(_page([{"id": "tx_2", "posted_at_date": "2024-01-02"}], None)),
-        ]
-
-        manager = _make_manager()
-        batches = list(get_rows("bxt_token", "cash_transactions", mock.MagicMock(), manager))
-
-        rows = [item for batch in batches for item in batch]
-        assert [(row["id"], row["account_id"]) for row in rows] == [("tx_1", "acc_1"), ("tx_2", "acc_2")]
-
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert urls[0] == "https://api.brex.com/v2/accounts/cash?limit=100"
-        assert urls[1].startswith("https://api.brex.com/v2/transactions/cash/acc_1")
-        assert urls[2].startswith("https://api.brex.com/v2/transactions/cash/acc_2")
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_saves_completed_accounts_between_accounts(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "acc_1"}, {"id": "acc_2"}], None)),
-            _response(_page([{"id": "tx_1"}], "cursor-a")),
-            _response(_page([{"id": "tx_2"}], None)),
-            _response(_page([{"id": "tx_3"}], None)),
-        ]
-
-        manager = _make_manager()
-        list(get_rows("bxt_token", "cash_transactions", mock.MagicMock(), manager))
-
-        saved_states = [call.args[0] for call in manager.save_state.call_args_list]
-        assert saved_states == [
-            BrexResumeConfig(cursor="cursor-a", account_id="acc_1", completed_account_ids=[]),
-            BrexResumeConfig(cursor=None, account_id=None, completed_account_ids=["acc_1"]),
-            BrexResumeConfig(cursor=None, account_id=None, completed_account_ids=["acc_1", "acc_2"]),
-        ]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_resume_skips_completed_accounts_and_uses_cursor(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "acc_1"}, {"id": "acc_2"}], None)),
-            _response(_page([{"id": "tx_9"}], None)),
-        ]
-
-        manager = _make_manager(
-            BrexResumeConfig(cursor="cursor-mid", account_id="acc_2", completed_account_ids=["acc_1"])
+        _rows(
+            _source(
+                "expenses",
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
+            )
         )
-        batches = list(get_rows("bxt_token", "cash_transactions", mock.MagicMock(), manager))
 
-        rows = [item for batch in batches for item in batch]
-        assert [(row["id"], row["account_id"]) for row in rows] == [("tx_9", "acc_2")]
+        assert snapshots[1]["params"]["updated_at_start"] == "2024-01-02T00:00:00Z"
+        assert snapshots[1]["params"]["cursor"] == "cursor-2"
 
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert len(urls) == 2
-        assert "transactions/cash/acc_2" in urls[1]
-        assert "cursor=cursor-mid" in urls[1]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_resume_cursor_not_applied_to_other_accounts(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "acc_1"}], None)),
-            _response(_page([{"id": "tx_1"}], None)),
-        ]
-
-        manager = _make_manager(BrexResumeConfig(cursor="cursor-mid", account_id="acc_gone", completed_account_ids=[]))
-        list(get_rows("bxt_token", "cash_transactions", mock.MagicMock(), manager))
-
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert "cursor=" not in urls[1]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_paginates_cash_account_listing(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "acc_1"}], "acc-cursor-2")),
-            _response(_page([{"id": "acc_2"}], None)),
-            _response(_page([], None)),
-            _response(_page([], None)),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_param_omitted_without_value(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page([{"id": "e1"}], None))])
 
         manager = _make_manager()
-        list(get_rows("bxt_token", "cash_transactions", mock.MagicMock(), manager))
+        _rows(_source("expenses", manager, should_use_incremental_field=True))
 
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert "accounts/cash" in urls[0]
-        assert "cursor=acc-cursor-2" in urls[1]
-        assert "transactions/cash/acc_1" in urls[2]
-        assert "transactions/cash/acc_2" in urls[3]
+        assert "updated_at_start" not in snapshots[0]["params"]
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.brex.brex.make_tracked_session")
-    def test_incremental_filter_applied_per_account(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "acc_1"}], None)),
-            _response(_page([{"id": "tx_1"}], None)),
-        ]
+    @pytest.mark.parametrize("endpoint", ["users", "departments", "locations", "vendors", "budgets"])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_value_ignored_for_full_refresh_endpoints(self, MockSession, endpoint):
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page([{"id": "x"}], None))])
 
         manager = _make_manager()
-        list(
-            get_rows(
-                "bxt_token",
-                "cash_transactions",
-                mock.MagicMock(),
+        _rows(
+            _source(
+                endpoint,
                 manager,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value="2024-01-02",
             )
         )
 
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
+        assert snapshots[0]["params"] == {"limit": 100}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_run_has_no_filter(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page([{"id": "e1"}], None))])
+
+        manager = _make_manager()
+        _rows(_source("expenses", manager))
+
+        assert "updated_at_start" not in snapshots[0]["params"]
+
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_429_honors_retry_after_then_retries(self, MockSession, mock_nap):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status_code=429, headers={"Retry-After": "7"}),
+                _response(_page([{"id": "u1"}], None)),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
+        assert [row["id"] for row in rows] == ["u1"]
+        mock_nap.assert_called_once_with(7.0)
+
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_429_with_unparseable_retry_after_still_retries(self, MockSession, mock_nap):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status_code=429, headers={"Retry-After": "not-a-number"}),
+                _response(_page([{"id": "u1"}], None)),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
+        assert [row["id"] for row in rows] == ["u1"]
+        assert session.send.call_count == 2
+
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_5xx_is_retried(self, MockSession, mock_nap):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status_code=502),
+                _response(_page([{"id": "u1"}], None)),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
+        assert [row["id"] for row in rows] == ["u1"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_4xx_raises_immediately(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=401)])
+
+        manager = _make_manager()
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("users", manager))
+
+        assert session.send.call_count == 1
+
+
+class TestGetRowsCashFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_over_cash_accounts_and_injects_account_id(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "acc_1"}, {"id": "acc_2"}], None)),
+                _response(_page([{"id": "tx_1", "posted_at_date": "2024-01-01"}], None)),
+                _response(_page([{"id": "tx_2", "posted_at_date": "2024-01-02"}], None)),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("cash_transactions", manager))
+
+        assert [(row["id"], row["account_id"]) for row in rows] == [("tx_1", "acc_1"), ("tx_2", "acc_2")]
+        # The framework's include_from_parent key is renamed away — rows keep their old shape.
+        assert all("_cash_accounts_id" not in row for row in rows)
+
+        urls = [snapshot["url"] for snapshot in snapshots]
+        assert urls[0] == "https://api.brex.com/v2/accounts/cash"
+        assert snapshots[0]["params"] == {"limit": 100}
+        assert urls[1] == "https://api.brex.com/v2/transactions/cash/acc_1"
+        assert urls[2] == "https://api.brex.com/v2/transactions/cash/acc_2"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_fanout_checkpoints_between_accounts(self, MockSession):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(_page([{"id": "acc_1"}, {"id": "acc_2"}], None)),
+                _response(_page([{"id": "tx_1"}], "cursor-a")),
+                _response(_page([{"id": "tx_2"}], None)),
+                _response(_page([{"id": "tx_3"}], None)),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("cash_transactions", manager))
+
+        saved_states = [call.args[0].fanout_state for call in manager.save_state.call_args_list]
+        acc_1_path = CASH_TX_PATH.format(account_id="acc_1")
+        # Mid-account checkpoint carries the account's cursor; completing an account moves it
+        # into the completed list.
+        assert {"completed": [], "current": acc_1_path, "child_state": {"cursor": "cursor-a"}} in saved_states
+        assert saved_states[-1]["completed"] == [
+            acc_1_path,
+            CASH_TX_PATH.format(account_id="acc_2"),
+        ]
+        assert saved_states[-1]["current"] is None
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_accounts_and_uses_cursor(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "acc_1"}, {"id": "acc_2"}], None)),
+                _response(_page([{"id": "tx_9"}], None)),
+            ],
+        )
+
+        manager = _make_manager(
+            BrexResumeConfig(
+                fanout_state={
+                    "completed": [CASH_TX_PATH.format(account_id="acc_1")],
+                    "current": CASH_TX_PATH.format(account_id="acc_2"),
+                    "child_state": {"cursor": "cursor-mid"},
+                }
+            )
+        )
+        rows = _rows(_source("cash_transactions", manager))
+
+        assert [(row["id"], row["account_id"]) for row in rows] == [("tx_9", "acc_2")]
+        assert len(snapshots) == 2
+        assert snapshots[1]["url"].endswith("/transactions/cash/acc_2")
+        assert snapshots[1]["params"]["cursor"] == "cursor-mid"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_translates_pre_framework_state(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "acc_1"}, {"id": "acc_2"}], None)),
+                _response(_page([{"id": "tx_9"}], None)),
+            ],
+        )
+
+        manager = _make_manager(
+            BrexResumeConfig(cursor="cursor-mid", account_id="acc_2", completed_account_ids=["acc_1"])
+        )
+        rows = _rows(_source("cash_transactions", manager))
+
+        assert [(row["id"], row["account_id"]) for row in rows] == [("tx_9", "acc_2")]
+        assert len(snapshots) == 2
+        assert snapshots[1]["url"].endswith("/transactions/cash/acc_2")
+        assert snapshots[1]["params"]["cursor"] == "cursor-mid"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_cursor_not_applied_to_other_accounts(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "acc_1"}], None)),
+                _response(_page([{"id": "tx_1"}], None)),
+            ],
+        )
+
+        manager = _make_manager(BrexResumeConfig(cursor="cursor-mid", account_id="acc_gone", completed_account_ids=[]))
+        _rows(_source("cash_transactions", manager))
+
+        assert "cursor" not in snapshots[1]["params"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_cash_account_listing(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "acc_1"}], "acc-cursor-2")),
+                _response(_page([{"id": "tx_1"}], None)),
+                _response(_page([{"id": "acc_2"}], None)),
+                _response(_page([{"id": "tx_2"}], None)),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("cash_transactions", manager))
+
+        assert [(row["id"], row["account_id"]) for row in rows] == [("tx_1", "acc_1"), ("tx_2", "acc_2")]
+        # Parent pages are consumed lazily: accounts page 1, its transactions, accounts page 2, ...
+        assert "accounts/cash" in snapshots[0]["url"]
+        assert "transactions/cash/acc_1" in snapshots[1]["url"]
+        assert "accounts/cash" in snapshots[2]["url"]
+        assert snapshots[2]["params"]["cursor"] == "acc-cursor-2"
+        assert "transactions/cash/acc_2" in snapshots[3]["url"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_applied_per_account(self, MockSession):
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "acc_1"}], None)),
+                _response(_page([{"id": "tx_1"}], None)),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(
+            _source(
+                "cash_transactions",
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value="2024-01-02",
+            )
+        )
+
         # Account listing carries no filter; the per-account transaction call does.
-        assert "posted_at_start" not in urls[0]
-        assert "posted_at_start=2024-01-02T00%3A00%3A00Z" in urls[1]
+        assert "posted_at_start" not in snapshots[0]["params"]
+        assert snapshots[1]["params"]["posted_at_start"] == "2024-01-02T00:00:00Z"
 
 
+@mock.patch(CLIENT_SESSION_PATCH)
 class TestBrexSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    def test_response_metadata_per_endpoint(self, MockSession, endpoint):
         config = BREX_ENDPOINTS[endpoint]
-        response = brex_source("bxt_token", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -395,18 +519,18 @@ class TestBrexSourceResponse:
             assert response.partition_mode is None
             assert response.partition_keys is None
 
-    def test_cash_transactions_use_composite_primary_key(self):
-        response = brex_source("bxt_token", "cash_transactions", mock.MagicMock(), _make_manager())
+    def test_cash_transactions_use_composite_primary_key(self, MockSession):
+        response = _source("cash_transactions", _make_manager())
         assert response.primary_keys == ["account_id", "id"]
 
-    def test_budgets_primary_key_is_budget_id(self):
-        response = brex_source("bxt_token", "budgets", mock.MagicMock(), _make_manager())
+    def test_budgets_primary_key_is_budget_id(self, MockSession):
+        response = _source("budgets", _make_manager())
         assert response.primary_keys == ["budget_id"]
 
     @pytest.mark.parametrize("config", list(BREX_ENDPOINTS.values()))
-    def test_partition_keys_are_stable_posted_dates(self, config):
+    def test_partition_keys_are_stable_posted_dates(self, MockSession, config):
         if config.partition_key:
             assert config.partition_key == "posted_at_date"
 
-    def test_incremental_fields_only_declared_for_filterable_endpoints(self):
+    def test_incremental_fields_only_declared_for_filterable_endpoints(self, MockSession):
         assert set(INCREMENTAL_FIELDS.keys()) == {"card_transactions", "cash_transactions", "expenses"}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brex/tests/test_brex_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brex/tests/test_brex_source.py
@@ -148,6 +148,8 @@ class TestBrexSource:
         kwargs = mock_brex_source.call_args.kwargs
         assert kwargs["api_key"] == "bxt_test_token"
         assert kwargs["endpoint"] == "expenses"
+        assert kwargs["team_id"] is inputs.team_id
+        assert kwargs["job_id"] is inputs.job_id
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2024-01-01T00:00:00Z"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/resource.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/resource.py
@@ -49,7 +49,10 @@ class Resource:
             return None
         return {key: value.get("data_type") for key, value in columns.items()}
 
-    def add_map(self, fn: Callable[[dict[str, Any]], dict[str, Any]]) -> "Resource":
+    def add_map(self, fn: Callable[[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]) -> "Resource":
+        """Add a per-item transform. Returning a dict maps 1:1; returning a list explodes the item
+        1-to-many (e.g. flattening a report bucket's ``results[]`` into one row per result, with
+        parent-bucket fields merged in). Later maps apply to each exploded row."""
         self._maps.append(fn)
         return self
 
@@ -75,9 +78,19 @@ class Resource:
                     break
             if skip:
                 continue
+            # A map may return a dict (1:1) or a list of dicts (1-to-many explode); subsequent
+            # maps apply to every row produced so far.
+            current: list[dict[str, Any]] = [item]
             for m in self._maps:
-                item = m(item)
-            result.append(item)
+                next_rows: list[dict[str, Any]] = []
+                for row in current:
+                    mapped = m(row)
+                    if isinstance(mapped, list):
+                        next_rows.extend(mapped)
+                    else:
+                        next_rows.append(mapped)
+                current = next_rows
+            result.extend(current)
         return result
 
     def _iter_generator(self, call_kwargs: dict[str, Any]) -> Iterator[list[dict[str, Any]]]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_resource.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_resource.py
@@ -128,3 +128,24 @@ class TestResource:
             {"id": 1, "name": "ALICE"},
             {"id": 3, "name": "CHARLIE"},
         ]
+
+
+class TestOneToManyMap:
+    def test_map_returning_list_explodes_item(self) -> None:
+        resource = Resource(lambda: iter([[{"bucket": "b1", "results": [{"v": 1}, {"v": 2}]}]]), name="r", hints={})
+        resource.add_map(lambda row: [{"bucket": row["bucket"], **r} for r in row["results"]])
+        pages = list(resource)
+        assert pages == [[{"bucket": "b1", "v": 1}, {"bucket": "b1", "v": 2}]]
+
+    def test_map_returning_empty_list_drops_item(self) -> None:
+        resource = Resource(lambda: iter([[{"results": []}, {"results": [{"v": 1}]}]]), name="r", hints={})
+        resource.add_map(lambda row: [dict(r) for r in row["results"]])
+        pages = list(resource)
+        assert pages == [[{"v": 1}]]
+
+    def test_later_maps_apply_to_exploded_rows(self) -> None:
+        resource = Resource(lambda: iter([[{"results": [{"v": 1}, {"v": 2}]}]]), name="r", hints={})
+        resource.add_map(lambda row: [dict(r) for r in row["results"]])
+        resource.add_map(lambda row: {**row, "doubled": row["v"] * 2})
+        pages = list(resource)
+        assert pages == [[{"v": 1, "doubled": 2}, {"v": 2, "doubled": 4}]]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -253,7 +253,7 @@ class EndpointResourceBase(ResourceBase, total=False):
     # Per-item transform applied after ``data_selector`` and before type coercion, for reshaping
     # a row the selector can't express (e.g. flattening JSON:API ``attributes`` into the row root).
     # Wired through to ``Resource.add_map``; must be dict -> dict (1:1).
-    data_map: Optional[Callable[[dict[str, Any]], dict[str, Any]]]
+    data_map: Optional[Callable[[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]]
 
 
 class EndpointResource(EndpointResourceBase, total=False):


### PR DESCRIPTION
## Problem

Sixth batch of hand-rolled source → `rest_source` migrations, stacked on #71565.

## Changes

**Framework: `data_map` may return a list (1-to-many explode).** Report-style APIs return buckets each containing N results; emitting one row per result with parent-bucket fields merged in needs a 1-to-many transform. A `data_map` returning a list of dicts now explodes the item (empty list drops it); returning a dict keeps the 1:1 behavior. This unlocked `anthropic` below.

**Three sources migrated** (behavior-preserving, suites green): `anthropic` (51 tests — usage/cost report bucket→results explode via the new `data_map`, cursor pagination, workspace fan-out), `baseten` (45 — cursor + fan-out with resume), `brex` (81).

**Vetted and skipped**: `azure_devops` (signals expired PATs via HTTP 203 + HTML sign-in page, which must classify as a permanent auth error; the framework classifies by status only — a generic `response_actions: raise` is the future fix), `bitly`/`bigcommerce` (unimplemented stubs, not migration targets).

> [!NOTE]
> Stacked on #71565 → #71559 → #71552 → #71540 → #71524 → #71520 → #71481/#71477.

## How did you test this code?

- Merged verification: **317 tests pass** across the 3 migrated sources + the full `rest_source` suite (incl. 3 new 1-to-many `data_map` tests: explode, empty-list drop, chained maps).
- Each source's suite passed in isolation first; coverage preserved. Worktree isolation verified before merge. `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
