### PR TITLE
feat(data-warehouse): migrate 5 sources to rest_source (batch 7)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
@@ -56,7 +56,7 @@ def _wire(session: mock.MagicMock, responses: dict[str, dict[str, Any]]) -> list
         prepared.url = url
         return prepared
 
-    def _send(prepared: Any) -> Response:
+    def _send(prepared: Any, **_kwargs: Any) -> Response:
         resp = Response()
         resp.status_code = 200
         resp.url = prepared.url

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/boldsign/boldsign.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/boldsign/boldsign.py
@@ -1,10 +1,8 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+import structlog
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.boldsign.settings import (
@@ -12,7 +10,18 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.boldsign.s
     BoldSignEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+
+logger = structlog.get_logger(__name__)
 
 # BoldSign serves separate US and EU regional hosts; the account decides which one is live.
 BOLDSIGN_HOSTS = {
@@ -22,15 +31,6 @@ BOLDSIGN_HOSTS = {
 PAGE_SIZE = 100
 # Page-number access is capped at 10,000 records; document/list pages past it via NextCursor.
 RECORD_CURSOR_THRESHOLD = 10_000
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
-# Backstop against a non-advancing cursor looping forever (10k records / 100 per page ≈ 100 pages,
-# so this only trips on a genuinely misbehaving response).
-MAX_PAGES = 100_000
-
-
-class BoldSignRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -58,143 +58,184 @@ def _get_headers(api_key: str) -> dict[str, str]:
     }
 
 
-@retry(
-    retry=retry_if_exception_type((BoldSignRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=2, max=90),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+class BoldSignPaginator(BasePaginator):
+    """Page-number pagination with BoldSign's 10,000-record page-number cap.
 
-    # 429 (account-level rate limit, 2000/hour prod) and transient 5xx are retried with backoff.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BoldSignRetryableError(f"BoldSign API error (retryable): status={response.status_code}, url={url}")
+    Standard pages advance ``Page``; once the running record count crosses the cap, endpoints that
+    support it (document/list) switch to cursor paging via ``NextCursor`` (taken from the last
+    row's ``cursor`` field, with ``Page`` reset to 1). Endpoints without cursor support stop at
+    the cap rather than loop.
+    """
 
-    if not response.ok:
-        logger.error(f"BoldSign API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
+    def __init__(self, endpoint: str, supports_cursor: bool) -> None:
+        super().__init__()
+        self._endpoint = endpoint
+        self._supports_cursor = supports_cursor
+        self._page = 1
+        self._next_cursor: str | int | None = None
+        self._records_fetched = 0
 
-    return response.json()
+    def _inject_params(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["Page"] = self._page
+        request.params["PageSize"] = PAGE_SIZE
+        if self._next_cursor is not None:
+            request.params["NextCursor"] = self._next_cursor
+
+    def init_request(self, request: Request) -> None:
+        self._inject_params(request)
+
+    def update_request(self, request: Request) -> None:
+        self._inject_params(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
+        if not items:
+            self._has_next_page = False
+            return
+
+        self._records_fetched += len(items)
+
+        # A short page means we've reached the end.
+        if len(items) < PAGE_SIZE:
+            self._has_next_page = False
+            return
+
+        if self._records_fetched >= RECORD_CURSOR_THRESHOLD:
+            if not self._supports_cursor:
+                # Page-number access is capped at 10k and this endpoint can't cursor past it.
+                logger.warning(
+                    f"BoldSign: {self._endpoint} reached the 10,000-record page-number cap; "
+                    "remaining records are not synced (endpoint has no cursor pagination)."
+                )
+                self._has_next_page = False
+                return
+            last = items[-1]
+            last_cursor = last.get("cursor") if isinstance(last, dict) else None
+            # No (or non-advancing) cursor means we can't make progress; stop rather than loop.
+            if last_cursor is None or last_cursor == self._next_cursor:
+                self._has_next_page = False
+                return
+            self._next_cursor = last_cursor
+            self._page = 1
+        else:
+            self._page += 1
+
+        self._has_next_page = True
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        if not self._has_next_page:
+            return None
+        return {
+            "page": self._page,
+            "next_cursor": self._next_cursor,
+            "records_fetched": self._records_fetched,
+        }
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        self._page = int(state.get("page") or 1)
+        self._next_cursor = state.get("next_cursor")
+        self._records_fetched = int(state.get("records_fetched") or 0)
+        self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"BoldSignPaginator(page={self._page}, next_cursor={self._next_cursor})"
 
 
 def validate_credentials(region: str, api_key: str) -> tuple[bool, str | None]:
     """Confirm the API key is genuine with one cheap, low-privilege list call."""
-    url = f"{_base_url(region)}/v1/document/list"
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(
-            url,
-            headers=_get_headers(api_key),
-            params={"Page": 1, "PageSize": 1},
-            timeout=10,
-        )
-    except Exception as e:
-        # A network error (timeout, connection failure) is not an auth problem — surface the
-        # real cause instead of misreporting it as an invalid key and sending the user on a
-        # fruitless key-rotation hunt during a transient outage.
-        return False, f"Could not reach BoldSign: {e}"
-
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{_base_url(region)}/v1/document/list?Page=1&PageSize=1",
+        headers=_get_headers(api_key),
+    )
+    if ok:
         return True, None
-    if response.status_code in (401, 403):
+    if status in (401, 403):
         return False, "Invalid BoldSign API key"
-    return False, f"Unexpected response from BoldSign (status {response.status_code})"
-
-
-def get_rows(
-    region: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BoldSignResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = BOLDSIGN_ENDPOINTS[endpoint]
-    url = f"{_base_url(region)}{config.path}"
-    headers = _get_headers(api_key)
-    session = make_tracked_session(redact_values=(api_key,))
-
-    if not config.paginated:
-        data = _fetch_page(session, url, headers, dict(config.extra_params), logger)
-        items = data.get(config.data_key) or []
-        if items:
-            yield items
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume is not None else 1
-    next_cursor = resume.next_cursor if resume is not None else None
-    records_fetched = resume.records_fetched if resume is not None else 0
-    if resume is not None:
-        logger.debug(f"BoldSign: resuming {endpoint} from page={page}, next_cursor={next_cursor}")
-
-    for _ in range(MAX_PAGES):
-        params: dict[str, Any] = dict(config.extra_params)
-        params["Page"] = page
-        params["PageSize"] = PAGE_SIZE
-        if next_cursor is not None:
-            params["NextCursor"] = next_cursor
-
-        data = _fetch_page(session, url, headers, params, logger)
-        items = data.get(config.data_key) or []
-        if not items:
-            break
-
-        yield items
-        records_fetched += len(items)
-
-        # A short page means we've reached the end.
-        if len(items) < PAGE_SIZE:
-            break
-
-        if records_fetched >= RECORD_CURSOR_THRESHOLD:
-            if not config.supports_cursor:
-                # Page-number access is capped at 10k and this endpoint can't cursor past it.
-                logger.warning(
-                    f"BoldSign: {endpoint} reached the 10,000-record page-number cap; "
-                    "remaining records are not synced (endpoint has no cursor pagination)."
-                )
-                break
-            last_cursor = items[-1].get("cursor")
-            # No (or non-advancing) cursor means we can't make progress; stop rather than loop.
-            if last_cursor is None or last_cursor == next_cursor:
-                break
-            next_cursor = last_cursor
-            page = 1
-        else:
-            page += 1
-
-        # Save AFTER yielding the page so a crash re-fetches from the next position and never
-        # skips a page; if we crash between the yield and this save, the prior state still points
-        # at the just-yielded page, which merge dedupes on the primary key.
-        resumable_source_manager.save_state(
-            BoldSignResumeConfig(page=page, next_cursor=next_cursor, records_fetched=records_fetched)
-        )
+    if status is None:
+        # A network error (timeout, connection failure) is not an auth problem — don't misreport
+        # it as an invalid key and send the user on a fruitless key-rotation hunt.
+        return False, "Could not reach BoldSign"
+    return False, f"Unexpected response from BoldSign (status {status})"
 
 
 def boldsign_source(
     region: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BoldSignResumeConfig],
 ) -> SourceResponse:
     config: BoldSignEndpointConfig = BOLDSIGN_ENDPOINTS[endpoint]
 
+    paginator: BasePaginator
+    if config.paginated:
+        paginator = BoldSignPaginator(endpoint=endpoint, supports_cursor=config.supports_cursor)
+    else:
+        # `brand/list` returns the full set in one response with no pagination params.
+        paginator = SinglePagePaginator()
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(region),
+            # The API key is supplied via the framework auth config so its value is redacted
+            # from logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-API-KEY", "location": "header"},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": dict(config.extra_params),
+                    # A missing data key is treated as an empty page (not an error), matching the
+                    # API's occasional key-less empty responses.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.paginated and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {
+                "page": resume.page,
+                "next_cursor": resume.next_cursor,
+                "records_fetched": resume.records_fetched,
+            }
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # from the next position and never skips a page — the prior state still points at the
+        # just-yielded page, which merge dedupes on the primary key.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(
+                BoldSignResumeConfig(
+                    page=int(state["page"]),
+                    next_cursor=state.get("next_cursor"),
+                    records_fetched=int(state.get("records_fetched") or 0),
+                )
+            )
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # every BoldSign endpoint is full refresh
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            region=region,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # Full refresh only — BoldSign timestamps are int64 epoch values, not datetimes, so there
         # is no stable datetime column to partition on.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/boldsign/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/boldsign/source.py
@@ -91,7 +91,7 @@ Pick the region your BoldSign account lives in — accounts are hosted on either
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # 401/403 surface as a requests HTTPError when `_fetch_page` calls `raise_for_status()`.
+            # 401/403 surface as a requests HTTPError when the REST client calls `raise_for_status()`.
             # Retrying can never satisfy a credential problem, so stop the sync. Match the stable
             # status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://api.boldsign.com": "Your BoldSign API key is invalid or has been revoked. Create a new key in your BoldSign account settings, then reconnect.",
@@ -144,6 +144,7 @@ Pick the region your BoldSign account lives in — accounts are hosted on either
             region=config.region,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/boldsign/tests/test_boldsign.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/boldsign/tests/test_boldsign.py
@@ -1,7 +1,10 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
+
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.boldsign import boldsign
 from products.warehouse_sources.backend.temporal.data_imports.sources.boldsign.boldsign import (
@@ -11,50 +14,76 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.boldsign.b
     _base_url,
     _get_headers,
     boldsign_source,
-    get_rows,
+    validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.boldsign.settings import BOLDSIGN_ENDPOINTS
 
-
-class _FakeResumableManager:
-    def __init__(self, state: BoldSignResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BoldSignResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> BoldSignResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: BoldSignResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the boldsign module.
+BOLDSIGN_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.boldsign.boldsign.make_tracked_session"
+)
 
 
-def _collect(
-    manager: _FakeResumableManager, monkeypatch: Any, endpoint: str, responses: list[dict]
-) -> tuple[list[dict], list[dict[str, Any]]]:
-    """Run get_rows against a queue of canned API responses and flatten the yielded pages."""
-    calls: list[dict[str, Any]] = []
-    queue = list(responses)
+def _response(items: list[dict[str, Any]] | None, *, data_key: str = "result", drop_key: bool = False) -> Response:
+    body: dict[str, Any] = {}
+    if not drop_key:
+        body[data_key] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], params: dict[str, Any], logger: Any) -> dict:
-        calls.append({"url": url, "params": dict(params)})
-        return queue.pop(0)
 
-    monkeypatch.setattr(boldsign, "_fetch_page", fake_fetch)
-    monkeypatch.setattr(boldsign, "make_tracked_session", lambda *a, **k: MagicMock())
+def _make_manager(resume_state: BoldSignResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    rows: list[dict] = []
-    for page in get_rows(
-        region="us",
-        api_key="key",
-        endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        rows.extend(page)
-    return rows, calls
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(
+    endpoint: str,
+    responses: list[Response],
+    session: mock.MagicMock,
+    manager: mock.MagicMock | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], mock.MagicMock]:
+    params = _wire(session, responses)
+    manager = manager if manager is not None else _make_manager()
+    rows = _rows(
+        boldsign_source(
+            region="us",
+            api_key="key",
+            endpoint=endpoint,
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=manager,
+        )
+    )
+    return rows, params, manager
 
 
 class TestBaseUrlAndHeaders:
@@ -80,91 +109,161 @@ class TestBaseUrlAndHeaders:
 
 
 class TestPagination:
-    def test_non_paginated_endpoint_makes_single_request(self, monkeypatch: Any) -> None:
-        responses = [{"result": [{"brandId": "B1"}, {"brandId": "B2"}]}]
-        rows, calls = _collect(_FakeResumableManager(), monkeypatch, "brands", responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_endpoint_makes_single_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows, params, _ = _run("brands", [_response([{"brandId": "B1"}, {"brandId": "B2"}])], session)
+
         assert rows == [{"brandId": "B1"}, {"brandId": "B2"}]
-        assert len(calls) == 1
-        assert "Page" not in calls[0]["params"]
+        assert session.send.call_count == 1
+        assert "Page" not in params[0]
 
-    def test_short_page_terminates_pagination(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_page_terminates_pagination(self, MockSession) -> None:
         # A page shorter than PAGE_SIZE is the last page.
-        responses = [{"result": [{"documentId": "D1"}]}]
-        rows, calls = _collect(_FakeResumableManager(), monkeypatch, "documents", responses)
+        session = MockSession.return_value
+        rows, params, _ = _run("documents", [_response([{"documentId": "D1"}])], session)
+
         assert rows == [{"documentId": "D1"}]
-        assert len(calls) == 1
-        assert calls[0]["params"]["Page"] == 1
-        assert calls[0]["params"]["PageSize"] == PAGE_SIZE
+        assert session.send.call_count == 1
+        assert params[0]["Page"] == 1
+        assert params[0]["PageSize"] == PAGE_SIZE
 
-    def test_full_page_advances_to_next_page(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_advances_to_next_page(self, MockSession) -> None:
+        session = MockSession.return_value
         full = [{"documentId": f"D{i}"} for i in range(PAGE_SIZE)]
-        responses = [{"result": full}, {"result": [{"documentId": "last"}]}]
-        rows, calls = _collect(_FakeResumableManager(), monkeypatch, "documents", responses)
+        rows, params, _ = _run("documents", [_response(full), _response([{"documentId": "last"}])], session)
+
         assert len(rows) == PAGE_SIZE + 1
-        assert [c["params"]["Page"] for c in calls] == [1, 2]
+        assert [p["Page"] for p in params] == [1, 2]
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        rows, calls = _collect(_FakeResumableManager(), monkeypatch, "documents", [{"result": []}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows, _, _ = _run("documents", [_response([])], session)
+
         assert rows == []
-        assert len(calls) == 1
+        assert session.send.call_count == 1
 
-    def test_teams_uses_results_data_key(self, monkeypatch: Any) -> None:
-        responses = [{"results": [{"teamId": "T1"}]}]
-        rows, _ = _collect(_FakeResumableManager(), monkeypatch, "teams", responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_is_treated_as_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows, _, _ = _run("documents", [_response(None, drop_key=True)], session)
+
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_teams_uses_results_data_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows, _, _ = _run("teams", [_response([{"teamId": "T1"}], data_key="results")], session)
+
         assert rows == [{"teamId": "T1"}]
 
-    def test_templates_send_template_type_param(self, monkeypatch: Any) -> None:
-        responses = [{"result": [{"documentId": "T1"}]}]
-        _, calls = _collect(_FakeResumableManager(), monkeypatch, "templates", responses)
-        assert calls[0]["params"]["TemplateType"] == "all"
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_templates_send_template_type_param(self, MockSession) -> None:
+        session = MockSession.return_value
+        _, params, _ = _run("templates", [_response([{"documentId": "T1"}])], session)
+
+        assert params[0]["TemplateType"] == "all"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_api_key_supplied_via_framework_auth(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"documentId": "D1"}])])
+        auths: list[Any] = []
+        original_prepare = session.prepare_request.side_effect
+
+        def _prepare(request: Any) -> mock.MagicMock:
+            auths.append(request.auth)
+            return original_prepare(request)
+
+        session.prepare_request.side_effect = _prepare
+        _rows(
+            boldsign_source(
+                region="us",
+                api_key="secret",
+                endpoint="documents",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
+            )
+        )
+
+        # The key rides on the framework's api_key auth (redacted from logs), not a raw header.
+        assert auths[0] is not None
+        assert auths[0].name == "X-API-KEY"
+        assert auths[0].api_key == "secret"
 
 
 class TestResume:
-    def test_saves_next_page_after_yielding_each_full_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_page_after_yielding_each_full_page(self, MockSession) -> None:
+        session = MockSession.return_value
         full = [{"documentId": f"D{i}"} for i in range(PAGE_SIZE)]
-        responses = [{"result": full}, {"result": [{"documentId": "tail"}]}]
-        _collect(manager, monkeypatch, "documents", responses)
-        # Only the page that had a full page of results (page 1) saves state, pointing at page 2.
-        assert [s.page for s in manager.saved] == [2]
+        _, _, manager = _run("documents", [_response(full), _response([{"documentId": "tail"}])], session)
 
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(BoldSignResumeConfig(page=5, next_cursor=None, records_fetched=400))
-        responses = [{"result": [{"documentId": "D5"}]}]
-        _, calls = _collect(manager, monkeypatch, "documents", responses)
-        assert calls[0]["params"]["Page"] == 5
+        # Only the page that had a full page of results (page 1) saves state, pointing at page 2.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BoldSignResumeConfig(
+            page=2, next_cursor=None, records_fetched=PAGE_SIZE
+        )
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        manager = _make_manager(BoldSignResumeConfig(page=5, next_cursor=None, records_fetched=400))
+        _, params, _ = _run("documents", [_response([{"documentId": "D5"}])], session, manager)
+
+        assert params[0]["Page"] == 5
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        manager = _make_manager(BoldSignResumeConfig(page=1, next_cursor=4242, records_fetched=10_000))
+        _, params, _ = _run("documents", [_response([{"documentId": "after"}])], session, manager)
+
+        assert params[0]["Page"] == 1
+        assert params[0]["NextCursor"] == 4242
 
 
 class TestCursorPagination:
-    def test_documents_switch_to_cursor_past_record_threshold(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_documents_switch_to_cursor_past_record_threshold(self, MockSession) -> None:
         # Fill exactly the 10k page-cap with full pages, then expect a NextCursor request.
-        boldsign_threshold_pages = boldsign.RECORD_CURSOR_THRESHOLD // PAGE_SIZE
+        session = MockSession.return_value
+        threshold_pages = boldsign.RECORD_CURSOR_THRESHOLD // PAGE_SIZE
         full_pages = [
-            {"result": [{"documentId": f"D{p}-{i}", "cursor": p * PAGE_SIZE + i} for i in range(PAGE_SIZE)]}
-            for p in range(boldsign_threshold_pages)
+            _response([{"documentId": f"D{p}-{i}", "cursor": p * PAGE_SIZE + i} for i in range(PAGE_SIZE)])
+            for p in range(threshold_pages)
         ]
         # One more page reached via cursor, then a short page to stop.
-        cursor_page = {"result": [{"documentId": "after-cursor", "cursor": 999999}]}
-        responses = [*full_pages, cursor_page]
+        cursor_page = _response([{"documentId": "after-cursor", "cursor": 999999}])
 
-        _, calls = _collect(_FakeResumableManager(), monkeypatch, "documents", responses)
+        _, params, manager = _run("documents", [*full_pages, cursor_page], session)
 
-        last_call = calls[-1]
-        assert "NextCursor" in last_call["params"]
-        # The cursor passed is the last record's cursor from the final full page.
-        expected_cursor = full_pages[-1]["result"][-1]["cursor"]
-        assert last_call["params"]["NextCursor"] == expected_cursor
+        # The cursor passed is the last record's cursor from the final full page, with Page reset.
+        expected_cursor = boldsign.RECORD_CURSOR_THRESHOLD - 1
+        assert params[-1]["NextCursor"] == expected_cursor
+        assert params[-1]["Page"] == 1
+        # The checkpoint written after the final full page carries the cursor position.
+        assert manager.save_state.call_args.args[0] == BoldSignResumeConfig(
+            page=1, next_cursor=expected_cursor, records_fetched=boldsign.RECORD_CURSOR_THRESHOLD
+        )
 
-    def test_non_cursor_endpoint_stops_at_record_threshold(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_cursor_endpoint_stops_at_record_threshold(self, MockSession) -> None:
         # users/list has no cursor support, so it must stop at the 10k page cap rather than loop.
+        session = MockSession.return_value
         threshold_pages = boldsign.RECORD_CURSOR_THRESHOLD // PAGE_SIZE
-        full_pages = [{"result": [{"userId": f"U{p}-{i}"} for i in range(PAGE_SIZE)]} for p in range(threshold_pages)]
+        full_pages = [_response([{"userId": f"U{p}-{i}"} for i in range(PAGE_SIZE)]) for p in range(threshold_pages)]
         # Provide an extra page that should never be requested.
-        responses = [*full_pages, {"result": [{"userId": "should-not-fetch"}]}]
+        responses = [*full_pages, _response([{"userId": "should-not-fetch"}])]
 
-        rows, calls = _collect(_FakeResumableManager(), monkeypatch, "users", responses)
+        rows, _, _ = _run("users", responses, session)
 
-        assert len(calls) == threshold_pages
+        assert session.send.call_count == threshold_pages
         assert len(rows) == boldsign.RECORD_CURSOR_THRESHOLD
 
 
@@ -186,11 +285,52 @@ class TestSourceResponse:
             region="us",
             api_key="key",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
         )
         assert response.name == endpoint
         assert response.primary_keys == expected_pk
         # Full refresh: BoldSign timestamps are epoch ints, so no datetime partitioning.
         assert response.partition_mode is None
         assert response.primary_keys == BOLDSIGN_ENDPOINTS[endpoint].primary_keys
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected_valid, expected_message",
+        [
+            (200, True, None),
+            (401, False, "Invalid BoldSign API key"),
+            (403, False, "Invalid BoldSign API key"),
+            (500, False, "Unexpected response from BoldSign (status 500)"),
+        ],
+    )
+    @mock.patch(BOLDSIGN_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status_code, expected_valid, expected_message) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+
+        is_valid, message = validate_credentials("us", "key")
+
+        assert is_valid is expected_valid
+        assert message == expected_message
+
+    @mock.patch(BOLDSIGN_SESSION_PATCH)
+    def test_network_error_is_not_reported_as_bad_key(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+
+        is_valid, message = validate_credentials("us", "key")
+
+        assert is_valid is False
+        assert message == "Could not reach BoldSign"
+
+    @mock.patch(BOLDSIGN_SESSION_PATCH)
+    def test_probes_the_region_host_with_the_api_key_header(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+
+        validate_credentials("eu", "secret")
+
+        url = mock_session.return_value.get.call_args.args[0]
+        headers = mock_session.return_value.get.call_args.kwargs["headers"]
+        assert url.startswith("https://api-eu.boldsign.com/v1/document/list")
+        assert headers["X-API-KEY"] == "secret"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braze/braze.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braze/braze.py
@@ -3,11 +3,9 @@ import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlparse
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.braze.settings import (
@@ -16,18 +14,20 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.braze.sett
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _is_host_safe
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # Shared so the source-layer 403 acceptance check can't drift from the message produced here.
 BRAZE_FORBIDDEN_MSG = "Your Braze API key does not have permission for this endpoint"
 HOST_NOT_ALLOWED_ERROR = "Braze REST endpoint URL is not allowed"
-
-
-class BrazeRetryableError(Exception):
-    pass
 
 
 class BrazeHostNotAllowedError(Exception):
@@ -36,8 +36,9 @@ class BrazeHostNotAllowedError(Exception):
 
 @dataclasses.dataclass
 class BrazeResumeConfig:
-    # Page index (page pagination) or row offset (offset pagination) of the
-    # last-yielded page, so a resume re-fetches it and merge dedupes on primary key.
+    # Page index (page pagination) or row offset (offset pagination) to resume from.
+    # Old checkpoints stored the last-yielded cursor, so re-loading one re-fetches that
+    # page and merge dedupes on primary key.
     cursor: int
 
 
@@ -55,13 +56,6 @@ def _host_from_url(base_url: str) -> str:
     return (urlparse(normalize_base_url(base_url)).hostname or "").lower()
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-    }
-
-
 def _format_modified_after(value: Any) -> str:
     """Format an incremental cursor value as an ISO-8601 string for Braze filters."""
     if isinstance(value, datetime):
@@ -72,31 +66,58 @@ def _format_modified_after(value: Any) -> str:
     return str(value)
 
 
-def _build_params(config: BrazeEndpointConfig, cursor: int, modified_after: str | None) -> dict[str, Any]:
-    params: dict[str, Any]
-    if config.pagination == "page":
-        params = {"page": cursor}
-    else:
-        # Braze's offset endpoints reject offset=0 (offset must be a positive integer),
-        # so omit it on the first page — equivalent to skipping nothing.
-        params = {"limit": config.page_size}
-        if cursor:
-            params["offset"] = cursor
-
-    if modified_after and config.modified_after_param:
-        params[config.modified_after_param] = modified_after
-
-    return params
-
-
-def _next_cursor(config: BrazeEndpointConfig, cursor: int) -> int:
-    return cursor + 1 if config.pagination == "page" else cursor + config.page_size
-
-
 def _normalize_items(config: BrazeEndpointConfig, items: list[Any]) -> list[dict[str, Any]]:
     if config.wrap_scalar_as:
         return [{config.wrap_scalar_as: item} for item in items]
     return [item for item in items if isinstance(item, dict)]
+
+
+class BrazeOffsetPaginator(BasePaginator):
+    """Braze's limit/offset pagination (templates/content blocks).
+
+    Diverges from the generic ``OffsetPaginator`` in two Braze-specific ways: the
+    ``offset`` param must be omitted when 0 (Braze rejects ``offset=0`` as not a
+    positive integer), and only an empty page terminates — a short page is not
+    treated as the last one.
+    """
+
+    def __init__(self, limit: int, offset: int = 0) -> None:
+        super().__init__()
+        self.limit = limit
+        self.offset = offset
+
+    def _inject_params(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["limit"] = self.limit
+        if self.offset:
+            request.params["offset"] = self.offset
+
+    def init_request(self, request: Request) -> None:
+        self._inject_params(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+        self.offset += self.limit
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        self._inject_params(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.offset already points at the next page to fetch (update_state incremented it).
+        return {"offset": self.offset} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        offset = state.get("offset")
+        if offset is not None:
+            self.offset = int(offset)
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"BrazeOffsetPaginator(offset={self.offset}, limit={self.limit})"
 
 
 def validate_credentials(
@@ -114,120 +135,110 @@ def validate_credentials(
         if not host_ok:
             return False, host_err or HOST_NOT_ALLOWED_ERROR
 
-    url = f"{normalize_base_url(base_url)}{path}?{urlencode({'page': 0})}"
-    try:
-        response = make_tracked_session(allow_redirects=False).get(url, headers=_get_headers(api_key), timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
-
-    if response.status_code == 200:
-        return True, None
-    if response.status_code == 401:
-        return False, "Invalid Braze API key"
-    if response.status_code == 403:
-        return False, BRAZE_FORBIDDEN_MSG
-
-    try:
-        message = response.json().get("message", response.text)
-    except Exception:
-        message = response.text
-    return False, message
-
-
-def get_rows(
-    api_key: str,
-    base_url: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrazeResumeConfig],
-    team_id: int,
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = BRAZE_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    root = normalize_base_url(base_url)
-
-    # Re-check at run time (not just at source-create) in case the URL was edited or now
-    # resolves to an internal address (SSRF / DNS rebinding). Only enforced on cloud.
-    host_ok, host_err = _is_host_safe(_host_from_url(base_url), team_id)
-    if not host_ok:
-        raise BrazeHostNotAllowedError(host_err or HOST_NOT_ALLOWED_ERROR)
-
-    modified_after: str | None = None
-    if config.modified_after_param and should_use_incremental_field and db_incremental_field_last_value:
-        modified_after = _format_modified_after(db_incremental_field_last_value)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    cursor = resume_config.cursor if resume_config is not None else 0
-    if resume_config is not None:
-        logger.debug(f"Braze: resuming {endpoint} from cursor={cursor}")
-
-    @retry(
-        retry=retry_if_exception_type((BrazeRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
+    url = f"{normalize_base_url(base_url)}{path}?page=0"
+    ok, status = validate_via_probe(
+        # No redirects: keep the probe pinned to the validated host (SSRF hardening).
+        lambda: make_tracked_session(allow_redirects=False, redact_values=(api_key,)),
+        url,
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
     )
-    def fetch_page(page_cursor: int) -> dict[str, Any]:
-        params = _build_params(config, page_cursor, modified_after)
-        page_url = f"{root}{config.path}?{urlencode(params)}"
-        response = make_tracked_session(allow_redirects=False).get(
-            page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
-        )
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise BrazeRetryableError(f"Braze API error (retryable): status={response.status_code}, url={page_url}")
-
-        if not response.ok:
-            logger.error(f"Braze API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(cursor)
-
-        raw_items = data.get(config.data_key, [])
-        if not raw_items:
-            break
-
-        yield _normalize_items(config, raw_items)
-
-        # Save the cursor of the page we just yielded (not the next one) so a
-        # resume re-fetches it; merge semantics on the primary key dedupe.
-        resumable_source_manager.save_state(BrazeResumeConfig(cursor=cursor))
-
-        cursor = _next_cursor(config, cursor)
+    if ok:
+        return True, None
+    if status == 401:
+        return False, "Invalid Braze API key"
+    if status == 403:
+        return False, BRAZE_FORBIDDEN_MSG
+    if status is None:
+        return False, "Could not reach the Braze API"
+    return False, f"Braze API returned status {status}"
 
 
 def braze_source(
     api_key: str,
     base_url: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrazeResumeConfig],
     team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[BrazeResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
-    incremental_field: str | None = None,
 ) -> SourceResponse:
     config = BRAZE_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {}
+    if config.modified_after_param and should_use_incremental_field and db_incremental_field_last_value:
+        params[config.modified_after_param] = _format_modified_after(db_incremental_field_last_value)
+
+    paginator: BasePaginator
+    if config.pagination == "page":
+        paginator = PageNumberPaginator(base_page=0)
+        state_key = "page"
+    else:
+        paginator = BrazeOffsetPaginator(limit=config.page_size)
+        state_key = "offset"
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": normalize_base_url(base_url),
+            "headers": {"Accept": "application/json"},
+            # Framework Bearer auth so the key is redacted from logs.
+            "auth": {"type": "bearer", "token": api_key},
+            # No redirects: the base URL is customer-supplied, so keep traffic pinned
+            # to the validated host (SSRF hardening).
+            "session": make_tracked_session(allow_redirects=False, redact_values=(api_key,)),
+            "paginator": paginator,
+        },
+        "resource_defaults": None,
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Braze omits the data key when there is nothing to return, so a missing
+                    # key is a normal end-of-data page — don't set data_selector_required.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {state_key: resume.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; saved AFTER a page is yielded so a crash
+        # never skips an undelivered page.
+        if state and state.get(state_key) is not None:
+            resumable_source_manager.save_state(BrazeResumeConfig(cursor=int(state[state_key])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    def get_rows() -> Iterator[list[dict[str, Any]]]:
+        # Re-check at run time (not just at source-create) in case the URL was edited or now
+        # resolves to an internal address (SSRF / DNS rebinding). Only enforced on cloud.
+        host_ok, host_err = _is_host_safe(_host_from_url(base_url), team_id)
+        if not host_ok:
+            raise BrazeHostNotAllowedError(host_err or HOST_NOT_ALLOWED_ERROR)
+
+        for page in resource:
+            # events/list returns bare event-name strings; other endpoints may carry
+            # stray non-dict rows — reshape/drop them exactly as before the migration.
+            yield _normalize_items(config, page)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            base_url=base_url,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            team_id=team_id,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=get_rows,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braze/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braze/source.py
@@ -30,7 +30,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BrazeSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -114,19 +117,7 @@ Your REST endpoint must match your Braze dashboard's region — see [Braze's API
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in list(ENDPOINTS)
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: BrazeSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -157,12 +148,11 @@ Your REST endpoint must match your Braze dashboard's region — see [Braze's API
             api_key=config.api_key,
             base_url=config.url,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
-            resumable_source_manager=resumable_source_manager,
             team_id=inputs.team_id,
+            job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,
-            incremental_field=inputs.incremental_field,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braze/tests/test_braze.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braze/tests/test_braze.py
@@ -1,26 +1,36 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
 
-import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze import (
     BrazeHostNotAllowedError,
     BrazeResumeConfig,
-    _build_params,
     _format_modified_after,
-    _next_cursor,
     _normalize_items,
     braze_source,
-    get_rows,
     normalize_base_url,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.braze.settings import BRAZE_ENDPOINTS, ENDPOINTS
 
 BASE_URL = "https://rest.iad-01.braze.com"
+
+# Both the data path and the credential probe build their session via
+# make_tracked_session imported into the braze module.
+SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session"
+HOST_SAFE_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze._is_host_safe"
+
+
+def _response(body: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: BrazeResumeConfig | None = None) -> mock.MagicMock:
@@ -30,12 +40,38 @@ def _make_manager(resume_state: BrazeResumeConfig | None = None) -> mock.MagicMo
     return manager
 
 
-def _response(body: dict[str, Any], status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = body
-    resp.status_code = status_code
-    resp.ok = 200 <= status_code < 400
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None, **kwargs: Any):
+    return braze_source(
+        "key",
+        BASE_URL,
+        endpoint,
+        team_id=1,
+        job_id="job",
+        resumable_source_manager=manager or _make_manager(),
+        **kwargs,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestNormalizeBaseUrl:
@@ -69,38 +105,6 @@ class TestFormatModifiedAfter:
         assert _format_modified_after(value) == expected
 
 
-class TestBuildParams:
-    def test_page_pagination(self):
-        params = _build_params(BRAZE_ENDPOINTS["campaigns"], cursor=3, modified_after=None)
-        assert params == {"page": 3}
-
-    def test_offset_pagination(self):
-        params = _build_params(BRAZE_ENDPOINTS["email_templates"], cursor=200, modified_after=None)
-        assert params == {"limit": 100, "offset": 200}
-
-    def test_offset_omitted_on_first_page(self):
-        # Braze 400s on offset=0, so the first page must not carry an offset param.
-        params = _build_params(BRAZE_ENDPOINTS["email_templates"], cursor=0, modified_after=None)
-        assert params == {"limit": 100}
-
-    def test_modified_after_added_only_for_incremental_endpoint(self):
-        params = _build_params(BRAZE_ENDPOINTS["email_templates"], cursor=0, modified_after="2026-01-01T00:00:00+00:00")
-        assert params["modified_after"] == "2026-01-01T00:00:00+00:00"
-
-    def test_modified_after_ignored_for_full_refresh_endpoint(self):
-        # campaigns has no modified_after_param, so the cutoff must never leak into params.
-        params = _build_params(BRAZE_ENDPOINTS["campaigns"], cursor=0, modified_after="2026-01-01T00:00:00+00:00")
-        assert "modified_after" not in params
-
-
-class TestNextCursor:
-    def test_page_increments_by_one(self):
-        assert _next_cursor(BRAZE_ENDPOINTS["campaigns"], 4) == 5
-
-    def test_offset_increments_by_page_size(self):
-        assert _next_cursor(BRAZE_ENDPOINTS["email_templates"], 200) == 300
-
-
 class TestNormalizeItems:
     def test_wraps_scalar_event_names(self):
         items = _normalize_items(BRAZE_ENDPOINTS["events"], ["purchase", "login"])
@@ -118,9 +122,10 @@ class TestValidateCredentials:
             (200, True, None),
             (401, False, "Invalid Braze API key"),
             (403, False, "Your Braze API key does not have permission for this endpoint"),
+            (500, False, "Braze API returned status 500"),
         ],
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
+    @mock.patch(SESSION_PATCH)
     def test_status_mapping(self, mock_session, status_code, expected_valid, expected_message):
         mock_session.return_value.get.return_value = _response({"message": "x"}, status_code=status_code)
 
@@ -129,21 +134,28 @@ class TestValidateCredentials:
         assert valid is expected_valid
         assert message == expected_message
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_uses_no_redirect_session(self, mock_session):
+    @mock.patch(SESSION_PATCH)
+    def test_uses_no_redirect_session_and_probes_with_bearer(self, mock_session):
         mock_session.return_value.get.return_value = _response({}, status_code=200)
+
         validate_credentials("key", BASE_URL)
+
         assert mock_session.call_args.kwargs["allow_redirects"] is False
+        get_call = mock_session.return_value.get.call_args
+        assert get_call.args[0] == f"{BASE_URL}/campaigns/list?page=0"
+        assert get_call.kwargs["headers"]["Authorization"] == "Bearer key"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
+    @mock.patch(SESSION_PATCH)
     def test_swallows_request_exceptions(self, mock_session):
-        mock_session.return_value.get.side_effect = requests.exceptions.ConnectionError("boom")
-        valid, message = validate_credentials("key", BASE_URL)
-        assert valid is False
-        assert message == "boom"
+        mock_session.return_value.get.side_effect = ConnectionError("boom")
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze._is_host_safe")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
+        valid, message = validate_credentials("key", BASE_URL)
+
+        assert valid is False
+        assert message == "Could not reach the Braze API"
+
+    @mock.patch(HOST_SAFE_PATCH)
+    @mock.patch(SESSION_PATCH)
     def test_blocks_internal_host_when_team_id_given(self, mock_session, mock_host_safe):
         mock_host_safe.return_value = (False, "host not allowed")
 
@@ -154,8 +166,8 @@ class TestValidateCredentials:
         # The host is rejected before any request is dispatched.
         mock_session.return_value.get.assert_not_called()
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze._is_host_safe")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
+    @mock.patch(HOST_SAFE_PATCH)
+    @mock.patch(SESSION_PATCH)
     def test_skips_host_check_when_team_id_omitted(self, mock_session, mock_host_safe):
         mock_session.return_value.get.return_value = _response({}, status_code=200)
 
@@ -165,158 +177,216 @@ class TestValidateCredentials:
 
 
 class TestGetRows:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_page_pagination_walks_until_empty(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response({"campaigns": [{"id": "1"}, {"id": "2"}]}),
-            _response({"campaigns": [{"id": "3"}]}),
-            _response({"campaigns": []}),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_page_pagination_walks_until_empty(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"campaigns": [{"id": "1"}, {"id": "2"}]}),
+                _response({"campaigns": [{"id": "3"}]}),
+                _response({"campaigns": []}),
+            ],
+        )
 
-        manager = _make_manager()
-        batches = list(get_rows("key", BASE_URL, "campaigns", mock.MagicMock(), manager, team_id=1))
+        rows = _rows(_source("campaigns"))
 
-        assert [item["id"] for batch in batches for item in batch] == ["1", "2", "3"]
-        # page param walked 0, 1, 2
-        pages = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert "page=0" in pages[0]
-        assert "page=1" in pages[1]
-        assert "page=2" in pages[2]
+        assert [row["id"] for row in rows] == ["1", "2", "3"]
+        assert [p["page"] for p in params] == [0, 1, 2]
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_offset_pagination_advances_by_page_size(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response({"templates": [{"email_template_id": "a"}]}),
-            _response({"templates": []}),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_offset_pagination_advances_by_page_size(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"templates": [{"email_template_id": "a"}]}),
+                _response({"templates": []}),
+            ],
+        )
 
-        manager = _make_manager()
-        list(get_rows("key", BASE_URL, "email_templates", mock.MagicMock(), manager, team_id=1))
+        _rows(_source("email_templates"))
 
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
         # First page omits offset (Braze rejects offset=0); later pages advance by page size.
-        assert "offset=" not in urls[0]
-        assert "limit=100" in urls[0]
-        assert "offset=100" in urls[1]
+        assert "offset" not in params[0]
+        assert params[0]["limit"] == 100
+        assert params[1]["offset"] == 100
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_saves_current_cursor_after_each_yield(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response({"campaigns": [{"id": "1"}]}),
-            _response({"campaigns": [{"id": "2"}]}),
-            _response({"campaigns": []}),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_offset_pagination_continues_past_short_page(self, MockSession):
+        # A short (non-empty) page is not the last one — only an empty page terminates.
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"templates": [{"email_template_id": "a"}]}),
+                _response({"templates": [{"email_template_id": "b"}]}),
+                _response({"templates": []}),
+            ],
+        )
+
+        rows = _rows(_source("email_templates"))
+
+        assert [row["email_template_id"] for row in rows] == ["a", "b"]
+        assert [p.get("offset") for p in params] == [None, 100, 200]
+
+    @mock.patch(SESSION_PATCH)
+    def test_uses_no_redirect_session_with_redacted_key(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"campaigns": []})])
+
+        _rows(_source("campaigns"))
+
+        assert MockSession.call_args.kwargs["allow_redirects"] is False
+        assert "key" in MockSession.call_args.kwargs["redact_values"]
+
+    @mock.patch(SESSION_PATCH)
+    def test_saves_next_cursor_after_each_yield(self, MockSession):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"campaigns": [{"id": "1"}]}),
+                _response({"campaigns": [{"id": "2"}]}),
+                _response({"campaigns": []}),
+            ],
+        )
 
         manager = _make_manager()
-        list(get_rows("key", BASE_URL, "campaigns", mock.MagicMock(), manager, team_id=1))
+        _rows(_source("campaigns", manager))
 
         saved = [call.args[0].cursor for call in manager.save_state.call_args_list]
-        # Saves the cursor of the page just yielded (0, then 1), not the next page.
-        assert saved == [0, 1]
+        # Checkpoints point at the next unfetched page; the terminal empty page saves nothing.
+        assert saved == [1, 2]
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_resumes_from_saved_cursor(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response({"campaigns": [{"id": "9"}]}),
-            _response({"campaigns": []}),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_response({"campaigns": [{"id": "9"}]}), _response({"campaigns": []})])
 
-        manager = _make_manager(BrazeResumeConfig(cursor=5))
-        list(get_rows("key", BASE_URL, "campaigns", mock.MagicMock(), manager, team_id=1))
+        _rows(_source("campaigns", _make_manager(BrazeResumeConfig(cursor=5))))
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "page=5" in first_url
+        assert params[0]["page"] == 5
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_empty_first_page_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _response({"campaigns": []})
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_offset_endpoint_from_saved_cursor(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_response({"templates": []})])
+
+        _rows(_source("email_templates", _make_manager(BrazeResumeConfig(cursor=200))))
+
+        assert params[0]["offset"] == 200
+        assert params[0]["limit"] == 100
+
+    @mock.patch(SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"campaigns": []})])
 
         manager = _make_manager()
