### PR TITLE
fix(batch-exports): resume S3 staging reads from last offset on retry

### DIFF
--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -20,6 +20,16 @@ class AsyncMessageReader:
     def __init__(self, bytes_iter: collections.abc.AsyncIterator[bytes]):
         self._bytes = bytes_iter
         self._buffer = bytearray()
+        self._bytes_consumed = 0
+
+    @property
+    def bytes_consumed(self) -> int:
+        """Total bytes of fully parsed IPC messages consumed from the stream.
+
+        Buffered but not yet parsed bytes are not counted, so this is always an
+        offset at an IPC message boundary.
+        """
+        return self._bytes_consumed
 
     def __aiter__(self) -> "AsyncMessageReader":
         return self
@@ -63,6 +73,7 @@ class AsyncMessageReader:
             msg = await loop.run_in_executor(None, pa.ipc.read_message, buffer_view[:total_message_size])
 
         self._buffer = self._buffer[total_message_size:]
+        self._bytes_consumed += total_message_size
 
         return msg
 
@@ -110,9 +121,25 @@ class AsyncMessageReader:
 class AsyncRecordBatchReader:
     """Asynchronously read PyArrow RecordBatches from an iterator of bytes."""
 
-    def __init__(self, bytes_iter: collections.abc.AsyncIterator[bytes]) -> None:
+    def __init__(self, bytes_iter: collections.abc.AsyncIterator[bytes], schema: pa.Schema | None = None) -> None:
+        """Initialize the reader.
+
+        Arguments:
+            bytes_iter: The stream of bytes to read record batches from.
+            schema: Pass a schema parsed from a previous read to resume a stream
+                mid-way: the stream is then expected to start at a record batch
+                message boundary, with no schema message.
+        """
         self._reader = AsyncMessageReader(bytes_iter)
-        self._schema: None | pa.Schema = None
+        self._schema: None | pa.Schema = schema
+
+    @property
+    def bytes_consumed(self) -> int:
+        return self._reader.bytes_consumed
+
+    @property
+    def schema(self) -> pa.Schema | None:
+        return self._schema
 
     def __aiter__(self) -> "AsyncRecordBatchReader":
         return self

--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -46,7 +46,7 @@ class AsyncMessageReader:
 
         if self._buffer[:4] != CONTINUATION_BYTES:
             raise InvalidMessageFormat(
-                f"Encapsulated IPC message format must begin with continuation bytes, received: '{self._buffer}'"
+                f"Encapsulated IPC message format must begin with continuation bytes, received: '{self._buffer[:4]}'"
             )
 
         await self.read_until(8)

--- a/posthog/temporal/tests/common/test_asyncpa.py
+++ b/posthog/temporal/tests/common/test_asyncpa.py
@@ -12,6 +12,23 @@ from posthog.temporal.common import asyncpa
 pytestmark = [pytest.mark.asyncio]
 
 
