### PR TITLE
fix(llm-gateway): lift per-user free cap for code-usage-billed orgs

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -94,6 +94,7 @@ async def get_usage(
         code_usage_billed=quota_status.code_usage_billing_active,
         billing_period_start=plan_info.billing_period.current_period_start if plan_info.billing_period else None,
         credits_exhausted=quota_status.limited,
+        quota_authoritative=quota_status.authoritative,
     )
     # The product's own credit bucket (resolve_plan_and_quota resolves per bucket;
     # always unlimited for unbilled products), reported under the legacy `ai_credits`

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -255,6 +255,7 @@ async def enforce_throttles(
         code_usage_billed=quota_status.code_usage_billing_active,
         billing_period_start=plan_info.billing_period.current_period_start if plan_info.billing_period else None,
         credits_exhausted=quota_status.limited,
+        quota_authoritative=quota_status.authoritative,
     )
     request.state.throttle_context = context
     set_throttle_context(runner, context)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -46,8 +46,11 @@ def _is_free_plan_throttled(context: ThrottleContext) -> bool:
     )
 
 
-def _is_org_billed_seatless(context: ThrottleContext) -> bool:
-    return context.product == POSTHOG_CODE_PRODUCT and context.seat_missing and context.code_usage_billed
+def _is_org_billed(context: ThrottleContext) -> bool:
+    # Seat state is deliberately ignored: with usage-based billing every request
+    # is metered into the org's credit bucket, so a leftover seat record from the
+    # retired seat products must not hold a paying org's user on the free-plan cap.
+    return context.product == POSTHOG_CODE_PRODUCT and context.code_usage_billed
 
 
 class CostThrottle(Throttle):
@@ -250,9 +253,9 @@ class _UserCostThrottleBase(CostThrottle):
         return f"{base}:m{mult}"
 
     def _get_config(self, context: ThrottleContext) -> UserCostLimit:
-        # Precedence matters: an org-billed seatless user is uncapped even though
-        # seat_missing would otherwise select the free-plan cap below.
-        if _is_org_billed_seatless(context):
+        # Precedence matters: an org-billed user is uncapped even though their
+        # seat state would otherwise select the free-plan cap below.
+        if _is_org_billed(context):
             return ORG_BILLED_USER_COST_LIMIT
         if _is_free_plan_throttled(context):
             return FREE_PLAN_COST_LIMIT

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -256,7 +256,13 @@ class _UserCostThrottleBase(CostThrottle):
         # Precedence matters: an org-billed user is uncapped even though their
         # seat state would otherwise select the free-plan cap below.
         if _is_org_billed(context):
-            return ORG_BILLED_USER_COST_LIMIT
+            if context.quota_authoritative:
+                return ORG_BILLED_USER_COST_LIMIT
+            # Fail-open quota state disables the org-level credit gate, so the
+            # uncapped limit would have no enforcement backstop at all. Hold
+            # billed users at the paid per-user defaults instead — never the
+            # free cap, which would re-cap a paying org on every upstream blip.
+            return get_settings().user_cost_limits.get(context.product) or DEFAULT_USER_COST_LIMIT
         if _is_free_plan_throttled(context):
             return FREE_PLAN_COST_LIMIT
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
@@ -51,6 +51,9 @@ class ThrottleContext:
     code_usage_billed: bool = False
     billing_period_start: str | None = None
     credits_exhausted: bool = False
+    # Whether code_usage_billed/credits_exhausted came from a successful quota
+    # fetch rather than a fail-open fallback (see QuotaResourceStatus.authoritative).
+    quota_authoritative: bool = False
 
 
 @dataclass

--- a/services/llm-gateway/src/llm_gateway/services/quota_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/quota_resolver.py
@@ -72,6 +72,11 @@ class QuotaResourceStatus:
     # synced numbers. None means unknown (unsynced org, fail-open) — never $0.
     used_usd: float | None = None
     limit_usd: float | None = None