-        batches = list(get_rows("key", BASE_URL, "campaigns", mock.MagicMock(), manager, team_id=1))
+        batches = list(_source("campaigns", manager).items())
 
         assert batches == []
         manager.save_state.assert_not_called()
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_incremental_applies_modified_after_filter(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response({"templates": [{"email_template_id": "a", "updated_at": "2026-02-01T00:00:00Z"}]}),
-            _response({"templates": []}),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_missing_data_key_ends_pagination_without_error(self, MockSession):
+        # Braze omits the data key when there is nothing to return — a normal end of data.
+        session = MockSession.return_value
+        _wire(session, [_response({"message": "success"})])
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                BASE_URL,
+        batches = list(_source("campaigns").items())
+
+        assert batches == []
+        assert session.send.call_count == 1
+
+    @mock.patch(SESSION_PATCH)
+    def test_incremental_applies_modified_after_filter(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"templates": [{"email_template_id": "a", "updated_at": "2026-02-01T00:00:00Z"}]}),
+                _response({"templates": []}),
+            ],
+        )
+
+        _rows(
+            _source(
                 "email_templates",
-                mock.MagicMock(),
-                manager,
-                team_id=1,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
-                incremental_field="updated_at",
             )
         )
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "modified_after=2026-01-01" in first_url
+        assert params[0]["modified_after"] == "2026-01-01T00:00:00+00:00"
+        # The filter is carried on every page of the run.
+        assert params[1]["modified_after"] == "2026-01-01T00:00:00+00:00"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_full_refresh_endpoint_never_sends_modified_after(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response({"campaigns": [{"id": "1"}]}),
-            _response({"campaigns": []}),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_full_refresh_endpoint_never_sends_modified_after(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"campaigns": [{"id": "1"}]}),
+                _response({"campaigns": []}),
+            ],
+        )
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                BASE_URL,
+        _rows(
+            _source(
                 "campaigns",
-                mock.MagicMock(),
-                manager,
-                team_id=1,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
-                incremental_field="created_at",
             )
         )
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "modified_after" not in first_url
+        assert all("modified_after" not in p for p in params)
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_events_endpoint_wraps_scalar_rows(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response({"events": ["purchase", "login"]}),
-            _response({"events": []}),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_events_endpoint_wraps_scalar_rows(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"events": ["purchase", "login"]}), _response({"events": []})])
 