+class AsyncWrapper:
+    def __init__(self, buffer: io.BytesIO, chunk_size: int = 1024) -> None:
+        self.buffer = buffer
+        self.chunk_size = chunk_size
+
+    def __aiter__(self) -> "AsyncWrapper":
+        return self
+
+    async def __anext__(self) -> bytes:
+        b = self.buffer.read(self.chunk_size)
+
+        if b == b"":
+            raise StopAsyncIteration
+        else:
+            return b
+
+
 def generate_record_batches(total_records: int = 1_000, total_batches: int = 10, target_size_bytes: int = 10 * 1024):
     """Generate record batches for testing.
 
@@ -60,22 +77,6 @@ async def test_record_batch_reader_reads_record_batches(record_batches: collecti
     buffer = io.BytesIO()
     first_batch = next(record_batches)
 
-    class AsyncWrapper:
-        def __init__(self, buffer: io.BytesIO, chunk_size: int = 1024) -> None:
-            self.buffer = buffer
-            self.chunk_size = chunk_size
-
-        def __aiter__(self) -> "AsyncWrapper":
-            return self
-
-        async def __anext__(self) -> bytes:
-            b = self.buffer.read(self.chunk_size)
-
-            if b == b"":
-                raise StopAsyncIteration
-            else:
-                return b
-
     reader = asyncpa.AsyncRecordBatchReader(AsyncWrapper(buffer))
 
     # We write a record batch into a buffer, immediately read it, and compare
@@ -107,3 +108,28 @@ async def test_record_batch_reader_reads_record_batches(record_batches: collecti
 
             _ = buffer.seek(0)
             _ = buffer.truncate()
+
+
+@pytest.mark.parametrize("batches_before_resume", [1, 5, 10])
+async def test_record_batch_reader_resumes_from_byte_offset(batches_before_resume: int):
+    total_batches = 10
+    batches = list(generate_record_batches(total_records=100, total_batches=total_batches, target_size_bytes=1024))
+
+    buffer = io.BytesIO()
+    with pa.ipc.new_stream(buffer, schema=batches[0].schema) as writer:
+        for batch in batches:
+            writer.write_batch(batch)
+    data = buffer.getvalue()
+
+    reader = asyncpa.AsyncRecordBatchReader(AsyncWrapper(io.BytesIO(data)))
+    batches_read = [await anext(reader) for _ in range(batches_before_resume)]
+    offset = reader.bytes_consumed
+
+    assert batches_read == batches[:batches_before_resume]
+    # The offset must land on an IPC message boundary (either the next record batch or the EOS marker).
+    assert data[offset : offset + 4] == asyncpa.CONTINUATION_BYTES
+
+    resumed_reader = asyncpa.AsyncRecordBatchReader(AsyncWrapper(io.BytesIO(data[offset:])), schema=reader.schema)
+    batches_resumed = [batch async for batch in resumed_reader]
+
+    assert batches_resumed == batches[batches_before_resume:]

--- a/products/batch_exports/backend/temporal/pipeline/producer.py
+++ b/products/batch_exports/backend/temporal/pipeline/producer.py
@@ -1,8 +1,11 @@
 import typing
 import asyncio
+import collections
+import dataclasses
 
 from django.conf import settings
 
+import pyarrow as pa
 from aiobotocore.response import StreamingBody
 from opentelemetry import trace
 
@@ -20,6 +23,22 @@ if typing.TYPE_CHECKING:
 
 LOGGER = get_write_only_logger(__name__)
 TRACER = trace.get_tracer(__name__)
+
+
+@dataclasses.dataclass
+class S3FileResumeState:
+    """Tracks how far into an S3 staging file we have fully enqueued record batches.
+
+    Used to resume from the last record batch boundary when retrying a failed
+    read, instead of re-reading (and re-emitting) the whole file.
+    """
+
+    # Absolute byte offset of the next unread IPC message.
+    offset: int = 0
+    # Cached schema, so a resumed stream (which lacks the schema message) can be parsed.
+    schema: pa.Schema | None = None
+    # Full object size, from the first (non-ranged) GET.
+    object_size: int | None = None
 
 
 class Producer:
@@ -96,7 +115,6 @@ class Producer:
                     if not keys:
                         return
 
-                    # Read in batches
                     await self._stream_record_batches_from_s3(
                         s3_client, keys, queue, max_record_batch_size_bytes, min_records_per_batch
                     )
@@ -123,6 +141,38 @@ class Producer:
         self.logger.info(f"Producer found {len(keys)} files in S3 stage, with prefix '{stage_folder}'")
         return keys
 
+    async def _open_staging_file(
+        self, s3_client: "S3Client", key: str, state: S3FileResumeState
+    ) -> StreamingBody | None:
+        """Open the S3 staging file for `key`, resuming from `state` if a previous attempt made progress.
+
+        Returns the byte stream to read, or `None` if the file was already fully consumed.
+        """
+        if state.offset > 0:
+            assert state.schema is not None and state.object_size is not None
+
+            if state.offset >= state.object_size:
+                # Defensive: a previous attempt consumed every batch (e.g. the file lacks
+                # an EOS marker); a range GET here would fail with 416 InvalidRange.
+                self.logger.info("Stream already fully consumed, nothing to resume", key=key, offset=state.offset)
+                return None
+
+            self.logger.info("Resuming stream after retryable failure", key=key, offset=state.offset)
+            s3_ob = await s3_client.get_object(
+                Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key, Range=f"bytes={state.offset}-"
+            )
+        else:
+            self.logger.info("Starting stream", key=key)
+            s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+
+        assert "Body" in s3_ob, "Body not found in S3 object"
+
+        if state.offset == 0:
+            # On a range GET, `ContentLength` is the length of the range, not the object.
+            state.object_size = s3_ob["ContentLength"]
+
+        return s3_ob["Body"]
+
     async def _stream_record_batches_from_s3(
         self,
         s3_client: "S3Client",
@@ -131,14 +181,24 @@ class Producer:
         max_record_batch_size_bytes: int = 0,
         min_records_per_batch: int = 100,
     ):
-        async def stream_from_s3_file(key):
-            self.logger.info("Starting stream", key=key)
+        # Per-key resume state, surviving across retries of `stream_from_s3_file` so a retry
+        # continues from the last fully-enqueued record batch instead of re-emitting duplicates.
+        resume_states: dict[str, S3FileResumeState] = collections.defaultdict(S3FileResumeState)
 
-            s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
-            assert "Body" in s3_ob, "Body not found in S3 object"
-            stream: StreamingBody = s3_ob["Body"]
-            # read in 128KB chunks of data from S3
-            reader = asyncpa.AsyncRecordBatchReader(stream.iter_chunks(chunk_size=128 * 1024))
+        async def stream_from_s3_file(key):
+            state = resume_states[key]
+            base_offset = state.offset
+
+            stream = await self._open_staging_file(s3_client, key, state)
+            if stream is None:
+                return
+
+            # read in 128KB chunks of data from S3. On a resumed read `state.schema` is set (it is
+            # only cached once `state.offset` advances past 0), so the reader skips the schema message.
+            reader = asyncpa.AsyncRecordBatchReader(
+                stream.iter_chunks(chunk_size=128 * 1024),
+                schema=state.schema,
+            )
 
             async for batch in reader:
                 for record_batch_slice in slice_record_batch(batch, max_record_batch_size_bytes, min_records_per_batch):
@@ -147,6 +207,11 @@ class Producer:
                     self.records_produced += record_batch_slice.num_rows
                     self.bytes_produced += record_batch_slice.nbytes
 
+                # Only advance the resume point once every slice of this batch is enqueued.
+                state.offset = base_offset + reader.bytes_consumed
+                state.schema = reader.schema
+
+            resume_states.pop(key, None)
             self.logger.info("Finished stream", key=key)
 
         stream_func = make_retryable_with_exponential_backoff(stream_from_s3_file, max_attempts=5, max_retry_delay=1)

--- a/products/batch_exports/backend/temporal/pipeline/producer.py
+++ b/products/batch_exports/backend/temporal/pipeline/producer.py
@@ -39,6 +39,9 @@ class S3FileResumeState:
     schema: pa.Schema | None = None
     # Full object size, from the first (non-ranged) GET.
     object_size: int | None = None
+    # ETag from the first GET, so a resumed range GET can assert (via IfMatch) it is
+    # reading the same object and fail loudly with a 412 if not.
+    etag: str | None = None
 
 
 class Producer:
@@ -115,6 +118,7 @@ class Producer:
                     if not keys:
                         return
 
+                    # Read in batches
                     await self._stream_record_batches_from_s3(
                         s3_client, keys, queue, max_record_batch_size_bytes, min_records_per_batch
                     )
@@ -149,7 +153,7 @@ class Producer:
         Returns the byte stream to read, or `None` if the file was already fully consumed.
         """
         if state.offset > 0:
-            assert state.schema is not None and state.object_size is not None
+            assert state.schema is not None and state.object_size is not None and state.etag is not None
 
             if state.offset >= state.object_size:
                 # Defensive: a previous attempt consumed every batch (e.g. the file lacks
@@ -158,8 +162,14 @@ class Producer:
                 return None
 
             self.logger.info("Resuming stream after retryable failure", key=key, offset=state.offset)
