### PR TITLE
feat(data-warehouse): migrate 4 sources to rest_source (batch 10)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clockodo/clockodo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clockodo/clockodo.py
@@ -1,20 +1,24 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.clockodo.settings import (
     CLOCKODO_ENDPOINTS,
     ENTRIES_TIME_SINCE,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # Clockodo's API is hosted at a single fixed host for every account (no per-tenant subdomain).
 CLOCKODO_BASE_URL = "https://my.clockodo.com/api"
@@ -23,12 +27,6 @@ CLOCKODO_BASE_URL = "https://my.clockodo.com/api"
 # "[application name];[email address]". We send our app name plus the connecting user's email.
 EXTERNAL_APPLICATION_NAME = "PostHog"
 
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class ClockodoRetryableError(Exception):
-    pass
-
 
 @dataclasses.dataclass
 class ClockodoResumeConfig:
@@ -36,10 +34,11 @@ class ClockodoResumeConfig:
     next_page: int
 
 
-def _build_headers(api_user: str, api_key: str) -> dict[str, str]:
+def _build_headers(api_user: str) -> dict[str, str]:
+    # The API key is supplied via the framework auth config so its value is redacted from
+    # logs; only the non-secret identification/accept headers are set here.
     return {
         "X-ClockodoApiUser": api_user,
-        "X-ClockodoApiKey": api_key,
         "X-Clockodo-External-Application": f"{EXTERNAL_APPLICATION_NAME};{api_user}",
         "Accept": "application/json",
     }
@@ -49,32 +48,6 @@ def _format_z(dt: datetime) -> str:
     """ISO 8601 in UTC with a Z suffix, the format the entries endpoint expects."""
     utc_dt = dt.astimezone(UTC)
     return utc_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-@retry(
-    retry=retry_if_exception_type((ClockodoRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # 429 (rate limit) and 5xx are transient — back off and retry.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ClockodoRetryableError(f"Clockodo API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Clockodo API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
 
 
 def _endpoint_params(endpoint: str) -> dict[str, Any]:
@@ -88,99 +61,78 @@ def _endpoint_params(endpoint: str) -> dict[str, Any]:
     return params
 
 
-def get_rows(
-    api_user: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ClockodoResumeConfig],
-) -> Iterator[Any]:
-    config = CLOCKODO_ENDPOINTS[endpoint]
-    headers = _build_headers(api_user, api_key)
-    params = _endpoint_params(endpoint)
-    url = f"{CLOCKODO_BASE_URL}/{config.path}"
-    # One session reused across every page so urllib3 keeps the connection alive.
-    # Redact the API key from logged URLs and captured samples — it travels in a custom
-    # header the name-based scrubbers don't recognise.
-    session = make_tracked_session(redact_values=(api_key,))
-    batcher = Batcher(logger=logger, chunk_size=5000, chunk_size_bytes=200 * 1024 * 1024)
-
-    if not config.paginated:
-        data = _fetch_page(session, url, headers, params, logger)
-        for item in data.get(config.data_key, []):
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-        if batcher.should_yield(include_incomplete_chunk=True):
-            yield batcher.get_table()
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume else 1
-
-    # Oldest page whose rows aren't yet in a durably-yielded batch. Resume re-fetches from here so a
-    # page's tail that hasn't been yielded is never skipped; already-yielded rows merge-dedupe on the
-    # primary key. A yield flushes every batched row, so it advances this pointer to the current page.
-    resume_page = page
-
-    while True:
-        params["page"] = page
-        data = _fetch_page(session, url, headers, params, logger)
-        items = data.get(config.data_key, [])
-
-        # The paging block tells us the total page count; missing for unpaginated responses.
-        paging = data.get("paging") or {}
-        count_pages = paging.get("count_pages", page)
-        has_more = page < count_pages and bool(items)
-
-        for item in items:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                resume_page = page
-
-        # Save once per page — even when the page produced no yield — so a crash resumes near where it
-        # stopped instead of from page 1. We can only advance past pages whose rows are durably yielded,
-        # so this points at the oldest still-unflushed page.
-        resumable_source_manager.save_state(ClockodoResumeConfig(next_page=resume_page))
-
-        if not has_more:
-            break
-        page += 1
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
-
 def clockodo_source(
     api_user: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ClockodoResumeConfig],
 ) -> SourceResponse:
     config = CLOCKODO_ENDPOINTS[endpoint]
+
+    # Clockodo only paginates a subset of resources; paginated responses carry the total
+    # page count at paging.count_pages, so we stop after the last page. An empty page also
+    # terminates (stop_after_empty_page default).
+    paginator: BasePaginator = (
+        PageNumberPaginator(base_page=1, page_param="page", total_path="paging.count_pages")
+        if config.paginated
+        else SinglePagePaginator()
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CLOCKODO_BASE_URL,
+            "headers": _build_headers(api_user),
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-ClockodoApiKey", "location": "header"},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": _endpoint_params(endpoint),
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.paginated and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; save AFTER a page is yielded so a crash
+        # re-fetches the last in-flight page (merge dedupes on the primary key) rather than
+        # skipping it. Unpaginated endpoints never produce a state, so they never checkpoint.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(ClockodoResumeConfig(next_page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # every Clockodo endpoint is full refresh — no incremental fields
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_user=api_user,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
     )
 
 
 def validate_credentials(api_user: str, api_key: str) -> bool:
     """Cheap probe to confirm the API user/key pair is genuine."""
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(
-            f"{CLOCKODO_BASE_URL}/v2/users",
-            headers=_build_headers(api_user, api_key),
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CLOCKODO_BASE_URL}/v2/users",
+        headers={"X-ClockodoApiKey": api_key, **_build_headers(api_user)},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clockodo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clockodo/source.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ClockodoSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -67,23 +70,19 @@ class ClockodoSource(ResumableSource[ClockodoSourceConfig, ClockodoResumeConfig]
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Clockodo exposes no server-side modified-since filter, so every table is full refresh only.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=CLOCKODO_ENDPOINTS[endpoint].should_sync_default,
-                description=CLOCKODO_ENDPOINTS[endpoint].description,
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions={
+                endpoint: config.description
+                for endpoint, config in CLOCKODO_ENDPOINTS.items()
+                if config.description is not None
+            },
+            should_sync_default={
+                endpoint: config.should_sync_default for endpoint, config in CLOCKODO_ENDPOINTS.items()
+            },
+        )
 
     def validate_credentials(
         self, config: ClockodoSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -106,7 +105,8 @@ class ClockodoSource(ResumableSource[ClockodoSourceConfig, ClockodoResumeConfig]
             api_user=config.api_user,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clockodo/tests/test_clockodo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clockodo/tests/test_clockodo.py
@@ -1,44 +1,89 @@
+import json
 from datetime import UTC, datetime
 from typing import Any
 
 from freezegun import freeze_time
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import pyarrow as pa
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
-from products.warehouse_sources.backend.temporal.data_imports.sources.clockodo import clockodo
 from products.warehouse_sources.backend.temporal.data_imports.sources.clockodo.clockodo import (
     EXTERNAL_APPLICATION_NAME,
     ClockodoResumeConfig,
-    _build_headers,
     _endpoint_params,
     _format_z,
     clockodo_source,
-    get_rows,
     validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the clockodo module.
+CLOCKODO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.clockodo.clockodo.make_tracked_session"
 )
 
 
-def _row_count(tables: list[pa.Table]) -> int:
-    return sum(t.num_rows for t in tables)
+def _response(
+    items: list[dict[str, Any]] | None,
+    *,
+    data_key: str = "customers",
+    count_pages: int | None = None,
+    drop_data: bool = False,
+) -> Response:
+    body: dict[str, Any] = {}
+    if count_pages is not None:
+        body["paging"] = {"count_pages": count_pages}
+    if not drop_data:
+        body[data_key] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _ids(tables: list[pa.Table]) -> list[Any]:
-    ids: list[Any] = []
-    for t in tables:
-        ids.extend(t.column("id").to_pylist())
-    return ids
+def _make_manager(resume_state: ClockodoResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class TestHeaders:
-    def test_includes_mandatory_external_application_header(self) -> None:
-        headers = _build_headers("me@example.com", "key123")
-        assert headers["X-ClockodoApiUser"] == "me@example.com"
-        assert headers["X-ClockodoApiKey"] == "key123"
-        # The API rejects every request without this identification header.
-        assert headers["X-Clockodo-External-Application"] == f"{EXTERNAL_APPLICATION_NAME};me@example.com"
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Wire a mock session; capture each request's params and auth AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    auth_snapshots: list[Any] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        auth_snapshots.append(request.auth)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, auth_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return clockodo_source(
+        api_user="me@example.com",
+        api_key="key123",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
 
 
 class TestFormatZ:
@@ -68,149 +113,160 @@ class TestEndpointParams:
         assert "time_until" not in params
 
 
-# Force a 1-row chunk so every row yields a table — exercises the resume save path.
-def _patch_small_batcher() -> Any:
-    def _factory(*_args: Any, logger: Any = None, **_kwargs: Any) -> Batcher:
-        return Batcher(logger=logger or MagicMock(), chunk_size=1, chunk_size_bytes=10**12)
+class TestHeadersAndAuth:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_identification_headers_and_api_key_auth(self, MockSession) -> None:
+        session = MockSession.return_value
+        _params, auths = _wire(session, [_response([{"id": 1}], count_pages=1)])
 
-    return patch.object(clockodo, "Batcher", side_effect=_factory)
+        _rows(_source("customers", _make_manager()))
+
+        # The API rejects every request without the identification headers.
+        assert session.headers["X-ClockodoApiUser"] == "me@example.com"
+        assert session.headers["X-Clockodo-External-Application"] == f"{EXTERNAL_APPLICATION_NAME};me@example.com"
+        # The API key travels via the framework auth config so its value is redacted from logs.
+        auth = auths[0]
+        assert isinstance(auth, APIKeyAuth)
+        assert auth.name == "X-ClockodoApiKey"
+        assert auth.api_key == "key123"
+        assert auth.location == "header"
 
 
-class TestGetRows:
-    def test_paginated_walks_all_pages_and_saves_state(self) -> None:
-        pages = {
-            1: {"paging": {"count_pages": 2}, "customers": [{"id": 1}, {"id": 2}]},
-            2: {"paging": {"count_pages": 2}, "customers": [{"id": 3}]},
-        }
-        seen_pages: list[int] = []
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginated_walks_all_pages_and_saves_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _auths = _wire(
+            session,
+            [
+                _response([{"id": 1}, {"id": 2}], count_pages=2),
+                _response([{"id": 3}], count_pages=2),
+            ],
+        )
 
-        def fake_fetch(_session: Any, _url: str, _headers: Any, params: dict, _logger: Any) -> dict:
-            seen_pages.append(params["page"])
-            return pages[params["page"]]
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
 
-        manager = MagicMock()
-        manager.can_resume.return_value = False
+        assert [r["id"] for r in rows] == [1, 2, 3]
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
+        # Checkpoint saved after the first page (points at the next page to fetch); the paging
+        # block says page 2 is the last, so no further checkpoint is written.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == ClockodoResumeConfig(next_page=2)
 
-        with (
-            patch.object(clockodo, "make_tracked_session", return_value=MagicMock()),
-            patch.object(clockodo, "_fetch_page", side_effect=fake_fetch),
-            _patch_small_batcher(),
-        ):
-            tables = list(get_rows("u", "k", "customers", MagicMock(), manager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_after_count_pages_without_extra_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}], count_pages=1)])
 
-        assert seen_pages == [1, 2]
-        assert _ids(tables) == [1, 2, 3]
-        # State is saved once per page, pointing at the oldest unflushed page (the page being
-        # processed here, since every row yields), so a crash re-fetches it rather than skipping its tail.
-        saved = [c.args[0].next_page for c in manager.save_state.call_args_list]
-        assert saved == [1, 2]
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
 
-    def test_paginated_saves_state_per_page_even_without_a_yield(self) -> None:
-        # Realistic batcher: pages are far under the chunk threshold, so nothing yields mid-walk.
-        # State must still be saved once per page (pointing at page 1, the oldest unflushed page)
-        # so a crash resumes near where it stopped rather than always from page 1.
-        pages = {
-            1: {"paging": {"count_pages": 2}, "customers": [{"id": 1}, {"id": 2}]},
-            2: {"paging": {"count_pages": 2}, "customers": [{"id": 3}]},
-        }
-
-        def fake_fetch(_session: Any, _url: str, _headers: Any, params: dict, _logger: Any) -> dict:
-            return pages[params["page"]]
-
-        manager = MagicMock()
-        manager.can_resume.return_value = False
-
-        with (
-            patch.object(clockodo, "make_tracked_session", return_value=MagicMock()),
-            patch.object(clockodo, "_fetch_page", side_effect=fake_fetch),
-        ):
-            tables = list(get_rows("u", "k", "customers", MagicMock(), manager))
-
-        assert _ids(tables) == [1, 2, 3]
-        saved = [c.args[0].next_page for c in manager.save_state.call_args_list]
-        assert saved == [1, 1]
-
-    def test_resumes_from_saved_page(self) -> None:
-        pages = {2: {"paging": {"count_pages": 2}, "customers": [{"id": 3}]}}
-        seen_pages: list[int] = []
-
-        def fake_fetch(_session: Any, _url: str, _headers: Any, params: dict, _logger: Any) -> dict:
-            seen_pages.append(params["page"])
-            return pages[params["page"]]
-
-        manager = MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = ClockodoResumeConfig(next_page=2)
-
-        with (
-            patch.object(clockodo, "make_tracked_session", return_value=MagicMock()),
-            patch.object(clockodo, "_fetch_page", side_effect=fake_fetch),
-            _patch_small_batcher(),
-        ):
-            tables = list(get_rows("u", "k", "customers", MagicMock(), manager))
-
-        # Picks up at the saved page rather than restarting at page 1.
-        assert seen_pages == [2]
-        assert _ids(tables) == [3]
-
-    def test_non_paginated_single_fetch(self) -> None:
-        seen_params: list[dict] = []
-
-        def fake_fetch(_session: Any, _url: str, _headers: Any, params: dict, _logger: Any) -> dict:
-            seen_params.append(dict(params))
-            return {"services": [{"id": 1}, {"id": 2}]}
-
-        manager = MagicMock()
-        manager.can_resume.return_value = False
-
-        with (
-            patch.object(clockodo, "make_tracked_session", return_value=MagicMock()),
-            patch.object(clockodo, "_fetch_page", side_effect=fake_fetch),
-            _patch_small_batcher(),
-        ):
-            tables = list(get_rows("u", "k", "services", MagicMock(), manager))
-
-        assert len(seen_params) == 1
-        # Non-paginated endpoints never send a page param.
-        assert "page" not in seen_params[0]
-        assert _ids(tables) == [1, 2]
+        assert [r["id"] for r in rows] == [1]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_empty_response_yields_nothing(self) -> None:
-        def fake_fetch(_session: Any, _url: str, _headers: Any, params: dict, _logger: Any) -> dict:
-            return {"paging": {"count_pages": 1}, "customers": []}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_terminates_before_count_pages(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": 1}], count_pages=3),
+                _response([], count_pages=3),
+            ],
+        )
 
-        manager = MagicMock()
-        manager.can_resume.return_value = False
+        rows = _rows(_source("customers", _make_manager()))
 
-        with (
-            patch.object(clockodo, "make_tracked_session", return_value=MagicMock()),
-            patch.object(clockodo, "_fetch_page", side_effect=fake_fetch),
-            _patch_small_batcher(),
-        ):
-            tables = list(get_rows("u", "k", "customers", MagicMock(), manager))
+        # An empty page ends the walk even when the paging block promises more pages.
+        assert [r["id"] for r in rows] == [1]
+        assert session.send.call_count == 2
 
-        assert _row_count(tables) == 0
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _auths = _wire(session, [_response([{"id": 3}], count_pages=2)])
+
+        manager = _make_manager(ClockodoResumeConfig(next_page=2))
+        rows = _rows(_source("customers", manager))
+
+        # Picks up at the saved page rather than restarting at page 1.
+        assert params[0]["page"] == 2
+        assert [r["id"] for r in rows] == [3]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_single_fetch(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _auths = _wire(session, [_response([{"id": 1}, {"id": 2}], data_key="services")])
+
+        manager = _make_manager()
+        rows = _rows(_source("services", manager))
+
+        assert session.send.call_count == 1
+        # Non-paginated endpoints never send a page param.
+        assert "page" not in params[0]
+        assert [r["id"] for r in rows] == [1, 2]
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    @freeze_time("2026-06-29T12:00:00Z")
+    def test_entries_sends_time_window(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _auths = _wire(session, [_response([{"id": 1}], data_key="entries", count_pages=1)])
+
+        _rows(_source("entries", _make_manager()))
+
+        assert params[0]["time_since"] == "2000-01-01T00:00:00Z"
+        assert params[0]["time_until"] == "2027-06-29T12:00:00Z"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], count_pages=1)])
+
+        rows = _rows(_source("customers", _make_manager()))
+
+        assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, count_pages=1, drop_data=True)])
+
+        rows = _rows(_source("customers", _make_manager()))
+
+        assert rows == []
 
 
 class TestClockodoSourceResponse:
     @parameterized.expand([("customers",), ("entries",), ("users",)])