-        manager = _make_manager()
-        batches = list(get_rows("key", BASE_URL, "events", mock.MagicMock(), manager, team_id=1))
+        rows = _rows(_source("events"))
 
-        assert [item for batch in batches for item in batch] == [{"event_name": "purchase"}, {"event_name": "login"}]
+        assert rows == [{"event_name": "purchase"}, {"event_name": "login"}]
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze._is_host_safe")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.braze.make_tracked_session")
-    def test_raises_when_host_not_allowed(self, mock_session, mock_host_safe):
+    @mock.patch(SESSION_PATCH)
+    def test_drops_non_dict_rows_from_object_endpoint(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"campaigns": [{"id": "a"}, "garbage"]}), _response({"campaigns": []})])
+
+        rows = _rows(_source("campaigns"))
+
+        assert rows == [{"id": "a"}]
+
+    @mock.patch(HOST_SAFE_PATCH)
+    @mock.patch(SESSION_PATCH)
+    def test_raises_when_host_not_allowed(self, MockSession, mock_host_safe):
         mock_host_safe.return_value = (False, "host not allowed")
 
-        manager = _make_manager()
+        response = braze_source(
+            "key",
+            "https://10.0.0.1",
+            "campaigns",
+            team_id=42,
+            job_id="job",
+            resumable_source_manager=_make_manager(),
+        )
         with pytest.raises(BrazeHostNotAllowedError):
-            list(get_rows("key", "https://10.0.0.1", "campaigns", mock.MagicMock(), manager, team_id=42))
+            list(response.items())
 
         # No request is made once the host is rejected.
-        mock_session.return_value.get.assert_not_called()
+        MockSession.return_value.send.assert_not_called()
 
 
 class TestBrazeSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = BRAZE_ENDPOINTS[endpoint]
-        response = braze_source("key", BASE_URL, endpoint, mock.MagicMock(), _make_manager(), team_id=1)
+        response = _source(endpoint)
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braze/tests/test_braze_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braze/tests/test_braze_source.py
@@ -183,8 +183,8 @@ class TestBrazeSource:
         inputs.schema_name = "email_templates"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2026-01-01T00:00:00Z"
-        inputs.incremental_field = "updated_at"
         inputs.team_id = 777
+        inputs.job_id = "job-1"
         manager = mock.MagicMock()
 
         self.source.source_for_pipeline(self.config, manager, inputs)
@@ -196,9 +196,9 @@ class TestBrazeSource:
         assert kwargs["endpoint"] == "email_templates"
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["team_id"] == 777
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2026-01-01T00:00:00Z"
-        assert kwargs["incremental_field"] == "updated_at"
 
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braze.source.braze_source")
     def test_source_for_pipeline_omits_last_value_on_full_refresh(self, mock_braze_source):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/brevo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/brevo.py
@@ -1,13 +1,6 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-from urllib3.util.retry import Retry
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.brevo.settings import (
@@ -15,28 +8,25 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.brevo.sett
     BrevoEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    OffsetPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BREVO_BASE_URL = "https://api.brevo.com/v3"
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-
-
-class BrevoRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class BrevoResumeConfig:
     # Offset (record index) of the next page to fetch within the current sync.
     offset: int
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "api-key": api_key,
-        "accept": "application/json",
-    }
 
 
 def _format_datetime(value: Any) -> str:
@@ -54,12 +44,12 @@ def _format_datetime(value: Any) -> str:
 
 def validate_credentials(api_key: str) -> bool:
     """Cheap probe to confirm the API key is genuine."""
