### PR TITLE
feat(data-warehouse): migrate 4 sources to rest_source (batch 9)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/chameleon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/chameleon.py
@@ -1,11 +1,7 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.chameleon.settings import (
@@ -13,7 +9,18 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.chameleon.
     ChameleonEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # Single base URL for every account — Chameleon has no per-account hostname.
 CHAMELEON_BASE_URL = "https://api.chameleon.io/v3"
@@ -21,53 +28,43 @@ CHAMELEON_BASE_URL = "https://api.chameleon.io/v3"
 CHAMELEON_ROOT_URL = "https://api.chameleon.io"
 
 
-class ChameleonRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class ChameleonResumeConfig:
     # Cursor for the next page: the `cursor.before` id from the previous response. None starts at page one.
     before: str | None = None
-    # The Microsurvey currently being paged through, for the `responses` fan-out. A stable survey-id
-    # bookmark (not a positional index) so surveys added/removed between a crash and the retry can't
-    # resume us into the wrong survey. None for the standard (non-fan-out) endpoints.
+    # Pre-framework fan-out bookmark (the Microsurvey being paged through). Kept with a default so
+    # previously saved state still parses; no longer written — fan-out resume lives in fanout_state.
     survey_id: str | None = None
+    # Framework fan-out resume state for the responses endpoint:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: dict | None = None
 
 
-def _get_headers(account_secret: str) -> dict[str, str]:
-    return {"X-Account-Secret": account_secret, "Accept": "application/json"}
+class ChameleonBeforeCursorPaginator(JSONResponseCursorPaginator):
+    """Chameleon returns records newest-first and paginates with a `cursor.before` id pointing at the
+    oldest record on the page; the next page is fetched with `before=<that id>`. Pagination stops once
+    a page is empty, the cursor is exhausted, or the cursor fails to advance (a defensive guard against
+    an unexpected repeated cursor wedging the sync in an infinite loop).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(cursor_path="cursor.before", cursor_param="before")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        previous = self._cursor_value
+        super().update_state(response, data)
+        if not data or (self._cursor_value is not None and self._cursor_value == previous):
+            self._has_next_page = False
 
 
-def _build_url(base_url: str, params: dict[str, Any]) -> str:
-    if not params:
-        return base_url
-    return f"{base_url}?{urlencode(params)}"
-
-
-@retry(
-    retry=retry_if_exception_type((ChameleonRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=60)
-
-    # 429 (rate limited) and 5xx are transient — retry. Chameleon returns rate-limit wait hints in
-    # X-Retry-After / X-Ratelimit-Wait headers; the exponential backoff below covers them conservatively.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ChameleonRetryableError(f"Chameleon API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # 404 is expected and handled during the responses fan-out (a survey deleted mid-sync).
-        log = logger.warning if response.status_code == 404 else logger.error
-        log(f"Chameleon API error: status={response.status_code}, body={response.text[:200]!r}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+def _client_config(account_secret: str) -> ClientConfig:
+    # The account secret rides in a custom `X-Account-Secret` header the name-based scrubbers don't
+    # recognise — framework api_key auth registers it for value-based redaction.
+    return {
+        "base_url": CHAMELEON_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "api_key", "api_key": account_secret, "name": "X-Account-Secret", "location": "header"},
+    }
 
 
 def validate_credentials(account_secret: str) -> tuple[bool, str | None]:
@@ -76,183 +73,168 @@ def validate_credentials(account_secret: str) -> tuple[bool, str | None]:
     # unexpected statuses (429, 5xx) are inconclusive: reporting them as an invalid secret would push
     # users to needlessly rotate a working credential, so they get a generic retry message instead.
     # `redact_values` masks the secret from any captured sample.
-    try:
-        response = make_tracked_session(redact_values=(account_secret,)).get(
-            CHAMELEON_ROOT_URL, headers=_get_headers(account_secret), timeout=10
-        )
-    except requests.RequestException:
-        return False, "Could not reach Chameleon to validate the account secret. Please try again."
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(account_secret,)),
+        CHAMELEON_ROOT_URL,
+        headers={"X-Account-Secret": account_secret, "Accept": "application/json"},
+    )
+    if ok:
         return True, None
-    if response.status_code in (401, 403):
+    if status in (401, 403):
         return False, "Invalid Chameleon account secret"
+    if status is None:
+        return False, "Could not reach Chameleon to validate the account secret. Please try again."
     return (
         False,
-        f"Chameleon could not validate the account secret right now (status {response.status_code}). Please try again.",
+        f"Chameleon could not validate the account secret right now (status {status}). Please try again.",
     )
 
 
-def _iter_pages(
-    session: requests.Session,
-    url: str,
-    data_key: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    base_params: dict[str, Any],
-    start_before: str | None,
-) -> Iterator[tuple[list[dict[str, Any]], str | None]]:
-    """Page a Chameleon list endpoint, yielding (rows, next_before) per page.
+def _standard_resource(
+    account_secret: str,
+    config: ChameleonEndpointConfig,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[ChameleonResumeConfig],
+) -> Resource:
+    # A body without the data key yields a zero-row page and pagination stops — the same tolerant
+    # behavior Chameleon's empty envelopes get.
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(account_secret),
+        "resources": [
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": config.page_size},
+                    "paginator": ChameleonBeforeCursorPaginator(),
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
 
-    Chameleon returns records newest-first and paginates with a `cursor.before` id pointing at the
-    oldest record on the page; the next page is fetched with `before=<that id>`. Pagination stops once
-    a page is empty, the cursor is exhausted, or the cursor fails to advance (a defensive guard against
-    an unexpected repeated cursor wedging the sync in an infinite loop).
-    """
-    before = start_before
-    while True:
-        params = dict(base_params)
-        if before:
-            params["before"] = before
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None and resume.before:
+            initial_paginator_state = {"cursor": resume.before}
 
-        data = _fetch_page(session, _build_url(url, params), headers, logger)
-        rows = data.get(data_key, [])
-        next_before = (data.get("cursor") or {}).get("before")
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint is saved AFTER a page is yielded so a
+        # crash re-fetches the in-flight page (the merge dedupes re-pulled rows) rather than skipping it.
+        if state and state.get("cursor"):
+            manager.save_state(ChameleonResumeConfig(before=state["cursor"]))
 
-        yield rows, next_before
-
-        if not rows or not next_before or next_before == before:
-            break
-        before = next_before
-
-
-def _iter_survey_ids(session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger) -> Iterator[str]:
-    config = CHAMELEON_ENDPOINTS["surveys"]
-    for rows, _ in _iter_pages(
-        session,
-        f"{CHAMELEON_BASE_URL}{config.path}",
-        config.data_key,
-        headers,
-        logger,
-        {"limit": config.page_size},
-        start_before=None,
-    ):
-        for survey in rows:
-            yield survey["id"]
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
 
-def _get_response_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ChameleonResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
+def _stamp_survey_id(row: dict[str, Any]) -> dict[str, Any]:
+    # include_from_parent lands the parent Microsurvey id as `_surveys_id`; rename it to the plain
+    # `survey_id` column responses rows carry.
+    value = row.pop("_surveys_id", None)
+    if value is not None:
+        row["survey_id"] = value
+    return row
+
+
+def _responses_resource(
+    account_secret: str,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[ChameleonResumeConfig],
+) -> Resource:
     """Fan out over every Microsurvey, listing its responses and stamping the parent `survey_id`.
 
     /analyze/responses requires an `id` (the Microsurvey id), so responses can only be pulled per
     survey. Full refresh — re-pulled rows on resume are deduped by the `id` primary key on merge.
     """
-    config = CHAMELEON_ENDPOINTS["responses"]
-    survey_ids = list(_iter_survey_ids(session, headers, logger))
+    surveys_config = CHAMELEON_ENDPOINTS["surveys"]
+    responses_config = CHAMELEON_ENDPOINTS["responses"]
 
-    # Resolve the saved survey-id bookmark to the slice of surveys still to process. If the bookmarked
-    # survey no longer exists (deleted between runs), start over from the first survey — merge dedupes
-    # the re-pulled rows on the primary key. `resume_before` is consumed by the first survey only.
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    remaining = survey_ids
-    resume_before: str | None = None
-    if resume is not None and resume.survey_id is not None and resume.survey_id in survey_ids:
-        remaining = survey_ids[survey_ids.index(resume.survey_id) :]
-        resume_before = resume.before
-        logger.debug(f"Chameleon: resuming responses from survey_id={resume.survey_id}, before={resume_before}")
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(account_secret),
+        "resources": [
+            {
+                "name": "surveys",
+                "endpoint": {
+                    "path": surveys_config.path,
+                    "params": {"limit": surveys_config.page_size},
+                    "paginator": ChameleonBeforeCursorPaginator(),
+                    "data_selector": surveys_config.data_key,
+                },
+            },
+            {
+                "name": "responses",
+                "endpoint": {
+                    # The survey id is a required QUERY param; the framework binds resolve params via
+                    # path templating, so the query string rides in the path (requests merges the
+                    # remaining params into it).
+                    "path": f"{responses_config.path}?id={{id}}",
+                    "params": {
+                        "id": {"type": "resolve", "resource": "surveys", "field": "id"},
+                        "limit": responses_config.page_size,
+                    },
+                    "paginator": ChameleonBeforeCursorPaginator(),
+                    "data_selector": responses_config.data_key,
+                    # A survey deleted between enumeration and this fetch 404s. Skip it rather than
+                    # failing the whole sync — the responses are genuinely gone.
+                    "response_actions": [{"status_code": 404, "action": "ignore"}],
+                },
+                "include_from_parent": ["id"],
+                "data_map": _stamp_survey_id,
+            },
+        ],
+    }
 
-    for index, survey_id in enumerate(remaining):
-        start_before = resume_before
-        resume_before = None  # only the resumed-into survey uses the saved cursor; the rest start fresh
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        # Only framework-shaped fan-out state is resumable. A pre-migration bookmark (survey_id +
+        # before) can't be translated into the completed/current path map, so such a sync restarts
+        # fresh — safe, because the merge dedupes re-pulled rows on the primary key.
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
 
-        try:
-            for rows, next_before in _iter_pages(
-                session,
-                f"{CHAMELEON_BASE_URL}{config.path}",
-                config.data_key,
-                headers,
-                logger,
-                {"id": survey_id, "limit": config.page_size},
-                start_before,
-            ):
-                if rows:
-                    yield [{**row, "survey_id": survey_id} for row in rows]
-                    # Save AFTER yielding (and only when more pages remain) so a crash re-yields the
-                    # last page rather than skipping it — merge dedupes on the primary key.
-                    if next_before:
-                        resumable_source_manager.save_state(
-                            ChameleonResumeConfig(before=next_before, survey_id=survey_id)
-                        )
-        except requests.HTTPError as exc:
-            # A survey deleted between enumeration and this fetch 404s. Skip it rather than failing the
-            # whole sync — the responses are genuinely gone. Any other HTTP error is re-raised.
-            if exc.response is not None and exc.response.status_code == 404:
-                logger.warning(f"Chameleon: survey {survey_id} not found while fetching responses, skipping")
-            else:
-                raise
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state:
+            manager.save_state(ChameleonResumeConfig(fanout_state=state))
 
-        # Advance the bookmark to the next survey so a crash between surveys resumes correctly.
-        if index + 1 < len(remaining):
-            resumable_source_manager.save_state(ChameleonResumeConfig(before=None, survey_id=remaining[index + 1]))
-
-
-def get_rows(
-    account_secret: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ChameleonResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = CHAMELEON_ENDPOINTS[endpoint]
-    headers = _get_headers(account_secret)
-    # One session reused across every page (and, for fan-out, every survey) so urllib3 keeps the
-    # connection alive instead of re-handshaking per request. The account secret rides in a custom
-    # `X-Account-Secret` header the name-based scrubbers don't recognise, so redact it explicitly.
-    session = make_tracked_session(redact_values=(account_secret,))
-
-    if config.fan_out_over_surveys:
-        yield from _get_response_rows(session, headers, logger, resumable_source_manager)
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_before = resume.before if resume is not None else None
-    if start_before:
-        logger.debug(f"Chameleon: resuming {endpoint} from before={start_before}")
-
-    for rows, next_before in _iter_pages(
-        session,
-        f"{CHAMELEON_BASE_URL}{config.path}",
-        config.data_key,
-        headers,
-        logger,
-        {"limit": config.page_size},
-        start_before,
-    ):
-        if rows:
-            yield rows
-            if next_before:
-                resumable_source_manager.save_state(ChameleonResumeConfig(before=next_before))
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(r for r in resources if r.name == "responses")
 
 
 def chameleon_source(
     account_secret: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ChameleonResumeConfig],
 ) -> SourceResponse:
     endpoint_config: ChameleonEndpointConfig = CHAMELEON_ENDPOINTS[endpoint]
 
+    if endpoint_config.fan_out_over_surveys:
+        resource = _responses_resource(account_secret, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _standard_resource(account_secret, endpoint_config, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            account_secret=account_secret,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=endpoint_config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -261,4 +243,5 @@ def chameleon_source(
         partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
         # Chameleon returns records most-recently-created first.
         sort_mode="desc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ChameleonSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -92,30 +95,18 @@ You can generate an account-specific API secret in your [Chameleon account setti
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _description(endpoint: str) -> str | None:
-            if endpoint == "responses":
-                return "Microsurvey responses, fanned out across every Microsurvey. Full refresh only"
-            return None
-
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = CHAMELEON_ENDPOINTS[endpoint]
-            # Chameleon's only server-side time filter (`after`) keys on creation time, so it can't catch
-            # updates to existing records. We ship every endpoint as full refresh until incremental
-            # semantics are verified against a live account.
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-                should_sync_default=endpoint_config.should_sync_default,
-                description=_description(endpoint),
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Chameleon's only server-side time filter (`after`) keys on creation time, so it can't catch
+        # updates to existing records. We ship every endpoint as full refresh (no incremental fields)
+        # until incremental semantics are verified against a live account.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            {},
+            names,
+            descriptions={"responses": "Microsurvey responses, fanned out across every Microsurvey. Full refresh only"},
+            should_sync_default={
+                endpoint: config.should_sync_default for endpoint, config in CHAMELEON_ENDPOINTS.items()
+            },
+        )
 
     def validate_credentials(
         self, config: ChameleonSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -134,6 +125,7 @@ You can generate an account-specific API secret in your [Chameleon account setti
         return chameleon_source(
             account_secret=config.account_secret,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/tests/test_chameleon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/tests/test_chameleon.py
@@ -1,74 +1,69 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.chameleon import chameleon
 from products.warehouse_sources.backend.temporal.data_imports.sources.chameleon.chameleon import (
     ChameleonResumeConfig,
-    _build_url,
     chameleon_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.chameleon.settings import CHAMELEON_ENDPOINTS
 
-
-class _FakeResumableManager:
-    def __init__(self, state: ChameleonResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[ChameleonResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> ChameleonResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: ChameleonResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the chameleon module.
+CHAMELEON_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.chameleon.chameleon.make_tracked_session"
+)
 
 
-def _response_with_status(status_code: int) -> requests.Response:
-    response = requests.Response()
-    response.status_code = status_code
-    return response
+def _response(body: dict[str, Any], status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _collect(
-    manager: _FakeResumableManager, monkeypatch: Any, pages: dict[str, Any], endpoint: str = "responses"
-) -> list[dict]:
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-        result = pages[url]
-        if isinstance(result, Exception):
-            raise result
-        return result
+def _make_manager(resume_state: ChameleonResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    monkeypatch.setattr(chameleon, "_fetch_page", fake_fetch)
 
-    rows: list[dict] = []
-    for batch in get_rows(
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's url/params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(endpoint: str, manager: mock.MagicMock) -> list[dict[str, Any]]:
+    source_response = chameleon_source(
         account_secret="secret",
         endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        rows.extend(batch)
-    return rows
-
-
-class TestBuildUrl:
-    def test_no_params_returns_base(self) -> None:
-        assert (
-            _build_url("https://api.chameleon.io/v3/edit/segments", {}) == "https://api.chameleon.io/v3/edit/segments"
-        )
-
-    def test_encodes_params(self) -> None:
-        url = _build_url("https://api.chameleon.io/v3/analyze/responses", {"id": "S1", "limit": 500})
-        assert url == "https://api.chameleon.io/v3/analyze/responses?id=S1&limit=500"
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+    return [row for page in source_response.items() for row in page]
 
 
 class TestValidateCredentials:
@@ -84,9 +79,9 @@ class TestValidateCredentials:
     def test_status_maps_to_result(
         self, _name: str, status_code: int, expected_ok: bool, expected_fragment: str | None
     ) -> None:
-        with patch.object(chameleon, "make_tracked_session") as make_session:
-            session = MagicMock()
-            session.get.return_value = MagicMock(status_code=status_code)
+        with mock.patch(CHAMELEON_SESSION_PATCH) as make_session:
+            session = mock.MagicMock()
+            session.get.return_value = mock.MagicMock(status_code=status_code)
             make_session.return_value = session
             ok, error = validate_credentials("secret")
             assert ok is expected_ok
@@ -96,132 +91,273 @@ class TestValidateCredentials:
                 assert error is not None and expected_fragment in error
 
     def test_network_error_is_inconclusive(self) -> None:
-        with patch.object(chameleon, "make_tracked_session") as make_session:
-            session = MagicMock()
+        with mock.patch(CHAMELEON_SESSION_PATCH) as make_session:
+            session = mock.MagicMock()
             session.get.side_effect = requests.ConnectionError("boom")
             make_session.return_value = session
             ok, error = validate_credentials("secret")
             assert ok is False
             assert error is not None and "Could not reach Chameleon" in error
 
+    def test_probe_sends_the_account_secret_header(self) -> None:
+        with mock.patch(CHAMELEON_SESSION_PATCH) as make_session:
+            session = mock.MagicMock()
+            session.get.return_value = mock.MagicMock(status_code=200)
+            make_session.return_value = session
+            validate_credentials("secret")
+            headers = session.get.call_args.kwargs["headers"]
+            assert headers["X-Account-Secret"] == "secret"
+
 
 class TestStandardEndpointPagination:
-    def test_follows_before_cursor_until_exhausted(self, monkeypatch: Any) -> None:
-        base = "https://api.chameleon.io/v3/edit/segments?limit=500"
-        page2 = "https://api.chameleon.io/v3/edit/segments?limit=500&before=S2"
-        pages = {
-            base: {"segments": [{"id": "S1"}, {"id": "S2"}], "cursor": {"limit": 500, "before": "S2"}},
-            page2: {"segments": [{"id": "S3"}], "cursor": {"limit": 500, "before": "S3"}},
-            "https://api.chameleon.io/v3/edit/segments?limit=500&before=S3": {"segments": [], "cursor": {}},
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, "segments")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_before_cursor_until_exhausted(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response({"segments": [{"id": "S1"}, {"id": "S2"}], "cursor": {"limit": 500, "before": "S2"}}),
+                _response({"segments": [{"id": "S3"}], "cursor": {"limit": 500, "before": "S3"}}),
+                _response({"segments": [], "cursor": {}}),
+            ],
+        )
+
+        rows = _rows("segments", _make_manager())
+
         assert [r["id"] for r in rows] == ["S1", "S2", "S3"]
+        assert [s["url"] for s in snapshots] == ["https://api.chameleon.io/v3/edit/segments"] * 3
+        assert "before" not in snapshots[0]["params"]
+        assert snapshots[0]["params"]["limit"] == 500
+        assert snapshots[1]["params"]["before"] == "S2"
+        assert snapshots[2]["params"]["before"] == "S3"
 
-    def test_stops_when_cursor_missing(self, monkeypatch: Any) -> None:
-        base = "https://api.chameleon.io/v3/edit/tours?limit=500"
-        pages = {base: {"tours": [{"id": "T1"}], "cursor": {}}}
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, "tours")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_cursor_missing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"tours": [{"id": "T1"}], "cursor": {}})])
+
+        rows = _rows("tours", _make_manager())
+
         assert [r["id"] for r in rows] == ["T1"]
+        assert session.send.call_count == 1
 
-    def test_saves_resume_state_after_each_page_with_more_to_come(self, monkeypatch: Any) -> None:
-        base = "https://api.chameleon.io/v3/edit/segments?limit=500"
-        page2 = "https://api.chameleon.io/v3/edit/segments?limit=500&before=S2"
-        pages = {
-            base: {"segments": [{"id": "S1"}, {"id": "S2"}], "cursor": {"before": "S2"}},
-            page2: {"segments": [{"id": "S3"}], "cursor": {}},
-        }
-        manager = _FakeResumableManager()
-        _collect(manager, monkeypatch, pages, "segments")
-        # Only the first page has a `next_before`, so exactly one checkpoint is saved, pointing at it.
-        assert manager.saved == [ChameleonResumeConfig(before="S2")]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_cursor_fails_to_advance(self, MockSession: mock.MagicMock) -> None:
+        # A repeated cursor must terminate the sync instead of wedging it in an infinite loop.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"tours": [{"id": "T1"}], "cursor": {"before": "T1"}}),
+                _response({"tours": [{"id": "T1"}], "cursor": {"before": "T1"}}),
+            ],
+        )
 
-    def test_resumes_from_saved_before(self, monkeypatch: Any) -> None:
+        rows = _rows("tours", _make_manager())
+
+        assert [r["id"] for r in rows] == ["T1", "T1"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_is_an_empty_page(self, MockSession: mock.MagicMock) -> None:
+        # Chameleon envelopes are tolerated when the data key is absent — zero rows, no crash.
+        session = MockSession.return_value
+        _wire(session, [_response({"cursor": {}})])
+
+        assert _rows("tours", _make_manager()) == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_resume_state_after_each_page_with_more_to_come(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"segments": [{"id": "S1"}, {"id": "S2"}], "cursor": {"before": "S2"}}),
+                _response({"segments": [{"id": "S3"}], "cursor": {}}),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows("segments", manager)
+
+        # Only the first page has a next cursor, so exactly one checkpoint is saved, pointing at it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == ChameleonResumeConfig(before="S2")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_before(self, MockSession: mock.MagicMock) -> None:
         # When state exists, the first request must start from the saved cursor, not page one.
-        resume_url = "https://api.chameleon.io/v3/edit/segments?limit=500&before=S2"
-        pages = {resume_url: {"segments": [{"id": "S3"}], "cursor": {}}}
-        manager = _FakeResumableManager(ChameleonResumeConfig(before="S2"))
-        rows = _collect(manager, monkeypatch, pages, "segments")
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"segments": [{"id": "S3"}], "cursor": {}})])
+
+        rows = _rows("segments", _make_manager(ChameleonResumeConfig(before="S2")))
+
         assert [r["id"] for r in rows] == ["S3"]
+        assert snapshots[0]["params"]["before"] == "S2"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_secret_travels_via_framework_auth(self, MockSession: mock.MagicMock) -> None:
+        # Framework api_key auth (not a hand-built header) so the secret is value-redacted from logs.
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"tours": [{"id": "T1"}], "cursor": {}})])
+
+        _rows("tours", _make_manager())
+
+        auth = snapshots[0]["auth"]
+        assert auth.api_key == "secret"
+        assert auth.name == "X-Account-Secret"
+        assert auth.location == "header"
+        assert session.headers.get("Accept") == "application/json"
 
 
 class TestResponsesFanOut:
-    def test_fans_out_over_surveys_and_stamps_survey_id(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.chameleon.io/v3/edit/surveys?limit=500": {
-                "surveys": [{"id": "SV1"}, {"id": "SV2"}],
-                "cursor": {},
-            },
-            "https://api.chameleon.io/v3/analyze/responses?id=SV1&limit=500": {
-                "responses": [{"id": "R1"}, {"id": "R2"}],
-                "cursor": {},
-            },
-            "https://api.chameleon.io/v3/analyze/responses?id=SV2&limit=500": {
-                "responses": [{"id": "R3"}],
-                "cursor": {},
-            },
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_over_surveys_and_stamps_survey_id(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response({"surveys": [{"id": "SV1"}, {"id": "SV2"}], "cursor": {}}),
+                _response({"responses": [{"id": "R1"}, {"id": "R2"}], "cursor": {}}),
+                _response({"responses": [{"id": "R3"}], "cursor": {}}),
+            ],
+        )
+
+        rows = _rows("responses", _make_manager())
+
         assert rows == [
             {"id": "R1", "survey_id": "SV1"},
             {"id": "R2", "survey_id": "SV1"},
             {"id": "R3", "survey_id": "SV2"},
         ]
+        assert [s["url"] for s in snapshots] == [
+            "https://api.chameleon.io/v3/edit/surveys",
+            "https://api.chameleon.io/v3/analyze/responses?id=SV1",
+            "https://api.chameleon.io/v3/analyze/responses?id=SV2",
+        ]
 
-    def test_paginates_within_a_survey(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.chameleon.io/v3/edit/surveys?limit=500": {"surveys": [{"id": "SV1"}], "cursor": {}},
-            "https://api.chameleon.io/v3/analyze/responses?id=SV1&limit=500": {
-                "responses": [{"id": "R1"}],
-                "cursor": {"before": "R1"},
-            },
-            "https://api.chameleon.io/v3/analyze/responses?id=SV1&limit=500&before=R1": {
-                "responses": [{"id": "R2"}],
-                "cursor": {},
-            },
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_within_a_survey(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response({"surveys": [{"id": "SV1"}], "cursor": {}}),
+                _response({"responses": [{"id": "R1"}], "cursor": {"before": "R1"}}),
+                _response({"responses": [{"id": "R2"}], "cursor": {}}),
+            ],
+        )
+
+        rows = _rows("responses", _make_manager())
+
+        assert [r["id"] for r in rows] == ["R1", "R2"]
+        assert "before" not in snapshots[1]["params"]
+        assert snapshots[2]["params"]["before"] == "R1"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_survey_deleted_mid_fan_out_is_skipped(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"surveys": [{"id": "SV1"}, {"id": "GONE"}, {"id": "SV2"}], "cursor": {}}),
+                _response({"responses": [{"id": "R1"}], "cursor": {}}),
+                _response({"error": "not found"}, status=404),
+                _response({"responses": [{"id": "R2"}], "cursor": {}}),
+            ],
+        )
+
+        rows = _rows("responses", _make_manager())
+
         assert [r["id"] for r in rows] == ["R1", "R2"]
 
-    def test_survey_deleted_mid_fan_out_is_skipped(self, monkeypatch: Any) -> None:
-        not_found = requests.HTTPError(response=_response_with_status(404))
-        pages = {
-            "https://api.chameleon.io/v3/edit/surveys?limit=500": {
-                "surveys": [{"id": "SV1"}, {"id": "GONE"}, {"id": "SV2"}],
-                "cursor": {},
-            },
-            "https://api.chameleon.io/v3/analyze/responses?id=SV1&limit=500": {
-                "responses": [{"id": "R1"}],
-                "cursor": {},
-            },
-            "https://api.chameleon.io/v3/analyze/responses?id=GONE&limit=500": not_found,
-            "https://api.chameleon.io/v3/analyze/responses?id=SV2&limit=500": {
-                "responses": [{"id": "R2"}],
-                "cursor": {},
-            },
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages)
-        assert [r["id"] for r in rows] == ["R1", "R2"]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_404_http_error_propagates(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"surveys": [{"id": "SV1"}], "cursor": {}}),
+                _response({"error": "forbidden"}, status=403),
+            ],
+        )
 
-    def test_non_404_http_error_propagates(self, monkeypatch: Any) -> None:
-        server_error = requests.HTTPError(response=_response_with_status(500))
-        pages = {
-            "https://api.chameleon.io/v3/edit/surveys?limit=500": {"surveys": [{"id": "SV1"}], "cursor": {}},
-            "https://api.chameleon.io/v3/analyze/responses?id=SV1&limit=500": server_error,
-        }
         with pytest.raises(requests.HTTPError):
-            _collect(_FakeResumableManager(), monkeypatch, pages)
+            _rows("responses", _make_manager())
 
-    def test_resume_from_deleted_survey_restarts_from_first(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.chameleon.io/v3/edit/surveys?limit=500": {"surveys": [{"id": "SV1"}], "cursor": {}},
-            "https://api.chameleon.io/v3/analyze/responses?id=SV1&limit=500": {
-                "responses": [{"id": "R1"}],
-                "cursor": {},
-            },
-        }
-        manager = _FakeResumableManager(ChameleonResumeConfig(before=None, survey_id="DELETED"))
-        rows = _collect(manager, monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_fan_out_progress(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"surveys": [{"id": "SV1"}], "cursor": {}}),
+                _response({"responses": [{"id": "R1"}], "cursor": {"before": "R1"}}),
+                _response({"responses": [{"id": "R2"}], "cursor": {}}),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows("responses", manager)
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        # Mid-survey: the in-progress survey path and its cursor are checkpointed so a crash
+        # resumes into the same survey at the saved page.
+        assert saved[0] == ChameleonResumeConfig(
+            fanout_state={"completed": [], "current": "/analyze/responses?id=SV1", "child_state": {"cursor": "R1"}}
+        )
+        # Survey finished: it lands in `completed` so a restart skips it.
+        assert saved[-1] == ChameleonResumeConfig(
+            fanout_state={"completed": ["/analyze/responses?id=SV1"], "current": None, "child_state": None}
+        )
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_by_skipping_completed_surveys(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response({"surveys": [{"id": "SV1"}, {"id": "SV2"}], "cursor": {}}),
+                _response({"responses": [{"id": "R2"}], "cursor": {}}),
+            ],
+        )
+
+        manager = _make_manager(
+            ChameleonResumeConfig(
+                fanout_state={"completed": ["/analyze/responses?id=SV1"], "current": None, "child_state": None}
+            )
+        )
+        rows = _rows("responses", manager)
+
+        assert rows == [{"id": "R2", "survey_id": "SV2"}]
+        assert snapshots[1]["url"] == "https://api.chameleon.io/v3/analyze/responses?id=SV2"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pre_migration_bookmark_restarts_fan_out_fresh(self, MockSession: mock.MagicMock) -> None:
+        # An old-shape bookmark (survey_id + before) can't seed the framework fan-out state — the
+        # sync restarts from the first survey and the merge dedupes re-pulled rows.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"surveys": [{"id": "SV1"}], "cursor": {}}),
+                _response({"responses": [{"id": "R1"}], "cursor": {}}),
+            ],
+        )
+
+        manager = _make_manager(ChameleonResumeConfig(before="R9", survey_id="DELETED"))
+        rows = _rows("responses", manager)
+
         assert [r["id"] for r in rows] == ["R1"]
+
+
+class TestResumeStateCompatibility:
+    def test_pre_migration_saved_state_still_parses(self) -> None:
+        # ResumableSourceManager._load_json does `dataclass(**saved)` — state saved before the
+        # framework migration must still construct.
+        assert ChameleonResumeConfig(**{"before": "S2", "survey_id": "SV1"}) == ChameleonResumeConfig(
+            before="S2", survey_id="SV1"
+        )
 
 
 class TestChameleonSourceResponse:
@@ -230,8 +366,9 @@ class TestChameleonSourceResponse:
         response = chameleon_source(
             account_secret="secret",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
         )
         assert response.name == endpoint
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/tests/test_chameleon_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chameleon/tests/test_chameleon_source.py
@@ -114,13 +114,16 @@ class TestChameleonPipelineWiring:
     def test_source_for_pipeline_passes_secret_and_schema_through(self) -> None:
         inputs = MagicMock()
         inputs.schema_name = "profiles"
+        inputs.team_id = 1
+        inputs.job_id = "job-1"
         manager = MagicMock()
         with patch.object(source_module, "chameleon_source") as chameleon_source_mock:
             self.source.source_for_pipeline(_config("my-secret"), manager, inputs)
         chameleon_source_mock.assert_called_once_with(
             account_secret="my-secret",
             endpoint="profiles",
-            logger=inputs.logger,
+            team_id=1,
+            job_id="job-1",
             resumable_source_manager=manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/chargedesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/chargedesk.py
@@ -2,27 +2,25 @@ import dataclasses
 from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
+from requests import Request, Response
+from requests.auth import HTTPBasicAuth
 from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk.settings import (
     CHARGEDESK_ENDPOINTS,
     ChargedeskEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CHARGEDESK_BASE_URL = "https://api.chargedesk.com/v1"
-
-# ChargeDesk doesn't document rate limits, so retry transient failures with capped exponential backoff.
-MAX_ATTEMPTS = 5
-
-
-class ChargedeskRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -38,160 +36,193 @@ class ChargedeskResumeConfig:
     phase: str = "full"
 
 
-def _auth(api_key: str) -> tuple[str, str]:
-    # HTTP Basic with the secret key as the username and an empty password.
-    return (api_key, "")
+class ChargedeskOffsetWindowPaginator(BasePaginator):
+    """Offset pagination within a ``[max]``-bounded time window.
 
-
-@retry(
-    retry=retry_if_exception_type((ChargedeskRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    auth: tuple[str, str],
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict:
-    response = session.get(url, auth=auth, params=params, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ChargedeskRetryableError(f"ChargeDesk API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"ChargeDesk API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _iter_pages(
-    session: requests.Session,
-    auth: tuple[str, str],
-    cfg: ChargedeskEndpointConfig,
-    logger: FilteringBoundLogger,
-    *,
-    min_value: int | None,
-    start_offset: int,
-    start_window_max: int | None,
-) -> Iterator[tuple[list[dict], tuple[int, int | None] | None]]:
-    """Page through a ChargeDesk list endpoint by offset.
-
-    Yields ``(page_items, resume_state)`` where ``resume_state`` is the ``(offset, window_max)`` to resume
-    from to fetch the *next* page, or ``None`` when this is the terminal page. Results come back newest
-    first, so once the offset nears the API's hard cap we reset it to 0 and pin ``[max]`` to the oldest row
-    we just saw (the boundary row is re-fetched and deduped on the primary key by the merge).
+    ChargeDesk list endpoints return rows newest first and reject an ``offset`` past a per-endpoint
+    cap. When the next page would step past the cap we reset the offset to 0 and pin
+    ``<filter>[max]`` to the oldest timestamp seen so far, as the docs recommend (the boundary row
+    is re-fetched and deduped on the primary key by the merge). A short page (fewer rows than
+    requested) means there's nothing after it in this window.
     """
-    url = f"{CHARGEDESK_BASE_URL}{cfg.path}"
-    offset = start_offset
-    window_max = start_window_max
 
-    while True:
-        params: dict[str, Any] = {"count": cfg.page_size, "offset": offset}
-        if min_value is not None:
-            params[f"{cfg.filter_param}[min]"] = min_value
-        if window_max is not None:
-            params[f"{cfg.filter_param}[max]"] = window_max
+    def __init__(
+        self,
+        cfg: ChargedeskEndpointConfig,
+        logger: Optional[FilteringBoundLogger] = None,
+        offset: int = 0,
+        window_max: int | None = None,
+    ) -> None:
+        super().__init__()
+        self._cfg = cfg
+        self._logger = logger
+        self.offset = offset
+        self.window_max = window_max
 
-        data = _fetch_page(session, url, auth, params, logger)
-        items = data.get("data", [])
+    def __deepcopy__(self, memo: dict[int, Any]) -> "ChargedeskOffsetWindowPaginator":
+        # RESTClient deep-copies the paginator per paginate() call; share the logger (structlog
+        # loggers may hold uncopyable handles) and copy only the pagination state.
+        clone = ChargedeskOffsetWindowPaginator(
+            self._cfg, logger=self._logger, offset=self.offset, window_max=self.window_max
+        )
+        clone._has_next_page = self._has_next_page
+        return clone
+
+    def _warn(self, message: str) -> None:
+        if self._logger is not None:
+            self._logger.warning(message)
+
+    def _inject(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["count"] = self._cfg.page_size
+        request.params["offset"] = self.offset
+        if self.window_max is not None:
+            request.params[f"{self._cfg.filter_param}[max]"] = self.window_max
+
+    def init_request(self, request: Request) -> None:
+        self._inject(request)
+
+    def update_request(self, request: Request) -> None:
+        self._inject(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
 
         # A short page (fewer rows than requested) means there's nothing after it in this window.
-        if len(items) < cfg.page_size:
-            yield items, None
+        if len(items) < self._cfg.page_size:
+            self._has_next_page = False
             return
 
-        next_offset = offset + cfg.page_size
-        next_window_max = window_max
+        next_offset = self.offset + self._cfg.page_size
 
-        if next_offset + cfg.page_size > cfg.max_offset:
+        if next_offset + self._cfg.page_size > self._cfg.max_offset:
+            cfg = self._cfg
             oldest_ts = items[-1].get(cfg.timestamp_field)
             if not isinstance(oldest_ts, int):
                 # Can't shift the window without a timestamp to anchor it, and stepping past the cap would
                 # 400. Surface it rather than silently dropping the tail.
-                logger.warning(
+                self._warn(
                     f"ChargeDesk: {cfg.name} hit the offset cap ({cfg.max_offset}) but the last row has no "
                     f"usable '{cfg.timestamp_field}' to continue from; stopping pagination for this window."
                 )
-                yield items, None
+                self._has_next_page = False
                 return
-            if oldest_ts == window_max:
+            if oldest_ts == self.window_max:
                 # The whole offset window collapsed onto a single timestamp: more than `max_offset` rows
                 # share `oldest_ts`, so re-pinning `[max]` to the same value would re-fetch this exact page
                 # forever (offset can't advance past the cap). Surface it and stop rather than spin until
                 # Temporal kills the activity. The unreachable tail is a hard limitation of an offset+`[max]`
                 # API when a single timestamp exceeds the offset cap.
-                logger.warning(
+                self._warn(
                     f"ChargeDesk: {cfg.name} has more than {cfg.max_offset} rows at {cfg.timestamp_field}="
                     f"{oldest_ts}; the offset cap prevents fetching the rest of this timestamp, stopping "
                     f"pagination for this window."
                 )
-                yield items, None
+                self._has_next_page = False
                 return
-            logger.debug(f"ChargeDesk: {cfg.name} reached offset cap, shifting {cfg.filter_param}[max] to {oldest_ts}")
-            next_offset = 0
-            next_window_max = oldest_ts
+            if self._logger is not None:
+                self._logger.debug(
+                    f"ChargeDesk: {cfg.name} reached offset cap, shifting {cfg.filter_param}[max] to {oldest_ts}"
+                )
+            self.offset = 0
+            self.window_max = oldest_ts
+        else:
+            self.offset = next_offset
 
-        yield items, (next_offset, next_window_max)
-        offset = next_offset
-        window_max = next_window_max
+        self._has_next_page = True
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # offset/window_max already point at the next page to fetch (update_state advanced them).
+        return {"offset": self.offset, "window_max": self.window_max} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        offset = state.get("offset")
+        if offset is not None:
+            self.offset = int(offset)
+        window_max = state.get("window_max")
+        if window_max is not None:
+            self.window_max = int(window_max)
+        self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"ChargedeskOffsetWindowPaginator(offset={self.offset}, window_max={self.window_max})"
 
 
 def _run_pass(
-    session: requests.Session,
-    auth: tuple[str, str],
+    api_key: str,
     cfg: ChargedeskEndpointConfig,
+    team_id: int,
+    job_id: str,
     logger: FilteringBoundLogger,
-    batcher: Batcher,
     resumable_source_manager: "ResumableSourceManager[ChargedeskResumeConfig]",
     *,
     phase: str,
     min_value: int | None,
     start_offset: int,
     start_window_max: int | None,
-) -> Iterator[Any]:
-    """Batch a single pass's pages, yielding tables and saving resume state at page boundaries.
+) -> Iterator[list[dict[str, Any]]]:
+    """Run a single pass over a list endpoint, saving resume state at page boundaries.
 
-    State is saved only after a whole page has been batched and a table yielded, so a crash re-fetches
-    from the next page rather than skipping the unyielded tail of a partially consumed page.
+    State is saved AFTER a page is yielded (framework contract), tagged with the current phase so
+    a resume picks up the right pass. The terminal page carries no state, matching the old
+    behavior of never checkpointing past the end of a pass.
     """
-    for items, resume_state in _iter_pages(
-        session,
-        auth,
-        cfg,
-        logger,
-        min_value=min_value,
-        start_offset=start_offset,
-        start_window_max=start_window_max,
-    ):
-        for item in items:
-            batcher.batch(item)
+    params: dict[str, Any] = {}
+    if min_value is not None:
+        params[f"{cfg.filter_param}[min]"] = min_value
 
-        if batcher.should_yield():
-            yield batcher.get_table()
-            if resume_state is not None:
-                resumable_source_manager.save_state(
-                    ChargedeskResumeConfig(offset=resume_state[0], window_max=resume_state[1], phase=phase)
-                )
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CHARGEDESK_BASE_URL,
+            # HTTP Basic with the secret key as the username and an empty password.
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            "paginator": ChargedeskOffsetWindowPaginator(cfg, logger=logger),
+        },
+        "resources": [
+            {
+                "name": cfg.name,
+                "endpoint": {
+                    "path": cfg.path,
+                    "params": params,
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Only persist when a next page remains; a crash re-yields the last page (merge dedupes)
+        # rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(
+                ChargedeskResumeConfig(offset=int(state["offset"]), window_max=state.get("window_max"), phase=phase)
+            )
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state={"offset": start_offset, "window_max": start_window_max},
+    )
+
+    yield from resource
 
 
 def get_rows(
     api_key: str,
     endpoint: str,
+    team_id: int,
+    job_id: str,
     logger: FilteringBoundLogger,
     resumable_source_manager: "ResumableSourceManager[ChargedeskResumeConfig]",
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Any = None,
     db_incremental_field_earliest_value: Any = None,
-) -> Iterator[Any]:
+) -> Iterator[list[dict[str, Any]]]:
     cfg = CHARGEDESK_ENDPOINTS[endpoint]
-    auth = _auth(api_key)
-    # Redact the secret key from logged URLs / captured samples — it rides in the Basic auth header.
-    session = make_tracked_session(redact_values=(api_key,))
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
     resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
 
@@ -203,11 +234,11 @@ def get_rows(
             (resume.offset, resume.window_max) if resume and resume.phase == "full" else (0, None)
         )
         yield from _run_pass(
-            session,
-            auth,
+            api_key,
             cfg,
+            team_id,
+            job_id,
             logger,
-            batcher,
             resumable_source_manager,
             phase="full",
             min_value=None,
@@ -224,11 +255,11 @@ def get_rows(
             else:
                 start_offset, window_max = 0, int(db_incremental_field_earliest_value)
             yield from _run_pass(
-                session,
-                auth,
+                api_key,
                 cfg,
+                team_id,
+                job_id,
                 logger,
-                batcher,
                 resumable_source_manager,
                 phase="earliest",
                 min_value=None,
@@ -242,11 +273,11 @@ def get_rows(
             else:
                 start_offset, window_max = 0, None
             yield from _run_pass(
-                session,
-                auth,
+                api_key,
                 cfg,
+                team_id,
+                job_id,
                 logger,
-                batcher,
                 resumable_source_manager,
                 phase="latest",
                 min_value=int(db_incremental_field_last_value),
@@ -254,13 +285,12 @@ def get_rows(
                 start_window_max=window_max,
             )
 
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
 
 def chargedesk_source(
     api_key: str,
     endpoint: str,
+    team_id: int,
+    job_id: str,
     logger: FilteringBoundLogger,
     resumable_source_manager: "ResumableSourceManager[ChargedeskResumeConfig]",
     should_use_incremental_field: bool = False,
@@ -274,6 +304,8 @@ def chargedesk_source(
         items=lambda: get_rows(
             api_key=api_key,
             endpoint=endpoint,
+            team_id=team_id,
+            job_id=job_id,
             logger=logger,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=should_use_incremental_field,
@@ -294,14 +326,11 @@ def chargedesk_source(
 
 def validate_credentials(api_key: str) -> bool:
     # A single company secret key grants full read access (ChargeDesk has no per-resource scopes), so one
-    # cheap probe against /charges confirms the key is genuine.
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(
-            f"{CHARGEDESK_BASE_URL}/charges",
-            auth=_auth(api_key),
-            params={"count": 1},
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+    # cheap probe against /charges confirms the key is genuine. The key rides in the Basic auth header, so
+    # register it for value-based redaction in logged URLs / captured samples.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CHARGEDESK_BASE_URL}/charges?count=1",
+        auth=HTTPBasicAuth(api_key, ""),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/source.py
@@ -19,7 +19,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk
     validate_credentials as validate_chargedesk_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk.settings import (
-    CHARGEDESK_ENDPOINTS,
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
@@ -29,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ChargedeskSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -78,7 +80,7 @@ Each company has its own secret key. Create one in your ChargeDesk account under
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # A bad or disabled secret key surfaces as a requests HTTPError when `_fetch_page` calls
+            # A bad or disabled secret key surfaces as a requests HTTPError when the REST client calls
             # `raise_for_status()`. Retrying can't fix a credential problem, so stop the sync. Match the
             # stable status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://api.chargedesk.com": "Your ChargeDesk secret API key is invalid or has been revoked. Issue a new key in your ChargeDesk account (Setup → API / Webhooks) and reconnect.",
@@ -93,20 +95,7 @@ Each company has its own secret key. Create one in your ChargeDesk account under
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            cfg = CHARGEDESK_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=cfg.supports_incremental,
-                supports_append=cfg.supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: ChargedeskSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -128,6 +117,8 @@ Each company has its own secret key. Create one in your ChargeDesk account under
         return chargedesk_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             logger=inputs.logger,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/tests/test_chargedesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/tests/test_chargedesk.py
@@ -1,314 +1,387 @@
 import json
+import dataclasses
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
-from products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk import chargedesk
 from products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk.chargedesk import (
     ChargedeskResumeConfig,
-    _iter_pages,
-    _run_pass,
     chargedesk_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk.settings import (
-    CHARGEDESK_ENDPOINTS,
-    ChargedeskEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk.settings import CHARGEDESK_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the chargedesk module.
+CHARGEDESK_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.chargedesk.chargedesk.make_tracked_session"
 )
 
 
-def _cfg(**overrides: Any) -> ChargedeskEndpointConfig:
-    base: dict[str, Any] = {
-        "name": "charges",
-        "path": "/charges",
-        "primary_keys": ["charge_id"],
-        "timestamp_field": "occurred",
-        "filter_param": "occurred",
-        "max_offset": 50000,
-        "page_size": 2,
-    }
-    base.update(overrides)
-    return ChargedeskEndpointConfig(**base)
+def _small_charges_cfg(**overrides: Any) -> dict[str, Any]:
+    """CHARGEDESK_ENDPOINTS override shrinking the charges page size (and optionally the offset cap)
+    so pagination/window-shift behavior is testable with a handful of rows."""
+    base = dataclasses.replace(CHARGEDESK_ENDPOINTS["charges"], **{"page_size": 2, **overrides})
+    return {"charges": base}
 
 
-class _FakeResponse:
-    def __init__(self, payload: dict, status: int = 200):
-        self._payload = payload
-        self.status_code = status
-        self.ok = 200 <= status < 300
-        self.text = json.dumps(payload)
-
-    def json(self) -> dict:
-        return self._payload
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            response = requests.Response()
-            response.status_code = self.status_code
-            raise requests.HTTPError(f"{self.status_code} Client Error", response=response)
+def _response(items: list[dict[str, Any]]) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps({"data": items}).encode()
+    return resp
 
 
-class _PagedSession:
-    """Fake session that slices a fixed (newest-first) dataset by offset, honoring [min]/[max] filters."""
-
-    def __init__(self, rows: list[dict], filter_param: str = "occurred", ts_field: str = "occurred"):
-        self.rows = rows
-        self.filter_param = filter_param
-        self.ts_field = ts_field
-        self.calls: list[dict] = []
-
-    def get(self, url: str, auth: Any = None, params: dict | None = None, timeout: Any = None) -> _FakeResponse:
-        params = params or {}
-        self.calls.append(params)
-        mn = params.get(f"{self.filter_param}[min]")
-        mx = params.get(f"{self.filter_param}[max]")
-        selected = [
-            r for r in self.rows if (mn is None or r[self.ts_field] >= mn) and (mx is None or r[self.ts_field] <= mx)
-        ]
-        offset = params["offset"]
-        count = params["count"]
-        page = selected[offset : offset + count]
-        return _FakeResponse({"count": count, "offset": offset, "data": page})
-
-
-class _FakeManager:
-    def __init__(self, state: ChargedeskResumeConfig | None = None):
-        self._state = state
-        self.saved: list[ChargedeskResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> ChargedeskResumeConfig | None:
-        return self._state
-
-    def save_state(self, state: ChargedeskResumeConfig) -> None:
-        self.saved.append(state)
-
-
-def _charges(ids_and_ts: list[tuple[str, int]]) -> list[dict]:
+def _charges(ids_and_ts: list[tuple[str, int]]) -> list[dict[str, Any]]:
     # Newest first, matching ChargeDesk's default list ordering.
     return [{"charge_id": cid, "occurred": ts} for cid, ts in ids_and_ts]
 
 
-class TestIterPages:
-    def test_single_short_page_is_terminal(self) -> None:
-        session = _PagedSession(_charges([("a", 30), ("b", 20)]))
-        cfg = _cfg(page_size=5)
-        results = list(
-            _iter_pages(session, ("k", ""), cfg, MagicMock(), min_value=None, start_offset=0, start_window_max=None)  # type: ignore[arg-type]
+def _make_manager(resume_state: ChargedeskResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(
+    endpoint: str = "charges",
+    manager: mock.MagicMock | None = None,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+    db_incremental_field_earliest_value: Any = None,
+):
+    return chargedesk_source(
+        api_key="sk_test",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job",
+        logger=mock.MagicMock(),
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+        db_incremental_field_earliest_value=db_incremental_field_earliest_value,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_is_terminal(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(_charges([("a", 30), ("b", 20)]))])
+
+        manager = _make_manager()
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg(page_size=5)):
+            rows = _rows(_source(manager=manager))
+
+        assert [r["charge_id"] for r in rows] == ["a", "b"]
+        assert session.send.call_count == 1  # short page -> no next page
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_multi_page_offsets_and_termination(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(_charges([("a", 50), ("b", 40)])),
+                _response(_charges([("c", 30), ("d", 20)])),
+                _response(_charges([("e", 10)])),
+            ],
         )
 
-        assert len(results) == 1
-        items, resume_state = results[0]
-        assert [r["charge_id"] for r in items] == ["a", "b"]
-        assert resume_state is None  # short page -> no next page
-
-    def test_multi_page_offsets_and_termination(self) -> None:
-        session = _PagedSession(_charges([("a", 50), ("b", 40), ("c", 30), ("d", 20), ("e", 10)]))
-        cfg = _cfg(page_size=2)
-        results = list(
-            _iter_pages(session, ("k", ""), cfg, MagicMock(), min_value=None, start_offset=0, start_window_max=None)  # type: ignore[arg-type]
-        )
+        manager = _make_manager()
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg()):
+            rows = _rows(_source(manager=manager))
 
         # 5 rows / page_size 2 => full pages [a,b],[c,d] then terminal short page [e]
-        all_ids = [r["charge_id"] for items, _ in results for r in items]
-        assert all_ids == ["a", "b", "c", "d", "e"]
-        # offsets requested are 0, 2, 4
-        assert [c["offset"] for c in session.calls] == [0, 2, 4]
-        assert results[-1][1] is None  # last page terminal
-        assert results[0][1] == (2, None)  # resume from offset 2 next
+        assert [r["charge_id"] for r in rows] == ["a", "b", "c", "d", "e"]
+        assert [p["offset"] for p in params] == [0, 2, 4]
+        assert all(p["count"] == 2 for p in params)
+        # Checkpoints save the NEXT page to fetch, tagged with the current phase; terminal page saves nothing.
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved[0] == ChargedeskResumeConfig(offset=2, window_max=None, phase="full")
+        assert all(s.phase == "full" for s in saved)
 
-    def test_window_shift_at_offset_cap(self) -> None:
-        # max_offset=2 forces a window shift after the first full page (offset would step to 2; 2+2 > 2).
-        session = _PagedSession(_charges([("a", 50), ("b", 40), ("c", 30), ("d", 20)]))
-        cfg = _cfg(page_size=2, max_offset=2)
-        results = list(
-            _iter_pages(session, ("k", ""), cfg, MagicMock(), min_value=None, start_offset=0, start_window_max=None)  # type: ignore[arg-type]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_window_shift_at_offset_cap(self, MockSession) -> None:
+        session = MockSession.return_value
+        # max_offset=2 forces a window shift after each full page (offset would step to 2; 2+2 > 2).
+        params = _wire(
+            session,
+            [
+                _response(_charges([("a", 50), ("b", 40)])),
+                _response(_charges([("b", 40), ("c", 30)])),
+                _response(_charges([("c", 30), ("d", 20)])),
+                _response(_charges([("d", 20)])),
+            ],
         )
 
-        # First page [a,b]; cap hit -> shift occurred[max] to oldest seen (40), reset offset 0.
-        first_items, first_resume = results[0]
-        assert [r["charge_id"] for r in first_items] == ["a", "b"]
-        assert first_resume == (0, 40)
-        # Subsequent calls carry occurred[max]=40 and start at offset 0.
-        shifted_calls = [c for c in session.calls if c.get("occurred[max]") == 40]
-        assert shifted_calls and shifted_calls[0]["offset"] == 0
-        # Every row is still surfaced (boundary row b re-fetched, deduped downstream on primary key).
-        all_ids = [r["charge_id"] for items, _ in results for r in items]
-        assert set(all_ids) == {"a", "b", "c", "d"}
+        manager = _make_manager()
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg(max_offset=2)):
+            rows = _rows(_source(manager=manager))
 
-    def test_stops_when_offset_cap_window_collapses_to_one_timestamp(self) -> None:
+        # Cap hit -> shift occurred[max] to oldest seen (40), reset offset 0.
+        assert params[1]["offset"] == 0
+        assert params[1]["occurred[max]"] == 40
+        assert params[2]["occurred[max]"] == 30
+        # First checkpoint records the shifted window.
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved[0] == ChargedeskResumeConfig(offset=0, window_max=40, phase="full")
+        # Every row is still surfaced (boundary rows re-fetched, deduped downstream on primary key).
+        assert {r["charge_id"] for r in rows} == {"a", "b", "c", "d"}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_offset_cap_window_collapses_to_one_timestamp(self, MockSession) -> None:
+        session = MockSession.return_value
         # More rows than the offset cap can reach all share the same timestamp. Re-pinning [max] to that
         # timestamp would re-fetch the same page forever; pagination must terminate instead of spinning.
-        session = _PagedSession(_charges([("a", 100), ("b", 100), ("c", 100), ("d", 100)]))
-        cfg = _cfg(page_size=2, max_offset=2)
-        results = list(
-            _iter_pages(session, ("k", ""), cfg, MagicMock(), min_value=None, start_offset=0, start_window_max=None)  # type: ignore[arg-type]
+        params = _wire(
+            session,
+            [
+                _response(_charges([("a", 100), ("b", 100)])),
+                _response(_charges([("a", 100), ("b", 100)])),
+            ],
         )
 
-        # Terminates (the final page carries no resume state) rather than looping indefinitely.
-        assert results[-1][1] is None
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg(max_offset=2)):
+            _rows(_source())
+
         # It shifted [max] to 100 exactly once, then stopped on the next identical-timestamp page.
-        assert sum(1 for c in session.calls if c.get("occurred[max]") == 100) >= 1
+        assert session.send.call_count == 2
+        assert params[1]["occurred[max]"] == 100
 
-    def test_min_filter_passed_through(self) -> None:
-        session = _PagedSession(_charges([("a", 50), ("b", 40), ("c", 30)]))
-        cfg = _cfg(page_size=5)
-        list(_iter_pages(session, ("k", ""), cfg, MagicMock(), min_value=35, start_offset=0, start_window_max=None))  # type: ignore[arg-type]
-        assert session.calls[0]["occurred[min]"] == 35
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_at_offset_cap_without_usable_timestamp(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Can't shift the window without a timestamp to anchor it; stepping past the cap would 400.
+        _wire(session, [_response([{"charge_id": "a"}, {"charge_id": "b"}])])
 
-    def test_filter_param_differs_from_timestamp_field(self) -> None:
-        # Subscriptions filter on `created` but the row timestamp column is `first_seen`.
-        rows = [{"subscription_id": "s1", "first_seen": 100}, {"subscription_id": "s2", "first_seen": 50}]
-        session = _PagedSession(rows, filter_param="created", ts_field="first_seen")
-        cfg = _cfg(
-            name="subscriptions",
-            path="/subscriptions",
-            primary_keys=["subscription_id"],
-            timestamp_field="first_seen",
-            filter_param="created",
-            page_size=5,
-        )
-        list(_iter_pages(session, ("k", ""), cfg, MagicMock(), min_value=60, start_offset=0, start_window_max=None))  # type: ignore[arg-type]
-        assert session.calls[0]["created[min]"] == 60
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg(max_offset=2)):
+            rows = _rows(_source())
 
+        assert session.send.call_count == 1
+        assert [r["charge_id"] for r in rows] == ["a", "b"]
 
-class TestRunPass:
-    def test_saves_state_after_yielding_each_batch(self) -> None:
-        session = _PagedSession(_charges([("a", 50), ("b", 40), ("c", 30), ("d", 20), ("e", 10)]))
-        cfg = _cfg(page_size=2)
-        manager = _FakeManager()
-        batcher = Batcher(logger=MagicMock(), chunk_size=2, chunk_size_bytes=10**9)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        resp = Response()
+        resp.status_code = 200
+        resp._content = json.dumps({"error": "nope"}).encode()
+        _wire(session, [resp])
 
-        tables = list(
-            _run_pass(
-                session,  # type: ignore[arg-type]
-                ("k", ""),
-                cfg,
-                MagicMock(),
-                batcher,
-                manager,  # type: ignore[arg-type]
-                phase="full",
-                min_value=None,
-                start_offset=0,
-                start_window_max=None,
-            )
-        )
+        rows = _rows(_source())
 
-        # chunk_size=2 -> a batch yields after each 2-row page that has a following page.
-        assert len(tables) >= 1
-        assert manager.saved  # state persisted after yielding
-        # Saved offsets advance and stay tagged with the current phase.
-        assert all(s.phase == "full" for s in manager.saved)
-        assert manager.saved[0].offset == 2
+        assert rows == []
+        assert session.send.call_count == 1
 
 
-class TestGetRows:
-    def _collect(self, gen: Any) -> list[dict]:
-        return [row for table in gen for row in table.to_pylist()]
+class TestIncrementalPasses:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_scan_when_not_incremental(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_charges([("a", 50), ("b", 40), ("c", 30)]))])
 
-    def test_full_scan_when_not_incremental(self) -> None:
-        session = _PagedSession(_charges([("a", 50), ("b", 40), ("c", 30)]))
-        manager = _FakeManager()
-        with patch.object(chargedesk, "make_tracked_session", return_value=session):
-            rows = self._collect(
-                get_rows("k", "charges", MagicMock(), manager, should_use_incremental_field=False)  # type: ignore[arg-type]
-            )
+        rows = _rows(_source(should_use_incremental_field=False))
+
         assert {r["charge_id"] for r in rows} == {"a", "b", "c"}
         # No incremental filters on a full scan.
-        assert all("occurred[min]" not in c for c in session.calls)
+        assert all("occurred[min]" not in p and "occurred[max]" not in p for p in params)
 
-    def test_latest_pass_uses_min_filter(self) -> None:
-        session = _PagedSession(_charges([("a", 50), ("b", 40)]))
-        manager = _FakeManager()
-        with patch.object(chargedesk, "make_tracked_session", return_value=session):
-            self._collect(
-                get_rows(
-                    "k",
-                    "charges",
-                    MagicMock(),
-                    manager,  # type: ignore[arg-type]
-                    should_use_incremental_field=True,
-                    db_incremental_field_last_value=45,
-                    db_incremental_field_earliest_value=None,
-                )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_latest_pass_uses_min_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_charges([("a", 50)]))])
+
+        _rows(
+            _source(
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=45,
+                db_incremental_field_earliest_value=None,
             )
-        assert session.calls[0]["occurred[min]"] == 45
+        )
 
-    def test_earliest_pass_then_latest_pass(self) -> None:
-        session = _PagedSession(_charges([("a", 50), ("b", 40), ("c", 30), ("d", 20)]))
-        manager = _FakeManager()
-        with patch.object(chargedesk, "make_tracked_session", return_value=session):
-            self._collect(
-                get_rows(
-                    "k",
-                    "charges",
-                    MagicMock(),
-                    manager,  # type: ignore[arg-type]
+        assert params[0]["occurred[min]"] == 45
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_earliest_pass_then_latest_pass(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(_charges([("d", 20)])),  # earliest backfill
+                _response(_charges([("a", 60)])),  # latest pass
+            ],
+        )
+
+        _rows(
+            _source(
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=50,
+                db_incremental_field_earliest_value=20,
+            )
+        )
+
+        # Earliest backfill runs first with occurred[max]=20, then latest with occurred[min]=50.
+        assert params[0].get("occurred[max]") == 20
+        assert "occurred[min]" not in params[0]
+        assert params[1].get("occurred[min]") == 50
+        assert "occurred[max]" not in params[1]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_filter_param_differs_from_timestamp_field(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Subscriptions filter on `created` but the row timestamp column is `first_seen`.
+        params = _wire(session, [_response([{"subscription_id": "s1", "first_seen": 100}])])
+
+        _rows(
+            _source(
+                endpoint="subscriptions",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=60,
+            )
+        )
+
+        assert params[0]["created[min]"] == 60
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_ignored_for_full_refresh_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"product_id": "p1", "first_seen": 10}])])
+
+        # products is full-refresh only, so the [min] filter must never be sent.
+        _rows(
+            _source(
+                endpoint="products",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=5,
+            )
+        )
+
+        assert all("created[min]" not in p for p in params)
+
+
+class TestResume:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_from_saved_full_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_charges([("c", 30)]))])
+
+        manager = _make_manager(ChargedeskResumeConfig(offset=2, window_max=None, phase="full"))
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg()):
+            _rows(_source(manager=manager))
+
+        # First fetch resumes from the saved offset, not 0.
+        assert params[0]["offset"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_full_state_restores_window(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_charges([("c", 30)]))])
+
+        manager = _make_manager(ChargedeskResumeConfig(offset=0, window_max=40, phase="full"))
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg()):
+            _rows(_source(manager=manager))
+
+        assert params[0]["offset"] == 0
+        assert params[0]["occurred[max]"] == 40
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_mid_earliest_pass_then_runs_latest(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(_charges([("d", 15)])),  # resumed earliest backfill
+                _response(_charges([("a", 60)])),  # latest pass
+            ],
+        )
+
+        manager = _make_manager(ChargedeskResumeConfig(offset=2, window_max=18, phase="earliest"))
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg()):
+            _rows(
+                _source(
+                    manager=manager,
                     should_use_incremental_field=True,
                     db_incremental_field_last_value=50,
                     db_incremental_field_earliest_value=20,
                 )
             )
-        # Earliest backfill runs first with occurred[max]=20, then latest with occurred[min]=50.
-        assert session.calls[0].get("occurred[max]") == 20
-        assert any(c.get("occurred[min]") == 50 for c in session.calls)
 
-    def test_incremental_ignored_for_full_refresh_endpoint(self) -> None:
-        session = _PagedSession([{"product_id": "p1", "first_seen": 10}], filter_param="created", ts_field="first_seen")
-        manager = _FakeManager()
-        with patch.object(chargedesk, "make_tracked_session", return_value=session):
-            self._collect(
-                get_rows(
-                    "k",
-                    "products",
-                    MagicMock(),
-                    manager,  # type: ignore[arg-type]
+        # Earliest pass resumes from the saved offset/window, not the earliest watermark.
+        assert params[0]["offset"] == 2
+        assert params[0]["occurred[max]"] == 18
+        assert params[1]["occurred[min]"] == 50
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_latest_phase_skips_earliest_pass(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_charges([("a", 60)]))])
+
+        manager = _make_manager(ChargedeskResumeConfig(offset=2, window_max=None, phase="latest"))
+        with mock.patch.dict(CHARGEDESK_ENDPOINTS, _small_charges_cfg()):
+            _rows(
+                _source(
+                    manager=manager,
                     should_use_incremental_field=True,
-                    db_incremental_field_last_value=5,
+                    db_incremental_field_last_value=50,
+                    db_incremental_field_earliest_value=20,
                 )
             )
-        # products is full-refresh only, so the [min] filter must never be sent.
-        assert all("created[min]" not in c for c in session.calls)
 
-    def test_resume_from_saved_full_state(self) -> None:
-        session = _PagedSession(_charges([("a", 50), ("b", 40), ("c", 30), ("d", 20)]))
-        manager = _FakeManager(state=ChargedeskResumeConfig(offset=2, window_max=None, phase="full"))
-        with patch.object(chargedesk, "make_tracked_session", return_value=session):
-            self._collect(
-                get_rows("k", "charges", MagicMock(), manager, should_use_incremental_field=False)  # type: ignore[arg-type]
-            )
-        # First fetch resumes from the saved offset, not 0.
-        assert session.calls[0]["offset"] == 2
+        # A single request: the earliest backfill already completed, only the latest pass resumes.
+        assert session.send.call_count == 1
+        assert params[0]["offset"] == 2
+        assert params[0]["occurred[min]"] == 50
+        assert "occurred[max]" not in params[0]
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
     def test_status_mapping(self, _name: str, status: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = _FakeResponse({}, status=status)
-        with patch.object(chargedesk, "make_tracked_session", return_value=session):
-            assert validate_credentials("k") is expected
+        with mock.patch(CHARGEDESK_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+            assert validate_credentials("sk_test") is expected
 
     def test_network_error_is_invalid(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(chargedesk, "make_tracked_session", return_value=session):
-            assert validate_credentials("k") is False
+        with mock.patch(CHARGEDESK_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.side_effect = Exception("boom")
+            assert validate_credentials("sk_test") is False
 
 
 class TestChargedeskSource:
     @parameterized.expand(list(CHARGEDESK_ENDPOINTS.keys()))
     def test_source_response_shape(self, endpoint: str) -> None:
         cfg = CHARGEDESK_ENDPOINTS[endpoint]
-        response = chargedesk_source("k", endpoint, MagicMock(), MagicMock())
+        response = _source(endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == cfg.primary_keys
         # ChargeDesk returns rows newest-first.
@@ -317,8 +390,8 @@ class TestChargedeskSource:
         assert response.partition_keys == [cfg.timestamp_field]
 
     def test_primary_keys_are_resource_specific(self) -> None:
-        assert chargedesk_source("k", "charges", MagicMock(), MagicMock()).primary_keys == ["charge_id"]
-        assert chargedesk_source("k", "customers", MagicMock(), MagicMock()).primary_keys == ["customer_id"]
+        assert _source(endpoint="charges").primary_keys == ["charge_id"]
+        assert _source(endpoint="customers").primary_keys == ["customer_id"]
 
 
 if __name__ == "__main__":

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/tests/test_chargedesk_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargedesk/tests/test_chargedesk_source.py
@@ -129,6 +129,8 @@ class TestSourceForPipeline:
 
         assert captured["endpoint"] == "charges"
         assert captured["api_key"] == "sk_test"
+        assert captured["team_id"] is not None
+        assert captured["job_id"] is not None
         assert captured["db_incremental_field_last_value"] == 1000
         assert captured["db_incremental_field_earliest_value"] == 500
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/charthop.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/charthop.py
@@ -1,13 +1,9 @@
-import time
 import dataclasses
-from collections.abc import Callable, Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import quote, urlencode
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.charthop.settings import (
@@ -15,21 +11,23 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.charthop.s
     ChartHopEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CHARTHOP_BASE_URL = "https://api.charthop.com"
 # No documented max page size; ChartHop's own sync tooling pages with limit=1000. 500 keeps
 # the request count low (rate limits are undocumented) while bounding per-page payload size.
 PAGE_SIZE = 500
 REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-MAX_RETRY_AFTER_SECONDS = 60
 
 AUTH_ERROR_HINT = "ChartHop API authentication or permission error"
-
-
-class ChartHopRetryableError(Exception):
-    pass
 
 
 class ChartHopAPIError(Exception):
@@ -78,79 +76,6 @@ def _endpoint_path(config: ChartHopEndpointConfig, org_id: str) -> str:
     return config.path.format(org_id=quote(org_id, safe=""))
 
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    clean_params = {key: value for key, value in params.items() if value is not None}
-    if not clean_params:
-        return f"{CHARTHOP_BASE_URL}{path}"
-    return f"{CHARTHOP_BASE_URL}{path}?{urlencode(clean_params)}"
-
-
-def _build_params(
-    config: ChartHopEndpointConfig,
-    from_token: Optional[str],
-    start_date: Optional[str],
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE, **config.extra_params}
-    if from_token is not None:
-        params["from"] = from_token
-    # The ``next`` token is a bare entity id, not a full query, so filters are re-sent on
-    # every page — the date window stays applied across the whole pagination walk.
-    if config.incremental_param is not None and start_date is not None:
-        params[config.incremental_param] = start_date
-    return params
-
-
-PageFetcher = Callable[[str], dict[str, Any]]
-
-
-def _make_page_fetcher(api_key: str, logger: FilteringBoundLogger) -> PageFetcher:
-    headers = _get_headers(api_key)
-    session = make_tracked_session()
-
-    @retry(
-        retry=retry_if_exception_type(
-            (
-                ChartHopRetryableError,
-                requests.ReadTimeout,
-                requests.ConnectionError,
-                requests.exceptions.ChunkedEncodingError,
-            )
-        ),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = session.get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # ChartHop's rate limits are undocumented; honor Retry-After when present and fall
-        # back to tenacity's exponential backoff.
-        if response.status_code == 429:
-            retry_after = response.headers.get("Retry-After")
-            if retry_after is not None:
-                try:
-                    time.sleep(min(int(retry_after), MAX_RETRY_AFTER_SECONDS))
-                except ValueError:
-                    pass
-            raise ChartHopRetryableError(f"ChartHop API rate limited: status=429, url={page_url}")
-
-        if response.status_code >= 500:
-            raise ChartHopRetryableError(
-                f"ChartHop API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if response.status_code in (401, 403):
-            raise ChartHopAPIError(f"{response.status_code} Client Error: {AUTH_ERROR_HINT} for url {page_url}")
-
-        if not response.ok:
-            logger.error(f"ChartHop API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    return fetch_page
-
-
 def resolve_org_id(api_key: str, configured_org_id: Optional[str]) -> str:
     """Resolve the org id (or slug) every data endpoint needs in its path.
 
@@ -161,8 +86,8 @@ def resolve_org_id(api_key: str, configured_org_id: Optional[str]) -> str:
     if configured_org_id and configured_org_id.strip():
         return configured_org_id.strip()
 
-    response = make_tracked_session().get(
-        _build_url("/v1/org", {"limit": 2}), headers=_get_headers(api_key), timeout=REQUEST_TIMEOUT_SECONDS
+    response = make_tracked_session(redact_values=(api_key,)).get(
+        f"{CHARTHOP_BASE_URL}/v1/org?limit=2", headers=_get_headers(api_key), timeout=REQUEST_TIMEOUT_SECONDS
     )
     if response.status_code in (401, 403):
         raise ChartHopAPIError(f"{response.status_code} Client Error: {AUTH_ERROR_HINT} for url /v1/org")
@@ -186,21 +111,8 @@ def check_access(api_key: str, org_id: Optional[str], schema_name: Optional[str]
     Validating a specific schema probes that endpoint with ``limit=1`` so tokens scoped
     to a subset of the data fail fast on the schemas they can't read.
     """
-    session = make_tracked_session()
     try:
         resolved_org_id = resolve_org_id(api_key, org_id)
-
-        if schema_name is not None:
-            config = CHARTHOP_ENDPOINTS[schema_name]
-            path = _endpoint_path(config, resolved_org_id)
-            response = session.get(
-                _build_url(path, {"limit": 1, **config.extra_params}),
-                headers=_get_headers(api_key),
-                timeout=15,
-            )
-            return response.status_code, None
-
-        return 200, None
     except ChartHopAPIError as e:
         message = str(e)
         if "401" in message:
@@ -214,72 +126,100 @@ def check_access(api_key: str, org_id: Optional[str], schema_name: Optional[str]
     except Exception as e:
         return 0, f"Could not connect to ChartHop: {e}"
 
+    if schema_name is None:
+        return 200, None
 
-def get_rows(
-    api_key: str,
-    org_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ChartHopResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CHARTHOP_ENDPOINTS[endpoint]
-    fetch_page = _make_page_fetcher(api_key, logger)
-    path = _endpoint_path(config, org_id)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        logger.debug(f"ChartHop: resuming {endpoint} from saved cursor")
-        from_token: Optional[str] = resume_config.from_token
-        start_date = resume_config.start_date
-    else:
-        from_token = None
-        start_date = (
-            _to_charthop_date(db_incremental_field_last_value)
-            if should_use_incremental_field and db_incremental_field_last_value is not None
-            else None
-        )
-
-    while True:
-        url = _build_url(path, _build_params(config, from_token, start_date))
-        data = fetch_page(url)
-        rows = data.get("data", []) or []
-
-        if rows:
-            yield rows
-
-        from_token = data.get("next")
-        if not from_token:
-            break
-
-        # Save AFTER yielding so a crash re-yields the last page (merge dedupes on the
-        # primary key) rather than skipping it.
-        resumable_source_manager.save_state(ChartHopResumeConfig(from_token=from_token, start_date=start_date))
+    config = CHARTHOP_ENDPOINTS[schema_name]
+    path = _endpoint_path(config, resolved_org_id)
+    query = urlencode({"limit": 1, **config.extra_params})
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CHARTHOP_BASE_URL}{path}?{query}",
+        headers=_get_headers(api_key),
+        timeout=15,
+    )
+    if status is None:
+        return 0, "Could not connect to ChartHop"
+    return status, None
 
 
 def charthop_source(
     api_key: str,
     org_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ChartHopResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = CHARTHOP_ENDPOINTS[endpoint]
+    path = _endpoint_path(config, org_id)
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume is not None:
+        initial_paginator_state = {"cursor": resume.from_token}
+        # The saved window wins over the advanced watermark — see ChartHopResumeConfig.
+        start_date = resume.start_date
+    else:
+        start_date = (
+            _to_charthop_date(db_incremental_field_last_value)
+            if should_use_incremental_field and db_incremental_field_last_value is not None
+            else None
+        )
+
+    params: dict[str, Any] = {"limit": PAGE_SIZE, **config.extra_params}
+    # The ``next`` token is a bare entity id, not a full query, so filters are re-sent on
+    # every page — the date window stays applied across the whole pagination walk.
+    if config.incremental_param is not None and start_date is not None:
+        params[config.incremental_param] = start_date
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CHARTHOP_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Auth (Bearer) via the framework auth config so its value is redacted from logs.
+            "auth": {"type": "bearer", "token": api_key},
+            # Every ChartHop list endpoint pages cursor-by-id: ``next`` in the body is
+            # re-sent as the ``from`` query param; a missing/empty ``next`` ends the walk.
+            "paginator": JSONResponseCursorPaginator(cursor_path="next", cursor_param="from"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": path,
+                    "params": params,
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the framework calls this AFTER a page is
+        # yielded, so a crash re-yields the last page (merge dedupes on the primary key)
+        # rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(
+                ChartHopResumeConfig(from_token=str(state["cursor"]), start_date=start_date)
+            )
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        # The date window is injected into ``params`` above (resume must reuse the saved
+        # window verbatim), so the framework's incremental plumbing is not used.
+        db_incremental_field_last_value=None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            org_id=org_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_key,
         # The change endpoint documents ascending effective-date order as its default
         # (``desc=false``); every other endpoint is full refresh, where sort mode doesn't
@@ -290,4 +230,5 @@ def charthop_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/settings.py
@@ -80,3 +80,7 @@ CHARTHOP_ENDPOINTS: dict[str, ChartHopEndpointConfig] = {
 }
 
 ENDPOINTS = tuple(CHARTHOP_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in CHARTHOP_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/source.py
@@ -23,6 +23,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.charthop.c
 from products.warehouse_sources.backend.temporal.data_imports.sources.charthop.settings import (
     CHARTHOP_ENDPOINTS,
     ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
@@ -30,7 +31,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ChartHopSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -103,19 +107,7 @@ The organization ID (or slug) is optional — it's detected automatically when y
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=CHARTHOP_ENDPOINTS[endpoint].incremental_param is not None,
-                supports_append=CHARTHOP_ENDPOINTS[endpoint].incremental_param is not None,
-                incremental_fields=CHARTHOP_ENDPOINTS[endpoint].incremental_fields,
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: ChartHopSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -160,7 +152,8 @@ The organization ID (or slug) is optional — it's detected automatically when y
             api_key=config.api_key,
             org_id=resolve_org_id(config.api_key, config.org_id),
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/tests/test_charthop.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/tests/test_charthop.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
@@ -5,6 +6,7 @@ import pytest
 from unittest import mock
 
 from parameterized import parameterized
+from requests import HTTPError, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.charthop.charthop import (
     CHARTHOP_BASE_URL,
@@ -13,48 +15,64 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.charthop.c
     ChartHopResumeConfig,
     _to_charthop_date,
     charthop_source,
-    get_rows,
     resolve_org_id,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.charthop.settings import ENDPOINTS
 
-SESSION_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.charthop.charthop.make_tracked_session"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# resolve_org_id builds its own tracked session in the charthop module.
+CHARTHOP_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.charthop.charthop.make_tracked_session"
+)
 
 
-class FakeResponse:
-    def __init__(self, status_code: int = 200, json_data: Optional[dict[str, Any]] = None) -> None:
-        self.status_code = status_code
-        self._json = json_data if json_data is not None else {}
-        self.text = str(self._json)
-        self.headers: dict[str, str] = {}
-
-    @property
-    def ok(self) -> bool:
-        return 200 <= self.status_code < 300
-
-    def json(self) -> dict[str, Any]:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            raise Exception(f"{self.status_code} Client Error")
+def _response(
+    items: Optional[list[dict[str, Any]]], *, next_token: Optional[str] = None, status_code: int = 200
+) -> Response:
+    body: dict[str, Any] = {"data": items or []}
+    if next_token is not None:
+        body["next"] = next_token
+    resp = Response()
+    resp.status_code = status_code
+    resp.url = f"{CHARTHOP_BASE_URL}/v2/org/org-1/job"
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class FakeSession:
-    def __init__(self, responses: list[FakeResponse]) -> None:
-        self._responses = list(responses)
-        self.calls: list[str] = []
-
-    def get(self, url: str, headers: Any = None, timeout: Any = None):
-        self.calls.append(url)
-        return self._responses[0] if len(self._responses) == 1 else self._responses.pop(0)
-
-
-def _manager(can_resume: bool = False, state: Optional[ChartHopResumeConfig] = None) -> mock.MagicMock:
+def _make_manager(resume_state: Optional[ChartHopResumeConfig] = None) -> mock.MagicMock:
     manager = mock.MagicMock()
-    manager.can_resume.return_value = can_resume
-    manager.load_state.return_value = state
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Wire a mock session, capturing each request's params and URL AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, url_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return charthop_source("key", "org-1", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
 
 
 class TestToChartHopDate:
@@ -77,122 +95,125 @@ class TestToChartHopDate:
         assert _to_charthop_date(future) == datetime.now(UTC).date().isoformat()
 
 
-class TestGetRows:
-    def test_paginates_forwarding_from_token(self) -> None:
-        responses = [
-            FakeResponse(json_data={"data": [{"id": "1"}], "next": "1"}),
-            FakeResponse(json_data={"data": [{"id": "2"}]}),
-        ]
-        session = FakeSession(responses)
-        manager = _manager()
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_forwarding_from_token(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, urls = _wire(session, [_response([{"id": "1"}], next_token="1"), _response([{"id": "2"}])])
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("key", "org-1", "jobs", mock.MagicMock(), manager))
+        manager = _make_manager()
+        rows = _rows(_source("jobs", manager))
 
-        assert batches == [[{"id": "1"}], [{"id": "2"}]]
-        assert session.calls[0] == f"{CHARTHOP_BASE_URL}/v2/org/org-1/job?limit={PAGE_SIZE}"
-        assert session.calls[1] == f"{CHARTHOP_BASE_URL}/v2/org/org-1/job?limit={PAGE_SIZE}&from=1"
+        assert [r["id"] for r in rows] == ["1", "2"]
+        assert urls[0] == f"{CHARTHOP_BASE_URL}/v2/org/org-1/job"
+        assert params[0] == {"limit": PAGE_SIZE}
+        assert params[1] == {"limit": PAGE_SIZE, "from": "1"}
 
-    def test_org_id_is_encoded_as_single_path_segment(self) -> None:
-        responses = [FakeResponse(json_data={"data": []})]
-        session = FakeSession(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_next_token_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "a"}])])
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            list(get_rows("key", "org/../evil?x=1", "jobs", mock.MagicMock(), _manager()))
+        manager = _make_manager()
+        rows = _rows(_source("jobs", manager))
 
-        assert session.calls[0].startswith(f"{CHARTHOP_BASE_URL}/v2/org/org%2F..%2Fevil%3Fx%3D1/job?")
+        assert [r["id"] for r in rows] == ["a"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_saves_state_after_yielding_each_page(self) -> None:
-        responses = [
-            FakeResponse(json_data={"data": [{"id": "1"}], "next": "1"}),
-            FakeResponse(json_data={"data": [{"id": "2"}]}),
-        ]
-        manager = _manager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_org_id_is_encoded_as_single_path_segment(self, MockSession) -> None:
+        session = MockSession.return_value
+        _params, urls = _wire(session, [_response([])])
 
-        with mock.patch(SESSION_PATH, return_value=FakeSession(responses)):
-            list(get_rows("key", "org-1", "jobs", mock.MagicMock(), manager))
+        list(
+            charthop_source(
+                "key", "org/../evil?x=1", "jobs", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+            ).items()
+        )
+
+        assert urls[0] == f"{CHARTHOP_BASE_URL}/v2/org/org%2F..%2Fevil%3Fx%3D1/job"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_yielding_each_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "1"}], next_token="1"), _response([{"id": "2"}])])
+
+        manager = _make_manager()
+        _rows(_source("jobs", manager))
 
         manager.save_state.assert_called_once_with(ChartHopResumeConfig(from_token="1", start_date=None))
 
-    def test_resumes_from_saved_cursor_and_start_date(self) -> None:
-        responses = [FakeResponse(json_data={"data": [{"id": "9"}]})]
-        session = FakeSession(responses)
-        manager = _manager(can_resume=True, state=ChartHopResumeConfig(from_token="8", start_date="2026-01-01"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor_and_start_date(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response([{"id": "9"}])])
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(
-                get_rows(
-                    "key",
-                    "org-1",
-                    "changes",
-                    mock.MagicMock(),
-                    manager,
-                    should_use_incremental_field=True,
-                    # The saved window must win over the advanced watermark on resume.
-                    db_incremental_field_last_value=date(2026, 2, 1),
-                )
+        manager = _make_manager(ChartHopResumeConfig(from_token="8", start_date="2026-01-01"))
+        rows = _rows(
+            _source(
+                "changes",
+                manager,
+                should_use_incremental_field=True,
+                # The saved window must win over the advanced watermark on resume.
+                db_incremental_field_last_value=date(2026, 2, 1),
             )
+        )
 
-        assert batches == [[{"id": "9"}]]
-        assert "from=8" in session.calls[0]
-        assert "date=2026-01-01" in session.calls[0]
+        assert [r["id"] for r in rows] == ["9"]
+        assert params[0]["from"] == "8"
+        assert params[0]["date"] == "2026-01-01"
 
-    def test_incremental_date_filter_sent_on_every_page(self) -> None:
-        responses = [
-            FakeResponse(json_data={"data": [{"id": "1"}], "next": "1"}),
-            FakeResponse(json_data={"data": [{"id": "2"}]}),
-        ]
-        session = FakeSession(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_date_filter_sent_on_every_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response([{"id": "1"}], next_token="1"), _response([{"id": "2"}])])
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            list(
-                get_rows(
-                    "key",
-                    "org-1",
-                    "changes",
-                    mock.MagicMock(),
-                    _manager(),
-                    should_use_incremental_field=True,
-                    db_incremental_field_last_value=date(2026, 1, 15),
-                )
+        _rows(
+            _source(
+                "changes",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 1, 15),
             )
+        )
 
-        assert all("date=2026-01-15" in url for url in session.calls)
+        assert all(page_params["date"] == "2026-01-15" for page_params in params)
 
-    def test_full_refresh_endpoint_never_sends_date_filter(self) -> None:
-        responses = [FakeResponse(json_data={"data": [{"id": "1"}]})]
-        session = FakeSession(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_never_sends_date_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response([{"id": "1"}])])
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            list(
-                get_rows(
-                    "key",
-                    "org-1",
-                    "jobs",
-                    mock.MagicMock(),
-                    _manager(),
-                    should_use_incremental_field=True,
-                    db_incremental_field_last_value=date(2026, 1, 15),
-                )
+        _rows(
+            _source(
+                "jobs",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 1, 15),
             )
+        )
 
-        assert "date=" not in session.calls[0]
+        assert "date" not in params[0]
 
-    def test_persons_includes_ex_employees(self) -> None:
-        responses = [FakeResponse(json_data={"data": []})]
-        session = FakeSession(responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_persons_includes_ex_employees(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response([])])
 
-        with mock.patch(SESSION_PATH, return_value=session):
-            batches = list(get_rows("key", "org-1", "persons", mock.MagicMock(), _manager()))
+        rows = _rows(_source("persons", _make_manager()))
 
-        assert batches == []
-        assert "includeAll=true" in session.calls[0]
+        assert rows == []
+        assert params[0]["includeAll"] == "true"
 
     @parameterized.expand([(401,), (403,)])
-    def test_http_auth_errors_raise_matchable_api_error(self, status_code: int) -> None:
-        with mock.patch(SESSION_PATH, return_value=FakeSession([FakeResponse(status_code=status_code)])):
-            with pytest.raises(ChartHopAPIError) as exc:
-                list(get_rows("key", "org-1", "jobs", mock.MagicMock(), _manager()))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_http_auth_errors_raise_matchable_error(self, status_code: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], status_code=status_code)])
+
+        with pytest.raises(HTTPError) as exc:
+            _rows(_source("jobs", _make_manager()))
         assert f"{status_code} Client Error" in str(exc.value)
 
 
@@ -200,13 +221,14 @@ class TestResolveOrgId:
     @parameterized.expand([("plain", "org-1"), ("padded", "  org-1  ")])
     def test_configured_org_id_skips_lookup(self, _name: str, configured: str) -> None:
         session = mock.MagicMock()
-        with mock.patch(SESSION_PATH, return_value=session):
+        with mock.patch(CHARTHOP_SESSION_PATCH, return_value=session):
             assert resolve_org_id("key", configured) == "org-1"
         session.get.assert_not_called()
 
     def test_single_org_auto_detected(self) -> None:
-        response = FakeResponse(json_data={"data": [{"id": "org-9"}]})
-        with mock.patch(SESSION_PATH, return_value=FakeSession([response])):
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=200, json=lambda: {"data": [{"id": "org-9"}]})
+        with mock.patch(CHARTHOP_SESSION_PATCH, return_value=session):
             assert resolve_org_id("key", None) == "org-9"
 
     @parameterized.expand(
@@ -216,14 +238,17 @@ class TestResolveOrgId:
         ]
     )
     def test_zero_or_multiple_orgs_raise(self, _name: str, orgs: list[dict[str, Any]], expected_message: str) -> None:
-        response = FakeResponse(json_data={"data": orgs})
-        with mock.patch(SESSION_PATH, return_value=FakeSession([response])):
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=200, json=lambda: {"data": orgs})
+        with mock.patch(CHARTHOP_SESSION_PATCH, return_value=session):
             with pytest.raises(ChartHopAPIError) as exc:
                 resolve_org_id("key", "")
         assert expected_message in str(exc.value)
 
     def test_auth_error_raises_matchable_api_error(self) -> None:
-        with mock.patch(SESSION_PATH, return_value=FakeSession([FakeResponse(status_code=401)])):
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=401)
+        with mock.patch(CHARTHOP_SESSION_PATCH, return_value=session):
             with pytest.raises(ChartHopAPIError) as exc:
                 resolve_org_id("key", None)
         assert "401 Client Error" in str(exc.value)
@@ -231,18 +256,18 @@ class TestResolveOrgId:
 
 class TestChartHopSource:
     def test_changes_partitioned_by_effective_date(self) -> None:
-        response = charthop_source("key", "org-1", "changes", mock.MagicMock(), _manager())
+        response = _source("changes", _make_manager())
         assert response.name == "changes"
         assert response.primary_keys == ["id"]
         assert response.partition_mode == "datetime"
         assert response.partition_keys == ["date"]
 
     def test_full_refresh_endpoint_is_unpartitioned(self) -> None:
-        response = charthop_source("key", "org-1", "persons", mock.MagicMock(), _manager())
+        response = _source("persons", _make_manager())
         assert response.partition_mode is None
         assert response.partition_keys is None
 
     def test_all_endpoints_buildable(self) -> None:
         for endpoint in ENDPOINTS:
-            response = charthop_source("key", "org-1", endpoint, mock.MagicMock(), _manager())
+            response = _source(endpoint, _make_manager())
             assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/tests/test_charthop_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/charthop/tests/test_charthop_source.py
@@ -68,6 +68,8 @@ class TestChartHopSource:
         [
             ("bad_token", "401 Client Error: ChartHop API authentication or permission error for url /v1/org"),
             ("no_permission", "403 Client Error: ChartHop API authentication or permission error for url x"),
+            ("bad_token_fetch", "401 Client Error: Unauthorized for url: https://api.charthop.com/v2/org/x/job"),
+            ("no_permission_fetch", "403 Client Error: Forbidden for url: https://api.charthop.com/v2/org/x/job"),
             ("no_org_access", "ChartHop API token has no access to any organization"),
             (
                 "multiple_orgs",
@@ -81,8 +83,8 @@ class TestChartHopSource:
 
     @parameterized.expand(
         [
-            ("server_error", "ChartHop API error (retryable): status=503, url=x"),
-            ("rate_limited", "ChartHop API rate limited: status=429, url=x"),
+            ("server_error", "HTTP 503 for https://api.charthop.com/v2/org/x/job"),
+            ("rate_limited", "HTTP 429 for https://api.charthop.com/v2/org/x/job"),
         ]
     )
     def test_non_retryable_errors_ignore_transient_failures(self, _name: str, unrelated_error: str) -> None:
@@ -147,6 +149,8 @@ class TestChartHopSource:
         mock_resolve.return_value = "org-42"
         inputs = mock.MagicMock()
         inputs.schema_name = "changes"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2026-01-01"
         manager = mock.MagicMock()
@@ -158,6 +162,8 @@ class TestChartHopSource:
         assert kwargs["api_key"] == "charthop-token"
         assert kwargs["org_id"] == "org-42"
         assert kwargs["endpoint"] == "changes"
+        assert kwargs["team_id"] == 123
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2026-01-01"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/checkout_com.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/checkout_com.py
@@ -1,16 +1,19 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import OAuth2Auth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CHECKOUT_HOSTS = {
     "production": {"api": "https://api.checkout.com", "auth": "https://access.checkout.com/connect/token"},
@@ -21,16 +24,10 @@ CHECKOUT_HOSTS = {
 }
 # Disputes list pages cap at 250.
 PAGE_SIZE = 250
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
 
 # Checkout.com has no list-all-payments endpoint — bulk payment data only
 # exists via report files. Disputes are the one honest list surface.
 ENDPOINTS = ("disputes",)
-
-
-class CheckoutComRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -40,10 +37,6 @@ class CheckoutComResumeConfig:
     skip: int
 
 
-def _get_session(client_secret: str) -> requests.Session:
-    return make_tracked_session(redact_values=(client_secret,))
-
-
 def _hosts(environment: str) -> dict[str, str]:
     hosts = CHECKOUT_HOSTS.get(environment)
     if hosts is None:
@@ -51,26 +44,16 @@ def _hosts(environment: str) -> dict[str, str]:
     return hosts
 
 
-@retry(
-    retry=retry_if_exception_type((CheckoutComRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _mint_token(session: requests.Session, environment: str, client_id: str, client_secret: str) -> str:
-    """Exchange client credentials for a bearer token (~1h lifetime)."""
-    response = session.post(
-        _hosts(environment)["auth"],
-        data={"grant_type": "client_credentials"},
-        auth=(client_id, client_secret),
-        timeout=REQUEST_TIMEOUT_SECONDS,
+def _make_auth(environment: str, client_id: str, client_secret: str) -> OAuth2Auth:
+    # Checkout.com's token endpoint takes the client credentials as HTTP Basic
+    # auth; tokens last ~1h and the framework re-mints on expiry mid-run.
+    return OAuth2Auth(
+        token_url=_hosts(environment)["auth"],
+        client_id=client_id,
+        client_secret=client_secret,
+        grant_type="client_credentials",
+        client_auth_method="basic",
     )
-    # A transient auth-host blip (429/5xx) during an in-flight re-mint must not
-    # kill the whole sync — retry it like any other retryable API error.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CheckoutComRetryableError(f"Checkout.com auth error (retryable): status={response.status_code}")
-    response.raise_for_status()
-    return response.json()["access_token"]
 
 
 def _format_timestamp(value: Any) -> str:
@@ -84,80 +67,22 @@ def _format_timestamp(value: Any) -> str:
 
 
 def validate_credentials(environment: str, client_id: str, client_secret: str) -> bool:
-    """Confirm the API credentials are valid by minting a token."""
+    """Confirm the API credentials are valid by minting a token and probing disputes."""
     try:
-        _mint_token(_get_session(client_secret), environment, client_id, client_secret)
-        return True
-    except Exception:
+        hosts = _hosts(environment)
+        auth = _make_auth(environment, client_id, client_secret)
+    except ValueError:
         return False
-
-
-def get_rows(
-    environment: str,
-    client_id: str,
-    client_secret: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CheckoutComResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    session = _get_session(client_secret)
-    api_base = _hosts(environment)["api"]
-    token = _mint_token(session, environment, client_id, client_secret)
-
-    @retry(
-        retry=retry_if_exception_type((CheckoutComRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(client_secret,)),
+        f"{hosts['api']}/disputes?limit=1",
+        auth=auth,
+        # 403 means the token minted (keys are valid) but lacks the disputes
+        # scope — accept at create time, like the mint-only check did; the
+        # sync-time non-retryable copy guides the scope fix.
+        ok_statuses=(200, 403),
     )
-    def fetch(params: dict[str, Any]) -> dict[str, Any]:
-        nonlocal token
-        url = f"{api_base}/{endpoint}?{urlencode(params)}"
-        response = session.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # Tokens last ~1h; re-mint once if the sync outlives one.
-        if response.status_code == 401:
-            token = _mint_token(session, environment, client_id, client_secret)
-            response = session.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise CheckoutComRetryableError(
-                f"Checkout.com API error (retryable): status={response.status_code}, url={url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Checkout.com API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    skip = resume_config.skip if resume_config is not None else 0
-    if resume_config is not None:
-        logger.debug(f"Checkout.com: resuming {endpoint} from skip {skip}")
-
-    base_params: dict[str, Any] = {"limit": PAGE_SIZE}
-    if should_use_incremental_field and db_incremental_field_last_value is not None:
-        # `from` filters on a dispute's last_update timestamp.
-        base_params["from"] = _format_timestamp(db_incremental_field_last_value)
-
-    while True:
-        data = fetch({**base_params, "skip": skip})
-        items = data.get("data", []) or []
-
-        if items:
-            yield items
-
-        total = data.get("total_count")
-        skip += len(items)
-        if not items or (isinstance(total, int) and skip >= total):
-            break
-
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(CheckoutComResumeConfig(skip=skip))
+    return ok
 
 
 def checkout_com_source(
@@ -165,23 +90,63 @@ def checkout_com_source(
     client_id: str,
     client_secret: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CheckoutComResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
+    params: dict[str, Any] = {"limit": PAGE_SIZE}
+    if should_use_incremental_field and db_incremental_field_last_value is not None:
+        # `from` filters on a dispute's last_update timestamp.
+        params["from"] = _format_timestamp(db_incremental_field_last_value)
+
+    config: RESTAPIConfig = {
+        "client": {
+            "base_url": _hosts(environment)["api"],
+            "auth": _make_auth(environment, client_id, client_secret),
+            # Disputes paginate with limit/skip and report a grand total_count.
+            "paginator": OffsetPaginator(limit=PAGE_SIZE, offset_param="skip", total_path="total_count"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": endpoint,
+                    "params": params,
+                    # A missing `data` key means no rows (the pre-framework code
+                    # treated it as end-of-list), so the selector is not required.
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.skip}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; saved AFTER the page is yielded
+        # so a crash re-yields the last page (merge dedupes on primary key)
+        # rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(CheckoutComResumeConfig(skip=int(state["offset"])))
+
+    resource = rest_api_resource(
+        config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            environment=environment,
-            client_id=client_id,
-            client_secret=client_secret,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         partition_count=1,
         partition_size=1,
@@ -191,4 +156,5 @@ def checkout_com_source(
         # Disputes are returned newest-first; the pipeline commits desc
         # watermarks only when a run completes.
         sort_mode="desc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/source.py
@@ -26,8 +26,14 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAUTH2_PERMANENT_ERROR_MARKER,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CheckoutComSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalField, IncrementalFieldType
 
@@ -53,10 +59,9 @@ class CheckoutComSource(ResumableSource[CheckoutComSourceConfig, CheckoutComResu
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            "401 Client Error: Unauthorized for url: https://access.checkout.com": "Checkout.com authentication failed. Please check your access key ID and secret.",
-            "401 Client Error: Unauthorized for url: https://access.sandbox.checkout.com": "Checkout.com authentication failed. Please check your access key ID and secret (and that they match the selected environment).",
-            "400 Client Error: Bad Request for url: https://access.checkout.com": "Checkout.com authentication failed. Please check your access key ID and secret.",
-            "400 Client Error: Bad Request for url: https://access.sandbox.checkout.com": "Checkout.com authentication failed. Please check your access key ID and secret.",
+            # Permanent token-exchange failures (invalid_client, bad request, …) all carry
+            # the framework's stable marker; transient 429/5xx token errors don't.
+            OAUTH2_PERMANENT_ERROR_MARKER: "Checkout.com authentication failed. Please check your access key ID and secret (and that they match the selected environment).",
             "403 Client Error: Forbidden for url: https://api.checkout.com": "Checkout.com denied access. Please check that your access key has the disputes scope.",
             "403 Client Error: Forbidden for url: https://api.sandbox.checkout.com": "Checkout.com denied access. Please check that your access key has the disputes scope.",
         }
@@ -122,21 +127,7 @@ Create an access key in the [Checkout.com dashboard](https://dashboard.checkout.
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Disputes support a server-side `from` filter on last_update.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=True,
-                supports_append=True,
-                incremental_fields=list(_DISPUTES_INCREMENTAL_FIELDS),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, {"disputes": _DISPUTES_INCREMENTAL_FIELDS}, names)
 
     def validate_credentials(
         self, config: CheckoutComSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -160,7 +151,8 @@ Create an access key in the [Checkout.com dashboard](https://dashboard.checkout.
             client_id=config.client_id,
             client_secret=config.client_secret,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com.py
@@ -1,11 +1,13 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 import pytest
 from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.checkout_com.checkout_com import (
     PAGE_SIZE,
@@ -13,11 +15,37 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.checkout_c
     _format_timestamp,
     _hosts,
     checkout_com_source,
-    get_rows,
     validate_credentials,
 )
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.checkout_com.checkout_com"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# OAuth2Auth mints tokens through its own tracked session in the auth module.
+AUTH_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth.make_tracked_session"
+)
+# validate_credentials probes through a tracked session built in the checkout_com module.
+PROBE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.checkout_com.checkout_com.make_tracked_session"
+)
+
+
+def _disputes_response(items: list[dict[str, Any]], total: int | None = None, *, drop_data: bool = False) -> Response:
+    body: dict[str, Any] = {"limit": PAGE_SIZE, "total_count": total if total is not None else len(items)}
+    if not drop_data:
+        body["data"] = items
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _token_response(expires_in: int = 3600) -> mock.MagicMock:
+    # OAuth2Auth reads the token exchange body via response.raw.read (stream=True).
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.raw.read.return_value = json.dumps({"access_token": "the-token", "expires_in": expires_in}).encode()
+    return resp
 
 
 def _make_manager(resume_state: CheckoutComResumeConfig | None = None) -> mock.MagicMock:
@@ -27,24 +55,49 @@ def _make_manager(resume_state: CheckoutComResumeConfig | None = None) -> mock.M
     return manager
 
 
-def _token_response() -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {"access_token": "the-token", "expires_in": 3600}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock RESTClient session and snapshot each request AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead. A real
+    ``requests.Session`` does the preparing so the auth (OAuth2 token mint + Bearer header) is
+    actually applied, letting tests assert on the minted Authorization header and the token host.
+    """
+    session.headers = {}
+    real_session = requests.Session()
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> requests.PreparedRequest:
+        prepared = real_session.prepare_request(request)
+        snapshots.append({"params": dict(request.params or {}), "url": prepared.url, "headers": dict(prepared.headers)})
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _disputes_response(items: list[dict[str, Any]], total: int | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {
-        "limit": PAGE_SIZE,
-        "total_count": total if total is not None else len(items),
-        "data": items,
-    }
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(
+    manager: mock.MagicMock,
+    environment: str = "production",
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+):
+    return checkout_com_source(
+        environment=environment,
+        client_id="ack_id",
+        client_secret="secret",
+        endpoint="disputes",
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
 
 
 class TestHosts:
@@ -72,120 +125,220 @@ class TestFormatTimestamp:
 
 
 class TestValidateCredentials:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_valid_when_token_mints(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        assert validate_credentials("production", "ack_id", "secret") is True
+    @pytest.mark.parametrize(
+        "status, expected",
+        [
+            (200, True),
+            # 403 = token minted (keys valid) but missing the disputes scope — accept at create time.
+            (403, True),
+            (401, False),
+        ],
+    )
+    @mock.patch(PROBE_SESSION_PATCH)
+    def test_maps_probe_status(self, mock_session, status, expected):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("production", "ack_id", "secret") is expected
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_invalid_when_token_mint_fails(self, mock_session):
-        resp = mock.MagicMock()
-        resp.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=resp)
-        mock_session.return_value.post.return_value = resp
-        assert validate_credentials("production", "ack_id", "secret") is False
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(PROBE_SESSION_PATCH)
     def test_invalid_on_exception(self, mock_session):
-        mock_session.return_value.post.side_effect = Exception("boom")
+        mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("production", "ack_id", "secret") is False
 
+    def test_invalid_environment(self):
+        assert validate_credentials("evil", "ack_id", "secret") is False
 
-class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_paginates_via_skip_until_total(self, mock_session):
+
+class TestPagination:
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_skip_until_total(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        MockAuthSession.return_value.post.return_value = _token_response()
         full_page = [{"id": f"dsp_{i}"} for i in range(PAGE_SIZE)]
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [
-            _disputes_response(full_page, total=PAGE_SIZE + 1),
-            _disputes_response([{"id": "dsp_last"}], total=PAGE_SIZE + 1),
-        ]
+        snapshots = _wire(
+            session,
+            [
+                _disputes_response(full_page, total=PAGE_SIZE + 1),
+                _disputes_response([{"id": "dsp_last"}], total=PAGE_SIZE + 1),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("production", "ack_id", "secret", "disputes", mock.MagicMock(), manager))
+        rows = _rows(_source(manager))
 
-        assert len(batches) == 2
+        assert [r["id"] for r in rows] == [*(f"dsp_{i}" for i in range(PAGE_SIZE)), "dsp_last"]
+        assert snapshots[0]["params"]["skip"] == 0
+        assert snapshots[0]["params"]["limit"] == PAGE_SIZE
+        assert snapshots[1]["params"]["skip"] == PAGE_SIZE
+        # Checkpoint saved after the first page (points at the next page); the final page ends it.
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].skip == PAGE_SIZE
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert parse_qs(urlparse(urls[0]).query)["skip"] == ["0"]
-        assert parse_qs(urlparse(urls[1]).query)["skip"] == [str(PAGE_SIZE)]
+        assert manager.save_state.call_args.args[0] == CheckoutComResumeConfig(skip=PAGE_SIZE)
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_incremental_request_includes_from_filter(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _disputes_response([], total=0)
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_at_total_count_without_saving(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        MockAuthSession.return_value.post.return_value = _token_response()
+        full_page = [{"id": f"dsp_{i}"} for i in range(PAGE_SIZE)]
+        _wire(session, [_disputes_response(full_page, total=PAGE_SIZE)])
 
         manager = _make_manager()
-        list(
-            get_rows(
-                "production",
-                "ack_id",
-                "secret",
-                "disputes",
-                mock.MagicMock(),
+        rows = _rows(_source(manager))
+
+        assert len(rows) == PAGE_SIZE
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_skip(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        MockAuthSession.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_disputes_response([{"id": "dsp_501"}])])
+
+        manager = _make_manager(CheckoutComResumeConfig(skip=500))
+        _rows(_source(manager))
+
+        assert snapshots[0]["params"]["skip"] == 500
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops_without_saving_state(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        MockAuthSession.return_value.post.return_value = _token_response()
+        _wire(session, [_disputes_response([], total=0)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_treated_as_end_of_list(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        MockAuthSession.return_value.post.return_value = _token_response()
+        _wire(session, [_disputes_response([], total=0, drop_data=True)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+
+
+class TestIncremental:
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_includes_from_filter(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        MockAuthSession.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_disputes_response([], total=0)])
+
+        manager = _make_manager()
+        _rows(
+            _source(
                 manager,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
             )
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["from"] == ["2024-01-02T00:00:00Z"]
+        assert snapshots[0]["params"]["from"] == "2024-01-02T00:00:00Z"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_remints_token_on_401(self, mock_session):
-        expired = mock.MagicMock()
-        expired.status_code = 401
-        expired.ok = False
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [expired, _disputes_response([{"id": "dsp_1"}])]
-
-        manager = _make_manager()
-        batches = list(get_rows("production", "ack_id", "secret", "disputes", mock.MagicMock(), manager))
-
-        assert batches == [[{"id": "dsp_1"}]]
-        # One mint at start + one re-mint after the 401.
-        assert mock_session.return_value.post.call_count == 2
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resumes_from_saved_skip(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _disputes_response([], total=0)
-
-        manager = _make_manager(CheckoutComResumeConfig(skip=500))
-        list(get_rows("production", "ack_id", "secret", "disputes", mock.MagicMock(), manager))
-
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["skip"] == ["500"]
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_sandbox_uses_sandbox_hosts(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _disputes_response([], total=0)
+    @pytest.mark.parametrize("should_use_incremental_field, last_value", [(False, None), (True, None)])
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_from_filter_without_watermark(
+        self, MockSession, MockAuthSession, should_use_incremental_field, last_value
+    ) -> None:
+        session = MockSession.return_value
+        MockAuthSession.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_disputes_response([], total=0)])
 
         manager = _make_manager()
-        list(get_rows("sandbox", "ack_id", "secret", "disputes", mock.MagicMock(), manager))
+        _rows(
+            _source(
+                manager,
+                should_use_incremental_field=should_use_incremental_field,
+                db_incremental_field_last_value=last_value,
+            )
+        )
 
-        token_url = mock_session.return_value.post.call_args.args[0]
+        assert "from" not in snapshots[0]["params"]
+
+
+class TestAuth:
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_mints_token_once_and_sends_bearer(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        auth_session = MockAuthSession.return_value
+        auth_session.post.return_value = _token_response()
+        full_page = [{"id": f"dsp_{i}"} for i in range(PAGE_SIZE)]
+        snapshots = _wire(
+            session,
+            [
+                _disputes_response(full_page, total=PAGE_SIZE + 1),
+                _disputes_response([{"id": "dsp_last"}], total=PAGE_SIZE + 1),
+            ],
+        )
+
+        _rows(_source(_make_manager()))
+
+        # One mint covers the whole run while the token is unexpired.
+        assert auth_session.post.call_count == 1
+        token_url = auth_session.post.call_args.args[0]
+        assert token_url == "https://access.checkout.com/connect/token"
+        # Client credentials travel as HTTP Basic; grant is client_credentials.
+        assert auth_session.post.call_args.kwargs["auth"] == ("ack_id", "secret")
+        assert auth_session.post.call_args.kwargs["data"]["grant_type"] == "client_credentials"
+        assert all(s["headers"]["Authorization"] == "Bearer the-token" for s in snapshots)
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_remints_token_when_expired_mid_run(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        auth_session = MockAuthSession.return_value
+        # expires_in=0 makes the token expire immediately, forcing a re-mint per request —
+        # the deterministic stand-in for a sync outliving the ~1h token lifetime.
+        auth_session.post.return_value = _token_response(expires_in=0)
+        full_page = [{"id": f"dsp_{i}"} for i in range(PAGE_SIZE)]
+        _wire(
+            session,
+            [
+                _disputes_response(full_page, total=PAGE_SIZE + 1),
+                _disputes_response([{"id": "dsp_last"}], total=PAGE_SIZE + 1),
+            ],
+        )
+
+        rows = _rows(_source(_make_manager()))
+
+        assert len(rows) == PAGE_SIZE + 1
+        assert auth_session.post.call_count == 2
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sandbox_uses_sandbox_hosts(self, MockSession, MockAuthSession) -> None:
+        session = MockSession.return_value
+        auth_session = MockAuthSession.return_value
+        auth_session.post.return_value = _token_response()
+        snapshots = _wire(session, [_disputes_response([], total=0)])
+
+        _rows(_source(_make_manager(), environment="sandbox"))
+
+        token_url = auth_session.post.call_args.args[0]
         assert urlparse(token_url).netloc == "access.sandbox.checkout.com"
-        api_url = mock_session.return_value.get.call_args.args[0]
-        assert urlparse(api_url).netloc == "api.sandbox.checkout.com"
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_response_stops_without_saving_state(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _disputes_response([], total=0)
-
-        manager = _make_manager()
-        batches = list(get_rows("production", "ack_id", "secret", "disputes", mock.MagicMock(), manager))
-
-        assert batches == []
-        manager.save_state.assert_not_called()
+        assert urlparse(snapshots[0]["url"]).netloc == "api.sandbox.checkout.com"
 
 
 class TestCheckoutComSourceResponse:
-    def test_response_metadata(self):
-        response = checkout_com_source("production", "ack_id", "secret", "disputes", mock.MagicMock(), _make_manager())
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata(self, MockSession, MockAuthSession):
+        response = _source(_make_manager())
 
         assert response.name == "disputes"
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_source.py
@@ -7,6 +7,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.checkout_c
     CheckoutComResumeConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.checkout_com.source import CheckoutComSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAUTH2_PERMANENT_ERROR_MARKER,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CheckoutComSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -52,8 +55,9 @@ class TestCheckoutComSource:
     @pytest.mark.parametrize(
         "observed_error",
         [
-            "401 Client Error: Unauthorized for url: https://access.checkout.com/connect/token",
-            "400 Client Error: Bad Request for url: https://access.sandbox.checkout.com/connect/token",
+            # Permanent token-exchange failures carry the framework's stable marker.
+            f"HTTP 401 from the OAuth2 token endpoint: invalid_client {OAUTH2_PERMANENT_ERROR_MARKER}",
+            f"HTTP 400 from the OAuth2 token endpoint {OAUTH2_PERMANENT_ERROR_MARKER}",
             "403 Client Error: Forbidden for url: https://api.checkout.com/disputes?limit=250",
         ],
     )
@@ -67,6 +71,8 @@ class TestCheckoutComSource:
             "500 Server Error for url: https://api.checkout.com/disputes",
             # Mid-sync 401s on the API host are handled by token re-mint.
             "401 Client Error: Unauthorized for url: https://api.checkout.com/disputes",
+            # Transient token-endpoint errors (429/5xx) carry no marker and stay retryable.
+            "HTTP 429 from the OAuth2 token endpoint",
         ],
     )
     def test_non_retryable_errors_does_not_match_unrelated(self, other_error):
@@ -127,6 +133,8 @@ class TestCheckoutComSource:
         assert kwargs["client_id"] == "ack_id"
         assert kwargs["client_secret"] == "secret"
         assert kwargs["endpoint"] == "disputes"
+        assert kwargs["team_id"] is inputs.team_id
+        assert kwargs["job_id"] is inputs.job_id
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2024-01-02T03:04:05Z"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/auth.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/auth.py
@@ -84,7 +84,9 @@ class HttpBasicAuth(AuthConfigBase):
         return request
 
     def secret_values(self) -> tuple[str, ...]:
-        return (self.password,) if self.password else ()
+        # Some APIs (e.g. ChargeDesk) pass the secret key as the Basic username with an empty
+        # password, so redact whichever of the two is set — not just the password.
+        return tuple(v for v in (self.username, self.password) if v)
 
 
 # Re-mint the access token this many seconds before its declared expiry, so a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_config_setup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_config_setup.py
@@ -192,7 +192,9 @@ class TestAuthSecretValues:
             (None, ()),
             (BearerTokenAuth(token="ya29.secret"), ("ya29.secret",)),
             (APIKeyAuth(api_key="sk_live_x", name="key", location="query"), ("sk_live_x",)),
-            (HttpBasicAuth(username="alice", password="hunter2"), ("hunter2",)),
+            (HttpBasicAuth(username="alice", password="hunter2"), ("alice", "hunter2")),
+            # ChargeDesk-style: secret key as the Basic username with an empty password.
+            (HttpBasicAuth(username="sk_live_x", password=""), ("sk_live_x",)),
             (BearerTokenAuth(), ()),
             (APIKeyAuth(name="key", location="query"), ()),
         ],


### PR DESCRIPTION
## Problem

Ninth batch of hand-rolled source → `rest_source` migrations, stacked on #71589.

## Changes

**Four sources migrated** (behavior-preserving, suites green): `chameleon` (48 tests), `chargedesk` (40), `charthop` (50), `checkout_com` (40).

**Vetted and skipped** (each names a concrete gap): `circleci` (two-level fan-out + deduped hydration), `clari` (async export-job create/poll/fetch workflow), `cimis` (client-planned date windows + appKey-in-URL exception sanitization the framework can't provide), `care_quality_commission` (list→detail hydration over a ~10⁵-record registry — the framework's fan-out resume tracks a completed-path list, which is O(parents) Redis state per child call and only suits small parent lists; a parent-pagination resume mode is the future fix).

> [!NOTE]
> Stacked on #71589 → #71580 → #71572 → #71565 → #71559 → #71552 → #71540 → #71524 → #71520 → #71481/#71477.

## How did you test this code?

- Merged verification: **318 tests pass** across the 4 migrated sources + the full `rest_source` suite.
- Each source's suite passed in isolation first; coverage preserved. Worktree isolation verified before merge. `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
