### PR TITLE
feat(data-warehouse): migrate 8 sources to rest_source (batch 8)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/buildkite.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/buildkite.py
@@ -1,47 +1,31 @@
-import re
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.buildkite.settings import (
     BUILDKITE_ENDPOINTS,
     BuildkiteEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BUILDKITE_BASE_URL = "https://api.buildkite.com"
 # Buildkite caps per_page at 100 (default 30).
 PAGE_SIZE = 100
-# The batcher flushes every CHUNK_SIZE items. State is saved only after a flush, pointing at the
-# next page, so the batcher must never flush mid-page — otherwise items after the flush point but
-# before the page end would be skipped on resume. Keeping CHUNK_SIZE an exact multiple of PAGE_SIZE
-# guarantees flushes land on page boundaries; the assertion below makes the dependency explicit.
-CHUNK_SIZE = 2000
-
-
-class BuildkiteRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class BuildkiteResumeConfig:
     next_url: str
-
-
-def _get_headers(api_access_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_access_token}",
-        "Accept": "application/json",
-    }
 
 
 def _format_incremental_value(value: Any) -> str:
@@ -52,17 +36,6 @@ def _format_incremental_value(value: Any) -> str:
     if isinstance(value, date):
         return datetime.combine(value, datetime.min.time(), tzinfo=UTC).isoformat()
     return str(value)
-
-
-def _parse_next_url(link_header: str) -> str | None:
-    """Return the URL with rel="next" from Buildkite's RFC 5988 Link header, if any."""
-    if not link_header:
-        return None
-    for part in link_header.split(","):
-        match = re.search(r'<([^>]+)>;\s*rel="next"', part.strip())
-        if match:
-            return match.group(1)
-    return None
 
 
 def _resolve_incremental_param(
@@ -96,13 +69,6 @@ def _build_initial_params(
     return params
 
 
-def _build_initial_url(config: BuildkiteEndpointConfig, organization: str, params: dict[str, Any]) -> str:
-    path = config.path.format(organization=organization)
-    if not params:
-        return f"{BUILDKITE_BASE_URL}{path}"
-    return f"{BUILDKITE_BASE_URL}{path}?{urlencode(params)}"
-
-
 def validate_credentials(
     api_access_token: str, organization: str, schema_name: str | None = None
 ) -> tuple[bool, str | None]:
@@ -120,137 +86,97 @@ def validate_credentials(
     else:
         url = f"{BUILDKITE_BASE_URL}/v2/organizations/{organization}"
 
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_access_token), timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_access_token,)),
+        url,
+        headers={"Authorization": f"Bearer {api_access_token}", "Accept": "application/json"},
+    )
 
-    if response.status_code == 200:
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status == 401:
         return False, "Invalid Buildkite API access token"
-    if response.status_code == 403:
+    if status == 403:
         if schema_name:
             return False, f"Your Buildkite API access token lacks the scope needed to read '{schema_name}'"
         return True, None
-    if response.status_code == 404:
+    if status == 404:
         return False, f"Organization '{organization}' not found or not accessible"
-
-    try:
-        message = response.json().get("message", response.text)
-    except Exception:
-        message = response.text
-    return False, message
-
-
-@retry(
-    retry=retry_if_exception_type((BuildkiteRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, page_url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> requests.Response:
-    response = session.get(page_url, headers=headers, timeout=60)
-
-    # Org-level rate limit is 200 req/min; Buildkite returns 429 with RateLimit-Reset on exceed.
-    # Back off and retry on 429 and transient 5xx.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BuildkiteRetryableError(f"Buildkite API error (retryable): status={response.status_code}, url={page_url}")
-
-    if not response.ok:
-        logger.error(f"Buildkite API error: status={response.status_code}, body={response.text}, url={page_url}")
-        response.raise_for_status()
-
-    return response
-
-
-def get_rows(
-    api_access_token: str,
-    organization: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BuildkiteResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = BUILDKITE_ENDPOINTS[endpoint]
-    headers = _get_headers(api_access_token)
-    assert CHUNK_SIZE % PAGE_SIZE == 0, (
-        "CHUNK_SIZE must be a multiple of PAGE_SIZE so the batcher only flushes at page boundaries"
-    )
-    batcher = Batcher(logger=logger, chunk_size=CHUNK_SIZE, chunk_size_bytes=100 * 1024 * 1024)
-    session = make_tracked_session()
-
-    params = _build_initial_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
-    )
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url = resume_config.next_url
-        logger.debug(f"Buildkite: resuming from URL: {url}")
-    else:
-        url = _build_initial_url(config, organization, params)
-
-    while True:
-        response = _fetch_page(session, url, headers, logger)
-        data = response.json()
-        # Buildkite list endpoints return a top-level JSON array.
-        if not isinstance(data, list) or not data:
-            break
-
-        next_url = _parse_next_url(response.headers.get("Link", ""))
-
-        for item in data:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save AFTER yielding (and only when more pages remain) so a crash re-yields the
-                # last page rather than skipping it — merge dedupes on the primary key.
-                if next_url:
-                    resumable_source_manager.save_state(BuildkiteResumeConfig(next_url=next_url))
-
-        if not next_url:
-            break
-
-        url = next_url
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    if status is None:
+        return False, "Could not connect to the Buildkite API"
+    return False, f"Buildkite API returned an unexpected status: {status}"
 
 
 def buildkite_source(
     api_access_token: str,
     organization: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BuildkiteResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
 ) -> SourceResponse:
-    endpoint_config = BUILDKITE_ENDPOINTS[endpoint]
+    config = BUILDKITE_ENDPOINTS[endpoint]
+
+    params = _build_initial_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BUILDKITE_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted
+            # from logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_access_token},
+            # Buildkite paginates via an RFC 5988 Link header with rel="next".
+            "paginator": HeaderLinkPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path.format(organization=organization),
+                    "params": params,
+                    # Buildkite list endpoints return a top-level JSON array; a non-list 200 body
+                    # means the response shape changed — fail loud instead of syncing garbage.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the hook fires AFTER a page is yielded so a crash
+        # re-yields the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(BuildkiteResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_access_token=api_access_token,
-            organization=organization,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
-        primary_keys=endpoint_config.primary_keys,
-        sort_mode=endpoint_config.sort_mode,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        sort_mode=config.sort_mode,
         partition_count=1,
         partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="week" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/source.py
@@ -31,7 +31,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BuildkiteSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -94,8 +97,8 @@ Make sure to grant the following read scopes:
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # An invalid or revoked token surfaces as a requests HTTPError when `_fetch_page` calls
-            # `raise_for_status()`. Retrying can't satisfy a credential problem, so stop the sync.
+            # An invalid or revoked token surfaces as a requests HTTPError when the REST client
+            # calls `raise_for_status()`. Retrying can't satisfy a credential problem, so stop the sync.
             "401 Client Error: Unauthorized for url: https://api.buildkite.com": "Your Buildkite API access token is invalid or has been revoked. Create a new token in your Buildkite account settings, then reconnect.",
             "403 Client Error: Forbidden for url: https://api.buildkite.com": "Your Buildkite API access token is missing the read scope needed to sync this data. Grant the required read scopes in your Buildkite account settings, then reconnect.",
         }
@@ -111,19 +114,7 @@ Make sure to grant the following read scopes:
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: BuildkiteSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -143,7 +134,8 @@ Make sure to grant the following read scopes:
             api_access_token=config.api_access_token,
             organization=config.organization,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/tests/test_buildkite.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/tests/test_buildkite.py
@@ -1,24 +1,31 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
+import pytest
+from unittest import mock
 from unittest.mock import MagicMock
 
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.buildkite import buildkite
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.buildkite.buildkite import (
-    CHUNK_SIZE,
-    PAGE_SIZE,
     BuildkiteResumeConfig,
     _build_initial_params,
-    _build_initial_url,
     _format_incremental_value,
-    _parse_next_url,
     buildkite_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.buildkite.settings import BUILDKITE_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import BearerTokenAuth
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the buildkite module.
+BUILDKITE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.buildkite.buildkite.make_tracked_session"
+)
 
 
 class TestFormatIncrementalValue:
@@ -34,22 +41,6 @@ class TestFormatIncrementalValue:
         assert _format_incremental_value(value) == expected
 
 
-class TestParseNextUrl:
-    def test_returns_next_url(self) -> None:
-        header = (
-            '<https://api.buildkite.com/v2/organizations/o/builds?page=2&per_page=100>; rel="next", '
-            '<https://api.buildkite.com/v2/organizations/o/builds?page=5&per_page=100>; rel="last"'
-        )
-        assert _parse_next_url(header) == "https://api.buildkite.com/v2/organizations/o/builds?page=2&per_page=100"
-
-    def test_last_page_has_no_next(self) -> None:
-        header = '<https://api.buildkite.com/v2/organizations/o/builds?page=1&per_page=100>; rel="prev"'
-        assert _parse_next_url(header) is None
-
-    def test_empty_header(self) -> None:
-        assert _parse_next_url("") is None
-
-
 class TestBuildInitialParams:
     def test_builds_incremental_maps_to_created_from(self) -> None:
         params = _build_initial_params(
@@ -58,7 +49,7 @@ class TestBuildInitialParams:
             db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
             incremental_field="created_at",
         )
-        assert params["per_page"] == buildkite.PAGE_SIZE
+        assert params["per_page"] == 100
         assert params["created_from"] == "2026-03-04T02:58:14+00:00"
 
     def test_builds_full_refresh_has_no_filter(self) -> None:
@@ -68,7 +59,7 @@ class TestBuildInitialParams:
             db_incremental_field_last_value=None,
             incremental_field=None,
         )
-        assert params == {"per_page": buildkite.PAGE_SIZE}
+        assert params == {"per_page": 100}
 
     @parameterized.expand([("organizations",), ("pipelines",), ("agents",)])
     def test_full_refresh_endpoints_never_get_a_time_filter(self, endpoint: str) -> None:
@@ -80,176 +71,184 @@ class TestBuildInitialParams:
             db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
             incremental_field="created_at",
         )
-        assert params == {"per_page": buildkite.PAGE_SIZE}
+        assert params == {"per_page": 100}
 
 
-class TestBuildInitialUrl:
-    def test_org_scoped_path_is_formatted(self) -> None:
-        url = _build_initial_url(BUILDKITE_ENDPOINTS["builds"], "my-org", {"per_page": 100})
-        assert url == "https://api.buildkite.com/v2/organizations/my-org/builds?per_page=100"
-
-    def test_non_org_scoped_path_ignores_placeholder(self) -> None:
-        url = _build_initial_url(BUILDKITE_ENDPOINTS["organizations"], "my-org", {"per_page": 100})
-        assert url == "https://api.buildkite.com/v2/organizations?per_page=100"
-
-
-class _FakeResponse:
-    def __init__(self, status_code: int, body: Any, link: str = "") -> None:
-        self.status_code = status_code
-        self._body = body
-        self.headers = {"Link": link} if link else {}
-        self.text = ""
-
-    def json(self) -> Any:
-        return self._body
+def _response(body: Any, link: str | None = None) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    if link:
+        # Buildkite paginates via an RFC 5988 Link header with rel="next".
+        resp.headers["Link"] = f'<{link}>; rel="next"'
+    return resp
 
 
-class TestValidateCredentials:
-    @staticmethod
-    def _patch_get(monkeypatch: Any, response: _FakeResponse) -> dict[str, str]:
-        captured: dict[str, str] = {}
-
-        def fake_get(url: str, headers: dict[str, str], timeout: int) -> _FakeResponse:
-            captured["url"] = url
-            return response
-
-        session = MagicMock()
-        session.get = fake_get
-        monkeypatch.setattr(buildkite, "make_tracked_session", lambda *a, **k: session)
-        return captured
-
-    def test_success(self, monkeypatch: Any) -> None:
-        self._patch_get(monkeypatch, _FakeResponse(200, {"slug": "my-org"}))
-        assert validate_credentials("bkua", "my-org") == (True, None)
-
-    def test_invalid_token(self, monkeypatch: Any) -> None:
-        self._patch_get(monkeypatch, _FakeResponse(401, {"message": "Authentication required"}))
-        ok, error = validate_credentials("bkua", "my-org")
-        assert ok is False
-        assert error is not None and "invalid" in error.lower()
-
-    def test_forbidden_accepted_at_source_create(self, monkeypatch: Any) -> None:
-        # A valid token may lack read_organizations while still holding the per-endpoint scopes the
-        # user wants — so a 403 at source-create (schema_name=None) must not block connecting.
-        self._patch_get(monkeypatch, _FakeResponse(403, {"message": "Forbidden"}))
-        assert validate_credentials("bkua", "my-org") == (True, None)
-
-    def test_forbidden_rejected_for_specific_schema(self, monkeypatch: Any) -> None:
-        self._patch_get(monkeypatch, _FakeResponse(403, {"message": "Forbidden"}))
-        ok, error = validate_credentials("bkua", "my-org", schema_name="builds")
-        assert ok is False
-        assert error is not None and "builds" in error
-
-    def test_org_not_found(self, monkeypatch: Any) -> None:
-        self._patch_get(monkeypatch, _FakeResponse(404, {"message": "Not Found"}))
-        ok, error = validate_credentials("bkua", "missing-org")
-        assert ok is False
-        assert error is not None and "missing-org" in error
-
-    def test_schema_probe_targets_endpoint_path(self, monkeypatch: Any) -> None:
-        captured = self._patch_get(monkeypatch, _FakeResponse(200, []))
-        validate_credentials("bkua", "my-org", schema_name="agents")
-        assert captured["url"] == "https://api.buildkite.com/v2/organizations/my-org/agents?per_page=1"
+def _make_manager(resume_state: BuildkiteResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class _FakeResumableManager:
-    def __init__(self, state: BuildkiteResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BuildkiteResumeConfig] = []
+def _wire(session: MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url/params/auth AT PREPARE TIME.
 
-    def can_resume(self) -> bool:
-        return self._state is not None
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
 
-    def load_state(self) -> BuildkiteResumeConfig | None:
-        return self._state
+    def _prepare(request: Any) -> MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return MagicMock()
 
-    def save_state(self, data: BuildkiteResumeConfig) -> None:
-        self.saved.append(data)
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _collect(
-    monkeypatch: Any, manager: _FakeResumableManager, pages: dict[str, _FakeResponse], **kwargs: Any
-) -> tuple[list[dict], list[str]]:
-    fetched: list[str] = []
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> _FakeResponse:
-        fetched.append(url)
-        return pages[url]
-
-    monkeypatch.setattr(buildkite, "make_tracked_session", lambda *a, **k: MagicMock())
-    monkeypatch.setattr(buildkite, "_fetch_page", fake_fetch)
-
-    rows: list[dict] = []
-    for table in get_rows(
+def _source(
+    endpoint: str,
+    manager: MagicMock,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+    incremental_field: str | None = None,
+) -> SourceResponse:
+    return buildkite_source(
         api_access_token="bkua",
         organization="my-org",
-        endpoint=kwargs.pop("endpoint", "pipelines"),
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-        **kwargs,
-    ):
-        rows.extend(table.to_pylist())
-    return rows, fetched
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+        incremental_field=incremental_field,
+    )
 
 
-class TestGetRows:
-    def test_follows_link_header_pagination(self, monkeypatch: Any) -> None:
-        page1 = "https://api.buildkite.com/v2/organizations/my-org/pipelines?per_page=100"
+def _rows(source_response: SourceResponse) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_link_header_pagination(self, MockSession) -> None:
+        session = MockSession.return_value
         page2 = "https://api.buildkite.com/v2/organizations/my-org/pipelines?page=2&per_page=100"
-        pages = {
-            page1: _FakeResponse(200, [{"id": "p1"}, {"id": "p2"}], link=f'<{page2}>; rel="next"'),
-            page2: _FakeResponse(200, [{"id": "p3"}]),
-        }
-        rows, fetched = _collect(monkeypatch, _FakeResumableManager(), pages, endpoint="pipelines")
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "p1"}, {"id": "p2"}], link=page2),
+                _response([{"id": "p3"}]),
+            ],
+        )
+
+        rows = _rows(_source("pipelines", _make_manager()))
+
         assert [r["id"] for r in rows] == ["p1", "p2", "p3"]
-        assert fetched == [page1, page2]
+        assert snapshots[0]["url"] == "https://api.buildkite.com/v2/organizations/my-org/pipelines"
+        assert snapshots[0]["params"] == {"per_page": 100}
+        # The next-page URL is self-contained; the original params must not be re-appended.
+        assert snapshots[1]["url"] == page2
+        assert snapshots[1]["params"] == {}
 
-    def test_stops_on_empty_page(self, monkeypatch: Any) -> None:
-        page1 = "https://api.buildkite.com/v2/organizations/my-org/agents?per_page=100"
-        pages = {page1: _FakeResponse(200, [])}
-        rows, fetched = _collect(monkeypatch, _FakeResumableManager(), pages, endpoint="agents")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_org_scoped_path_ignores_placeholder(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": "o1"}])])
+
+        _rows(_source("organizations", _make_manager()))
+
+        assert snapshots[0]["url"] == "https://api.buildkite.com/v2/organizations"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_empty_page_without_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows(_source("agents", manager))
+
         assert rows == []
-        assert fetched == [page1]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resumes_from_saved_state(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession) -> None:
+        session = MockSession.return_value
         resume_url = "https://api.buildkite.com/v2/organizations/my-org/pipelines?page=3&per_page=100"
-        pages = {resume_url: _FakeResponse(200, [{"id": "p9"}])}
-        manager = _FakeResumableManager(BuildkiteResumeConfig(next_url=resume_url))
-        rows, fetched = _collect(monkeypatch, manager, pages, endpoint="pipelines")
+        snapshots = _wire(session, [_response([{"id": "p9"}])])
+
+        manager = _make_manager(BuildkiteResumeConfig(next_url=resume_url))
+        rows = _rows(_source("pipelines", manager))
+
         # Resume must start at the saved URL, not the freshly-built first-page URL.
-        assert fetched == [resume_url]
+        assert snapshots[0]["url"] == resume_url
         assert [r["id"] for r in rows] == ["p9"]
 
-    def test_saves_state_after_yielding_a_batch(self, monkeypatch: Any) -> None:
-        # Mirror the real API contract: Buildkite caps per_page at PAGE_SIZE, so the batcher only
-        # reaches its CHUNK_SIZE buffer after CHUNK_SIZE / PAGE_SIZE consecutive full pages. State is
-        # saved at that page boundary, pointing at the NEXT page, so a crash re-yields the last page
-        # rather than skipping it. CHUNK_SIZE must be a multiple of PAGE_SIZE for this to hold.
-        assert CHUNK_SIZE % PAGE_SIZE == 0
-        full_pages = CHUNK_SIZE // PAGE_SIZE
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_yielding_a_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        page2 = "https://api.buildkite.com/v2/organizations/my-org/builds?page=2&per_page=100"
+        _wire(
+            session,
+            [
+                _response([{"id": "b1"}], link=page2),
+                _response([{"id": "b2"}]),
+            ],
+        )
 
-        base = "https://api.buildkite.com/v2/organizations/my-org/builds?per_page=100"
+        manager = _make_manager()
+        _rows(_source("builds", manager))
 
-        def page_url(n: int) -> str:
-            return base if n == 1 else f"{base}&page={n}"
+        # State is saved AFTER a page is yielded and points at the NEXT page, so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it. The final page
+        # has no next link, so no checkpoint is written for it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == BuildkiteResumeConfig(next_url=page2)
 
-        # full_pages pages of PAGE_SIZE items each fill exactly one chunk; the boundary page after
-        # them holds the final straggler row.
-        boundary_page = page_url(full_pages + 1)
-        pages = {
-            page_url(n): _FakeResponse(
-                200,
-                [{"id": f"b{(n - 1) * PAGE_SIZE + i}"} for i in range(PAGE_SIZE)],
-                link=f'<{page_url(n + 1)}>; rel="next"',
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_sync_sends_created_from(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": "b1"}])])
+
+        _rows(
+            _source(
+                "builds",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+                incremental_field="created_at",
             )
-            for n in range(1, full_pages + 1)
-        }
-        pages[boundary_page] = _FakeResponse(200, [{"id": "b-last"}])
+        )
 
-        manager = _FakeResumableManager()
-        rows, _fetched = _collect(monkeypatch, manager, pages, endpoint="builds")
-        assert len(rows) == CHUNK_SIZE + 1
-        assert manager.saved == [BuildkiteResumeConfig(next_url=boundary_page)]
+        assert snapshots[0]["params"] == {"per_page": 100, "created_from": "2026-03-04T02:58:14+00:00"}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_is_framework_bearer(self, MockSession) -> None:
+        # The token must flow through the framework auth config (so it's redacted from logs),
+        # not a hand-built Authorization header.
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": "p1"}])])
+
+        _rows(_source("pipelines", _make_manager()))
+
+        auth = snapshots[0]["auth"]
+        assert isinstance(auth, BearerTokenAuth)
+        assert auth.token == "bkua"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_fails_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"message": "something unexpected"})])
+
+        # Buildkite list endpoints return a top-level JSON array; a 200 with a non-list body means
+        # the response shape changed — fail loud instead of syncing garbage.
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source("pipelines", _make_manager()))
 
 
 class TestBuildkiteSourceResponse:
@@ -261,18 +260,80 @@ class TestBuildkiteSourceResponse:
             ("agents", ["id"], "asc", "created_at"),
         ]
     )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_source_response_shape(
-        self, endpoint: str, primary_keys: list[str], sort_mode: str, partition_key: str
+        self, endpoint: str, primary_keys: list[str], sort_mode: str, partition_key: str, MockSession
     ) -> None:
-        response = buildkite_source(
-            api_access_token="bkua",
-            organization="my-org",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        MockSession.return_value.headers = {}
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == primary_keys
         assert response.sort_mode == sort_mode
         assert response.partition_mode == "datetime"
+        assert response.partition_format == "week"
         assert response.partition_keys == [partition_key]
+
+
+class TestValidateCredentials:
+    @staticmethod
+    def _patch_get(mock_session: MagicMock, status_code: int) -> dict[str, str]:
+        captured: dict[str, str] = {}
+
+        def fake_get(url: str, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            return MagicMock(status_code=status_code)
+
+        mock_session.return_value.get.side_effect = fake_get
+        return captured
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_success(self, mock_session) -> None:
+        self._patch_get(mock_session, 200)
+        assert validate_credentials("bkua", "my-org") == (True, None)
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_invalid_token(self, mock_session) -> None:
+        self._patch_get(mock_session, 401)
+        ok, error = validate_credentials("bkua", "my-org")
+        assert ok is False
+        assert error is not None and "invalid" in error.lower()
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_forbidden_accepted_at_source_create(self, mock_session) -> None:
+        # A valid token may lack read_organizations while still holding the per-endpoint scopes the
+        # user wants — so a 403 at source-create (schema_name=None) must not block connecting.
+        self._patch_get(mock_session, 403)
+        assert validate_credentials("bkua", "my-org") == (True, None)
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_forbidden_rejected_for_specific_schema(self, mock_session) -> None:
+        self._patch_get(mock_session, 403)
+        ok, error = validate_credentials("bkua", "my-org", schema_name="builds")
+        assert ok is False
+        assert error is not None and "builds" in error
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_org_not_found(self, mock_session) -> None:
+        self._patch_get(mock_session, 404)
+        ok, error = validate_credentials("bkua", "missing-org")
+        assert ok is False
+        assert error is not None and "missing-org" in error
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_schema_probe_targets_endpoint_path(self, mock_session) -> None:
+        captured = self._patch_get(mock_session, 200)
+        validate_credentials("bkua", "my-org", schema_name="agents")
+        assert captured["url"] == "https://api.buildkite.com/v2/organizations/my-org/agents?per_page=1"
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_source_create_probe_targets_org(self, mock_session) -> None:
+        captured = self._patch_get(mock_session, 200)
+        validate_credentials("bkua", "my-org")
+        assert captured["url"] == "https://api.buildkite.com/v2/organizations/my-org"
+
+    @mock.patch(BUILDKITE_SESSION_PATCH)
+    def test_swallows_transport_errors(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        ok, error = validate_credentials("bkua", "my-org")
+        assert ok is False
+        assert error is not None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/tests/test_buildkite_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/tests/test_buildkite_source.py
@@ -90,7 +90,7 @@ class TestBuildkiteSource:
         [
             ("read_timeout", "HTTPSConnectionPool(host='api.buildkite.com', port=443): Read timed out."),
             ("server_error", "500 Server Error: Internal Server Error for url: https://api.buildkite.com/v2"),
-            ("rate_limited", "Buildkite API error (retryable): status=429"),
+            ("rate_limited", "HTTP 429 for https://api.buildkite.com/v2/organizations/my-org/builds"),
         ]
     )
     def test_transient_errors_remain_retryable(self, _name: str, other_error: str) -> None:
@@ -140,6 +140,8 @@ class TestBuildkiteSource:
         assert captured["api_access_token"] == "bkua_test"
         assert captured["organization"] == "my-org"
         assert captured["endpoint"] == "builds"
+        assert captured["team_id"] is inputs.team_id
+        assert captured["job_id"] is inputs.job_id
         assert captured["should_use_incremental_field"] is True
         assert captured["db_incremental_field_last_value"] == "2026-01-01T00:00:00Z"
         assert captured["incremental_field"] == "created_at"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/bunny.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/bunny.py
@@ -1,28 +1,28 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.bunny.settings import BUNNY_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BUNNY_BASE_URL = "https://api.bunny.net"
 # The list endpoints accept perPage 5..1000; 1000 minimises round trips for the typically small
 # zone/library tables.
 PER_PAGE = 1000
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm an account API key is genuine. The AccessKey is account-wide, so
 # one probe validates access to every Core API list endpoint.
 DEFAULT_PROBE_PATH = "/pullzone"
-
-
-class BunnyRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -32,116 +32,103 @@ class BunnyResumeConfig:
     next_page: int = 1
 
 
-def _headers(access_key: str) -> dict[str, str]:
-    return {"AccessKey": access_key, "Accept": "application/json"}
+class BunnyHasMoreItemsPaginator(PageNumberPaginator):
+    """Page-number paginator that stops on bunny.net's explicit ``HasMoreItems`` flag.
 
+    The built-in stop conditions don't fit: bunny.net reports total ITEMS (not pages) and an
+    empty ``Items`` page with ``HasMoreItems: true`` must not end the sync, while a final page
+    can be full — so neither ``total_path`` nor ``stop_after_empty_page`` matches the API's
+    own termination signal.
+    """
 
-@retry(
-    retry=retry_if_exception_type((BunnyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    page: int,
-    per_page: int,
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    # Always request page>=1 so the API returns the paginated envelope
-    # ({Items, CurrentPage, TotalItems, HasMoreItems}); page=0 would return a bare array.
-    response = session.get(
-        f"{BUNNY_BASE_URL}{path}",
-        params={"page": page, "perPage": per_page},
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BunnyRetryableError(f"bunny.net API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        logger.error(f"bunny.net API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def get_rows(
-    access_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[BunnyResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = BUNNY_ENDPOINTS[endpoint]
-    # `redact_values` masks the account key in logged URLs and captured samples.
-    session = make_tracked_session(headers=_headers(access_key), redact_values=(access_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume else 1
-    if resume and resume.next_page > 1:
-        logger.debug(f"bunny.net: resuming {endpoint} from page {page}")
-
-    while True:
-        data = _fetch_page(session, config.path, page, PER_PAGE, logger)
-
-        # `Items` is always present in the paginated envelope; missing it means a malformed
-        # response, so fail loudly rather than silently advancing the cursor past lost rows.
-        items = data["Items"]
-        if items:
-            yield items
-
-        if not data.get("HasMoreItems", False):
-            break
-
-        page += 1
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(BunnyResumeConfig(next_page=page))
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        self.page += 1
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        self._has_next_page = isinstance(body, dict) and bool(body.get("HasMoreItems", False))
 
 
 def bunny_source(
     access_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[BunnyResumeConfig],
 ) -> SourceResponse:
     config = BUNNY_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BUNNY_BASE_URL,
+            # The AccessKey travels via the framework auth config so its value is redacted from
+            # logged URLs and captured samples; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": access_key, "name": "AccessKey", "location": "header"},
+            # Always request page>=1 so the API returns the paginated envelope
+            # ({Items, CurrentPage, TotalItems, HasMoreItems}); page=0 would return a bare array.
+            "paginator": BunnyHasMoreItemsPaginator(base_page=1),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"perPage": PER_PAGE},
+                    "data_selector": "Items",
+                    # `Items` is always present in the paginated envelope; missing it means a
+                    # malformed response, so fail loudly rather than silently syncing 0 rows.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while more pages remain; saved AFTER a page is yielded so a crash
+        # re-fetches from the next page (already-yielded pages are persisted) and merge
+        # dedupes the re-pulled page on the primary key.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(BunnyResumeConfig(next_page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # every bunny.net endpoint is full refresh — no incremental cursor
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            access_key=access_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(access_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
+def check_access(access_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[bool, Optional[int]]:
     """Probe a single list endpoint to validate the account API key.
 
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise. bunny.net returns clean HTTP status codes
-    (401 for ``Authorization has been denied``), so no body sniffing is needed.
+    Returns ``(ok, status)``: ``status`` is the HTTP status of the probe (401/403 means an auth
+    failure — bunny.net returns clean HTTP status codes, so no body sniffing is needed) or
+    ``None`` when the probe couldn't connect at all.
     """
-    session = make_tracked_session(headers=_headers(access_key), redact_values=(access_key,))
-    try:
-        response = session.get(f"{BUNNY_BASE_URL}{path}", params={"page": 1, "perPage": 5}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to bunny.net: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"bunny.net returned HTTP {response.status_code}"
-
-    return 200, None
+    return validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_key,)),
+        f"{BUNNY_BASE_URL}{path}?page=1&perPage=5",
+        headers={"AccessKey": access_key, "Accept": "application/json"},
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/source.py
@@ -25,7 +25,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BunnySourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -94,31 +97,21 @@ You can find your account API key under **Account Settings → API** in the [bun
     ) -> list[SourceSchema]:
         # Every endpoint is full refresh only — bunny.net's list endpoints expose no server-side
         # timestamp filter, so there is no incremental cursor to advance.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, {}, names)
 
     def validate_credentials(
         self, config: BunnySourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
         # The account API key is account-wide, so a single probe validates access to every schema;
         # there is no per-endpoint scope to check.
-        status, message = check_access(config.access_key)
-        if status == 200:
+        ok, status = check_access(config.access_key)
+        if ok:
             return True, None
         if status in (401, 403):
             return False, "Invalid bunny.net account API key"
-        return False, message or "Could not validate bunny.net account API key"
+        if status is None:
+            return False, "Could not connect to bunny.net"
+        return False, f"bunny.net returned HTTP {status}"
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[BunnyResumeConfig]:
         return ResumableSourceManager[BunnyResumeConfig](inputs, BunnyResumeConfig)
@@ -135,6 +128,7 @@ You can find your account API key under **Account Settings → API** in the [bun
         return bunny_source(
             access_key=config.access_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/tests/test_bunny.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/tests/test_bunny.py
@@ -1,180 +1,248 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.bunny import bunny
 from products.warehouse_sources.backend.temporal.data_imports.sources.bunny.bunny import (
+    BUNNY_BASE_URL,
+    PER_PAGE,
     BunnyResumeConfig,
-    BunnyRetryableError,
     bunny_source,
     check_access,
-    get_rows,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.bunny.settings import BUNNY_ENDPOINTS, ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = bunny._fetch_page.__wrapped__  # type: ignore[attr-defined]
-
-
-class _FakeResumableManager:
-    def __init__(self, state: BunnyResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[BunnyResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> BunnyResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: BunnyResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# check_access builds its own tracked session in the bunny module.
+BUNNY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.bunny.bunny.make_tracked_session"
+)
 
 
-def _page(items: list[dict], has_more: bool) -> dict[str, Any]:
-    return {"Items": items, "CurrentPage": 1, "TotalItems": len(items), "HasMoreItems": has_more}
+def _response(
+    items: list[dict[str, Any]] | None,
+    *,
+    has_more: bool = False,
+    drop_items: bool = False,
+    status_code: int = 200,
+) -> Response:
+    body: dict[str, Any] = {"CurrentPage": 1, "TotalItems": len(items or []), "HasMoreItems": has_more}
+    if not drop_items:
+        body["Items"] = items or []
+    resp = Response()
+    resp.status_code = status_code
+    resp.url = f"{BUNNY_BASE_URL}/pullzone"
+    resp.reason = "Error" if status_code >= 400 else "OK"
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager, monkeypatch: Any, pages: dict[int, dict], endpoint: str = "pull_zones"
-    ) -> list[dict]:
-        def fake_fetch(session: Any, path: str, page: int, per_page: int, logger: Any) -> dict:
-            return pages[page]
+def _make_manager(resume_state: BunnyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-        monkeypatch.setattr(bunny, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(bunny, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            access_key="bunny-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
 
-    def test_single_page_yields_items_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {1: _page([{"Id": 1}, {"Id": 2}], has_more=False)})
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(manager: mock.MagicMock, endpoint: str = "pull_zones"):
+    return bunny_source(
+        access_key="bunny-key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_yields_items_and_stops(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"Id": 1}, {"Id": 2}], has_more=False)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == [{"Id": 1}, {"Id": 2}]
+        assert session.send.call_count == 1
+        assert params[0] == {"page": 1, "perPage": PER_PAGE}
         # No further pages, so no resume state is persisted.
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_follows_pagination_until_has_more_is_false(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            1: _page([{"Id": 1}], has_more=True),
-            2: _page([{"Id": 2}], has_more=True),
-            3: _page([{"Id": 3}], has_more=False),
-        }
-        rows = self._collect(manager, monkeypatch, pages)
-        assert rows == [{"Id": 1}, {"Id": 2}, {"Id": 3}]
-
-    def test_saves_next_page_after_yielding_each_batch(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            1: _page([{"Id": 1}], has_more=True),
-            2: _page([{"Id": 2}], has_more=False),
-        }
-        self._collect(manager, monkeypatch, pages)
-        # State is saved AFTER page 1 is yielded (pointing at page 2), and never for the final page.
-        assert [s.next_page for s in manager.saved] == [2]
-
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(BunnyResumeConfig(next_page=2))
-        pages = {
-            # Page 1 must never be fetched on resume.
-            2: _page([{"Id": 2}], has_more=True),
-            3: _page([{"Id": 3}], has_more=False),
-        }
-        rows = self._collect(manager, monkeypatch, pages)
-        assert rows == [{"Id": 2}, {"Id": 3}]
-
-    def test_empty_items_does_not_yield(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {1: _page([], has_more=False)})
-        assert rows == []
-
-
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: dict | None = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body or {}
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_pagination_until_has_more_is_false(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response([{"Id": 1}], has_more=True),
+                _response([{"Id": 2}], has_more=True),
+                _response([{"Id": 3}], has_more=False),
+            ],
         )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
 
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == [{"Id": 1}, {"Id": 2}, {"Id": 3}]
+        assert [p["page"] for p in params] == [1, 2, 3]
+        assert all(p["perPage"] == PER_PAGE for p in params)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_page_after_yielding_each_batch(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"Id": 1}], has_more=True), _response([{"Id": 2}], has_more=False)])
+
+        manager = _make_manager()
+        _rows(_source(manager))
+
+        # State is saved AFTER page 1 is yielded (pointing at page 2), and never for the final page.
+        assert [call.args[0] for call in manager.save_state.call_args_list] == [BunnyResumeConfig(next_page=2)]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Page 1 must never be fetched on resume.
+        params = _wire(session, [_response([{"Id": 2}], has_more=True), _response([{"Id": 3}], has_more=False)])
+
+        manager = _make_manager(BunnyResumeConfig(next_page=2))
+        rows = _rows(_source(manager))
+
+        assert rows == [{"Id": 2}, {"Id": 3}]
+        assert [p["page"] for p in params] == [2, 3]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_with_has_more_continues(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Termination follows HasMoreItems, not page emptiness — an empty page mid-stream must not
+        # end the sync early.
+        _wire(session, [_response([], has_more=True), _response([{"Id": 9}], has_more=False)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == [{"Id": 9}]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_items_key_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_items=True)])
+
+        # A 200 body without "Items" means the response shape changed — fail loud, not silently 0 rows.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(_make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_access_key_travels_via_redacting_auth(self, MockSession) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        captured_auth: list[Any] = []
+
+        def _prepare(request: Any) -> mock.MagicMock:
+            captured_auth.append(request.auth)
+            return mock.MagicMock()
+
+        session.prepare_request.side_effect = _prepare
+        session.send.side_effect = [_response([{"Id": 1}], has_more=False)]
+
+        _rows(_source(_make_manager()))
+
+        # The secret goes through the framework auth (value-redacted in logs), not plain headers.
+        assert captured_auth[0].api_key == "bunny-key"
+        assert captured_auth[0].name == "AccessKey"
+        assert captured_auth[0].location == "header"
+        assert session.headers.get("Accept") == "application/json"
+        assert "AccessKey" not in session.headers
+
+
+class TestErrorHandling:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(BunnyRetryableError):
-            _fetch_page_unwrapped(session, "/pullzone", 1, 1000, MagicMock())
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_are_retried_then_succeed(
+        self, _name: str, status: int, MockSession, _mock_sleep
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], status_code=status), _response([{"Id": 1}], has_more=False)])
+
+        rows = _rows(_source(_make_manager()))
+
+        assert rows == [{"Id": 1}]
+        assert session.send.call_count == 2
+
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_persistent_server_error_exhausts_retries(self, MockSession, _mock_sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], status_code=500)] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source(_make_manager()))
+        assert session.send.call_count == 5
 
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_for_status(self, _name: str, status: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], status_code=status)])
+
         with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "/pullzone", 1, 1000, MagicMock())
-
-    def test_success_returns_json_body(self) -> None:
-        body = _page([{"Id": 1}], has_more=False)
-        session = self._session_returning(200, body)
-        result = _fetch_page_unwrapped(session, "/pullzone", 1, 1000, MagicMock())
-        assert result == body
-
-    def test_request_uses_page_and_per_page_params(self) -> None:
-        session = self._session_returning(200, _page([], has_more=False))
-        _fetch_page_unwrapped(session, "/dnszone", 3, 1000, MagicMock())
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"page": 3, "perPage": 1000}
+            _rows(_source(_make_manager()))
+        # Credential problems are permanent — no retries.
+        assert session.send.call_count == 1
 
 
 class TestCheckAccess:
-    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        monkeypatch.setattr(bunny, "make_tracked_session", lambda **kwargs: session)
-        return session
-
     @pytest.mark.parametrize(
-        "status, ok, expected_status, expected_message",
+        "status, expected",
         [
-            (200, True, 200, None),
-            (401, False, 401, None),
-            (403, False, 403, None),
-            (500, False, 500, "bunny.net returned HTTP 500"),
+            (200, (True, 200)),
+            (401, (False, 401)),
+            (403, (False, 403)),
+            (500, (False, 500)),
         ],
     )
-    def test_status_mapping(
-        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        self._patch_session(monkeypatch, response)
-        assert check_access("bunny-key") == (expected_status, expected_message)
+    @mock.patch(BUNNY_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status: int, expected: tuple[bool, int]) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert check_access("bunny-key") == expected
 
-    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
-        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
-        status, message = check_access("bunny-key")
-        assert status == 0
-        assert message is not None and "boom" in message
+    @mock.patch(BUNNY_SESSION_PATCH)
+    def test_connection_error_maps_to_none(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert check_access("bunny-key") == (False, None)
 
 
 class TestBunnySourceResponse:
@@ -186,13 +254,10 @@ class TestBunnySourceResponse:
             ("video_libraries", "DateCreated"),
         ]
     )
-    def test_partitioning_matches_endpoint_config(self, endpoint: str, partition_key: str | None) -> None:
-        response = bunny_source(
-            access_key="bunny-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_partitioning_matches_endpoint_config(self, endpoint: str, partition_key: str | None, MockSession) -> None:
+        MockSession.return_value.headers = {}
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["Id"]
         if partition_key is None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/tests/test_bunny_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bunny/tests/test_bunny_source.py
@@ -95,29 +95,24 @@ class TestBunnySource:
         assert not any(key in unrelated_error for key in non_retryable)
 
     @pytest.mark.parametrize(
-        "status, expected_valid, expected_message",
+        "probe_result, expected_valid, expected_message",
         [
-            (200, True, None),
-            (401, False, "Invalid bunny.net account API key"),
-            (403, False, "Invalid bunny.net account API key"),
-            (500, False, "bunny.net returned HTTP 500"),
-            (0, False, "Could not connect to bunny.net: boom"),
+            ((True, 200), True, None),
+            ((False, 401), False, "Invalid bunny.net account API key"),
+            ((False, 403), False, "Invalid bunny.net account API key"),
+            ((False, 500), False, "bunny.net returned HTTP 500"),
+            ((False, None), False, "Could not connect to bunny.net"),
         ],
     )
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.bunny.source.check_access")
     def test_validate_credentials(
         self,
         mock_check: mock.MagicMock,
-        status: int,
+        probe_result: tuple[bool, int | None],
         expected_valid: bool,
         expected_message: str | None,
     ) -> None:
-        message = (
-            "bunny.net returned HTTP 500"
-            if status == 500
-            else ("Could not connect to bunny.net: boom" if status == 0 else None)
-        )
-        mock_check.return_value = (status, message)
+        mock_check.return_value = probe_result
         is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
         assert is_valid is expected_valid
         assert returned == expected_message
@@ -125,7 +120,7 @@ class TestBunnySource:
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.bunny.source.check_access")
     def test_validate_credentials_probes_the_account_key(self, mock_check: mock.MagicMock) -> None:
         # The account API key is account-wide, so validation probes the key, not a per-schema scope.
-        mock_check.return_value = (200, None)
+        mock_check.return_value = (True, 200)
         self.source.validate_credentials(self.config, self.team_id, schema_name="dns_zones")
         mock_check.assert_called_once_with("bunny-key")
 
@@ -138,6 +133,8 @@ class TestBunnySource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_bunny_source: mock.MagicMock) -> None:
         inputs = mock.MagicMock()
         inputs.schema_name = "pull_zones"
+        inputs.team_id = self.team_id
+        inputs.job_id = "job-1"
         manager = mock.MagicMock()
 
         self.source.source_for_pipeline(self.config, manager, inputs)
@@ -146,6 +143,8 @@ class TestBunnySource:
         kwargs = mock_bunny_source.call_args.kwargs
         assert kwargs["access_key"] == "bunny-key"
         assert kwargs["endpoint"] == "pull_zones"
+        assert kwargs["team_id"] == self.team_id
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
 
     def test_source_for_pipeline_rejects_unknown_schema(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/buzzsprout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/buzzsprout.py
@@ -1,3 +1,5 @@
+import re
+
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.buzzsprout.settings import (
     BUZZSPROUT_ENDPOINTS,
@@ -25,16 +27,34 @@ def _auth_header_value(api_token: str) -> str:
     return f"Token token={api_token}"
 
 
+# A Buzzsprout podcast ID is a bare identifier (numeric in practice). `podcast_id` is a non-secret,
+# editable field that ends up as a REST path segment, so anything that could make that path resolve
+# to a different origin — a URL scheme, path separators, a query/fragment marker, whitespace, or a
+# `..` traversal — is rejected. Otherwise a value like `https://attacker.example/../<id>` would be
+# treated as an absolute URL by the request layer and the stored token sent to the attacker's host.
+_INVALID_PODCAST_ID = re.compile(r"[\s/\\?#:]|\.\.")
+
+
+def _clean_podcast_id(podcast_id: str) -> str:
+    cleaned = podcast_id.strip()
+    if not cleaned:
+        raise ValueError("A Buzzsprout podcast ID is required.")
+    if _INVALID_PODCAST_ID.search(cleaned):
+        raise ValueError("Invalid Buzzsprout podcast ID. Enter the numeric ID from your Buzzsprout API settings.")
+    return cleaned
+
+
 def _build_path(podcast_id: str, config: BuzzsproutEndpointConfig) -> str:
     if config.account_scoped:
         return config.path
-    return f"{podcast_id.strip()}/{config.path}"
+    return f"{podcast_id}/{config.path}"
 
 
 def validate_credentials(api_token: str, podcast_id: str) -> tuple[bool, str | None]:
-    podcast_id = podcast_id.strip()
-    if not podcast_id:
-        return False, "A Buzzsprout podcast ID is required."
+    try:
+        podcast_id = _clean_podcast_id(podcast_id)
+    except ValueError as e:
+        return False, str(e)
 
     # The episodes endpoint is scoped to the podcast_id, so a 200 confirms both the token and the ID
     # in a single cheap probe.
@@ -66,6 +86,9 @@ def validate_credentials(api_token: str, podcast_id: str) -> tuple[bool, str | N
 
 def buzzsprout_source(api_token: str, podcast_id: str, endpoint: str, team_id: int, job_id: str) -> SourceResponse:
     config = BUZZSPROUT_ENDPOINTS[endpoint]
+    # Guard the sync path with the same check as validation so an edited-in absolute/traversal
+    # podcast_id can never retarget the authenticated request off the Buzzsprout host.
+    podcast_id = _clean_podcast_id(podcast_id)
 
     rest_config: RESTAPIConfig = {
         "client": {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/buzzsprout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/buzzsprout.py
@@ -1,69 +1,34 @@
-from collections.abc import Iterator
-from typing import Any
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.buzzsprout.settings import (
     BUZZSPROUT_ENDPOINTS,
     BuzzsproutEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 BUZZSPROUT_BASE_URL = "https://www.buzzsprout.com/api"
 
 # Buzzsprout blocks requests sent with a default/bot User-Agent, so we identify ourselves explicitly.
 USER_AGENT = "PostHog Data Warehouse (https://posthog.com)"
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
+
+def _auth_header_value(api_token: str) -> str:
+    # Buzzsprout's documented auth scheme is a static account token in the Authorization header,
+    # using a custom `Token token=` prefix rather than standard Bearer.
+    return f"Token token={api_token}"
 
 
-class BuzzsproutRetryableError(Exception):
-    pass
-
-
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Token token={api_token}",
-        "User-Agent": USER_AGENT,
-        "Accept": "application/json",
-    }
-
-
-def _build_url(podcast_id: str, config: BuzzsproutEndpointConfig) -> str:
+def _build_path(podcast_id: str, config: BuzzsproutEndpointConfig) -> str:
     if config.account_scoped:
-        return f"{BUZZSPROUT_BASE_URL}/{config.path}"
-    return f"{BUZZSPROUT_BASE_URL}/{podcast_id.strip()}/{config.path}"
-
-
-@retry(
-    retry=retry_if_exception_type((BuzzsproutRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[dict[str, Any]]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Buzzsprout's docs recommend retrying on transient 5xx; 429 is retried too should rate limiting
-    # ever be introduced (none is documented today).
-    if response.status_code == 429 or response.status_code >= 500:
-        raise BuzzsproutRetryableError(f"Buzzsprout API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Only the status and URL are logged — the upstream response body can carry account-specific
-        # data (private episode metadata, emails) that must not be copied into PostHog logs.
-        logger.error(f"Buzzsprout API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    # Every documented Buzzsprout endpoint returns a bare JSON array.
-    return data if isinstance(data, list) else []
+        return config.path
+    return f"{podcast_id.strip()}/{config.path}"
 
 
 def validate_credentials(api_token: str, podcast_id: str) -> tuple[bool, str | None]:
@@ -73,48 +38,69 @@ def validate_credentials(api_token: str, podcast_id: str) -> tuple[bool, str | N
 
     # The episodes endpoint is scoped to the podcast_id, so a 200 confirms both the token and the ID
     # in a single cheap probe.
-    url = f"{BUZZSPROUT_BASE_URL}/{podcast_id}/episodes.json"
-    try:
-        response = make_tracked_session(redact_values=(api_token,)).get(
-            url, headers=_get_headers(api_token), timeout=REQUEST_TIMEOUT_SECONDS
-        )
-    except Exception:
-        return False, "Could not reach the Buzzsprout API. Please try again."
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{BUZZSPROUT_BASE_URL}/{podcast_id}/episodes.json",
+        headers={
+            "Authorization": _auth_header_value(api_token),
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        },
+    )
 
-    if response.status_code == 200:
+    if ok:
         return True, None
-    if response.status_code in (401, 403):
+    if status is None:
+        return False, "Could not reach the Buzzsprout API. Please try again."
+    if status in (401, 403):
         return False, "Invalid Buzzsprout API token. Create a new token in your Buzzsprout account settings."
-    if response.status_code == 404:
+    if status == 404:
         return False, "Buzzsprout podcast not found. Check the podcast ID."
     # A transient 429/5xx (after the session's own retries are exhausted) is not a credential problem,
     # so surface it as a retryable condition rather than rejecting otherwise-valid credentials.
-    if response.status_code == 429 or response.status_code >= 500:
+    if status == 429 or status >= 500:
         return False, "Buzzsprout API is temporarily unavailable. Please try again in a moment."
 
-    return False, f"Buzzsprout API returned an unexpected status code: {response.status_code}"
+    return False, f"Buzzsprout API returned an unexpected status code: {status}"
 
 
-def get_rows(
-    api_token: str, podcast_id: str, endpoint: str, logger: FilteringBoundLogger
-) -> Iterator[list[dict[str, Any]]]:
+def buzzsprout_source(api_token: str, podcast_id: str, endpoint: str, team_id: int, job_id: str) -> SourceResponse:
     config = BUZZSPROUT_ENDPOINTS[endpoint]
-    session = make_tracked_session(redact_values=(api_token,))
-    url = _build_url(podcast_id, config)
 
-    # Buzzsprout has no pagination: each endpoint returns its full array in one response, so a single
-    # fetch is the whole table. The pipeline batches the yielded list for us.
-    rows = _fetch(session, url, _get_headers(api_token), logger)
-    if rows:
-        yield rows
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BUZZSPROUT_BASE_URL,
+            # The token rides in the framework auth config so its value is redacted from logs;
+            # only the non-secret headers are set here.
+            "headers": {"User-Agent": USER_AGENT, "Accept": "application/json"},
+            "auth": {
+                "type": "api_key",
+                "name": "Authorization",
+                "api_key": _auth_header_value(api_token),
+                "location": "header",
+            },
+            # Buzzsprout has no pagination: each endpoint returns its full array in one response,
+            # so a single fetch is the whole table.
+            "paginator": SinglePagePaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": _build_path(podcast_id, config),
+                    # Every documented endpoint returns a bare JSON array; require a list so an
+                    # unexpected object body fails loud instead of syncing it as a row.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
 
-
-def buzzsprout_source(api_token: str, podcast_id: str, endpoint: str, logger: FilteringBoundLogger) -> SourceResponse:
-    config = BUZZSPROUT_ENDPOINTS[endpoint]
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_token=api_token, podcast_id=podcast_id, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -122,4 +108,5 @@ def buzzsprout_source(api_token: str, podcast_id: str, endpoint: str, logger: Fi
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/source.py
@@ -27,7 +27,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import BuzzsproutSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -84,7 +87,7 @@ You can find both your API token and podcast ID in your [Buzzsprout API settings
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # An invalid or revoked token surfaces as a requests HTTPError when `_fetch` calls
+            # An invalid or revoked token surfaces as a requests HTTPError when the REST client calls
             # `raise_for_status()`. Retrying can never satisfy a credential problem. Match the stable
             # status text and base host, not the per-request path.
             "401 Client Error: Unauthorized for url: https://www.buzzsprout.com": "Your Buzzsprout API token is invalid or has been revoked. Create a new token in your Buzzsprout account settings, then reconnect.",
@@ -99,24 +102,23 @@ You can find both your API token and podcast ID in your [Buzzsprout API settings
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                # Buzzsprout returns the full array on every request with no server-side timestamp
-                # filter, so an "incremental" sync would cost the same as a full refresh. Ship full
-                # refresh only — merge on the primary key keeps mutable fields (e.g. total_plays) fresh.
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=BUZZSPROUT_ENDPOINTS[endpoint].should_sync_default,
-                description=BUZZSPROUT_ENDPOINTS[endpoint].description,
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Buzzsprout returns the full array on every request with no server-side timestamp filter, so
+        # an "incremental" sync would cost the same as a full refresh. Every endpoint has no
+        # incremental fields, so this ships full refresh only — merge on the primary key keeps
+        # mutable fields (e.g. total_plays) fresh.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions={
+                endpoint: config.description
+                for endpoint, config in BUZZSPROUT_ENDPOINTS.items()
+                if config.description is not None
+            },
+            should_sync_default={
+                endpoint: config.should_sync_default for endpoint, config in BUZZSPROUT_ENDPOINTS.items()
+            },
+        )
 
     def validate_credentials(
         self, config: BuzzsproutSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -128,5 +130,6 @@ You can find both your API token and podcast ID in your [Buzzsprout API settings
             api_token=config.api_token,
             podcast_id=config.podcast_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/tests/test_buzzsprout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/tests/test_buzzsprout.py
@@ -1,130 +1,178 @@
 import json
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from unittest import mock
 
 import requests
-import tenacity
-import structlog
+from requests import PreparedRequest, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.buzzsprout.buzzsprout import (
     BUZZSPROUT_BASE_URL,
     USER_AGENT,
-    BuzzsproutRetryableError,
-    _build_url,
-    _fetch,
-    _get_headers,
     buzzsprout_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.buzzsprout.settings import (
-    BUZZSPROUT_ENDPOINTS,
-    ENDPOINTS,
+from products.warehouse_sources.backend.temporal.data_imports.sources.buzzsprout.settings import ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the buzzsprout module.
+BUZZSPROUT_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.buzzsprout.buzzsprout.make_tracked_session"
 )
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.buzzsprout.buzzsprout"
 
-
-def _response(status: int = 200, body: Optional[Any] = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
+def _response(body: Any, status: int = 200) -> Response:
+    resp = Response()
     resp.status_code = status
-    resp.ok = 200 <= status < 300
-    resp.json.return_value = body if body is not None else []
-    resp.text = json.dumps(body if body is not None else [])
-    if not resp.ok:
-        reason = "Unauthorized" if status == 401 else "Forbidden" if status == 403 else "Error"
-        resp.raise_for_status.side_effect = requests.HTTPError(
-            f"{status} Client Error: {reason} for url: {BUZZSPROUT_BASE_URL}/123456/episodes.json",
-            response=requests.Response(),
-        )
+    resp._content = json.dumps(body).encode()
+    resp.url = f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
+    resp.reason = {401: "Unauthorized", 403: "Forbidden"}.get(status, "Error" if status >= 400 else "OK")
     return resp
 
 
-class TestGetHeaders:
-    def test_token_and_user_agent(self):
-        headers = _get_headers("abc123")
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return snapshots of each request captured AT PREPARE TIME.
+
+    Request state is mutated in place across pages, so inspecting it after the run shows only the
+    final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _applied_auth_headers(auth: Any) -> dict[str, str]:
+    prepared = PreparedRequest()
+    prepared.prepare(method="GET", url="https://example.com")
+    auth(prepared)
+    return dict(prepared.headers)
+
+
+class TestBuzzsproutRows:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_request_yields_full_array(self, MockSession) -> None:
+        # Buzzsprout has no pagination, so a single fetch returns the whole table.
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 1}, {"id": 2}])])
+
+        rows = _rows(buzzsprout_source("test-token", "123456", "episodes", team_id=1, job_id="j"))
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 1
+        assert snapshots[0]["url"] == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        assert _rows(buzzsprout_source("test-token", "123456", "episodes", team_id=1, job_id="j")) == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_podcasts_endpoint_omits_podcast_id(self, MockSession) -> None:
+        # The podcasts endpoint is account-scoped, so the podcast_id must not appear in the path.
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 9}])])
+
+        _rows(buzzsprout_source("test-token", "123456", "podcasts", team_id=1, job_id="j"))
+
+        assert snapshots[0]["url"] == f"{BUZZSPROUT_BASE_URL}/podcasts.json"
+        assert "123456" not in snapshots[0]["url"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_surrounding_whitespace_in_podcast_id_is_stripped(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 1}])])
+
+        _rows(buzzsprout_source("test-token", "  123456  ", "episodes", team_id=1, job_id="j"))
+
+        assert snapshots[0]["url"] == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_token_auth_scheme_and_user_agent(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": 1}])])
+
+        _rows(buzzsprout_source("abc123", "123456", "episodes", team_id=1, job_id="j"))
 
         # Buzzsprout's documented auth scheme is a static account token in the Authorization header.
-        assert headers["Authorization"] == "Token token=abc123"
+        assert _applied_auth_headers(snapshots[0]["auth"])["Authorization"] == "Token token=abc123"
         # A non-default User-Agent is mandatory or Buzzsprout may block the request.
-        assert headers["User-Agent"] == USER_AGENT
+        assert session.headers.get("User-Agent") == USER_AGENT
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_token_is_redacted_in_tracked_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}])])
+
+        _rows(buzzsprout_source("secret-token", "123456", "episodes", team_id=1, job_id="j"))
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("Token token=secret-token",)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises_loudly(self, MockSession) -> None:
+        # Every documented endpoint returns a bare array; an object body means the response shape
+        # changed (e.g. an error envelope on a 200) — fail loud rather than syncing it as a row.
+        session = MockSession.return_value
+        _wire(session, [_response({"unexpected": "object"})])
+
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(buzzsprout_source("test-token", "123456", "episodes", team_id=1, job_id="j"))
+
+    @pytest.mark.parametrize("status", [401, 403])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_errors_raise_http_error_matching_non_retryable_keys(self, MockSession, status) -> None:
+        # The HTTPError message must keep the "<status> Client Error: <reason> for url: <host>" shape
+        # so `get_non_retryable_errors` keys keep matching credential failures.
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status)])
+
+        with pytest.raises(requests.HTTPError, match=f"{status} Client Error: .* for url: https://www.buzzsprout.com"):
+            _rows(buzzsprout_source("test-token", "123456", "episodes", team_id=1, job_id="j"))
 
 
-class TestBuildUrl:
-    def test_podcast_scoped_includes_id(self):
-        url = _build_url("123456", BUZZSPROUT_ENDPOINTS["episodes"])
+class TestBuzzsproutSourceResponse:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_episodes_partitions_on_stable_published_at(self, MockSession) -> None:
+        response = buzzsprout_source("test-token", "123456", "episodes", team_id=1, job_id="j")
 