-    try:
-        session = make_tracked_session(headers=_get_headers(api_key), redact_values=(api_key,))
-        response = session.get(f"{BREVO_BASE_URL}/account", timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{BREVO_BASE_URL}/account",
+        headers={"api-key": api_key, "accept": "application/json"},
+    )
+    return ok
 
 
 def _build_base_params(
@@ -83,101 +73,75 @@ def _build_base_params(
     return params
 
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrevoResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: Optional[str] = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = BREVO_ENDPOINTS[endpoint]
-    base_params = _build_base_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
-    )
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume_config.offset if resume_config else 0
-    if resume_config is not None:
-        logger.debug(f"Brevo: resuming {endpoint} from offset {offset}")
-
-    # One session reused across all pages (TCP/connection reuse). `tenacity` below is the sole
-    # retry mechanism, so disable the transport's built-in urllib3 retries to avoid nested backoff.
-    # `redact_values` masks the api-key header value in logs and sample capture.
-    session = make_tracked_session(headers=_get_headers(api_key), retry=Retry(total=0), redact_values=(api_key,))
-
-    @retry(
-        retry=retry_if_exception_type((BrevoRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(params: dict[str, Any]) -> dict[str, Any]:
-        url = f"{BREVO_BASE_URL}{config.path}"
-        if params:
-            url = f"{url}?{urlencode(params)}"
-
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise BrevoRetryableError(f"Brevo API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"Brevo API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    try:
-        while True:
-            params = dict(base_params)
-            if config.paginate:
-                params["limit"] = config.page_size
-                params["offset"] = offset
-
-            data = fetch_page(params)
-            # Brevo omits the array key entirely (or sets it to null) for an empty collection,
-            # e.g. {"count": 0} with no "campaigns"/"segments" key. Treat that as an empty page
-            # rather than crashing the sync.
-            items = data.get(config.data_key) or []
-
-            if items:
-                yield items
-
-            if not config.paginate or len(items) < config.page_size:
-                break
-
-            offset += config.page_size
-            # Save AFTER yielding so a crash re-yields the last page (merge dedupes on primary key)
-            # rather than skipping it.
-            resumable_source_manager.save_state(BrevoResumeConfig(offset=offset))
-    finally:
-        session.close()
-
-
 def brevo_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BrevoResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: Optional[str] = None,
 ) -> SourceResponse:
     config = BREVO_ENDPOINTS[endpoint]
+    params = _build_base_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+
+    # Brevo reports a top-level `count`, but termination stays short/empty page (total_path=None):
+    # counts drift as rows are inserted mid-sync, and the short-page rule is exact.
+    paginator: BasePaginator = (
+        OffsetPaginator(limit=config.page_size, total_path=None) if config.paginate else SinglePagePaginator()
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BREVO_BASE_URL,
+            "headers": {"accept": "application/json"},
+            # Framework auth so the key is redacted from logs/samples wherever it appears.
+            "auth": {"type": "api_key", "name": "api-key", "api_key": api_key, "location": "header"},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Brevo omits the array key entirely (or sets it to null) for an empty
+                    # collection, e.g. {"count": 0} with no "campaigns"/"segments" key. That must
+                    # read as an empty page rather than crash the sync, so the selector is NOT
+                    # required.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.paginate and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the framework saves AFTER a page is yielded so a
+        # crash re-yields the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(BrevoResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BrevoSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -93,21 +96,7 @@ You can create an API key in your [Brevo account settings](https://app.brevo.com
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=(fields := INCREMENTAL_FIELDS.get(endpoint)) is not None,
-                supports_append=fields is not None,
-                incremental_fields=fields or [],
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: BrevoSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -129,7 +118,8 @@ You can create an API key in your [Brevo account settings](https://app.brevo.com
         return brevo_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/tests/test_brevo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/tests/test_brevo.py
@@ -1,10 +1,9 @@
 import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlsplit
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 from requests import Response
 from requests.exceptions import HTTPError
@@ -15,14 +14,20 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.brevo.brev
     _build_base_params,
     _format_datetime,
     brevo_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.brevo.settings import BREVO_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the brevo module.
+BREVO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.brevo.brevo.make_tracked_session"
+)
 
-def _make_response(body: dict[str, Any], status_code: int = 200) -> Response:
+
+def _response(body: dict[str, Any], status_code: int = 200) -> Response:
     resp = Response()
     resp.status_code = status_code
     resp._content = json.dumps(body).encode()
@@ -32,38 +37,44 @@ def _make_response(body: dict[str, Any], status_code: int = 200) -> Response:
     return resp
 
 
-def _query(url: str) -> dict[str, list[str]]:
-    return parse_qs(urlsplit(url).query)
+def _make_manager(resume_state: BrevoResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-def _drive_get_rows(
-    endpoint: str,
-    manager: MagicMock,
-    responses: list[Response],
-    **kwargs: Any,
-) -> tuple[list[str], list[list[dict[str, Any]]]]:
-    sent_urls: list[str] = []
-    response_iter = iter(responses)
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
 
-    def fake_get(url: str, headers: Any = None, timeout: Any = None) -> Response:
-        sent_urls.append(url)
-        return next(response_iter)
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
 
-    with patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.brevo.brevo.make_tracked_session"
-    ) as MockSession:
-        MockSession.return_value.get.side_effect = fake_get
-        rows = list(
-            get_rows(
-                api_key="test-key",
-                endpoint=endpoint,
-                logger=MagicMock(),
-                resumable_source_manager=manager,
-                **kwargs,
-            )
-        )
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
 
-    return sent_urls, rows
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return brevo_source(
+        api_key="test-key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
 
 
 class TestFormatDatetime:
@@ -116,99 +127,127 @@ class TestBuildBaseParams:
         assert params == {"sort": "asc"}
 
 
-class TestGetRowsPagination:
-    def test_offset_advances_and_terminates_on_short_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_offset_advances_and_terminates_on_short_page(self, MockSession, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(BREVO_ENDPOINTS["contacts"], "page_size", 2)
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"contacts": [{"id": 1}, {"id": 2}], "count": 3}),
+                _response({"contacts": [{"id": 3}], "count": 3}),
+            ],
+        )
 
-        responses = [
-            _make_response({"contacts": [{"id": 1}, {"id": 2}], "count": 3}),
-            _make_response({"contacts": [{"id": 3}], "count": 3}),
-        ]
-        sent_urls, rows = _drive_get_rows("contacts", manager, responses)
+        rows = _rows(_source("contacts", _make_manager()))
 
-        offsets = [_query(u).get("offset", [None])[0] for u in sent_urls]
-        assert offsets == ["0", "2"]
-        assert rows == [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+        assert [r["id"] for r in rows] == [1, 2, 3]
+        assert [p["offset"] for p in params] == [0, 2]
+        assert params[0]["limit"] == 2
+        assert params[0]["sort"] == "asc"
 
-    def test_saves_state_after_each_non_terminal_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_each_non_terminal_page(self, MockSession, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(BREVO_ENDPOINTS["contacts"], "page_size", 2)
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"contacts": [{"id": 1}, {"id": 2}]}),
+                _response({"contacts": [{"id": 3}]}),
+            ],
+        )
 
-        responses = [
-            _make_response({"contacts": [{"id": 1}, {"id": 2}]}),
-            _make_response({"contacts": [{"id": 3}]}),
-        ]
-        _drive_get_rows("contacts", manager, responses)
+        manager = _make_manager()
+        _rows(_source("contacts", manager))
 
         saved = [saved_call.args[0] for saved_call in manager.save_state.call_args_list]
         assert saved == [BrevoResumeConfig(offset=2)]
 
-    def test_single_terminal_page_does_not_save_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(BREVO_ENDPOINTS["contacts"], "page_size", 1000)
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_terminal_page_does_not_save_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"contacts": [{"id": 1}]})])
 
-        responses = [_make_response({"contacts": [{"id": 1}]})]
-        _drive_get_rows("contacts", manager, responses)
+        manager = _make_manager()
+        _rows(_source("contacts", manager))
 
         manager.save_state.assert_not_called()
 
-    def test_resume_seeds_starting_offset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_seeds_starting_offset(self, MockSession, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(BREVO_ENDPOINTS["contacts"], "page_size", 2)
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = BrevoResumeConfig(offset=4)
+        session = MockSession.return_value
+        params = _wire(session, [_response({"contacts": [{"id": 5}]})])
 
-        responses = [_make_response({"contacts": [{"id": 5}]})]
-        sent_urls, _ = _drive_get_rows("contacts", manager, responses)
+        manager = _make_manager(BrevoResumeConfig(offset=4))
+        _rows(_source("contacts", manager))
 
-        assert _query(sent_urls[0])["offset"] == ["4"]
+        assert params[0]["offset"] == 4
         manager.load_state.assert_called_once()
 
-    def test_does_not_load_state_when_cannot_resume(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_does_not_load_state_when_cannot_resume(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"contacts": [{"id": 1}]})])
 
-        responses = [_make_response({"contacts": [{"id": 1}]})]
-        _drive_get_rows("contacts", manager, responses)
+        manager = _make_manager()
+        _rows(_source("contacts", manager))
 
         manager.load_state.assert_not_called()
 
-    def test_empty_page_yields_nothing(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"contacts": [], "count": 0})])
 
-        responses = [_make_response({"contacts": [], "count": 0})]
-        _, rows = _drive_get_rows("contacts", manager, responses)
+        rows = _rows(_source("contacts", _make_manager()))
 
         assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_param_is_sent(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response({"contacts": [{"id": 1}]})])
+
+        _rows(
+            _source(
+                "contacts",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+                incremental_field="modifiedAt",
+            )
+        )
+
+        assert params[0]["modifiedSince"] == "2026-03-04T02:58:14.000Z"
 
 
-class TestGetRowsNonPaginated:
-    def test_senders_fetched_once_without_pagination_params(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+class TestNonPaginated:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_senders_fetched_once_without_pagination_params(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response({"senders": [{"id": 1}, {"id": 2}]})])
 
-        responses = [_make_response({"senders": [{"id": 1}, {"id": 2}]})]
-        sent_urls, rows = _drive_get_rows("senders", manager, responses)
+        manager = _make_manager()
+        rows = _rows(_source("senders", manager))
 
-        assert len(sent_urls) == 1
-        assert urlsplit(sent_urls[0]).query == ""
-        assert rows == [[{"id": 1}, {"id": 2}]]
+        assert session.send.call_count == 1
+        assert params[0] == {}
+        assert rows == [{"id": 1}, {"id": 2}]
         manager.save_state.assert_not_called()
 
 
-class TestGetRowsErrors:
-    def test_non_retryable_status_raises(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+class TestErrors:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_retryable_status_raises(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"message": "Key not found", "code": "unauthorized"}, status_code=401)])
 
-        responses = [_make_response({"message": "Key not found", "code": "unauthorized"}, status_code=401)]
         with pytest.raises(HTTPError):
-            _drive_get_rows("contacts", manager, responses)
+            _rows(_source("contacts", _make_manager()))
 
     @pytest.mark.parametrize(
         ("endpoint", "body"),
@@ -221,41 +260,33 @@ class TestGetRowsErrors:
             ("email_campaigns", {"campaigns": None, "count": 0}),
         ],
     )
-    def test_missing_or_null_envelope_key_yields_nothing(self, endpoint: str, body: dict[str, Any]) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_or_null_envelope_key_yields_nothing(
+        self, MockSession, endpoint: str, body: dict[str, Any]
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
 
-        _, rows = _drive_get_rows(endpoint, manager, [_make_response(body)])
+        manager = _make_manager()
+        rows = _rows(_source(endpoint, manager))
 
         assert rows == []
         manager.save_state.assert_not_called()
 
 
-class TestGetRowsSession:
-    def test_session_disables_transport_retry_and_redacts_key(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+class TestSession:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_session_redacts_key_and_sets_accept_header(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"contacts": [{"id": 1}]})])
 
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.brevo.brevo.make_tracked_session"
-        ) as MockSession:
-            MockSession.return_value.get.return_value = _make_response({"contacts": [{"id": 1}]})
-            list(
-                get_rows(
-                    api_key="test-key",
-                    endpoint="contacts",
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,
-                )
-            )
+        _rows(_source("contacts", _make_manager()))
 
-        kwargs = MockSession.call_args.kwargs
-        assert kwargs["retry"].total == 0
-        assert kwargs["redact_values"] == ("test-key",)
-        assert kwargs["headers"]["api-key"] == "test-key"
-        # Session is created once and reused across the sync.
+        # The api key travels via framework auth, so it's registered for value-based redaction
+        # rather than being a plain client header.
+        assert MockSession.call_args.kwargs["redact_values"] == ("test-key",)
+        assert session.headers.get("accept") == "application/json"
         MockSession.assert_called_once()
-        MockSession.return_value.close.assert_called_once()
 
 
 class TestValidateCredentials:
@@ -264,16 +295,19 @@ class TestValidateCredentials:
         [(200, True), (401, False), (403, False), (500, False)],
     )
     def test_validate_credentials_status_mapping(self, status_code: int, expected: bool) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.brevo.brevo.make_tracked_session"
-        ) as MockSession:
-            MockSession.return_value.get.return_value = _make_response({}, status_code=status_code)
+        with mock.patch(BREVO_SESSION_PATCH) as MockSession:
+            MockSession.return_value.get.return_value = _response({}, status_code=status_code)
             assert validate_credentials("test-key") is expected
 
+    def test_validate_credentials_sends_api_key_header(self) -> None:
+        with mock.patch(BREVO_SESSION_PATCH) as MockSession:
+            MockSession.return_value.get.return_value = _response({})
+            validate_credentials("test-key")
+        assert MockSession.call_args.kwargs["redact_values"] == ("test-key",)
+        assert MockSession.return_value.get.call_args.kwargs["headers"]["api-key"] == "test-key"
+
     def test_validate_credentials_network_error_returns_false(self) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.brevo.brevo.make_tracked_session"
-        ) as MockSession:
+        with mock.patch(BREVO_SESSION_PATCH) as MockSession:
             MockSession.return_value.get.side_effect = Exception("network down")
             assert validate_credentials("test-key") is False
 
@@ -292,14 +326,10 @@ class TestBrevoSourceResponse:
             ("senders", False),
         ],
     )
