### PR TITLE
fix(clickhouse): stop dev CH crash-looping on stale named collections

### DIFF
--- a/docker/clickhouse/config.d/default.xml
+++ b/docker/clickhouse/config.d/default.xml
@@ -77,6 +77,19 @@
         </sessions>
     </remote_servers>
 
+    <!--
+      Keep SQL-created named collections out of the default /var/lib/clickhouse/named_collections/
+      path. ClickHouse loads the config-defined <named_collections> below AND any *.sql files in
+      that default path; when both define the same name (e.g. a warpstream_* collection left over
+      in an older dev volume from before these moved to config) startup aborts fatally with
+      NAMED_COLLECTION_ALREADY_EXISTS (code 670) and the container crash-loops. Pointing SQL storage
+      at a separate path makes the config definitions authoritative and orphans the stale files.
+    -->
+    <named_collections_storage>
+        <type>local</type>
+        <path>/var/lib/clickhouse/named_collections_sql/</path>
+    </named_collections_storage>
+
     <named_collections>
         <msk_cluster>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>


### PR DESCRIPTION
## Problem

The dev ClickHouse container can get stuck in a startup crash loop, taking down every backend test that needs ClickHouse (they fail at setup with a connection reset).

Root cause: ClickHouse loads named collections from **two** places at startup — the config-defined ones in `docker/clickhouse/config.d/default.xml` (`<named_collections>`), and any `*.sql` files in the default SQL-storage path `/var/lib/clickhouse/named_collections/`. These `warpstream_*` collections used to be created via SQL and now live in config. A dev volume created before that move still carries a SQL-persisted `warpstream_traces.sql` in the default path. On startup, ClickHouse 26.6 sees the same name defined in both and aborts fatally:

```
Code: 670. DB::Exception: A named collection `warpstream_traces` already exists. (NAMED_COLLECTION_ALREADY_EXISTS)
```

Because the container's restart policy is `on-failure`, it then crash-loops. Docker still reports the container "healthy" (the healthcheck races the crash), so it looks like ClickHouse is up while every query gets `Connection reset by peer (clickhouse:9000)`.

A fresh checkout with an empty volume is fine — the crash only bites volumes carrying the legacy SQL collection. That's exactly the long-lived dev volume most people have.

## Changes

Point SQL named-collection storage at a separate path so the config definitions are authoritative and any legacy `*.sql` files in the old default path are ignored (orphaned, not deleted):

```xml
<named_collections_storage>
    <type>local</type>
    <path>/var/lib/clickhouse/named_collections_sql/</path>
</named_collections_storage>
```

Config-defined collections are loaded from XML regardless of the SQL storage path, so all the `warpstream_*` collections still resolve. Dev doesn't create named collections via SQL anywhere in the repo, so nothing depends on the old path.

Scoped to the single-node dev config (`default.xml`). The multinode configs under `config.d/multinode/` define the same collections but run on ephemeral smoke-test volumes that never accumulate stale SQL files, so they can't hit this.

## How did you test this code?

Reproduced and verified in an isolated throwaway container (never touched a shared volume), against the **real** `default.xml`:

- **Repro:** planted a stale `warpstream_traces.sql` in `/var/lib/clickhouse/named_collections/`, started `clickhouse/clickhouse-server:26.6.1.1193` with `default.xml` → confirmed the `Code: 670` fatal crash at startup.
- **Fix:** same setup with this change → container reaches "Ready for connections", stays `running` (no crash loop), `SELECT ... FROM system.named_collections` returns all 8 config-defined collections including `warpstream_traces`.
- Also confirmed a candidate fix (`allow_named_collection_override_by_config`) did **not** work on 26.6 before settling on the storage-path redirect.

No automated test added — this is dev-container config; the behavior is only observable by booting the actual ClickHouse image, which isn't part of the unit suites.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank hit this crash loop while I (Claude, via PostHog Code) was rebasing another branch — the dev ClickHouse started refusing connections, and restarting it surfaced the `NAMED_COLLECTION_ALREADY_EXISTS` fatal. Frank asked for a separate PR to fix the dev-stack issue.

I traced it to the config-vs-SQL-storage name collision, confirmed nothing in the repo creates these collections via SQL (so the persisted file is legacy volume cruft), then reproduced the crash and validated the fix in an isolated container rather than by re-breaking the shared stack. I tried the `allow_named_collection_override_by_config` storage setting first; it didn't prevent the crash on 26.6, so the fix redirects the SQL storage path instead.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