-        assert url == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
+        assert response.name == "episodes"
+        assert response.primary_keys == ["id"]
+        assert response.partition_mode == "datetime"
+        assert response.partition_format == "month"
+        assert response.partition_keys == ["published_at"]
+        assert response.sort_mode == "asc"
 
-    def test_account_scoped_omits_id(self):
-        # The podcasts endpoint is account-scoped, so the podcast_id must not appear in the path.
-        url = _build_url("123456", BUZZSPROUT_ENDPOINTS["podcasts"])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_podcasts_is_unpartitioned(self, MockSession) -> None:
+        # Podcasts carry no stable datetime field, so no datetime partitioning is applied.
+        response = buzzsprout_source("test-token", "123456", "podcasts", team_id=1, job_id="j")
 
-        assert url == f"{BUZZSPROUT_BASE_URL}/podcasts.json"
-        assert "123456" not in url
+        assert response.name == "podcasts"
+        assert response.primary_keys == ["id"]
+        assert response.partition_mode is None
+        assert response.partition_keys is None
 
-    def test_surrounding_whitespace_is_stripped(self):
-        url = _build_url("  123456  ", BUZZSPROUT_ENDPOINTS["episodes"])
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_names_match_endpoints(self, MockSession, endpoint) -> None:
+        response = buzzsprout_source("test-token", "123456", endpoint, team_id=1, job_id="j")
 
-        assert url == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
-
-
-# tenacity exposes the undecorated function via `__wrapped__`, so status classification can be
-# asserted without waiting through retry backoff.
-_fetch_once = _fetch.__wrapped__  # type: ignore[attr-defined]
-
-
-class TestFetch:
-    def test_ok_returns_array(self):
-        session = mock.MagicMock()
-        session.get.return_value = _response(200, [{"id": 1}, {"id": 2}])
-
-        assert _fetch_once(session, "https://example.com", {}, structlog.get_logger()) == [{"id": 1}, {"id": 2}]
-
-    def test_non_list_body_returns_empty(self):
-        # Every documented endpoint returns a bare array; defend against an unexpected object body.
-        session = mock.MagicMock()
-        session.get.return_value = _response(200, {"unexpected": "object"})
-
-        assert _fetch_once(session, "https://example.com", {}, structlog.get_logger()) == []
-
-    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
-    def test_retryable_statuses_raise_retryable(self, status):
-        session = mock.MagicMock()
-        session.get.return_value = _response(status)
-
-        with pytest.raises(BuzzsproutRetryableError):
-            _fetch_once(session, "https://example.com", {}, structlog.get_logger())
-
-    @pytest.mark.parametrize("status", [400, 401, 403, 404])
-    def test_client_errors_raise_for_status(self, status):
-        session = mock.MagicMock()
-        session.get.return_value = _response(status)
-
-        with pytest.raises(requests.HTTPError):
-            _fetch_once(session, "https://example.com", {}, structlog.get_logger())
-
-    def test_retries_transient_status_then_succeeds(self):
-        # Drive the real tenacity decorator (not `__wrapped__`) with no backoff to confirm a transient
-        # error is retried rather than re-raised on the first attempt.
-        fast_fetch = tenacity.retry(
-            retry=tenacity.retry_if_exception_type(
-                (BuzzsproutRetryableError, requests.ReadTimeout, requests.ConnectionError)
-            ),
-            stop=tenacity.stop_after_attempt(5),
-            wait=tenacity.wait_none(),
-            reraise=True,
-        )(_fetch_once)
-
-        session = mock.MagicMock()
-        session.get.side_effect = [_response(500), _response(200, [{"id": 1}])]
-
-        result = fast_fetch(session, "https://example.com", {}, structlog.get_logger())
-
-        assert result == [{"id": 1}]
-        assert session.get.call_count == 2
+        assert response.name == endpoint
 
 
 class TestValidateCredentials:
@@ -138,34 +186,35 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    def test_status_mapping(self, status, expected_valid):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(status)
+    def test_status_mapping(self, status, expected_valid) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
 
             is_valid, _ = validate_credentials("test-token", "123456")
 
         assert is_valid is expected_valid
 
-    def test_blank_podcast_id_is_invalid_without_request(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+    def test_blank_podcast_id_is_invalid_without_request(self) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
             is_valid, message = validate_credentials("test-token", "   ")
 
         assert is_valid is False
         assert message is not None
         mock_session.return_value.get.assert_not_called()
 
-    def test_network_error_is_invalid(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+    def test_network_error_is_invalid(self) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
             mock_session.return_value.get.side_effect = Exception("boom")
 
             is_valid, message = validate_credentials("test-token", "123456")
 
         assert is_valid is False
         assert message is not None
+        assert "reach the Buzzsprout API" in message
 
-    def test_probes_episodes_with_podcast_id_and_headers(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200)
+    def test_probes_episodes_with_podcast_id_and_headers(self) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
             validate_credentials("test-token", "123456")
 
@@ -173,10 +222,11 @@ class TestValidateCredentials:
 
         assert call.args[0] == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
         assert call.kwargs["headers"]["Authorization"] == "Token token=test-token"
+        assert call.kwargs["headers"]["User-Agent"] == USER_AGENT
 
-    def test_surrounding_whitespace_in_podcast_id_is_stripped(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200)
+    def test_surrounding_whitespace_in_podcast_id_is_stripped(self) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
             validate_credentials("test-token", "  123456  ")
 
@@ -184,89 +234,48 @@ class TestValidateCredentials:
 
         assert call.args[0] == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
 
-    @pytest.mark.parametrize("status", [429, 500, 503])
-    def test_transient_status_is_distinguished_from_invalid_credentials(self, status):
-        # A 429/5xx (after the session's own retries) is a temporary outage, not a credential problem,
-        # so the message must steer the user to retry rather than recreate their token.
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(status)
+    @pytest.mark.parametrize(
+        "status, message_fragment",
+        [
+            (401, "Invalid Buzzsprout API token"),
+            (403, "Invalid Buzzsprout API token"),
+            (404, "podcast not found"),
+        ],
+    )
+    def test_credential_error_messages(self, status: int, message_fragment: str) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
 
             is_valid, message = validate_credentials("test-token", "123456")
 
         assert is_valid is False
-        assert message is not None
-        assert "temporarily unavailable" in message
+        assert message_fragment in (message or "")
 
-    def test_token_is_redacted_in_tracked_session(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200)
+    @pytest.mark.parametrize("status", [429, 500, 503])
+    def test_transient_status_is_distinguished_from_invalid_credentials(self, status) -> None:
+        # A 429/5xx (after the session's own retries) is a temporary outage, not a credential problem,
+        # so the message must steer the user to retry rather than recreate their token.
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+
+            is_valid, message = validate_credentials("test-token", "123456")
+
+        assert is_valid is False
+        assert "temporarily unavailable" in (message or "")
+
+    def test_unexpected_status_is_reported(self) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=418)
+
+            is_valid, message = validate_credentials("test-token", "123456")
+
+        assert is_valid is False
+        assert "unexpected status code: 418" in (message or "")
+
+    def test_token_is_redacted_in_tracked_session(self) -> None:
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
             validate_credentials("secret-token", "123456")
 
         assert mock_session.call_args.kwargs["redact_values"] == ("secret-token",)
-
-
-class TestGetRows:
-    def test_yields_single_batch_with_full_array(self):
-        # Buzzsprout has no pagination, so a single fetch returns the whole table in one batch.
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200, [{"id": 1}, {"id": 2}])
-
-            batches = list(get_rows("test-token", "123456", "episodes", structlog.get_logger()))
-
-            called_url = mock_session.return_value.get.call_args.args[0]
-
-        assert batches == [[{"id": 1}, {"id": 2}]]
-        assert called_url == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
-
-    def test_skips_empty_response(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200, [])
-
-            batches = list(get_rows("test-token", "123456", "episodes", structlog.get_logger()))
-
-        assert batches == []
-
-    def test_podcasts_endpoint_omits_podcast_id(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200, [{"id": 9}])
-
-            list(get_rows("test-token", "123456", "podcasts", structlog.get_logger()))
-
-            called_url = mock_session.return_value.get.call_args.args[0]
-
-        assert called_url == f"{BUZZSPROUT_BASE_URL}/podcasts.json"
-
-    def test_token_is_redacted_in_tracked_session(self):
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200, [{"id": 1}])
-
-            list(get_rows("secret-token", "123456", "episodes", structlog.get_logger()))
-
-        assert mock_session.call_args.kwargs["redact_values"] == ("secret-token",)
-
-
-class TestBuzzsproutSource:
-    def test_episodes_partitions_on_stable_published_at(self):
-        response = buzzsprout_source("test-token", "123456", "episodes", structlog.get_logger())
-
-        assert response.name == "episodes"
-        assert response.primary_keys == ["id"]
-        assert response.partition_mode == "datetime"
-        assert response.partition_keys == ["published_at"]
-        assert response.sort_mode == "asc"
-
-    def test_podcasts_is_unpartitioned(self):
-        # Podcasts carry no stable datetime field, so no datetime partitioning is applied.
-        response = buzzsprout_source("test-token", "123456", "podcasts", structlog.get_logger())
-
-        assert response.name == "podcasts"
-        assert response.primary_keys == ["id"]
-        assert response.partition_mode is None
-        assert response.partition_keys is None
-
-    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_source_response_names_match_endpoints(self, endpoint):
-        response = buzzsprout_source("test-token", "123456", endpoint, structlog.get_logger())
-
-        assert response.name == endpoint

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/tests/test_buzzsprout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/tests/test_buzzsprout.py
@@ -102,6 +102,29 @@ class TestBuzzsproutRows:
 
         assert snapshots[0]["url"] == f"{BUZZSPROUT_BASE_URL}/123456/episodes.json"
 
+    @pytest.mark.parametrize(
+        "podcast_id",
+        [
+            "https://attacker.example/../../../123456",
+            "http://attacker.example/123456",
+            "123456/../../evil",
+            "123456?x=1",
+            "foo#bar",
+            "foo\\bar",
+        ],
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retargeting_podcast_id_is_rejected_without_request(self, MockSession, podcast_id) -> None:
+        # `podcast_id` is a non-secret editable field that becomes a REST path segment; a value that
+        # could resolve to another origin must be rejected before any authenticated request is sent.
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}])])
+
+        with pytest.raises(ValueError, match="Invalid Buzzsprout podcast ID"):
+            _rows(buzzsprout_source("test-token", podcast_id, "episodes", team_id=1, job_id="j"))
+
+        session.send.assert_not_called()
+
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_token_auth_scheme_and_user_agent(self, MockSession) -> None:
         session = MockSession.return_value
@@ -197,6 +220,25 @@ class TestValidateCredentials:
     def test_blank_podcast_id_is_invalid_without_request(self) -> None:
         with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
             is_valid, message = validate_credentials("test-token", "   ")
+
+        assert is_valid is False
+        assert message is not None
+        mock_session.return_value.get.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "podcast_id",
+        [
+            "https://attacker.example/../../../123456",
+            "123456/../../evil",
+            "123456?x=1",
+            "foo#bar",
+        ],
+    )
+    def test_retargeting_podcast_id_is_invalid_without_request(self, podcast_id) -> None:
+        # Validation must reject a retargeting podcast_id the same way the sync does, so the probe
+        # and the sync can never disagree on the request destination.
+        with mock.patch(BUZZSPROUT_SESSION_PATCH) as mock_session:
+            is_valid, message = validate_credentials("test-token", podcast_id)
 
         assert is_valid is False
         assert message is not None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/tests/test_buzzsprout_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buzzsprout/tests/test_buzzsprout_source.py