+            # `IfMatch` guards against the object changing under us: staging files are write-once
+            # today, but if that ever changes, ranging into a different object fails with a 412
+            # instead of silently yielding the wrong data.
             s3_ob = await s3_client.get_object(
-                Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key, Range=f"bytes={state.offset}-"
+                Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
+                Key=key,
+                Range=f"bytes={state.offset}-",
+                IfMatch=state.etag,
             )
         else:
             self.logger.info("Starting stream", key=key)
@@ -170,6 +180,7 @@ class Producer:
         if state.offset == 0:
             # On a range GET, `ContentLength` is the length of the range, not the object.
             state.object_size = s3_ob["ContentLength"]
+            state.etag = s3_ob["ETag"]
 
         return s3_ob["Body"]
 
@@ -211,7 +222,6 @@ class Producer:
                 state.offset = base_offset + reader.bytes_consumed
                 state.schema = reader.schema
 
-            resume_states.pop(key, None)
             self.logger.info("Finished stream", key=key)
 
         stream_func = make_retryable_with_exponential_backoff(stream_from_s3_file, max_attempts=5, max_retry_delay=1)

--- a/products/batch_exports/backend/temporal/pipeline/producer.py
+++ b/products/batch_exports/backend/temporal/pipeline/producer.py
@@ -1,6 +1,5 @@
 import typing
 import asyncio
-import collections
 import dataclasses
 
 from django.conf import settings
@@ -31,17 +30,20 @@ class S3FileResumeState:
 
     Used to resume from the last record batch boundary when retrying a failed
     read, instead of re-reading (and re-emitting) the whole file.
+
+    Attributes:
+        offset: Absolute byte offset of the next unread IPC message.
+        schema: Cached schema, so a resumed stream (which lacks the schema
+            message) can be parsed.
+        object_size: Full object size.
+        etag: Object ETag so a resumed range GET can assert (via IfMatch) it is
+            reading the same object, and fail loudly with a 412 if not.
     """
 
-    # Absolute byte offset of the next unread IPC message.
-    offset: int = 0
-    # Cached schema, so a resumed stream (which lacks the schema message) can be parsed.
-    schema: pa.Schema | None = None
-    # Full object size, from the first (non-ranged) GET.
-    object_size: int | None = None
-    # ETag from the first GET, so a resumed range GET can assert (via IfMatch) it is
-    # reading the same object and fail loudly with a 412 if not.
-    etag: str | None = None
+    offset: int
+    schema: pa.Schema | None
+    object_size: int
+    etag: str
 
 
 class Producer:
@@ -145,44 +147,51 @@ class Producer:
         self.logger.info(f"Producer found {len(keys)} files in S3 stage, with prefix '{stage_folder}'")
         return keys
 
-    async def _open_staging_file(
+    async def _resume_staging_file(
         self, s3_client: "S3Client", key: str, state: S3FileResumeState
     ) -> StreamingBody | None:
-        """Open the S3 staging file for `key`, resuming from `state` if a previous attempt made progress.
+        """Resume the S3 staging file for `key` from `state`.
 
-        Returns the byte stream to read, or `None` if the file was already fully consumed.
+        Returns the remaining byte stream to read resuming from `state` as
+        returned by `_open_staging_file` or `None` if the `state` indicates that
+        the file was already fully consumed.
         """
-        if state.offset > 0:
-            assert state.schema is not None and state.object_size is not None and state.etag is not None
+        if state.offset >= state.object_size:
+            # Defensive: a previous attempt consumed every batch (e.g. the file lacks
+            # an EOS marker); a range GET here would fail with 416 InvalidRange.
+            self.logger.info("Stream already fully consumed, nothing to resume", key=key, offset=state.offset)
+            return None
 
-            if state.offset >= state.object_size:
-                # Defensive: a previous attempt consumed every batch (e.g. the file lacks
-                # an EOS marker); a range GET here would fail with 416 InvalidRange.
-                self.logger.info("Stream already fully consumed, nothing to resume", key=key, offset=state.offset)
-                return None
-
-            self.logger.info("Resuming stream after retryable failure", key=key, offset=state.offset)
-            # `IfMatch` guards against the object changing under us: staging files are write-once
-            # today, but if that ever changes, ranging into a different object fails with a 412
-            # instead of silently yielding the wrong data.
-            s3_ob = await s3_client.get_object(
-                Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
-                Key=key,
-                Range=f"bytes={state.offset}-",
-                IfMatch=state.etag,
-            )
-        else:
-            self.logger.info("Starting stream", key=key)
-            s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+        self.logger.info("Resuming stream after retryable failure", key=key, offset=state.offset)
+        # `IfMatch` guards against the object changing under us: staging files are write-once
+        # today, but if that ever changes, ranging into a different object fails with a 412
+        # instead of silently yielding the wrong data.
+        s3_ob = await s3_client.get_object(
+            Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
+            Key=key,
+            Range=f"bytes={state.offset}-",
+            IfMatch=state.etag,
+        )
 
         assert "Body" in s3_ob, "Body not found in S3 object"
 
-        if state.offset == 0:
-            # On a range GET, `ContentLength` is the length of the range, not the object.
-            state.object_size = s3_ob["ContentLength"]
-            state.etag = s3_ob["ETag"]
-
         return s3_ob["Body"]
+
+    async def _open_staging_file(self, s3_client: "S3Client", key: str) -> tuple[StreamingBody, S3FileResumeState]:
+        """Open the S3 staging file for `key`.
+
+        Returns the full byte stream to read, as well as the initial state
+        required to eventually resume this byte stream in case we fail part way
+        through.
+        """
+        self.logger.info("Starting stream", key=key)
+        s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+
+        assert "Body" in s3_ob, "Body not found in S3 object"
+
+        return s3_ob["Body"], S3FileResumeState(
+            offset=0, schema=None, object_size=s3_ob["ContentLength"], etag=s3_ob["ETag"]
+        )
 
     async def _stream_record_batches_from_s3(
         self,
@@ -194,20 +203,30 @@ class Producer:
     ):
         # Per-key resume state, surviving across retries of `stream_from_s3_file` so a retry
         # continues from the last fully-enqueued record batch instead of re-emitting duplicates.
