### PR TITLE
feat(mcp): add skill usage suite for learn search quality and reference pulling

### DIFF
--- a/products/posthog_ai/eval_harness/harness/services.py
+++ b/products/posthog_ai/eval_harness/harness/services.py
@@ -99,7 +99,7 @@ def start_mcp_server(
     Pointed at the in-process Django live server (which uses the test DB).
     Uses a non-default port to avoid conflicts with a running dev MCP server.
 
-    Runs the Node-native Hono server via ``pnpm dev:hono``. In production the
+    Runs the Node-native Hono server via ``pnpm dev``. In production the
     Cloudflare Worker is now a proxy that forwards to a regional Hono
     deployment, so Hono is what real users hit.
     """
@@ -114,7 +114,7 @@ def start_mcp_server(
     api_url = live_server_url
 
     # The Hono server reads config directly from process env — no wrangler
-    # --var wiring needed. PORT picks the listen port; the dev:hono script
+    # --var wiring needed. PORT picks the listen port; the dev script
     # bundles via esbuild then spawns Node on the bundle.
     env = {
         **os.environ,
@@ -145,7 +145,7 @@ def start_mcp_server(
     _, stop = LONG_LIVED_SUBPROCESSES.start(
         name="MCP server",
         port=MCP_PORT,
-        cmd=["pnpm", "dev:hono"],
+        cmd=["pnpm", "dev"],
         cwd=mcp_dir,
         env=env,
         log_prefix="mcp",

--- a/products/posthog_ai/eval_harness/test/test_skill_distribution_scorers.py
+++ b/products/posthog_ai/eval_harness/test/test_skill_distribution_scorers.py
@@ -18,8 +18,10 @@ from products.posthog_ai.evals.cli_mcp.skill_distribution_scorers import (
 
 SKILL = "querying-posthog-data"
 QUALIFIED_SKILL = f"posthog:{SKILL}"
+PROJECT_QUALIFIED_SKILL = f"project:{SKILL}"
 EXEC_EXPECTED = skill_distribution_expectations(SKILL, ["execute-sql"], "exec")
 BUNDLED_EXPECTED = skill_distribution_expectations(SKILL, ["execute-sql"], "bundled")
+PROJECT_EXEC_EXPECTED = skill_distribution_expectations(SKILL, ["execute-sql"], "exec", source="project")
 
 
 def _acp_line(update: dict) -> str:
@@ -252,3 +254,23 @@ def test_exec_batch_read_counts_as_load_but_describe_does_not(load_command: str,
 )
 def test_delivery_specific_scorers_skip_the_other_arm(scorer: Scorer, expected: dict[str, dict[str, object]]) -> None:
     assert _score(scorer, _happy_path(), expected).score is None
+
+
+@pytest.mark.parametrize(
+    "scorer,output",
+    [
+        (
+            ExpectedSkillDiscovered(),
+            _output(_exec("search", "learn -s revenue", f'{{"name":"{PROJECT_QUALIFIED_SKILL}"}}')),
+        ),
+        (
+            ExpectedSkillLoaded(),
+            _output(
+                _exec("search", "learn -s revenue", PROJECT_QUALIFIED_SKILL),
+                _exec("load", f"learn {PROJECT_QUALIFIED_SKILL}"),
+            ),
+        ),
+    ],
+)
+def test_project_source_discovery_and_loading(scorer: Scorer, output: dict[str, object]) -> None:
+    assert _score(scorer, output, PROJECT_EXEC_EXPECTED).score == 1.0

--- a/products/posthog_ai/eval_harness/test/test_skill_usage_scorers.py
+++ b/products/posthog_ai/eval_harness/test/test_skill_usage_scorers.py
@@ -88,6 +88,16 @@ def test_expected_reference_pulled_self_skips_when_not_requested() -> None:
         ([_exec("zero", "learn -s xyz", ZERO_HIT), _exec("recover", "learn skills", "posthog:s")], 1.0),
         ([_exec("zero", "learn -s xyz", ZERO_HIT), _exec("recover", "learn -s broader", "posthog:s")], 1.0),
         ([_exec("zero", "learn -s xyz", ZERO_HIT), _exec("give-up", "call execute-sql {}", "[]")], 0.0),
+        # A gate-rejected (errored) product call is still the agent jumping to product
+        # tools — a later learn must not hide it from the ordering.
+        (
+            [
+                _exec("zero", "learn -s xyz", ZERO_HIT),
+                _exec("gated", "call execute-sql {}", "No skills loaded this session.", failed=True),
+                _exec("recover", "learn skills", "posthog:s"),
+            ],
+            0.0,
+        ),
         ([_exec("zero", "learn -s xyz", ZERO_HIT)], 0.0),
         ([_exec("zero", "learn -s xyz", ZERO_HIT, failed=True)], None),
         (

--- a/products/posthog_ai/eval_harness/test/test_skill_usage_scorers.py
+++ b/products/posthog_ai/eval_harness/test/test_skill_usage_scorers.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from braintrust import Score
+
+from products.posthog_ai.eval_harness.test.test_skill_distribution_scorers import _exec, _output, _score, _tool_call
+from products.posthog_ai.evals.cli_mcp.skill_usage_scorers import (
+    ExpectedReferencePulled,
+    SearchRecoveryAfterZeroHit,
+    SkillAnswerCorrectness,
+)
+
+ZERO_HIT = 'No skills matched "xyz". None of the query words appear in any skill.'
+
+
+def _ref_expected(
+    paths: list[str], *, skill: str = "s", source: str = "posthog", delivery: str = "exec"
+) -> dict[str, dict[str, object]]:
+    return {"expected_reference_pulled": {"skill": skill, "delivery": delivery, "source": source, "paths": paths}}
+
+
+def _recovery_expected() -> dict[str, dict[str, object]]:
+    return {"search_recovery_after_zero_hit": {}}
+
+
+@pytest.mark.parametrize(
+    "command,paths,skill,source",
+    [
+        ("learn posthog:s references/a.md", ["references/a.md"], "s", "posthog"),
+        ("learn posthog:s references/a.md references/b.md", ["references/b.md"], "s", "posthog"),
+        ("learn posthog:s references/a.md -s query", ["references/a.md"], "s", "posthog"),
+        ("learn posthog:s references/a.md --lines 1:40", ["references/a.md"], "s", "posthog"),
+        ("learn project:p references/policy-details.md", ["references/policy-details.md"], "p", "project"),
+        ("learn posthog:s ./references/a.md", ["references/a.md"], "s", "posthog"),
+    ],
+)
+def test_expected_reference_pulled_accepts_exec_reference_reads(
+    command: str, paths: list[str], skill: str, source: str
+) -> None:
+    output = _output(_exec("ref", command))
+    expected = _ref_expected(paths, skill=skill, source=source)
+    assert _score(ExpectedReferencePulled(), output, expected).score == 1.0
+
+
+@pytest.mark.parametrize(
+    "command,paths,skill,failed",
+    [
+        ("learn posthog:s", ["references/a.md"], "s", False),
+        ("learn posthog:s SKILL.md", ["references/a.md"], "s", False),
+        ("learn posthog:other references/a.md", ["references/a.md"], "s", False),
+        ("learn posthog:s references/a.md", ["references/a.md"], "s", True),
+        ("learn posthog:s posthog:other", ["references/a.md"], "s", False),
+        ("learn posthog:s -s query", ["references/a.md"], "s", False),
+    ],
+)
+def test_expected_reference_pulled_rejects_non_reference_exec_calls(
+    command: str, paths: list[str], skill: str, failed: bool
+) -> None:
+    output = _output(_exec("ref", command, failed=failed))
+    assert _score(ExpectedReferencePulled(), output, _ref_expected(paths, skill=skill)).score == 0.0
+
+
+@pytest.mark.parametrize(
+    "file_path,expected_score",
+    [
+        ("/root/.claude/skills/s/references/a.md", 1.0),
+        ("/root/.claude/skills/s/references/unrelated.md", 0.0),
+    ],
+)
+def test_expected_reference_pulled_bundled_arm_matches_reference_file_path(
+    file_path: str, expected_score: float
+) -> None:
+    output = _output(_tool_call("read", "Read", {"file_path": file_path}))
+    expected = _ref_expected(["references/a.md"], delivery="bundled")
+    assert _score(ExpectedReferencePulled(), output, expected).score == expected_score
+
+
+def test_expected_reference_pulled_self_skips_when_not_requested() -> None:
+    output = _output(_exec("ref", "learn posthog:s references/a.md"))
+    assert _score(ExpectedReferencePulled(), output, {}).score is None
+
+
+@pytest.mark.parametrize(
+    "calls,expected_score",
+    [
+        ([_exec("search", "learn -s revenue", "posthog:s")], None),
+        ([_exec("zero", "learn -s xyz", ZERO_HIT), _exec("recover", "learn skills", "posthog:s")], 1.0),
+        ([_exec("zero", "learn -s xyz", ZERO_HIT), _exec("recover", "learn -s broader", "posthog:s")], 1.0),
+        ([_exec("zero", "learn -s xyz", ZERO_HIT), _exec("give-up", "call execute-sql {}", "[]")], 0.0),
+        ([_exec("zero", "learn -s xyz", ZERO_HIT)], 0.0),
+        ([_exec("zero", "learn -s xyz", ZERO_HIT, failed=True)], None),
+        (
+            [
+                _exec("zero-1", "learn -s xyz", ZERO_HIT),
+                _exec("zero-2", "learn -s abc", ZERO_HIT),
+                _exec("give-up", "call execute-sql {}", "[]"),
+            ],
+            0.0,
+        ),
+    ],
+)
+def test_search_recovery_after_zero_hit(calls: list[list[str]], expected_score: float | None) -> None:
+    result = _score(SearchRecoveryAfterZeroHit(), _output(*calls), _recovery_expected())
+    if expected_score is None:
+        assert result.score is None
+    else:
+        assert result.score == expected_score
+
+
+def test_skill_answer_correctness_self_skips_when_not_requested() -> None:
+    prepared = SkillAnswerCorrectness()._prepare({"last_message": "anything"}, {})
+    assert isinstance(prepared, Score)
+    assert prepared.score is None
+
+
+def test_skill_answer_correctness_fails_without_final_message() -> None:
+    expected = {"skill_answer_correctness": {"expected_answer": "the answer"}}
+    prepared = SkillAnswerCorrectness()._prepare({"last_message": "  "}, expected)
+    assert isinstance(prepared, Score)
+    assert prepared.score == 0.0
+
+
+def test_skill_answer_correctness_forwards_answer_to_judge() -> None:
+    expected = {"skill_answer_correctness": {"expected_answer": "the answer"}}
+    output = {"last_message": "some final answer", "prompt": "the question"}
+    prepared = SkillAnswerCorrectness()._prepare(output, expected)
+    assert isinstance(prepared, dict)
+    assert prepared["expected"]["expected_answer"] == "the answer"
+    assert prepared["output"]["final_message"] == "some final answer"

--- a/products/posthog_ai/evals/cli_mcp/eval_skill_distribution.py
+++ b/products/posthog_ai/evals/cli_mcp/eval_skill_distribution.py
@@ -4,7 +4,6 @@ from products.posthog_ai.eval_harness.base import SandboxedPublicEval
 from products.posthog_ai.eval_harness.config import SandboxedEvalCase
 from products.posthog_ai.eval_harness.harness.cli import SkillDelivery
 from products.posthog_ai.eval_harness.harness.context import EvalContext
-from products.posthog_ai.eval_harness.scorers import ExitCodeZero
 from products.posthog_ai.evals.cli_mcp.skill_distribution_scorers import (
     ExpectedSkillDiscovered,
     ExpectedSkillLoaded,
@@ -99,7 +98,6 @@ async def eval_skill_distribution(ctx: EvalContext) -> None:
         experiment_name="sandboxed-cli-mcp-skill-distribution-cli",
         cases=cases,
         scorers=[
-            ExitCodeZero(),
             SkillSearchFirst(),
             ExpectedSkillDiscovered(),
             ExpectedSkillLoaded(),

--- a/products/posthog_ai/evals/cli_mcp/eval_skill_usage.py
+++ b/products/posthog_ai/evals/cli_mcp/eval_skill_usage.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from products.posthog_ai.eval_harness.base import SandboxedPublicEval
+from products.posthog_ai.eval_harness.config import SandboxedEvalCase
+from products.posthog_ai.eval_harness.harness.cli import SkillDelivery
+from products.posthog_ai.eval_harness.harness.context import EvalContext
+from products.posthog_ai.evals.cli_mcp.skill_distribution_scorers import (
+    ExpectedSkillDiscovered,
+    ExpectedSkillLoaded,
+    NoBundledSkillBypass,
+    NoExecSkillBypass,
+    SkillLoadedBeforeTool,
+    SkillSearchFirst,
+)
+from products.posthog_ai.evals.cli_mcp.skill_usage_scorers import (
+    ExpectedReferencePulled,
+    SearchRecoveryAfterZeroHit,
+    SkillAnswerCorrectness,
+    skill_usage_expectations,
+)
+from products.posthog_ai.evals.cli_mcp.skill_usage_seeder import (
+    PROJECT_SKILL_EXPECTED_ANSWER,
+    PROJECT_SKILL_NAME,
+    PROJECT_SKILL_REFERENCE_PATH,
+    seed_project_skill,
+)
+
+
+def _case(
+    name: str,
+    prompt: str,
+    skill: str,
+    downstream_tools: list[str],
+    skill_delivery: SkillDelivery,
+    *,
+    source: str = "posthog",
+    reference_paths: list[str] | None = None,
+    expected_answer: str | None = None,
+    setup: Callable[[Any], dict[str, Any]] | None = None,
+) -> SandboxedEvalCase:
+    return SandboxedEvalCase(
+        name=name,
+        prompt=prompt,
+        expected=skill_usage_expectations(
+            skill,
+            downstream_tools,
+            skill_delivery,
+            source=source,
+            reference_paths=reference_paths,
+            expected_answer=expected_answer,
+        ),
+        metadata={"expected_skill": skill, "skill_delivery": skill_delivery},
+        setup=setup,
+    )
+
+
+async def eval_skill_usage(ctx: EvalContext) -> None:
+    cases = [
+        _case(
+            name="bias_threshold_reference_pull",
+            prompt=(
+                "The 'bias-warning-demo-uneven-split' experiment is showing a bias warning. "
+                "At exactly what multi-variant ($multiple) exposure share does that warning fire, "
+                "and at what share does the Exposures tab show a $multiple row? "
+                "Compute this experiment's actual $multiple exposure share from its data and state "
+                "whether the row is visible for it."
+            ),
+            skill="diagnosing-experiment-results",
+            downstream_tools=["experiment-get", "experiment-stats", "execute-sql"],
+            skill_delivery=ctx.skill_delivery,
+            reference_paths=["references/bias-and-skew.md"],
+            expected_answer=(
+                "The bias warning fires when the $multiple exposure share is above 0.1%. "
+                "The Exposures tab hides the $multiple row when its share is at or below 0.5%. "
+                "This experiment's actual $multiple exposure share is above 0.5%, "
+                "so the $multiple row is visible for it."
+            ),
+        ),
+        _case(
+            name="error_volume_schema_reference_pull",
+            prompt=(
+                "Which error tracking issue had the most exceptions over the last 30 days? "
+                "Return the issue's exact title and its issue id."
+            ),
+            skill="querying-posthog-data",
+            downstream_tools=["execute-sql"],
+            skill_delivery=ctx.skill_delivery,
+            reference_paths=["references/models-error-tracking.md", "references/example-error-tracking.md"],
+            expected_answer=(
+                "The answer names exactly one error tracking issue as the highest-volume one — one of "
+                '"Checkout API timeout", "File preview render failure", or "Team invite rejected" — '
+                "and includes that issue's UUID issue id."
+            ),
+        ),
+        _case(
+            name="automated_visitor_share_paraphrase",
+            prompt=(
+                "Our pageview numbers for the last 30 days look inflated by non-human visitors. "
+                "Work out what share of pageviews came from scrapers and AI agents crawling the site, "
+                "and report a cleaned pageview figure that counts people only."
+            ),
+            skill="filtering-bot-traffic",
+            downstream_tools=["query-trends", "execute-sql"],
+            skill_delivery=ctx.skill_delivery,
+        ),
+    ]
+
+    if ctx.skill_delivery == "exec":
+        cases.append(
+            _case(
+                name="project_enterprise_revenue_policy",
+                prompt=(
+                    "Finance asked for our qualified enterprise revenue over the last 90 days. "
+                    "Compute it, apply the standard definition our team has documented for this, "
+                    "and quote the exact rules you applied, including any exclusions."
+                ),
+                skill=PROJECT_SKILL_NAME,
+                downstream_tools=["execute-sql"],
+                skill_delivery=ctx.skill_delivery,
+                source="project",
+                reference_paths=[PROJECT_SKILL_REFERENCE_PATH],
+                expected_answer=PROJECT_SKILL_EXPECTED_ANSWER,
+                setup=seed_project_skill,
+            )
+        )
+
+    await SandboxedPublicEval(
+        experiment_name="sandboxed-cli-mcp-skill-usage-cli",
+        cases=cases,
+        scorers=[
+            SkillSearchFirst(),
+            ExpectedSkillDiscovered(),
+            ExpectedSkillLoaded(),
+            SkillLoadedBeforeTool(),
+            NoBundledSkillBypass(),
+            NoExecSkillBypass(),
+            ExpectedReferencePulled(),
+            SearchRecoveryAfterZeroHit(),
+            SkillAnswerCorrectness(),
+        ],
+        ctx=ctx,
+    )

--- a/products/posthog_ai/evals/cli_mcp/skill_distribution_scorers.py
+++ b/products/posthog_ai/evals/cli_mcp/skill_distribution_scorers.py
@@ -28,13 +28,14 @@ class _SkillLoad:
 
 
 def skill_distribution_expectations(
-    skill: str, downstream_tools: list[str], skill_delivery: SkillDelivery
+    skill: str, downstream_tools: list[str], skill_delivery: SkillDelivery, *, source: str = "posthog"
 ) -> dict[str, dict[str, object]]:
     expectations: dict[str, dict[str, object]] = {
-        "expected_skill_loaded": {"skill": skill, "delivery": skill_delivery},
+        "expected_skill_loaded": {"skill": skill, "delivery": skill_delivery, "source": source},
         "skill_loaded_before_tool": {
             "skill": skill,
             "delivery": skill_delivery,
+            "source": source,
             "tools": downstream_tools,
         },
     }
@@ -42,7 +43,7 @@ def skill_distribution_expectations(
         expectations.update(
             {
                 "skill_search_first": {},
-                "expected_skill_discovered": {"skill": skill},
+                "expected_skill_discovered": {"skill": skill, "source": source},
                 "no_bundled_skill_bypass": {},
             }
         )
@@ -95,8 +96,8 @@ def _skill_search_calls(parser: LogParser) -> list[ToolCall]:
     return [call for call in _successful_exec_calls(parser) if _is_skill_search(call)]
 
 
-def _qualified_skill(skill: str) -> str:
-    return f"posthog:{skill}"
+def _qualified_skill(skill: str, source: str = "posthog") -> str:
+    return f"{source}:{skill}"
 
 
 def _output_mentions_skill(output: str, qualified_skill: str) -> bool:
@@ -139,21 +140,24 @@ def _bundled_skill_loads(parser: LogParser, skill: str) -> list[_SkillLoad]:
     return sorted(loads, key=lambda load: load.position)
 
 
-def _skill_loads(parser: LogParser, skill: str, delivery: SkillDelivery) -> list[_SkillLoad]:
+def _skill_loads(parser: LogParser, skill: str, delivery: SkillDelivery, source: str = "posthog") -> list[_SkillLoad]:
     if delivery == "bundled":
         return _bundled_skill_loads(parser, skill)
     return [
         _SkillLoad(position=call.position, call_id=call.call_id, matched_via="exec_learn")
-        for call in _exec_skill_load_calls(parser, _qualified_skill(skill))
+        for call in _exec_skill_load_calls(parser, _qualified_skill(skill, source))
     ]
 
 
-def _skill_and_delivery(spec: dict[str, object]) -> tuple[str, SkillDelivery] | None:
+def _skill_and_delivery(spec: dict[str, object]) -> tuple[str, SkillDelivery, str] | None:
     skill = spec.get("skill")
     delivery = spec.get("delivery")
+    source = spec.get("source", "posthog")
     if not isinstance(skill, str) or not skill or delivery not in ("bundled", "exec"):
         return None
-    return skill, cast(SkillDelivery, delivery)
+    if source not in ("posthog", "project"):
+        return None
+    return skill, cast(SkillDelivery, delivery), cast(str, source)
 
 
 def _is_exec_skill_command(call: ToolCall) -> bool:
@@ -225,11 +229,14 @@ class ExpectedSkillDiscovered(Scorer):
         skill = spec.get("skill")
         if not isinstance(skill, str) or not skill:
             return Score(name=self._name(), score=0.0, metadata={"reason": "Expected skill is missing"})
+        source = spec.get("source", "posthog")
+        if source not in ("posthog", "project"):
+            return Score(name=self._name(), score=0.0, metadata={"reason": "Invalid scorer expectation"})
         parser = _parser(output)
         if parser is None:
             return Score(name=self._name(), score=0.0, metadata={"reason": "No raw log"})
 
-        qualified_skill = _qualified_skill(skill)
+        qualified_skill = _qualified_skill(skill, cast(str, source))
         for call in _skill_search_calls(parser):
             if _output_mentions_skill(call.output, qualified_skill):
                 return Score(name=self._name(), score=1.0, metadata={"skill": qualified_skill, "call_id": call.call_id})
@@ -259,12 +266,12 @@ class ExpectedSkillLoaded(Scorer):
         skill_spec = _skill_and_delivery(spec)
         if skill_spec is None:
             return Score(name=self._name(), score=0.0, metadata={"reason": "Invalid scorer expectation"})
-        skill, delivery = skill_spec
+        skill, delivery, source = skill_spec
         parser = _parser(output)
         if parser is None:
             return Score(name=self._name(), score=0.0, metadata={"reason": "No raw log"})
 
-        loads = _skill_loads(parser, skill, delivery)
+        loads = _skill_loads(parser, skill, delivery, source)
         if delivery == "bundled" and loads:
             load = loads[0]
             return Score(
@@ -278,7 +285,7 @@ class ExpectedSkillLoaded(Scorer):
                 },
             )
 
-        qualified_skill = _qualified_skill(skill)
+        qualified_skill = _qualified_skill(skill, source)
         matching_searches = [
             call for call in _skill_search_calls(parser) if _output_mentions_skill(call.output, qualified_skill)
         ]
@@ -321,12 +328,12 @@ class SkillLoadedBeforeTool(Scorer):
         tools = spec.get("tools")
         if skill_spec is None or not isinstance(tools, list) or not all(isinstance(tool, str) for tool in tools):
             return Score(name=self._name(), score=0.0, metadata={"reason": "Invalid scorer expectation"})
-        skill, delivery = skill_spec
+        skill, delivery, source = skill_spec
         parser = _parser(output)
         if parser is None:
             return Score(name=self._name(), score=0.0, metadata={"reason": "No raw log"})
 
-        loads = _skill_loads(parser, skill, delivery)
+        loads = _skill_loads(parser, skill, delivery, source)
         downstream_calls = [call for call in parser.get_tool_calls() if not call.is_error and call.name in tools]
         for load in loads:
             for downstream in downstream_calls:

--- a/products/posthog_ai/evals/cli_mcp/skill_usage_scorers.py
+++ b/products/posthog_ai/evals/cli_mcp/skill_usage_scorers.py
@@ -19,7 +19,7 @@ from braintrust import Score
 from braintrust_core.score import Scorer
 
 from products.posthog_ai.eval_harness.harness.cli import SkillDelivery
-from products.posthog_ai.eval_harness.log_parser import LogParser
+from products.posthog_ai.eval_harness.log_parser import EXEC_TOOL_NAME, LogParser, ToolCall, normalize_tool_name
 from products.posthog_ai.eval_harness.scorers import BINARY_CHOICE_SCORES, JUDGE_MODEL, JudgedScorer
 from products.posthog_ai.evals.cli_mcp.skill_distribution_scorers import (
     _exec_command,
@@ -33,6 +33,10 @@ from products.posthog_ai.evals.cli_mcp.skill_distribution_scorers import (
 )
 
 _ZERO_HIT_PREFIX = 'No skills matched "'
+
+
+def _exec_calls(parser: LogParser) -> list[ToolCall]:
+    return [call for call in parser.get_tool_calls() if normalize_tool_name(call.raw_name) == EXEC_TOOL_NAME]
 
 
 class ExpectedReferencePulled(Scorer):
@@ -157,7 +161,10 @@ class SearchRecoveryAfterZeroHit(Scorer):
         if not zero_hits:
             return Score(name=self._name(), score=None, metadata={"reason": "No zero-hit search occurred"})
 
-        exec_calls = _successful_exec_calls(parser)
+        # Ordering must see errored calls too: a gate-rejected product call after a
+        # zero-hit search is still the agent jumping to product tools, even though
+        # the agent may run `learn` right after the rejection.
+        exec_calls = _exec_calls(parser)
         for zero_hit in zero_hits:
             following = [call for call in exec_calls if call.position > zero_hit.position]
             if not following:

--- a/products/posthog_ai/evals/cli_mcp/skill_usage_scorers.py
+++ b/products/posthog_ai/evals/cli_mcp/skill_usage_scorers.py
@@ -1,0 +1,275 @@
+"""Scorers for the skill-usage eval — the layer above skill *distribution*.
+
+Distribution scorers (``skill_distribution_scorers``) grade whether the agent found
+and loaded the right skill. These grade what it did with the skill once loaded:
+pulling the reference files the skill points at, recovering from a zero-hit search
+instead of giving up, and answering the question with the facts the skill teaches.
+
+Every scorer self-skips (``Score(score=None)``) when its ``expected`` key is absent,
+so one global scorer list works across every case — Braintrust drops ``None`` from
+per-metric aggregates.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from braintrust import Score
+from braintrust_core.score import Scorer
+
+from products.posthog_ai.eval_harness.harness.cli import SkillDelivery
+from products.posthog_ai.eval_harness.log_parser import LogParser
+from products.posthog_ai.eval_harness.scorers import BINARY_CHOICE_SCORES, JUDGE_MODEL, JudgedScorer
+from products.posthog_ai.evals.cli_mcp.skill_distribution_scorers import (
+    _exec_command,
+    _expected_spec,
+    _is_qualified_skill_token,
+    _parser,
+    _qualified_skill,
+    _skill_search_calls,
+    _successful_exec_calls,
+    skill_distribution_expectations,
+)
+
+_ZERO_HIT_PREFIX = 'No skills matched "'
+
+
+class ExpectedReferencePulled(Scorer):
+    """Binary: did the agent read one of the skill's reference files (not just the skill)?
+
+    A skill's ``SKILL.md`` points at reference files under ``references/`` that hold the
+    detail needed to answer well. This checks the agent actually pulled one — via
+    ``learn <qualified> <path>`` in exec mode, or a native file read of the bundled
+    skill's reference in bundled mode. A bare skill load or all-qualified batch load
+    does not count.
+    """
+
+    def _name(self) -> str:
+        return "expected_reference_pulled"
+
+    def _run_eval_sync(
+        self,
+        output: dict[str, object] | None,
+        expected: dict[str, object] | None = None,
+        **kwargs: object,
+    ) -> Score:
+        spec = _expected_spec(expected, self._name())
+        if spec is None:
+            return Score(name=self._name(), score=None, metadata={"reason": "Scorer does not apply"})
+        skill = spec.get("skill")
+        delivery = spec.get("delivery")
+        source = spec.get("source", "posthog")
+        paths = spec.get("paths")
+        if (
+            not isinstance(skill, str)
+            or not skill
+            or delivery not in ("bundled", "exec")
+            or source not in ("posthog", "project")
+            or not isinstance(paths, list)
+            or not paths
+            or not all(isinstance(path, str) and path for path in paths)
+        ):
+            return Score(name=self._name(), score=0.0, metadata={"reason": "Invalid scorer expectation"})
+        parser = _parser(output)
+        if parser is None:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "No raw log"})
+
+        accepted = [cast(str, path) for path in paths]
+        if delivery == "exec":
+            matched = self._exec_match(parser, cast(str, skill), cast(str, source), accepted)
+        else:
+            matched = self._bundled_match(parser, cast(str, skill), accepted)
+        if matched is not None:
+            return Score(name=self._name(), score=1.0, metadata=matched)
+        return Score(
+            name=self._name(),
+            score=0.0,
+            metadata={"reason": "No expected reference file was pulled", "skill": skill, "paths": accepted},
+        )
+
+    def _exec_match(self, parser: LogParser, skill: str, source: str, accepted: list[str]) -> dict[str, object] | None:
+        qualified = _qualified_skill(skill, source)
+        for call in _successful_exec_calls(parser):
+            verb, rest = _exec_command(call)
+            if verb != "learn":
+                continue
+            tokens = rest.split()
+            if not tokens or tokens[0] != qualified or len(tokens) <= 1:
+                continue
+            # An all-qualified token list is a batch skill load (`learn posthog:a posthog:b`),
+            # not a reference pull.
+            if all(_is_qualified_skill_token(token) for token in tokens):
+                continue
+            for token in self._path_tokens(tokens[1:]):
+                normalized = token[2:] if token.startswith("./") else token
+                for path in accepted:
+                    if token == path or normalized == path:
+                        return {"call_id": call.call_id, "matched_path": path}
+        return None
+
+    @staticmethod
+    def _path_tokens(rest_tokens: list[str]) -> list[str]:
+        # Path tokens run until the first scoped-search / line-range flag; anything after
+        # that is search or slicing arguments, not a file path.
+        tokens: list[str] = []
+        for token in rest_tokens:
+            if token in ("-s", "--lines"):
+                break
+            tokens.append(token)
+        return tokens
+
+    def _bundled_match(self, parser: LogParser, skill: str, accepted: list[str]) -> dict[str, object] | None:
+        for call in parser.get_tool_calls():
+            if call.is_error:
+                continue
+            reference = f"{call.name}\n{json.dumps(call.input, default=str)}".lower()
+            for path in accepted:
+                if f"{skill}/{path}".lower() in reference:
+                    return {"call_id": call.call_id, "matched_path": path}
+        return None
+
+
+class SearchRecoveryAfterZeroHit(Scorer):
+    """Binary: after a zero-hit skill search, did the agent keep learning rather than give up?
+
+    A ``learn -s`` that matches nothing returns text starting with ``No skills matched "``.
+    The right move is another ``learn`` command (broaden the query, list skills, describe) —
+    not to jump straight into product tools guessing. Self-skips when no zero-hit search ran.
+    """
+
+    def _name(self) -> str:
+        return "search_recovery_after_zero_hit"
+
+    def _run_eval_sync(
+        self,
+        output: dict[str, object] | None,
+        expected: dict[str, object] | None = None,
+        **kwargs: object,
+    ) -> Score:
+        if _expected_spec(expected, self._name()) is None:
+            return Score(name=self._name(), score=None, metadata={"reason": "Scorer does not apply"})
+        parser = _parser(output)
+        if parser is None:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "No raw log"})
+
+        zero_hits = [call for call in _skill_search_calls(parser) if call.output.startswith(_ZERO_HIT_PREFIX)]
+        if not zero_hits:
+            return Score(name=self._name(), score=None, metadata={"reason": "No zero-hit search occurred"})
+
+        exec_calls = _successful_exec_calls(parser)
+        for zero_hit in zero_hits:
+            following = [call for call in exec_calls if call.position > zero_hit.position]
+            if not following:
+                return Score(
+                    name=self._name(),
+                    score=0.0,
+                    metadata={"reason": "No learning follow-up after zero-hit search", "call_id": zero_hit.call_id},
+                )
+            nxt = min(following, key=lambda call: call.position)
+            verb, rest = _exec_command(nxt)
+            if verb != "learn":
+                return Score(
+                    name=self._name(),
+                    score=0.0,
+                    metadata={
+                        "reason": "A non-learning command followed a zero-hit search",
+                        "call_id": nxt.call_id,
+                        "command": f"{verb} {rest}".strip(),
+                    },
+                )
+        return Score(name=self._name(), score=1.0, metadata={"zero_hits": len(zero_hits)})
+
+
+SKILL_ANSWER_PROMPT = """
+You are judging whether an agent's final answer states every fact from an expected answer.
+
+The agent was asked USER_PROMPT and produced FINAL_MESSAGE. EXPECTED_ANSWER lists the facts the final message must convey.
+
+Grade only whether FINAL_MESSAGE states every fact in EXPECTED_ANSWER:
+- Paraphrase is fine — the wording does not need to match.
+- Numeric values must match; a different number is a failure.
+- Extra correct material in FINAL_MESSAGE is fine and never a reason to fail.
+- Missing or contradicting any fact from EXPECTED_ANSWER is a failure.
+
+<user_prompt>
+{{output.prompt}}
+</user_prompt>
+
+<expected_answer>
+{{expected.expected_answer}}
+</expected_answer>
+
+<final_message>
+{{output.final_message}}
+</final_message>
+
+Does the final message state every fact in the expected answer? Answer `yes` or `no`.
+""".strip()
+
+
+class SkillAnswerCorrectness(JudgedScorer):
+    """Binary LLM judge: does the final message state every fact the skill's answer requires?
+
+    Self-skips (``None``) when not requested. Scores 0.0 (not ``None``) when the expected
+    answer is missing/blank or the agent produced no final message, so a broken run surfaces
+    as a failing score rather than being silently dropped from the aggregate.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            name="skill_answer_correctness",
+            prompt_template=SKILL_ANSWER_PROMPT,
+            choice_scores=BINARY_CHOICE_SCORES,
+            model=JUDGE_MODEL,
+            max_completion_tokens=512,
+            **kwargs,
+        )
+
+    def _prepare(self, output: Any, expected: Any) -> dict[str, Any] | Score:
+        spec = _expected_spec(expected, self._name())
+        if spec is None:
+            return Score(name=self._name(), score=None, metadata={"reason": "Scorer does not apply"})
+        expected_answer = spec.get("expected_answer")
+        if not isinstance(expected_answer, str) or not expected_answer.strip():
+            return Score(name=self._name(), score=0.0, metadata={"reason": "No expected answer configured"})
+        last_message = output.get("last_message") if isinstance(output, dict) else None
+        if not isinstance(last_message, str) or not last_message.strip():
+            return Score(name=self._name(), score=0.0, metadata={"reason": "No final agent message"})
+        prompt = output.get("prompt") if isinstance(output, dict) else ""
+        return {
+            "output": {"prompt": prompt if isinstance(prompt, str) else "", "final_message": last_message},
+            "expected": {"expected_answer": expected_answer},
+        }
+
+
+def skill_usage_expectations(
+    skill: str,
+    downstream_tools: list[str],
+    skill_delivery: SkillDelivery,
+    *,
+    source: str = "posthog",
+    reference_paths: list[str] | None = None,
+    expected_answer: str | None = None,
+) -> dict[str, dict[str, object]]:
+    expectations = skill_distribution_expectations(skill, downstream_tools, skill_delivery, source=source)
+    if reference_paths:
+        expectations["expected_reference_pulled"] = {
+            "skill": skill,
+            "delivery": skill_delivery,
+            "source": source,
+            "paths": reference_paths,
+        }
+    if expected_answer:
+        expectations["skill_answer_correctness"] = {"expected_answer": expected_answer}
+    if skill_delivery == "exec":
+        expectations["search_recovery_after_zero_hit"] = {}
+    return expectations
+
+
+__all__ = [
+    "ExpectedReferencePulled",
+    "SearchRecoveryAfterZeroHit",
+    "SkillAnswerCorrectness",
+    "skill_usage_expectations",
+]

--- a/products/posthog_ai/evals/cli_mcp/skill_usage_seeder.py
+++ b/products/posthog_ai/evals/cli_mcp/skill_usage_seeder.py
@@ -1,0 +1,104 @@
+"""Seeder hook that installs a project-scoped skill into a per-case team.
+
+The skill-usage eval's ``project`` source arm needs a real ``project:`` skill the
+agent can discover, load, and pull a reference file from. This seeder writes one
+``LLMSkill`` (with a body that instructs applying an exclusion rule documented in a
+reference file) and its ``LLMSkillFile`` reference onto the per-case team, so the
+MCP ``learn`` command surfaces it under ``project:``.
+
+Runs synchronously in a worker thread (``asyncio.to_thread``) from ``base.py:task()``
+after the per-case team/user has been provisioned; the returned dict is merged into
+the task output under ``seed`` for scorers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from products.tasks.backend.facade.agents import CustomPromptSandboxContext
+
+__all__ = [
+    "PROJECT_SKILL_NAME",
+    "PROJECT_SKILL_DESCRIPTION",
+    "PROJECT_SKILL_REFERENCE_PATH",
+    "PROJECT_SKILL_PLAN",
+    "PROJECT_SKILL_EXCLUSION_FLOOR_USD",
+    "PROJECT_SKILL_RULE_LABEL",
+    "PROJECT_SKILL_BODY",
+    "PROJECT_SKILL_REFERENCE_CONTENT",
+    "PROJECT_SKILL_EXPECTED_ANSWER",
+    "seed_project_skill",
+]
+
+PROJECT_SKILL_NAME = "hedgebox-revenue-policy"
+PROJECT_SKILL_REFERENCE_PATH = "references/policy-details.md"
+PROJECT_SKILL_PLAN = "business/enterprise"
+PROJECT_SKILL_EXCLUSION_FLOOR_USD = 500
+PROJECT_SKILL_RULE_LABEL = "REV-7"
+
+PROJECT_SKILL_DESCRIPTION = (
+    "How Hedgebox defines qualified enterprise revenue for finance reporting. Qualified enterprise "
+    f"revenue counts only `paid_bill` events on the `{PROJECT_SKILL_PLAN}` plan, and rule "
+    f"{PROJECT_SKILL_RULE_LABEL} must be applied to drop pilot-tier bills before the figure is reported "
+    f"to finance. Read `{PROJECT_SKILL_REFERENCE_PATH}` for the exact exclusions before quoting a number."
+)
+
+PROJECT_SKILL_BODY = f"""# Hedgebox revenue policy
+
+Use this skill whenever finance asks for **qualified enterprise revenue**.
+
+## Definition
+
+Qualified enterprise revenue is the SUM of the `paid_bill` event's `amount_usd`
+property, filtered to bills on the `{PROJECT_SKILL_PLAN}` plan (the `plan` property
+equals `'{PROJECT_SKILL_PLAN}'`). Bills on any other plan do not count.
+
+## Before reporting
+
+Before reporting the number to finance, apply the exclusions documented in
+`{PROJECT_SKILL_REFERENCE_PATH}`. Quoting a total without applying those exclusions
+is incorrect. Read that reference file and state which rules you applied.
+"""
+
+PROJECT_SKILL_REFERENCE_CONTENT = f"""# Policy details
+
+## Rule {PROJECT_SKILL_RULE_LABEL}
+
+Exclude any individual `paid_bill` whose `amount_usd` is below
+${PROJECT_SKILL_EXCLUSION_FLOOR_USD} from qualified enterprise revenue. These are
+pilot-tier billing charges and must not be counted toward the figure reported to
+finance, even when they sit on the `{PROJECT_SKILL_PLAN}` plan.
+"""
+
+PROJECT_SKILL_EXPECTED_ANSWER = (
+    "Revenue was computed from the `paid_bill` event's `amount_usd` filtered to the "
+    f"`{PROJECT_SKILL_PLAN}` plan. Rule {PROJECT_SKILL_RULE_LABEL} was applied, excluding any individual "
+    f"paid_bill under ${PROJECT_SKILL_EXCLUSION_FLOOR_USD} (pilot-tier billing) from qualified revenue. "
+    "The answer reports a total USD figure."
+)
+
+
+def seed_project_skill(context: CustomPromptSandboxContext) -> dict[str, Any]:
+    """Create the project-scoped revenue-policy skill and its reference file for the case team."""
+    from products.skills.backend.models.skills import LLMSkill, LLMSkillFile, category_for_skill_name
+
+    skill = LLMSkill.objects.create(
+        team_id=context.team_id,
+        name=PROJECT_SKILL_NAME,
+        description=PROJECT_SKILL_DESCRIPTION,
+        body=PROJECT_SKILL_BODY,
+        category=category_for_skill_name(PROJECT_SKILL_NAME),
+        created_by_id=context.user_id,
+    )
+    LLMSkillFile.objects.create(
+        skill=skill,
+        path=PROJECT_SKILL_REFERENCE_PATH,
+        content=PROJECT_SKILL_REFERENCE_CONTENT,
+        content_type="text/markdown",
+    )
+    return {
+        "project_skill_id": str(skill.id),
+        "project_skill_name": PROJECT_SKILL_NAME,
+        "reference_path": PROJECT_SKILL_REFERENCE_PATH,
+    }