-    def test_source_response_shape(self, endpoint: str, expects_partition: bool) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        response = brevo_source(
-            api_key="test-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, MockSession, endpoint: str, expects_partition: bool) -> None:
+        MockSession.return_value.headers = {}
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/tests/test_brevo_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/tests/test_brevo_source.py
@@ -126,6 +126,8 @@ class TestBrevoSource:
         _, kwargs = mock_brevo_source.call_args
         assert kwargs["api_key"] == "test-key"
         assert kwargs["endpoint"] == "contacts"
+        assert kwargs["team_id"] == 1
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2026-01-01T00:00:00.000Z"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browser_use/browser_use.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browser_use/browser_use.py
@@ -1,11 +1,7 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response, Session
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.browser_use.settings import (
@@ -13,232 +9,279 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.browser_us
     BrowserUseEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BROWSER_USE_BASE_URL = "https://api.browser-use.com/api/v3"
 API_KEY_HEADER = "X-Browser-Use-API-Key"
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class BrowserUseRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class BrowserUseResumeConfig:
     # Next 1-indexed page/pageNumber to fetch for a top-level list endpoint. None for fan-out.
     page: int | None = None
-    # Fan-out (session_messages): the session currently being read. A stable session id (not a
-    # positional index) so sessions added/removed between a crash and the retry can't resume us
-    # into the wrong session.
+    # Legacy fan-out bookmark fields (session id + `after` message cursor). Kept with defaults so
+    # state saved before the framework migration still parses; such state restarts the fan-out
+    # fresh (merge dedupes the re-pulled rows on the [sessionId, id] primary key).
     session_id: str | None = None
-    # Fan-out: the `after` message-id cursor within the current session.
     after: str | None = None
+    # Framework fan-out checkpoint for session_messages (completed/current child paths plus the
+    # in-progress child paginator state).
+    fanout_state: dict[str, Any] | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {API_KEY_HEADER: api_key, "Accept": "application/json"}
+class BrowserUsePagePaginator(BasePaginator):
+    """1-indexed page-number pagination with a total-ITEMS stop and a short-page stop.
+
+    The built-in ``PageNumberPaginator`` interprets ``total_path`` as a page count and pays one
+    extra empty-page request when no total is present; Browser Use reports the total number of
+    ITEMS (``total`` / ``totalItems``) and its lists guarantee full pages until the last, so a
+    short page also terminates without an extra request.
+    """
+
+    def __init__(self, page_param: str, page_size: int, total_key: str) -> None:
+        super().__init__()
+        self.page_param = page_param
+        self.page_size = page_size
+        self.total_key = total_key
+        self.page = 1
+
+    def _inject(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params[self.page_param] = self.page
+
+    def init_request(self, request: Request) -> None:
+        self._inject(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if data is None or len(data) == 0:
+            self._has_next_page = False
+            return
+
+        self.page += 1
+
+        total: Any = None
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                total = body.get(self.total_key)
+        except Exception:
+            total = None
+
+        if isinstance(total, int):
+            # self.page now points at the NEXT page; the one just fetched is self.page - 1.
+            self._has_next_page = (self.page - 1) * self.page_size < total
+            return
+
+        # No total reported: a short page means the end was reached.
+        self._has_next_page = len(data) >= self.page_size
+
+    def update_request(self, request: Request) -> None:
+        self._inject(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page already points at the next page to fetch (update_state incremented it).
+        return {"page": self.page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"BrowserUsePagePaginator(page_param={self.page_param}, page={self.page})"
 
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    url = f"{BROWSER_USE_BASE_URL}{path}"
-    clean = {k: v for k, v in params.items() if v is not None}
-    return f"{url}?{urlencode(clean)}" if clean else url
+class BrowserUseMessagesPaginator(BasePaginator):
+    """`after`-cursor pagination for GET /sessions/{id}/messages.
 
+    The cursor is the id of the last message on the page (not a body field a jsonpath could
+    select), and the stop signal is the body's ``hasMore`` flag — a page with rows but
+    ``hasMore: false`` must terminate, which the built-in cursor paginator can't express.
+    """
 
-@retry(
-    retry=retry_if_exception_type(
-        (
-            BrowserUseRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+    def __init__(self) -> None:
+        super().__init__()
+        self._after: Optional[str] = None
 
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BrowserUseRetryableError(f"Browser Use API error (retryable): status={response.status_code}, url={url}")
+    def _inject(self, request: Request) -> None:
+        if self._after is not None:
+            if request.params is None:
+                request.params = {}
+            request.params["after"] = self._after
 
-    if not response.ok:
-        # Log status + URL only. Error bodies can echo prompt/message content or other tenant data,
-        # which must not land in application logs outside warehouse-table access controls.
-        logger.error(f"Browser Use API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
+    def init_request(self, request: Request) -> None:
+        self._inject(request)
 
-    return response.json()
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        has_more = False
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                has_more = bool(body.get("hasMore"))
+        except Exception:
+            has_more = False
 
-
-def validate_credentials(api_key: str) -> bool:
-    # The cheapest genuine token probe: list a single session. 200 means the key is accepted.
-    url = _build_url("/sessions", {"page_size": 1})
-    try:
-        # capture=False: the probe lists a session, whose body carries the same free-form agent
-        # content as the export bodies below — keep it out of HTTP sample capture.
-        # allow_redirects=False: the API key rides in a custom header that `requests` preserves
-        # across cross-host 3xx (it only strips `Authorization`), so pin redirects off to keep the
-        # key from replaying to a redirect target. The fixed API host never needs redirects.
-        response = make_tracked_session(redact_values=(api_key,), capture=False, allow_redirects=False).get(
-            url, headers=_get_headers(api_key), timeout=10
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _page_params(config: BrowserUseEndpointConfig, page: int) -> dict[str, Any]:
-    if config.pagination == "page":
-        return {"page": page, "page_size": config.page_size}
-    return {"pageNumber": page, "pageSize": config.page_size}
-
-
-def _get_paged_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrowserUseResumeConfig],
-    config: BrowserUseEndpointConfig,
-) -> Iterator[list[dict[str, Any]]]:
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume is not None and resume.page else 1
-
-    while True:
-        data = _fetch_page(session, _build_url(config.path, _page_params(config, page)), headers, logger)
-        items = data.get(config.data_key) or []
-        if not items:
-            break
-
-        yield items
-
-        # `total`/`totalItems` gives an exact stopping point; without it, a short page (fewer rows
-        # than requested) means we've reached the end. Save AFTER yielding so a crash re-yields the
-        # last page rather than skipping it (merge dedupes on the primary key).
-        total = data.get("total") if config.pagination == "page" else data.get("totalItems")
-        if total is not None:
-            has_more = page * config.page_size < total
+        if has_more and data:
+            self._after = data[-1]["id"]
+            self._has_next_page = True
         else:
-            has_more = len(items) >= config.page_size
+            self._has_next_page = False
 
-        if not has_more:
-            break
+    def update_request(self, request: Request) -> None:
+        self._inject(request)
 
-        page += 1
-        resumable_source_manager.save_state(BrowserUseResumeConfig(page=page))
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"after": self._after} if self._has_next_page and self._after is not None else None
 
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        after = state.get("after")
+        if after is not None:
+            self._after = after
+            self._has_next_page = True
 
-def _iter_session_ids(
-    session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger
-) -> Iterator[str]:
-    page = 1
-    while True:
-        data = _fetch_page(session, _build_url("/sessions", {"page": page, "page_size": 100}), headers, logger)
-        sessions = data.get("sessions") or []
-        if not sessions:
-            break
-
-        for item in sessions:
-            yield item["id"]
-
-        total = data.get("total")
-        if total is not None:
-            if page * 100 >= total:
-                break
-        elif len(sessions) < 100:
-            break
-
-        page += 1
+    def __str__(self) -> str:
+        return f"BrowserUseMessagesPaginator(after={self._after})"
 
 
-def _get_session_message_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrowserUseResumeConfig],
-    config: BrowserUseEndpointConfig,
-) -> Iterator[list[dict[str, Any]]]:
-    session_ids = list(_iter_session_ids(session, headers, logger))
-
-    # Resume only fast-forwards the message cursor *within* the session that was mid-read at the
-    # crash; we deliberately re-walk every session rather than slicing the list from the bookmark.
-    # The API guarantees no session ordering, so a session that reorders (or is newly inserted)
-    # ahead of the bookmark between runs would be skipped for the whole resumed run if we sliced.
-    # Re-pulling already-synced sessions is cheap correctness insurance — merge dedupes the rows on
-    # the [sessionId, id] primary key.
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    resume_session_id = resume.session_id if resume is not None else None
-    resume_after = resume.after if resume is not None else None
-    if resume_session_id is not None:
-        logger.debug(f"Browser Use: resuming session_messages cursor within session_id={resume_session_id}")
-
-    for index, session_id in enumerate(session_ids):
-        # Only the bookmarked session continues from its saved cursor; every other session restarts.
-        after = resume_after if session_id == resume_session_id else None
-        path = config.path.format(session_id=session_id)
-
-        while True:
-            data = _fetch_page(session, _build_url(path, {"after": after, "limit": config.page_size}), headers, logger)
-            messages = data.get(config.data_key) or []
-            if messages:
-                # Stamp the parent session id: the child endpoint may omit it from each message, but
-                # it's half of the declared [sessionId, id] primary key, so the merge needs it present.
-                yield [{**message, "sessionId": session_id} for message in messages]
-
-            has_more = bool(data.get("hasMore")) and bool(messages)
-            if not has_more:
-                break
-
-            after = messages[-1]["id"]
-            resumable_source_manager.save_state(BrowserUseResumeConfig(session_id=session_id, after=after))
-
-        # Advance the bookmark to the next session so a crash between sessions resumes correctly.
-        if index + 1 < len(session_ids):
-            resumable_source_manager.save_state(BrowserUseResumeConfig(session_id=session_ids[index + 1], after=None))
+# Params the two list-pagination styles use: (page param, page-size param, total-items body key).
+_PAGINATION_PARAMS: dict[str, tuple[str, str, str]] = {
+    "page": ("page", "page_size", "total"),
+    "pageNumber": ("pageNumber", "pageSize", "totalItems"),
+}
 
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BrowserUseResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = BROWSER_USE_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every page (and, for fan-out, every child request) so urllib3 keeps
-    # the connection alive instead of re-handshaking per request. Register the key for redaction so
-    # the shared HTTP observer masks it anywhere it surfaces in captured URLs or samples.
+def _make_session(api_key: str) -> Session:
     # capture=False: session titles and session_messages.data hold arbitrary user/agent content the
     # name-based scrubbers can't recognise, so exclude the bodies from HTTP sample capture entirely.
     # allow_redirects=False: the API key rides in a custom header that `requests` preserves across
-    # cross-host 3xx, so pin redirects off to keep it from replaying to a redirect target.
-    session = make_tracked_session(redact_values=(api_key,), capture=False, allow_redirects=False)
+    # cross-host 3xx (it only strips `Authorization`), so pin redirects off to keep it from
+    # replaying to a redirect target. The fixed API host never needs redirects.
+    return make_tracked_session(redact_values=(api_key,), capture=False, allow_redirects=False)
 
-    if config.fan_out_over_sessions:
-        yield from _get_session_message_rows(session, headers, logger, resumable_source_manager, config)
-    else:
-        yield from _get_paged_rows(session, headers, logger, resumable_source_manager, config)
+
+def _client_config(api_key: str) -> ClientConfig:
+    return {
+        "base_url": BROWSER_USE_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        # Auth via the framework config so the key is registered for log redaction.
+        "auth": {"type": "api_key", "api_key": api_key, "name": API_KEY_HEADER, "location": "header"},
+        "session": _make_session(api_key),
+    }
+
+
+def _list_endpoint_resource(config: BrowserUseEndpointConfig) -> EndpointResource:
+    page_param, size_param, total_key = _PAGINATION_PARAMS[config.pagination]
+    return {
+        "name": config.name,
+        "endpoint": {
+            "path": config.path,
+            "params": {size_param: config.page_size},
+            # A missing data key is treated as an empty page (matching the API's envelope for
+            # zero rows), which terminates pagination.
+            "data_selector": config.data_key,
+            "paginator": BrowserUsePagePaginator(
+                page_param=page_param, page_size=config.page_size, total_key=total_key
+            ),
+        },
+    }
+
+
+def _stamp_parent_session_id(row: dict[str, Any]) -> dict[str, Any]:
+    # The child endpoint may omit the session id from each message, but it's half of the declared
+    # [sessionId, id] primary key, so the merge needs it present. `pop` without a default on
+    # purpose: a silent None here would collapse rows across sessions.
+    row["sessionId"] = row.pop("_sessions_id")
+    return row
 
 
 def browser_use_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BrowserUseResumeConfig],
 ) -> SourceResponse:
     config = BROWSER_USE_ENDPOINTS[endpoint]
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resource_defaults": {},
+        "resources": [],
+    }
+
+    resource: Resource
+    if config.fan_out_over_sessions:
+        # session_messages: fan out one cursor-paginated request per agent session. The framework
+        # checkpoints completed child paths and the in-progress child cursor; the (cheap) parent
+        # session list is re-fetched on every attempt.
+        def save_fanout_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            if state is not None:
+                resumable_source_manager.save_state(BrowserUseResumeConfig(fanout_state=state))
+
+        sessions_config = BROWSER_USE_ENDPOINTS["sessions"]
+        rest_config["resources"] = [
+            _list_endpoint_resource(sessions_config),
+            {
+                "name": config.name,
+                "include_from_parent": ["id"],
+                "data_map": _stamp_parent_session_id,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {
+                        "session_id": {"type": "resolve", "resource": sessions_config.name, "field": "id"},
+                        "limit": config.page_size,
+                    },
+                    "data_selector": config.data_key,
+                    "paginator": BrowserUseMessagesPaginator(),
+                },
+            },
+        ]
+        resources = rest_api_resources(
+            rest_config,
+            team_id,
+            job_id,
+            None,
+            resume_hook=save_fanout_checkpoint,
+            initial_paginator_state=resume.fanout_state if resume is not None else None,
+        )
+        resource = next(r for r in resources if r.name == config.name)
+    else:
+        initial_paginator_state = {"page": resume.page} if resume is not None and resume.page else None
+
+        def save_page_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only when a next page remains; the hook fires AFTER a page is yielded so a
+            # crash re-yields the last page (merge dedupes) rather than skipping it.
+            if state and state.get("page") is not None:
+                resumable_source_manager.save_state(BrowserUseResumeConfig(page=int(state["page"])))
+
+        rest_config["resources"] = [_list_endpoint_resource(config)]
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            None,
+            resume_hook=save_page_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # Full-refresh endpoints with no guaranteed API ordering; the watermark is not used, but
         # the batches arrive oldest-first within each page so "asc" is the honest default.
@@ -248,4 +291,16 @@ def browser_use_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    # The cheapest genuine token probe: list a single session. 200 means the key is accepted.
+    # The probe session shares the export path's capture/redirect posture (see _make_session).
+    ok, _status = validate_via_probe(
+        lambda: _make_session(api_key),
+        f"{BROWSER_USE_BASE_URL}/sessions?page_size=1",
+        headers={API_KEY_HEADER: api_key, "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browser_use/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browser_use/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BrowserUseSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -97,23 +100,17 @@ You can create a non-expiring API key at [cloud.browser-use.com/settings](https:
     ) -> list[SourceSchema]:
         # The Browser Use v3 list endpoints expose no server-side created/updated-since filter and
         # no sort parameter, so there is no reliable way to fetch only new rows. Every endpoint is
-        # therefore full-refresh only — declaring incremental would advertise a mode that still
-        # scans the whole list each run.
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = BROWSER_USE_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # therefore full-refresh only (no incremental fields declared) — declaring incremental
+        # would advertise a mode that still scans the whole list each run.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            {},
+            names,
+            should_sync_default={
+                endpoint: endpoint_config.should_sync_default
+                for endpoint, endpoint_config in BROWSER_USE_ENDPOINTS.items()
+            },
+        )
 
     def validate_credentials(
         self, config: BrowserUseSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -138,6 +135,7 @@ You can create a non-expiring API key at [cloud.browser-use.com/settings](https:
         return browser_use_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browser_use/tests/test_browser_use.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browser_use/tests/test_browser_use.py
@@ -1,318 +1,354 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.browser_use import browser_use
 from products.warehouse_sources.backend.temporal.data_imports.sources.browser_use.browser_use import (
+    BROWSER_USE_BASE_URL,
     BrowserUseResumeConfig,
     browser_use_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.browser_use.settings import BROWSER_USE_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
+
+# browser_use builds its tracked session in its own module and hands it to the REST client.
+SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.browser_use.browser_use.make_tracked_session"
+)
 
 
-class _FakeResumableManager:
-    def __init__(self, state: BrowserUseResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BrowserUseResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> BrowserUseResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: BrowserUseResumeConfig) -> None:
-        self.saved.append(data)
+def _response(body: dict[str, Any], status: int = 200, url: str = f"{BROWSER_USE_BASE_URL}/sessions") -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = url
+    resp.reason = {200: "OK", 401: "Unauthorized", 403: "Forbidden", 429: "Too Many Requests"}.get(status, "Error")
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _run(endpoint: str, fetch: Any, manager: _FakeResumableManager | None = None) -> list[dict]:
-    manager = manager or _FakeResumableManager()
-    rows: list[dict] = []
-    with patch.object(browser_use, "make_tracked_session", return_value=MagicMock()):
-        with patch.object(browser_use, "_fetch_page", side_effect=fetch):
-            for batch in get_rows(
-                api_key="bu_test",
-                endpoint=endpoint,
-                logger=MagicMock(),
-                resumable_source_manager=manager,  # type: ignore[arg-type]
-            ):
-                rows.extend(batch)
-    return rows
+def _make_manager(resume_state: BrowserUseResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-def _paged_fetch(data_key: str, page_param: str, pages: list[list[dict]], include_total: bool):
-    """A fetch stub that returns the page indexed by the request's page/pageNumber param."""
-    requested: list[int] = []
-    total = sum(len(p) for p in pages)
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return snapshots of each request's url/params AT PREPARE TIME.
 
-    def fetch(session: Any, url: str, headers: dict, logger: Any) -> dict:
-        qs = parse_qs(urlparse(url).query)
-        page = int(qs[page_param][0])
-        requested.append(page)
-        items = pages[page - 1] if page - 1 < len(pages) else []
-        body: dict = {data_key: items}
-        if include_total:
-            body["total" if page_param == "page" else "totalItems"] = total
-        return body
+    ``request.params`` is a dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
 
-    fetch.requested = requested  # type: ignore[attr-defined]
-    return fetch
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None):
+    return browser_use_source(
+        "bu_test", endpoint, team_id=1, job_id="j", resumable_source_manager=manager or _make_manager()
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestPagination:
     @parameterized.expand(
         [
-            ("sessions", "sessions", "page"),
-            ("browser_sessions", "items", "pageNumber"),
-            ("profiles", "items", "pageNumber"),
-            ("workspaces", "items", "pageNumber"),
+            ("sessions", "sessions", "page", "page_size"),
+            ("browser_sessions", "items", "pageNumber", "pageSize"),
+            ("profiles", "items", "pageNumber", "pageSize"),
+            ("workspaces", "items", "pageNumber", "pageSize"),
         ]
     )
-    def test_all_pages_aggregated_and_terminates(self, endpoint: str, data_key: str, page_param: str) -> None:
-        # Two full pages (100 each) then a short page: guards both that every page is collected and
-        # that a short page terminates the loop instead of paging forever.
+    @mock.patch(SESSION_PATCH)
+    def test_all_pages_aggregated_and_terminates(
+        self, endpoint: str, data_key: str, page_param: str, size_param: str, MockSession
+    ) -> None:
+        # Two full pages then a short page: guards that every page is collected, that the endpoint's
+        # own page/pageSize param names are sent (the wrong name would silently return page 1
+        # forever), and that a short page terminates the loop instead of paging forever.
+        session = MockSession.return_value
         size = BROWSER_USE_ENDPOINTS[endpoint].page_size
         pages = [
             [{"id": f"a{i}"} for i in range(size)],
             [{"id": f"b{i}"} for i in range(size)],
             [{"id": "c0"}, {"id": "c1"}],
         ]
-        fetch = _paged_fetch(data_key, page_param, pages, include_total=False)
-        rows = _run(endpoint, fetch)
+        params = _wire(session, [_response({data_key: page}) for page in pages])
+
+        rows = _rows(_source(endpoint))
 
         assert len(rows) == size * 2 + 2
-        assert fetch.requested == [1, 2, 3]
+        assert [p["params"][page_param] for p in params] == [1, 2, 3]
+        assert all(p["params"][size_param] == size for p in params)
 
-    def test_total_stops_before_an_empty_page(self) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_total_stops_before_an_empty_page(self, MockSession) -> None:
         # A full final page whose count equals `total` must not trigger one more (empty) request.
+        session = MockSession.return_value
         size = BROWSER_USE_ENDPOINTS["sessions"].page_size
-        pages = [[{"id": f"a{i}"} for i in range(size)], [{"id": "b0"}]]
-        fetch = _paged_fetch("sessions", "page", pages, include_total=True)
-        rows = _run("sessions", fetch)
+        full_page = [{"id": f"a{i}"} for i in range(size)]
+        _wire(session, [_response({"sessions": full_page, "total": size})])
 
-        assert len(rows) == size + 1
-        assert fetch.requested == [1, 2]
+        rows = _rows(_source("sessions"))
 
-    def test_correct_pagination_param_sent(self) -> None:
-        # /browsers uses pageNumber/pageSize, not page/page_size — sending the wrong name would
-        # silently return page 1 forever (or 422).
-        seen: list[str] = []
+        assert len(rows) == size
+        assert session.send.call_count == 1
 
-        def fetch(session: Any, url: str, headers: dict, logger: Any) -> dict:
-            seen.append(urlparse(url).query)
-            return {"items": []}
+    @mock.patch(SESSION_PATCH)
+    def test_missing_data_key_is_empty_page(self, MockSession) -> None:
+        # The API envelopes zero rows as a missing/empty array — treat it as the end, not an error.
+        session = MockSession.return_value
+        _wire(session, [_response({})])
 
-        _run("browser_sessions", fetch)
-        assert "pageNumber=1" in seen[0]
-        assert "pageSize=100" in seen[0]
+        assert _rows(_source("sessions")) == []
+        assert session.send.call_count == 1
 
-    def test_state_saved_after_each_yield(self) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_state_saved_after_each_yield(self, MockSession) -> None:
         # Resume state must advance to the NEXT page and only be saved when more pages remain, so a
         # crash re-yields the last page rather than skipping it.
+        session = MockSession.return_value
         size = BROWSER_USE_ENDPOINTS["sessions"].page_size
         pages = [[{"id": f"a{i}"} for i in range(size)], [{"id": "b0"}]]
-        fetch = _paged_fetch("sessions", "page", pages, include_total=False)
-        manager = _FakeResumableManager()
-        _run("sessions", fetch, manager)
+        _wire(session, [_response({"sessions": page}) for page in pages])
+
+        manager = _make_manager()
+        _rows(_source("sessions", manager))
 
         # Only the first (full) page has a successor, so exactly one save advancing to page 2.
-        assert [s.page for s in manager.saved] == [2]
+        manager.save_state.assert_called_once_with(BrowserUseResumeConfig(page=2))
 
-    def test_resumes_from_saved_page(self) -> None:
-        requested: list[int] = []
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response({"sessions": [{"id": "p3"}]})])
 
-        def fetch(session: Any, url: str, headers: dict, logger: Any) -> dict:
-            page = int(parse_qs(urlparse(url).query)["page"][0])
-            requested.append(page)
-            return {"sessions": [{"id": "p3"}] if page == 3 else []}
-
-        manager = _FakeResumableManager(BrowserUseResumeConfig(page=3))
-        rows = _run("sessions", fetch, manager)
+        manager = _make_manager(BrowserUseResumeConfig(page=3))
+        rows = _rows(_source("sessions", manager))
 
         assert rows == [{"id": "p3"}]
-        assert requested == [3]
+        assert [p["params"]["page"] for p in params] == [3]
 
 
 class TestSessionMessagesFanOut:
-    def _fetch(self, sessions_pages: list[list[dict]], messages_by_session: dict[str, list[list[dict]]]):
-        def fetch(session: Any, url: str, headers: dict, logger: Any) -> dict:
-            parsed = urlparse(url)
-            qs = parse_qs(parsed.query)
-            if parsed.path.endswith("/sessions"):
-                page = int(qs["page"][0])
-                items = sessions_pages[page - 1] if page - 1 < len(sessions_pages) else []
-                return {"sessions": items}
-            # /sessions/{id}/messages
-            session_id = parsed.path.split("/")[-2]
-            batches = messages_by_session[session_id]
-            after = qs.get("after", [None])[0]
-            if after is None:
-                batch = batches[0]
-            else:
-                # Find the batch after the one ending in `after`.
-                idx = next(i for i, b in enumerate(batches) if b and b[-1]["id"] == after)
-                batch = batches[idx + 1] if idx + 1 < len(batches) else []
-            has_more = batch != batches[-1] and bool(batch)
-            return {"messages": batch, "hasMore": has_more}
-
-        return fetch
-
-    def test_fans_out_over_sessions_with_cursor(self) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_fans_out_over_sessions_with_cursor(self, MockSession) -> None:
         # Two sessions, one paginated via the `after` cursor; every message must be collected and
         # stamped with its parent session id. The raw child payload omits `sessionId`, so the source
         # has to inject it — the composite [sessionId, id] primary key depends on it being present.
-        sessions_pages = [[{"id": "s1"}, {"id": "s2"}]]
-        messages = {
-            "s1": [
-                [{"id": "m1"}, {"id": "m2"}],
-                [{"id": "m3"}],
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"sessions": [{"id": "s1"}, {"id": "s2"}]}),
+                _response({"messages": [{"id": "m1"}, {"id": "m2"}], "hasMore": True}),
+                _response({"messages": [{"id": "m3"}], "hasMore": False}),
+                _response({"messages": [{"id": "m9"}], "hasMore": False}),
             ],
-            "s2": [[{"id": "m9"}]],
+        )
+
+        rows = _rows(_source("session_messages"))
+
+        assert [(r["id"], r["sessionId"]) for r in rows] == [("m1", "s1"), ("m2", "s1"), ("m3", "s1"), ("m9", "s2")]
+        assert [p["url"] for p in params] == [
+            f"{BROWSER_USE_BASE_URL}/sessions",
+            f"{BROWSER_USE_BASE_URL}/sessions/s1/messages",
+            f"{BROWSER_USE_BASE_URL}/sessions/s1/messages",
+            f"{BROWSER_USE_BASE_URL}/sessions/s2/messages",
+        ]
+        # The second s1 request continues from the last yielded message id.
+        assert params[2]["params"]["after"] == "m2"
+        assert "after" not in params[3]["params"]
+
+    @mock.patch(SESSION_PATCH)
+    def test_checkpoints_track_fanout_progress(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"sessions": [{"id": "s1"}, {"id": "s2"}]}),
+                _response({"messages": [{"id": "m1"}, {"id": "m2"}], "hasMore": True}),
+                _response({"messages": [{"id": "m3"}], "hasMore": False}),
+                _response({"messages": [{"id": "m9"}], "hasMore": False}),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("session_messages", manager))
+
+        saved = [call.args[0].fanout_state for call in manager.save_state.call_args_list]
+        # Mid-s1 the checkpoint carries the in-progress cursor so a crash resumes from m2.
+        assert {
+            "completed": [],
+            "current": "/sessions/s1/messages",
+            "child_state": {"after": "m2"},
+        } in saved
+        # The final checkpoint marks both sessions completed.
+        assert saved[-1] == {
+            "completed": ["/sessions/s1/messages", "/sessions/s2/messages"],
+            "current": None,
+            "child_state": None,
         }