@@ -133,5 +133,6 @@ class TestBuzzsproutSource:
             api_token="test-token",
             podcast_id="123456",
             endpoint="podcasts",
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/cal_com.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/cal_com.py
@@ -1,12 +1,6 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlsplit, urlunsplit
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com.settings import (
@@ -14,29 +8,23 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com.se
     CalComEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    JSONResponseCursorPaginator,
+    OffsetPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CAL_COM_BASE_URL = "https://api.cal.com/v2"
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap single-object endpoint used to confirm an API key is genuine. The key is account-wide, so
 # one probe validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/me"
-
-
-class CalComRetryableError(Exception):
-    pass
-
-
-def _scrub_url(url: str | None) -> str:
-    # Drop the query string before a URL reaches any error message or log line. Today the API key
-    # rides in the Authorization header, but callers can append an arbitrary `path` (with a query)
-    # in `check_access`, and future endpoints may take query-string credentials, so scrubbing keeps
-    # those out of persisted job errors. The scheme/host/path stays intact so
-    # `get_non_retryable_errors()` can still match on the base URL.
-    if not url:
-        return CAL_COM_BASE_URL
-    parts = urlsplit(url)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
 @dataclasses.dataclass
@@ -48,8 +36,12 @@ class CalComResumeConfig:
     skip: int | None = None
 
 
-def _headers(api_key: str, config: CalComEndpointConfig) -> dict[str, str]:
-    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+def _headers(config: CalComEndpointConfig) -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs;
+    # only the non-secret headers are set here. Cal.com versions endpoints individually via the
+    # `cal-api-version` header; omitting it silently falls back to a legacy behavior, so it must be
+    # pinned per endpoint.
+    headers = {"Accept": "application/json"}
     if config.api_version:
         headers["cal-api-version"] = config.api_version
     return headers
@@ -86,151 +78,27 @@ def _build_incremental_params(
     return {param: _format_incremental_value(db_incremental_field_last_value)}
 
 
-@retry(
-    retry=retry_if_exception_type((CalComRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.get(url, params=params or None, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Default rate limit is 120 req/min; 429s and transient 5xx are retried with backoff.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CalComRetryableError(
-            f"Cal.com API error (retryable): status={response.status_code}, url={_scrub_url(response.url)}"
-        )
-
-    if not response.ok:
-        logger.error(
-            f"Cal.com API error: status={response.status_code}, body={response.text}, url={_scrub_url(response.url)}"
-        )
-        # Raise with the query scrubbed from the URL rather than calling raise_for_status(), whose
-        # message embeds the full request URL. The base host stays intact so
-        # `get_non_retryable_errors()` can still match on it.
-        raise requests.HTTPError(
-            f"{response.status_code} Client Error: {response.reason} for url: {_scrub_url(response.url)}",
-            response=response,
-        )
-
-    data = response.json()
-    # Every v2 endpoint wraps its payload as {"status": "success", "data": ...}.
-    if not isinstance(data, dict) or "data" not in data:
-        raise CalComRetryableError(f"Cal.com returned an unexpected payload for {url}: {type(data).__name__}")
-
-    return data
-
-
-def _rows_from_body(body: dict[str, Any], config: CalComEndpointConfig, url: str) -> list[dict[str, Any]]:
-    data = body["data"]
-    if config.single_object:
-        return [data] if isinstance(data, dict) else []
-    if not isinstance(data, list):
-        raise CalComRetryableError(f"Cal.com returned a non-list payload for {url}: {type(data).__name__}")
-    return data
-
-
-def _get_cursor_rows(
-    session: requests.Session,
-    config: CalComEndpointConfig,
-    url: str,
-    base_params: dict[str, Any],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CalComResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    cursor = resume.cursor if resume else None
-    if cursor is not None:
-        logger.debug(f"Cal.com: resuming {config.name} from cursor {cursor}")
-
-    while True:
-        params = {**base_params, "limit": config.page_size}
-        if cursor is not None:
-            params["cursor"] = cursor
-
-        body = _fetch_page(session, url, params, logger)
-        items = _rows_from_body(body, config, url)
-        if items:
-            yield items
-
-        pagination = body.get("pagination") or {}
-        next_cursor = pagination.get("nextCursor")
-        if not pagination.get("hasMore") or not next_cursor:
-            break
-
-        cursor = next_cursor
-        # Save AFTER yielding so a crash re-fetches from the next cursor (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(CalComResumeConfig(cursor=next_cursor))
-
-
-def _get_offset_rows(
-    session: requests.Session,
-    config: CalComEndpointConfig,
-    url: str,
-    base_params: dict[str, Any],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CalComResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    skip = resume.skip if resume and resume.skip is not None else 0
-    if skip:
-        logger.debug(f"Cal.com: resuming {config.name} from offset {skip}")
-
-    while True:
-        params = {**base_params, "take": config.page_size, "skip": skip}
-        body = _fetch_page(session, url, params, logger)
-        items = _rows_from_body(body, config, url)
-        if items:
-            yield items
-
-        # These endpoints return no pagination metadata; a short (or empty) page means we're done.
-        if len(items) < config.page_size:
-            break
-
-        skip += config.page_size
-        resumable_source_manager.save_state(CalComResumeConfig(skip=skip))
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CalComResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CAL_COM_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(api_key, config), redact_values=(api_key,))
-    url = f"{CAL_COM_BASE_URL}{config.path}"
-    base_params = _build_incremental_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
-    )
-
+def _make_paginator(config: CalComEndpointConfig) -> BasePaginator:
     if config.pagination == "cursor":
-        yield from _get_cursor_rows(session, config, url, base_params, logger, resumable_source_manager)
-        return
-
+        # Bookings pages carry {"pagination": {"nextCursor": ..., "hasMore": ...}}; a null/absent
+        # nextCursor (always the case when hasMore is false) terminates.
+        return JSONResponseCursorPaginator(cursor_path="pagination.nextCursor", cursor_param="cursor")
     if config.pagination == "offset":
-        yield from _get_offset_rows(session, config, url, base_params, logger, resumable_source_manager)
-        return
-
-    body = _fetch_page(session, url, base_params, logger)
-    items = _rows_from_body(body, config, url)
-    if items:
-        yield items
+        # These endpoints return no pagination metadata; a short (or empty) page means we're done.
+        return OffsetPaginator(
+            limit=config.page_size,
+            offset_param="skip",
+            limit_param="take",
+            total_path=None,
+        )
+    return SinglePagePaginator()
 
 
 def cal_com_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CalComResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -238,17 +106,69 @@ def cal_com_source(
 ) -> SourceResponse:
     config = CAL_COM_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = _build_incremental_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+    if config.pagination == "cursor":
+        # Bookings `limit` maxes at 100; a larger value is rejected with 400 Bad Request. The
+        # offset paginator injects its own `take`/`skip` pair.
+        params["limit"] = config.page_size
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CAL_COM_BASE_URL,
+            "headers": _headers(config),
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": _make_paginator(config),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Every v2 endpoint wraps its payload as {"status": "success", "data": ...}.
+                    # A 200 body without `data` means the response shape changed — fail loud
+                    # instead of silently syncing 0 rows.
+                    "data_selector": "data",
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            if config.pagination == "cursor" and resume.cursor is not None:
+                initial_paginator_state = {"cursor": resume.cursor}
+            elif config.pagination == "offset" and resume.skip is not None:
+                initial_paginator_state = {"offset": resume.skip}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the framework checkpoints AFTER a page is yielded
+        # so a crash re-fetches from the next page (already-yielded pages are persisted) and merge
+        # dedupes the re-pulled page on the primary key.
+        if not state:
+            return
+        if config.pagination == "cursor" and state.get("cursor") is not None:
+            resumable_source_manager.save_state(CalComResumeConfig(cursor=state["cursor"]))
+        elif config.pagination == "offset" and state.get("offset") is not None:
+            resumable_source_manager.save_state(CalComResumeConfig(skip=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint if config.pagination in ("cursor", "offset") else None,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -263,34 +183,17 @@ def cal_com_source(
     )
 
 
-def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the API key.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(
-        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
-        redact_values=(api_key,),
-    )
-    try:
-        response = session.get(f"{CAL_COM_BASE_URL}{path}", timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Cal.com: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Cal.com returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_key)
-    if status == 200:
+    # The API key is account-wide, so a single probe validates access to every list endpoint.
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CAL_COM_BASE_URL}{DEFAULT_PROBE_PATH}",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid Cal.com API key"
-    return False, message or "Could not validate Cal.com API key"
+    if status is None:
+        return False, "Could not connect to Cal.com"
+    return False, f"Cal.com returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/source.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CalComSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -94,19 +97,7 @@ You can create an API key under **Settings → Security → API keys** in [Cal.c
     ) -> list[SourceSchema]:
         # Only bookings exposes server-side timestamp filters (afterUpdatedAt / afterCreatedAt), so
         # it is the only endpoint that supports incremental sync.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CalComSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -129,7 +120,8 @@ You can create an API key under **Settings → Security → API keys** in [Cal.c
         return cal_com_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/tests/test_cal_com.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/tests/test_cal_com.py
@@ -1,20 +1,18 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com import cal_com
 from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com.cal_com import (
     CAL_COM_BASE_URL,
     CalComResumeConfig,
-    CalComRetryableError,
     cal_com_source,
-    check_access,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com.settings import (
@@ -22,121 +20,152 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com.se
     ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = cal_com._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the cal_com module.
+CAL_COM_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.cal_com.cal_com.make_tracked_session"
+)
 
 
-class _FakeResumableManager:
-    def __init__(self, state: CalComResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[CalComResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> CalComResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: CalComResumeConfig) -> None:
-        self.saved.append(data)
+def _response(body: Any, status_code: int = 200, url: str | None = None, reason: str = "OK") -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.reason = reason
+    resp.url = url or f"{CAL_COM_BASE_URL}/bookings"
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _collect(
-    manager: _FakeResumableManager,
-    fake_fetch: Any,
-    endpoint: str,
-    **kwargs: Any,
-) -> tuple[list[dict], list[dict[str, Any]]]:
-    calls: list[dict[str, Any]] = []
+def _page(items: Any, next_cursor: str | None = None, has_more: bool = False) -> Response:
+    return _response(
+        {"status": "success", "data": items, "pagination": {"nextCursor": next_cursor, "hasMore": has_more}}
+    )
 
-    def _fetch(session: Any, url: str, params: dict[str, Any], logger: Any) -> dict[str, Any]:
-        calls.append({"url": url, "params": params})
-        return fake_fetch(url, params)
 
-    with (
-        patch.object(cal_com, "_fetch_page", _fetch),
-        patch.object(cal_com, "make_tracked_session", return_value=MagicMock()),
-    ):
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="cal_live_key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(batch)
-    return rows, calls
+def _make_manager(resume_state: CalComResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None, **kwargs: Any):
+    return cal_com_source(
+        api_key="cal_live_key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        **kwargs,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestBookingsCursorPagination:
-    def _pages(self, url: str, params: dict[str, Any]) -> dict[str, Any]:
-        cursor = params.get("cursor")
-        if cursor is None:
-            return {"data": [{"id": 1}], "pagination": {"nextCursor": "c2", "hasMore": True}}
-        if cursor == "c2":
-            return {"data": [{"id": 2}], "pagination": {"nextCursor": None, "hasMore": False}}
-        raise AssertionError(f"unexpected cursor {cursor}")
+    def _pages(self) -> list[Response]:
+        return [
+            _page([{"id": 1}], next_cursor="c2", has_more=True),
+            _page([{"id": 2}], next_cursor=None, has_more=False),
+        ]
 
-    def test_follows_next_cursor_until_has_more_false(self) -> None:
-        manager = _FakeResumableManager()
-        rows, calls = _collect(manager, self._pages, "bookings")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_next_cursor_until_exhausted(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, self._pages())
+
+        manager = _make_manager()
+        rows = _rows(_source("bookings", manager))
+
         assert rows == [{"id": 1}, {"id": 2}]
         # Bookings `limit` maxes at 100; a larger value is rejected with 400 Bad Request.
-        assert calls[0]["params"] == {"limit": 100}
-        assert calls[1]["params"] == {"limit": 100, "cursor": "c2"}
+        assert params[0] == {"limit": 100}
+        assert params[1] == {"limit": 100, "cursor": "c2"}
         # State is saved once — after the first page, pointing at the next cursor — then we stop.
-        assert [s.cursor for s in manager.saved] == ["c2"]
+        assert [call.args[0].cursor for call in manager.save_state.call_args_list] == ["c2"]
 
-    def test_resumes_from_saved_cursor(self) -> None:
-        manager = _FakeResumableManager(CalComResumeConfig(cursor="c2"))
-        rows, calls = _collect(manager, self._pages, "bookings")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page([{"id": 2}], next_cursor=None, has_more=False)])
+
+        manager = _make_manager(CalComResumeConfig(cursor="c2"))
+        rows = _rows(_source("bookings", manager))
+
         # The first page must never be re-fetched on resume.
         assert rows == [{"id": 2}]
-        assert calls[0]["params"]["cursor"] == "c2"
+        assert session.send.call_count == 1
+        assert params[0]["cursor"] == "c2"
 
-    def test_empty_first_page_yields_nothing(self) -> None:
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([], next_cursor=None, has_more=False)])
 
-        def pages(url: str, params: dict[str, Any]) -> dict[str, Any]:
-            return {"data": [], "pagination": {"nextCursor": None, "hasMore": False}}
+        manager = _make_manager()
+        rows = _rows(_source("bookings", manager))
 
-        rows, _ = _collect(manager, pages, "bookings")
         assert rows == []
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_incremental_filter_param_sent_on_every_page(self) -> None:
-        manager = _FakeResumableManager()
-        _, calls = _collect(
-            manager,
-            self._pages,
-            "bookings",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
-            incremental_field="updatedAt",
-        )
-        for call in calls:
-            assert call["params"]["afterUpdatedAt"] == "2026-01-02T03:04:05.000Z"
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_param_sent_on_every_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, self._pages())
 
-    def test_incremental_created_at_maps_to_after_created_at(self) -> None:
-        manager = _FakeResumableManager()
-        _, calls = _collect(
-            manager,
-            self._pages,
-            "bookings",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=date(2026, 1, 2),
-            incremental_field="createdAt",
+        _rows(
+            _source(
+                "bookings",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+                incremental_field="updatedAt",
+            )
         )
-        assert calls[0]["params"]["afterCreatedAt"] == "2026-01-02T00:00:00.000Z"
-        assert "afterUpdatedAt" not in calls[0]["params"]
+
+        for call_params in params:
+            assert call_params["afterUpdatedAt"] == "2026-01-02T03:04:05.000Z"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_created_at_maps_to_after_created_at(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, self._pages())
+
+        _rows(
+            _source(
+                "bookings",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 1, 2),
+                incremental_field="createdAt",
+            )
+        )
+
+        assert params[0]["afterCreatedAt"] == "2026-01-02T00:00:00.000Z"
+        assert "afterUpdatedAt" not in params[0]
 
     def test_unknown_incremental_field_raises(self) -> None:
-        manager = _FakeResumableManager()
         with pytest.raises(ValueError, match="no server-side filter"):
-            _collect(
-                manager,
-                self._pages,
+            _source(
                 "bookings",
                 should_use_incremental_field=True,
                 db_incremental_field_last_value="2026-01-01",
@@ -149,148 +178,146 @@ class TestBookingsCursorPagination:
             ("no_last_value", True, None),
         ]
     )
-    def test_no_filter_param_without_watermark(self, _name: str, should_use: bool, last_value: Any) -> None:
-        manager = _FakeResumableManager()
-        _, calls = _collect(
-            manager,
-            self._pages,
-            "bookings",
-            should_use_incremental_field=should_use,
-            db_incremental_field_last_value=last_value,
-            incremental_field="updatedAt",
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_filter_param_without_watermark(
+        self, _name: str, should_use: bool, last_value: Any, MockSession
+    ) -> None:
+        session = MockSession.return_value
+        params = _wire(session, self._pages())
+
+        _rows(
+            _source(
+                "bookings",
+                should_use_incremental_field=should_use,
+                db_incremental_field_last_value=last_value,
+                incremental_field="updatedAt",
+            )
         )
-        assert "afterUpdatedAt" not in calls[0]["params"]
+
+        assert "afterUpdatedAt" not in params[0]
 
 
 class TestWebhooksOffsetPagination:
-    def test_advances_skip_until_short_page(self) -> None:
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_advances_skip_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
         page_size = CAL_COM_ENDPOINTS["webhooks"].page_size
         full_page = [{"id": i} for i in range(page_size)]
+        params = _wire(session, [_response({"data": full_page}), _response({"data": [{"id": "last"}]})])
 
-        def pages(url: str, params: dict[str, Any]) -> dict[str, Any]:
-            return {"data": full_page if params["skip"] == 0 else [{"id": "last"}]}
+        manager = _make_manager()
+        rows = _rows(_source("webhooks", manager))
 
-        rows, calls = _collect(manager, pages, "webhooks")
         assert len(rows) == page_size + 1
         # Webhooks `take` maxes at 250; a larger value is rejected with 400 Bad Request.
-        assert calls[0]["params"]["take"] == 250
-        assert [c["params"]["skip"] for c in calls] == [0, page_size]
-        assert [s.skip for s in manager.saved] == [page_size]
+        assert params[0]["take"] == 250
+        assert [p["skip"] for p in params] == [0, page_size]
+        assert [call.args[0].skip for call in manager.save_state.call_args_list] == [page_size]
 
-    def test_resumes_from_saved_offset(self) -> None:
-        manager = _FakeResumableManager(CalComResumeConfig(skip=500))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response({"data": [{"id": "resumed"}]})])
 
-        def pages(url: str, params: dict[str, Any]) -> dict[str, Any]:
-            assert params["skip"] == 500
-            return {"data": [{"id": "resumed"}]}
+        manager = _make_manager(CalComResumeConfig(skip=500))
+        rows = _rows(_source("webhooks", manager))
 
-        rows, _ = _collect(manager, pages, "webhooks")
         assert rows == [{"id": "resumed"}]
+        assert params[0]["skip"] == 500
 
 
 class TestSingleFetchEndpoints:
     @parameterized.expand([("event_types",), ("schedules",), ("teams",)])
-    def test_list_endpoints_yield_single_batch(self, endpoint: str) -> None:
-        manager = _FakeResumableManager()
-        rows, calls = _collect(manager, lambda url, params: {"data": [{"id": 1}, {"id": 2}]}, endpoint)
-        assert rows == [{"id": 1}, {"id": 2}]
-        assert len(calls) == 1
-        assert manager.saved == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_list_endpoints_yield_single_batch(self, endpoint: str, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"data": [{"id": 1}, {"id": 2}]})])
 
-    def test_me_wraps_single_object_in_list(self) -> None:
-        manager = _FakeResumableManager()
-        rows, _ = _collect(manager, lambda url, params: {"data": {"id": 42, "username": "tom"}}, "me")
+        manager = _make_manager()
+        rows = _rows(_source(endpoint, manager))
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_me_wraps_single_object_in_list(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"data": {"id": 42, "username": "tom"}})])
+
+        rows = _rows(_source("me"))
         assert rows == [{"id": 42, "username": "tom"}]
 
-    def test_endpoint_versions_pinned_in_headers(self) -> None:
+    @parameterized.expand(
+        [
+            ("bookings", "2026-05-01"),
+            ("event_types", "2024-06-14"),
+            ("schedules", "2024-06-11"),
+            ("teams", None),
+        ]
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_endpoint_versions_pinned_in_headers(
+        self, endpoint: str, expected_version: str | None, MockSession
+    ) -> None:
         # Omitting cal-api-version silently falls back to legacy endpoint behavior, so the
         # versioned endpoints must pin it.
-        assert cal_com._headers("k", CAL_COM_ENDPOINTS["bookings"])["cal-api-version"] == "2026-05-01"
-        assert cal_com._headers("k", CAL_COM_ENDPOINTS["event_types"])["cal-api-version"] == "2024-06-14"
-        assert cal_com._headers("k", CAL_COM_ENDPOINTS["schedules"])["cal-api-version"] == "2024-06-11"
-        assert "cal-api-version" not in cal_com._headers("k", CAL_COM_ENDPOINTS["teams"])
+        session = MockSession.return_value
+        session.headers = {}
+
+        _source(endpoint)
+
+        assert session.headers.get("cal-api-version") == expected_version
 
 
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.reason = "Unauthorized"
-        # A query string that would carry credentials on a query-bearing endpoint; the error path
-        # must strip it before the URL reaches the exception message.
-        response.url = f"{CAL_COM_BASE_URL}/bookings?apiKey=secret-token"
-        response.json.return_value = body if body is not None else {"status": "success", "data": []}
-        response.text = ""
-        session = MagicMock()
-        session.get.return_value = response
-        return session
+class TestErrorHandling:
+    @parameterized.expand(
+        [
+            ("bare_list", [{"id": 1}]),
+            ("missing_data", {"status": "success"}),
+        ]
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unexpected_payload_shape_fails_loudly(self, _name: str, body: Any, MockSession) -> None:
+        # A 200 body without `data` means the response shape changed — fail loud, not silently 0 rows.
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
 
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(CalComRetryableError):
-            _fetch_page_unwrapped(session, f"{CAL_COM_BASE_URL}/bookings", {}, MagicMock())
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source("me"))
 
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_http_error_with_scrubbed_url(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
+    @parameterized.expand(
+        [
+            ("unauthorized", 401, "Unauthorized"),
+            ("forbidden", 403, "Forbidden"),
+            ("not_found", 404, "Not Found"),
+        ]
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_http_error_with_base_url(
+        self, _name: str, status: int, reason: str, MockSession
+    ) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response({}, status_code=status, url=f"{CAL_COM_BASE_URL}/bookings?limit=100", reason=reason)],
+        )
+
         with pytest.raises(requests.HTTPError) as exc_info:
-            _fetch_page_unwrapped(session, f"{CAL_COM_BASE_URL}/bookings", {}, MagicMock())
-        # The base URL stays so `get_non_retryable_errors()` can match, but the credential-bearing
-        # query string must never reach the persisted error message.
-        message = str(exc_info.value)
-        assert f"for url: {CAL_COM_BASE_URL}/bookings" in message
-        assert "secret-token" not in message
-        assert "?" not in message
+            _rows(_source("bookings"))
 
-    @parameterized.expand([("bare_list", [{"id": 1}]), ("missing_data", {"status": "success"})])
-    def test_unexpected_payload_is_retryable(self, _name: str, body: Any) -> None:
-        session = self._session_returning(200, body)
-        with pytest.raises(CalComRetryableError):
-            _fetch_page_unwrapped(session, f"{CAL_COM_BASE_URL}/me", {}, MagicMock())
-
-    def test_success_returns_full_body(self) -> None:
-        body = {"status": "success", "data": [{"id": 1}], "pagination": {"nextCursor": "c2", "hasMore": True}}
-        session = self._session_returning(200, body)
-        assert _fetch_page_unwrapped(session, f"{CAL_COM_BASE_URL}/bookings", {"limit": 250}, MagicMock()) == body
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"limit": 250}
+        # The base URL must be in the message so `get_non_retryable_errors()` can match on it.
+        assert f"{status} Client Error: {reason} for url: {CAL_COM_BASE_URL}/bookings" in str(exc_info.value)
 
 
-class TestCheckAccess:
-    def _session(self, response: Any) -> MagicMock:
-        session = MagicMock()
+class TestValidateCredentials:
+    def _session(self, response: Any) -> mock.MagicMock:
+        session = mock.MagicMock()
         if isinstance(response, Exception):
             session.get.side_effect = response
         else:
             session.get.return_value = response
         return session
-
-    @parameterized.expand(
-        [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "Cal.com returned HTTP 500"),
-        ]
-    )
-    def test_status_mapping(
-        self, _name: str, status: int, ok: bool, expected_status: int, expected_message: str | None
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        with patch.object(cal_com, "make_tracked_session", return_value=self._session(response)):
-            assert check_access("cal_live_key") == (expected_status, expected_message)
-
-    def test_connection_error_maps_to_zero(self) -> None:
-        session = self._session(requests.ConnectionError("boom"))
-        with patch.object(cal_com, "make_tracked_session", return_value=session):
-            status, message = check_access("cal_live_key")
-        assert status == 0
-        assert message is not None and "boom" in message
 
     @parameterized.expand(
         [
@@ -300,41 +327,39 @@ class TestCheckAccess:
             ("server_error", 500, False, "Cal.com returned HTTP 500"),
         ]
     )
-    def test_validate_credentials(
-        self, _name: str, status: int, expected_valid: bool, expected_message: str | None
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        with patch.object(cal_com, "make_tracked_session", return_value=self._session(response)):
+    def test_status_mapping(self, _name: str, status: int, expected_valid: bool, expected_message: str | None) -> None:
+        response = mock.MagicMock(status_code=status)
+        with mock.patch(CAL_COM_SESSION_PATCH, return_value=self._session(response)):
             assert validate_credentials("cal_live_key") == (expected_valid, expected_message)
+
+    def test_connection_error_is_swallowed(self) -> None:
+        session = self._session(requests.ConnectionError("boom"))
+        with mock.patch(CAL_COM_SESSION_PATCH, return_value=session):
+            assert validate_credentials("cal_live_key") == (False, "Could not connect to Cal.com")
 
 
 class TestCalComSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        response = cal_com_source(
-            api_key="cal_live_key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, MockSession) -> None:
+        MockSession.return_value.headers = {}
+        response = _source(endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
 
-    def test_bookings_partitions_on_stable_created_at(self) -> None:
-        response = cal_com_source(
-            api_key="cal_live_key", endpoint="bookings", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_bookings_partitions_on_stable_created_at(self, MockSession) -> None:
+        MockSession.return_value.headers = {}
+        response = _source("bookings")
         assert response.partition_mode == "datetime"
         assert response.partition_keys == ["createdAt"]
         # Bookings arrive newest-first, so the watermark must only commit after a complete sync.
         assert response.sort_mode == "desc"
 
     @parameterized.expand([(e,) for e in ENDPOINTS if e != "bookings"])
-    def test_full_refresh_endpoints_do_not_partition(self, endpoint: str) -> None:
-        response = cal_com_source(
-            api_key="cal_live_key", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoints_do_not_partition(self, endpoint: str, MockSession) -> None:
+        MockSession.return_value.headers = {}
+        response = _source(endpoint)
         assert response.partition_mode is None
         assert response.sort_mode == "asc"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/callrail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/callrail.py
@@ -2,19 +2,21 @@ import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.callrail.settings import (
-    CALLRAIL_ENDPOINTS,
-    CallRailEndpointConfig,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.callrail.settings import CALLRAIL_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ApiKeyAuthConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CALLRAIL_BASE_URL = "https://api.callrail.com/v3"
 
@@ -25,10 +27,6 @@ PER_PAGE = 250
 # Hard cap so a runaway pagination loop (e.g. the API never signaling the last page) can't scan
 # forever. 250 rows/page * this cap bounds a single endpoint sync.
 MAX_PAGES = 100_000
-
-
-class CallRailRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -48,6 +46,17 @@ def _get_headers(api_key: str) -> dict[str, str]:
     }
 
 
+def _auth_config(api_key: str) -> ApiKeyAuthConfig:
+    # Framework auth so the credential value is redacted from logs/samples; the full header value
+    # is the secret since CallRail wraps the key in token="...".
+    return {
+        "type": "api_key",
+        "name": "Authorization",
+        "api_key": f'Token token="{api_key}"',
+        "location": "header",
+    }
+
+
 def _format_start_date(value: Any) -> str | None:
     """Format an incremental cursor value as the YYYY-MM-DD `start_date` the API filters on.
 
@@ -64,35 +73,7 @@ def _format_start_date(value: Any) -> str | None:
     return None
 
 
-@retry(
-    retry=retry_if_exception_type((CallRailRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, headers=headers, timeout=60)
-
-    # 429 is the per-account rate limit (1,000/hour, 10,000/day). Back off and retry rather than
-    # failing the sync. 5xx are transient server errors.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CallRailRetryableError(f"CallRail API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"CallRail API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _build_url(base: str, params: dict[str, Any]) -> str:
-    clean = {k: v for k, v in params.items() if v is not None}
-    return f"{base}?{urlencode(clean)}" if clean else base
-
-
-def resolve_account_id(
-    session: requests.Session, api_key: str, logger: FilteringBoundLogger, account_id: str | None = None
-) -> str:
+def resolve_account_id(api_key: str, team_id: int, job_id: str, account_id: str | None = None) -> str:
     """Return the account id to scope data requests to.
 
     CallRail data endpoints are all nested under /v3/a/{account_id}/, so we must resolve one first.
@@ -102,97 +83,122 @@ def resolve_account_id(
         return account_id
 
     # We only ever read the first account, so request a single row like validate_credentials does.
-    url = _build_url(f"{CALLRAIL_BASE_URL}/a.json", {"per_page": 1})
-    data = _fetch_page(session, url, _get_headers(api_key), logger)
-    accounts = data.get("accounts", [])
-    if not accounts:
-        raise ValueError("No CallRail accounts are accessible with this API key.")
-    return str(accounts[0]["id"])
+    accounts_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CALLRAIL_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": _auth_config(api_key),
+        },
+        "resources": [
+            {
+                "name": "accounts",
+                "endpoint": {
+                    "path": "/a.json",
+                    "params": {"per_page": 1},
+                    "data_selector": "accounts",
+                    "paginator": SinglePagePaginator(),
+                },
+            }
+        ],
+    }
+    for page in rest_api_resource(accounts_config, team_id, job_id, None):
+        for account in page:
+            return str(account["id"])
+    raise ValueError("No CallRail accounts are accessible with this API key.")
 
 
 def validate_credentials(api_key: str) -> bool:
     """Confirm the API key is genuine by hitting the accounts endpoint."""
-    url = _build_url(f"{CALLRAIL_BASE_URL}/a.json", {"per_page": 1})
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _build_params(
-    config: CallRailEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"per_page": PER_PAGE}
-
-    if config.sort_field:
-        # Ascending on the cursor field so the pipeline watermark advances safely and full-refresh
-        # pages don't skip/duplicate rows inserted mid-sync.
-        params["sort"] = config.sort_field
-        params["order"] = "asc"
-
-    if config.supports_incremental and should_use_incremental_field:
-        start_date = _format_start_date(db_incremental_field_last_value)
-        if start_date:
-            params["start_date"] = start_date
-
-    return params
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CALLRAIL_BASE_URL}/a.json?per_page=1",
+        headers=_get_headers(api_key),
+    )
+    return ok
 
 
 def get_rows(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CallRailResumeConfig],
     account_id: str | None = None,
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Any = None,
 ) -> Iterator[list[dict[str, Any]]]:
     config = CALLRAIL_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across pages so urllib3 keeps the connection alive.
-    session = make_tracked_session()
 
     resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    initial_paginator_state: Optional[dict[str, Any]] = None
     if resume is not None:
         resolved_account_id = resume.account_id
-        page = resume.page
-        logger.debug(f"CallRail: resuming {endpoint} from page={page}, account_id={resolved_account_id}")
+        initial_paginator_state = {"page": resume.page}
     else:
-        resolved_account_id = resolve_account_id(session, api_key, logger, account_id)
-        page = 1
+        resolved_account_id = resolve_account_id(api_key, team_id, job_id, account_id)
 
-    base = f"{CALLRAIL_BASE_URL}/a/{resolved_account_id}{config.path}"
-    params = _build_params(config, should_use_incremental_field, db_incremental_field_last_value)
+    params: dict[str, Any] = {"per_page": PER_PAGE}
+    if config.sort_field:
+        # Ascending on the cursor field so the pipeline watermark advances safely and full-refresh
+        # pages don't skip/duplicate rows inserted mid-sync.
+        params["sort"] = config.sort_field
+        params["order"] = "asc"
 
-    while page <= MAX_PAGES:
-        url = _build_url(base, {**params, "page": page})
-        data = _fetch_page(session, url, headers, logger)
+    endpoint_config: dict[str, Any] = {
+        "path": f"/a/{resolved_account_id}{config.path}",
+        "params": params,
+        # Key the list lives under in the JSON envelope; a missing key reads as an empty page and
+        # ends pagination, matching the API's "no more data" signal.
+        "data_selector": config.response_key,
+        # `total_pages` in the body is the number of PAGES, so pagination stops after the last page
+        # without paying an extra empty-page request.
+        "paginator": PageNumberPaginator(
+            base_page=1,
+            page_param="page",
+            total_path="total_pages",
+            maximum_page=MAX_PAGES,
+        ),
+    }
+    if config.supports_incremental and should_use_incremental_field:
+        endpoint_config["incremental"] = {
+            "start_param": "start_date",
+            "cursor_path": config.sort_field,
+            "convert": _format_start_date,
+        }
 
-        rows = data.get(config.response_key, [])
-        if not rows:
-            break
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CALLRAIL_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": _auth_config(api_key),
+        },
+        "resources": [{"name": endpoint, "endpoint": endpoint_config}],
+    }
 
-        yield rows
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the framework calls this AFTER a page is yielded
+        # so a crash re-pulls from the next page rather than losing the page we just handed off;
+        # the merge dedupes any overlap on the primary key.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(
+                CallRailResumeConfig(account_id=resolved_account_id, page=int(state["page"]))
+            )
 
