### PR TITLE
feat(data-modeling): expose node suspension state in the nodes API

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -79,6 +79,7 @@ import type {
 import { QueryContext } from '~/queries/types'
 
 import { AlertType } from 'products/alerts/frontend/types'
+import type { NodeApiSuspended } from 'products/data_modeling/frontend/generated/api.schemas'
 import type { ExperimentFeatureFlagInputApi } from 'products/experiments/frontend/generated/api.schemas'
 import type { InsightFilterOverrideContextApi } from 'products/product_analytics/frontend/generated/api.schemas'
 import type { AIPromptConfigApi } from 'products/subscriptions/frontend/generated/api.schemas'
@@ -6046,6 +6047,8 @@ export interface DataModelingNode {
     last_run_at?: string
     last_run_status?: DataModelingJobStatus
     sync_interval?: DataModelingSyncInterval
+    /** Suspension state keyed by materialization engine; null/absent when not suspended */
+    suspended?: NodeApiSuspended
 }
 
 export interface DataModelingEdge {

--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -121,15 +121,15 @@ class AsyncRecordBatchReader:
         return await self.read_next_record_batch()
 
     async def read_next_record_batch(self) -> pa.RecordBatch:
-        if self._schema is None:
-            schema = await self.read_schema()
-            self._schema = schema
-        else:
-            schema = self._schema
-
+        schema = await self.get_schema()
         message = await anext(self._reader)
 
         return pa.ipc.read_record_batch(message, schema)
+
+    async def get_schema(self) -> pa.Schema:
+        if self._schema is None:
+            self._schema = await self.read_schema()
+        return self._schema
 
     async def read_schema(self) -> pa.Schema:
         """Read the schema, which should be the first message."""

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -892,6 +892,7 @@ class ClickHouseClient:
         *data,
         query_parameters=None,
         query_id: str | None = None,
+        on_schema: collections.abc.Callable[[pa.Schema], None] | None = None,
     ) -> typing.AsyncGenerator[pa.RecordBatch]:
         """Execute the given query in ClickHouse and stream back the response as Arrow record batches.
 
@@ -899,6 +900,8 @@ class ClickHouseClient:
         """
         async with self.apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
             reader = asyncpa.AsyncRecordBatchReader(ChunkBytesAsyncStreamIterator(response.content))
+            if on_schema is not None:
+                on_schema(await reader.get_schema())
             async for batch in reader:
                 yield batch
 

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -273,20 +273,6 @@ async def _write_empty_parquet_for_zero_rows(table_uri: str, schema: pa.Schema, 
     return file_uri
 
 
-async def _read_arrow_schema_from_query(client, query: str, query_parameters: dict) -> pa.Schema:
-    """Fetch just the Arrow schema for a query that returned zero rows.
-
-    The streaming reader hides the schema when there are no batches, so we re-issue the
-    same query and read the schema message that ClickHouse always sends in ArrowStream
-    format. The response for a zero-row result is just the schema + EOS, so reading the
-    full body is cheap.
-    """
-    async with client.apost_query(query=query, query_parameters=query_parameters, query_id=str(uuid.uuid4())) as resp:
-        data = await resp.content.read()
-    reader = pa.ipc.open_stream(pa.BufferReader(data))
-    return reader.schema
-
-
 async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view_name: str | None = None):
     """Execute a HogQL query and yield batches of results."""
     query_node = parse_select(query)
@@ -412,8 +398,18 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
         batches = []
         batches_size = 0
         yielded_results = False
+        arrow_schema: pa.Schema | None = None
         ch_typings_pairs = [(column_name, column_type) for column_name, column_type, _ in query_typings]
-        async for batch in client.astream_query_as_arrow(arrow_printed, query_parameters=context.values):
+
+        def capture_arrow_schema(schema: pa.Schema) -> None:
+            nonlocal arrow_schema
+            arrow_schema = schema
+
+        async for batch in client.astream_query_as_arrow(
+            arrow_printed,
+            query_parameters=context.values,
+            on_schema=capture_arrow_schema,
+        ):
             batches_size = batches_size + batch.nbytes
             batches.append(batch)
 
@@ -436,8 +432,11 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
             await logger.adebug(
                 "Query returned zero batches; yielding empty batch with schema for queryable empty table"
             )
-            schema = await _read_arrow_schema_from_query(client, arrow_printed, context.values)
-            empty_batch = pa.RecordBatch.from_arrays([pa.array([], type=field.type) for field in schema], schema=schema)
+            if arrow_schema is None:
+                raise EmptyHogQLResponseColumnsError()
+            empty_batch = pa.RecordBatch.from_arrays(
+                [pa.array([], type=field.type) for field in arrow_schema], schema=arrow_schema
+            )
             yield (empty_batch, ch_typings_pairs)
 
 

--- a/posthog/temporal/tests/common/test_asyncpa.py
+++ b/posthog/temporal/tests/common/test_asyncpa.py
@@ -86,6 +86,7 @@ async def test_record_batch_reader_reads_record_batches(record_batches: collecti
 
         _ = buffer.seek(0)
 
+        assert await reader.get_schema() == first_batch.schema
         read_batch = await anext(reader)
 
         assert first_batch == read_batch

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,3 +1,4 @@
+import contextlib
 from collections.abc import Collection, Iterable
 from typing import Any, cast
 
@@ -25,8 +26,10 @@ from posthog.temporal.data_modeling.activities import (
     succeed_materialization_activity,
 )
 from posthog.temporal.data_modeling.activities.materialize_view import (
+    LOGGER,
     InvalidNodeTypeException,
     _get_aws_storage_options,
+    hogql_table,
 )
 
 from products.data_modeling.backend.facade.api import compute_enrichment_hash
@@ -1052,3 +1055,57 @@ class TestMaterializeViewActivity:
             )
             with pytest.raises(RuntimeError, match="boom"):
                 await activity_environment.run(materialize_view_activity, inputs)
+
+
+class _EmptyArrowClient:
+    def __init__(self, schema: pa.Schema):
+        self.schema = schema
+        self.arrow_query_calls = 0
+        self.schema_query_calls = 0
+
+    async def astream_query_as_arrow(self, query, *data, query_parameters=None, query_id=None, on_schema=None):
+        self.arrow_query_calls += 1
+        if on_schema is not None:
+            on_schema(self.schema)
+        return
+        yield
+
+    @contextlib.asynccontextmanager
+    async def apost_query(self, query, *data, query_parameters=None, query_id=None):
+        if query.startswith("DESCRIBE TABLE"):
+            body = b"id\tInt64\n"
+        else:
+            self.schema_query_calls += 1
+            buffer = pa.BufferOutputStream()
+            with pa.ipc.new_stream(buffer, self.schema):
+                pass
+            body = buffer.getvalue().to_pybytes()
+
+        class _Response:
+            def __init__(self, response_body: bytes):
+                self.content = self
+                self.body = response_body
+
+            async def read(self) -> bytes:
+                return self.body
+
+        yield _Response(body)
+
+
+class TestHogqlTableEmptyResults:
+    async def test_zero_row_query_uses_the_initial_stream_schema(self, ateam):
+        client = _EmptyArrowClient(pa.schema([pa.field("id", pa.int64())]))
+
+        @contextlib.asynccontextmanager
+        async def fake_get_client(**kwargs):
+            yield client
+
+        with unittest.mock.patch(
+            "posthog.temporal.data_modeling.activities.materialize_view.get_clickhouse_client", fake_get_client
+        ):
+            batches = [batch async for batch in hogql_table("SELECT 1", ateam, LOGGER.bind())]
+
+        assert len(batches) == 1
+        assert batches[0][0].num_rows == 0
+        assert client.arrow_query_calls == 1
+        assert client.schema_query_calls == 0

--- a/products/data_modeling/backend/presentation/views/node.py
+++ b/products/data_modeling/backend/presentation/views/node.py
@@ -29,9 +29,11 @@ from products.warehouse_sources.backend.facade.models import sync_frequency_inte
 
 
 class NodeSuspensionEntrySerializer(serializers.Serializer):
-    at = serializers.DateTimeField(help_text="When the node was suspended.")
-    reason = serializers.CharField(help_text="Error from the failing run that triggered the suspension.")
-    job_id = serializers.CharField(help_text="ID of the data modeling job whose failure triggered the suspension.")
+    at = serializers.DateTimeField(allow_null=True, help_text="When the node was suspended, if available.")
+    reason = serializers.CharField(
+        allow_null=True, help_text="Error from the failing run that triggered the suspension, if available."
+    )
+    job_id = serializers.CharField(allow_null=True, help_text="ID of the triggering data modeling job, if available.")
 
 
 class NodeSerializer(serializers.ModelSerializer):
@@ -103,7 +105,20 @@ class NodeSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(serializers.DictField(child=NodeSuspensionEntrySerializer(), allow_null=True))
     def get_suspended(self, node: Node) -> dict[str, Any] | None:
-        return (node.properties or {}).get("system", {}).get("suspended") or None
+        suspended = (node.properties or {}).get("system", {}).get("suspended")
+        if not isinstance(suspended, dict):
+            return None
+
+        normalized_suspensions = {
+            str(engine): self._normalize_suspension_entry(entry) for engine, entry in suspended.items() if entry
+        }
+        return normalized_suspensions or None
+
+    @staticmethod
+    def _normalize_suspension_entry(entry: Any) -> dict[str, Any]:
+        if not isinstance(entry, dict):
+            return {"at": None, "reason": None, "job_id": None}
+        return {"at": entry.get("at"), "reason": entry.get("reason"), "job_id": entry.get("job_id")}
 
     def get_sync_interval(self, node: Node) -> str | None:
         if node.saved_query:

--- a/products/data_modeling/backend/presentation/views/node.py
+++ b/products/data_modeling/backend/presentation/views/node.py
@@ -9,7 +9,7 @@ from django.db import models
 from django.db.models import OuterRef, Subquery
 
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from rest_framework import filters, request, response, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
@@ -28,6 +28,12 @@ from products.data_modeling.backend.facade.models import DAG, Edge, Node, NodeTy
 from products.warehouse_sources.backend.facade.models import sync_frequency_interval_to_sync_frequency
 
 
+class NodeSuspensionEntrySerializer(serializers.Serializer):
+    at = serializers.DateTimeField(help_text="When the node was suspended.")
+    reason = serializers.CharField(help_text="Error from the failing run that triggered the suspension.")
+    job_id = serializers.CharField(help_text="ID of the data modeling job whose failure triggered the suspension.")
+
+
 class NodeSerializer(serializers.ModelSerializer):
     upstream_count = serializers.SerializerMethodField(read_only=True)
     downstream_count = serializers.SerializerMethodField(read_only=True)
@@ -36,6 +42,10 @@ class NodeSerializer(serializers.ModelSerializer):
     user_tag = serializers.SerializerMethodField(read_only=True)
     sync_interval = serializers.SerializerMethodField(read_only=True)
     dag_name = serializers.SerializerMethodField(read_only=True)
+    suspended = serializers.SerializerMethodField(
+        read_only=True,
+        help_text="Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.",
+    )
     dag = TeamScopedPrimaryKeyRelatedField(queryset=DAG.objects.all())
 
     class Meta:
@@ -56,6 +66,7 @@ class NodeSerializer(serializers.ModelSerializer):
             "last_run_status",
             "user_tag",
             "sync_interval",
+            "suspended",
         ]
         read_only_fields = [
             "upstream_count",
@@ -64,6 +75,7 @@ class NodeSerializer(serializers.ModelSerializer):
             "last_run_status",
             "user_tag",
             "sync_interval",
+            "suspended",
             "dag_name",
             "saved_query_id",
         ]