-        rows = _run("session_messages", self._fetch(sessions_pages, messages))
 
-        assert [r["id"] for r in rows] == ["m1", "m2", "m3", "m9"]
-        assert {r["id"] for r in rows if r["sessionId"] == "s1"} == {"m1", "m2", "m3"}
-        assert {r["id"] for r in rows if r["sessionId"] == "s2"} == {"m9"}
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_cursor_within_bookmarked_session(self, MockSession) -> None:
+        # A crash mid-s2 leaves completed=[s1] plus s2's `after` cursor; on resume s2 must continue
+        # from m8 (not restart) while the already-completed s1 is skipped.
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"sessions": [{"id": "s1"}, {"id": "s2"}]}),
+                _response({"messages": [{"id": "m9"}], "hasMore": False}),
+            ],
+        )
 
-    def test_resumes_cursor_within_bookmarked_session(self) -> None:
-        # The saved `after` cursor must apply only to the bookmarked session (s2 continues from m8).
-        # Earlier sessions are re-walked rather than sliced away: the API has no stable ordering, so
-        # skipping them would drop rows for any session that reordered ahead of the bookmark. Merge
-        # dedupes the re-pulled rows downstream on the [sessionId, id] primary key.
-        sessions_pages = [[{"id": "s1"}, {"id": "s2"}]]
-        messages = {
-            "s1": [[{"id": "m1", "sessionId": "s1"}]],
-            "s2": [[{"id": "m8", "sessionId": "s2"}], [{"id": "m9", "sessionId": "s2"}]],
-        }
-        manager = _FakeResumableManager(BrowserUseResumeConfig(session_id="s2", after="m8"))
-        rows = _run("session_messages", self._fetch(sessions_pages, messages), manager)
+        manager = _make_manager(
+            BrowserUseResumeConfig(
+                fanout_state={
+                    "completed": ["/sessions/s1/messages"],
+                    "current": "/sessions/s2/messages",
+                    "child_state": {"after": "m8"},
+                }
+            )
+        )
+        rows = _rows(_source("session_messages", manager))
 
-        assert [r["id"] for r in rows] == ["m1", "m9"]
+        assert [(r["id"], r["sessionId"]) for r in rows] == [("m9", "s2")]
+        assert params[1]["url"] == f"{BROWSER_USE_BASE_URL}/sessions/s2/messages"
+        assert params[1]["params"]["after"] == "m8"
 
-    def test_missing_bookmark_restarts_from_first_session(self) -> None:
-        # If the bookmarked session was deleted between runs, fan-out restarts (merge dedupes).
-        sessions_pages = [[{"id": "s1"}]]
-        messages = {"s1": [[{"id": "m1", "sessionId": "s1"}]]}
-        manager = _FakeResumableManager(BrowserUseResumeConfig(session_id="gone", after="x"))
-        rows = _run("session_messages", self._fetch(sessions_pages, messages), manager)
+    @mock.patch(SESSION_PATCH)
+    def test_completed_sessions_are_skipped_on_resume(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"sessions": [{"id": "s1"}, {"id": "s2"}]}),
+                _response({"messages": [{"id": "m9"}], "hasMore": False}),
+            ],
+        )
+
+        manager = _make_manager(
+            BrowserUseResumeConfig(
+                fanout_state={"completed": ["/sessions/s1/messages"], "current": None, "child_state": None}
+            )
+        )
+        rows = _rows(_source("session_messages", manager))
+
+        assert [(r["id"], r["sessionId"]) for r in rows] == [("m9", "s2")]
+        assert [p["url"] for p in params] == [
+            f"{BROWSER_USE_BASE_URL}/sessions",
+            f"{BROWSER_USE_BASE_URL}/sessions/s2/messages",
+        ]
+
+    @mock.patch(SESSION_PATCH)
+    def test_legacy_resume_state_restarts_fanout(self, MockSession) -> None:
+        # State saved before the framework migration bookmarked a session id + `after` cursor.
+        # It still parses (the dataclass keeps the fields) but restarts the fan-out fresh —
+        # merge dedupes the re-pulled rows.
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"sessions": [{"id": "s1"}]}),
+                _response({"messages": [{"id": "m1"}], "hasMore": False}),
+            ],
+        )
+
+        manager = _make_manager(BrowserUseResumeConfig(session_id="s1", after="m0"))
+        rows = _rows(_source("session_messages", manager))
 
         assert [r["id"] for r in rows] == ["m1"]
+        assert "after" not in params[1]["params"]
 
 
-class TestFetchPage:
+class TestErrorHandling:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_status_raises_retryable(self, _name: str, status: int) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = False
-        session = MagicMock()
-        session.get.return_value = response
+    @mock.patch(SESSION_PATCH)
+    def test_retryable_status_retries_then_raises(self, _name: str, status: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status) for _ in range(5)])
 
-        with patch.object(browser_use._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(browser_use.BrowserUseRetryableError):
-                browser_use._fetch_page(session, "https://api.browser-use.com/api/v3/sessions", {}, MagicMock())
+        with mock.patch.object(RESTClient._send_request.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
+            with pytest.raises(RESTClientRetryableError):
+                _rows(_source("sessions"))
         # Retried up to the 5-attempt cap before giving up.
-        assert session.get.call_count == 5
+        assert session.send.call_count == 5
 
-    def test_client_error_raises_for_status(self) -> None:
-        response = MagicMock()
-        response.status_code = 401
-        response.ok = False
-        response.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=response)
-        session = MagicMock()
-        session.get.return_value = response
+    @mock.patch(SESSION_PATCH)
+    def test_client_error_raises_for_status(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=401)])
 
-        with pytest.raises(requests.HTTPError):
-            browser_use._fetch_page(session, "https://api.browser-use.com/api/v3/sessions", {}, MagicMock())
-        # A credential error is terminal — no retry.
-        assert session.get.call_count == 1
+        # A credential error is terminal — no retry, and the message carries the stable
+        # "401 Client Error: Unauthorized for url: <base host>" prefix the source's
+        # get_non_retryable_errors classifier matches on.
+        with pytest.raises(
+            requests.HTTPError, match="401 Client Error: Unauthorized for url: https://api.browser-use.com"
+        ):
+            _rows(_source("sessions"))
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    def test_status_maps_to_bool(self, _name: str, status: int, expected: bool) -> None:
-        response = MagicMock()
-        response.status_code = status
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(browser_use, "make_tracked_session", return_value=session):
-            assert validate_credentials("bu_test") is expected
+    @mock.patch(SESSION_PATCH)
+    def test_status_maps_to_bool(self, _name: str, status: int, expected: bool, MockSession) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("bu_test") is expected
 
-    def test_network_error_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(browser_use, "make_tracked_session", return_value=session):
-            assert validate_credentials("bu_test") is False
+    @mock.patch(SESSION_PATCH)
+    def test_network_error_is_false(self, MockSession) -> None:
+        MockSession.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("bu_test") is False
 
 
-class TestHttpSampleCapture:
+class TestSessionHardening:
     # Every Browser Use endpoint returns free-form agent content — session titles and
     # session_messages.data hold whatever a user's agent typed or browsed, which the name-based
-    # scrubbers can't recognise. So both the export path and the credential probe must build their
-    # tracked session with capture=False. A regression that drops the flag (falling back to the
-    # capture=True default) would serialize that tenant content into the HTTP sample bucket.
-    def test_get_rows_disables_capture(self) -> None:
-        session = MagicMock()
-        with (
-            patch.object(browser_use, "make_tracked_session", return_value=session) as mock_session,
-            patch.object(browser_use, "_fetch_page", return_value={"sessions": []}),
-        ):
-            list(
-                get_rows(
-                    api_key="bu_test",
-                    endpoint="sessions",
-                    logger=MagicMock(),
-                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-                )
-            )
-        assert mock_session.call_args.kwargs["capture"] is False
+    # scrubbers can't recognise — so both the export path and the credential probe must build
+    # their tracked session with capture=False. And the API key rides in the custom
+    # X-Browser-Use-API-Key header, which requests preserves across a cross-host 3xx (it only
+    # strips Authorization), so both must also pin allow_redirects=False. A regression that drops
+    # either flag re-opens the corresponding leak.
+    @mock.patch(SESSION_PATCH)
+    def test_source_session_disables_capture_and_redirects(self, MockSession) -> None:
+        _source("sessions")
 
-    def test_validate_credentials_disables_capture(self) -> None:
-        response = MagicMock()
-        response.status_code = 200
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(browser_use, "make_tracked_session", return_value=session) as mock_session:
-            validate_credentials("bu_test")
-        assert mock_session.call_args.kwargs["capture"] is False
+        kwargs = MockSession.call_args.kwargs
+        assert kwargs["capture"] is False
+        assert kwargs["allow_redirects"] is False
+        assert kwargs["redact_values"] == ("bu_test",)
 
+    @mock.patch(SESSION_PATCH)
+    def test_validate_credentials_disables_capture_and_redirects(self, MockSession) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("bu_test")
 
-class TestRedirectsDisabled:
-    # The API key rides in the custom X-Browser-Use-API-Key header, which requests preserves across
-    # a cross-host 3xx (it only strips Authorization). Both sessions must pin allow_redirects=False
-    # so the key can't replay to a redirect target; a regression that drops the flag re-opens that leak.
-    def test_get_rows_disables_redirects(self) -> None:
-        session = MagicMock()
-        with (
-            patch.object(browser_use, "make_tracked_session", return_value=session) as mock_session,
-            patch.object(browser_use, "_fetch_page", return_value={"sessions": []}),
-        ):
-            list(
-                get_rows(
-                    api_key="bu_test",
-                    endpoint="sessions",
-                    logger=MagicMock(),
-                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-                )
-            )
-        assert mock_session.call_args.kwargs["allow_redirects"] is False
-
-    def test_validate_credentials_disables_redirects(self) -> None:
-        response = MagicMock()
-        response.status_code = 200
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(browser_use, "make_tracked_session", return_value=session) as mock_session:
-            validate_credentials("bu_test")
-        assert mock_session.call_args.kwargs["allow_redirects"] is False
+        kwargs = MockSession.call_args.kwargs
+        assert kwargs["capture"] is False
+        assert kwargs["allow_redirects"] is False
 
 
 class TestSourceResponse:
@@ -325,8 +361,12 @@ class TestSourceResponse:
             ("session_messages", ["sessionId", "id"], "createdAt"),
         ]
     )