-        total_pages = data.get("total_pages")
-        page += 1
-        if total_pages is not None and page > total_pages:
-            break
-
-        # Save AFTER yielding so a crash re-pulls from the next page rather than losing the page we
-        # just handed off; the merge dedupes any overlap on the primary key.
-        resumable_source_manager.save_state(CallRailResumeConfig(account_id=resolved_account_id, page=page))
-    else:
-        logger.warning(f"CallRail: hit MAX_PAGES={MAX_PAGES} for {endpoint}, stopping pagination")
+    yield from rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
 
 def callrail_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CallRailResumeConfig],
     account_id: str | None = None,
     should_use_incremental_field: bool = False,
@@ -202,10 +208,13 @@ def callrail_source(
 
     return SourceResponse(
         name=endpoint,
+        # Lazy so account resolution (a network call) happens at iteration time, not when the
+        # SourceResponse is built.
         items=lambda: get_rows(
             api_key=api_key,
             endpoint=endpoint,
-            logger=logger,
+            team_id=team_id,
+            job_id=job_id,
             resumable_source_manager=resumable_source_manager,
             account_id=account_id,
             should_use_incremental_field=should_use_incremental_field,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/source.py
@@ -19,7 +19,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.callrail.c
     validate_credentials as validate_callrail_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.callrail.settings import (
-    CALLRAIL_ENDPOINTS,
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
@@ -29,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CallRailSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -110,21 +112,7 @@ Leave **Account ID** blank to use the first account your key can access, or set 
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = CALLRAIL_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=endpoint_config.supports_incremental,
-                supports_append=endpoint_config.supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CallRailSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -146,7 +134,8 @@ Leave **Account ID** blank to use the first account your key can access, or set 
         return callrail_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             account_id=config.account_id or None,
             should_use_incremental_field=inputs.should_use_incremental_field,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/tests/test_callrail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/tests/test_callrail.py
@@ -1,13 +1,14 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail import (
     CallRailResumeConfig,
-    _build_params,
-    _build_url,
     _format_start_date,
     callrail_source,
     get_rows,
@@ -19,6 +20,28 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.callrail.s
     ENDPOINTS,
 )
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the callrail module.
+CALLRAIL_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
+)
+
+
+def _response(body: dict[str, Any]) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _page(response_key: str, items: list[dict[str, Any]], total_pages: int) -> Response:
+    return _response({response_key: items, "total_pages": total_pages, "total_records": 999})
+
+
+def _accounts(ids: list[str]) -> Response:
+    return _response({"accounts": [{"id": account_id} for account_id in ids]})
+
 
 def _make_manager(resume_state: CallRailResumeConfig | None = None) -> mock.MagicMock:
     manager = mock.MagicMock()
@@ -27,14 +50,36 @@ def _make_manager(resume_state: CallRailResumeConfig | None = None) -> mock.Magi
     return manager
 
 
-def _page(response_key: str, items: list[dict[str, Any]], total_pages: int) -> dict[str, Any]:
-    return {response_key: items, "total_pages": total_pages, "total_records": 999}
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return snapshots of each request AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _response(body: dict[str, Any]) -> mock.MagicMock:
-    resp = mock.MagicMock(status_code=200, ok=True)
-    resp.json.return_value = body
-    return resp
+def _collect(
+    endpoint: str,
+    responses: list[Response],
+    MockSession: mock.MagicMock,
+    manager: mock.MagicMock | None = None,
+    **kwargs: Any,
+) -> tuple[list[list[dict[str, Any]]], list[dict[str, Any]], mock.MagicMock]:
+    session = MockSession.return_value
+    snapshots = _wire(session, responses)
+    manager = manager if manager is not None else _make_manager()
+    batches = list(get_rows("key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs))
+    return batches, snapshots, manager
 
 
 class TestFormatStartDate:
@@ -57,54 +102,6 @@ class TestFormatStartDate:
         assert _format_start_date(datetime(2026, 3, 4, 12, 0, 0)) is not None
 
 
-class TestBuildParams:
-    def test_incremental_endpoint_requests_ascending_sort(self) -> None:
-        params = _build_params(
-            CALLRAIL_ENDPOINTS["calls"], should_use_incremental_field=False, db_incremental_field_last_value=None
-        )
-        assert params["sort"] == "start_time"
-        assert params["order"] == "asc"
-        assert params["per_page"] == 250
-        assert "start_date" not in params
-
-    def test_start_date_included_only_when_incremental_and_value_present(self) -> None:
-        params = _build_params(
-            CALLRAIL_ENDPOINTS["calls"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
-        )
-        assert params["start_date"] == "2026-03-04"
-
-    def test_start_date_omitted_when_not_using_incremental(self) -> None:
-        params = _build_params(
-            CALLRAIL_ENDPOINTS["calls"],
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
-        )
-        assert "start_date" not in params
-
-    def test_full_refresh_endpoint_has_no_sort_or_start_date(self) -> None:
-        params = _build_params(
-            CALLRAIL_ENDPOINTS["users"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime.now(UTC),
-        )
-        assert "sort" not in params
-        assert "order" not in params
-        assert "start_date" not in params
-
-
-class TestBuildUrl:
-    def test_no_params(self) -> None:
-        assert _build_url("https://api.callrail.com/v3/a/A/calls.json", {}) == (
-            "https://api.callrail.com/v3/a/A/calls.json"
-        )
-
-    def test_drops_none_values_and_encodes(self) -> None:
-        url = _build_url("https://x/calls.json", {"per_page": 250, "start_date": None, "page": 2})
-        assert url == "https://x/calls.json?per_page=250&page=2"
-
-
 class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected",
@@ -115,9 +112,7 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
-    )
+    @mock.patch(CALLRAIL_SESSION_PATCH)
     def test_validate_credentials_status_mapping(
         self, mock_session: mock.MagicMock, status_code: int, expected: bool
     ) -> None:
@@ -127,124 +122,176 @@ class TestValidateCredentials:
 
         assert validate_credentials("key") is expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
-    )
+    @mock.patch(CALLRAIL_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("key") is False
 
 
 class TestResolveAccountId:
-    def test_returns_provided_account_id_without_request(self) -> None:
-        session = mock.MagicMock()
-        assert resolve_account_id(session, "key", mock.MagicMock(), account_id="ACC123") == "ACC123"
-        session.get.assert_not_called()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_returns_provided_account_id_without_request(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [])
+        assert resolve_account_id("key", 1, "j", account_id="ACC123") == "ACC123"
+        session.send.assert_not_called()
 
-    def test_resolves_first_account_when_unset(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response({"accounts": [{"id": "ACC1"}, {"id": "ACC2"}]})
-        assert resolve_account_id(session, "key", mock.MagicMock()) == "ACC1"
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resolves_first_account_when_unset(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_accounts(["ACC1", "ACC2"])])
+        assert resolve_account_id("key", 1, "j") == "ACC1"
         # Only the first account is used, so we request a single row rather than a full page.
-        assert "per_page=1" in session.get.call_args.args[0]
+        assert snapshots[0]["params"]["per_page"] == 1
 
-    def test_raises_when_no_accounts(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response({"accounts": []})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_when_no_accounts(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_accounts([])])
         with pytest.raises(ValueError):
-            resolve_account_id(session, "key", mock.MagicMock())
+            resolve_account_id("key", 1, "j")
 
 
 class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
-    )
-    def test_paginates_by_page_number(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.side_effect = [
-            _response(_page("calls", [{"id": "1"}, {"id": "2"}], total_pages=2)),
-            _response(_page("calls", [{"id": "3"}], total_pages=2)),
-        ]
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "calls", mock.MagicMock(), manager, account_id="ACC"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_by_page_number(self, MockSession: mock.MagicMock) -> None:
+        batches, snapshots, manager = _collect(
+            "calls",
+            [
+                _page("calls", [{"id": "1"}, {"id": "2"}], total_pages=2),
+                _page("calls", [{"id": "3"}], total_pages=2),
+            ],
+            MockSession,
+            account_id="ACC",
+        )
 
         assert [item["id"] for batch in batches for item in batch] == ["1", "2", "3"]
+        assert snapshots[0]["params"]["page"] == 1
+        assert snapshots[0]["params"]["per_page"] == 250
+        assert snapshots[1]["params"]["page"] == 2
         # State saved once (after page 1, pointing at page 2); page 2 is the last so no save after it.
         manager.save_state.assert_called_once()
         saved = manager.save_state.call_args.args[0]
-        assert saved.page == 2
-        assert saved.account_id == "ACC"
+        assert saved == CallRailResumeConfig(account_id="ACC", page=2)
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
-    )
-    def test_resumes_from_saved_page(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response(_page("calls", [{"id": "9"}], total_pages=5))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_header_wraps_key_in_token_format(self, MockSession: mock.MagicMock) -> None:
+        _, snapshots, _ = _collect(
+            "calls", [_page("calls", [{"id": "1"}], total_pages=1)], MockSession, account_id="ACC"
+        )
+        # CallRail expects the token wrapped in token="..." per its v3 docs; sent via framework auth.
+        assert snapshots[0]["auth"].api_key == 'Token token="key"'
+        assert snapshots[0]["auth"].name == "Authorization"
 
-        manager = _make_manager(CallRailResumeConfig(account_id="ACC9", page=5))
-        list(get_rows("key", "calls", mock.MagicMock(), manager, account_id="ACC"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _, snapshots, _ = _collect(
+            "calls",
+            [_page("calls", [{"id": "9"}], total_pages=5)],
+            MockSession,
+            manager=_make_manager(CallRailResumeConfig(account_id="ACC9", page=5)),
+            account_id="ACC",
+        )
 
-        # Resumes at the saved page and pinned account, ignoring the passed account_id.
-        url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "page=5" in url
-        assert "/a/ACC9/" in url
+        # Resumes at the saved page and pinned account, ignoring the passed account_id, and
+        # without re-resolving accounts.
+        assert session.send.call_count == 1
+        assert snapshots[0]["params"]["page"] == 5
+        assert "/a/ACC9/" in snapshots[0]["url"]
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
-    )
-    def test_resolves_account_when_not_resuming(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.side_effect = [
-            _response({"accounts": [{"id": "RESOLVED"}]}),
-            _response(_page("users", [{"id": "u1"}], total_pages=1)),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resolves_account_when_not_resuming(self, MockSession: mock.MagicMock) -> None:
+        _, snapshots, _ = _collect(
+            "users",
+            [
+                _accounts(["RESOLVED"]),
+                _page("users", [{"id": "u1"}], total_pages=1),
+            ],
+            MockSession,
+        )
 
-        manager = _make_manager()
-        list(get_rows("key", "users", mock.MagicMock(), manager))
+        assert "/a/RESOLVED/users.json" in snapshots[1]["url"]
 
-        data_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert "/a/RESOLVED/users.json" in data_url
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
-    )
-    def test_empty_page_stops_without_saving(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response(_page("calls", [], total_pages=0))
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "calls", mock.MagicMock(), manager, account_id="ACC"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_stops_without_saving(self, MockSession: mock.MagicMock) -> None:
+        batches, _, manager = _collect("calls", [_page("calls", [], total_pages=0)], MockSession, account_id="ACC")
 
         assert batches == []
         manager.save_state.assert_not_called()
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.callrail.callrail.make_tracked_session"
-    )
-    def test_incremental_request_carries_start_date(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response(_page("calls", [{"id": "1"}], total_pages=1))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_response_key_stops_without_rows(self, MockSession: mock.MagicMock) -> None:
+        # A 200 body without the list key reads as an empty page — end of data, not an error.
+        batches, _, manager = _collect("calls", [_response({"total_pages": 3})], MockSession, account_id="ACC")
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                "calls",
-                mock.MagicMock(),
-                manager,
-                account_id="ACC",
-                should_use_incremental_field=True,
-                db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
-            )
+        assert batches == []
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_carries_start_date_and_sort(self, MockSession: mock.MagicMock) -> None:
+        _, snapshots, _ = _collect(
+            "calls",
+            [_page("calls", [{"id": "1"}], total_pages=1)],
+            MockSession,
+            account_id="ACC",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
         )
 
-        url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "start_date=2026-01-01" in url
-        assert "sort=start_time" in url
+        assert snapshots[0]["params"]["start_date"] == "2026-01-01"
+        assert snapshots[0]["params"]["sort"] == "start_time"
+        assert snapshots[0]["params"]["order"] == "asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_start_date_omitted_when_not_using_incremental(self, MockSession: mock.MagicMock) -> None:
+        _, snapshots, _ = _collect(
+            "calls",
+            [_page("calls", [{"id": "1"}], total_pages=1)],
+            MockSession,
+            account_id="ACC",
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        assert "start_date" not in snapshots[0]["params"]
+        # Sort is still ascending on the cursor field so full-refresh pages don't skip/duplicate.
+        assert snapshots[0]["params"]["sort"] == "start_time"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_start_date_omitted_when_last_value_missing(self, MockSession: mock.MagicMock) -> None:
+        _, snapshots, _ = _collect(
+            "calls",
+            [_page("calls", [{"id": "1"}], total_pages=1)],
+            MockSession,
+            account_id="ACC",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=None,
+        )
+
+        assert "start_date" not in snapshots[0]["params"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_has_no_sort_or_start_date(self, MockSession: mock.MagicMock) -> None:
+        _, snapshots, _ = _collect(
+            "users",
+            [_page("users", [{"id": "u1"}], total_pages=1)],
+            MockSession,
+            account_id="ACC",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        assert "sort" not in snapshots[0]["params"]
+        assert "order" not in snapshots[0]["params"]
+        assert "start_date" not in snapshots[0]["params"]
 
 
 class TestCallRailSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint: str) -> None:
         config = CALLRAIL_ENDPOINTS[endpoint]
-        response = callrail_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = callrail_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/tests/test_callrail_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/callrail/tests/test_callrail_source.py
@@ -153,6 +153,8 @@ class TestCallRailSource:
         assert kwargs["api_key"] == "key"
         assert kwargs["account_id"] == "ACC1"
         assert kwargs["endpoint"] == "calls"
+        assert kwargs["team_id"] is inputs.team_id
+        assert kwargs["job_id"] is inputs.job_id
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == 1700000000

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/campaign_monitor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/campaign_monitor.py
@@ -1,13 +1,8 @@
-import functools
 import dataclasses
-from collections.abc import Callable, Iterator
-from typing import Any
-from urllib.parse import urlencode
+from collections.abc import Callable
+from typing import Any, Optional
 
-import requests
 from requests.auth import HTTPBasicAuth
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.campaign_monitor.settings import (
@@ -15,276 +10,249 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.campaign_m
     CampaignMonitorEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CAMPAIGN_MONITOR_BASE_URL = "https://api.createsend.com/api/v3.3"
 DEFAULT_PAGE_SIZE = 1000  # Campaign Monitor's documented maximum page size.
 # Subscriber-state endpoints require a `date`; this fetches the full history (the filter is
 # inclusive from the given date onward). Used until server-side incremental is verified live.
 FULL_REFRESH_SINCE_DATE = "1900-01-01"
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
-
-
-class CampaignMonitorRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class CampaignMonitorResumeConfig:
-    # The fan-out list currently being processed. A stable list-ID bookmark (not a positional
-    # index) so reordered/added/removed lists between a crash and the retry can't resume us into
-    # the wrong list and write rows under the wrong primary key. None for non-fan-out endpoints.
+    # Pre-framework fan-out bookmarks. Kept (with defaults) so previously saved state still
+    # parses; no longer written — fan-out resume now lives in fanout_state.
     list_id: str | None = None
-    # The fan-out campaign currently being processed (campaign report endpoints). Same stable-ID
-    # bookmark rationale as `list_id`. None for endpoints that don't fan out over campaigns.
     campaign_id: str | None = None
-    # Next page to fetch (1-based). Always 1 for non-paginated array endpoints.
+    # Next page to fetch (1-based) on a top-level paginated endpoint. Always 1 otherwise.
     page: int = 1
+    # Framework fan-out resume state for list-/campaign-scoped endpoints:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: dict | None = None
 
 
-def _auth(api_key: str) -> HTTPBasicAuth:
+def _client_config(api_key: str) -> ClientConfig:
     # Campaign Monitor uses the API key as the HTTP Basic username; the password is ignored.
-    return HTTPBasicAuth(api_key, "x")
+    # Framework auth (not a hand-built header) so the key is redacted from logged URLs/headers.
+    return {
+        "base_url": CAMPAIGN_MONITOR_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "http_basic", "username": api_key, "password": "x"},
+    }
 
 
-def _build_url(path: str, params: dict[str, Any] | None = None) -> str:
-    url = f"{CAMPAIGN_MONITOR_BASE_URL}/{path}"
-    if params:
-        url = f"{url}?{urlencode(params)}"
-    return url
+def _paginator() -> PageNumberPaginator:
+    # Paged envelopes are `{"Results": [...], "NumberOfPages": N, ...}` with 1-based pages;
+    # NumberOfPages is the TOTAL NUMBER OF PAGES, so pagination stops after the last page.
+    return PageNumberPaginator(base_page=1, page_param="page", total_path="NumberOfPages")
 
 
-def validate_credentials(api_key: str) -> bool:
-    """Cheap probe that confirms the API key is genuine via the account-level clients endpoint."""
-    url = _build_url("clients.json")
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(
-            url, auth=_auth(api_key), timeout=REQUEST_TIMEOUT_SECONDS
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type((CampaignMonitorRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_json(session: requests.Session, api_key: str, url: str, logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, auth=_auth(api_key), timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # 1 request/second on most endpoints, so 429s are expected; back off and retry.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CampaignMonitorRetryableError(
-            f"Campaign Monitor API error (retryable): status={response.status_code}, url={url}"
-        )
-
-    if not response.ok:
-        logger.error(f"Campaign Monitor API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _list_ids_for_client(
-    session: requests.Session, api_key: str, client_id: str, logger: FilteringBoundLogger
-) -> list[str]:
-    data = _fetch_json(session, api_key, _build_url(f"clients/{client_id}/lists.json"), logger)
-    if not isinstance(data, list):
-        return []
-    return [item["ListID"] for item in data if isinstance(item, dict) and "ListID" in item]
-
-
-def _campaign_ids_for_client(
-    session: requests.Session, api_key: str, client_id: str, logger: FilteringBoundLogger
-) -> list[str]:
-    # Only sent campaigns have reports, which is exactly what this endpoint returns.
-    data = _fetch_json(session, api_key, _build_url(f"clients/{client_id}/campaigns.json"), logger)
-    if not isinstance(data, list):
-        return []
-    return [item["CampaignID"] for item in data if isinstance(item, dict) and "CampaignID" in item]
-
-
-def _page_params(config: CampaignMonitorEndpointConfig, page: int) -> dict[str, Any]:
-    params: dict[str, Any] = {"page": page, "pagesize": DEFAULT_PAGE_SIZE}
+def _page_params(config: CampaignMonitorEndpointConfig) -> dict[str, Any]:
+    # The `page` param itself is injected by the paginator.
+    params: dict[str, Any] = {"pagesize": DEFAULT_PAGE_SIZE}
     if config.uses_date_filter:
         params["date"] = FULL_REFRESH_SINCE_DATE
     if config.order_field:
+        # `orderfield` keeps pagination stable across the sync.
         params["orderfield"] = config.order_field
         params["orderdirection"] = "asc"
     return params
 
 
-def _iter_paginated(
-    session: requests.Session,
-    api_key: str,
-    config: CampaignMonitorEndpointConfig,
-    path: str,
-    logger: FilteringBoundLogger,
-    extra_row_fields: dict[str, Any],
-    resumable_source_manager: ResumableSourceManager[CampaignMonitorResumeConfig],
-    make_resume: Callable[[int], CampaignMonitorResumeConfig],
-    start_page: int,
-) -> Iterator[list[dict[str, Any]]]:
-    page = start_page
-    while True:
-        data = _fetch_json(session, api_key, _build_url(path, _page_params(config, page)), logger)
-        results = data.get("Results", []) if isinstance(data, dict) else []
-        number_of_pages = data.get("NumberOfPages", page) if isinstance(data, dict) else page
-        is_last_page = not results or page >= number_of_pages
-
-        if results:
-            yield [{**row, **extra_row_fields} for row in results]
-            # Save AFTER yielding (and only when more pages remain) so a crash re-yields the last
-            # page rather than skipping it — the pipeline's merge dedupes on the primary key.
-            if not is_last_page:
-                resumable_source_manager.save_state(make_resume(page + 1))
-
-        if is_last_page:
-            break
-        page += 1
-
-
-def _iter_fan_out(
-    session: requests.Session,
-    api_key: str,
-    config: CampaignMonitorEndpointConfig,
-    parent_ids: list[str],
-    path_param: str,
-    row_id_field: str,
-    make_resume: Callable[[str | None, int], CampaignMonitorResumeConfig],
-    resume_parent_id: str | None,
-    resume_page: int,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CampaignMonitorResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    # Resolve the saved parent-ID bookmark to a position. If the parent no longer exists (deleted
-    # between runs), fall back to restarting from the first parent — merge dedupes the re-pulled
-    # rows on the primary key.
-    start_index = 0
-    start_page = 1
-    if resume_parent_id is not None and resume_parent_id in parent_ids:
-        start_index = parent_ids.index(resume_parent_id)
-        start_page = resume_page
-
-    for parent_index in range(start_index, len(parent_ids)):
-        parent_id = parent_ids[parent_index]
-        path = config.path.format(**{path_param: parent_id})
-        extra_row_fields = {row_id_field: parent_id}
-
-        if config.paginated:
-            # Only the parent we resumed into keeps its saved page; later parents start at page 1.
-            page = start_page if parent_index == start_index else 1
-            yield from _iter_paginated(
-                session,
-                api_key,
-                config,
-                path,
-                logger,
-                extra_row_fields,
-                resumable_source_manager,
-                functools.partial(make_resume, parent_id),
-                page,
-            )
-        else:
-            # Single-object endpoints (e.g. campaign summary) return one JSON object per parent.
-            data = _fetch_json(session, api_key, _build_url(path), logger)
-            if isinstance(data, dict) and data:
-                yield [{**data, **extra_row_fields}]
-
-        # Advance the bookmark to the next parent so a crash between parents resumes correctly.
-        if parent_index + 1 < len(parent_ids):
-            resumable_source_manager.save_state(make_resume(parent_ids[parent_index + 1], 1))
-
-
-def get_rows(
+def _top_level_resource(
     api_key: str,
     client_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CampaignMonitorResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = CAMPAIGN_MONITOR_ENDPOINTS[endpoint]
-    session = make_tracked_session(redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if config.fan_out_over_lists:
-        yield from _iter_fan_out(
-            session,
-            api_key,
-            config,
-            _list_ids_for_client(session, api_key, client_id, logger),
-            "list_id",
-            "ListID",
-            lambda parent_id, page: CampaignMonitorResumeConfig(list_id=parent_id, page=page),
-            resume.list_id if resume else None,
-            resume.page if resume else 1,
-            logger,
-            resumable_source_manager,
-        )
-        return
-
-    if config.fan_out_over_campaigns:
-        yield from _iter_fan_out(
-            session,
-            api_key,
-            config,
-            _campaign_ids_for_client(session, api_key, client_id, logger),
-            "campaign_id",
-            "CampaignID",
-            lambda parent_id, page: CampaignMonitorResumeConfig(campaign_id=parent_id, page=page),
-            resume.campaign_id if resume else None,
-            resume.page if resume else 1,
-            logger,
-            resumable_source_manager,
-        )
-        return
-
+    config: CampaignMonitorEndpointConfig,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[CampaignMonitorResumeConfig],
+) -> Resource:
     path = config.path.format(client_id=client_id)
 
+    endpoint: Endpoint
     if config.paginated:
-        start_page = resume.page if resume else 1
-        yield from _iter_paginated(
-            session,
-            api_key,
-            config,
-            path,
-            logger,
-            {},
-            resumable_source_manager,
-            lambda next_page: CampaignMonitorResumeConfig(page=next_page),
-            start_page,
-        )
-        return
+        # A body without `Results` yields a zero-row page and pagination stops — same tolerant
+        # behavior the API's empty envelopes get.
+        endpoint = {
+            "path": path,
+            "params": _page_params(config),
+            "paginator": _paginator(),
+            "data_selector": "Results",
+        }
+    else:
+        # Bare-array endpoints: a non-list 200 body means the response shape changed — fail loud
+        # instead of syncing a stray object as a row.
+        endpoint = {
+            "path": path,
+            "paginator": SinglePagePaginator(),
+            "data_selector_required": True,
+        }
 
-    # Non-paginated endpoints return a bare JSON array.
-    data = _fetch_json(session, api_key, _build_url(path), logger)
-    if isinstance(data, list) and data:
-        yield data
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [{"name": config.name, "endpoint": endpoint}],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None and resume.page > 1:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint is saved AFTER a page is yielded so
+        # a crash re-fetches the in-flight page (the merge dedupes re-pulled rows) rather than
+        # skipping it.
+        if state and state.get("page") is not None:
+            manager.save_state(CampaignMonitorResumeConfig(page=int(state["page"])))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _inject_parent_id(prefixed_key: str, target_key: str) -> Callable[[dict[str, Any]], dict[str, Any] | list[Any]]:
+    def _map(row: dict[str, Any]) -> dict[str, Any] | list[Any]:
+        value = row.pop(prefixed_key, None)
+        if not row:
+            # An empty body (e.g. a summary object with no fields) is not a row — drop it rather
+            # than emitting a record that carries only the injected parent id.
+            return []
+        if value is not None:
+            row[target_key] = value
+        return row
+
+    return _map
+
+
+def _fan_out_resource(
+    api_key: str,
+    client_id: str,
+    config: CampaignMonitorEndpointConfig,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[CampaignMonitorResumeConfig],
+) -> Resource:
+    """Fan a list-/campaign-scoped endpoint out over every parent via a dependent resource: the
+    framework fetches the client's lists (or sent campaigns), pages each parent's child endpoint,
+    and injects the parent id into every row."""
+    if config.fan_out_over_lists:
+        parent_name = "lists"
+        parent_path = f"clients/{client_id}/lists.json"
+        resolve_param, parent_id_field = "list_id", "ListID"
+    else:
+        # Only sent campaigns have reports, which is exactly what campaigns.json returns.
+        parent_name = "campaigns"
+        parent_path = f"clients/{client_id}/campaigns.json"
+        resolve_param, parent_id_field = "campaign_id", "CampaignID"
+
+    child_params: dict[str, Any] = {
+        resolve_param: {"type": "resolve", "resource": parent_name, "field": parent_id_field},
+    }
+    child_endpoint: Endpoint
+    if config.paginated:
+        child_params.update(_page_params(config))
+        child_endpoint = {
+            "path": config.path,
+            "params": child_params,
+            "paginator": _paginator(),
+            "data_selector": "Results",
+        }
+    else:
+        # Single-object endpoints (e.g. campaign summary) return one JSON object per parent,
+        # which the framework wraps as a single row.
+        child_endpoint = {
+            "path": config.path,
+            "params": child_params,
+            "paginator": SinglePagePaginator(),
+        }
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": parent_name,
+                "endpoint": {
+                    "path": parent_path,
+                    "paginator": SinglePagePaginator(),
+                    "data_selector_required": True,
+                },
+            },
+            {
+                "name": config.name,
+                "endpoint": child_endpoint,
+                "include_from_parent": [parent_id_field],
+                # include_from_parent lands the parent id as `_lists_ListID`/`_campaigns_CampaignID`;
+                # rename it to the plain column the composite primary keys expect.
+                "data_map": _inject_parent_id(f"_{parent_name}_{parent_id_field}", parent_id_field),
+            },
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        # Only framework-shaped fan-out state is resumable. A pre-migration bookmark
+        # (list_id/campaign_id + page) can't be translated into the completed/current path map, so
+        # such a sync restarts fresh — safe, because the merge dedupes re-pulled rows on the
+        # primary key.
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state:
+            manager.save_state(CampaignMonitorResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(r for r in resources if r.name == config.name)
 
 
 def campaign_monitor_source(
     api_key: str,
     client_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CampaignMonitorResumeConfig],
 ) -> SourceResponse:
     config = CAMPAIGN_MONITOR_ENDPOINTS[endpoint]
 
+    if config.fan_out_over_lists or config.fan_out_over_campaigns:
+        resource = _fan_out_resource(api_key, client_id, config, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _top_level_resource(api_key, client_id, config, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            client_id=client_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -292,4 +260,15 @@ def campaign_monitor_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Cheap probe that confirms the API key is genuine via the account-level clients endpoint."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CAMPAIGN_MONITOR_BASE_URL}/clients.json",
+        auth=HTTPBasicAuth(api_key, "x"),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
     CampaignMonitorSourceConfig,
 )
@@ -74,24 +77,10 @@ class CampaignMonitorSource(ResumableSource[CampaignMonitorSourceConfig, Campaig
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                # Every endpoint ships full refresh until the server-side `date` filter is verified
-                # against a live account (see settings.py for the incremental migration path), so
-                # INCREMENTAL_FIELDS is empty for all endpoints today.
-                supports_incremental=bool(INCREMENTAL_FIELDS[endpoint]),
-                supports_append=bool(INCREMENTAL_FIELDS[endpoint]),
-                incremental_fields=INCREMENTAL_FIELDS[endpoint],
-            )
-            for endpoint in list(ENDPOINTS)
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # Every endpoint ships full refresh until the server-side `date` filter is verified
+        # against a live account (see settings.py for the incremental migration path), so
+        # INCREMENTAL_FIELDS is empty for all endpoints today.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CampaignMonitorSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -114,7 +103,8 @@ class CampaignMonitorSource(ResumableSource[CampaignMonitorSourceConfig, Campaig
             api_key=config.api_key,
             client_id=config.client_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/tests/test_campaign_monitor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/tests/test_campaign_monitor.py
@@ -2,25 +2,29 @@ import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
+import requests
 from requests import Response
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.campaign_monitor.campaign_monitor import (
     FULL_REFRESH_SINCE_DATE,
     CampaignMonitorResumeConfig,
-    _page_params,
     campaign_monitor_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.campaign_monitor.settings import (
     CAMPAIGN_MONITOR_ENDPOINTS,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the campaign_monitor module.
+CM_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.campaign_monitor.campaign_monitor.make_tracked_session"
 
 
-def _make_response(body: Any, status_code: int = 200) -> Response:
+def _response(body: Any, status_code: int = 200) -> Response:
     resp = Response()
     resp.status_code = status_code
     resp._content = json.dumps(body).encode()
@@ -28,250 +32,397 @@ def _make_response(body: Any, status_code: int = 200) -> Response:
     return resp
 
 
-class _FakeSession:
-    """Records request URLs and returns queued responses in order."""
-
-    def __init__(self, responses: list[Response]) -> None:
-        self._responses = iter(responses)
-        self.urls: list[str] = []
-
-    def get(self, url: str, *_args: Any, **_kwargs: Any) -> Response:
-        self.urls.append(url)
-        return next(self._responses)
+def _envelope(items: list[dict[str, Any]], number_of_pages: int = 1, page_number: int = 1) -> Response:
+    return _response({"Results": items, "NumberOfPages": number_of_pages, "PageNumber": page_number})
 
 
-def _patch_session(session: _FakeSession):
-    return patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.campaign_monitor.campaign_monitor.make_tracked_session",
-        return_value=session,
-    )
-
-
-def _manager(can_resume: bool = False, state: CampaignMonitorResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock(spec=ResumableSourceManager)
-    manager.can_resume.return_value = can_resume
-    manager.load_state.return_value = state
+def _make_manager(resume_state: CampaignMonitorResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-def _drive(endpoint: str, responses: list[Response], manager: MagicMock) -> tuple[_FakeSession, list[list[dict]]]:
-    session = _FakeSession(responses)
-    with _patch_session(session):
-        batches = list(
-            get_rows(
-                api_key="test-key",
-                client_id="client-abc",
-                endpoint=endpoint,
-                logger=MagicMock(),
-                resumable_source_manager=manager,
-            )
-        )
-    return session, batches
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session and return (url, params) snapshots captured AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[tuple[str, dict[str, Any]]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append((request.url, dict(request.params or {})))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None) -> SourceResponse:
+    return campaign_monitor_source(
+        api_key="test-key",
+        client_id="client-abc",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+    )
+
+
+def _rows(source_response: SourceResponse) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestValidateCredentials:
-    @pytest.mark.parametrize(
-        "status_code, expected",
-        [(200, True), (401, False), (403, False), (500, False)],
-    )
-    def test_validate_credentials_status_mapping(self, status_code: int, expected: bool) -> None:
-        session = _FakeSession([_make_response({}, status_code=status_code)])
-        with _patch_session(session):
-            assert validate_credentials("test-key") is expected
-        assert session.urls[0].endswith("/clients.json")
+    @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
+    @mock.patch(CM_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status_code: int, expected: bool) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("test-key") is expected
+        url = mock_session.return_value.get.call_args.args[0]
+        assert url.endswith("/clients.json")
 
-    def test_validate_credentials_swallows_exceptions(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = ConnectionError("boom")
-        with _patch_session(session):
-            assert validate_credentials("test-key") is False
+    @mock.patch(CM_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("test-key") is False
 
 
-class TestPageParams:
-    def test_date_filter_endpoint_includes_full_history_date(self) -> None:
-        params = _page_params(CAMPAIGN_MONITOR_ENDPOINTS["active_subscribers"], page=1)
-
-        assert params["date"] == FULL_REFRESH_SINCE_DATE
-        assert params["orderfield"] == "date"
-        assert params["orderdirection"] == "asc"
-        assert params["page"] == 1
-        assert params["pagesize"] == 1000
-
-    def test_non_date_filter_endpoint_omits_date(self) -> None:
-        params = _page_params(CAMPAIGN_MONITOR_ENDPOINTS["suppression_list"], page=2)
-
-        assert "date" not in params
-        assert params["page"] == 2
-        assert params["orderfield"] == "date"
-
-
-class TestGetRowsNonPaginated:
-    def test_array_endpoint_yields_once_and_does_not_save_state(self) -> None:
-        manager = _manager()
+class TestNonPaginatedEndpoints:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_array_endpoint_yields_once_and_does_not_save_state(self, MockSession) -> None:
+        session = MockSession.return_value
         rows = [{"ClientID": "c1"}, {"ClientID": "c2"}]
-        session, batches = _drive("clients", [_make_response(rows)], manager)
+        snapshots = _wire(session, [_response(rows)])
 
-        assert batches == [rows]
-        assert session.urls == ["https://api.createsend.com/api/v3.3/clients.json"]
+        manager = _make_manager()
+        assert _rows(_source("clients", manager)) == rows
+        assert snapshots[0][0] == "https://api.createsend.com/api/v3.3/clients.json"
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_empty_array_yields_nothing(self) -> None:
-        manager = _manager()
-        _, batches = _drive("lists", [_make_response([])], manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_array_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
-        assert batches == []
+        assert _rows(_source("lists")) == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises_loudly(self, MockSession) -> None:
+        # A 200 body that isn't a JSON array means the response shape changed — fail loud rather
+        # than syncing a stray object as a row.
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unexpected"})])
+
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source("clients"))
 
 
-class TestGetRowsPaginated:
-    def test_multi_page_saves_state_between_pages_only(self) -> None:
-        manager = _manager()
-        responses = [
-            _make_response({"Results": [{"EmailAddress": "a@x.com"}], "NumberOfPages": 2, "PageNumber": 1}),
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 2, "PageNumber": 2}),
-        ]
-        session, batches = _drive("suppression_list", responses, manager)
+class TestPaginatedEndpoints:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_multi_page_saves_state_between_pages_only(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _envelope([{"EmailAddress": "a@x.com"}], number_of_pages=2, page_number=1),
+                _envelope([{"EmailAddress": "b@x.com"}], number_of_pages=2, page_number=2),
+            ],
+        )
 
-        assert batches == [[{"EmailAddress": "a@x.com"}], [{"EmailAddress": "b@x.com"}]]
+        manager = _make_manager()
+        rows = _rows(_source("suppression_list", manager))
+
+        assert rows == [{"EmailAddress": "a@x.com"}, {"EmailAddress": "b@x.com"}]
+        assert snapshots[0][1]["page"] == 1
+        assert snapshots[1][1]["page"] == 2
         # First page is not terminal -> save next page; second page is terminal -> no save.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == CampaignMonitorResumeConfig(page=2)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_at_number_of_pages_without_extra_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_envelope([{"EmailAddress": "a@x.com"}], number_of_pages=1, page_number=1)])
+
+        rows = _rows(_source("suppression_list"))
+
+        assert rows == [{"EmailAddress": "a@x.com"}]
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_page_params_omit_date_for_non_date_filter_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_envelope([{"EmailAddress": "a@x.com"}])])
+
+        _rows(_source("suppression_list"))
+
+        _url, params = snapshots[0]
+        assert "date" not in params
+        assert params["pagesize"] == 1000
+        assert params["orderfield"] == "date"
+        assert params["orderdirection"] == "asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_starts_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_envelope([{"EmailAddress": "b@x.com"}], number_of_pages=2, page_number=2)])
+
+        manager = _make_manager(CampaignMonitorResumeConfig(page=2))
+        rows = _rows(_source("suppression_list", manager))
+
+        assert rows == [{"EmailAddress": "b@x.com"}]
+        assert session.send.call_count == 1
+        assert snapshots[0][1]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_results_key_yields_nothing(self, MockSession) -> None:
+        # Campaign Monitor's paged envelope without Results is treated as a zero-row page.
+        session = MockSession.return_value
+        _wire(session, [_response({"NumberOfPages": 1, "PageNumber": 1})])
+
+        assert _rows(_source("suppression_list")) == []
+
+
+class TestListFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_iterates_every_list_and_injects_list_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"ListID": "l1"}, {"ListID": "l2"}]),  # lists.json
+                _envelope([{"EmailAddress": "a@x.com"}]),  # l1
+                _envelope([{"EmailAddress": "b@x.com"}]),  # l2
+            ],
+        )
+
+        rows = _rows(_source("active_subscribers"))
+
+        # the injected id must be the plain `ListID` column, not the prefixed parent key
+        assert rows == [
+            {"EmailAddress": "a@x.com", "ListID": "l1"},
+            {"EmailAddress": "b@x.com", "ListID": "l2"},
+        ]
+        assert snapshots[0][0].endswith("clients/client-abc/lists.json")
+        assert snapshots[1][0].endswith("lists/l1/active.json")
+        assert snapshots[2][0].endswith("lists/l2/active.json")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_date_filter_endpoint_requests_full_history(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"ListID": "l1"}]),
+                _envelope([{"EmailAddress": "a@x.com"}]),
+            ],
+        )
+
+        _rows(_source("active_subscribers"))
+
+        _url, params = snapshots[1]
+        assert params["date"] == FULL_REFRESH_SINCE_DATE
+        assert params["page"] == 1
+        assert params["pagesize"] == 1000
+        assert params["orderfield"] == "date"
+        assert params["orderdirection"] == "asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_within_a_list(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"ListID": "l1"}]),
+                _envelope([{"EmailAddress": "a@x.com"}], number_of_pages=2, page_number=1),
+                _envelope([{"EmailAddress": "b@x.com"}], number_of_pages=2, page_number=2),
+            ],
+        )
+
+        rows = _rows(_source("active_subscribers"))
+
+        assert [r["EmailAddress"] for r in rows] == ["a@x.com", "b@x.com"]
+        assert snapshots[2][0].endswith("lists/l1/active.json")
+        assert snapshots[2][1]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_completed_lists(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"ListID": "l1"}, {"ListID": "l2"}]),
+                _envelope([{"EmailAddress": "a@x.com"}]),
+                _envelope([{"EmailAddress": "b@x.com"}]),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("active_subscribers", manager))
+
+        # after finishing l1 a checkpoint marks it completed, so a crash resumes on l2, not l1
         saved = [call.args[0] for call in manager.save_state.call_args_list]
-        assert saved == [CampaignMonitorResumeConfig(list_id=None, page=2)]
-        assert "page=1" in session.urls[0]
-        assert "page=2" in session.urls[1]
+        assert any(
+            state.fanout_state is not None and "lists/l1/active.json" in state.fanout_state["completed"]
+            for state in saved
+        )
 
-    def test_resume_starts_from_saved_page(self) -> None:
-        manager = _manager(can_resume=True, state=CampaignMonitorResumeConfig(list_id=None, page=2))
-        responses = [
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 2, "PageNumber": 2}),
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_lists_and_resumes_page(self, MockSession) -> None:
+        # Resuming mid-fan-out must not re-request lists completed before the crash, and must start
+        # the in-progress list from its saved page.
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"ListID": "l1"}, {"ListID": "l2"}, {"ListID": "l3"}]),  # lists.json re-fetched
+                _envelope([{"EmailAddress": "b@x.com"}], number_of_pages=2, page_number=2),  # l2 resumed
+                _envelope([{"EmailAddress": "c@x.com"}]),  # l3 fresh
+            ],
+        )
+
+        manager = _make_manager(
+            CampaignMonitorResumeConfig(
+                fanout_state={
+                    "completed": ["lists/l1/active.json"],
+                    "current": "lists/l2/active.json",
+                    "child_state": {"page": 2},
+                }
+            )
+        )
+        rows = _rows(_source("active_subscribers", manager))
+
+        urls = [url for url, _params in snapshots]
+        assert not any("lists/l1/active.json" in url for url in urls)
+        assert snapshots[1][0].endswith("lists/l2/active.json")
+        assert snapshots[1][1]["page"] == 2
+        assert snapshots[2][0].endswith("lists/l3/active.json")
+        assert snapshots[2][1]["page"] == 1
+        assert [(r["EmailAddress"], r["ListID"]) for r in rows] == [("b@x.com", "l2"), ("c@x.com", "l3")]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pre_migration_resume_state_starts_fresh(self, MockSession) -> None:
+        # An old-shape bookmark (list_id + page, no fanout_state) can't be translated into the
+        # framework's completed/current map — the fan-out restarts from the first list instead.
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"ListID": "l1"}, {"ListID": "l2"}]),
+                _envelope([{"EmailAddress": "a@x.com"}]),
+                _envelope([{"EmailAddress": "b@x.com"}]),
+            ],
+        )
+
+        manager = _make_manager(CampaignMonitorResumeConfig(list_id="l2", page=3))
+        rows = _rows(_source("active_subscribers", manager))
+
+        assert [(r["EmailAddress"], r["ListID"]) for r in rows] == [("a@x.com", "l1"), ("b@x.com", "l2")]
+        assert snapshots[1][0].endswith("lists/l1/active.json")
+        assert snapshots[1][1]["page"] == 1
+
+
+class TestCampaignFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_iterates_every_campaign_and_injects_campaign_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),  # campaigns.json
+                _envelope([{"EmailAddress": "a@x.com"}]),  # c1
+                _envelope([{"EmailAddress": "b@x.com"}]),  # c2
+            ],
+        )
+
+        rows = _rows(_source("campaign_opens"))
+
+        assert rows == [
+            {"EmailAddress": "a@x.com", "CampaignID": "c1"},
+            {"EmailAddress": "b@x.com", "CampaignID": "c2"},
         ]