-        resume_states: dict[str, S3FileResumeState] = collections.defaultdict(S3FileResumeState)
+        resume_states: dict[str, S3FileResumeState] = {}
 
-        async def stream_from_s3_file(key):
+        async def stream_from_s3_file(key: str) -> None:
+            is_starting = key not in resume_states or resume_states[key].offset == 0
+
+            if is_starting:
+                stream, new_state = await self._open_staging_file(s3_client, key)
+                resume_states[key] = new_state
+
+            else:
+                maybe_stream = await self._resume_staging_file(s3_client, key, resume_states[key])
+                if maybe_stream is None:
+                    return
+
+                stream = maybe_stream
+
             state = resume_states[key]
             base_offset = state.offset
 
-            stream = await self._open_staging_file(s3_client, key, state)
-            if stream is None:
-                return
-
-            # read in 128KB chunks of data from S3. On a resumed read `state.schema` is set (it is
-            # only cached once `state.offset` advances past 0), so the reader skips the schema message.
             reader = asyncpa.AsyncRecordBatchReader(
-                stream.iter_chunks(chunk_size=128 * 1024),
+                stream.iter_chunks(chunk_size=128 * 1024),  # 128 KiB
+                # Schema will be set on the state if we managed to fully read and
+                # enqueue at least one batch before failing and retrying. This is
+                # required as the schema message is only present at the start.
                 schema=state.schema,
             )
 
@@ -220,7 +239,8 @@ class Producer:
 
                 # Only advance the resume point once every slice of this batch is enqueued.
                 state.offset = base_offset + reader.bytes_consumed
-                state.schema = reader.schema
+                if not state.schema:
+                    state.schema = reader.schema
 
             self.logger.info("Finished stream", key=key)
 

--- a/products/batch_exports/backend/tests/temporal/pipeline/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/conftest.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+
+import pytest_asyncio
+
+from products.batch_exports.backend.tests.temporal.utils.s3 import create_test_client, delete_all_from_s3
+
+
+@pytest_asyncio.fixture
+async def minio_client():
+    """Manage an S3 client to interact with a MinIO bucket."""
+    async with create_test_client(
+        "s3",
+        aws_access_key_id="object_storage_root_user",
+        aws_secret_access_key="object_storage_root_password",
+    ) as minio_client:
+        yield minio_client
+
+        await delete_all_from_s3(minio_client, settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, key_prefix="")

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.test.utils import override_settings
 
 import pyarrow as pa
-import pytest_asyncio
 from structlog.testing import capture_logs
 from temporalio.testing import ActivityEnvironment
 
@@ -41,11 +40,7 @@ from products.batch_exports.backend.tests.temporal.utils.persons import (
     generate_test_person_distinct_id2_in_clickhouse,
     generate_test_persons_in_clickhouse,
 )
-from products.batch_exports.backend.tests.temporal.utils.s3 import (
-    assert_files_in_s3,
-    create_test_client,
-    delete_all_from_s3,
-)
+from products.batch_exports.backend.tests.temporal.utils.s3 import assert_files_in_s3
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
@@ -212,19 +207,6 @@ async def test_write_batch_export_record_batches_to_internal_stage_rejects_futur
 
     mock_wait.assert_not_called()
     mock_get_client.assert_not_called()