+    # True only when these values came from a successful quota fetch (directly
+    # or via its cache entry); False on every fail-open shape. `limited` is only
+    # enforcing when this is True, so consumers must not grant fail-open state
+    # privileges that lean on the credit gate (e.g. the uncapped per-user limit).
+    authoritative: bool = False
 
 
 def _optional_number(value: object) -> float | None:
@@ -209,6 +214,7 @@ class QuotaResolver:
             code_usage_billing_active=bool(data.get("code_usage_billing_active")),
             used_usd=_credits_to_usd(resource.get("usage")),
             limit_usd=_credits_to_usd(resource.get("limit")),
+            authoritative=True,
         ), self._cache_ttl
 
     async def _get_cached(self, resource_key: str, team_id: int) -> QuotaResourceStatus | None:
@@ -221,11 +227,12 @@ class QuotaResolver:
             payload = json.loads(val.decode())
             return QuotaResourceStatus(
                 limited=bool(payload.get("limited")),
-                # Entries written before this field existed read as False (capped)
-                # until the TTL turns them over.
+                # Entries written before these fields existed read as False
+                # (capped / non-authoritative) until the TTL turns them over.
                 code_usage_billing_active=bool(payload.get("code_usage_billing_active")),
                 used_usd=_optional_number(payload.get("used_usd")),
                 limit_usd=_optional_number(payload.get("limit_usd")),
+                authoritative=bool(payload.get("authoritative")),
             )
         except Exception:
             logger.debug("quota_cache_read_failed", resource=resource_key, team_id=team_id)
@@ -241,6 +248,7 @@ class QuotaResolver:
                     "code_usage_billing_active": status.code_usage_billing_active,
                     "used_usd": status.used_usd,
                     "limit_usd": status.limit_usd,
+                    "authoritative": status.authoritative,
                 }
             )
             await self._redis.set(_redis_key(resource_key, team_id), payload, ex=ttl)

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1419,12 +1419,14 @@ class TestPlanAwareThrottling:
             # Seatless + not billed: the free cap holds (this pair pins that the
             # bypass never leaks to orgs that would get the usage for free).
             (True, False, False),
-            # Seat still exists (pre-retirement): org billing doesn't lift the cap -
-            # seat-covered usage stays bounded until the seat is deleted.
-            (False, True, False),
+            # Leftover seat record + org-billed: usage bills to the org regardless
+            # of the retired seat, so the seat must not re-cap a paying org's user.
+            (False, True, True),
+            # Seat + not billed: the free cap holds.
+            (False, False, False),
         ],
     )