### PR DESCRIPTION
## Problem

`eval_skill_distribution` scores the discovery protocol (search first, load by qualified name, tool after load) but leaves two gaps: search quality is only evaluated indirectly, and pulling nested reference files isn't evaluated at all — an agent that ignores every `references/*.md` scores identically to one that follows them. None of the `learn` improvements on the base branch (stem-tolerant matching, cross-source relevance merge, zero-hit recovery, batch reads) had eval-level signal.

## Changes

New sandboxed suite `eval_skill_usage` (experiment `sandboxed-cli-mcp-skill-usage-cli`) with four cases and three new scorers, reusing the distribution scorers for the shared protocol checks:

- **`ExpectedReferencePulled`** — did the agent read one of the skill's reference files (exec: `learn <skill> <path>` incl. batch/`-s`/`--lines` forms; bundled: native file read of the mounted reference)? A bare skill load or all-qualified batch load doesn't count.
- **`SearchRecoveryAfterZeroHit`** — opportunistic: after a zero-hit `learn -s`, the next command must be another `learn`, not a product tool. Self-skips when no zero-hit occurred.
- **`SkillAnswerCorrectness`** — binary judge: the final message states every fact of an expected answer (paraphrase ok, numbers must match).

Cases: experiment bias thresholds that live only in `bias-and-skew.md`; error-tracking system-table query routed through the `querying-posthog-data` dispatcher; a paraphrased-vocabulary bot-traffic prompt exercising stem-tolerant search; and an exec-only case whose `setup` seeder plants an `LLMSkill` project skill (`project:hedgebox-revenue-policy` with a needle exclusion rule in a reference file) to cover cross-source merged search, `learn project:` loads, and project reference reads end to end.