-
-
-@pytest_asyncio.fixture
-async def minio_client():
-    """Manage an S3 client to interact with a MinIO bucket."""
-    async with create_test_client(
-        "s3",
-        aws_access_key_id="object_storage_root_user",
-        aws_secret_access_key="object_storage_root_password",
-    ) as minio_client:
-        yield minio_client
-
-        await delete_all_from_s3(minio_client, settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, key_prefix="")
 
 
 async def _generate_record_batches_from_internal_stage(

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
@@ -1,20 +1,35 @@
 import io
+import uuid
 import random
 import string
 import typing
+import asyncio
+import datetime as dt
 import functools
+import contextlib
 import collections
 
 import pytest
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test.utils import override_settings
 
 import pyarrow as pa
 
 from posthog.temporal.common import asyncpa
+from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
+from products.batch_exports.backend.service import BatchExportModel
 from products.batch_exports.backend.temporal.pipeline import producer as producer_module
+from products.batch_exports.backend.temporal.pipeline.internal_stage import (
+    BatchExportInsertIntoInternalStageInputs,
+    insert_into_internal_stage_activity,
+)
 from products.batch_exports.backend.temporal.pipeline.producer import Producer, S3FileResumeState
-from products.batch_exports.backend.temporal.spmc import RecordBatchQueue
+from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_for_schema_or_producer
 from products.batch_exports.backend.temporal.utils import make_retryable_with_exponential_backoff
+from products.batch_exports.backend.tests.temporal.utils.s3 import assert_files_in_s3
 
 if typing.TYPE_CHECKING:
     from types_aiobotocore_s3.client import S3Client
@@ -204,3 +219,184 @@ async def test_open_staging_file_short_circuits_when_fully_consumed():
 
     assert stream is None
     assert fake_s3_client.get_object_requests == []
+
+
+class _FailOnceStreamingBody:
+    """Wraps a real S3 streaming body so a read fails partway through, once.
+
+    Emits the body in `emit_chunk_size` pieces (ignoring the producer's requested chunk size) and
+    raises immediately after emitting `fail_after_bytes`. With `fail_after_bytes` set between two
+    record batch boundaries, the reader consumes and enqueues the earlier batches before the failure
+    but not the later ones, so the retry must resume mid-file.
+    """
+
+    def __init__(self, body, fail_after_bytes: int, emit_chunk_size: int) -> None:
+        self._body = body
+        self._fail_after_bytes = fail_after_bytes
+        self._emit_chunk_size = emit_chunk_size
+
+    def iter_chunks(self, chunk_size: int):
+        async def chunks():
+            data = await self._body.read()
+            emitted = 0
+            for start in range(0, len(data), self._emit_chunk_size):
+                piece = data[start : start + self._emit_chunk_size]
+                yield piece
+                emitted += len(piece)
+                if emitted >= self._fail_after_bytes:
+                    raise ConnectionResetError("Simulated mid-stream failure")
+
+        return chunks()
+
+
+class _FailFirstReadS3Client:
+    """Delegates to a real S3 client, failing only the body of the first get_object per client."""
+
+    def __init__(self, real_client, fail_after_bytes: int, emit_chunk_size: int) -> None:
+        self._real = real_client
+        self._fail_after_bytes = fail_after_bytes
+        self._emit_chunk_size = emit_chunk_size
+        self._get_object_count = 0
+        self.get_object_calls: list[dict] = []
+
+    async def list_objects_v2(self, **kwargs):
+        return await self._real.list_objects_v2(**kwargs)
+
+    async def get_object(self, **kwargs):
+        self._get_object_count += 1
+        self.get_object_calls.append(kwargs)
+        response = await self._real.get_object(**kwargs)
+        if self._get_object_count == 1:
+            response["Body"] = _FailOnceStreamingBody(response["Body"], self._fail_after_bytes, self._emit_chunk_size)
+        return response
+
+
+async def _drain_stage_via_producer(
+    stage_folder: str, data_interval_start: dt.datetime, data_interval_end: dt.datetime
+) -> list[dict]:
+    """Run the real producer over the internal stage and collect every emitted row."""
+    queue = RecordBatchQueue()
+    producer = Producer()
+    producer_task = await producer.start(
+        queue=queue,
+        batch_export_id=str(uuid.uuid4()),
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        stage_folder=stage_folder,
+    )
+    await wait_for_schema_or_producer(queue, producer_task)
+
+    rows: list[dict] = []
+    while True:
+        try:
+            rows.extend(queue.get_nowait().to_pylist())
+        except asyncio.QueueEmpty:
+            if producer_task.done():
+                break
+            await asyncio.sleep(0.1)
+
+    # Surface a producer failure rather than a confusing row-count mismatch.
+    await producer_task
+    return rows
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("interval", ["day"], indirect=True)
+@pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
+async def test_producer_resumes_from_offset_after_mid_file_failure(
+    interval,
+    activity_environment,
+    data_interval_start,
+    data_interval_end,
+    minio_client,
+    ateam,
+    clickhouse_client,
+    model: BatchExportModel,
+):
+    """A mid-file read failure resumes from the last batch boundary instead of re-delivering rows."""
+
+    # ClickHouse writes one Arrow record batch per source block, so several separate inserts (plus a
+    # tiny insert-block size to prevent coalescing) yield a staging file with several record batches.
+    num_inserts = 10
+    events_per_insert = 100
+    for n in range(num_inserts):
+        await generate_test_events_in_clickhouse(
+            client=clickhouse_client,
+            team_id=ateam.pk,
+            start_time=data_interval_start,
+            end_time=data_interval_end,
+            count=events_per_insert,
+            count_outside_range=0,
+            count_other_team=0,
+            event_name=f"resume-test-{n}-{{i}}",
+            table="events_recent",
+        )
+    total_events = num_inserts * events_per_insert
+
+    insert_inputs = BatchExportInsertIntoInternalStageInputs(
+        team_id=ateam.pk,
+        batch_export_id=str(uuid.uuid4()),
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        exclude_events=None,
+        include_events=None,
+        run_id=None,
+        batch_export_schema=None,
+        batch_export_model=model,
+        backfill_details=None,
+        destination_default_fields=None,
+    )
+    with override_settings(
+        BATCH_EXPORT_DYNAMIC_PARTITIONING_ENABLED=False,
+        BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS=1,
+        BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES=1,
+    ):
+        stage_result = await activity_environment.run(insert_into_internal_stage_activity, insert_inputs)
+    stage_folder = stage_result.stage_folder
+
+    _, keys = await assert_files_in_s3(
+        minio_client,
+        bucket_name=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
+        key_prefix=stage_folder,
+        file_format="Arrow",
+        compression=None,
+        json_columns=None,
+    )
+    assert len(keys) == 1
+    key = keys[0]
+
+    file_response = await minio_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+    file_bytes = await file_response["Body"].read()
+    offsets = await record_batch_end_offsets(file_bytes)
+    assert len(offsets) > 1, "test needs a multi-record-batch file to exercise resume"
+
+    # Fail in the last record batch: at least the first batch is enqueued before the failure, and the
+    # last one is not, so the retry must resume from a batch boundary partway through the file. The
+    # emit size keeps the failure point strictly between two boundaries regardless of batch sizes.
+    fail_after_bytes = (offsets[0] + offsets[-1]) // 2
+    emit_chunk_size = max(1, (offsets[-1] - offsets[0]) // 8)
+
+    wrapper: _FailFirstReadS3Client | None = None
+    real_get_s3_client = producer_module.get_s3_client
+
+    @contextlib.asynccontextmanager
+    async def failing_get_s3_client():
+        nonlocal wrapper
+        async with real_get_s3_client() as real_client:
+            wrapper = _FailFirstReadS3Client(real_client, fail_after_bytes, emit_chunk_size)
+            yield wrapper
+
+    with patch.object(producer_module, "get_s3_client", failing_get_s3_client):
+        exported_rows = await _drain_stage_via_producer(stage_folder, data_interval_start, data_interval_end)
+
+    # Every event delivered exactly once, despite the mid-file failure (a re-read would duplicate).
+    assert len(exported_rows) == total_events
+    assert len({row["uuid"] for row in exported_rows}) == total_events
+
+    # The retry resumed with a ranged, ETag-pinned GET rather than re-reading from the start.
+    assert wrapper is not None
+    assert len(wrapper.get_object_calls) == 2
+    resume_call = wrapper.get_object_calls[1]
+    assert resume_call.get("Range", "").startswith("bytes=")
+    assert int(resume_call["Range"].removeprefix("bytes=").removesuffix("-")) > 0
+    assert resume_call.get("IfMatch")

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
@@ -1,0 +1,133 @@
+import io
+import random
+import string
+import typing
+import functools
+import collections
+
+import pytest
+
+import pyarrow as pa
+
+from posthog.temporal.common import asyncpa
+
+from products.batch_exports.backend.temporal.pipeline import producer as producer_module
+from products.batch_exports.backend.temporal.pipeline.producer import Producer
+from products.batch_exports.backend.temporal.spmc import RecordBatchQueue
+from products.batch_exports.backend.temporal.utils import make_retryable_with_exponential_backoff
+
+if typing.TYPE_CHECKING:
+    from types_aiobotocore_s3.client import S3Client
+
+pytestmark = [pytest.mark.asyncio]
+
+# The producer reads S3 objects in chunks of this size, so test objects must be larger for a
+# mid-file failure to be observable.
+PRODUCER_CHUNK_SIZE = 128 * 1024
+
+
+class FakeStreamingBody:
+    def __init__(self, data: bytes, fail_after_bytes: int | None = None) -> None:
+        self._data = data
+        self._fail_after_bytes = fail_after_bytes
+
+    def iter_chunks(self, chunk_size: int):
+        async def chunks():
+            position = 0
+            while position < len(self._data):
+                if self._fail_after_bytes is not None and position >= self._fail_after_bytes:
+                    raise ConnectionResetError("Simulated mid-stream failure")
+
+                yield self._data[position : position + chunk_size]
+                position += chunk_size
+
+        return chunks()
+
+
+class FakeS3Client:
+    """In-memory S3 client that fails the body stream of the first GET per key after N bytes."""
+
+    def __init__(self, objects: dict[str, bytes], fail_first_read_after_bytes: int | None = None) -> None:
+        self._objects = objects
+        self._fail_first_read_after_bytes = fail_first_read_after_bytes
+        self._get_counts: collections.Counter[str] = collections.Counter()
+        self.get_object_requests: list[tuple[str, str | None]] = []
+
+    async def get_object(self, Bucket: str, Key: str, Range: str | None = None) -> dict:
+        self.get_object_requests.append((Key, Range))
+        self._get_counts[Key] += 1
+
+        offset = int(Range.removeprefix("bytes=").removesuffix("-")) if Range is not None else 0
+        assert offset < len(self._objects[Key]), "Invalid range requested"
+
+        fail_after_bytes = self._fail_first_read_after_bytes if self._get_counts[Key] == 1 else None
+        return {
+            "Body": FakeStreamingBody(self._objects[Key][offset:], fail_after_bytes),
+            "ContentLength": len(self._objects[Key]) - offset,
+        }
+
+
+def generate_arrow_ipc_file(
+    total_batches: int = 5, rows_per_batch: int = 10, text_size_bytes: int = 10 * 1024
+) -> tuple[list[pa.RecordBatch], bytes]:
+    batches = []
+    for batch_number in range(total_batches):
+        records = [
+            {
+                "id": row + batch_number * rows_per_batch,
+                "text": "".join(random.choices(string.ascii_letters, k=text_size_bytes)),
+            }
+            for row in range(rows_per_batch)
+        ]
+        batches.append(pa.RecordBatch.from_pylist(records))
+
+    buffer = io.BytesIO()
+    with pa.ipc.new_stream(buffer, schema=batches[0].schema) as writer:
+        for batch in batches:
+            writer.write_batch(batch)
+
+    return batches, buffer.getvalue()
+
+
+@pytest.mark.parametrize("fail_after_bytes", [0, PRODUCER_CHUNK_SIZE])
+async def test_stream_record_batches_from_s3_resumes_after_mid_file_failure(
+    fail_after_bytes: int, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        producer_module,
+        "make_retryable_with_exponential_backoff",
+        functools.partial(make_retryable_with_exponential_backoff, initial_retry_delay=0, max_delay_jitter=0),
+    )
+
+    batches, ipc_bytes = generate_arrow_ipc_file()
+    assert len(ipc_bytes) > PRODUCER_CHUNK_SIZE
+
+    key = "batch-export-data/file_0.arrow"
+    fake_s3_client = FakeS3Client({key: ipc_bytes}, fail_first_read_after_bytes=fail_after_bytes)
+    queue = RecordBatchQueue()
+    producer = Producer()
+
+    s3_client = typing.cast("S3Client", fake_s3_client)
+    await producer._stream_record_batches_from_s3(s3_client, [key], queue)
+
+    consumed = []
+    while not queue.empty():
+        consumed.append(queue.get_nowait())
+
+    expected_table = pa.Table.from_batches(batches)
+    assert pa.Table.from_batches(consumed, schema=expected_table.schema).equals(expected_table)
+    assert producer.records_produced == expected_table.num_rows
+
+    assert len(fake_s3_client.get_object_requests) == 2
+    retry_key, retry_range = fake_s3_client.get_object_requests[1]
+    assert retry_key == key
+
+    if fail_after_bytes == 0:
+        # Failed before any batch was enqueued: the retry must re-read the whole file.
+        assert retry_range is None
+    else:
+        assert retry_range is not None
+        offset = int(retry_range.removeprefix("bytes=").removesuffix("-"))
+        assert 0 < offset < len(ipc_bytes)
+        # The resume offset must land on an IPC message boundary, past the schema message.
+        assert ipc_bytes[offset : offset + 4] == asyncpa.CONTINUATION_BYTES

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
@@ -12,7 +12,7 @@ import pyarrow as pa
 from posthog.temporal.common import asyncpa
 
 from products.batch_exports.backend.temporal.pipeline import producer as producer_module
-from products.batch_exports.backend.temporal.pipeline.producer import Producer
+from products.batch_exports.backend.temporal.pipeline.producer import Producer, S3FileResumeState
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue
 from products.batch_exports.backend.temporal.utils import make_retryable_with_exponential_backoff
 
@@ -24,6 +24,7 @@ pytestmark = [pytest.mark.asyncio]
 # The producer reads S3 objects in chunks of this size, so test objects must be larger for a
 # mid-file failure to be observable.
 PRODUCER_CHUNK_SIZE = 128 * 1024
+FAKE_ETAG = '"fake-etag"'
 
 
 class FakeStreamingBody:
@@ -45,25 +46,30 @@ class FakeStreamingBody:
 
 
 class FakeS3Client:
-    """In-memory S3 client that fails the body stream of the first GET per key after N bytes."""
+    """In-memory S3 client that can fail chosen read attempts and honors Range/IfMatch."""
 
-    def __init__(self, objects: dict[str, bytes], fail_first_read_after_bytes: int | None = None) -> None:
+    def __init__(self, objects: dict[str, bytes], fail_after_bytes_per_attempt: list[int | None] | None = None) -> None:
         self._objects = objects
-        self._fail_first_read_after_bytes = fail_first_read_after_bytes
+        # Index i is the byte offset (into attempt i's returned body) at which that read fails, or None.
+        self._fail_after_bytes_per_attempt = fail_after_bytes_per_attempt or []
         self._get_counts: collections.Counter[str] = collections.Counter()
-        self.get_object_requests: list[tuple[str, str | None]] = []
+        self.get_object_requests: list[tuple[str, str | None, str | None]] = []
 
-    async def get_object(self, Bucket: str, Key: str, Range: str | None = None) -> dict:
-        self.get_object_requests.append((Key, Range))
+    async def get_object(self, Bucket: str, Key: str, Range: str | None = None, IfMatch: str | None = None) -> dict:
+        attempt = self._get_counts[Key]
         self._get_counts[Key] += 1
+        self.get_object_requests.append((Key, Range, IfMatch))
 
         offset = int(Range.removeprefix("bytes=").removesuffix("-")) if Range is not None else 0
         assert offset < len(self._objects[Key]), "Invalid range requested"
 
-        fail_after_bytes = self._fail_first_read_after_bytes if self._get_counts[Key] == 1 else None
+        fail_after_bytes = (
+            self._fail_after_bytes_per_attempt[attempt] if attempt < len(self._fail_after_bytes_per_attempt) else None
+        )
         return {
             "Body": FakeStreamingBody(self._objects[Key][offset:], fail_after_bytes),
             "ContentLength": len(self._objects[Key]) - offset,
+            "ETag": FAKE_ETAG,
         }
 
 
@@ -89,45 +95,112 @@ def generate_arrow_ipc_file(
     return batches, buffer.getvalue()
 
 
-@pytest.mark.parametrize("fail_after_bytes", [0, PRODUCER_CHUNK_SIZE])
-async def test_stream_record_batches_from_s3_resumes_after_mid_file_failure(
-    fail_after_bytes: int, monkeypatch: pytest.MonkeyPatch
-):
+async def record_batch_end_offsets(ipc_bytes: bytes) -> list[int]:
+    """Absolute byte offset after each record batch message, as the producer would resume from."""
+    reader = asyncpa.AsyncRecordBatchReader(FakeStreamingBody(ipc_bytes).iter_chunks(PRODUCER_CHUNK_SIZE))
+    offsets = []
+    async for _ in reader:
+        offsets.append(reader.bytes_consumed)
+    return offsets
+
+
+def drain(queue: RecordBatchQueue) -> list[pa.RecordBatch]:
+    consumed = []
+    while not queue.empty():
+        consumed.append(queue.get_nowait())
+    return consumed
+
+
+@pytest.fixture(autouse=True)
+def no_retry_delay(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         producer_module,
         "make_retryable_with_exponential_backoff",
         functools.partial(make_retryable_with_exponential_backoff, initial_retry_delay=0, max_delay_jitter=0),
     )
 
+
+@pytest.mark.parametrize("fail_after_bytes", [0, PRODUCER_CHUNK_SIZE])
+async def test_stream_record_batches_from_s3_resumes_after_mid_file_failure(fail_after_bytes: int):
     batches, ipc_bytes = generate_arrow_ipc_file()
     assert len(ipc_bytes) > PRODUCER_CHUNK_SIZE
 
     key = "batch-export-data/file_0.arrow"
-    fake_s3_client = FakeS3Client({key: ipc_bytes}, fail_first_read_after_bytes=fail_after_bytes)
+    fake_s3_client = FakeS3Client({key: ipc_bytes}, fail_after_bytes_per_attempt=[fail_after_bytes])
     queue = RecordBatchQueue()
     producer = Producer()
 
+    # keep mypy happy
     s3_client = typing.cast("S3Client", fake_s3_client)
     await producer._stream_record_batches_from_s3(s3_client, [key], queue)
 
-    consumed = []
-    while not queue.empty():
-        consumed.append(queue.get_nowait())
-
     expected_table = pa.Table.from_batches(batches)
-    assert pa.Table.from_batches(consumed, schema=expected_table.schema).equals(expected_table)
+    assert pa.Table.from_batches(drain(queue), schema=expected_table.schema).equals(expected_table)
     assert producer.records_produced == expected_table.num_rows
 
     assert len(fake_s3_client.get_object_requests) == 2
-    retry_key, retry_range = fake_s3_client.get_object_requests[1]
+    retry_key, retry_range, retry_if_match = fake_s3_client.get_object_requests[1]
     assert retry_key == key
 
     if fail_after_bytes == 0:
         # Failed before any batch was enqueued: the retry must re-read the whole file.
         assert retry_range is None
+        assert retry_if_match is None
     else:
         assert retry_range is not None
         offset = int(retry_range.removeprefix("bytes=").removesuffix("-"))
         assert 0 < offset < len(ipc_bytes)
         # The resume offset must land on an IPC message boundary, past the schema message.
         assert ipc_bytes[offset : offset + 4] == asyncpa.CONTINUATION_BYTES
+        # And it must pin the object it was resuming so a swapped object fails loudly.
+        assert retry_if_match == FAKE_ETAG
+
+
+async def test_stream_record_batches_from_s3_resumes_across_multiple_failures():
+    batches, ipc_bytes = generate_arrow_ipc_file()
+    offsets = await record_batch_end_offsets(ipc_bytes)
+    assert len(offsets) >= 3
+
+    key = "batch-export-data/file_0.arrow"
+    # Fail the first two reads after a single chunk each (~one batch), so every retry resumes
+    # from a strictly greater offset than the last and the read completes on the third attempt.
+    fake_s3_client = FakeS3Client({key: ipc_bytes}, fail_after_bytes_per_attempt=[1, 1])
+    queue = RecordBatchQueue()
+    producer = Producer()
+
+    # keep mypy happy
+    s3_client = typing.cast("S3Client", fake_s3_client)
+    await producer._stream_record_batches_from_s3(s3_client, [key], queue)
+
+    expected_table = pa.Table.from_batches(batches)
+    assert pa.Table.from_batches(drain(queue), schema=expected_table.schema).equals(expected_table)
+    assert producer.records_produced == expected_table.num_rows
+
+    # Initial read plus two resumes, each from the boundary the previous attempt reached.
+    ranges = [(rng, if_match) for _, rng, if_match in fake_s3_client.get_object_requests]
+    assert ranges == [
+        (None, None),
+        (f"bytes={offsets[0]}-", FAKE_ETAG),
+        (f"bytes={offsets[1]}-", FAKE_ETAG),
+    ]
+
+
+async def test_open_staging_file_short_circuits_when_fully_consumed():
+    key = "batch-export-data/file_0.arrow"
+    _, ipc_bytes = generate_arrow_ipc_file(total_batches=1)
+    fake_s3_client = FakeS3Client({key: ipc_bytes})
+    producer = Producer()
+
+    # Resume state that has already consumed the whole object: a range GET would 416.
+    state = S3FileResumeState(
+        offset=len(ipc_bytes),
+        schema=pa.schema([("id", pa.int64()), ("text", pa.string())]),
+        object_size=len(ipc_bytes),
+        etag=FAKE_ETAG,
+    )
+    # keep mypy happy
+    s3_client = typing.cast("S3Client", fake_s3_client)
+    stream = await producer._open_staging_file(s3_client, key, state)
+
+    assert stream is None
+    assert fake_s3_client.get_object_requests == []

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
@@ -200,7 +200,7 @@ async def test_stream_record_batches_from_s3_resumes_across_multiple_failures():
     ]
 
 
-async def test_open_staging_file_short_circuits_when_fully_consumed():
+async def test_resume_staging_file_short_circuits_when_fully_consumed():
     key = "batch-export-data/file_0.arrow"
     _, ipc_bytes = generate_arrow_ipc_file(total_batches=1)
     fake_s3_client = FakeS3Client({key: ipc_bytes})
@@ -209,13 +209,15 @@ async def test_open_staging_file_short_circuits_when_fully_consumed():
     # Resume state that has already consumed the whole object: a range GET would 416.
     state = S3FileResumeState(
         offset=len(ipc_bytes),
-        schema=pa.schema([("id", pa.int64()), ("text", pa.string())]),
+        # Mypy takes the common suppertype of StringType and Int64Type, which is not
+        # datatype but object, so this fails. Until the stub is fixed, just ignore
+        schema=pa.schema([("id", pa.int64()), ("text", pa.string())]),  # type: ignore
         object_size=len(ipc_bytes),
         etag=FAKE_ETAG,
     )
     # keep mypy happy
     s3_client = typing.cast("S3Client", fake_s3_client)
-    stream = await producer._open_staging_file(s3_client, key, state)
+    stream = await producer._resume_staging_file(s3_client, key, state)
 
     assert stream is None
     assert fake_s3_client.get_object_requests == []


### PR DESCRIPTION
## Problem

The batch export producer streams Arrow IPC files from the internal S3 staging area onto a queue for destination writers. Each file read is wrapped in a retry with backoff.

On a mid-file failure (e.g. a connection reset), the retry re-opened the file with a plain GET from byte 0 and re-emitted any batches already queued, so customers could receive duplicate rows.

## Changes

Track how far we've read into each file and resume from there on retry.

- `asyncpa.py`: `AsyncMessageReader` exposes `bytes_consumed` (always at an IPC message boundary); `AsyncRecordBatchReader` accepts a pre-parsed `schema` so a resumed stream, which starts mid-file with no schema message, parses directly.
- `producer.py`: per-key `S3FileResumeState` (offset, cached schema, object size, ETag) survives across retries in the read closure. On resume it issues a ranged GET (`Range: bytes=<offset>-`) pinned with `IfMatch` to the original ETag, so a changed object 412s instead of yielding garbage. The offset only advances after a batch's slices are all enqueued, so a batch is never half-counted.

This relies on stage files being plain uncompressed Arrow IPC streams (ClickHouse `FORMAT ArrowStream`), so message-boundary offsets are valid resume points. Side benefit: `records_produced`/`bytes_produced` no longer double-count on retried files.

## How did you test this code?

I (Claude, agent-assisted) did not test manually. Automated coverage:

- `test_asyncpa.py` — reader resumes from a captured byte offset with a seeded schema (parameterized, incl. resuming exactly at the EOS marker).
- `test_producer.py` (new) — against a fake S3 client: single mid-file failure resumes with a ranged, ETag-pinned GET (and a clean full re-read when the failure precedes any batch); consecutive failures resume from successive boundaries; the fully-consumed short-circuit. Plus one e2e test that runs the real staging activity into real MinIO and reads it back through the real producer with a mid-file failure injected, asserting every row is delivered exactly once.

I confirmed the tests catch the bug: against the unfixed producer, the mid-file cases fail on the exactly-once assertion (a batch is delivered twice); with the fix they pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ross directed this work; I (Claude, via PostHog Code) explored, planned, and implemented it. Skill invoked: `/writing-tests`.

Notes for reviewers:

- Rejected the simpler "re-read from 0 and skip N emitted batches" alternative: it re-downloads the consumed prefix each retry and makes no forward progress on a persistently flaky connection. Ranged resume needs only a small `asyncpa.py` change (a byte counter + optional schema arg).

---

_Created with [PostHog Code](https://posthog.com/code?ref=pr)_