### PR TITLE
chore(surveys): regenerate kea types for optional param unions

### DIFF
--- a/frontend/src/scenes/surveys/forms/surveyFormBuilderLogic.ts
+++ b/frontend/src/scenes/surveys/forms/surveyFormBuilderLogic.ts
@@ -20,8 +20,15 @@ export interface surveyFormBuilderLogicValues {
 export interface surveyFormBuilderLogicActions {
     reportSurveyCreated: (
         survey: Survey,
-        isDuplicate?: boolean,
-        creationSource?: 'form_builder' | 'full_editor' | 'llm_analytics' | 'quick_create' | 'template' | 'wizard'
+        isDuplicate?: boolean | undefined,
+        creationSource?:
+            | 'form_builder'
+            | 'full_editor'
+            | 'llm_analytics'
+            | 'quick_create'
+            | 'template'
+            | 'wizard'
+            | undefined
     ) => {
         creationSource:
             | 'form_builder'

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -779,8 +779,15 @@ export interface surveyLogicActions {
     } // eventUsageLogic
     reportSurveyCreated: (
         survey: Survey,
-        isDuplicate?: boolean,
-        creationSource?: 'form_builder' | 'full_editor' | 'llm_analytics' | 'quick_create' | 'template' | 'wizard'
+        isDuplicate?: boolean | undefined,
+        creationSource?:
+            | 'form_builder'
+            | 'full_editor'
+            | 'llm_analytics'
+            | 'quick_create'
+            | 'template'
+            | 'wizard'
+            | undefined
     ) => {
         creationSource:
             | 'form_builder'

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -98,8 +98,15 @@ export interface surveyWizardLogicValues {
 export interface surveyWizardLogicActions {
     reportSurveyCreated: (
         survey: Survey,
-        isDuplicate?: boolean,
-        creationSource?: 'form_builder' | 'full_editor' | 'llm_analytics' | 'quick_create' | 'template' | 'wizard'
+        isDuplicate?: boolean | undefined,
+        creationSource?:
+            | 'form_builder'
+            | 'full_editor'
+            | 'llm_analytics'
+            | 'quick_create'
+            | 'template'
+            | 'wizard'
+            | undefined
     ) => {
         creationSource:
             | 'form_builder'
@@ -117,7 +124,7 @@ export interface surveyWizardLogicActions {
     } // eventUsageLogic
     reportSurveyTemplateClicked: (
         template: SurveyTemplateType,
-        source?: string
+        source?: string | undefined
     ) => {
         source: string | undefined
         template: SurveyTemplateType


### PR DESCRIPTION
> [!NOTE]
> Superseded: an equivalent regeneration landed on master directly (master Frontend CI green as of 15:19 UTC, files now match this diff). Closing.

## Problem

Master's `Frontend typechecking` job has been failing since ~14:13 UTC today: the kea typegen check reports drift in three surveys logic type interfaces. #71456 ("inline Kea types batch 2") changed how kea-typegen renders optional action parameters (`isDuplicate?: boolean` → `isDuplicate?: boolean | undefined`), and these three files were not regenerated with it. Every in-flight PR fails the same check on its merge ref.

## Changes

Commits the checker's own regeneration diff — no hand-written changes — for:

- `frontend/src/scenes/surveys/forms/surveyFormBuilderLogic.ts`
- `frontend/src/scenes/surveys/surveyLogic.tsx`
- `frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts`

Type-level no-op (`T | undefined` on already-optional parameters); no runtime code touched.

## How did you test this code?

The diff is byte-for-byte what CI's typegen check printed as the expected content, so the check passes by construction; this PR's own `Frontend typechecking` run is the verification. No new tests — generated type interfaces only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — generated types only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Hit this while shepherding an unrelated web analytics PR; traced the failure to master (same job red on master itself since #71456) rather than the PR's diff.
- A full local `typegen:write` was rejected as the fix source: it produced a 21-file restructuring that doesn't match CI's environment. CI's printed diff is the deterministic ground truth and is what's committed here.