-        session, batches = _drive("suppression_list", responses, manager)
+        assert snapshots[0][0].endswith("clients/client-abc/campaigns.json")
+        assert snapshots[1][0].endswith("campaigns/c1/opens.json")
+        assert snapshots[2][0].endswith("campaigns/c2/opens.json")
 
-        assert batches == [[{"EmailAddress": "b@x.com"}]]
-        assert len(session.urls) == 1
-        assert "page=2" in session.urls[0]
-        manager.load_state.assert_called_once()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_campaign_summary_yields_object_per_campaign_and_checkpoints(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),
+                _response({"Name": "Newsletter", "Recipients": 100, "UniqueOpened": 40}),  # c1 summary
+                _response({"Name": "Promo", "Recipients": 50, "UniqueOpened": 10}),  # c2 summary
+            ],
+        )
 
+        manager = _make_manager()
+        rows = _rows(_source("campaign_summary", manager))
 
-class TestGetRowsFanOut:
-    def test_fan_out_over_lists_injects_list_id(self) -> None:
-        manager = _manager()
-        responses = [
-            _make_response([{"ListID": "l1"}, {"ListID": "l2"}]),  # lists.json
-            _make_response({"Results": [{"EmailAddress": "a@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),  # l1
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),  # l2
+        assert rows == [
+            {"Name": "Newsletter", "Recipients": 100, "UniqueOpened": 40, "CampaignID": "c1"},
+            {"Name": "Promo", "Recipients": 50, "UniqueOpened": 10, "CampaignID": "c2"},
         ]
-        session, batches = _drive("active_subscribers", responses, manager)
-
-        assert batches == [
-            [{"EmailAddress": "a@x.com", "ListID": "l1"}],
-            [{"EmailAddress": "b@x.com", "ListID": "l2"}],
-        ]
-        assert session.urls[0].endswith("clients/client-abc/lists.json")
-        assert "lists/l1/active.json" in session.urls[1]
-        assert "lists/l2/active.json" in session.urls[2]
-
-    def test_fan_out_advances_bookmark_to_next_list(self) -> None:
-        manager = _manager()
-        responses = [
-            _make_response([{"ListID": "l1"}, {"ListID": "l2"}]),
-            _make_response({"Results": [{"EmailAddress": "a@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),
-        ]
-        _drive("active_subscribers", responses, manager)
-
+        assert snapshots[1][0].endswith("campaigns/c1/summary.json")
+        assert snapshots[2][0].endswith("campaigns/c2/summary.json")
+        # after finishing c1 a checkpoint marks it completed, so a crash resumes on c2, not c1
         saved = [call.args[0] for call in manager.save_state.call_args_list]
-        # Each list finishes on a single (terminal) page, so the only save is the cross-list
-        # advance written after the first list. No save after the last list (nothing follows).
-        assert saved == [CampaignMonitorResumeConfig(list_id="l2", page=1)]
+        assert any(
+            state.fanout_state is not None and "campaigns/c1/summary.json" in state.fanout_state["completed"]
+            for state in saved
+        )
 
-    def test_fan_out_resumes_into_correct_list_and_page(self) -> None:
-        manager = _manager(can_resume=True, state=CampaignMonitorResumeConfig(list_id="l2", page=1))
-        responses = [
-            _make_response([{"ListID": "l1"}, {"ListID": "l2"}]),
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),  # l2 only
-        ]
-        session, batches = _drive("active_subscribers", responses, manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_summary_object_yields_no_row(self, MockSession) -> None:
+        # An empty summary body is not a row — no record carrying only the injected CampaignID.
+        session = MockSession.return_value
+        _wire(session, [_response([{"CampaignID": "c1"}]), _response({})])
 
-        assert batches == [[{"EmailAddress": "b@x.com", "ListID": "l2"}]]
-        # lists.json is re-fetched to rebuild the ordering, then we skip straight to l2.
-        assert "lists/l2/active.json" in session.urls[1]
+        assert _rows(_source("campaign_summary")) == []
 
-    def test_fan_out_resume_restarts_when_bookmarked_list_is_gone(self) -> None:
-        # The bookmarked list was deleted between runs: fall back to the first list rather than
-        # resuming into the wrong one (the index-based bookmark would have silently mis-resumed).
-        manager = _manager(can_resume=True, state=CampaignMonitorResumeConfig(list_id="deleted", page=3))
-        responses = [
-            _make_response([{"ListID": "l1"}, {"ListID": "l2"}]),
-            _make_response({"Results": [{"EmailAddress": "a@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),
-        ]
-        session, batches = _drive("active_subscribers", responses, manager)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_campaigns(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),  # campaigns.json re-fetched
+                _envelope([{"EmailAddress": "b@x.com"}]),  # c2 only
+            ],
+        )
 
-        assert batches == [
-            [{"EmailAddress": "a@x.com", "ListID": "l1"}],
-            [{"EmailAddress": "b@x.com", "ListID": "l2"}],
-        ]
-        assert "lists/l1/active.json" in session.urls[1]
-        assert "page=1" in session.urls[1]
+        manager = _make_manager(
+            CampaignMonitorResumeConfig(
+                fanout_state={"completed": ["campaigns/c1/opens.json"], "current": None, "child_state": None}
+            )
+        )
+        rows = _rows(_source("campaign_opens", manager))
+
+        assert rows == [{"EmailAddress": "b@x.com", "CampaignID": "c2"}]
+        assert snapshots[1][0].endswith("campaigns/c2/opens.json")
 
 
-class TestGetRowsCampaignFanOut:
-    def test_fan_out_over_campaigns_injects_campaign_id(self) -> None:
-        manager = _manager()
-        responses = [
-            _make_response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),  # campaigns.json
-            _make_response({"Results": [{"EmailAddress": "a@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),  # c1
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),  # c2
-        ]
-        session, batches = _drive("campaign_opens", responses, manager)
-
-        assert batches == [
-            [{"EmailAddress": "a@x.com", "CampaignID": "c1"}],
-            [{"EmailAddress": "b@x.com", "CampaignID": "c2"}],
-        ]
-        assert session.urls[0].endswith("clients/client-abc/campaigns.json")
-        assert "campaigns/c1/opens.json" in session.urls[1]
-        assert "campaigns/c2/opens.json" in session.urls[2]
-
-    def test_campaign_summary_yields_object_per_campaign_and_advances_bookmark(self) -> None:
-        manager = _manager()
-        responses = [
-            _make_response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),
-            _make_response({"Name": "Newsletter", "Recipients": 100, "UniqueOpened": 40}),  # c1 summary
-            _make_response({"Name": "Promo", "Recipients": 50, "UniqueOpened": 10}),  # c2 summary
-        ]
-        session, batches = _drive("campaign_summary", responses, manager)
-
-        assert batches == [
-            [{"Name": "Newsletter", "Recipients": 100, "UniqueOpened": 40, "CampaignID": "c1"}],
-            [{"Name": "Promo", "Recipients": 50, "UniqueOpened": 10, "CampaignID": "c2"}],
-        ]
-        assert "campaigns/c1/summary.json" in session.urls[1]
-        assert "campaigns/c2/summary.json" in session.urls[2]
-        saved = [call.args[0] for call in manager.save_state.call_args_list]
-        assert saved == [CampaignMonitorResumeConfig(campaign_id="c2", page=1)]
-
-    def test_fan_out_resumes_into_correct_campaign(self) -> None:
-        manager = _manager(can_resume=True, state=CampaignMonitorResumeConfig(campaign_id="c2", page=1))
-        responses = [
-            _make_response([{"CampaignID": "c1"}, {"CampaignID": "c2"}]),
-            _make_response({"Results": [{"EmailAddress": "b@x.com"}], "NumberOfPages": 1, "PageNumber": 1}),  # c2 only
-        ]
-        session, batches = _drive("campaign_opens", responses, manager)
-
-        assert batches == [[{"EmailAddress": "b@x.com", "CampaignID": "c2"}]]
-        assert "campaigns/c2/opens.json" in session.urls[1]
+class TestResumeConfigCompatibility:
+    def test_old_saved_state_still_parses(self) -> None:
+        # ResumableSourceManager._load_json does dataclass(**saved) — state saved by the
+        # pre-framework implementation must keep loading after the migration.
+        state = CampaignMonitorResumeConfig(**{"list_id": "l1", "campaign_id": None, "page": 3})
+        assert state.list_id == "l1"
+        assert state.campaign_id is None
+        assert state.page == 3
+        assert state.fanout_state is None
 
 
 class TestCampaignMonitorSourceResponse:
     @pytest.mark.parametrize("endpoint", list(CAMPAIGN_MONITOR_ENDPOINTS.keys()))
     def test_source_response_primary_keys_match_settings(self, endpoint: str) -> None:
-        response = campaign_monitor_source(
-            api_key="test-key",
-            client_id="client-abc",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        response = _source(endpoint)
 
         config = CAMPAIGN_MONITOR_ENDPOINTS[endpoint]
         assert response.name == endpoint
@@ -291,13 +442,7 @@ class TestCampaignMonitorSourceResponse:
         ],
     )
     def test_source_response_partition_keys(self, endpoint: str, expected_partition_key: str | None) -> None:
-        response = campaign_monitor_source(
-            api_key="test-key",
-            client_id="client-abc",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        response = _source(endpoint)
 
         if expected_partition_key is None:
             assert response.partition_keys is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/tests/test_campaign_monitor_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/campaign_monitor/tests/test_campaign_monitor_source.py
@@ -125,6 +125,7 @@ class TestCampaignMonitorSource:
             api_key="test-key",
             client_id="client-abc",
             endpoint="campaigns",
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/canny/canny.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/canny/canny.py
@@ -1,28 +1,27 @@
+import json
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import PreparedRequest, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.canny.settings import (
-    CANNY_ENDPOINTS,
-    CannyEndpointConfig,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.canny.settings import CANNY_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import AuthConfigBase
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 CANNY_BASE_URL = "https://canny.io/api"
 # Airbyte's community connector pages every Canny list endpoint at 100 records.
 PAGE_SIZE = 100
 REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-
-
-class CannyRetryableError(Exception):
-    """Raised on 429/5xx so tenacity retries; never reaches get_non_retryable_errors."""
 
 
 @dataclasses.dataclass
@@ -32,106 +31,132 @@ class CannyResumeConfig:
     skip: int = 0
 
 
-def _build_body(api_key: str, config: CannyEndpointConfig, skip: int) -> dict[str, Any]:
-    body: dict[str, Any] = {"apiKey": api_key}
-    if config.paginated:
-        body["skip"] = skip
-        body["limit"] = PAGE_SIZE
-    return body
+class CannyBodyAuth(AuthConfigBase):
+    """Injects the secret `apiKey` into the JSON POST body.
+
+    Canny authenticates via an `apiKey` request-body parameter rather than a header, which no
+    built-in auth location covers. Going through the framework auth contract (instead of a static
+    body param) keeps the secret registered for value-based redaction in tracked HTTP logs/samples.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def __call__(self, request: PreparedRequest) -> PreparedRequest:
+        body: dict[str, Any] = json.loads(request.body) if request.body else {}
+        body["apiKey"] = self.api_key
+        request.prepare_body(data=None, files=None, json=body)
+        return request
+
+    def secret_values(self) -> tuple[str, ...]:
+        return (self.api_key,)
 
 
-def _handle_response(response: requests.Response, url: str, logger: FilteringBoundLogger) -> dict[str, Any]:
-    """Classify a single Canny response: retryable, terminal failure, or success body."""
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CannyRetryableError(f"Canny API error (retryable): status={response.status_code}, url={url}")
+class CannyPaginator(OffsetPaginator):
+    """Canny's skip/limit POST-body pagination, terminated by the body's `hasMore` flag.
 
-    if not response.ok:
-        logger.error(f"Canny API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
+    Also fails loud on Canny's 200-with-`{"error": ...}` envelope (e.g. an invalid API key),
+    surfacing it as an HTTPError so the friendly non-retryable mapping can match the error text.
+    `paginated=False` (boards/list) sends no skip/limit and always stops after one page, but still
+    gets the error-envelope check.
+    """
 
-    data = response.json()
-    # Canny returns 200 with an `{"error": "..."}` body for some failures (e.g. an invalid
-    # API key). Surface it as an HTTPError so the friendly non-retryable mapping can match it.
-    if isinstance(data, dict) and data.get("error"):
-        raise requests.HTTPError(f"Canny API error: {data['error']} (url: {url})", response=response)
+    def __init__(self, *, paginated: bool = True, offset: int = 0) -> None:
+        super().__init__(
+            limit=PAGE_SIZE,
+            offset=offset,
+            offset_param="skip",
+            limit_param="limit",
+            total_path=None,
+            param_location="json",
+        )
+        self.paginated = paginated
 
-    return data
+    def init_request(self, request: requests.Request) -> None:
+        if self.paginated:
+            super().init_request(request)
 
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except ValueError:
+            # An empty/non-JSON body already surfaced as an empty page upstream; there is
+            # no `hasMore` to read, so just stop.
+            body = None
+        if isinstance(body, dict) and body.get("error"):
+            raise requests.HTTPError(f"Canny API error: {body['error']} (url: {response.url})", response=response)
 
-@retry(
-    retry=retry_if_exception_type((CannyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    body: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    # Canny authenticates via the `apiKey` POST body parameter, so every list request is a
-    # form-encoded POST rather than a GET.
-    response = session.post(url, data=body, timeout=REQUEST_TIMEOUT_SECONDS)
-    return _handle_response(response, url, logger)
+        if not self.paginated:
+            self._has_next_page = False
+            return
 
+        self.offset += self.limit
+        self._has_next_page = bool(isinstance(body, dict) and body.get("hasMore"))
 
-def _extract_records(data: dict[str, Any], config: CannyEndpointConfig) -> list[dict[str, Any]]:
-    records = data.get(config.data_key)
-    if isinstance(records, list):
-        return records
-    return []
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CannyResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = CANNY_ENDPOINTS[endpoint]
-    url = f"{CANNY_BASE_URL}{config.path}"
-    # Redact the secret so it never lands in tracked HTTP logs/samples — it travels in the POST body.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    skip = resume.skip if resume is not None else 0
-    if resume is not None:
-        logger.debug(f"Canny: resuming endpoint={endpoint} from skip={skip}")
-
-    while True:
-        data = _fetch_page(session, url, _build_body(api_key, config, skip), logger)
-        records = _extract_records(data, config)
-
-        if records:
-            yield records
-
-        if not config.paginated or not data.get("hasMore"):
-            break
-
-        # Advance, then persist — saving AFTER yielding means a crash re-yields the last page
-        # (the merge dedupes on the primary key) rather than skipping it.
-        skip += PAGE_SIZE
-        if records:
-            resumable_source_manager.save_state(CannyResumeConfig(skip=skip))
+    def update_request(self, request: requests.Request) -> None:
+        if self.paginated:
+            super().update_request(request)
 
 
 def canny_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CannyResumeConfig],
 ) -> SourceResponse:
     config = CANNY_ENDPOINTS[endpoint]
 
+    def extract_records(body: dict[str, Any]) -> list[dict[str, Any]]:
+        # Canny nests the record array under a per-endpoint key; anything else (missing key,
+        # non-list value) is treated as an empty page, matching how the source always behaved.
+        records = body.get(config.data_key)
+        return records if isinstance(records, list) else []
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CANNY_BASE_URL,
+            "auth": CannyBodyAuth(api_key),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "method": "post",
+                    "paginator": CannyPaginator(paginated=config.paginated),
+                },
+                # The whole body reaches the transform (no data_selector) so the record-array
+                # extraction above can keep the exact legacy empty-page semantics.
+                "data_map": extract_records,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.skip}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (the merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(CannyResumeConfig(skip=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -144,7 +169,8 @@ def canny_source(
 def validate_credentials(api_key: str) -> bool:
     # boards/list is the cheapest probe: no pagination, returns quickly, and requires only a
     # valid API key (every workspace has at least one board). Reuse the catalog path so this can
-    # never drift from the synced endpoint.
+    # never drift from the synced endpoint. validate_via_probe only issues GETs, and Canny needs
+    # the key POSTed in the body, so the probe stays hand-rolled.
     url = f"{CANNY_BASE_URL}{CANNY_ENDPOINTS['boards'].path}"
     try:
         response = make_tracked_session(redact_values=(api_key,)).post(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/canny/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/canny/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CannySourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -89,22 +92,9 @@ Find your secret API key under **Settings → API** in your Canny dashboard.""",
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # No Canny list endpoint exposes a server-side updated-since filter, so every stream is
-        # full refresh only — neither incremental nor append is offered.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in CANNY_ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # full refresh only — neither incremental nor append is offered (every INCREMENTAL_FIELDS
+        # entry is empty, which build_endpoint_schemas maps to both flags off).
+        return build_endpoint_schemas(CANNY_ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CannySourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -133,6 +123,7 @@ Find your secret API key under **Settings → API** in your Canny dashboard.""",
         return canny_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/canny/tests/test_canny.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/canny/tests/test_canny.py
@@ -1,197 +1,273 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.canny.canny import (
     PAGE_SIZE,
+    CannyBodyAuth,
     CannyResumeConfig,
-    CannyRetryableError,
-    _build_body,
-    _extract_records,
-    _handle_response,
     canny_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.canny.settings import (
-    CANNY_ENDPOINTS,
-    ENDPOINTS,
-    CannyEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.canny.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
-_POSTS = CANNY_ENDPOINTS["posts"]
-_BOARDS = CANNY_ENDPOINTS["boards"]
-
-
-def _resp(body: Any, status: int = 200) -> Any:
-    response = MagicMock()
-    response.status_code = status
-    response.ok = 200 <= status < 400
-    response.json.return_value = body
-    response.text = str(body)
-    return response
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the canny module.
+CANNY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.canny.canny.make_tracked_session"
+)
 
 
-def _full_page(key: str) -> dict[str, Any]:
-    return {key: [{"id": str(i)} for i in range(PAGE_SIZE)], "hasMore": True}
+def _response(body: Any, status: int = 200, reason: str = "") -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.reason = reason
+    resp.url = "https://canny.io/api/v1/posts/list"
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _drive(
-    endpoint: str, manager: Any, responses: list[Any]
-) -> tuple[list[dict[str, Any]], list[list[dict[str, Any]]]]:
-    """Drive ``get_rows`` with a mocked tracked session, returning (posted_bodies, yielded_batches)."""
-    posted_bodies: list[dict[str, Any]] = []
-    response_iter = iter(responses)
-
-    def fake_post(url: str, data: Any = None, timeout: Any = None, **_kwargs: Any) -> Any:
-        posted_bodies.append(dict(data or {}))
-        return next(response_iter)
-
-    with patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.canny.canny.make_tracked_session"
-    ) as MockSession:
-        MockSession.return_value.post.side_effect = fake_post
-        batches = list(get_rows(api_key="k", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=manager))
-
-    return posted_bodies, batches
+def _page(key: str, ids: list[str], has_more: bool) -> Response:
+    return _response({key: [{"id": i} for i in ids], "hasMore": has_more})
 
 
-class TestBuildBody:
-    def test_paginated_includes_skip_and_limit(self) -> None:
-        assert _build_body("k", _POSTS, skip=200) == {"apiKey": "k", "skip": 200, "limit": PAGE_SIZE}
-
-    def test_unpaginated_only_api_key(self) -> None:
-        # boards/list takes no pagination params.
-        assert _build_body("k", _BOARDS, skip=0) == {"apiKey": "k"}
+def _full_page(key: str, start: int, has_more: bool = True) -> Response:
+    return _page(key, [str(i) for i in range(start, start + PAGE_SIZE)], has_more)
 
 
-class TestExtractRecords:
-    def test_extracts_configured_key(self) -> None:
-        config = CannyEndpointConfig(path="/v1/x/list", data_key="statusChanges")
-        assert _extract_records({"statusChanges": [{"id": "1"}]}, config) == [{"id": "1"}]
-
-    @pytest.mark.parametrize("body", [{}, {"posts": None}, {"posts": {"id": "1"}}, {"other": [{"id": "1"}]}])
-    def test_missing_or_non_list_returns_empty(self, body: dict[str, Any]) -> None:
-        assert _extract_records(body, _POSTS) == []
+def _make_manager(resume_state: CannyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class TestHandleResponse:
-    # Exercise the per-response classification directly, so a single attempt's behaviour can be
-    # asserted without driving the tenacity retry loop (and its real backoff sleeps).
-    def _handle(self, response: Any) -> dict[str, Any]:
-        return _handle_response(response, "https://canny.io/api/v1/posts/list", MagicMock())
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's JSON body AT SEND TIME.
 
-    @pytest.mark.parametrize("status", [429, 500, 503])
-    def test_retryable_statuses_raise_retryable_error(self, status: int) -> None:
-        with pytest.raises(CannyRetryableError):
-            self._handle(_resp({}, status=status))
+    ``request.json`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    body_snapshots: list[dict[str, Any]] = []
 
-    @pytest.mark.parametrize("status", [400, 401, 403])
-    def test_client_errors_raise_http_error(self, status: int) -> None:
-        response = _resp({}, status=status)
-        response.raise_for_status.side_effect = requests.HTTPError(f"{status} Client Error", response=response)
-        with pytest.raises(requests.HTTPError):
-            self._handle(response)
+    def _prepare(request: Any) -> mock.MagicMock:
+        body_snapshots.append(dict(request.json or {}))
+        return mock.MagicMock()
 
-    def test_error_body_on_200_raises_http_error(self) -> None:
-        # Canny can return 200 with an {"error": ...} body for a bad API key.
-        with pytest.raises(requests.HTTPError, match="invalid API key"):
-            self._handle(_resp({"error": "invalid API key"}))
-
-    def test_success_returns_body(self) -> None:
-        assert self._handle(_resp({"posts": [], "hasMore": False})) == {"posts": [], "hasMore": False}
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return body_snapshots
 
 
-class TestGetRows:
-    def test_paginates_until_has_more_false_and_saves_after_each_page(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
-        responses = [
-            _full_page("posts"),
-            _full_page("posts"),
-            {"posts": [{"id": "final"}], "hasMore": False},
-        ]
-        posted, batches = _drive("posts", manager, [_resp(r) for r in responses])
 
-        assert [b.get("skip") for b in posted] == [0, PAGE_SIZE, PAGE_SIZE * 2]
-        assert len(batches) == 3
+def _source(endpoint: str, manager: mock.MagicMock, api_key: str = "k"):
+    return canny_source(api_key=api_key, endpoint=endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+class TestCannyBodyAuth:
+    def test_injects_api_key_into_existing_json_body(self) -> None:
+        request = requests.Request(
+            method="POST",
+            url="https://canny.io/api/v1/posts/list",
+            json={"skip": 0, "limit": PAGE_SIZE},
+            auth=CannyBodyAuth("secret"),
+        )
+        prepared = requests.Session().prepare_request(request)
+        assert json.loads(prepared.body) == {"skip": 0, "limit": PAGE_SIZE, "apiKey": "secret"}
+
+    def test_creates_body_when_absent(self) -> None:
+        # boards/list sends no pagination params, so the body is just the key.
+        request = requests.Request(
+            method="POST", url="https://canny.io/api/v1/boards/list", auth=CannyBodyAuth("secret")
+        )
+        prepared = requests.Session().prepare_request(request)
+        assert json.loads(prepared.body) == {"apiKey": "secret"}
+
+    def test_declares_api_key_as_secret_for_redaction(self) -> None:
+        assert CannyBodyAuth("secret").secret_values() == ("secret",)
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_has_more_false_and_saves_after_each_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(
+            session,
+            [_full_page("posts", 0), _full_page("posts", PAGE_SIZE), _page("posts", ["final"], has_more=False)],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("posts", manager))
+
+        assert [r["id"] for r in rows] == [*(str(i) for i in range(2 * PAGE_SIZE)), "final"]
+        assert [b.get("skip") for b in bodies] == [0, PAGE_SIZE, PAGE_SIZE * 2]
+        assert all(b.get("limit") == PAGE_SIZE for b in bodies)
         # State is saved after each non-terminal page so a crash re-yields rather than skips.
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [CannyResumeConfig(skip=PAGE_SIZE), CannyResumeConfig(skip=PAGE_SIZE * 2)]
 
-    def test_resume_seeds_skip_from_saved_state(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = CannyResumeConfig(skip=PAGE_SIZE * 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_with_has_more_false_stops_without_extra_request(self, MockSession) -> None:
+        # Termination is driven by Canny's hasMore flag, not page size — a full last page must
+        # not trigger a wasted empty-page probe.
+        session = MockSession.return_value
+        _wire(session, [_full_page("posts", 0, has_more=False)])
 
-        posted, batches = _drive("posts", manager, [_resp({"posts": [{"id": "x"}], "hasMore": False})])
+        rows = _rows(_source("posts", _make_manager()))
 
-        assert posted[0].get("skip") == PAGE_SIZE * 2
+        assert len(rows) == PAGE_SIZE
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_seeds_skip_from_saved_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(session, [_page("posts", ["x"], has_more=False)])
+
+        manager = _make_manager(CannyResumeConfig(skip=PAGE_SIZE * 2))
+        rows = _rows(_source("posts", manager))
+
+        assert bodies[0].get("skip") == PAGE_SIZE * 2
         manager.load_state.assert_called_once()
-        assert len(batches) == 1
+        assert [r["id"] for r in rows] == ["x"]
 
-    def test_terminal_single_page_does_not_save_state(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_terminal_single_page_does_not_save_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("posts", ["only"], has_more=False)])
 
-        _, batches = _drive("posts", manager, [_resp({"posts": [{"id": "only"}], "hasMore": False})])
+        manager = _make_manager()
+        rows = _rows(_source("posts", manager))
 
-        assert len(batches) == 1
+        assert [r["id"] for r in rows] == ["only"]
         manager.save_state.assert_not_called()
 
-    def test_unpaginated_endpoint_fetches_once(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unpaginated_endpoint_fetches_once_without_pagination_params(self, MockSession) -> None:
+        session = MockSession.return_value
         # boards/list has no hasMore flag; a single fetch must terminate the loop.
-        posted, batches = _drive("boards", manager, [_resp({"boards": [{"id": "b1"}]})])
+        bodies = _wire(session, [_response({"boards": [{"id": "b1"}]})])
 
-        assert len(posted) == 1
-        assert "skip" not in posted[0]
-        assert batches == [[{"id": "b1"}]]
+        manager = _make_manager()
+        rows = _rows(_source("boards", manager))
+
+        assert session.send.call_count == 1
+        assert "skip" not in bodies[0]
+        assert "limit" not in bodies[0]
+        assert rows == [{"id": "b1"}]
         manager.save_state.assert_not_called()
 
-    def test_empty_page_yields_nothing(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("posts", [], has_more=False)])
 
-        _, batches = _drive("posts", manager, [_resp({"posts": [], "hasMore": False})])
-
-        assert batches == []
+        manager = _make_manager()
+        assert _rows(_source("posts", manager)) == []
         manager.save_state.assert_not_called()
 
-    def test_error_body_propagates(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @pytest.mark.parametrize(
+        "body",
+        [{}, {"posts": None}, {"posts": {"id": "1"}}, {"other": [{"id": "1"}]}],
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_or_non_list_data_key_yields_nothing(self, MockSession, body: dict[str, Any]) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
 
-        with pytest.raises(requests.HTTPError):
-            _drive("posts", manager, [_resp({"error": "invalid API key"})])
+        assert _rows(_source("posts", _make_manager())) == []
 
-    def test_registers_api_key_for_redaction(self) -> None:
-        # The secret rides in the POST body through the tracked transport; it must be redacted so it
-        # never lands in HTTP logs/samples.
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_error_body_on_200_raises_http_error(self, MockSession) -> None:
+        # Canny can return 200 with an {"error": ...} body for a bad API key; the message must
+        # carry the error text so the friendly non-retryable mapping can match it.
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "invalid API key"})])
 
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.canny.canny.make_tracked_session"
-        ) as MockSession:
-            MockSession.return_value.post.return_value = _resp({"posts": [], "hasMore": False})
-            list(get_rows(api_key="secret", endpoint="posts", logger=MagicMock(), resumable_source_manager=manager))
+        with pytest.raises(requests.HTTPError, match="invalid API key"):
+            _rows(_source("posts", _make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_error_body_on_unpaginated_endpoint_raises(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "invalid API key"})])
+
+        with pytest.raises(requests.HTTPError, match="invalid API key"):
+            _rows(_source("boards", _make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_registers_api_key_for_redaction(self, MockSession) -> None:
+        # The secret rides in the POST body through the tracked transport; it must be redacted so
+        # it never lands in HTTP logs/samples.
+        session = MockSession.return_value
+        _wire(session, [_page("posts", [], has_more=False)])
+
+        _rows(_source("posts", _make_manager(), api_key="secret"))
 
         MockSession.assert_called_once_with(redact_values=("secret",))
 
 
+class TestRetries:
+    @pytest.mark.parametrize("status", [429, 500, 503])
+    @mock.patch("time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(self, MockSession, _sleep, status: int) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status), _page("posts", ["a"], has_more=False)])
+
+        rows = _rows(_source("posts", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["a"]
+        assert session.send.call_count == 2
+
+    @mock.patch("time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_exhaust_then_raise(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=500)] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source("posts", _make_manager()))
+        assert session.send.call_count == 5
+
+    @pytest.mark.parametrize(
+        ("status", "reason"),
+        [(400, "Bad Request"), (401, "Unauthorized"), (403, "Forbidden")],
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_http_error_without_retry(self, MockSession, status: int, reason: str) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status, reason=reason)])
+
+        with pytest.raises(requests.HTTPError, match=f"{status} Client Error"):
+            _rows(_source("posts", _make_manager()))
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unauthorized_message_matches_non_retryable_mapping(self, MockSession) -> None:
+        # source.py maps this exact substring to the friendly invalid-key message.
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=401, reason="Unauthorized")])
+
+        with pytest.raises(requests.HTTPError, match="401 Client Error: Unauthorized for url: https://canny.io"):
+            _rows(_source("posts", _make_manager()))
+
+
 class TestValidateCredentials:
     def _validate(self, response: Any = None, raises: Exception | None = None) -> bool:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.canny.canny.make_tracked_session"
-        ) as MockSession:
+        with mock.patch(CANNY_SESSION_PATCH) as MockSession:
             post = MockSession.return_value.post
             if raises is not None:
                 post.side_effect = raises
@@ -200,22 +276,20 @@ class TestValidateCredentials:
             return validate_credentials("k")
 
     def test_valid_key(self) -> None:
-        assert self._validate(_resp({"boards": []})) is True
+        assert self._validate(_response({"boards": []})) is True
 
     def test_error_body_is_invalid(self) -> None:
-        assert self._validate(_resp({"error": "invalid API key"})) is False
+        assert self._validate(_response({"error": "invalid API key"})) is False
 
     def test_non_ok_is_invalid(self) -> None:
-        assert self._validate(_resp({}, status=401)) is False
+        assert self._validate(_response({}, status=401)) is False
 
     def test_network_error_is_invalid(self) -> None:
         assert self._validate(raises=requests.ConnectionError("boom")) is False
 
     def test_registers_api_key_for_redaction(self) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.canny.canny.make_tracked_session"
-        ) as MockSession:
-            MockSession.return_value.post.return_value = _resp({"boards": []})
+        with mock.patch(CANNY_SESSION_PATCH) as MockSession:
+            MockSession.return_value.post.return_value = _response({"boards": []})
             validate_credentials("secret")
 
         MockSession.assert_called_once_with(redact_values=("secret",))
@@ -224,9 +298,7 @@ class TestValidateCredentials:
 class TestCannySource:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_source_response_shape(self, endpoint: str) -> None:
-        response = canny_source(
-            api_key="k", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         # Every Canny object carries a stable `created` timestamp we partition on.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/canny/tests/test_canny_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/canny/tests/test_canny_source.py
@@ -126,7 +126,8 @@ class TestCannySource:
         mock_source.assert_called_once_with(
             api_key="test-key",
             endpoint="comments",
-            logger=inputs.logger,
+            team_id=99,
+            job_id="job-xyz",
             resumable_source_manager=manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/capsule_crm/capsule_crm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/capsule_crm/capsule_crm.py
@@ -1,21 +1,23 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import urlsplit
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 from urllib3.util.retry import Retry
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.capsule_crm.settings import (
-    CAPSULE_CRM_ENDPOINTS,
-    CapsuleCRMEndpointConfig,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.capsule_crm.settings import CAPSULE_CRM_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CAPSULE_CRM_BASE_URL = "https://api.capsulecrm.com/api/v2"
 CAPSULE_CRM_HOST = "api.capsulecrm.com"
@@ -23,12 +25,6 @@ CAPSULE_CRM_PATH_PREFIX = "/api/v2/"
 
 # Capsule caps perPage at 100; always request the max to minimize round-trips.
 PAGE_SIZE = 100
-
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class CapsuleCRMRetryableError(Exception):
-    pass
 
 
 class CapsuleCRMUntrustedURLError(Exception):
@@ -52,19 +48,32 @@ def _validate_pagination_url(url: str) -> str:
     return url
 
 
+class CapsuleCRMLinkPaginator(HeaderLinkPaginator):
+    """`HeaderLinkPaginator` that pins every followed or resumed next-page URL to the Capsule API.
+
+    Rejecting the URL in `update_state` (before the page is yielded) also keeps a poisoned URL from
+    ever reaching the resume checkpoint.
+    """
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and self._next_url:
+            _validate_pagination_url(self._next_url)
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_url = state.get("next_url")
+        if next_url is not None:
+            # Resume state comes from Redis — validate before sending the token to it.
+            _validate_pagination_url(next_url)
+        super().set_resume_state(state)
+
+
 @dataclasses.dataclass
 class CapsuleCRMResumeConfig:
     # Absolute URL of the next page (from the RFC 5988 Link header). Capsule echoes the original
     # query params — perPage, embed and `since` — into this URL, so resuming from it preserves the
     # incremental window without recomputing it. None means "start from the first page".
     next_url: str | None = None
-
-
-def _get_headers(access_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json",
-    }
 
 
 def _format_since_value(value: Any) -> str:
@@ -93,131 +102,94 @@ def _clamp_future_value_to_now(value: Any) -> Any:
     return value
 
 
-def _build_initial_url(
-    config: CapsuleCRMEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> str:
-    params: dict[str, Any] = {"perPage": PAGE_SIZE}
-    if config.embed:
-        params["embed"] = config.embed
-
-    if config.supports_since and should_use_incremental_field and db_incremental_field_last_value is not None:
-        params["since"] = _format_since_value(_clamp_future_value_to_now(db_incremental_field_last_value))
-
-    return f"{CAPSULE_CRM_BASE_URL}{config.path}?{urlencode(params)}"
-
-
-@retry(
-    retry=retry_if_exception_type((CapsuleCRMRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> tuple[dict, str | None]:
-    """Fetch one page, returning the parsed body and the next-page URL from the Link header.
-
-    Capsule signals pagination via the RFC 5988 `Link` header (rel="next"), not the body, so the
-    caller follows the returned URL rather than building its own.
-    """
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CapsuleCRMRetryableError(f"Capsule CRM API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Capsule CRM API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    next_url = response.links.get("next", {}).get("url")
-    return response.json(), next_url
-
-
-def get_rows(
-    access_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CapsuleCRMResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict]]:
-    config = CAPSULE_CRM_ENDPOINTS[endpoint]
-    headers = _get_headers(access_token)
-    # One session reused across every page so urllib3 keeps the connection alive. `redact_values`
-    # masks the bearer token in logged URLs and captured request samples. `allow_redirects=False`
-    # stops a redirect response from sending the bearer token to another host. `retry=Retry(total=0)`
-    # disables the adapter's built-in retries — `_fetch_page` already retries 429/5xx via tenacity, so
-    # the adapter default would stack a second retry layer.
-    session = make_tracked_session(redact_values=(access_token,), allow_redirects=False, retry=Retry(total=0))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None and resume.next_url:
-        # Resume state comes from Redis — validate before sending the token to it.
-        url = _validate_pagination_url(resume.next_url)
-        logger.debug(f"Capsule CRM: resuming from URL: {url}")
-    else:
-        url = _build_initial_url(config, should_use_incremental_field, db_incremental_field_last_value)
-
-    while True:
-        data, next_url = _fetch_page(session, url, headers, logger)
-        items = data.get(config.data_key, [])
-        if items:
-            yield items
-
-        if not next_url:
-            break
-
-        # The upstream-supplied next-page URL is followed verbatim with the bearer token — pin it to
-        # the Capsule CRM API so a hostile response can't retarget the authenticated request.
-        next_url = _validate_pagination_url(next_url)
-
-        # Save AFTER yielding (and only when more pages remain) so a crash re-yields the last page
-        # rather than skipping it — merge dedupes on the primary key.
-        resumable_source_manager.save_state(CapsuleCRMResumeConfig(next_url=next_url))
-        url = next_url
-
-
-def validate_credentials(access_token: str) -> bool:
-    """Probe a cheap, always-available endpoint to confirm the access token is genuine."""
-    url = f"{CAPSULE_CRM_BASE_URL}/users?perPage=1"
-    try:
-        session = make_tracked_session(redact_values=(access_token,), allow_redirects=False, retry=Retry(total=0))
-        response = session.get(url, headers=_get_headers(access_token), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
 def capsule_crm_source(
     access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CapsuleCRMResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = CAPSULE_CRM_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {"perPage": PAGE_SIZE}
+    if config.embed:
+        params["embed"] = config.embed
+    if config.supports_since and should_use_incremental_field and db_incremental_field_last_value is not None:
+        params["since"] = _format_since_value(_clamp_future_value_to_now(db_incremental_field_last_value))
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CAPSULE_CRM_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted from
+            # logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": access_token},
+            # A custom session pins `allow_redirects` off so a redirect response can't send the
+            # bearer token to another host; `redact_values` masks the token in logged URLs and
+            # captured request samples.
+            "session": make_tracked_session(redact_values=(access_token,), allow_redirects=False),
+            # Capsule signals pagination via the RFC 5988 `Link` header (rel="next"), not the body.
+            "paginator": CapsuleCRMLinkPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # A missing wrapper key is tolerated as a zero-row page (Capsule omits it on
+                    # some empty responses), so the selector is not required.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_url:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the framework calls this AFTER a page is yielded so
+        # a crash re-yields the last page (merge dedupes) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(CapsuleCRMResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            access_token=access_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
         # Capsule does not document an ordering guarantee for `since`, but the ResumableSource
         # next-URL state (not the watermark) drives mid-sync resume, so the dominant interruption
         # path is order-independent. `asc` matches the framework's default incremental checkpointing.
         sort_mode="asc",
     )
+
+
+def validate_credentials(access_token: str) -> bool:
+    """Probe a cheap, always-available endpoint to confirm the access token is genuine."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_token,), allow_redirects=False, retry=Retry(total=0)),
+        f"{CAPSULE_CRM_BASE_URL}/users?perPage=1",
+        headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/capsule_crm/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/capsule_crm/source.py
@@ -19,7 +19,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.capsule_cr
     validate_credentials as validate_capsule_crm_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.capsule_crm.settings import (
-    CAPSULE_CRM_ENDPOINTS,
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
@@ -29,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CapsuleCRMSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -83,7 +85,7 @@ The token inherits your user's permissions, so make sure your user can see the r
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # An invalid or revoked token surfaces as a requests HTTPError when `_fetch_page` calls
+            # An invalid or revoked token surfaces as a requests HTTPError when the REST client calls
             # `raise_for_status()`. Match the stable status text and base host, not the per-request path.
             "401 Client Error: Unauthorized for url: https://api.capsulecrm.com": "Your Capsule CRM Personal Access Token is invalid or has been revoked. Create a new token in your Capsule account settings, then reconnect.",
             "403 Client Error: Forbidden for url: https://api.capsulecrm.com": "Your Capsule CRM user does not have permission to read this data. Check the user's permissions in Capsule, then reconnect.",
@@ -97,22 +99,9 @@ The token inherits your user's permissions, so make sure your user can see the r
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = CAPSULE_CRM_ENDPOINTS[endpoint]
-            has_incremental = endpoint_config.supports_since and bool(INCREMENTAL_FIELDS.get(endpoint))
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=has_incremental,
-                supports_append=has_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Only the `?since`-capable endpoints declare incremental fields in settings, so the
+        # fields-driven default matches the old supports_since check exactly.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CapsuleCRMSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -134,7 +123,8 @@ The token inherits your user's permissions, so make sure your user can see the r
         return capsule_crm_source(
             access_token=config.access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/capsule_crm/tests/test_capsule_crm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/capsule_crm/tests/test_capsule_crm.py
@@ -1,27 +1,77 @@
-from datetime import UTC, date, datetime
+import json
+from datetime import UTC, date, datetime, timedelta, timezone
 from typing import Any
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.capsule_crm import capsule_crm
 from products.warehouse_sources.backend.temporal.data_imports.sources.capsule_crm.capsule_crm import (
     CAPSULE_CRM_BASE_URL,
     CapsuleCRMResumeConfig,
     CapsuleCRMUntrustedURLError,
-    _build_initial_url,
     _clamp_future_value_to_now,
     _format_since_value,
     _validate_pagination_url,
     capsule_crm_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.capsule_crm.settings import CAPSULE_CRM_ENDPOINTS
+
+# capsule_crm_source builds its own SSRF-guarded session in the capsule_crm module (passed to the
+# REST client), so both the pagination path and validate_credentials patch the module-level factory.
+SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.capsule_crm.capsule_crm.make_tracked_session"
+)
+
+
+def _response(
+    body: dict[str, Any], *, next_url: str | None = None, status_code: int = 200, url: str | None = None
+) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    resp.url = url or f"{CAPSULE_CRM_BASE_URL}/parties"
+    if next_url:
+        resp.headers["Link"] = f'<{next_url}>; rel="next"'
+    return resp
+
+
+def _make_manager(resume_state: CapsuleCRMResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[requests.Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request's url/params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(manager: mock.MagicMock, endpoint: str = "parties", access_token: str = "tok", **kwargs: Any):
+    return capsule_crm_source(
+        access_token=access_token, endpoint=endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatSinceValue:
@@ -41,8 +91,6 @@ class TestFormatSinceValue:
         assert "+00:00" not in _format_since_value(datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC))
 
     def test_non_utc_datetime_is_converted_to_utc(self) -> None:
-        from datetime import timedelta, timezone
-
         value = datetime(2026, 3, 4, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
         assert _format_since_value(value) == "2026-03-04T07:00:00Z"
 
@@ -73,148 +121,218 @@ class TestClampFutureValueToNow:
         assert _clamp_future_value_to_now("some-cursor") == "some-cursor"
 
 
-class TestBuildInitialUrl:
-    def test_full_refresh_url_has_no_since(self) -> None:
-        url = _build_initial_url(
-            CAPSULE_CRM_ENDPOINTS["users"], should_use_incremental_field=False, db_incremental_field_last_value=None
-        )
-        assert url == f"{CAPSULE_CRM_BASE_URL}/users?perPage=100"
+class TestRequestParams:
+    @mock.patch(SESSION_PATCH)
+    def test_full_refresh_request_has_no_since(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"users": [{"id": 1}]})])
 
-    def test_incremental_endpoint_embeds_related_data(self) -> None:
-        url = _build_initial_url(
-            CAPSULE_CRM_ENDPOINTS["parties"], should_use_incremental_field=False, db_incremental_field_last_value=None
-        )
-        # embed values are folded in to reduce round-trips; urlencode escapes the comma.
-        assert "perPage=100" in url
-        assert "embed=tags%2Cfields%2Corganisation" in url
-        assert "since" not in url
+        _rows(_source(_make_manager(), endpoint="users"))
 
-    def test_first_incremental_sync_omits_since(self) -> None:
+        assert snapshots[0]["url"] == f"{CAPSULE_CRM_BASE_URL}/users"
+        assert snapshots[0]["params"] == {"perPage": 100}
+
+    @mock.patch(SESSION_PATCH)
+    def test_incremental_endpoint_embeds_related_data(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"parties": [{"id": 1}]})])
+
+        _rows(_source(_make_manager()))
+
+        # embed values are folded in to reduce round-trips.
+        assert snapshots[0]["params"]["embed"] == "tags,fields,organisation"
+        assert "since" not in snapshots[0]["params"]
+
+    @mock.patch(SESSION_PATCH)
+    def test_first_incremental_sync_omits_since(self, MockSession) -> None:
         # No watermark yet -> pull full history, no `since` filter.
-        url = _build_initial_url(
-            CAPSULE_CRM_ENDPOINTS["opportunities"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=None,
-        )
-        assert "since" not in url
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"opportunities": []})])
 
-    def test_incremental_sync_with_watermark_adds_since(self) -> None:
-        url = _build_initial_url(
-            CAPSULE_CRM_ENDPOINTS["opportunities"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+        _rows(
+            _source(
+                _make_manager(),
+                endpoint="opportunities",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=None,
+            )
         )
-        assert "since=2026-03-04T02%3A58%3A14Z" in url
 
-    def test_since_ignored_for_full_refresh_only_endpoint(self) -> None:
+        assert "since" not in snapshots[0]["params"]
+
+    @mock.patch(SESSION_PATCH)
+    def test_incremental_sync_with_watermark_adds_since(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"opportunities": []})])
+
+        _rows(
+            _source(
+                _make_manager(),
+                endpoint="opportunities",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            )
+        )
+
+        assert snapshots[0]["params"]["since"] == "2026-03-04T02:58:14Z"
+
+    @mock.patch(SESSION_PATCH)
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_future_watermark_is_clamped_to_now(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"parties": []})])
+
+        _rows(
+            _source(
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2027, 2, 5, 21, 46, 42, tzinfo=UTC),
+            )
+        )
+
+        assert snapshots[0]["params"]["since"] == "2026-06-15T12:00:00Z"
+
+    @mock.patch(SESSION_PATCH)
+    def test_since_ignored_for_full_refresh_only_endpoint(self, MockSession) -> None:
         # tasks has no server-side `since` filter, so a watermark must not produce a `since` param.
-        url = _build_initial_url(
-            CAPSULE_CRM_ENDPOINTS["tasks"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"tasks": []})])
+
+        _rows(
+            _source(
+                _make_manager(),
+                endpoint="tasks",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            )
         )
-        assert "since" not in url
+
+        assert "since" not in snapshots[0]["params"]
 
 
-class _FakeResumableManager:
-    def __init__(self, state: CapsuleCRMResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[CapsuleCRMResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> CapsuleCRMResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: CapsuleCRMResumeConfig) -> None:
-        self.saved.append(data)
-
-
-def _collect(
-    manager: _FakeResumableManager, monkeypatch: Any, pages: dict[str, Any], endpoint: str = "parties", **kwargs: Any
-) -> list[dict]:
-    fetched: list[str] = []
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> tuple[dict, str | None]:
-        fetched.append(url)
-        result = pages[url]
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    monkeypatch.setattr(capsule_crm, "_fetch_page", fake_fetch)
-    rows: list[dict] = []
-    for batch in get_rows(
-        access_token="tok",
-        endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-        **kwargs,
-    ):
-        rows.extend(batch)
-    manager.fetched = fetched  # type: ignore[attr-defined]
-    return rows
-
-
-class TestGetRows:
-    def test_follows_link_header_pagination(self, monkeypatch: Any) -> None:
+class TestPagination:
+    @mock.patch(SESSION_PATCH)
+    def test_follows_link_header_pagination(self, MockSession) -> None:
+        session = MockSession.return_value
         page2 = f"{CAPSULE_CRM_BASE_URL}/parties?perPage=100&page=2"
-        start = _build_initial_url(CAPSULE_CRM_ENDPOINTS["parties"], False, None)
-        pages = {
-            start: ({"parties": [{"id": 1}, {"id": 2}]}, page2),
-            page2: ({"parties": [{"id": 3}]}, None),
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages)
+        snapshots = _wire(
+            session,
+            [
+                _response({"parties": [{"id": 1}, {"id": 2}]}, next_url=page2),
+                _response({"parties": [{"id": 3}]}),
+            ],
+        )
+
+        rows = _rows(_source(_make_manager()))
+
         assert rows == [{"id": 1}, {"id": 2}, {"id": 3}]
+        # The next-page URL is self-contained; the original params must not be re-appended.
+        assert snapshots[1]["url"] == page2
+        assert snapshots[1]["params"] == {}
 
-    def test_saves_resume_state_after_each_page_with_more(self, monkeypatch: Any) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_saves_resume_state_after_each_page_with_more(self, MockSession) -> None:
+        session = MockSession.return_value
         page2 = f"{CAPSULE_CRM_BASE_URL}/parties?perPage=100&page=2"
-        start = _build_initial_url(CAPSULE_CRM_ENDPOINTS["parties"], False, None)
-        pages = {
-            start: ({"parties": [{"id": 1}]}, page2),
-            page2: ({"parties": [{"id": 2}]}, None),
-        }
-        manager = _FakeResumableManager()
-        _collect(manager, monkeypatch, pages)
+        _wire(
+            session,
+            [
+                _response({"parties": [{"id": 1}]}, next_url=page2),
+                _response({"parties": [{"id": 2}]}),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source(manager))
+
         # State saved once (after page 1, which still had a next page); not after the final page.
-        assert [s.next_url for s in manager.saved] == [page2]
+        manager.save_state.assert_called_once_with(CapsuleCRMResumeConfig(next_url=page2))
 
-    def test_resumes_from_saved_next_url(self, monkeypatch: Any) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_from_saved_next_url(self, MockSession) -> None:
+        session = MockSession.return_value
         page2 = f"{CAPSULE_CRM_BASE_URL}/parties?perPage=100&page=2"
-        start = _build_initial_url(CAPSULE_CRM_ENDPOINTS["parties"], False, None)
-        pages = {
-            # The starting URL must NOT be fetched when resuming.
-            start: (Exception("should not fetch first page on resume"), None),
-            page2: ({"parties": [{"id": 2}]}, None),
-        }
-        manager = _FakeResumableManager(CapsuleCRMResumeConfig(next_url=page2))
-        rows = _collect(manager, monkeypatch, pages)
-        assert rows == [{"id": 2}]
-        assert manager.fetched == [page2]  # type: ignore[attr-defined]
+        snapshots = _wire(session, [_response({"parties": [{"id": 2}]})])
 
-    def test_extracts_rows_from_endpoint_specific_wrapper_key(self, monkeypatch: Any) -> None:
+        manager = _make_manager(CapsuleCRMResumeConfig(next_url=page2))
+        rows = _rows(_source(manager))
+
+        assert rows == [{"id": 2}]
+        # The starting URL must NOT be fetched when resuming.
+        assert session.send.call_count == 1
+        assert snapshots[0]["url"] == page2
+        assert snapshots[0]["params"] == {}
+
+    @mock.patch(SESSION_PATCH)
+    def test_extracts_rows_from_endpoint_specific_wrapper_key(self, MockSession) -> None:
         # lost_reasons nests its array under "lostReasons", not the endpoint name.
-        start = _build_initial_url(CAPSULE_CRM_ENDPOINTS["lost_reasons"], False, None)
-        pages = {start: ({"lostReasons": [{"id": 7, "name": "No budget"}]}, None)}
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, endpoint="lost_reasons")
+        session = MockSession.return_value
+        _wire(session, [_response({"lostReasons": [{"id": 7, "name": "No budget"}]})])
+
+        rows = _rows(_source(_make_manager(), endpoint="lost_reasons"))
+
         assert rows == [{"id": 7, "name": "No budget"}]
 
-    def test_hostile_upstream_next_url_is_rejected(self, monkeypatch: Any) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_missing_wrapper_key_is_treated_as_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"unexpected": []})])
+
+        assert _rows(_source(_make_manager())) == []
+
+    @mock.patch(SESSION_PATCH)
+    def test_hostile_upstream_next_url_is_rejected(self, MockSession) -> None:
         # An upstream Link header pointing at another host must abort before the bearer token is sent
         # there, and the poisoned URL must not be persisted as resume state.