-    async def test_code_usage_billing_gates_seatless_cap_bypass(
+    async def test_code_usage_billing_gates_user_cap_bypass(
         self, seat_missing: bool, code_usage_billed: bool, expected_allowed: bool
     ) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
@@ -1443,12 +1445,17 @@ class TestPlanAwareThrottling:
         assert result.allowed is expected_allowed
 
     @pytest.mark.asyncio
-    async def test_org_billed_seatless_status_reports_unlimited(self) -> None:
+    @pytest.mark.parametrize("seat_missing", [True, False])
+    async def test_org_billed_status_reports_unlimited(self, seat_missing: bool) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(
-            product="posthog_code", plan_key=None, seat_created_at=None, seat_missing=True, code_usage_billed=True
+            product="posthog_code",
+            plan_key=None if seat_missing else "posthog-code-free-20260301",
+            seat_created_at=None if seat_missing else "2026-01-01T00:00:00+00:00",
+            seat_missing=seat_missing,
+            code_usage_billed=True,
         )
 
         await throttle.record_cost(context, 600.0)

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -28,6 +28,8 @@ def make_context(
     seat_missing: bool = False,
     code_usage_billed: bool = False,
     billing_period_start: str | None = None,
+    # Defaults to the successful-fetch path; fail-open cases opt out.
+    quota_authoritative: bool = True,
 ) -> ThrottleContext:
     user = user or make_user()
     if end_user_id is None and user.auth_method == "oauth_access_token":
@@ -41,6 +43,7 @@ def make_context(
         seat_missing=seat_missing,
         code_usage_billed=code_usage_billed,
         billing_period_start=billing_period_start,
+        quota_authoritative=quota_authoritative,
     )
 
 
@@ -1441,6 +1444,40 @@ class TestPlanAwareThrottling:
         )
 
         await throttle.record_cost(context, 600.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is expected_allowed
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("seat_missing", "spent", "expected_allowed"),
+        [
+            # Fail-open quota state means the org credit gate isn't enforcing, so
+            # the paid default ($500/day burst) replaces the uncapped limit: $600
+            # must be denied whether or not a seat record lingers.
+            (True, 600.0, False),
+            (False, 600.0, False),
+            # ...but the fallback is never the $20 free cap - $80 stays allowed,
+            # seat or not, so an upstream blip can't re-cap a paying org's users.
+            (True, 80.0, True),
+            (False, 80.0, True),
+        ],
+    )
+    async def test_org_billed_without_authoritative_quota_uses_paid_defaults(
+        self, seat_missing: bool, spent: float, expected_allowed: bool
+    ) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(
+            product="posthog_code",
+            plan_key=None if seat_missing else "posthog-code-free-20260301",
+            seat_created_at=None if seat_missing else "2026-01-01T00:00:00+00:00",
+            seat_missing=seat_missing,
+            code_usage_billed=True,
+            quota_authoritative=False,
+        )
+
+        await throttle.record_cost(context, spent)
         result = await throttle.allow_request(context)
         assert result.allowed is expected_allowed
 

--- a/services/llm-gateway/tests/test_quota_resolver.py
+++ b/services/llm-gateway/tests/test_quota_resolver.py
@@ -152,7 +152,7 @@ class TestQuotaResolver:
 
         status = await resolver.get_resource_status("ai_credits", team_id=42, auth_header="Bearer phx_test")
 
-        assert status == QuotaResourceStatus(limited=True)
+        assert status == QuotaResourceStatus(limited=True, authoritative=True)
         http_client.get.assert_awaited_once()
         assert http_client.get.await_args.kwargs["headers"]["Authorization"] == "Bearer phx_test"
 
@@ -225,6 +225,7 @@ class TestQuotaResolver:
                 "code_usage_billing_active": True,
                 "used_usd": None,
                 "limit_usd": None,
+                "authoritative": False,
             }
             assert redis.ttls[_redis_key("ai_credits", 42)] == _FAIL_OPEN_CACHE_TTL_SECONDS
         else:
@@ -292,7 +293,7 @@ class TestQuotaResolver:
 
         status = await resolver.get_resource_status("ai_credits", team_id=42, auth_header="Bearer phx_test")
 
-        assert status == QuotaResourceStatus(limited=False)
+        assert status == QuotaResourceStatus(limited=False, authoritative=True)
 
     @pytest.mark.asyncio
     async def test_4xx_fails_open_without_retrying(self) -> None:
@@ -319,7 +320,7 @@ class TestQuotaResolver:
 
         status = await resolver.get_resource_status("ai_credits", team_id=42, auth_header="Bearer phx_test")
 
-        assert status == QuotaResourceStatus(limited=True)
+        assert status == QuotaResourceStatus(limited=True, authoritative=True)
         assert http_client.get.await_count == 2
 
     @pytest.mark.asyncio
@@ -334,7 +335,7 @@ class TestQuotaResolver:
 
         status = await resolver.get_resource_status("ai_credits", team_id=42, auth_header="Bearer phx_test")
 
-        assert status == QuotaResourceStatus(limited=False)
+        assert status == QuotaResourceStatus(limited=False, authoritative=True)
         assert http_client.get.await_count == 2
 
     @pytest.mark.asyncio
@@ -387,6 +388,7 @@ class TestQuotaResolver:
             "code_usage_billing_active": False,
             "used_usd": None,
             "limit_usd": None,
+            "authoritative": True,
         }
         # Successful fetches use the gateway settings default of 5 minutes.
         assert call.kwargs.get("ex") == 300


