### PR TITLE
chore(posthog-ai): fix stale toolPolicy provenance comment

### DIFF
--- a/products/posthog_ai/frontend/policy/toolPolicy.ts
+++ b/products/posthog_ai/frontend/policy/toolPolicy.ts
@@ -6,14 +6,16 @@ import type { PermissionRequestRecord } from '../types/streamTypes'
 export { isPostHogExecTool } from '../components/tool/posthogExecDisplay'
 
 /**
- * Default sandbox tool-permission policy, ported from Twig
- * (`packages/agent/src/adapters/claude/permissions/posthog-exec-gate.ts`).
+ * Default sandbox tool-permission policy, mirroring the agent-server's exec gate
+ * (`packages/agent/src/adapters/claude/permissions/posthog-exec-gate.ts` in PostHog/code).
  *
- * The deployed agent-server runs in `default` mode and asks for approval on every PostHog `exec`
- * call. We mirror Twig's policy on the client instead: auto-approve every built-in (default) tool
- * and every PostHog `exec` operation EXCEPT the destructive ones (update/delete/destroy/
- * partial-update), which still surface the approval card. Non-PostHog MCP tools fall outside the
- * default-allow contract and also prompt.
+ * The web surface starts runs in `auto` mode (`INITIAL_PERMISSION_MODE`): the agent-server
+ * auto-runs built-ins (edits, shell) server-side and emits a `permission_request` for every
+ * PostHog `exec` call — including destructive sub-tools, which its gate deliberately does not
+ * skip in `auto` mode. This client policy decides those requests: auto-approve every `exec`
+ * operation EXCEPT the destructive ones (update/delete/destroy/partial-update), which surface
+ * the approval card. Built-ins are auto-approved too as a fallback for modes where the server
+ * does ask. Non-PostHog MCP tools fall outside the default-allow contract and also prompt.
  */
 
 /** A sub-tool is destructive when one of these verbs appears as a whole `-`-bounded segment. */


### PR DESCRIPTION
## Problem

The header comment in `products/posthog_ai/frontend/policy/toolPolicy.ts` claims the deployed agent-server runs in `default` permission mode and asks for approval on every PostHog exec call. That's stale: the web surface starts runs in `auto` mode (`INITIAL_PERMISSION_MODE`), where the agent-server auto-runs built-ins server-side. Worse, until PostHog/code#3514 the server's exec gate silently allowed destructive sub-tools in `auto` mode, so the approval card this policy is supposed to drive never appeared.

## Changes

Comment-only. Rewrites the header to describe the actual contract: the agent-server emits a `permission_request` for every PostHog exec call in `auto` mode (including destructive sub-tools, as of PostHog/code#3514), and this client policy auto-approves the safe ones while surfacing the approval card for update/delete/destroy/partial-update.

## How did you test this code?

No runtime change, comment only. `hogli test products/posthog_ai/frontend/policy/toolPolicy.test.ts` still passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal code comment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code traced why the posthog_ai permission card never triggered for destructive PostHog MCP exec sub-tools. Root cause and fix live in the agent server (PostHog/code#3514); this PR only corrects the provenance comment that documented the old (wrong) assumption about the server's permission mode.