-    def test_primary_keys_and_partition(self, endpoint: str, primary_keys: list[str], partition_key: str) -> None:
-        response = browser_use_source("bu_test", endpoint, MagicMock(), _FakeResumableManager())  # type: ignore[arg-type]
+    @mock.patch(SESSION_PATCH)
+    def test_primary_keys_and_partition(
+        self, endpoint: str, primary_keys: list[str], partition_key: str, MockSession
+    ) -> None:
+        MockSession.return_value.headers = {}
+        response = _source(endpoint)
 
         assert response.name == endpoint
         assert response.primary_keys == primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/browserbase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/browserbase.py
@@ -1,98 +1,68 @@
-from collections.abc import Iterator
-from typing import Any
-
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.settings import BROWSERBASE_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BROWSERBASE_BASE_URL = "https://api.browserbase.com/v1"
 
 
-class BrowserbaseRetryableError(Exception):
-    pass
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "X-BB-API-Key": api_key,
-        "Accept": "application/json",
-    }
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            BrowserbaseRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, headers=headers, timeout=60)
-
-    # 429 (rate limited) and 5xx are transient; retry with backoff. Browserbase sends standard
-    # x-ratelimit-* / retry-after headers, but exponential jitter is a safe default without them.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BrowserbaseRetryableError(f"Browserbase API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Log only status and url — the response body can echo imported third-party data.
-        logger.error(f"Browserbase API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+def _make_session(api_key: str) -> requests.Session:
+    # `redact_values` masks the key in tracked logs/samples. `capture=False` keeps response bodies out
+    # of HTTP sample storage — session objects carry arbitrary `userMetadata` (and projects can carry
+    # other customer-defined fields) that the name-based sample scrubbers can't recognise. Requests
+    # are still metered and logged (status + url).
+    return make_tracked_session(redact_values=(api_key,), capture=False)
 
 
 def validate_credentials(api_key: str) -> bool:
     # `/projects` is the cheapest authenticated probe: a project-scoped key can always list at least
     # its own project, so a 200 confirms the key is genuine without needing any session data.
-    # `redact_values` masks the key in tracked logs/samples. `capture=False` keeps response bodies out
-    # of HTTP sample storage — project objects can carry arbitrary customer fields the name-based
-    # scrubbers can't recognise. Transport errors (timeout, DNS, reset) propagate rather than being
-    # swallowed as False, so a temporary outage isn't reported as a bad key.
-    url = f"{BROWSERBASE_BASE_URL}/projects"
-    response = make_tracked_session(redact_values=(api_key,), capture=False).get(
-        url, headers=_get_headers(api_key), timeout=10
+    ok, _status = validate_via_probe(
+        lambda: _make_session(api_key),
+        f"{BROWSERBASE_BASE_URL}/projects",
+        headers={"X-BB-API-Key": api_key, "Accept": "application/json"},
     )
-    return response.status_code == 200
+    return ok
 
 
-def get_rows(api_key: str, endpoint: str, logger: FilteringBoundLogger) -> Iterator[list[dict[str, Any]]]:
-    config = BROWSERBASE_ENDPOINTS[endpoint]
-    # `capture=False`: session objects carry arbitrary `userMetadata` (and projects can carry other
-    # customer-defined fields) that the name-based sample scrubbers can't recognise, so keep response
-    # bodies out of HTTP sample storage entirely. Requests are still metered and logged (status + url).
-    session = make_tracked_session(redact_values=(api_key,), capture=False)
-    headers = _get_headers(api_key)
-
-    # Browserbase list endpoints return a plain JSON array with no pagination, page, or cursor params,
-    # so a single request yields the whole collection. The pipeline batches the yielded rows for us.
-    data = _fetch(session, f"{BROWSERBASE_BASE_URL}{config.path}", headers, logger)
-
-    # A non-list success body is an unexpected/error shape. Raise so the sync fails loudly instead of
-    # finishing "successfully" with zero rows and silently hiding the bad response.
-    if not isinstance(data, list):
-        raise ValueError(f"Browserbase: expected a list for endpoint {endpoint}, got {type(data).__name__}")
-
-    if data:
-        yield data
-
-
-def browserbase_source(api_key: str, endpoint: str, logger: FilteringBoundLogger) -> SourceResponse:
+def browserbase_source(api_key: str, endpoint: str, team_id: int, job_id: str) -> SourceResponse:
     endpoint_config = BROWSERBASE_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BROWSERBASE_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Framework auth (not a hand-built header) so the key is redacted wherever it surfaces.
+            "auth": {"type": "api_key", "name": "X-BB-API-Key", "api_key": api_key, "location": "header"},
+            # Browserbase list endpoints return a plain JSON array with no pagination, page, or cursor
+            # params, so a single request yields the whole collection.
+            "paginator": "single_page",
+            "session": _make_session(api_key),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": endpoint_config.path,
+                    # The whole body is the row list; a non-list success body is an unexpected/error
+                    # shape. Fail loud instead of finishing "successfully" with zero rows.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_key=api_key, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=endpoint_config.primary_keys,
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/source.py
@@ -27,7 +27,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BrowserbaseSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -94,20 +97,12 @@ You can find your project API key in your [Browserbase dashboard](https://www.br
     ) -> list[SourceSchema]:
         # Every Browserbase list endpoint is full refresh: there is no server-side timestamp filter,
         # so nothing can be synced incrementally (see settings.py).
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=BROWSERBASE_ENDPOINTS[endpoint].should_sync_default,
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            should_sync_default={name: config.should_sync_default for name, config in BROWSERBASE_ENDPOINTS.items()},
+        )
 
     def validate_credentials(
         self, config: BrowserbaseSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -121,5 +116,6 @@ You can find your project API key in your [Browserbase dashboard](https://www.br
         return browserbase_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/tests/test_browserbase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/tests/test_browserbase.py
@@ -56,7 +56,13 @@ def _rows(source_response) -> list[dict[str, Any]]:
 class TestGetRows:
     def setup_method(self) -> None:
         # Drop the exponential backoff so retryable-status tests don't actually sleep.
+        # Saved and restored in teardown_method — this attribute is process-global, and leaving
+        # wait_none in place breaks rest_client's own retry-wait tests in the same run.
+        self._original_wait = RESTClient._send_request.retry.wait  # type: ignore[attr-defined]
         RESTClient._send_request.retry.wait = wait_none()  # type: ignore[attr-defined]
+
+    def teardown_method(self) -> None:
+        RESTClient._send_request.retry.wait = self._original_wait  # type: ignore[attr-defined]
 
     @mock.patch(SESSION_PATCH)
     def test_single_request_yields_all_rows(self, MockSession) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/tests/test_browserbase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/tests/test_browserbase.py
@@ -1,173 +1,209 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
 from tenacity import wait_none
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.browserbase import browserbase
 from products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.browserbase import (
     BROWSERBASE_BASE_URL,
-    BrowserbaseRetryableError,
-    _fetch,
     browserbase_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
+
+# Both the sync transport and the credential probe build their session via the
+# browserbase module's make_tracked_session (passed into the client config).
+SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.browserbase.make_tracked_session"
+)
 
 
-def _response(status_code: int, json_body: Any = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    response.text = "" if json_body is None else str(json_body)
-    response.json.return_value = json_body
-
-    def _raise() -> None:
-        if not response.ok:
-            raise requests.HTTPError(f"{status_code} Client Error", response=response)
-
-    response.raise_for_status.side_effect = _raise
-    return response
+def _response(status_code: int, json_body: Any = None) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp.url = f"{BROWSERBASE_BASE_URL}/sessions"
+    resp._content = json.dumps(json_body if json_body is not None else []).encode()
+    return resp
 
 
-class TestFetch:
-    def setup_method(self) -> None:
-        # Drop the exponential backoff so retryable-status tests don't actually sleep.
-        _fetch.retry.wait = wait_none()  # type: ignore[attr-defined]
+def _wire(session: mock.MagicMock, responses: list[requests.Response]) -> list[requests.PreparedRequest]:
+    """Wire a mock session and capture each request AS PREPARED (auth applied, URL resolved)."""
+    session.headers = {}
+    prepared_requests: list[requests.PreparedRequest] = []
 
-    def test_returns_parsed_json_on_success(self) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(200, [{"id": "sess_1"}])
+    def _prepare(request: requests.Request) -> requests.PreparedRequest:
+        prepared = request.prepare()
+        prepared_requests.append(prepared)
+        return prepared
 
-        result = _fetch(session, f"{BROWSERBASE_BASE_URL}/sessions", {}, MagicMock())
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return prepared_requests
 
-        assert result == [{"id": "sess_1"}]
-        assert session.get.call_count == 1
 
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_status_raises_retryable_error(self, _name: str, status_code: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status_code, {"error": "nope"})
-
-        with pytest.raises(BrowserbaseRetryableError):
-            _fetch(session, f"{BROWSERBASE_BASE_URL}/sessions", {}, MagicMock())
-
-        # 5 attempts before giving up (stop_after_attempt(5)).
-        assert session.get.call_count == 5
-
-    def test_recovers_after_transient_error(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [_response(500, {}), _response(200, [{"id": "sess_1"}])]
-
-        result = _fetch(session, f"{BROWSERBASE_BASE_URL}/sessions", {}, MagicMock())
-
-        assert result == [{"id": "sess_1"}]
-        assert session.get.call_count == 2
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_error_raises_immediately(self, _name: str, status_code: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status_code, {"error": "nope"})
-
-        with pytest.raises(requests.HTTPError):
-            _fetch(session, f"{BROWSERBASE_BASE_URL}/sessions", {}, MagicMock())
-
-        # Client errors are not retried - they can never succeed on retry.
-        assert session.get.call_count == 1
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestGetRows:
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.browserbase._fetch")
-    def test_yields_list_of_rows(self, mock_fetch: MagicMock) -> None:
-        rows = [{"id": "sess_1"}, {"id": "sess_2"}]
-        mock_fetch.return_value = rows
+    def setup_method(self) -> None:
+        # Drop the exponential backoff so retryable-status tests don't actually sleep.
+        RESTClient._send_request.retry.wait = wait_none()  # type: ignore[attr-defined]
 
-        result = list(get_rows("bb_key", "sessions", MagicMock()))
+    @mock.patch(SESSION_PATCH)
+    def test_single_request_yields_all_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows_body = [{"id": "sess_1"}, {"id": "sess_2"}]
+        prepared = _wire(session, [_response(200, rows_body)])
 
-        assert result == [rows]
+        rows = _rows(browserbase_source("bb_key", "sessions", team_id=1, job_id="j"))
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.browserbase._fetch")
-    def test_empty_list_yields_nothing(self, mock_fetch: MagicMock) -> None:
-        mock_fetch.return_value = []
+        assert rows == rows_body
+        # No pagination params exist - the whole collection comes back in one request.
+        assert session.send.call_count == 1
+        assert prepared[0].url == f"{BROWSERBASE_BASE_URL}/sessions"
 
-        assert list(get_rows("bb_key", "sessions", MagicMock())) == []
+    @mock.patch(SESSION_PATCH)
+    def test_empty_list_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(200, [])])
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.browserbase._fetch")
-    def test_non_list_response_raises(self, mock_fetch: MagicMock) -> None:
-        # Browserbase list endpoints return arrays; a dict means an unexpected/error shape. Raise so the
-        # sync fails loudly instead of finishing "successfully" with zero rows.
-        mock_fetch.return_value = {"statusCode": 500}
+        assert _rows(browserbase_source("bb_key", "sessions", team_id=1, job_id="j")) == []
 
-        with pytest.raises(ValueError):
-            list(get_rows("bb_key", "sessions", MagicMock()))
+    @mock.patch(SESSION_PATCH)
+    def test_non_list_response_raises(self, MockSession) -> None:
+        # Browserbase list endpoints return arrays; a dict means an unexpected/error shape. Raise so
+        # the sync fails loudly instead of finishing "successfully" with zero rows.
+        session = MockSession.return_value
+        _wire(session, [_response(200, {"statusCode": 500})])
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.browserbase._fetch")
-    def test_requests_the_endpoint_path(self, mock_fetch: MagicMock) -> None:
-        mock_fetch.return_value = [{"id": "proj_1"}]
+        with pytest.raises(ValueError, match="Required a list response body"):
+            _rows(browserbase_source("bb_key", "sessions", team_id=1, job_id="j"))
 
-        list(get_rows("bb_key", "projects", MagicMock()))
+    @mock.patch(SESSION_PATCH)
+    def test_requests_the_endpoint_path(self, MockSession) -> None:
+        session = MockSession.return_value
+        prepared = _wire(session, [_response(200, [{"id": "proj_1"}])])
 
-        called_url = mock_fetch.call_args.args[1]
-        assert called_url == f"{BROWSERBASE_BASE_URL}/projects"
+        _rows(browserbase_source("bb_key", "projects", team_id=1, job_id="j"))
+
+        assert prepared[0].url == f"{BROWSERBASE_BASE_URL}/projects"
+
+    @mock.patch(SESSION_PATCH)
+    def test_api_key_sent_via_header_auth(self, MockSession) -> None:
+        session = MockSession.return_value
+        prepared = _wire(session, [_response(200, [{"id": "sess_1"}])])
+
+        _rows(browserbase_source("bb_test_key", "sessions", team_id=1, job_id="j"))
+
+        assert prepared[0].headers["X-BB-API-Key"] == "bb_test_key"
+        assert session.headers.get("Accept") == "application/json"
+
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    @mock.patch(SESSION_PATCH)
+    def test_retryable_status_raises_after_retries(self, _name: str, status_code: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status_code, {"error": "nope"})] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(browserbase_source("bb_key", "sessions", team_id=1, job_id="j"))
+
+        # 5 attempts before giving up.
+        assert session.send.call_count == 5
+
+    @mock.patch(SESSION_PATCH)
+    def test_recovers_after_transient_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(500, {}), _response(200, [{"id": "sess_1"}])])
+
+        rows = _rows(browserbase_source("bb_key", "sessions", team_id=1, job_id="j"))
+
+        assert rows == [{"id": "sess_1"}]
+        assert session.send.call_count == 2
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    @mock.patch(SESSION_PATCH)
+    def test_client_error_raises_immediately(self, _name: str, status_code: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status_code, {"error": "nope"})] * 5)
+
+        with pytest.raises(requests.HTTPError):
+            _rows(browserbase_source("bb_key", "sessions", team_id=1, job_id="j"))
+
+        # Client errors are not retried - they can never succeed on retry.
+        assert session.send.call_count == 1
 
 
 class TestKeyRedaction:
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.browserbase.browserbase._fetch")
-    @patch.object(browserbase, "make_tracked_session")
-    def test_get_rows_redacts_key(self, mock_session_factory: MagicMock, mock_fetch: MagicMock) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_source_session_redacts_key(self, MockSession) -> None:
         # The API key must be masked in tracked HTTP logs/samples, not left recoverable from a bucket.
-        mock_fetch.return_value = []
-        mock_session_factory.return_value = MagicMock()
+        session = MockSession.return_value
+        _wire(session, [_response(200, [])])
 
-        list(get_rows("bb_secret", "sessions", MagicMock()))
+        _rows(browserbase_source("bb_secret", "sessions", team_id=1, job_id="j"))
 
-        assert mock_session_factory.call_args.kwargs["redact_values"] == ("bb_secret",)
+        assert MockSession.call_args.kwargs["redact_values"] == ("bb_secret",)
         # Response bodies carry arbitrary customer userMetadata the scrubbers can't recognise.
-        assert mock_session_factory.call_args.kwargs["capture"] is False
+        assert MockSession.call_args.kwargs["capture"] is False
 
-    @patch.object(browserbase, "make_tracked_session")
-    def test_validate_credentials_redacts_key(self, mock_session_factory: MagicMock) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(200)
-        mock_session_factory.return_value = session
+    @mock.patch(SESSION_PATCH)
+    def test_validate_credentials_redacts_key(self, MockSession) -> None:
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=200)
+        MockSession.return_value = session
 
         validate_credentials("bb_secret")
 
-        assert mock_session_factory.call_args.kwargs["redact_values"] == ("bb_secret",)
-        assert mock_session_factory.call_args.kwargs["capture"] is False
+        assert MockSession.call_args.kwargs["redact_values"] == ("bb_secret",)
+        assert MockSession.call_args.kwargs["capture"] is False
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    @patch.object(browserbase, "make_tracked_session")
-    def test_maps_status_to_bool(
-        self, _name: str, status_code: int, expected: bool, mock_session_factory: MagicMock
-    ) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status_code)
-        mock_session_factory.return_value = session
+    @mock.patch(SESSION_PATCH)
+    def test_maps_status_to_bool(self, _name: str, status_code: int, expected: bool, MockSession) -> None:
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=status_code)
+        MockSession.return_value = session
 
         assert validate_credentials("bb_key") is expected
 
-    @patch.object(browserbase, "make_tracked_session")
-    def test_network_error_propagates(self, mock_session_factory: MagicMock) -> None:
-        # A transport failure is transient - it must surface, not be reported as an invalid key.
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        mock_session_factory.return_value = session
+    @mock.patch(SESSION_PATCH)
+    def test_probes_projects_with_key_header(self, MockSession) -> None:
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=200)
+        MockSession.return_value = session
 