-    def test_primary_keys_default_to_id(self, endpoint: str) -> None:
-        response = clockodo_source("u", "k", endpoint, MagicMock(), MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_primary_keys_default_to_id(self, endpoint: str, MockSession) -> None:
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    def test_validate_credentials_status_mapping(self, _name: str, status: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status)
-        with patch.object(clockodo, "make_tracked_session", return_value=session):
-            assert validate_credentials("u", "k") is expected
+    @mock.patch(CLOCKODO_SESSION_PATCH)
+    def test_validate_credentials_status_mapping(self, _name: str, status: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("u", "k") is expected
 
-    def test_validate_credentials_swallows_transport_errors(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        with patch.object(clockodo, "make_tracked_session", return_value=session):
-            assert validate_credentials("u", "k") is False
+    @mock.patch(CLOCKODO_SESSION_PATCH)
+    def test_validate_credentials_swallows_transport_errors(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("u", "k") is False
+
+    @mock.patch(CLOCKODO_SESSION_PATCH)
+    def test_probe_sends_credentials(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("me@example.com", "key123")
+        _args, kwargs = mock_session.return_value.get.call_args
+        headers = kwargs["headers"]
+        assert headers["X-ClockodoApiUser"] == "me@example.com"
+        assert headers["X-ClockodoApiKey"] == "key123"
+        assert headers["X-Clockodo-External-Application"] == f"{EXTERNAL_APPLICATION_NAME};me@example.com"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/cloudflare.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/cloudflare.py
@@ -1,69 +1,135 @@
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import quote, urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.settings import CLOUDFLARE_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.settings import (
+    CLOUDFLARE_ENDPOINTS,
+    CloudflareEndpointConfig,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.jsonpath_utils import (
+    find_values,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    EndpointResource,
+)
 
 CLOUDFLARE_BASE_URL = "https://api.cloudflare.com/client/v4"
 # Cloudflare list pages cap at 50 by default; most endpoints allow more.
 PAGE_SIZE = 50
-REQUEST_TIMEOUT_SECONDS = 60
-# 1200 req/5min global API rate limit; a 429 stays rate-limited until the window
-# resets, so we honor the Retry-After header it carries instead of guessing.
-MAX_RETRY_ATTEMPTS = 5
-# Cap how long a single Retry-After can stall us, so a misbehaving header can't
-# pin the activity open for the full 5-minute window times every attempt.
-MAX_RETRY_AFTER_SECONDS = 120
-# Stateless backoff used when a retryable error carries no Retry-After hint.
-_FALLBACK_WAIT = wait_exponential_jitter(initial=1, max=60)
 # A token can list zones (account-level Zone:Read) without holding DNS:Read on
 # every one of them. Per-zone 403/404s mean "this zone is inaccessible/gone" —
 # skip it and keep syncing the rest rather than failing the whole stream.
-ZONE_SKIP_STATUS_CODES = frozenset({403, 404})
+ZONE_SKIP_STATUS_CODES = (403, 404)
 
 
-class CloudflareRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        # Seconds Cloudflare asked us to wait (from a 429 Retry-After), if any.
-        self.retry_after = retry_after
+class CloudflarePaginator(PageNumberPaginator):
+    """Cloudflare page-number pagination: stop via ``result_info.total_pages``,
+    with a short-page fallback for responses that omit it."""
+
+    def __init__(self) -> None:
+        super().__init__(base_page=1, page_param="page", total_path="result_info.total_pages")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if not self._has_next_page or not data:
+            return
+        try:
+            values = find_values(self.total_path, response.json())
+        except Exception:
+            values = []
+        total_pages = values[0] if values else None
+        # Without a total-pages hint, a short page is the last one — stop rather
+        # than paying an extra empty-page request.
+        if total_pages is None and len(data) < PAGE_SIZE:
+            self._has_next_page = False
 
 
-def _parse_retry_after(response: requests.Response) -> float | None:
-    """Cloudflare sends Retry-After as delta-seconds on 429s; ignore other forms."""
-    raw = response.headers.get("Retry-After")
-    if raw is None:
-        return None
-    try:
-        seconds = float(raw)
-    except (TypeError, ValueError):
-        return None
-    return max(0.0, seconds)
+def _client_config(api_token: str) -> ClientConfig:
+    return {
+        "base_url": CLOUDFLARE_BASE_URL,
+        "auth": {"type": "bearer", "token": api_token},
+        "paginator": CloudflarePaginator(),
+    }
 
 
-def _wait_strategy(retry_state: RetryCallState) -> float:
-    """Honor a 429's Retry-After when present, else fall back to jittered backoff."""
-    exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
-    if isinstance(exc, CloudflareRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_AFTER_SECONDS)
-    return _FALLBACK_WAIT(retry_state)
+def _list_resource(name: str, path: str) -> EndpointResource:
+    return {
+        "name": name,
+        "endpoint": {
+            "path": path,
+            "params": {"per_page": PAGE_SIZE},
+            "data_selector": "result",
+        },
+    }
 
 
-def _get_session(api_token: str) -> requests.Session:
-    return make_tracked_session(headers={"Authorization": f"Bearer {api_token}"}, redact_values=(api_token,))
+def _flat_resource(
+    api_token: str, endpoint: str, config: CloudflareEndpointConfig, team_id: int, job_id: str
+) -> Resource:
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_token),
+        "resource_defaults": {},
+        "resources": [_list_resource(endpoint, config.path)],
+    }
+    return rest_api_resource(rest_config, team_id, job_id, None)
+
+
+def _zone_fanout_resource(
+    api_token: str, endpoint: str, config: CloudflareEndpointConfig, team_id: int, job_id: str
+) -> Resource:
+    assert config.parent_key is not None, (
+        f"Zone-scoped endpoint '{endpoint}' must define parent_key in CLOUDFLARE_ENDPOINTS"
+    )
+    parent_key = config.parent_key
+
+    child: EndpointResource = {
+        "name": endpoint,
+        "endpoint": {
+            "path": config.path,
+            "params": {
+                "per_page": PAGE_SIZE,
+                "zone_id": {"type": "resolve", "resource": "zones", "field": "id"},
+            },
+            "data_selector": "result",
+            "response_actions": [{"status_code": status, "action": "ignore"} for status in ZONE_SKIP_STATUS_CODES],
+        },
+        "include_from_parent": ["id"],
+    }
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_token),
+        "resource_defaults": {},
+        "resources": [_list_resource("zones", "/zones"), child],
+    }
+    resources = {r.name: r for r in rest_api_resources(rest_config, team_id, job_id, None)}
+    # A zone row without an id can't be fanned out — skip it rather than failing the stream.
+    resources["zones"].add_filter(lambda zone: bool(zone.get("id")))
+
+    def _rename_parent_key(row: dict[str, Any]) -> dict[str, Any]:
+        if "_zones_id" in row:
+            row[parent_key] = row.pop("_zones_id")
+        return row
+
+    return resources[endpoint].add_map(_rename_parent_key)
 
 
 def validate_credentials(api_token: str) -> bool:
     """Confirm the API token is valid with Cloudflare's token verify endpoint."""
     try:
-        response = _get_session(api_token).get(
+        response = make_tracked_session(redact_values=(api_token,)).get(
             f"{CLOUDFLARE_BASE_URL}/user/tokens/verify",
+            headers={"Authorization": f"Bearer {api_token}"},
             timeout=10,
         )
         return response.status_code == 200 and bool(response.json().get("success"))
@@ -71,88 +137,22 @@ def validate_credentials(api_token: str) -> bool:
         return False
 
 
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CLOUDFLARE_ENDPOINTS[endpoint]
-    session = _get_session(api_token)
-
-    @retry(
-        retry=retry_if_exception_type((CloudflareRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=_wait_strategy,
-        reraise=True,
-    )
-    def fetch(path: str, page: int) -> dict[str, Any]:
-        url = f"{CLOUDFLARE_BASE_URL}{path}?{urlencode({'page': page, 'per_page': PAGE_SIZE})}"
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise CloudflareRetryableError(
-                f"Cloudflare API error (retryable): status={response.status_code}, url={url}",
-                retry_after=_parse_retry_after(response) if response.status_code == 429 else None,
-            )
-
-        if not response.ok:
-            logger.error(f"Cloudflare API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    def iterate_pages(path: str) -> Iterator[list[dict[str, Any]]]:
-        page = 1
-        while True:
-            body = fetch(path, page)
-            items = body.get("result", []) or []
-            if items:
-                yield items
-            total_pages = (body.get("result_info") or {}).get("total_pages")
-            if not items or (isinstance(total_pages, int) and page >= total_pages):
-                return
-            if total_pages is None and len(items) < PAGE_SIZE:
-                return
-            page += 1
-
-    if not config.zone_scoped:
-        yield from iterate_pages(config.path)
-        return
-
-    assert config.parent_key is not None, (
-        f"Zone-scoped endpoint '{endpoint}' must define parent_key in CLOUDFLARE_ENDPOINTS"
-    )
-    zone_ids = [zone["id"] for page in iterate_pages("/zones") for zone in page if zone.get("id")]
-    for zone_id in zone_ids:
-        path = config.path.replace("{zone_id}", quote(zone_id))
-        try:
-            for page_items in iterate_pages(path):
-                yield [{**item, config.parent_key: zone_id} for item in page_items]
-        except requests.HTTPError as e:
-            status_code = e.response.status_code if e.response is not None else None
-            if status_code in ZONE_SKIP_STATUS_CODES:
-                logger.warning(
-                    f"Skipping Cloudflare zone {zone_id} for endpoint '{endpoint}': "
-                    f"token lacks access (status={status_code})"
-                )
-                continue
-            raise
-
-
 def cloudflare_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     config = CLOUDFLARE_ENDPOINTS[endpoint]
 
+    if config.zone_scoped:
+        resource = _zone_fanout_resource(api_token, endpoint, config, team_id, job_id)
+    else:
+        resource = _flat_resource(api_token, endpoint, config, team_id, job_id)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
@@ -118,5 +118,6 @@ Create an API token in the [Cloudflare dashboard](https://dash.cloudflare.com/pr
         return cloudflare_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
@@ -1,232 +1,260 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
 import requests
-from tenacity import Future, RetryCallState
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.cloudflare import (
-    MAX_RETRY_AFTER_SECONDS,
     PAGE_SIZE,
-    CloudflareRetryableError,
-    _parse_retry_after,
-    _wait_strategy,
     cloudflare_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.settings import (
     CLOUDFLARE_ENDPOINTS,
     ENDPOINTS,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.cloudflare"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the cloudflare module.
+CLOUDFLARE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.cloudflare.make_tracked_session"
+)
 
 
-def _response(result: list[dict[str, Any]], total_pages: int | None = None, success: bool = True) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    body: dict[str, Any] = {"success": success, "result": result}
+def _response(
+    result: list[dict[str, Any]],
+    total_pages: int | None = None,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> Response:
+    body: dict[str, Any] = {"success": True, "result": result}
     if total_pages is not None:
         body["result_info"] = {"total_pages": total_pages}
-    resp.json.return_value = body
-    resp.status_code = 200
-    resp.ok = True
-    return resp
-
-
-def _rate_limited_response(headers: dict[str, str] | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.status_code = 429
-    resp.ok = False
-    resp.headers = headers or {}
-    return resp
-
-
-def _retry_state(exc: BaseException) -> RetryCallState:
-    state = RetryCallState(retry_object=mock.MagicMock(), fn=None, args=(), kwargs={})
-    state.outcome = Future.construct(1, exc, has_exception=True)
-    return state
-
-
-def _error_response(status_code: int) -> mock.MagicMock:
-    resp = mock.MagicMock()
+    resp = Response()
     resp.status_code = status_code
-    resp.ok = False
-    resp.raise_for_status.side_effect = requests.HTTPError(
-        f"{status_code} Client Error for url: https://api.cloudflare.com", response=resp
-    )
+    resp._content = json.dumps(body).encode()
+    if headers:
+        resp.headers.update(headers)
     return resp
+
+
+def _error_response(status_code: int) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.url = "https://api.cloudflare.com/client/v4/probe"
+    resp._content = json.dumps({"success": False, "errors": [{"code": status_code}]}).encode()
+    return resp
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request's url/params AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestValidateCredentials:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_valid_on_verify_success(self, mock_session):
-        mock_session.return_value.get.return_value = _response([], success=True)
+    @mock.patch(CLOUDFLARE_SESSION_PATCH)
+    def test_valid_on_verify_success(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = _response([], total_pages=1)
         assert validate_credentials("token") is True
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_invalid_when_success_false(self, mock_session):
-        mock_session.return_value.get.return_value = _response([], success=False)
+    @mock.patch(CLOUDFLARE_SESSION_PATCH)
+    def test_invalid_when_success_false(self, mock_session) -> None:
+        resp = Response()
+        resp.status_code = 200
+        resp._content = json.dumps({"success": False, "result": None}).encode()
+        mock_session.return_value.get.return_value = resp
         assert validate_credentials("token") is False
 
     @pytest.mark.parametrize("status_code", [401, 403, 500])
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_invalid_on_error_status(self, mock_session, status_code):
-        response = mock.MagicMock()
-        response.status_code = status_code
-        mock_session.return_value.get.return_value = response
+    @mock.patch(CLOUDFLARE_SESSION_PATCH)
+    def test_invalid_on_error_status(self, mock_session, status_code) -> None:
+        mock_session.return_value.get.return_value = _error_response(status_code)
         assert validate_credentials("token") is False
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_invalid_on_exception(self, mock_session):
+    @mock.patch(CLOUDFLARE_SESSION_PATCH)
+    def test_invalid_on_exception(self, mock_session) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("token") is False
 
 
-class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_zones_paginate_via_total_pages(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "z1"}], total_pages=2),
-            _response([{"id": "z2"}], total_pages=2),
-        ]
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_zones_paginate_via_total_pages(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "z1"}], total_pages=2),
+                _response([{"id": "z2"}], total_pages=2),
+            ],
+        )
 
-        batches = list(get_rows("token", "zones", mock.MagicMock()))
+        rows = _rows(cloudflare_source("token", "zones", team_id=1, job_id="j"))
 
-        assert [item["id"] for batch in batches for item in batch] == ["z1", "z2"]
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert parse_qs(urlparse(urls[0]).query)["page"] == ["1"]
-        assert parse_qs(urlparse(urls[1]).query)["page"] == ["2"]
+        assert [r["id"] for r in rows] == ["z1", "z2"]
+        assert snapshots[0]["params"]["page"] == 1
+        assert snapshots[0]["params"]["per_page"] == PAGE_SIZE
+        assert snapshots[1]["params"]["page"] == 2
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_missing_result_info_falls_back_to_short_page(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "a1"}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_result_info_falls_back_to_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "a1"}])])
 