### PR DESCRIPTION
## Problem

When an organization pays for PostHog Code usage (usage-based billing with its own billing limit), the LLM gateway's per-user free-tier valve ($20 burst/sustained) is only bypassed for *seatless* users. A user who still has a leftover seat record from the retired seat products resolves as "free plan with a seat" and stays capped at $20 — even though every request they make is metered into the org's paid credit bucket. Because the sustained counter is keyed to the billing period, once such a user crosses $20 they get `429 User sustained rate limit exceeded` for the rest of the period, and raising the org's billing limit does nothing. Support's only remedy is manually resetting the user's counters per ~$20 of usage.

Seats were retired in favor of usage-based billing, so lingering seat records should no longer control cost caps for paying orgs.

## Changes

- `_is_org_billed_seatless` → `_is_org_billed`: the org-billed per-user cap bypass in the gateway's cost throttles no longer requires `seat_missing`. If the org pays for Code usage, the per-user free-plan valve never applies, seat record or not. Org-level spend is still enforced by `BillableCreditThrottle` and the product cost throttle. This matches how the free-tier model gate already works (`check_free_tier_model_access` keys off `code_usage_billed` alone).
- Hardening from review (bot findings below): `QuotaResourceStatus` now carries an `authoritative` bit — True only when the values came from a successful quota fetch (or its cache entry), False on every fail-open shape. The uncapped org-billed limit is granted only when the quota answer is authoritative; during fail-open windows (where `limited=False` is hardcoded and the org gate isn't enforcing) org-billed users are held at the paid per-user defaults ($500 burst / $3,000 sustained) instead of uncapped — and never the $20 free cap, so a transient upstream blip can't re-block a paying org's users. Cache entries written before the field read as non-authoritative and roll over within the 5-minute TTL.

## How did you test this code?

- Flipped the previously pinned case in `test_code_usage_billing_gates_user_cap_bypass`: seat present + org-billed must now allow (this is the regression that produced the incident — a paying org's user re-capped at $20 by a leftover seat), and completed the 2x2 matrix with seat present + not billed still capped (guards against the bypass leaking to free orgs).
- Parameterized `test_org_billed_status_reports_unlimited` over seat presence so the usage endpoint never reports a paying org's seated user as rate limited (that flag drives the app's "limit reached" UI).
- Added `test_org_billed_without_authoritative_quota_uses_paid_defaults`: during fail-open quota state, $600 spend is denied (catches the uncapped-during-fail-open regression the review bots flagged) and $80 stays allowed (catches falling back to the free cap, which would reintroduce the incident on every blip).
- Updated `test_quota_resolver` expectations so success paths, cached round-trips, and both fail-open shapes pin the `authoritative` bit; the existing legacy-cache-entry test pins that pre-existing entries read as non-authoritative.
- Ran the full llm-gateway unit suite: 1248 passed. `ruff check` and `ruff format --check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal gateway rate-limiting behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Code) while diagnosing a support report of a paying org's user being 429'd by the gateway despite org usage far below its billing limit. Traced the denial to `UserCostSustainedThrottle` resolving the user as free-plan because a retired seat record is still returned by the seats API, while the org-billed bypass required `seat_missing`.
- Skills invoked: `/writing-tests`.
- Considered instead routing seated org-billed users to the default paid per-user limits rather than unlimited; chose unlimited to match the existing seatless org-billed behavior, keeping one rule: org pays → org-level limits govern.
- Second commit responds to the hex-security and greptile review findings: rejected always-finite limits for billed orgs (regresses the legitimate uncapped path) and deny-on-fail-open (turns Django blips into hard Code outages, contradicting the resolver's documented fail-open stance); chose the authoritative-bit + paid-defaults-fallback middle ground.

**Why**

A paying customer raised their Code usage billing limit and stayed throttled anyway: the block was the per-user free-tier counter, kept in force by a leftover retired seat, and it persists for the whole billing period. This removes that class of stuck-throttle until seat records are gone.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