Supporting changes:

- `skill_distribution_scorers.py` — expectations optionally carry `source: posthog|project` (default posthog, fully backward compatible).
- `eval_skill_distribution.py` — drive-by: removed the explicit `ExitCodeZero()`; the harness auto-adds it and rejects the duplicate with a `ValueError`, so the suite could not construct.
- `harness/services.py` — carries the `pnpm dev` launch fix, also submitted separately as #71583 against master; this copy falls away on rebase once that merges.

## How did you test this code?

- Unit: 62 scorer tests pass (`test_skill_usage_scorers.py` + extended `test_skill_distribution_scorers.py`). New tests catch: reference-pull grammar parsing (flag truncation, batch-load vs reference-read distinction, project source), zero-hit recovery ordering, and judge `_prepare` short-circuits — none covered before.
- Live smoke runs (docker provider):
  - `project_enterprise_revenue_policy` exec: reference pull, answer judge, load-before-tool all 1.0. **Found a real gap on the first run:** `expected_skill_discovered` is 0 because the backend `llm_skills/search/` matches the whole query string via `icontains`, so natural multi-word queries never return project skills and the cross-source merge gets nothing to merge. The agent recovered via `learn skills`. Known-red until that's fixed (MCP-side tokenized fallback over the memoized listing is the cheap option).
  - `bias_threshold_reference_pull` exec: the agent grepped the sandbox's PostHog checkout for the thresholds instead of running `learn -s` — a genuine triggering failure the suite is designed to expose (`skill_search_first` 0), since the exec instructions mandate skills-first.
  - `bias_threshold_reference_pull` bundled: 100% — native skill loaded, reference read, judge passed; also validates the bundled-arm reference matching.
  - Regression: `eval_skill_distribution --eval paid_bill_revenue_by_account_plan --skill-delivery exec` scores 100% after the `source` generalization and `ExitCodeZero` fix.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — evals are internal tooling; suite discovery and running are covered by the existing eval harness README conventions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Planned and built with Claude Code in the same session as the base branch. Skills invoked: /writing-evals, /writing-tests (plus /improving-drf-endpoints earlier in the session; no DRF changes here). Implementation was delegated to an Opus subagent against an approved plan; the orchestrating session independently re-ran tests, ruff, suite discovery, and all four live smoke runs, and reviewed every diff. Decisions: new suite instead of extending `eval_skill_distribution` (keeps its Braintrust history comparable); client-side `source` generalization instead of new scorer classes; the `expected_answer` for the bias case was recalibrated after the first smoke run (the seeded $multiple share is ~0.9%, not the ~2% flip probability). The two known-red scorers on the project case are deliberate: they document the backend search gap described above.