-        batches = list(get_rows("token", "accounts", mock.MagicMock()))
+        rows = _rows(cloudflare_source("token", "accounts", team_id=1, job_id="j"))
 
-        assert len(batches) == 1
-        assert mock_session.return_value.get.call_count == 1
+        assert [r["id"] for r in rows] == ["a1"]
+        assert session.send.call_count == 1
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_dns_records_fan_out_over_zones_and_inject_zone_id(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "z1"}, {"id": "z2"}], total_pages=1),
-            _response([{"id": "r1"}], total_pages=1),
-            _response([{"id": "r2"}], total_pages=1),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_without_result_info_continues(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
+        _wire(session, [_response(full_page), _response([{"id": "tail"}])])
 
-        batches = list(get_rows("token", "dns_records", mock.MagicMock()))
+        rows = _rows(cloudflare_source("token", "accounts", team_id=1, job_id="j"))
 
-        flat = [item for batch in batches for item in batch]
-        assert [(r["id"], r["_zone_id"]) for r in flat] == [("r1", "z1"), ("r2", "z2")]
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert urlparse(urls[1]).path == "/client/v4/zones/z1/dns_records"
-        assert urlparse(urls[2]).path == "/client/v4/zones/z2/dns_records"
+        assert len(rows) == PAGE_SIZE + 1
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], total_pages=0)])
+
+        assert _rows(cloudflare_source("token", "zones", team_id=1, job_id="j")) == []
+        assert session.send.call_count == 1
+
+
+class TestZoneFanout:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_dns_records_fan_out_over_zones_and_inject_zone_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "z1"}, {"id": "z2"}], total_pages=1),
+                _response([{"id": "r1"}], total_pages=1),
+                _response([{"id": "r2"}], total_pages=1),
+            ],
+        )
+
+        rows = _rows(cloudflare_source("token", "dns_records", team_id=1, job_id="j"))
+
+        assert [(r["id"], r["_zone_id"]) for r in rows] == [("r1", "z1"), ("r2", "z2")]
+        assert snapshots[0]["url"] == "https://api.cloudflare.com/client/v4/zones"
+        assert snapshots[1]["url"] == "https://api.cloudflare.com/client/v4/zones/z1/dns_records"
+        assert snapshots[2]["url"] == "https://api.cloudflare.com/client/v4/zones/z2/dns_records"
 
     @pytest.mark.parametrize("status_code", [403, 404])
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_dns_records_skips_inaccessible_zone_and_continues(self, mock_session, status_code):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_dns_records_skips_inaccessible_zone_and_continues(self, MockSession, status_code) -> None:
         # A token can list every zone but lack DNS access on a subset; one
         # forbidden zone must not abort the whole stream.
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "z1"}, {"id": "z2"}], total_pages=1),
-            _error_response(status_code),
-            _response([{"id": "r2"}], total_pages=1),
-        ]
-        logger = mock.MagicMock()
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "z1"}, {"id": "z2"}], total_pages=1),
+                _error_response(status_code),
+                _response([{"id": "r2"}], total_pages=1),
+            ],
+        )
 
-        batches = list(get_rows("token", "dns_records", logger))
+        rows = _rows(cloudflare_source("token", "dns_records", team_id=1, job_id="j"))
 
-        flat = [item for batch in batches for item in batch]
-        assert [(r["id"], r["_zone_id"]) for r in flat] == [("r2", "z2")]
-        logger.warning.assert_called_once()
+        assert [(r["id"], r["_zone_id"]) for r in rows] == [("r2", "z2")]
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_dns_records_reraises_unexpected_zone_error(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "z1"}], total_pages=1),
-            _error_response(400),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_dns_records_reraises_unexpected_zone_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "z1"}], total_pages=1),
+                _error_response(400),
+            ],
+        )
 
         with pytest.raises(requests.HTTPError):
