### PR TITLE
fix(evals): launch the MCP hono server with its renamed dev script

### DIFF
--- a/products/posthog_ai/eval_harness/harness/services.py
+++ b/products/posthog_ai/eval_harness/harness/services.py
@@ -89,7 +89,7 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
     Pointed at the in-process Django live server (which uses the test DB).
     Uses a non-default port to avoid conflicts with a running dev MCP server.
 
-    Runs the Node-native Hono server via ``pnpm dev:hono``. In production the
+    Runs the Node-native Hono server via ``pnpm dev``. In production the
     Cloudflare Worker is now a proxy that forwards to a regional Hono
     deployment, so Hono is what real users hit.
     """
@@ -101,7 +101,7 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
     api_url = live_server_url
 
     # The Hono server reads config directly from process env — no wrangler
-    # --var wiring needed. PORT picks the listen port; the dev:hono script
+    # --var wiring needed. PORT picks the listen port; the dev script
     # bundles via esbuild then spawns Node on the bundle.
     env = {
         **os.environ,
@@ -123,7 +123,7 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
     _, stop = LONG_LIVED_SUBPROCESSES.start(
         name="MCP server",
         port=MCP_PORT,
-        cmd=["pnpm", "dev:hono"],
+        cmd=["pnpm", "dev"],
         cwd=mcp_dir,
         env=env,
         log_prefix="mcp",


### PR DESCRIPTION
## Problem

Every sandboxed eval run with `--skill-delivery exec` fails during bootstrap with `SubprocessStartupError: MCP server subprocess exited with code 254`. #70298 renamed the `services/mcp` package script `dev:hono` to `dev` (and moved `wrangler dev` to `dev:proxy`), but the eval harness still launches the MCP server with `pnpm dev:hono`, which pnpm rejects with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "dev:hono" not found`.

## Changes

`start_mcp_server` in `products/posthog_ai/eval_harness/harness/services.py` now runs `pnpm dev` — the same underlying command (`tsx watch scripts/dev-hono.ts`) the old alias pointed at. Docstring and comment references updated to match.

## How did you test this code?

Reproduced the failure manually (`pnpm dev:hono` in `services/mcp` fails with the pnpm error above), then ran a sandboxed eval with `--skill-delivery exec` after the fix: the harness now boots the MCP server and proceeds to the Braintrust experiment. No automated test — the launch command is exercised by every real sandboxed eval run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — no documented workflow names the script.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code while smoke-testing a new eval suite: the exec-delivery harness could not boot on master since the script rename landed. The same one-commit fix is also carried on the `feat/mcp-learn-usage-evals` branch (it needs it to run) and will fall out on rebase once this merges. Also reported via `hogli devex:feedback`. An alternative considered and rejected was restoring a `dev:hono` alias in `services/mcp/package.json`, since #70298 deliberately retired that name.