-        with pytest.raises(requests.ConnectionError):
-            validate_credentials("bb_key")
+        validate_credentials("bb_key")
+
+        assert session.get.call_args.args[0] == f"{BROWSERBASE_BASE_URL}/projects"
+        assert session.get.call_args.kwargs["headers"]["X-BB-API-Key"] == "bb_key"
+
+    @mock.patch(SESSION_PATCH)
+    def test_network_error_maps_to_not_validated(self, MockSession) -> None:
+        # The probe must never raise out of validate_credentials - an unreachable API means
+        # "not validated", not a crashed source-create request.
+        session = mock.MagicMock()
+        session.get.side_effect = requests.ConnectionError("boom")
+        MockSession.return_value = session
+
+        assert validate_credentials("bb_key") is False
 
 
 class TestBrowserbaseSource:
     @parameterized.expand([(endpoint,) for endpoint in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        response = browserbase_source("bb_key", endpoint, MagicMock())
+    @mock.patch(SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, MockSession) -> None:
+        response = browserbase_source("bb_key", endpoint, team_id=1, job_id="j")
 
         assert response.name == endpoint
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/tests/test_browserbase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/browserbase/tests/test_browserbase_source.py
@@ -1,8 +1,10 @@
+import json
 from collections.abc import Iterable
 from typing import Any, cast
 
 from unittest.mock import MagicMock, patch
 
+import requests
 from parameterized import parameterized
 
 from posthog.schema import DataWarehouseSourceCategory, ReleaseStatus, SourceFieldInputConfig
@@ -101,15 +103,25 @@ class TestBrowserbasePipelineHandoff:
     @patch.object(browserbase, "make_tracked_session")
     def test_source_for_pipeline_plumbs_endpoint_and_key(self, mock_session_factory: MagicMock) -> None:
         session = MagicMock()
-        response = MagicMock()
+        session.headers = {}
+        prepared_requests: list[requests.PreparedRequest] = []
+
+        def _prepare(request: requests.Request) -> requests.PreparedRequest:
+            prepared = request.prepare()
+            prepared_requests.append(prepared)
+            return prepared
+
+        response = requests.Response()
         response.status_code = 200
-        response.ok = True
-        response.json.return_value = [{"id": "sess_1", "createdAt": "2026-01-01T00:00:00Z"}]
-        session.get.return_value = response
+        response._content = json.dumps([{"id": "sess_1", "createdAt": "2026-01-01T00:00:00Z"}]).encode()
+        session.prepare_request.side_effect = _prepare
+        session.send.return_value = response
         mock_session_factory.return_value = session
 
         inputs = MagicMock()
         inputs.schema_name = "sessions"
+        inputs.team_id = 1
+        inputs.job_id = "job_1"
 
         source_response = BrowserbaseSource().source_for_pipeline(_config(), inputs)
 
@@ -119,4 +131,4 @@ class TestBrowserbasePipelineHandoff:
         # The items thunk should actually pull rows using the configured key/endpoint.
         rows = list(cast(Iterable[Any], source_response.items()))
         assert rows == [[{"id": "sess_1", "createdAt": "2026-01-01T00:00:00Z"}]]
-        assert session.get.call_args.kwargs["headers"]["X-BB-API-Key"] == "bb_test_key"
+        assert prepared_requests[0].headers["X-BB-API-Key"] == "bb_test_key"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -19,7 +19,7 @@ from .config_setup import (
 from .jsonpath_utils import TJsonPath
 from .paginators import BasePaginator
 from .resource import Resource
-from .rest_client import DEFAULT_REQUEST_TIMEOUT_SECONDS, DEFAULT_RETRY_ATTEMPTS, RESTClient
+from .rest_client import DEFAULT_RETRY_ATTEMPTS, RESTClient, resolve_request_timeout
 from .typing import ClientConfig, Endpoint, EndpointResource, HTTPMethodBasic, ResolvedParam, RESTAPIConfig
 from .utils import exclude_keys  # noqa: F401
 
@@ -262,7 +262,9 @@ def create_resources(
             paginator=create_paginator(client_config.get("paginator")),
             session=client_config.get("session"),
             max_retry_attempts=client_config.get("max_retries", DEFAULT_RETRY_ATTEMPTS),
-            request_timeout=client_config.get("request_timeout", DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            # Coerce through `resolve_request_timeout`: manifests are client-authored, so a
+            # `null`/malformed value must land on the default bound, never `None` (unbounded).
+            request_timeout=resolve_request_timeout(client_config.get("request_timeout")),
         )
 
         hooks = create_response_hooks(endpoint_config.get("response_actions"))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -19,7 +19,7 @@ from .config_setup import (
 from .jsonpath_utils import TJsonPath
 from .paginators import BasePaginator
 from .resource import Resource
-from .rest_client import DEFAULT_RETRY_ATTEMPTS, RESTClient
+from .rest_client import DEFAULT_REQUEST_TIMEOUT_SECONDS, DEFAULT_RETRY_ATTEMPTS, RESTClient
 from .typing import ClientConfig, Endpoint, EndpointResource, HTTPMethodBasic, ResolvedParam, RESTAPIConfig
 from .utils import exclude_keys  # noqa: F401
 
@@ -262,6 +262,7 @@ def create_resources(
             paginator=create_paginator(client_config.get("paginator")),
             session=client_config.get("session"),
             max_retry_attempts=client_config.get("max_retries", DEFAULT_RETRY_ATTEMPTS),
+            request_timeout=client_config.get("request_timeout", DEFAULT_REQUEST_TIMEOUT_SECONDS),
         )
 
         hooks = create_response_hooks(endpoint_config.get("response_actions"))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -38,6 +38,11 @@ MAX_RETRY_AFTER_SECONDS = 300.0
 # rate-limited endpoint surfaces an error instead of sleeping on `Retry-After`.
 DEFAULT_RETRY_ATTEMPTS = 5
 
+# Per-request timeout (seconds) applied to every `session.send`. `requests` waits forever
+# without one, so a stalled — or customer-controlled — upstream could tie up an import worker
+# indefinitely. A read timeout on an idempotent GET is retried by the adapter's DEFAULT_RETRY.
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
+
 
 def _parse_retry_after(response: Response) -> Optional[float]:
     """Best-effort retry delay (seconds) from a rate-limited / erroring response.
@@ -106,12 +111,16 @@ class RESTClient:
         paginator: Optional[BasePaginator] = None,
         session: Optional[Session] = None,
         max_retry_attempts: int = DEFAULT_RETRY_ATTEMPTS,
+        request_timeout: Optional[float | tuple[float, float]] = DEFAULT_REQUEST_TIMEOUT_SECONDS,
     ) -> None:
         self.base_url = base_url or ""
         self.headers = headers or {}
         self.auth = auth
         self.paginator = paginator
         self._max_retry_attempts = max_retry_attempts
+        # `None` disables the bound (only for callers that manage their own timeout on the
+        # passed-in session, e.g. the inline preview). A `(connect, read)` tuple splits it.
+        self._request_timeout = request_timeout
         # Default to the tracked session so every source built on top of
         # `RESTClient` participates in HTTP logging, metrics, and sample
         # capture. Callers can pass a pre-built `Session` for tests or
@@ -190,7 +199,7 @@ class RESTClient:
         # `send` reads the body eagerly (stream=False), so a connection dropped mid-stream
         # surfaces here as ChunkedEncodingError. Reissue it like a truncated/partial body below.
         try:
-            response = self.session.send(prepared)
+            response = self.session.send(prepared, timeout=self._request_timeout)
         except ChunkedEncodingError as e:
             raise RESTClientRetryableError(f"Connection broken while reading response: {e}") from e
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -1,4 +1,5 @@
 import copy
+import math
 import logging
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
@@ -42,6 +43,27 @@ DEFAULT_RETRY_ATTEMPTS = 5
 # without one, so a stalled — or customer-controlled — upstream could tie up an import worker
 # indefinitely. A read timeout on an idempotent GET is retried by the adapter's DEFAULT_RETRY.
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
+
+
+def _is_positive_finite(value: Any) -> bool:
+    # `bool` is an `int` subclass — a stray `True`/`False` must not read as a timeout.
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value) and value > 0
+
+
+def resolve_request_timeout(value: Any) -> float | tuple[float, float]:
+    """Coerce a declarative/client-supplied timeout to a bounded value.
+
+    Custom-source manifests feed `client.request_timeout` straight through, so a missing,
+    `null`, or malformed value must fall back to the default bound rather than disabling it
+    — `timeout=None` restores requests' infinite wait, letting an unresponsive host hold a
+    shared import worker indefinitely. Accepts a positive finite number of seconds or a
+    `(connect, read)` pair of positive finite numbers; anything else becomes the default.
+    """
+    if _is_positive_finite(value):
+        return float(value)
+    if isinstance(value, (tuple, list)) and len(value) == 2 and all(_is_positive_finite(v) for v in value):
+        return (float(value[0]), float(value[1]))
+    return DEFAULT_REQUEST_TIMEOUT_SECONDS
 
 
 def _parse_retry_after(response: Response) -> Optional[float]:
@@ -118,8 +140,9 @@ class RESTClient:
         self.auth = auth
         self.paginator = paginator
         self._max_retry_attempts = max_retry_attempts
-        # `None` disables the bound (only for callers that manage their own timeout on the
-        # passed-in session, e.g. the inline preview). A `(connect, read)` tuple splits it.
+        # `None` disables the bound — reserved for trusted in-process callers that manage
+        # their own timeout on the passed-in session. Declarative/manifest config is coerced
+        # to a bounded value first (see `resolve_request_timeout`). A tuple is `(connect, read)`.
         self._request_timeout = request_timeout
         # Default to the tracked session so every source built on top of
         # `RESTClient` participates in HTTP logging, metrics, and sample

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -1,6 +1,6 @@
 import json
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from requests import Response
 from requests.exceptions import ChunkedEncodingError
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import rest_api_resource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.exceptions import (
     IgnoreResponseException,
@@ -17,11 +18,14 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     SinglePagePaginator,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
     MAX_RETRY_AFTER_SECONDS,
     RESTClient,
     RESTClientRetryableError,
     _parse_retry_after,
+    resolve_request_timeout,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import RESTAPIConfig
 
 
 def _make_response(json_body: Any, status_code: int = 200) -> Response:
@@ -527,3 +531,56 @@ class TestRESTClient:
         response.headers["X-Sentry-Rate-Limit-Reset"] = str(int(now.timestamp()) - 5)
 
         assert _parse_retry_after(response) is None
+
+
+class TestRequestTimeout:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, DEFAULT_REQUEST_TIMEOUT_SECONDS),  # null/missing manifest value must not disable the bound
+            (30, 30.0),
+            (30.5, 30.5),
+            ((5, 10), (5.0, 10.0)),
+            ([5, 10], (5.0, 10.0)),
+            (0, DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            (-1, DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            (float("inf"), DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            (float("nan"), DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            (True, DEFAULT_REQUEST_TIMEOUT_SECONDS),  # bool is an int subclass but is not a timeout
+            ("60", DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            ((5,), DEFAULT_REQUEST_TIMEOUT_SECONDS),  # wrong-length tuple
+            ((5, 0), DEFAULT_REQUEST_TIMEOUT_SECONDS),  # tuple with a non-positive member
+            ((5, "x"), DEFAULT_REQUEST_TIMEOUT_SECONDS),  # tuple with a non-numeric member
+        ],
+    )
+    def test_resolve_request_timeout(self, value: Any, expected: Any) -> None:
+        assert resolve_request_timeout(value) == expected
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.RESTClient")
+    def test_manifest_cannot_disable_request_timeout(self, MockClient: MagicMock) -> None:
+        # A client-authored manifest that sets request_timeout to null must still land on the
+        # bounded default — never None, which would restore requests' infinite wait.
+        config = cast(
+            RESTAPIConfig,
+            {
+                "client": {"base_url": "https://api.example.com", "request_timeout": None},
+                "resource_defaults": None,
+                "resources": [{"name": "items", "endpoint": {"path": "/items", "data_selector": "data"}}],
+            },
+        )
+
+        rest_api_resource(config, team_id=1, job_id="j", db_incremental_field_last_value=None)
+
+        assert MockClient.call_args.kwargs["request_timeout"] == DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+    def test_send_request_passes_configured_timeout(self) -> None:
+        # The configured timeout must reach session.send — otherwise the bound is silently dropped.
+        session = MagicMock()
+        session.headers = {}
+        session.prepare_request.return_value = MagicMock()
+        session.send.return_value = _make_response({"data": []})
+
+        client = RESTClient(base_url="https://api.example.com", session=session, request_timeout=42.0)
+        list(client.paginate(path="/items", data_selector="data", paginator=SinglePagePaginator()))
+
+        assert session.send.call_args.kwargs["timeout"] == 42.0

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -171,8 +171,9 @@ class ClientConfig(TypedDict, total=False):
     # the inline preview sets 1 so a rate-limited endpoint errors instead of sleeping.
     max_retries: int
     # Per-request timeout (seconds, or a `(connect, read)` tuple) passed to `session.send`.
-    # Left unset, RESTClient applies its bounded default; `None` disables the bound for
-    # callers that manage their own timeout on the passed-in session.
+    # Manifests are client-authored, so this is coerced through `resolve_request_timeout`:
+    # a missing, `null`, or malformed value falls back to the bounded default — it can never
+    # disable the timeout.
     request_timeout: Optional[float | tuple[float, float]]
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -170,6 +170,10 @@ class ClientConfig(TypedDict, total=False):
     # Cap on retry attempts per request. Left unset, RESTClient uses its default;
     # the inline preview sets 1 so a rate-limited endpoint errors instead of sleeping.
     max_retries: int
+    # Per-request timeout (seconds, or a `(connect, read)` tuple) passed to `session.send`.
+    # Left unset, RESTClient applies its bounded default; `None` disables the bound for
+    # callers that manage their own timeout on the passed-in session.
+    request_timeout: Optional[float | tuple[float, float]]
 
 
 class IncrementalArgs(TypedDict, total=False):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -1243,6 +1243,9 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
                     # One attempt only — a rate-limited endpoint must surface an error
                     # inline, not sleep on `Retry-After` and tie up the request thread.
                     "max_retries": 1,
+                    # Short probe timeout so a stalled upstream can't hang the preview — the
+                    # default sync bound is far longer than an interactive preview should wait.
+                    "request_timeout": (PROBE_CONNECT_TIMEOUT, PROBE_READ_TIMEOUT),
                 },
             },
         )
@@ -1302,10 +1305,11 @@ class PreviewResponseTooLargeError(Exception):
 class _PreviewSession(_NoRedirectSession):
     """No-redirect session for the inline preview read, bounded on time and size.
 
-    Pins a session-level timeout (``RESTClient.send()`` passes none, so a stalled
-    upstream can't hang the request thread) and caps the response bytes parsed via a
-    budget shared across the preview — one session serves one preview. See
-    ``_read_within_budget`` for the size enforcement.
+    The preview's request timeout is set via the client config's ``request_timeout``
+    (``RESTClient`` passes it to ``send``); the ``setdefault`` below is a fallback for
+    any direct ``send`` that omits it. Caps the response bytes parsed via a budget shared
+    across the preview — one session serves one preview. See ``_read_within_budget`` for
+    the size enforcement.
     """
 
     def __init__(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -2663,7 +2663,7 @@ class TestCustomSourcePreviewResource(SimpleTestCase):
 
         sent_urls: list[str] = []
 
-        def _send(prepared):
+        def _send(prepared, **kwargs):
             sent_urls.append(prepared.url)
             if prepared.url.endswith("/forms"):
                 return _response({"items": [{"id": f"f{index}"} for index in range(PREVIEW_MAX_FANOUT_PARENTS + 20)]})


### PR DESCRIPTION
## Problem

Seventh batch of hand-rolled source → `rest_source` migrations, stacked on #71572.

## Changes

**Five sources migrated** (behavior-preserving, suites green): `boldsign` (55 tests), `braze` (68), `brevo` (52), `browser_use` (44), `browserbase` (33).

Also fixes a test-pollution bug the merged run caught: browserbase's tests replaced the process-global `RESTClient._send_request.retry.wait` with `wait_none` and never restored it, breaking rest_client's retry-wait tests in the same process — now saved/restored in `teardown_method`.

**Vetted and skipped**: `breezometer` (client-side fan-out over a config-defined location list with per-request dynamic POST bodies and requested-coordinate row stamping), `bing_ads` (vendor SDK), `braintree` (GraphQL) — pre-vetted, not framework targets.

> [!NOTE]
> Stacked on #71572 → #71565 → #71559 → #71552 → #71540 → #71524 → #71520 → #71481/#71477.

## How did you test this code?

- Merged verification: **392 tests pass** across the 5 migrated sources + the full `rest_source` suite (this run is what caught the retry-wait leak — the fix is included and re-verified).
- Each source's suite passed in isolation first; coverage preserved. Worktree isolation verified before merge. `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