-            list(get_rows("token", "dns_records", mock.MagicMock()))
+            _rows(cloudflare_source("token", "dns_records", team_id=1, job_id="j"))
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_forbidden_zone_listing_propagates(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_forbidden_zone_listing_propagates(self, MockSession) -> None:
         # No zone access at all (the top-level listing) must still fail loudly
         # so the schema is flagged non-retryable rather than silently emptied.
-        mock_session.return_value.get.side_effect = [_error_response(403)]
+        session = MockSession.return_value
+        _wire(session, [_error_response(403)])
 
         with pytest.raises(requests.HTTPError):
-            list(get_rows("token", "dns_records", mock.MagicMock()))
+            _rows(cloudflare_source("token", "dns_records", team_id=1, job_id="j"))
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_full_page_without_result_info_continues(self, mock_session):
-        full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
-        mock_session.return_value.get.side_effect = [
-            _response(full_page),
-            _response([{"id": "tail"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_zone_without_id_is_skipped(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"name": "no-id"}, {"id": "z1"}], total_pages=1),
+                _response([{"id": "r1"}], total_pages=1),
+            ],
+        )
 
-        batches = list(get_rows("token", "accounts", mock.MagicMock()))
+        rows = _rows(cloudflare_source("token", "dns_records", team_id=1, job_id="j"))
 
-        assert len(batches) == 2
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_response_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _response([], total_pages=0)
-
-        assert list(get_rows("token", "zones", mock.MagicMock())) == []
+        assert [(r["id"], r["_zone_id"]) for r in rows] == [("r1", "z1")]
+        assert session.send.call_count == 2
 
 
-class TestRetryAfterHandling:
-    @pytest.mark.parametrize(
-        "headers, expected",
-        [
-            ({"Retry-After": "30"}, 30.0),
-            ({"Retry-After": "0"}, 0.0),
-            ({"Retry-After": "12.5"}, 12.5),
-            ({}, None),
-            ({"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}, None),
-            ({"Retry-After": "soon"}, None),
-        ],
-    )
-    def test_parse_retry_after(self, headers, expected):
-        assert _parse_retry_after(_rate_limited_response(headers)) == expected
-
-    def test_wait_strategy_honors_retry_after(self):
-        exc = CloudflareRetryableError("rate limited", retry_after=45.0)
-        assert _wait_strategy(_retry_state(exc)) == 45.0
-
-    def test_wait_strategy_caps_retry_after(self):
-        exc = CloudflareRetryableError("rate limited", retry_after=10_000.0)
-        assert _wait_strategy(_retry_state(exc)) == MAX_RETRY_AFTER_SECONDS
-
-    def test_wait_strategy_falls_back_to_backoff_without_retry_after(self):
-        exc = CloudflareRetryableError("server error", retry_after=None)
-        # Jittered exponential backoff for the first attempt stays small and bounded.
-        assert 0 < _wait_strategy(_retry_state(exc)) <= 60
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_429_carries_retry_after_into_exception(self, mock_session):
+class TestRetry:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_429_honors_retry_after_and_exhausts_attempts(self, MockSession) -> None:
         # Retry-After of 0 keeps the test fast while still exercising the honored-wait path.
-        mock_session.return_value.get.return_value = _rate_limited_response({"Retry-After": "0"})
+        session = MockSession.return_value
+        responses = [_error_response(429) for _ in range(5)]
+        for resp in responses:
+            resp.headers["Retry-After"] = "0"
+        _wire(session, responses)
 
-        with pytest.raises(CloudflareRetryableError) as exc_info:
-            list(get_rows("token", "zones", mock.MagicMock()))
+        with pytest.raises(RESTClientRetryableError) as exc_info:
+            _rows(cloudflare_source("token", "zones", team_id=1, job_id="j"))
 
         assert exc_info.value.retry_after == 0.0
         # Exhausts all attempts since every page stays rate-limited.
-        assert mock_session.return_value.get.call_count == 5
+        assert session.send.call_count == 5
 
 
 class TestCloudflareSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata_per_endpoint(self, MockSession, endpoint) -> None:
+        MockSession.return_value.headers = {}
         config = CLOUDFLARE_ENDPOINTS[endpoint]
-        response = cloudflare_source("token", endpoint, mock.MagicMock())
+        response = cloudflare_source("token", endpoint, team_id=1, job_id="j")
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/coassemble.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/coassemble.py
@@ -1,22 +1,32 @@
+import logging
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.coassemble.settings import COASSEMBLE_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+
+logger = logging.getLogger(__name__)
 
 # Single shared host — Coassemble has no per-workspace subdomains.
 COASSEMBLE_BASE_URL = "https://api.coassemble.com/api/v1/headless"
 # The documented default page size for every list endpoint. We request it explicitly so the
 # "short page means last page" termination check compares against the size the server enforces.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
 # Hard cap on trackings pages per course (PAGE_SIZE * cap rows) so a paging bug on the vendor side
 # can never produce an unbounded scan of a single course.
 MAX_TRACKING_PAGES_PER_COURSE = 1_000
@@ -24,9 +34,10 @@ MAX_TRACKING_PAGES_PER_COURSE = 1_000
 # workspace-wide, so one probe validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/courses"
 
-
-class CoassembleRetryableError(Exception):
-    pass
+# Trackings can only be listed per course: `id` is a required QUERY param. The framework binds
+# resolve params via path templating, so the query string rides in the path (requests merges the
+# remaining params into it).
+TRACKINGS_CHILD_PATH = f"{COASSEMBLE_ENDPOINTS['course_trackings'].path}?id={{id}}"
 
 
 @dataclasses.dataclass
@@ -35,216 +46,245 @@ class CoassembleResumeConfig:
     # resumes from the page after the last one yielded; merge dedupes the re-pulled page on the
     # primary key.
     next_page: int = 0
-    # Trackings fan-out bookkeeping: courses fully paged through, and the course currently being
-    # paged (whose next page is `next_page`). Course ids rather than an index so a shifted course
-    # list between resume attempts can't skip a course.
+    # Pre-framework trackings fan-out bookkeeping. Kept with defaults so previously saved state
+    # still parses (and is translated into fanout_state on load); no longer written.
     completed_course_ids: list[int] = dataclasses.field(default_factory=list)
     current_course_id: int | None = None
+    # Framework fan-out resume state for the course_trackings endpoint:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: dict | None = None
 
 
-def _headers(workspace_id: str, api_key: str) -> dict[str, str]:
-    # Vendor-specific scheme documented at https://developers.coassemble.com/get-started.
+class CoassemblePageNumberPaginator(PageNumberPaginator):
+    """0-indexed page-number pagination where every list endpoint serves fixed-length pages, so a
+    short page marks the end of the collection (we always request PAGE_SIZE — no extra empty-page
+    request). ``max_pages`` caps how many pages one paginate call fetches (the runaway-course guard
+    for trackings); the paginator is deep-copied per fan-out parent, so the cap is per course.
+    """
+
+    def __init__(self, page_size: int = PAGE_SIZE, max_pages: Optional[int] = None) -> None:
+        super().__init__(base_page=0, page_param="page")
+        self.page_size = page_size
+        self.max_pages = max_pages
+        self._pages_fetched = 0
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        self._pages_fetched += 1
+        if data is not None and len(data) < self.page_size:
+            self._has_next_page = False
+        if self.max_pages is not None and self._pages_fetched >= self.max_pages and self._has_next_page:
+            logger.warning(
+                "Coassemble: hit trackings page cap (%s); remaining rows for this parent are skipped this sync",
+                self.max_pages,
+            )
+            self._has_next_page = False
+
+
+def _auth_header_value(workspace_id: str, api_key: str) -> str:
+    # Vendor-specific scheme documented at https://developers.coassemble.com/get-started —
+    # Coassemble rejects standard schemes (Bearer etc.) with "Invalid Authorization header".
+    return f"COASSEMBLE:{workspace_id}:{api_key}"
+
+
+def _client_config(workspace_id: str, api_key: str) -> ClientConfig:
+    # The credential travels via framework api_key auth (not a hand-built header) so its value is
+    # registered for redaction wherever it surfaces in logs; only non-secret headers go here.
     return {
-        "Authorization": f"COASSEMBLE:{workspace_id}:{api_key}",
-        "Accept": "application/json",
+        "base_url": COASSEMBLE_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {
+            "type": "api_key",
+            "api_key": _auth_header_value(workspace_id, api_key),
+            "name": "Authorization",
+            "location": "header",
+        },
     }
 
 
-def _extract_items(data: Any, path: str) -> list[dict[str, Any]]:
-    # List endpoints document a plain JSON array; accept common object wrappers defensively since
-    # not every endpoint's response envelope is shown in the docs.
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict):
-        for key in ("data", "results", "items"):
-            if isinstance(data.get(key), list):
-                return data[key]
-    raise CoassembleRetryableError(f"Coassemble returned an unexpected payload for {path}: {type(data).__name__}")
-
-
-@retry(
-    retry=retry_if_exception_type((CoassembleRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    page: int,
-    logger: FilteringBoundLogger,
-    extra_params: dict[str, Any] | None = None,
-) -> list[dict[str, Any]]:
-    params: dict[str, Any] = {"page": page, "length": PAGE_SIZE, **(extra_params or {})}
-
-    response = session.get(f"{COASSEMBLE_BASE_URL}{path}", params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CoassembleRetryableError(f"Coassemble API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        logger.error(f"Coassemble API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
-
-    return _extract_items(response.json(), path)
-
-
-def _iter_pages(
-    session: requests.Session,
-    path: str,
-    logger: FilteringBoundLogger,
-    start_page: int = 0,
-    extra_params: dict[str, Any] | None = None,
-) -> Iterator[tuple[int, list[dict[str, Any]]]]:
-    """Yield ``(page_number, items)`` from ``start_page`` until a short or empty page."""
-    page = start_page
-    while True:
-        items = _fetch_page(session, path, page, logger, extra_params=extra_params)
-        if items:
-            yield page, items
-
-        # A short page marks the end of the collection (we always request PAGE_SIZE).
-        if len(items) < PAGE_SIZE:
-            break
-
-        page += 1
-
-
-def _list_course_ids(session: requests.Session, logger: FilteringBoundLogger) -> list[int]:
-    course_ids: list[int] = []
-    for _, courses in _iter_pages(session, COASSEMBLE_ENDPOINTS["courses"].path, logger):
-        course_ids.extend(course["id"] for course in courses)
-    return course_ids
-
-
-def get_rows(
+def _standard_resource(
     workspace_id: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CoassembleResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[CoassembleResumeConfig],
+) -> Resource:
     config = COASSEMBLE_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(workspace_id, api_key), redact_values=(api_key,))
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    # List endpoints document a plain JSON array; a 200 body of any other shape means the response
+    # shape changed — fail loud instead of silently syncing 0 rows.
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(workspace_id, api_key),
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"length": PAGE_SIZE},
+                    "paginator": CoassemblePageNumberPaginator(),
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
 
-    if config.fan_out_by_course:
-        yield from _get_tracking_rows(session, logger, resumable_source_manager, resume)
-        return
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None and resume.next_page > 0:
+            initial_paginator_state = {"page": resume.next_page}
 
-    page = resume.next_page if resume else 0
-    if resume and resume.next_page > 0:
-        logger.debug(f"Coassemble: resuming {endpoint} from page {page}")
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint is saved AFTER a page is yielded so
+        # a crash re-fetches the in-flight page (merge dedupes re-pulled rows) rather than skipping it.
+        if state and state.get("page") is not None:
+            manager.save_state(CoassembleResumeConfig(next_page=int(state["page"])))
 
-    for fetched_page, items in _iter_pages(session, config.path, logger, start_page=page):
-        yield items
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(CoassembleResumeConfig(next_page=fetched_page + 1))
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
 
-def _get_tracking_rows(
-    session: requests.Session,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CoassembleResumeConfig],
-    resume: CoassembleResumeConfig | None,
-) -> Iterator[list[dict[str, Any]]]:
-    path = COASSEMBLE_ENDPOINTS["course_trackings"].path
-    completed_course_ids = list(resume.completed_course_ids) if resume else []
-    completed_set = set(completed_course_ids)
+def _tracking_child_path(course_id: int) -> str:
+    return TRACKINGS_CHILD_PATH.format(id=course_id)
 
-    for course_id in _list_course_ids(session, logger):
-        if course_id in completed_set:
-            continue
 
-        start_page = resume.next_page if resume and resume.current_course_id == course_id else 0
-        last_page_fetched: int | None = None
+def _stamp_course_id(row: dict[str, Any]) -> dict[str, Any]:
+    # include_from_parent lands the parent course id as `_courses_id`; rename it to the plain
+    # `course_id` column tracking rows carry (also part of the primary key — see settings.py).
+    value = row.pop("_courses_id", None)
+    if value is not None:
+        row["course_id"] = value
+    return row
 
-        for page, items in _iter_pages(session, path, logger, start_page=start_page, extra_params={"id": course_id}):
-            for item in items:
-                # Tracking rows don't reference their course, so inject it (also part of the
-                # primary key — see settings.py).
-                item["course_id"] = course_id
-            yield items
-            last_page_fetched = page
-            resumable_source_manager.save_state(
-                CoassembleResumeConfig(
-                    next_page=page + 1,
-                    completed_course_ids=completed_course_ids,
-                    current_course_id=course_id,
-                )
-            )
 
-            if page - start_page + 1 >= MAX_TRACKING_PAGES_PER_COURSE:
-                logger.warning(
-                    f"Coassemble: hit trackings page cap ({MAX_TRACKING_PAGES_PER_COURSE}) for course {course_id}; "
-                    "remaining trackings for this course are skipped this sync"
-                )
-                break
+def _translate_legacy_fanout_state(resume: CoassembleResumeConfig) -> Optional[dict[str, Any]]:
+    """Translate a pre-framework trackings bookmark into the framework's fan-out resume shape.
 
-        completed_course_ids.append(course_id)
-        completed_set.add(course_id)
-        resumable_source_manager.save_state(
-            CoassembleResumeConfig(
-                next_page=0,
-                completed_course_ids=completed_course_ids,
-                current_course_id=None,
-            )
-        )
-        if last_page_fetched is not None:
-            logger.debug(f"Coassemble: finished trackings for course {course_id}")
+    The old bookkeeping tracked course ids (completed + the one being paged) and the next page of
+    the current course; the framework keys the same information by resolved child path, so the
+    translation is exact and a pre-migration crash resumes precisely where it left off.
+    """
+    if not resume.completed_course_ids and resume.current_course_id is None:
+        return None
+    current = _tracking_child_path(resume.current_course_id) if resume.current_course_id is not None else None
+    return {
+        "completed": [_tracking_child_path(course_id) for course_id in resume.completed_course_ids],
+        "current": current,
+        "child_state": {"page": resume.next_page} if current is not None else None,
+    }
+
+
+def _trackings_resource(
+    workspace_id: str,
+    api_key: str,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[CoassembleResumeConfig],
+) -> Resource:
+    """Fan out over every course, listing its trackings and stamping the parent `course_id`.
+
+    /trackings requires an `id` (the course id), so trackings can only be pulled per course. Full
+    refresh — re-pulled rows on resume are deduped by the (course_id, id) primary key on merge.
+    """
+    courses_config = COASSEMBLE_ENDPOINTS["courses"]
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(workspace_id, api_key),
+        "resources": [
+            {
+                "name": "courses",
+                "endpoint": {
+                    "path": courses_config.path,
+                    "params": {"length": PAGE_SIZE},
+                    "paginator": CoassemblePageNumberPaginator(),
+                    "data_selector_required": True,
+                },
+            },
+            {
+                "name": "course_trackings",
+                "endpoint": {
+                    "path": TRACKINGS_CHILD_PATH,
+                    "params": {
+                        "id": {"type": "resolve", "resource": "courses", "field": "id"},
+                        "length": PAGE_SIZE,
+                    },
+                    "paginator": CoassemblePageNumberPaginator(max_pages=MAX_TRACKING_PAGES_PER_COURSE),
+                    "data_selector_required": True,
+                },
+                "include_from_parent": ["id"],
+                "data_map": _stamp_course_id,
+            },
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None:
+            if resume.fanout_state is not None:
+                initial_paginator_state = resume.fanout_state
+            else:
+                initial_paginator_state = _translate_legacy_fanout_state(resume)
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state:
+            manager.save_state(CoassembleResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(r for r in resources if r.name == "course_trackings")
 
 
 def coassemble_source(
     workspace_id: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CoassembleResumeConfig],
 ) -> SourceResponse:
     config = COASSEMBLE_ENDPOINTS[endpoint]
 
+    if config.fan_out_by_course:
+        resource = _trackings_resource(workspace_id, api_key, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _standard_resource(workspace_id, api_key, endpoint, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            workspace_id=workspace_id,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(workspace_id: str, api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the workspace credentials.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(headers=_headers(workspace_id, api_key), redact_values=(api_key,))
-    try:
-        response = session.get(f"{COASSEMBLE_BASE_URL}{path}", params={"page": 0, "length": 1}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Coassemble: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Coassemble returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(workspace_id: str, api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(workspace_id, api_key)
-    if status == 200:
+    # A bad or revoked credential is rejected with 401/403 — the only conclusive "invalid" signals.
+    # Transport failures and unexpected statuses are inconclusive and keep their own messages.
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{COASSEMBLE_BASE_URL}{DEFAULT_PROBE_PATH}?page=0&length=1",
+        headers={"Authorization": _auth_header_value(workspace_id, api_key), "Accept": "application/json"},
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid Coassemble workspace ID or API key"
-    return False, message or "Could not validate Coassemble credentials"
+    if status is None:
+        return False, "Could not connect to Coassemble"
+    return False, f"Coassemble returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/source.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.coassemble
 from products.warehouse_sources.backend.temporal.data_imports.sources.coassemble.settings import (
     COASSEMBLE_ENDPOINTS,
     ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
@@ -28,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CoassembleSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -100,19 +104,7 @@ You can generate an API key from your workspace API settings in [Coassemble](htt
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Every endpoint is full refresh only — see the rationale in settings.py.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CoassembleSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -136,6 +128,7 @@ You can generate an API key from your workspace API settings in [Coassemble](htt
             workspace_id=config.workspace_id,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/tests/test_coassemble.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/tests/test_coassemble.py
@@ -1,21 +1,19 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.coassemble import coassemble
 from products.warehouse_sources.backend.temporal.data_imports.sources.coassemble.coassemble import (
     COASSEMBLE_BASE_URL,
     PAGE_SIZE,
     CoassembleResumeConfig,
-    CoassembleRetryableError,
-    _headers,
-    check_access,
     coassemble_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.coassemble.settings import (
@@ -23,254 +21,279 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.coassemble
     ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = coassemble._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the coassemble module.
+COASSEMBLE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.coassemble.coassemble.make_tracked_session"
+)
 
 
-class _FakeResumableManager:
-    def __init__(self, state: CoassembleResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[CoassembleResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> CoassembleResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: CoassembleResumeConfig) -> None:
-        self.saved.append(data)
+def _response(body: Any, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _page(prefix: str, start: int, count: int) -> list[dict[str, Any]]:
     return [{"id": f"{prefix}-{i}"} for i in range(start, start + count)]
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        pages: dict[tuple[str, int], list[dict]],
-        endpoint: str = "courses",
-    ) -> list[dict]:
-        def fake_fetch(session: Any, path: str, page: int, logger: Any, extra_params: Any = None) -> list[dict]:
-            return pages.get((path, page), [])
+def _make_manager(resume_state: CoassembleResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-        monkeypatch.setattr(coassemble, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(coassemble, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            workspace_id="ws-1",
-            api_key="sk-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's url/params AT SEND TIME.
 
-    def test_short_page_yields_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {("/courses", 0): _page("c", 0, 2)})
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(endpoint: str, manager: mock.MagicMock) -> list[dict[str, Any]]:
+    source_response = coassemble_source(
+        workspace_id="ws-1",
+        api_key="sk-key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+    return [row for page in source_response.items() for row in page]
+
+
+class TestListEndpointPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page("c", 0, 2))])
+
+        manager = _make_manager()
+        rows = _rows("courses", manager)
+
+        # A short page marks the end of the collection — no extra empty-page request is paid.
         assert rows == _page("c", 0, 2)
-        # A short first page ends the sync; state is still saved after the yield so a crash
-        # mid-persist re-fetches only the final page.
-        assert [s.next_page for s in manager.saved] == [1]
+        assert session.send.call_count == 1
+        assert snapshots[0]["url"] == f"{COASSEMBLE_BASE_URL}/courses"
+        assert snapshots[0]["params"] == {"page": 0, "length": PAGE_SIZE}
+        manager.save_state.assert_not_called()
 
-    def test_full_page_advances_until_short_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {("/courses", 0): _page("c", 0, PAGE_SIZE), ("/courses", 1): _page("c", PAGE_SIZE, 3)}
-        rows = self._collect(manager, monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_advances_until_short_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page("c", 0, PAGE_SIZE)), _response(_page("c", PAGE_SIZE, 3))])
+
+        manager = _make_manager()
+        rows = _rows("courses", manager)
+
         assert len(rows) == PAGE_SIZE + 3
-        assert [s.next_page for s in manager.saved] == [1, 2]
+        assert [s["params"]["page"] for s in snapshots] == [0, 1]
+        # Checkpoint saved after the first full page (points at the next page); the short page ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == CoassembleResumeConfig(next_page=1)
 
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(CoassembleResumeConfig(next_page=2))
-        # Pages 0 and 1 must never be fetched on resume; the pages dict only knows page 2.
-        rows = self._collect(manager, monkeypatch, {("/courses", 2): _page("c", 0, 1)})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page("c", 0, 1))])
+
+        rows = _rows("courses", _make_manager(CoassembleResumeConfig(next_page=2)))
+
+        # Pages 0 and 1 must never be re-fetched on resume.
         assert rows == _page("c", 0, 1)
+        assert session.send.call_count == 1
+        assert snapshots[0]["params"]["page"] == 2
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows("courses", manager)
+
         assert rows == []
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @parameterized.expand([("string", "nope"), ("object_without_list", {"count": 1})])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_fails_loudly(self, _name: str, body: Any, MockSession: mock.MagicMock) -> None:
+        # List endpoints document a plain JSON array; any other 200 body means the response shape
+        # changed — fail loud instead of silently syncing 0 rows.
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
+
+        with pytest.raises(ValueError, match="Required a list response body"):
+            _rows("courses", _make_manager())
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_for_status(self, _name: str, status: int, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "denied"}, status=status)])
+
+        with pytest.raises(requests.HTTPError):
+            _rows("courses", _make_manager())
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_credential_travels_via_framework_auth(self, MockSession: mock.MagicMock) -> None:
+        # Coassemble rejects standard schemes (Bearer etc.) with "Invalid Authorization header"; the
+        # documented format is COASSEMBLE:<workspace_id>:<api_key>, sent via framework api_key auth
+        # (not a hand-built header) so the secret is value-redacted from logs.
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response(_page("c", 0, 1))])
+
+        _rows("courses", _make_manager())
+
+        auth = snapshots[0]["auth"]
+        assert auth.api_key == "COASSEMBLE:ws-1:sk-key"
+        assert auth.name == "Authorization"
+        assert auth.location == "header"
+        assert session.headers.get("Accept") == "application/json"
 
 
 class TestTrackingFanOut:
-    @staticmethod
-    def _run(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        courses: list[dict],
-        trackings: dict[tuple[int, int], list[dict]],
-    ) -> tuple[list[dict], list[dict[str, Any]]]:
-        calls: list[dict[str, Any]] = []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_iterates_courses_and_injects_course_id(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": 11}, {"id": 22}]),
+                _response([{"id": 1}, {"id": 2}]),
+                _response([{"id": 3}]),
+            ],
+        )
 
-        def fake_fetch(session: Any, path: str, page: int, logger: Any, extra_params: Any = None) -> list[dict]:
-            calls.append({"path": path, "page": page, "extra_params": extra_params})
-            if path == "/courses":
-                return courses if page == 0 else []
-            assert extra_params is not None
-            return trackings.get((extra_params["id"], page), [])
+        manager = _make_manager()
+        rows = _rows("course_trackings", manager)
 
-        monkeypatch.setattr(coassemble, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(coassemble, "make_tracked_session", lambda **kwargs: MagicMock())
-
-        rows: list[dict] = []
-        for batch in get_rows(
-            workspace_id="ws-1",
-            api_key="sk-key",
-            endpoint="course_trackings",
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows, calls
-
-    def test_iterates_courses_and_injects_course_id(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        courses = [{"id": 11}, {"id": 22}]
-        trackings = {(11, 0): [{"id": 1}, {"id": 2}], (22, 0): [{"id": 3}]}
-        rows, _ = self._run(manager, monkeypatch, courses, trackings)
+        # Tracking rows don't reference their course, so the parent id is stamped in (also part of
+        # the primary key — see settings.py).
         assert rows == [
             {"id": 1, "course_id": 11},
             {"id": 2, "course_id": 11},
             {"id": 3, "course_id": 22},
         ]
-        # Each course is marked completed after its pages are exhausted.
-        assert manager.saved[-1].completed_course_ids == [11, 22]
-        assert manager.saved[-1].current_course_id is None
-
-    def test_resume_skips_completed_courses_and_starts_at_saved_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(
-            CoassembleResumeConfig(next_page=1, completed_course_ids=[11], current_course_id=22)
+        assert [s["url"] for s in snapshots] == [
+            f"{COASSEMBLE_BASE_URL}/courses",
+            f"{COASSEMBLE_BASE_URL}/trackings?id=11",
+            f"{COASSEMBLE_BASE_URL}/trackings?id=22",
+        ]
+        # Each course lands in `completed` once its pages are exhausted.
+        assert manager.save_state.call_args_list[-1].args[0] == CoassembleResumeConfig(
+            fanout_state={"completed": ["/trackings?id=11", "/trackings?id=22"], "current": None, "child_state": None}
         )
-        courses = [{"id": 11}, {"id": 22}]
-        # Only page 1 of course 22 exists in the fixture: fetching course 11 or page 0 of course 22
-        # would yield rows that then fail the assertion below.
-        trackings = {(22, 1): [{"id": 9}]}
-        rows, calls = self._run(manager, monkeypatch, courses, trackings)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_within_a_course_and_checkpoints(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": 11}]),
+                _response([{"id": i} for i in range(PAGE_SIZE)]),
+                _response([{"id": PAGE_SIZE}]),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows("course_trackings", manager)
+
+        assert len(rows) == PAGE_SIZE + 1
+        tracking_snapshots = [s for s in snapshots if "/trackings" in s["url"]]
+        assert [s["params"]["page"] for s in tracking_snapshots] == [0, 1]
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        # Mid-course: the in-progress course path and its next page are checkpointed so a crash
+        # resumes into the same course at the saved page.
+        assert saved[0] == CoassembleResumeConfig(
+            fanout_state={"completed": [], "current": "/trackings?id=11", "child_state": {"page": 1}}
+        )
+        # Course finished: it lands in `completed` so a restart skips it.
+        assert saved[-1] == CoassembleResumeConfig(
+            fanout_state={"completed": ["/trackings?id=11"], "current": None, "child_state": None}
+        )
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_by_skipping_completed_courses(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": 11}, {"id": 22}]),
+                _response([{"id": 9}]),
+            ],
+        )
+
+        manager = _make_manager(
+            CoassembleResumeConfig(
+                fanout_state={"completed": ["/trackings?id=11"], "current": None, "child_state": None}
+            )
+        )
+        rows = _rows("course_trackings", manager)
+
         assert rows == [{"id": 9, "course_id": 22}]
-        tracking_calls = [c for c in calls if c["path"] == "/trackings"]
-        assert all(c["extra_params"]["id"] == 22 for c in tracking_calls)
-        assert tracking_calls[0]["page"] == 1
+        assert snapshots[1]["url"] == f"{COASSEMBLE_BASE_URL}/trackings?id=22"
 
-    def test_state_saved_after_each_trackings_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        courses = [{"id": 11}]
-        trackings = {
-            (11, 0): [{"id": i} for i in range(PAGE_SIZE)],
-            (11, 1): [{"id": PAGE_SIZE}],
-        }
-        self._run(manager, monkeypatch, courses, trackings)
-        # Two in-course saves (after each yielded page) then the completion save.
-        assert [(s.current_course_id, s.next_page) for s in manager.saved] == [(11, 1), (11, 2), (None, 0)]
-
-    def test_page_cap_stops_runaway_course(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(coassemble, "MAX_TRACKING_PAGES_PER_COURSE", 2)
-        manager = _FakeResumableManager()
-        courses = [{"id": 11}]
-        # Every page is full, so without the cap this would loop past page 2.
-        trackings = {(11, page): [{"id": page}] * PAGE_SIZE for page in range(10)}
-        rows, calls = self._run(manager, monkeypatch, courses, trackings)
-        assert len(rows) == 2 * PAGE_SIZE
-        assert len([c for c in calls if c["path"] == "/trackings"]) == 2
-
-
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else []
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pre_migration_bookmark_resumes_exactly(self, MockSession: mock.MagicMock) -> None:
+        # An old-shape bookmark (completed_course_ids + current_course_id + next_page) is translated
+        # into the framework fan-out state: completed courses are skipped and the in-progress course
+        # resumes at the saved page.
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": 11}, {"id": 22}]),
+                _response([{"id": 9}]),
+            ],
         )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
 
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(CoassembleRetryableError):
-            _fetch_page_unwrapped(session, "/courses", 0, MagicMock())
+        manager = _make_manager(CoassembleResumeConfig(next_page=1, completed_course_ids=[11], current_course_id=22))
+        rows = _rows("course_trackings", manager)
 
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "/courses", 0, MagicMock())
+        assert rows == [{"id": 9, "course_id": 22}]
+        tracking_snapshots = [s for s in snapshots if "/trackings" in s["url"]]
+        assert [s["url"] for s in tracking_snapshots] == [f"{COASSEMBLE_BASE_URL}/trackings?id=22"]
+        assert tracking_snapshots[0]["params"]["page"] == 1
 
-    @parameterized.expand(
-        [
-            ("plain_array", [{"id": 1}]),
-            ("data_wrapper", {"data": [{"id": 1}]}),
-            ("results_wrapper", {"results": [{"id": 1}]}),
-        ]
-    )
-    def test_accepts_documented_and_wrapped_payloads(self, _name: str, body: Any) -> None:
-        session = self._session_returning(200, body)
-        assert _fetch_page_unwrapped(session, "/courses", 0, MagicMock()) == [{"id": 1}]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_page_cap_stops_runaway_course(self, MockSession: mock.MagicMock) -> None:
+        with mock.patch.object(coassemble, "MAX_TRACKING_PAGES_PER_COURSE", 2):
+            session = MockSession.return_value
+            # Every trackings page is full, so without the cap this would page forever.
+            _wire(
+                session,
+                [
+                    _response([{"id": 11}]),
+                    _response([{"id": i} for i in range(PAGE_SIZE)]),
+                    _response([{"id": i} for i in range(PAGE_SIZE)]),
+                ],
+            )
 
-    @parameterized.expand([("string", "nope"), ("object_without_list", {"count": 1})])
-    def test_unexpected_payload_is_retryable(self, _name: str, body: Any) -> None:
-        session = self._session_returning(200, body)
-        with pytest.raises(CoassembleRetryableError):
-            _fetch_page_unwrapped(session, "/courses", 0, MagicMock())
+            rows = _rows("course_trackings", _make_manager())
 
-    def test_request_carries_pagination_and_extra_params(self) -> None:
-        session = self._session_returning(200, [])
-        _fetch_page_unwrapped(session, "/trackings", 3, MagicMock(), extra_params={"id": 42})
-        args, kwargs = session.get.call_args
-        assert args[0] == f"{COASSEMBLE_BASE_URL}/trackings"
-        assert kwargs["params"] == {"page": 3, "length": PAGE_SIZE, "id": 42}
+        assert len(rows) == 2 * PAGE_SIZE
+        assert session.send.call_count == 3  # 1 courses page + 2 capped trackings pages
 
 
-class TestAuthHeaders:
-    def test_uses_vendor_specific_authorization_scheme(self) -> None:
-        # Coassemble rejects standard schemes (Bearer etc.) with "Invalid Authorization header";
-        # the documented format is COASSEMBLE:<workspace_id>:<api_key>.
-        assert _headers("ws-1", "sk-key")["Authorization"] == "COASSEMBLE:ws-1:sk-key"
-
-
-class TestCheckAccess:
-    def _session(self, response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        return session
-
-    @parameterized.expand(
-        [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "Coassemble returned HTTP 500"),
-        ]
-    )
-    def test_status_mapping(
-        self, _name: str, status: int, ok: bool, expected_status: int, expected_message: str | None
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        with patch.object(coassemble, "make_tracked_session", return_value=self._session(response)):
-            assert check_access("ws-1", "sk-key") == (expected_status, expected_message)
-
-    def test_connection_error_maps_to_zero(self) -> None:
-        session = self._session(requests.ConnectionError("boom"))
-        with patch.object(coassemble, "make_tracked_session", return_value=session):
-            status, message = check_access("ws-1", "sk-key")
-        assert status == 0
-        assert message is not None and "boom" in message
-
+class TestValidateCredentials:
     @parameterized.expand(
         [
             ("ok", 200, True, None),
@@ -279,14 +302,41 @@ class TestCheckAccess:
             ("server_error", 500, False, "Coassemble returned HTTP 500"),
         ]
     )
-    def test_validate_credentials(
-        self, _name: str, status: int, expected_valid: bool, expected_message: str | None
+    def test_status_maps_to_result(
+        self, _name: str, status: int, expected_ok: bool, expected_message: str | None
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        with patch.object(coassemble, "make_tracked_session", return_value=self._session(response)):
-            assert validate_credentials("ws-1", "sk-key") == (expected_valid, expected_message)
+        with mock.patch(COASSEMBLE_SESSION_PATCH) as make_session:
+            session = mock.MagicMock()
+            session.get.return_value = mock.MagicMock(status_code=status)
+            make_session.return_value = session
+            assert validate_credentials("ws-1", "sk-key") == (expected_ok, expected_message)
+
+    def test_connection_error_is_inconclusive(self) -> None:
+        with mock.patch(COASSEMBLE_SESSION_PATCH) as make_session:
+            session = mock.MagicMock()
+            session.get.side_effect = requests.ConnectionError("boom")
+            make_session.return_value = session
+            ok, message = validate_credentials("ws-1", "sk-key")
+        assert ok is False
+        assert message is not None and "Could not connect to Coassemble" in message
+
+    def test_probe_sends_vendor_authorization_scheme(self) -> None:
+        with mock.patch(COASSEMBLE_SESSION_PATCH) as make_session:
+            session = mock.MagicMock()
+            session.get.return_value = mock.MagicMock(status_code=200)
+            make_session.return_value = session
+            validate_credentials("ws-1", "sk-key")
+            headers = session.get.call_args.kwargs["headers"]
+            assert headers["Authorization"] == "COASSEMBLE:ws-1:sk-key"
+
+
+class TestResumeStateCompatibility:
+    def test_pre_migration_saved_state_still_parses(self) -> None:
+        # ResumableSourceManager._load_json does `dataclass(**saved)` — state saved before the
+        # framework migration must still construct.
+        assert CoassembleResumeConfig(
+            **{"next_page": 3, "completed_course_ids": [11], "current_course_id": 22}
+        ) == CoassembleResumeConfig(next_page=3, completed_course_ids=[11], current_course_id=22)
 
 
 class TestCoassembleSourceResponse:
@@ -296,8 +346,9 @@ class TestCoassembleSourceResponse:
             workspace_id="ws-1",
             api_key="sk-key",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
         )
         assert response.name == endpoint
         assert response.primary_keys == COASSEMBLE_ENDPOINTS[endpoint].primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/tests/test_coassemble_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coassemble/tests/test_coassemble_source.py
@@ -118,6 +118,8 @@ class TestCoassembleSource:
         assert kwargs["workspace_id"] == "ws-1"
         assert kwargs["api_key"] == "sk-key"
         assert kwargs["endpoint"] == "courses"
+        assert kwargs["team_id"] is inputs.team_id
+        assert kwargs["job_id"] is inputs.job_id
         assert kwargs["resumable_source_manager"] is manager
 
     def test_source_for_pipeline_rejects_unknown_schema(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/codefresh/codefresh.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/codefresh/codefresh.py
@@ -1,11 +1,7 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.codefresh.settings import (
@@ -13,17 +9,21 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.codefresh.
     CodefreshEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    OffsetPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # Only the US SaaS host is supported. EU / self-hosted installs use a different host, which we don't
 # let the user retarget yet (it would mean sending the stored API key to an arbitrary host).
 CODEFRESH_BASE_URL = "https://g.codefresh.io/api"
-
-_DEFAULT_TIMEOUT = 60
-
-
-class CodefreshRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -36,29 +36,63 @@ class CodefreshResumeConfig:
     session_id: str | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    # Codefresh expects the raw token as the Authorization header value — no "Bearer " prefix.
-    return {"Authorization": api_key, "Accept": "application/json"}
+class CodefreshPagePaginator(BasePaginator):
+    """Codefresh's builds pagination: a 1-indexed ``page`` param, a ``pagination.nextPage`` flag,
+    and a stable ``pagination.sessionId`` snapshot cursor that every page after the first must pin
+    via the ``X-Pagination-Session-Id`` header, so builds created mid-sync can't shift the window
+    underneath us. No built-in paginator covers the flag + header pair, hence this local subclass."""
 
+    def __init__(self, page: int = 1, session_id: str | None = None) -> None:
+        super().__init__()
+        self.page = page
+        self.session_id = session_id
 
-def _build_url(path: str, params: Optional[dict[str, Any]] = None) -> str:
-    url = f"{CODEFRESH_BASE_URL}{path}"
-    if params:
-        url = f"{url}?{urlencode(params)}"
-    return url
+    def _apply(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
+        if self.session_id:
+            # Pin every page to the snapshot the first page opened.
+            request.headers = {**(request.headers or {}), "X-Pagination-Session-Id": self.session_id}
 
+    def init_request(self, request: Request) -> None:
+        self._apply(request)
 
-def _extract_items(data: Any, data_key: Optional[list[str]]) -> list[dict[str, Any]]:
-    """Pull the record list out of a response. Codefresh returns either a bare array or an envelope
-    (``{docs: [...]}``, ``{workflows: {docs: [...]}}``), so ``data_key`` is the path to walk."""
-    if data_key is None:
-        return data if isinstance(data, list) else []
-    node: Any = data
-    for key in data_key:
-        if not isinstance(node, dict):
-            return []
-        node = node.get(key)
-    return node if isinstance(node, list) else []
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        pagination = body.get("pagination") or {} if isinstance(body, dict) else {}
+        self.session_id = pagination.get("sessionId") or self.session_id
+
+        # An empty page terminates the stream even if the API keeps advertising nextPage. Without
+        # this, a server-side cursor bug that streams empty pages forever would loop indefinitely.
+        if not data or not pagination.get("nextPage"):
+            self._has_next_page = False
+            return
+
+        self.page += 1
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        self._apply(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page already points at the next page to fetch (update_state incremented it).
+        return {"page": self.page, "session_id": self.session_id} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._has_next_page = True
+        session_id = state.get("session_id")
+        if session_id:
+            self.session_id = session_id
+
+    def __str__(self) -> str:
+        return f"CodefreshPagePaginator(page={self.page})"
 
 
 def _flatten(item: dict[str, Any], flatten_key: Optional[str]) -> dict[str, Any]:
@@ -97,117 +131,95 @@ def _transform_row(item: dict[str, Any], config: CodefreshEndpointConfig) -> dic
     return row
 
 
-@retry(
-    retry=retry_if_exception_type((CodefreshRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, headers=headers, timeout=_DEFAULT_TIMEOUT)
-
-    # Codefresh rate-limits per account with a 429; retry those and transient 5xx with backoff.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CodefreshRetryableError(f"Codefresh API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Codefresh API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+def _build_paginator_and_params(config: CodefreshEndpointConfig) -> tuple[BasePaginator, dict[str, Any]]:
+    if config.pagination == "offset":
+        # No usable body total; termination is short/empty page. The paginator injects limit+offset.
+        return OffsetPaginator(limit=config.page_size, total_path=None), {}
+    if config.pagination == "page":
+        return CodefreshPagePaginator(), {"limit": config.page_size}
+    # "none": single request, no pagination params (triggers).
+    return SinglePagePaginator(), {}
 
 
-def _iter_offset(
-    session: requests.Session,
-    config: CodefreshEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[CodefreshResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    resume = manager.load_state() if manager.can_resume() else None
-    offset = resume.offset if resume is not None and resume.offset is not None else 0
-
-    while True:
-        url = _build_url(config.path, {"limit": config.page_size, "offset": offset})
-        data = _fetch_page(session, url, headers, logger)
-        items = _extract_items(data, config.data_key)
-        if not items:
-            break
-
-        yield [_transform_row(item, config) for item in items]
-
-        # A short page is the last page. We don't save state on it: there's nothing left to resume to.
-        if len(items) < config.page_size:
-            break
-
-        offset += config.page_size
-        # Save AFTER yielding so a crash re-pulls the page we just emitted rather than skipping it —
-        # merge dedupes the re-pulled rows on the primary key.
-        manager.save_state(CodefreshResumeConfig(offset=offset))
-
-
-def _iter_page(
-    session: requests.Session,
-    config: CodefreshEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[CodefreshResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    resume = manager.load_state() if manager.can_resume() else None
-    page = resume.page if resume is not None and resume.page is not None else 1
-    session_id = resume.session_id if resume is not None else None
-
-    while True:
-        req_headers = dict(headers)
-        if session_id:
-            # Pin every page to the snapshot the first page opened, so builds created mid-sync can't
-            # shift the window underneath us.
-            req_headers["X-Pagination-Session-Id"] = session_id
-
-        url = _build_url(config.path, {"limit": config.page_size, "page": page})
-        data = _fetch_page(session, url, req_headers, logger)
-
-        items = _extract_items(data, config.data_key)
-        pagination = data.get("pagination", {}) if isinstance(data, dict) else {}
-        session_id = pagination.get("sessionId") or session_id
-
-        # An empty page terminates the stream even if the API keeps advertising nextPage. Without
-        # this, a server-side cursor bug that streams empty pages forever would loop indefinitely.
-        if not items:
-            break
-
-        yield [_transform_row(item, config) for item in items]
-
-        if not pagination.get("nextPage"):
-            break
-
-        page += 1
-        manager.save_state(CodefreshResumeConfig(page=page, session_id=session_id))
-
-
-def get_rows(
+def codefresh_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CodefreshResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
+) -> SourceResponse:
     config = CODEFRESH_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = make_tracked_session()
+    paginator, params = _build_paginator_and_params(config)
 
-    if config.pagination == "none":
-        data = _fetch_page(session, _build_url(config.path), headers, logger)
-        items = [_transform_row(item, config) for item in _extract_items(data, config.data_key)]
-        if items:
-            yield items
-        return
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CODEFRESH_BASE_URL,
+            # Auth is supplied via the framework auth config so its value is redacted from logs.
+            # Codefresh expects the raw token as the Authorization header value — no "Bearer " prefix.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "Authorization", "location": "header"},
+            "headers": {"Accept": "application/json"},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Codefresh returns either a bare array or an envelope ({docs: [...]},
+                    # {workflows: {docs: [...]}}); data_key is the path to walk.
+                    "data_selector": ".".join(config.data_key) if config.data_key else None,
+                    # For bare-array endpoints a 200 body that isn't a list means the response shape
+                    # changed — fail loud instead of syncing a stray object as a row.
+                    "data_selector_required": config.data_key is None,
+                },
+                "data_map": lambda item, config=config: _transform_row(item, config),
+            }
+        ],
+    }
 
-    if config.pagination == "offset":
-        yield from _iter_offset(session, config, headers, logger, resumable_source_manager)
-        return
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            if config.pagination == "offset" and resume.offset is not None:
+                initial_paginator_state = {"offset": resume.offset}
+            elif config.pagination == "page" and (resume.page is not None or resume.session_id is not None):
+                initial_paginator_state = {"page": resume.page, "session_id": resume.session_id}
 
-    yield from _iter_page(session, config, headers, logger, resumable_source_manager)
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the hook fires AFTER a page is yielded so a crash
+        # re-pulls the page we just emitted rather than skipping it — merge dedupes the re-pulled
+        # rows on the primary key. A short/last page passes None: nothing left to resume to.
+        if not state:
+            return
+        if config.pagination == "offset" and state.get("offset") is not None:
+            resumable_source_manager.save_state(CodefreshResumeConfig(offset=int(state["offset"])))
+        elif config.pagination == "page" and state.get("page") is not None:
+            resumable_source_manager.save_state(
+                CodefreshResumeConfig(page=int(state["page"]), session_id=state.get("session_id"))
+            )
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
+    )
 
 
 def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tuple[bool, str | None]:
@@ -217,47 +229,24 @@ def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tup
     config = CODEFRESH_ENDPOINTS.get(schema_name) if schema_name else None
     path = config.path if config is not None else "/projects"
 
-    try:
-        response = make_tracked_session().get(_build_url(path, {"limit": 1}), headers=_get_headers(api_key), timeout=10)
-    except Exception:
-        return False, "Could not connect to Codefresh. Please try again."
-
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CODEFRESH_BASE_URL}{path}?limit=1",
+        headers={"Authorization": api_key, "Accept": "application/json"},
+    )
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status is None:
+        return False, "Could not connect to Codefresh. Please try again."
+    if status == 401:
         return False, "Your Codefresh API key is invalid or has been revoked."
-    if response.status_code == 403:
+    if status == 403:
         if schema_name:
             return False, f"Your Codefresh API key is missing the access scope required to sync '{schema_name}'."
         # Valid token, but it lacks scope for the probe resource — don't block source creation.
         return True, None
-    if response.status_code == 429 or response.status_code >= 500:
+    if status == 429 or status >= 500:
         # Transient: a rate-limit or server error doesn't mean the key is bad. Surface it as a
         # retryable failure rather than telling the user their credentials are invalid.
         return False, "Codefresh is temporarily unavailable. Please try again in a moment."
-    return False, f"Codefresh API returned an unexpected status ({response.status_code})."
-
-
-def codefresh_source(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CodefreshResumeConfig],
-) -> SourceResponse:
-    config = CODEFRESH_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=config.primary_keys,
-        partition_count=1,
-        partition_size=1,
-        partition_mode="datetime" if config.partition_key else None,
-        partition_format="month" if config.partition_key else None,
-        partition_keys=[config.partition_key] if config.partition_key else None,
-    )
+    return False, f"Codefresh API returned an unexpected status ({status})."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/codefresh/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/codefresh/source.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CodefreshSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -101,24 +104,15 @@ Only the US SaaS host (`g.codefresh.io`) is supported. EU and self-hosted/on-pre
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = CODEFRESH_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                # Codefresh exposes no server-side updated-since filter on any list endpoint, so
-                # every table is full refresh only — an "incremental" sync would re-page the whole
-                # resource anyway.
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Codefresh exposes no server-side updated-since filter on any list endpoint, so every
+        # table is full refresh only (INCREMENTAL_FIELDS is empty per endpoint) — an "incremental"
+        # sync would re-page the whole resource anyway.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            should_sync_default={name: cfg.should_sync_default for name, cfg in CODEFRESH_ENDPOINTS.items()},
+        )
 
     def validate_credentials(
         self, config: CodefreshSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -140,6 +134,7 @@ Only the US SaaS host (`g.codefresh.io`) is supported. EU and self-hosted/on-pre
         return codefresh_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/codefresh/tests/test_codefresh.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/codefresh/tests/test_codefresh.py
@@ -1,20 +1,17 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
 from parameterized import parameterized
+from requests import PreparedRequest, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.codefresh import codefresh
 from products.warehouse_sources.backend.temporal.data_imports.sources.codefresh.codefresh import (
     CodefreshResumeConfig,
-    _extract_items,
     _flatten,
-    _iter_offset,
-    _iter_page,
     _transform_row,
     codefresh_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.codefresh.settings import (
@@ -22,54 +19,56 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.codefresh.
     CodefreshEndpointConfig,
 )
 
-
-class _FakeResumableManager:
-    def __init__(self, state: CodefreshResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[CodefreshResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> CodefreshResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: CodefreshResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the codefresh module.
+CODEFRESH_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.codefresh.codefresh.make_tracked_session"
+)
 
 
-def _fetch_stub(pages: dict[str, Any], captured_headers: list[dict[str, str]] | None = None):
-    """Build a `_fetch_page` replacement that returns canned bodies keyed by URL."""
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> Any:
-        if captured_headers is not None:
-            captured_headers.append(dict(headers))
-        result = pages[url]
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    return fake_fetch
+def _response(body: Any) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class TestExtractItems:
-    @parameterized.expand(
-        [
-            ("bare_array", [{"id": "1"}, {"id": "2"}], None, [{"id": "1"}, {"id": "2"}]),
-            ("docs_envelope", {"docs": [{"id": "1"}], "count": 1}, ["docs"], [{"id": "1"}]),
-            (
-                "nested_workflows_docs",
-                {"workflows": {"docs": [{"id": "b1"}]}, "pagination": {}},
-                ["workflows", "docs"],
-                [{"id": "b1"}],
-            ),
-            ("missing_key_returns_empty", {"other": []}, ["docs"], []),
-            ("non_list_value_returns_empty", {"docs": {"not": "a list"}}, ["docs"], []),
-            ("bare_array_on_non_list_returns_empty", {"docs": []}, None, []),
-        ]
+def _make_manager(resume_state: CodefreshResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Wire a mock session; return (param_snapshots, header_snapshots) captured AT PREPARE TIME.
+
+    ``request.params`` / ``request.headers`` are single dicts mutated in place across pages, so
+    inspecting them after the run shows only the final state — snapshot a copy per request instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    header_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        header_snapshots.append(dict(request.headers or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, header_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None):
+    return codefresh_source(
+        "token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager or _make_manager()
     )
-    def test_extract_items(self, _name: str, data: Any, data_key: list[str] | None, expected: list) -> None:
-        assert _extract_items(data, data_key) == expected
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFlatten:
@@ -158,175 +157,224 @@ class TestTransformRow:
         assert redacted_key in CODEFRESH_ENDPOINTS[endpoint].redact_keys
 
 
-def _offset_config(page_size: int = 2) -> CodefreshEndpointConfig:
-    return CodefreshEndpointConfig(
-        name="projects", path="/projects", pagination="offset", data_key=None, page_size=page_size
-    )
-
-
 class TestOffsetPagination:
-    def test_short_first_page_stops_without_saving(self, monkeypatch: Any) -> None:
-        config = _offset_config(page_size=2)
-        pages = {"https://g.codefresh.io/api/projects?limit=2&offset=0": [{"id": "1"}]}
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_stops_without_saving(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "1"}])])
+        manager = _make_manager()
 
-        batches = list(_iter_offset(MagicMock(), config, {}, MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("projects", manager))
 
-        assert batches == [[{"id": "1"}]]
+        assert rows == [{"id": "1"}]
+        assert session.send.call_count == 1
         # A short page is the last page — nothing left to resume to, so no state is saved.
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_full_page_then_short_page_paginates_and_saves(self, monkeypatch: Any) -> None:
-        config = _offset_config(page_size=2)
-        pages = {
-            "https://g.codefresh.io/api/projects?limit=2&offset=0": [{"id": "1"}, {"id": "2"}],
-            "https://g.codefresh.io/api/projects?limit=2&offset=2": [{"id": "3"}],
-        }
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_then_short_page_paginates_and_saves(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": f"p_{i}"} for i in range(100)]
+        params, _headers = _wire(session, [_response(full_page), _response([{"id": "p_last"}])])
+        manager = _make_manager()
 
-        batches = list(_iter_offset(MagicMock(), config, {}, MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("projects", manager))
 
-        assert batches == [[{"id": "1"}, {"id": "2"}], [{"id": "3"}]]
+        assert [r["id"] for r in rows] == [*(f"p_{i}" for i in range(100)), "p_last"]
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == 100
+        assert params[1]["offset"] == 100
         # State saved exactly once, after the first (full) page is yielded, pointing at the next offset.
-        assert manager.saved == [CodefreshResumeConfig(offset=2)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == CodefreshResumeConfig(offset=100)
 
-    def test_resume_starts_from_saved_offset(self, monkeypatch: Any) -> None:
-        config = _offset_config(page_size=2)
-        pages = {"https://g.codefresh.io/api/projects?limit=2&offset=4": [{"id": "5"}]}
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
-        manager = _FakeResumableManager(CodefreshResumeConfig(offset=4))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_starts_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _headers = _wire(session, [_response([{"id": "p_201"}])])
+        manager = _make_manager(CodefreshResumeConfig(offset=200))
 
-        batches = list(_iter_offset(MagicMock(), config, {}, MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("projects", manager))
 
-        assert batches == [[{"id": "5"}]]
+        assert rows == [{"id": "p_201"}]
+        assert params[0]["offset"] == 200
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_on_bare_array_endpoint_fails_loud(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unexpected envelope"})])
 
-def _page_config(page_size: int = 2) -> CodefreshEndpointConfig:
-    return CodefreshEndpointConfig(
-        name="builds",
-        path="/workflow",
-        pagination="page",
-        data_key=["workflows", "docs"],
-        page_size=page_size,
-    )
+        # A 200 body that isn't a list means the response shape changed — fail loud instead of
+        # syncing the stray object as a row.
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source("projects"))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_projects_variables_are_redacted(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "p1", "variables": [{"key": "TOKEN", "value": "secret"}]}])])
+
+        rows = _rows(_source("projects"))
+
+        assert rows == [{"id": "p1"}]
 
 
 class TestPagePagination:
-    def test_follows_next_page_and_forwards_session_id(self, monkeypatch: Any) -> None:
-        config = _page_config(page_size=2)
-        pages = {
-            "https://g.codefresh.io/api/workflow?limit=2&page=1": {
-                "workflows": {"docs": [{"id": "b1"}, {"id": "b2"}]},
-                "pagination": {"sessionId": "sess-1", "nextPage": True},
-            },
-            "https://g.codefresh.io/api/workflow?limit=2&page=2": {
-                "workflows": {"docs": [{"id": "b3"}]},
-                "pagination": {"sessionId": "sess-1", "nextPage": False},
-            },
-        }
-        captured: list[dict[str, str]] = []
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages, captured))
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_next_page_and_forwards_session_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, headers = _wire(
+            session,
+            [
+                _response(
+                    {
+                        "workflows": {"docs": [{"id": "b1"}, {"id": "b2"}]},
+                        "pagination": {"sessionId": "sess-1", "nextPage": True},
+                    }
+                ),
+                _response(
+                    {
+                        "workflows": {"docs": [{"id": "b3"}]},
+                        "pagination": {"sessionId": "sess-1", "nextPage": False},
+                    }
+                ),
+            ],
+        )
+        manager = _make_manager()
 
-        batches = list(_iter_page(MagicMock(), config, {}, MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("builds", manager))
 
-        assert batches == [[{"id": "b1"}, {"id": "b2"}], [{"id": "b3"}]]
+        assert [r["id"] for r in rows] == ["b1", "b2", "b3"]
+        assert params[0] == {"limit": 100, "page": 1}
+        assert params[1]["page"] == 2
         # The session cursor opened by page 1 must be pinned on page 2 so the snapshot is stable.
-        assert "X-Pagination-Session-Id" not in captured[0]
-        assert captured[1]["X-Pagination-Session-Id"] == "sess-1"
-        assert manager.saved == [CodefreshResumeConfig(page=2, session_id="sess-1")]
+        assert "X-Pagination-Session-Id" not in headers[0]
+        assert headers[1]["X-Pagination-Session-Id"] == "sess-1"
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == CodefreshResumeConfig(page=2, session_id="sess-1")
 
-    def test_single_page_no_next(self, monkeypatch: Any) -> None:
-        config = _page_config(page_size=2)
-        pages = {
-            "https://g.codefresh.io/api/workflow?limit=2&page=1": {
-                "workflows": {"docs": [{"id": "b1"}]},
-                "pagination": {"nextPage": False},
-            },
-        }
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_no_next(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"workflows": {"docs": [{"id": "b1"}]}, "pagination": {"nextPage": False}})])
+        manager = _make_manager()
 
-        batches = list(_iter_page(MagicMock(), config, {}, MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("builds", manager))
 
-        assert batches == [[{"id": "b1"}]]
-        assert manager.saved == []
+        assert rows == [{"id": "b1"}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_empty_page_stops_even_when_next_page_advertised(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_stops_even_when_next_page_advertised(self, MockSession) -> None:
         # A misbehaving API that streams empty pages with nextPage=True must not loop forever.
-        config = _page_config(page_size=2)
-        pages = {
-            "https://g.codefresh.io/api/workflow?limit=2&page=1": {
-                "workflows": {"docs": []},
-                "pagination": {"nextPage": True},
-            },
-        }
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
-        manager = _FakeResumableManager()
+        session = MockSession.return_value
+        _wire(session, [_response({"workflows": {"docs": []}, "pagination": {"nextPage": True}})])
+        manager = _make_manager()
 
-        batches = list(_iter_page(MagicMock(), config, {}, MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("builds", manager))
 
-        assert batches == []
-        assert manager.saved == []
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resume_starts_from_saved_page_and_session(self, monkeypatch: Any) -> None:
-        config = _page_config(page_size=2)
-        pages = {
-            "https://g.codefresh.io/api/workflow?limit=2&page=3": {
-                "workflows": {"docs": [{"id": "b9"}]},
-                "pagination": {"nextPage": False},
-            },
-        }
-        captured: list[dict[str, str]] = []
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages, captured))
-        manager = _FakeResumableManager(CodefreshResumeConfig(page=3, session_id="sess-resume"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_docs_envelope_stops_without_rows(self, MockSession) -> None:
+        # A body without workflows.docs yields no rows and terminates (parity with the old transport).
+        session = MockSession.return_value
+        _wire(session, [_response({"pagination": {"nextPage": True}})])
 
-        batches = list(_iter_page(MagicMock(), config, {}, MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("builds"))
 
-        assert batches == [[{"id": "b9"}]]
-        assert captured[0]["X-Pagination-Session-Id"] == "sess-resume"
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_starts_from_saved_page_and_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, headers = _wire(
+            session,
+            [_response({"workflows": {"docs": [{"id": "b9"}]}, "pagination": {"nextPage": False}})],
+        )
+        manager = _make_manager(CodefreshResumeConfig(page=3, session_id="sess-resume"))
+
+        rows = _rows(_source("builds", manager))
+
+        assert rows == [{"id": "b9"}]
+        assert params[0]["page"] == 3
+        assert headers[0]["X-Pagination-Session-Id"] == "sess-resume"
 
 
 class TestUnpaginatedEndpoint:
-    def test_triggers_single_fetch_yields_one_list(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://g.codefresh.io/api/hermes/triggers": [
-                {"event": "e1", "pipeline": "p1"},
-                {"event": "e2", "pipeline": "p1"},
-            ]
-        }
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_triggers_single_fetch_yields_rows_without_pagination_params(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _headers = _wire(
+            session,
+            [
+                _response(
+                    [
+                        {"event": "e1", "pipeline": "p1", "event-data": {"secret": "s", "endpoint": "u"}},
+                        {"event": "e2", "pipeline": "p1"},
+                    ]
+                )
+            ],
+        )
+        manager = _make_manager()
 
-        batches = list(get_rows("token", "triggers", MagicMock(), manager))  # type: ignore[arg-type]
+        rows = _rows(_source("triggers", manager))
 
-        assert batches == [[{"event": "e1", "pipeline": "p1"}, {"event": "e2", "pipeline": "p1"}]]
-        assert manager.saved == []
+        # Single request, no pagination params, and the webhook secret/endpoint are redacted.
+        assert rows == [{"event": "e1", "pipeline": "p1", "event-data": {}}, {"event": "e2", "pipeline": "p1"}]
+        assert session.send.call_count == 1
+        assert params[0] == {}
+        manager.save_state.assert_not_called()
 
-    def test_empty_response_yields_nothing(self, monkeypatch: Any) -> None:
-        pages: dict[str, Any] = {"https://g.codefresh.io/api/hermes/triggers": []}
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
-        batches = list(get_rows("token", "triggers", MagicMock(), _FakeResumableManager()))  # type: ignore[arg-type]
+        rows = _rows(_source("triggers"))
 
-        assert batches == []
+        assert rows == []
 
 
 class TestGetRowsFlattensPipelines:
-    def test_pipeline_metadata_lifted_to_top_level(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://g.codefresh.io/api/pipelines?limit=100&offset=0": {
-                "docs": [{"metadata": {"id": "p1", "name": "deploy"}, "spec": {"steps": {}}}],
-                "count": 1,
-            }
-        }
-        monkeypatch.setattr(codefresh, "_fetch_page", _fetch_stub(pages))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pipeline_metadata_lifted_to_top_level(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response({"docs": [{"metadata": {"id": "p1", "name": "deploy"}, "spec": {"steps": {}}}], "count": 1})],
+        )
 
-        batches = list(get_rows("token", "pipelines", MagicMock(), _FakeResumableManager()))  # type: ignore[arg-type]
+        rows = _rows(_source("pipelines"))
 
-        assert batches == [[{"id": "p1", "name": "deploy", "spec": {"steps": {}}}]]
+        assert rows == [{"id": "p1", "name": "deploy", "spec": {"steps": {}}}]
+
+
+class TestAuth:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_authorization_header_is_raw_token_without_bearer_prefix(self, MockSession) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        captured_auth: list[Any] = []
+
+        def _prepare(request: Any) -> mock.MagicMock:
+            captured_auth.append(request.auth)
+            return mock.MagicMock()
+
+        session.prepare_request.side_effect = _prepare
+        session.send.side_effect = [_response([{"id": "1"}])]
+
+        _rows(_source("projects"))
+
+        # Codefresh expects the raw token as the Authorization header value — no "Bearer " prefix.
+        prepared = PreparedRequest()
+        prepared.prepare(method="GET", url="https://g.codefresh.io/api/projects", headers={})
+        captured_auth[0](prepared)
+        assert prepared.headers["Authorization"] == "token"
 
 
 class _FakeResponse:
@@ -346,18 +394,18 @@ class TestValidateCredentials:
         ]
     )
     def test_status_mapping(self, _name: str, status: int, schema_name: str | None, expected_valid: bool) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.return_value = _FakeResponse(status)
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(codefresh, "make_tracked_session", lambda *a, **k: session)
-            valid, _error = validate_credentials("token", schema_name=schema_name)
+        with mock.patch(CODEFRESH_SESSION_PATCH, return_value=session):
+            valid, error = validate_credentials("token", schema_name=schema_name)
         assert valid is expected_valid
+        if not expected_valid:
+            assert error is not None
 
     def test_connection_error_is_invalid(self) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = ConnectionError("boom")
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setattr(codefresh, "make_tracked_session", lambda *a, **k: session)
+        with mock.patch(CODEFRESH_SESSION_PATCH, return_value=session):
             valid, error = validate_credentials("token")
         assert valid is False
         assert error is not None
@@ -377,7 +425,7 @@ class TestCodefreshSourceResponse:
     def test_source_response_primary_keys_and_partition(
         self, endpoint: str, expected_keys: list[str], partition_key: str | None
     ) -> None:
-        response = codefresh_source("token", endpoint, MagicMock(), _FakeResumableManager())  # type: ignore[arg-type]
+        response = _source(endpoint)
         assert response.name == endpoint
         assert response.primary_keys == expected_keys
         if partition_key is None:
@@ -390,5 +438,5 @@ class TestCodefreshSourceResponse:
     def test_every_endpoint_has_a_source_response(self) -> None:
         # Guards against an endpoint added to settings without transport wiring.
         for endpoint in CODEFRESH_ENDPOINTS:
-            response = codefresh_source("token", endpoint, MagicMock(), _FakeResumableManager())  # type: ignore[arg-type]
+            response = _source(endpoint)
             assert response.primary_keys


### PR DESCRIPTION
## Problem

Tenth batch of hand-rolled source → `rest_source` migrations, stacked on #71598.

## Changes

**Four sources migrated** (behavior-preserving, suites green): `clockodo` (35 tests), `cloudflare` (33), `codefresh` (57), `coassemble` (46).

**Vetted and skipped**: `clickup`, `clockify`, `coda` (all two-level fan-out — this cluster is now the largest recurring gap and the next planned framework feature), `cloudbeds` (HTTP-200 body-level errors classified retryable-vs-permanent).

> [!NOTE]
> Stacked on #71598 → #71589 → #71580 → #71572 → #71565 → #71559 → #71552 → #71540 → #71524 → #71520 → #71481/#71477.

## How did you test this code?

- Merged verification: **311 tests pass** across the 4 migrated sources + the full `rest_source` suite.
- Each source's suite passed in isolation first; coverage preserved. Worktree isolation verified before merge. `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