-        start = _build_initial_url(CAPSULE_CRM_ENDPOINTS["parties"], False, None)
-        pages = {start: ({"parties": [{"id": 1}]}, "https://evil.example.com/api/v2/parties")}
-        manager = _FakeResumableManager()
-        with pytest.raises(CapsuleCRMUntrustedURLError):
-            _collect(manager, monkeypatch, pages)
-        assert manager.saved == []
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response({"parties": [{"id": 1}]}, next_url="https://evil.example.com/api/v2/parties")],
+        )
 
-    def test_hostile_resumed_next_url_is_rejected(self, monkeypatch: Any) -> None:
-        # A poisoned resume state from Redis must never be requested with the bearer token.
-        manager = _FakeResumableManager(CapsuleCRMResumeConfig(next_url="https://evil.example.com/api/v2/parties"))
+        manager = _make_manager()
         with pytest.raises(CapsuleCRMUntrustedURLError):
-            _collect(manager, monkeypatch, {})
+            _rows(_source(manager))
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(SESSION_PATCH)
+    def test_hostile_resumed_next_url_is_rejected(self, MockSession) -> None:
+        # A poisoned resume state from Redis must never be requested with the bearer token.
+        session = MockSession.return_value
+        _wire(session, [])
+
+        manager = _make_manager(CapsuleCRMResumeConfig(next_url="https://evil.example.com/api/v2/parties"))
+        with pytest.raises(CapsuleCRMUntrustedURLError):
+            _rows(_source(manager))
+        session.send.assert_not_called()
+
+
+class TestErrorHandling:
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(self, MockSession, mock_sleep) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status_code=429),
+                _response({"parties": [{"id": 1}]}),
+            ],
+        )
+
+        assert _rows(_source(_make_manager())) == [{"id": 1}]
+        assert session.send.call_count == 2
+
+    @parameterized.expand([(401,), (403,), (404,)])
+    @mock.patch(SESSION_PATCH)
+    def test_client_errors_raise_for_status(self, status: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=status, url=f"{CAPSULE_CRM_BASE_URL}/parties")])
+
+        # `get_non_retryable_errors` matches on this stable "NNN Client Error ... for url" text.
+        with pytest.raises(requests.HTTPError, match=f"{status} Client Error"):
+            _rows(_source(_make_manager()))
 
 
 class TestValidatePaginationUrl:
@@ -244,31 +362,41 @@ class TestValidatePaginationUrl:
 
 
 class TestTokenRedaction:
-    def test_validate_credentials_redacts_token_and_disables_redirects(self) -> None:
-        session = MagicMock()
-        response = MagicMock()
-        response.status_code = 200
-        session.get.return_value = response
-        with patch.object(capsule_crm, "make_tracked_session", return_value=session) as make_session:
-            validate_credentials("secret-token")
-        assert make_session.call_args.kwargs["redact_values"] == ("secret-token",)
-        assert make_session.call_args.kwargs["allow_redirects"] is False
+    @mock.patch(SESSION_PATCH)
+    def test_validate_credentials_redacts_token_and_disables_redirects(self, MockSession) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=200)
 
-    def test_get_rows_redacts_token_and_disables_redirects(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        make_session = MagicMock(return_value=session)
-        monkeypatch.setattr(capsule_crm, "make_tracked_session", make_session)
-        monkeypatch.setattr(capsule_crm, "_fetch_page", lambda *a, **k: ({"parties": []}, None))
-        list(
-            get_rows(
-                access_token="secret-token",
-                endpoint="parties",
-                logger=MagicMock(),
-                resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-            )
-        )
-        assert make_session.call_args.kwargs["redact_values"] == ("secret-token",)
-        assert make_session.call_args.kwargs["allow_redirects"] is False
+        validate_credentials("secret-token")
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("secret-token",)
+        assert MockSession.call_args.kwargs["allow_redirects"] is False
+
+    @mock.patch(SESSION_PATCH)
+    def test_source_session_redacts_token_and_disables_redirects(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"parties": []})])
+
+        _rows(_source(_make_manager(), access_token="secret-token"))
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("secret-token",)
+        assert MockSession.call_args.kwargs["allow_redirects"] is False
+
+
+class TestValidateCredentials:
+    @mock.patch(SESSION_PATCH)
+    def test_ok(self, MockSession) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("tok") is True
+
+    @mock.patch(SESSION_PATCH)
+    def test_unauthorized(self, MockSession) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=401)
+        assert validate_credentials("tok") is False
+
+    @mock.patch(SESSION_PATCH)
+    def test_swallows_exceptions(self, MockSession) -> None:
+        MockSession.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("tok") is False
 
 
 class TestSourceResponse:
@@ -281,9 +409,7 @@ class TestSourceResponse:
         ]
     )
     def test_incremental_and_taskish_endpoints_partition_on_created_at(self, endpoint: str, partition_key: str) -> None:
-        response = capsule_crm_source(
-            access_token="tok", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         assert response.partition_mode == "datetime"
@@ -292,38 +418,7 @@ class TestSourceResponse:
 
     @parameterized.expand([("users",), ("milestones",), ("pipelines",), ("categories",), ("lost_reasons",)])
     def test_metadata_endpoints_are_unpartitioned(self, endpoint: str) -> None:
-        response = capsule_crm_source(
-            access_token="tok", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.primary_keys == ["id"]
         assert response.partition_mode is None
         assert response.partition_keys is None
-
-
-def _response_with(status_code: int) -> requests.Response:
-    response = requests.Response()
-    response.status_code = status_code
-    response._content = b"{}"
-    response.url = "https://api.capsulecrm.com/api/v2/users"
-    return response
-
-
-# The undecorated function behind tenacity's retry wrapper — call it to exercise status handling
-# without the retry/backoff loop actually sleeping.
-_fetch_page_unwrapped = capsule_crm._fetch_page.__wrapped__  # type: ignore[attr-defined]
-
-
-class TestRetryableErrorClassification:
-    @parameterized.expand([(429,), (500,), (503,)])
-    def test_retryable_statuses_raise_retryable_error(self, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response_with(status)
-        with pytest.raises(capsule_crm.CapsuleCRMRetryableError):
-            _fetch_page_unwrapped(session, "https://api.capsulecrm.com/api/v2/users", {}, MagicMock())
-
-    @parameterized.expand([(401,), (403,), (404,)])
-    def test_client_errors_raise_for_status(self, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response_with(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "https://api.capsulecrm.com/api/v2/users", {}, MagicMock())

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -581,6 +581,7 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
         hooks: Optional[Any] = None,
         resume_hook: Optional[Any] = None,
         initial_paginator_state: Optional[dict[str, Any]] = None,
+        data_selector_required: bool = False,
     ):
         return iter(mock_data_response)
 
@@ -596,6 +597,7 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
         hooks: Optional[Any] = None,
         resume_hook: Optional[Any] = None,
         initial_paginator_state: Optional[dict[str, Any]] = None,
+        data_selector_required: bool = False,
     ):
         # Yield each record as its own page so tests that probe chunking
         # by record size still see one call per record.


### PR DESCRIPTION
## Problem

Eighth batch of hand-rolled source → `rest_source` migrations, stacked on #71580.

## Changes

**Eight sources migrated** (behavior-preserving, suites green): `buildkite` (48 tests), `bunny` (47), `buzzsprout` (44), `cal_com` (59), `callrail` (67), `campaign_monitor` (61), `canny` (52), `capsule_crm` (71).

Pre-vetted out without migration attempts: none this batch — all eight candidates passed vetting and migrated cleanly (candidates are now detector-verified before dispatch: real transport module + `get_schemas` + tests, no SDK/GraphQL/CSV markers).

> [!NOTE]
> Stacked on #71580 → #71572 → #71565 → #71559 → #71552 → #71540 → #71524 → #71520 → #71481/#71477.

## How did you test this code?

- Merged verification: **589 tests pass** across the 8 migrated sources + the full `rest_source` suite.
- Each source's suite passed in isolation first; coverage preserved. Worktree isolation verified before merge. `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
