### PR TITLE
fix(data-modeling): drop duplicate count() execution in v2 materialization

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -273,62 +273,6 @@ async def _write_empty_parquet_for_zero_rows(table_uri: str, schema: pa.Schema, 
     return file_uri
 
 
-async def get_query_row_count(
-    query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None
-) -> int:
-    """Get the total row count for a HogQL query."""
-    count_query = f"SELECT count() FROM ({query})"
-
-    query_node = parse_select(count_query)
-
-    settings = HogQLGlobalSettings()
-    settings.max_execution_time = HOGQL_INCREASED_MAX_EXECUTION_TIME
-
-    context = HogQLContext(
-        team=team,
-        enable_select_queries=True,
-        limit_top_select=False,
-    )
-    context.output_format = "TabSeparated"
-    # Userless materialization context; bypass warehouse HogQL access control so the model query
-    # can resolve its source tables/views.
-    context.database = await database_sync_to_async_pool(Database.create_for)(
-        team=team, modifiers=context.modifiers, bypass_warehouse_access_control=True
-    )
-
-    prepared_hogql_query = await database_sync_to_async_pool(prepare_ast_for_printing)(
-        query_node,
-        context=context,
-        dialect="clickhouse",
-        settings=settings,
-        stack=[],
-        resolver_factory=bounded_resolver_factory_for_view(view_name),
-    )
-
-    if prepared_hogql_query is None:
-        raise EmptyHogQLResponseColumnsError()
-
-    printed = await database_sync_to_async_pool(print_prepared_ast)(
-        prepared_hogql_query,
-        context=context,
-        dialect="clickhouse",
-        settings=settings,
-        stack=[],
-    )
-
-    await logger.adebug(f"Running count query: {printed}")
-
-    async with _clickhouse_query_semaphore, get_clickhouse_client() as client:
-        async with client.apost_query(
-            query=printed,
-            query_parameters=context.values,
-            query_id=str(uuid.uuid4()),
-        ) as response:
-            result = await response.content.read()
-        count = int(result.decode("utf-8").strip())
-        return count
-
-
 async def _read_arrow_schema_from_query(client, query: str, query_parameters: dict) -> pa.Schema:
     """Fetch just the Arrow schema for a query that returned zero rows.
 
@@ -547,15 +491,6 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
             await logger.adebug(f"Skipping deletion because table not found: uri={table_uri}")
 
         hogql_query = typing.cast(dict, saved_query.query)["query"]
-        try:
-            rows_expected = await get_query_row_count(hogql_query, team, logger, view_name=saved_query.name)
-            await logger.ainfo(f"Expected rows: {rows_expected}")
-            job.rows_expected = rows_expected
-            await database_sync_to_async_pool(job.save)()
-        except Exception as e:
-            await logger.awarning(f"Failed to get expected row count: {str(e)}. Continuing without progress tracking.")
-            job.rows_expected = None
-            await database_sync_to_async_pool(job.save)()
 
         row_count = 0
         storage_options = _get_aws_storage_options()
@@ -601,14 +536,6 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
             await database_sync_to_async_pool(job.save)()
 
         await logger.ainfo(f"Finished writing to delta table. row_count={row_count}")
-        # row count validation warning
-        if job.rows_expected is not None:
-            if row_count != job.rows_expected:
-                await logger.awarning(
-                    "Row count mismatch after materialization",
-                    expected=job.rows_expected,
-                    actual=row_count,
-                )
         file_uris = []
         if delta_table is not None:
             await logger.ainfo("Compacting delta table")

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -798,10 +798,6 @@ class TestMaterializeViewActivity:
             unittest.mock.patch(
                 "posthog.temporal.data_modeling.activities.materialize_view.hogql_table", mock_hogql_table
             ),
-            unittest.mock.patch(
-                "posthog.temporal.data_modeling.activities.materialize_view.get_query_row_count",
-                return_value=3,
-            ),
         ):
             inputs = MaterializeViewInputs(
                 team_id=ateam.pk,
@@ -841,10 +837,6 @@ class TestMaterializeViewActivity:
             unittest.mock.patch(
                 "posthog.temporal.data_modeling.activities.materialize_view.hogql_table", mock_hogql_table
             ),
-            unittest.mock.patch(
-                "posthog.temporal.data_modeling.activities.materialize_view.get_query_row_count",
-                return_value=5,
-            ),
         ):
             inputs = MaterializeViewInputs(
                 team_id=ateam.pk,
@@ -854,7 +846,7 @@ class TestMaterializeViewActivity:
             )
             result = await activity_environment.run(materialize_view_activity, inputs)
             await database_sync_to_async(ajob.refresh_from_db)()
-            assert ajob.rows_expected == 5
+            assert ajob.rows_expected is None
             assert ajob.rows_materialized == 5
             assert result.row_count == 5
 
@@ -897,10 +889,6 @@ class TestMaterializeViewActivity:
             ),
             unittest.mock.patch(
                 "posthog.temporal.data_modeling.activities.materialize_view.hogql_table", mock_hogql_table
-            ),
-            unittest.mock.patch(
-                "posthog.temporal.data_modeling.activities.materialize_view.get_query_row_count",
-                return_value=6,
             ),
         ):
             inputs = MaterializeViewInputs(
@@ -957,10 +945,6 @@ class TestMaterializeViewActivity:
             unittest.mock.patch(
                 "posthog.temporal.data_modeling.activities.materialize_view.hogql_table", mock_hogql_table
             ),
-            unittest.mock.patch(
-                "posthog.temporal.data_modeling.activities.materialize_view.get_query_row_count",
-                return_value=6,
-            ),
         ):
             inputs = MaterializeViewInputs(
                 team_id=ateam.pk,
@@ -1008,10 +992,6 @@ class TestMaterializeViewActivity:
             ),
             unittest.mock.patch(
                 "posthog.temporal.data_modeling.activities.materialize_view.hogql_table", mock_hogql_table
-            ),
-            unittest.mock.patch(
-                "posthog.temporal.data_modeling.activities.materialize_view.get_query_row_count",
-                return_value=0,
             ),
         ):
             inputs = MaterializeViewInputs(
@@ -1061,10 +1041,6 @@ class TestMaterializeViewActivity:
             ),
             unittest.mock.patch(
                 "posthog.temporal.data_modeling.activities.materialize_view.hogql_table", mock_hogql_table
-            ),
-            unittest.mock.patch(
-                "posthog.temporal.data_modeling.activities.materialize_view.get_query_row_count",
-                return_value=16,
             ),
             unittest.mock.patch("deltalake.write_deltalake", side_effect=raising_write),
         ):


### PR DESCRIPTION
## Problem

V2 data-modeling refreshes scanned each model twice: once for a row-count progress estimate and once to materialize the result.

## Changes

- Remove the v2-only count pre-pass.
- Continue reporting streamed `rows_materialized` while leaving `rows_expected` unset.

## How did you test this code?

- Ran the focused data-modeling materialization and node API pytest suite through the activated environment.
- The focused suite exercises v2 materialization after the count pre-pass removal.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this user-directed, v2-only change. The `/writing-tests` skill informed the focused regression coverage. V1 remains untouched.