@@ -88,6 +100,10 @@ class NodeSerializer(serializers.ModelSerializer):
 
     def get_user_tag(self, node: Node) -> str | None:
         return node.properties.get("user", {}).get("tag")
+
+    @extend_schema_field(serializers.DictField(child=NodeSuspensionEntrySerializer(), allow_null=True))
+    def get_suspended(self, node: Node) -> dict[str, Any] | None:
+        return (node.properties or {}).get("system", {}).get("suspended") or None
 
     def get_sync_interval(self, node: Node) -> str | None:
         if node.saved_query:

--- a/products/data_modeling/backend/tests/api/test_node_api.py
+++ b/products/data_modeling/backend/tests/api/test_node_api.py
@@ -130,6 +130,18 @@ class TestNodeViewSet(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.json()["suspended"])
 
+    def test_node_response_normalizes_legacy_suspension_state(self):
+        self.view_node.properties = {"system": {"suspended": {"duckdb": True}}}
+        self.view_node.save()
+
+        response = self.client.get(f"/api/environments/{self.team.id}/data_modeling_nodes/{self.view_node.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["suspended"],
+            {"duckdb": {"at": None, "reason": None, "job_id": None}},
+        )
+
     def test_dag_ids_action(self):
         another_dag = DAG.objects.create(team=self.team, name="another_dag")
         Node.objects.create(

--- a/products/data_modeling/backend/tests/api/test_node_api.py
+++ b/products/data_modeling/backend/tests/api/test_node_api.py
@@ -117,6 +117,19 @@ class TestNodeViewSet(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["dag_name"], self.dag_id)
 
+    def test_node_response_includes_suspension_state(self):
+        suspension = {"at": "2026-07-16T00:00:00+00:00", "reason": "Timeout exceeded", "job_id": "job-1"}
+        self.view_node.properties = {"system": {"suspended": {"clickhouse": suspension}}}
+        self.view_node.save()
+
+        response = self.client.get(f"/api/environments/{self.team.id}/data_modeling_nodes/{self.view_node.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["suspended"], {"clickhouse": suspension})
+
+        response = self.client.get(f"/api/environments/{self.team.id}/data_modeling_nodes/{self.table_node.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.json()["suspended"])
+
     def test_dag_ids_action(self):
         another_dag = DAG.objects.create(team=self.team, name="another_dag")
         Node.objects.create(

--- a/products/data_modeling/frontend/generated/api.schemas.ts
+++ b/products/data_modeling/frontend/generated/api.schemas.ts
@@ -104,6 +104,21 @@ export const NodeTypeEnumApi = {
     Endpoint: 'endpoint',
 } as const
 
+export interface NodeSuspensionEntryApi {
+    /** When the node was suspended. */
+    at: string
+    /** Error from the failing run that triggered the suspension. */
+    reason: string
+    /** ID of the data modeling job whose failure triggered the suspension. */
+    job_id: string
+}
+
+/**
+ * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+ * @nullable
+ */
+export type NodeApiSuspended = { [key: string]: NodeSuspensionEntryApi } | null
+
 export interface NodeApi {
     readonly id: string
     /** @maxLength 2048 */
@@ -128,6 +143,11 @@ export interface NodeApi {
     readonly user_tag: string | null
     /** @nullable */
     readonly sync_interval: string | null
+    /**
+     * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+     * @nullable
+     */
+    readonly suspended: NodeApiSuspended
 }
 
 export interface PaginatedNodeListApi {
@@ -138,6 +158,12 @@ export interface PaginatedNodeListApi {
     previous?: string | null
     results: NodeApi[]
 }
+
+/**
+ * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+ * @nullable
+ */
+export type PatchedNodeApiSuspended = { [key: string]: NodeSuspensionEntryApi } | null
 
 export interface PatchedNodeApi {
     readonly id?: string
@@ -163,6 +189,11 @@ export interface PatchedNodeApi {
     readonly user_tag?: string | null
     /** @nullable */
     readonly sync_interval?: string | null
+    /**
+     * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+     * @nullable
+     */
+    readonly suspended?: PatchedNodeApiSuspended
 }
 
 export type DataModelingDagsListParams = {

--- a/products/data_modeling/frontend/generated/api.schemas.ts
+++ b/products/data_modeling/frontend/generated/api.schemas.ts
@@ -105,12 +105,21 @@ export const NodeTypeEnumApi = {
 } as const
 
 export interface NodeSuspensionEntryApi {
-    /** When the node was suspended. */
-    at: string
-    /** Error from the failing run that triggered the suspension. */
-    reason: string
-    /** ID of the data modeling job whose failure triggered the suspension. */
-    job_id: string
+    /**
+     * When the node was suspended, if available.
+     * @nullable
+     */
+    at: string | null
+    /**
+     * Error from the failing run that triggered the suspension, if available.
+     * @nullable
+     */
+    reason: string | null
+    /**
+     * ID of the triggering data modeling job, if available.
+     * @nullable
+     */
+    job_id: string | null
 }
 
 /**

--- a/products/data_modeling/frontend/lineage/LineageNode.test.tsx
+++ b/products/data_modeling/frontend/lineage/LineageNode.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { SuspendedTag } from './LineageNode'
+
+afterEach(cleanup)
+
+describe('SuspendedTag', () => {
+    it('shows suspension details when they are available', async () => {
+        render(
+            <SuspendedTag
+                suspended={{
+                    clickhouse: {
+                        at: '2026-07-16T12:00:00Z',
+                        reason: 'Query exceeded its resource limit',
+                        job_id: 'job-id',
+                    },
+                }}
+            />
+        )
+
+        await userEvent.hover(screen.getByText('suspended'))
+
+        await waitFor(() => {
+            expect(document.body.textContent).toContain('Query exceeded its resource limit')
+        })
+    })
+
+    it('shows a safe fallback when legacy suspension details are unavailable', async () => {
+        render(
+            <SuspendedTag
+                suspended={{
+                    clickhouse: {
+                        at: null,
+                        reason: null,
+                        job_id: null,
+                    },
+                }}
+            />
+        )
+
+        await userEvent.hover(screen.getByText('suspended'))
+
+        await waitFor(() => {
+            expect(screen.getByText('Suspended (details unavailable)')).toBeTruthy()
+        })
+    })
+})

--- a/products/data_modeling/frontend/lineage/LineageNode.tsx
+++ b/products/data_modeling/frontend/lineage/LineageNode.tsx
@@ -93,15 +93,21 @@ function StatusDot({ status }: { status?: DataModelingJobStatus }): JSX.Element 
     )
 }
 
-function SuspendedTag({ suspended }: { suspended: NonNullable<LineageNodeShape['suspended']> }): JSX.Element {
+export function SuspendedTag({ suspended }: { suspended: NonNullable<LineageNodeShape['suspended']> }): JSX.Element {
     return (
         <Tooltip
             title={
                 <div className="space-y-1">
                     {Object.entries(suspended).map(([engine, entry]) => (
                         <div key={engine}>
-                            Suspended after repeated failed runs (<TZLabel time={entry.at} />
-                            ): {entry.reason}
+                            {entry.at && entry.reason ? (
+                                <>
+                                    Suspended after repeated failed runs (<TZLabel time={entry.at} />
+                                    ): {entry.reason}
+                                </>
+                            ) : (
+                                'Suspended (details unavailable)'
+                            )}
                         </div>
                     ))}
                 </div>

--- a/products/data_modeling/frontend/lineage/LineageNode.tsx
+++ b/products/data_modeling/frontend/lineage/LineageNode.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import React, { useCallback, useState } from 'react'
 
 import { IconActivity, IconClockRewind, IconPencil, IconPlay, IconPlayFilled, IconTarget } from '@posthog/icons'
-import { LemonButton, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { ElkDirection, NodeHandle } from 'scenes/data-warehouse/scene/modeling/types'
@@ -28,6 +28,7 @@ export type LineageNodeShape = Pick<
     | 'upstream_count'
     | 'downstream_count'
     | 'user_tag'
+    | 'suspended'
 >
 
 export interface LineageNodeState {
@@ -88,6 +89,27 @@ function StatusDot({ status }: { status?: DataModelingJobStatus }): JSX.Element 
                     !status && 'bg-surface-primary'
                 )}
             />
+        </Tooltip>
+    )
+}
+
+function SuspendedTag({ suspended }: { suspended: NonNullable<LineageNodeShape['suspended']> }): JSX.Element {
+    return (
+        <Tooltip
+            title={
+                <div className="space-y-1">
+                    {Object.entries(suspended).map(([engine, entry]) => (
+                        <div key={engine}>
+                            Suspended after repeated failed runs (<TZLabel time={entry.at} />
+                            ): {entry.reason}
+                        </div>
+                    ))}
+                </div>
+            }
+        >
+            <LemonTag type="warning" size="small">
+                suspended
+            </LemonTag>
         </Tooltip>
     )
 }
@@ -156,7 +178,10 @@ function MetadataBar({ node }: { node: LineageNodeShape }): JSX.Element {
                     <Tooltip title="This node has not been run yet">Never</Tooltip>
                 )}
             </div>
-            <StatusDot status={node.last_run_status} />
+            <div className="flex items-center gap-1">
+                {node.suspended && <SuspendedTag suspended={node.suspended} />}
+                <StatusDot status={node.last_run_status} />
+            </div>
         </div>
     )
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -35970,6 +35970,21 @@ export namespace Schemas {
       specificity_rejection?: SpecificityMetadata | null;
     }
 
+    export interface NodeSuspensionEntry {
+      /** When the node was suspended. */
+      at: string;
+      /** Error from the failing run that triggered the suspension. */
+      reason: string;
+      /** ID of the data modeling job whose failure triggered the suspension. */
+      job_id: string;
+    }
+
+    /**
+     * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+     * @nullable
+     */
+    export type NodeSuspended = {[key: string]: NodeSuspensionEntry} | null;
+
     /**
      * * `table` - Table
      * * `view` - View
@@ -36010,6 +36025,11 @@ export namespace Schemas {
       readonly user_tag: string | null;
       /** @nullable */
       readonly sync_interval: string | null;
+      /**
+         * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+         * @nullable
+         */
+      readonly suspended: NodeSuspended;
     }
 
     /**
@@ -46015,6 +46035,12 @@ export namespace Schemas {
       tile?: MoveTileTile;
     }
 
+    /**
+     * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+     * @nullable
+     */
+    export type PatchedNodeSuspended = {[key: string]: NodeSuspensionEntry} | null;
+
     export interface PatchedNode {
       readonly id?: string;
       /** @maxLength 2048 */
@@ -46039,6 +46065,11 @@ export namespace Schemas {
       readonly user_tag?: string | null;
       /** @nullable */
       readonly sync_interval?: string | null;
+      /**
+         * Suspension state keyed by materialization engine, set after repeated consecutive failures; null when the node is not suspended.
+         * @nullable
+         */
+      readonly suspended?: PatchedNodeSuspended;
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -35971,12 +35971,21 @@ export namespace Schemas {
     }
 
     export interface NodeSuspensionEntry {
-      /** When the node was suspended. */
-      at: string;
-      /** Error from the failing run that triggered the suspension. */
-      reason: string;
-      /** ID of the data modeling job whose failure triggered the suspension. */
-      job_id: string;
+      /**
+         * When the node was suspended, if available.
+         * @nullable
+         */
+      at: string | null;
+      /**
+         * Error from the failing run that triggered the suspension, if available.
+         * @nullable
+         */
+      reason: string | null;
+      /**
+         * ID of the triggering data modeling job, if available.
+         * @nullable
+         */
+      job_id: string | null;
     }
 
     /**


### PR DESCRIPTION
## Problem

Previously stored boolean suspension entries remain meaningful, but they do not contain the timestamp, reason, or job ID expected by the newer API and lineage tooltip.

## Changes

- Normalize legacy truthy suspension entries to structured entries with nullable details.
- Regenerate the OpenAPI-derived frontend and MCP types.
- Render detailed suspension context when available and a safe details-unavailable tooltip otherwise.

## How did you test this code?

- Ran the focused data-modeling materialization and node API pytest suite through the activated environment.
- Added API coverage for legacy boolean suspension state.
- Ran the focused `LineageNode.test.tsx` Jest suite, covering both detailed and legacy tooltips.
- Regenerated OpenAPI types.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this user-directed compatibility update. The `/improving-drf-endpoints`, `/adopting-generated-api-types`, and `/writing-tests` skills guided the serializer, generated type, and focused rendering coverage. Full workspace TypeScript checks are blocked by unrelated missing generated types and Quill packages in this workspace.
