### PR TITLE
feat(flags): add etag support for remote config endpoint

### DIFF
--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -238,12 +238,12 @@ pub async fn flags_definitions(
     ))
 }
 
-fn format_weak_etag(raw: &str) -> String {
+pub(crate) fn format_weak_etag(raw: &str) -> String {
     format!("W/\"{}\"", raw)
 }
 
 /// Build a 304 Not Modified response with ETag and Cache-Control headers.
-fn not_modified_response(etag: &str) -> Response {
+pub(crate) fn not_modified_response(etag: &str) -> Response {
     (
         StatusCode::NOT_MODIFIED,
         [
@@ -275,7 +275,7 @@ fn ok_response_with_etag(data: Value, etag: Option<&str>) -> Response {
 ///
 /// Handles both strong ETags (`"abc123"`) and weak ETags (`W/"abc123"`) per RFC 7232.
 /// Returns `None` if the header is absent or empty.
-fn extract_etag_from_header(header: Option<&axum::http::HeaderValue>) -> Option<String> {
+pub(crate) fn extract_etag_from_header(header: Option<&axum::http::HeaderValue>) -> Option<String> {
     let value = header?.to_str().ok()?;
     let trimmed = value.trim();
     if trimmed.is_empty() {

--- a/rust/feature-flags/src/api/remote_config.rs
+++ b/rust/feature-flags/src/api/remote_config.rs
@@ -15,12 +15,20 @@
 //! feature flag access, even though this endpoint can return decrypted payloads. OAuth
 //! access tokens are also not accepted — any non-`phs_` bearer goes through personal-key
 //! validation and gets 401; only `phs_` and `phx_` credentials work.
+//!
+//! Supports `If-None-Match` conditional requests like `/flags/definitions`, but with a
+//! content-derived ETag: no cache backs this endpoint (the payload is read from Postgres
+//! per request), so the etag is a hash of the exact response body computed after payload
+//! resolution. That makes it caller-dependent by construction — a secret-key caller's
+//! redacted body and a personal-key caller's decrypted body hash to different etags, so a
+//! 304 never validates one credential class's cached body against the other's. A match
+//! saves the body transfer, not the DB read.
 
 use crate::{
     api::{auth, errors::FlagError, flag_definitions},
     database::get_connection_with_metrics,
     flags::flag_payload_decryptor::REDACTED_PAYLOAD_VALUE,
-    metrics::consts::REMOTE_CONFIG_AUTH_COUNTER,
+    metrics::consts::{REMOTE_CONFIG_AUTH_COUNTER, REMOTE_CONFIG_ETAG_COUNTER},
     router::State as AppState,
     team::team_models::Team,
 };
@@ -28,11 +36,12 @@ use axum::{
     debug_handler,
     extract::{Path, Query, State},
     http::{HeaderMap, Method, StatusCode},
-    response::{IntoResponse, Json, Response},
+    response::{IntoResponse, Response},
 };
 use common_metrics::inc;
 use serde::Deserialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tracing::warn;
 
 /// Query params. SDKs pass `?token=phc_...` (the project key) and call this with `@current`
@@ -192,10 +201,63 @@ pub async fn remote_config(
     // Django applies `or None` to the final value and renders None as an empty body, not
     // the JSON literal `null`. Apply the falsy check after decryption so an empty decrypted
     // string nulls out too.
-    match payload.filter(|v| !is_falsy(v)) {
-        Some(v) => Ok(Json(v).into_response()),
-        None => Ok(empty_ok_no_content_type()),
+    let payload = payload.filter(|v| !is_falsy(v));
+
+    // `Value::to_string` produces the same compact JSON `Json(v)` would serialize, so the
+    // etag hashes the exact bytes the client receives (empty payloads hash the empty body).
+    let body = payload.as_ref().map(Value::to_string).unwrap_or_default();
+    let current_etag = compute_etag(&body);
+
+    let client_etag = flag_definitions::extract_etag_from_header(headers.get("if-none-match"));
+    if client_etag.as_deref() == Some(current_etag.as_str()) {
+        inc(
+            REMOTE_CONFIG_ETAG_COUNTER,
+            &[("result".to_string(), "hit".to_string())],
+            1,
+        );
+        return Ok(flag_definitions::not_modified_response(&current_etag));
     }
+    inc(
+        REMOTE_CONFIG_ETAG_COUNTER,
+        &[(
+            "result".to_string(),
+            if client_etag.is_some() {
+                "miss"
+            } else {
+                "none"
+            }
+            .to_string(),
+        )],
+        1,
+    );
+
+    match payload {
+        Some(_) => Ok(json_ok_with_etag(body, &current_etag)),
+        None => Ok(empty_ok_no_content_type(&current_etag)),
+    }
+}
+
+/// Content-derived ETag: sha256 of the exact response body, truncated to 16 hex chars —
+/// the same shape HyperCache's `_compute_etag` produces for `/flags/definitions`, so SDKs
+/// see one etag format across both endpoints.
+fn compute_etag(body: &str) -> String {
+    let digest = Sha256::digest(body.as_bytes());
+    hex::encode(digest)[..16].to_string()
+}
+
+/// 200 with a pre-serialized JSON body plus ETag and Cache-Control headers, mirroring the
+/// sibling endpoint's `ok_response_with_etag`.
+fn json_ok_with_etag(body: String, etag: &str) -> Response {
+    (
+        StatusCode::OK,
+        [
+            ("content-type", "application/json".to_string()),
+            ("etag", flag_definitions::format_weak_etag(etag)),
+            ("cache-control", "private, must-revalidate".to_string()),
+        ],
+        body,
+    )
+        .into_response()
 }
 
 /// Decrypts the stored ciphertext on the personal-key path. Returns `None` when there is no
@@ -223,9 +285,17 @@ fn resolve_decrypted_payload(
 }
 
 /// 200 with an empty body and no Content-Type (NOT a JSON `null`), matching DRF's `Response(None)`:
-/// the renderer emits no bytes and DRF then deletes the Content-Type header.
-fn empty_ok_no_content_type() -> Response {
-    StatusCode::OK.into_response()
+/// the renderer emits no bytes and DRF then deletes the Content-Type header. Still carries the
+/// ETag/Cache-Control pair so a client polling a not-yet-set payload can 304 too.
+fn empty_ok_no_content_type(etag: &str) -> Response {
+    (
+        StatusCode::OK,
+        [
+            ("etag", flag_definitions::format_weak_etag(etag)),
+            ("cache-control", "private, must-revalidate".to_string()),
+        ],
+    )
+        .into_response()
 }
 
 /// Mirrors Python truthiness for `payloads.get("true") or None`. In practice the payload

--- a/rust/feature-flags/src/api/remote_config.rs
+++ b/rust/feature-flags/src/api/remote_config.rs
@@ -49,6 +49,12 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::warn;
 
+/// The body varies by `Authorization` at the same URL (decrypted vs redacted), so caches
+/// must revalidate on every reuse (`no-cache`, stronger than the sibling endpoint's
+/// `must-revalidate`) and key entries by credential (`Vary: Authorization`).
+const CACHE_CONTROL: &str = "private, no-cache";
+const VARY: &str = "Authorization";
+
 /// Query params. SDKs pass `?token=phc_...` (the project key) and call this with `@current`
 /// as the URL segment; the token resolves the project, matching Django. `api_key` is Django's
 /// accepted alias for `token` (see `get_token`).
@@ -249,40 +255,33 @@ fn compute_etag(body: &str) -> String {
     common_hypercache::writer::compute_etag(body)
 }
 
-/// The body varies by `Authorization` at the same URL (decrypted vs redacted), so caches
-/// must revalidate on every reuse (`no-cache`, stronger than the sibling endpoint's
-/// `must-revalidate`) and key entries by credential (`Vary: Authorization`).
-const CACHE_CONTROL: &str = "private, no-cache";
-const VARY: &str = "Authorization";
+/// The ETag/Cache-Control/Vary trio every response carries. Shared so the credential
+/// isolation (`no-cache` + `Vary: Authorization`) can't silently drop off one response
+/// path while surviving on the others.
+fn revalidation_headers(etag: &str) -> [(&'static str, String); 3] {
+    [
+        ("etag", flag_definitions::format_weak_etag(etag)),
+        ("cache-control", CACHE_CONTROL.to_string()),
+        ("vary", VARY.to_string()),
+    ]
+}
 
-/// 200 with a pre-serialized JSON body plus ETag, Cache-Control, and Vary headers.
+/// 200 with a pre-serialized JSON body plus the revalidation headers.
 fn json_ok_with_etag(body: String, etag: &str) -> Response {
     (
         StatusCode::OK,
-        [
-            ("content-type", "application/json".to_string()),
-            ("etag", flag_definitions::format_weak_etag(etag)),
-            ("cache-control", CACHE_CONTROL.to_string()),
-            ("vary", VARY.to_string()),
-        ],
+        [("content-type", "application/json")],
+        revalidation_headers(etag),
         body,
     )
         .into_response()
 }
 
-/// 304 carrying the same ETag/Cache-Control/Vary trio as the 200s — not the sibling
-/// endpoint's `not_modified_response`, whose `must-revalidate` would weaken the stored
-/// entry's policy when a cache updates its headers from the 304.
+/// 304 carrying the same revalidation headers as the 200s — not the sibling endpoint's
+/// `not_modified_response`, whose `must-revalidate` would weaken the stored entry's
+/// policy when a cache updates its headers from the 304.
 fn not_modified(etag: &str) -> Response {
-    (
-        StatusCode::NOT_MODIFIED,
-        [
-            ("etag", flag_definitions::format_weak_etag(etag)),
-            ("cache-control", CACHE_CONTROL.to_string()),
-            ("vary", VARY.to_string()),
-        ],
-    )
-        .into_response()
+    (StatusCode::NOT_MODIFIED, revalidation_headers(etag)).into_response()
 }
 
 /// Decrypts the stored ciphertext on the personal-key path. Returns `None` when there is no
@@ -311,17 +310,9 @@ fn resolve_decrypted_payload(
 
 /// 200 with an empty body and no Content-Type (NOT a JSON `null`), matching DRF's `Response(None)`:
 /// the renderer emits no bytes and DRF then deletes the Content-Type header. Still carries the
-/// ETag/Cache-Control pair so a client polling a not-yet-set payload can 304 too.
+/// revalidation headers so a client polling a not-yet-set payload can 304 too.
 fn empty_ok_no_content_type(etag: &str) -> Response {
-    (
-        StatusCode::OK,
-        [
-            ("etag", flag_definitions::format_weak_etag(etag)),
-            ("cache-control", CACHE_CONTROL.to_string()),
-            ("vary", VARY.to_string()),
-        ],
-    )
-        .into_response()
+    (StatusCode::OK, revalidation_headers(etag)).into_response()
 }
 
 /// Mirrors Python truthiness for `payloads.get("true") or None`. In practice the payload

--- a/rust/feature-flags/src/api/remote_config.rs
+++ b/rust/feature-flags/src/api/remote_config.rs
@@ -41,7 +41,6 @@ use axum::{
 use common_metrics::inc;
 use serde::Deserialize;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use tracing::warn;
 
 /// Query params. SDKs pass `?token=phc_...` (the project key) and call this with `@current`
@@ -237,12 +236,11 @@ pub async fn remote_config(
     }
 }
 
-/// Content-derived ETag: sha256 of the exact response body, truncated to 16 hex chars —
-/// the same shape HyperCache's `_compute_etag` produces for `/flags/definitions`, so SDKs
-/// see one etag format across both endpoints.
+/// Content-derived ETag over the exact response body, using the same HyperCache helper
+/// that produces `/flags/definitions` etags, so SDKs see one etag format across both
+/// endpoints.
 fn compute_etag(body: &str) -> String {
-    let digest = Sha256::digest(body.as_bytes());
-    hex::encode(digest)[..16].to_string()
+    common_hypercache::writer::compute_etag(body)
 }
 
 /// 200 with a pre-serialized JSON body plus ETag and Cache-Control headers, mirroring the

--- a/rust/feature-flags/src/api/remote_config.rs
+++ b/rust/feature-flags/src/api/remote_config.rs
@@ -23,6 +23,12 @@
 //! redacted body and a personal-key caller's decrypted body hash to different etags, so a
 //! 304 never validates one credential class's cached body against the other's. A match
 //! saves the body transfer, not the DB read.
+//!
+//! Because the body varies by `Authorization` at the same URL, responses carry
+//! `Cache-Control: private, no-cache` (revalidate on every reuse, not just when stale)
+//! and `Vary: Authorization` — otherwise a private cache primed by a personal-key
+//! request could replay the decrypted body to a secret-key caller without ever hitting
+//! the etag check.
 
 use crate::{
     api::{auth, errors::FlagError, flag_definitions},
@@ -214,7 +220,7 @@ pub async fn remote_config(
             &[("result".to_string(), "hit".to_string())],
             1,
         );
-        return Ok(flag_definitions::not_modified_response(&current_etag));
+        return Ok(not_modified(&current_etag));
     }
     inc(
         REMOTE_CONFIG_ETAG_COUNTER,
@@ -243,17 +249,38 @@ fn compute_etag(body: &str) -> String {
     common_hypercache::writer::compute_etag(body)
 }
 
-/// 200 with a pre-serialized JSON body plus ETag and Cache-Control headers, mirroring the
-/// sibling endpoint's `ok_response_with_etag`.
+/// The body varies by `Authorization` at the same URL (decrypted vs redacted), so caches
+/// must revalidate on every reuse (`no-cache`, stronger than the sibling endpoint's
+/// `must-revalidate`) and key entries by credential (`Vary: Authorization`).
+const CACHE_CONTROL: &str = "private, no-cache";
+const VARY: &str = "Authorization";
+
+/// 200 with a pre-serialized JSON body plus ETag, Cache-Control, and Vary headers.
 fn json_ok_with_etag(body: String, etag: &str) -> Response {
     (
         StatusCode::OK,
         [
             ("content-type", "application/json".to_string()),
             ("etag", flag_definitions::format_weak_etag(etag)),
-            ("cache-control", "private, must-revalidate".to_string()),
+            ("cache-control", CACHE_CONTROL.to_string()),
+            ("vary", VARY.to_string()),
         ],
         body,
+    )
+        .into_response()
+}
+
+/// 304 carrying the same ETag/Cache-Control/Vary trio as the 200s — not the sibling
+/// endpoint's `not_modified_response`, whose `must-revalidate` would weaken the stored
+/// entry's policy when a cache updates its headers from the 304.
+fn not_modified(etag: &str) -> Response {
+    (
+        StatusCode::NOT_MODIFIED,
+        [
+            ("etag", flag_definitions::format_weak_etag(etag)),
+            ("cache-control", CACHE_CONTROL.to_string()),
+            ("vary", VARY.to_string()),
+        ],
     )
         .into_response()
 }
@@ -290,7 +317,8 @@ fn empty_ok_no_content_type(etag: &str) -> Response {
         StatusCode::OK,
         [
             ("etag", flag_definitions::format_weak_etag(etag)),
-            ("cache-control", "private, must-revalidate".to_string()),
+            ("cache-control", CACHE_CONTROL.to_string()),
+            ("vary", VARY.to_string()),
         ],
     )
         .into_response()

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -329,6 +329,12 @@ pub const REMOTE_CONFIG_REQUESTS_COUNTER: &str = "flags_remote_config_requests_t
 // split decides redact-vs-decrypt, so the mix is worth watching during the phase 2/3 cutover.
 pub const REMOTE_CONFIG_AUTH_COUNTER: &str = "flags_remote_config_auth_total";
 
+// Remote config ETag metrics
+// Labels: result (hit = 304, miss = 200 with stale etag, none = 200 without etag). Unlike flag
+// definitions there is no redis_error case: no cache backs this endpoint, so the etag is
+// content-derived per request and can always be computed.
+pub const REMOTE_CONFIG_ETAG_COUNTER: &str = "flags_remote_config_etag_total";
+
 // Flag definitions cache metrics
 // Labels: source (redis, s3, fallback)
 pub const FLAG_DEFINITIONS_CACHE_HIT_COUNTER: &str = "flags_flag_definitions_cache_hit_total";

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -330,7 +330,8 @@ pub const REMOTE_CONFIG_REQUESTS_COUNTER: &str = "flags_remote_config_requests_t
 pub const REMOTE_CONFIG_AUTH_COUNTER: &str = "flags_remote_config_auth_total";
 
 // Remote config ETag metrics
-// Labels: result (hit = 304, miss = 200 with stale etag, none = 200 without etag). Unlike flag
+// Labels: result (hit = 304, miss = 200 with stale etag, none = request sent no
+// If-None-Match; the 200 still carries an etag since it is computed per request). Unlike flag
 // definitions there is no redis_error case: no cache backs this endpoint, so the etag is
 // content-derived per request and can always be computed.
 pub const REMOTE_CONFIG_ETAG_COUNTER: &str = "flags_remote_config_etag_total";

--- a/rust/feature-flags/tests/test_remote_config.rs
+++ b/rust/feature-flags/tests/test_remote_config.rs
@@ -839,8 +839,196 @@ async fn test_remote_config_empty_payload_returns_empty_body() {
         .unwrap();
 
     assert_eq!(response.status(), 200);
+    // Empty responses still carry an etag so a client polling a not-yet-set payload can 304.
+    let etag = response
+        .headers()
+        .get("etag")
+        .expect("empty response should carry an etag")
+        .to_str()
+        .unwrap()
+        .to_string();
     // Empty body, not the JSON literal "null".
     assert_eq!(response.text().await.unwrap(), "");
+
+    let revalidated = reqwest::Client::new()
+        .get(url(&server.addr, team.id, "rc-empty"))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .header("If-None-Match", &etag)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(revalidated.status(), 304);
+}
+
+#[tokio::test]
+async fn test_remote_config_etag_roundtrip() {
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+    insert_rc_flag(&context, team.id, "rc-etag", "etag-payload", true, false).await;
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    // First request: 200 with a weak etag and revalidation cache headers.
+    let response = client
+        .get(url(&server.addr, team.id, "rc-etag"))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let etag = response
+        .headers()
+        .get("etag")
+        .expect("200 response should carry an etag")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(etag.starts_with("W/\""), "expected weak etag, got {etag}");
+    assert_eq!(
+        response
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "private, must-revalidate"
+    );
+    assert_eq!(
+        response.json::<Value>().await.unwrap(),
+        Value::String("etag-payload".to_string())
+    );
+
+    // Matching If-None-Match: 304 with no body, echoing the etag.
+    let revalidated = client
+        .get(url(&server.addr, team.id, "rc-etag"))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .header("If-None-Match", &etag)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(revalidated.status(), 304);
+    assert_eq!(
+        revalidated.headers().get("etag").unwrap().to_str().unwrap(),
+        etag
+    );
+    assert_eq!(
+        revalidated
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "private, must-revalidate"
+    );
+    assert_eq!(revalidated.text().await.unwrap(), "");
+
+    // Stale If-None-Match: full 200 with the payload and the current etag.
+    let stale = client
+        .get(url(&server.addr, team.id, "rc-etag"))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .header("If-None-Match", "W/\"0000000000000000\"")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stale.status(), 200);
+    assert_eq!(stale.headers().get("etag").unwrap().to_str().unwrap(), etag);
+    assert_eq!(
+        stale.json::<Value>().await.unwrap(),
+        Value::String("etag-payload".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_remote_config_encrypted_etag_differs_by_credential() {
+    // The etag is derived from the resolved body, so a secret-key caller's redacted response
+    // and a personal-key caller's decrypted response must carry different etags — an etag
+    // computed from the stored row (or shared across credential classes) would let a client
+    // that cached the redacted body 304-validate it where plaintext should be served.
+    let mut config = Config::default_test_config();
+    config.flags_secret_keys = K1.to_string();
+    let context = TestContext::new(Some(&config)).await;
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    let org_id = context.get_organization_id_for_team(&team).await.unwrap();
+    let user_email = TestContext::generate_test_email("rc_etag_pak");
+    let user_id = context
+        .create_user(&user_email, &org_id, team.id)
+        .await
+        .unwrap();
+    context
+        .add_user_to_organization(user_id, &org_id, 15)
+        .await
+        .unwrap();
+    let (_pak_id, api_key) = context
+        .create_personal_api_key(
+            user_id,
+            "RC ETag PAK",
+            vec!["feature_flag:read"],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    insert_rc_flag(&context, team.id, "rc-enc-etag", TOK_PRIMARY, true, true).await;
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    let redacted_response = client
+        .get(url(&server.addr, team.id, "rc-enc-etag"))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(redacted_response.status(), 200);
+    let redacted_etag = redacted_response
+        .headers()
+        .get("etag")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // The redacted-body etag must not 304 a decrypting caller: they get plaintext and its etag.
+    let decrypted_response = client
+        .get(url(&server.addr, team.id, "rc-enc-etag"))
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("If-None-Match", &redacted_etag)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(decrypted_response.status(), 200);
+    let decrypted_etag = decrypted_response
+        .headers()
+        .get("etag")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_ne!(decrypted_etag, redacted_etag);
+    assert_eq!(
+        decrypted_response.json::<Value>().await.unwrap(),
+        Value::String(PLAINTEXT.to_string())
+    );
+
+    // A decrypting caller revalidating its own etag gets a 304 (decryption is deterministic).
+    let revalidated = client
+        .get(url(&server.addr, team.id, "rc-enc-etag"))
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("If-None-Match", &decrypted_etag)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(revalidated.status(), 304);
 }
 
 #[tokio::test]

--- a/rust/feature-flags/tests/test_remote_config.rs
+++ b/rust/feature-flags/tests/test_remote_config.rs
@@ -896,7 +896,11 @@ async fn test_remote_config_etag_roundtrip() {
             .unwrap()
             .to_str()
             .unwrap(),
-        "private, must-revalidate"
+        "private, no-cache"
+    );
+    assert_eq!(
+        response.headers().get("vary").unwrap().to_str().unwrap(),
+        "Authorization"
     );
     assert_eq!(
         response.json::<Value>().await.unwrap(),
@@ -923,7 +927,11 @@ async fn test_remote_config_etag_roundtrip() {
             .unwrap()
             .to_str()
             .unwrap(),
-        "private, must-revalidate"
+        "private, no-cache"
+    );
+    assert_eq!(
+        revalidated.headers().get("vary").unwrap().to_str().unwrap(),
+        "Authorization"
     );
     assert_eq!(revalidated.text().await.unwrap(), "");
 

--- a/rust/feature-flags/tests/test_remote_config.rs
+++ b/rust/feature-flags/tests/test_remote_config.rs
@@ -847,6 +847,22 @@ async fn test_remote_config_empty_payload_returns_empty_body() {
         .to_str()
         .unwrap()
         .to_string();
+    // The credential-isolation headers must hold on the empty-body path too.
+    assert_eq!(
+        response
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "private, no-cache"
+    );
+    assert_eq!(
+        response.headers().get("vary").unwrap().to_str().unwrap(),
+        "Authorization"
+    );
+    // No Content-Type, matching DRF's `Response(None)`.
+    assert!(response.headers().get("content-type").is_none());
     // Empty body, not the JSON literal "null".
     assert_eq!(response.text().await.unwrap(), "");
 
@@ -889,6 +905,17 @@ async fn test_remote_config_etag_roundtrip() {
         .unwrap()
         .to_string();
     assert!(etag.starts_with("W/\""), "expected weak etag, got {etag}");
+    // The body is written as a pre-serialized String, so the JSON content type is an
+    // explicit override of axum's text/plain default.
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/json"
+    );
     assert_eq!(
         response
             .headers()


### PR DESCRIPTION
## Problem

SDKs poll `GET /api/projects/{project_id}/feature_flags/{key}/remote_config` for payloads that rarely change, and every poll ships the full body. `/flags/definitions` already supports `If-None-Match`/304 conditional requests; the remote config endpoint (now served by the Rust feature-flags service) should too.

Closes #60314

## Changes

- The Rust `remote_config` handler now answers `If-None-Match` with a 304 when the client's etag matches, and attaches `ETag` (weak) plus `Cache-Control: private, no-cache` and `Vary: Authorization` to all responses (200, empty-body 200, and 304), so caches revalidate on every reuse and key entries by credential.
- Unlike `/flags/definitions` there is no cache (and no Redis-stored etag) backing this endpoint, so the etag is content-derived: sha256 of the exact response body, truncated to 16 hex chars, computed after payload resolution. Same etag shape as HyperCache's `_compute_etag`, so SDKs see one format across both endpoints.
- Deriving the etag from the resolved body makes it caller-dependent by construction. For encrypted flags, a secret-key caller's redacted body and a personal-key caller's decrypted body carry different etags, so a 304 never validates one credential class's cached body against the other's.
- A match saves the body transfer, not the DB read, since the payload has to be resolved to compute the etag.
- Reuses the sibling endpoint's etag helpers (header parsing, weak formatting, 304 builder) by widening them to `pub(crate)`, and adds a `flags_remote_config_etag_total` counter with hit/miss/none labels.

> [!NOTE]
> Server side only. SDK clients still need to send `If-None-Match` from `getRemoteConfigPayload()` to benefit, which is per-SDK-repo work.

## How did you test this code?

Automated tests, each catching a regression no existing test covered:

- `test_remote_config_etag_roundtrip`: 200 carries a weak etag and revalidation cache headers, a matching `If-None-Match` gets 304 with no body, a stale one gets a full 200. Catches the 304 path breaking or the headers being dropped.
- `test_remote_config_encrypted_etag_differs_by_credential`: redacted and decrypted responses for the same encrypted flag carry different etags, and the redacted etag does not 304 a decrypting caller. Catches an etag computed from the stored row or shared across credential classes, which would validate a cached redacted body where plaintext should be served.
- Extended `test_remote_config_empty_payload_returns_empty_body` to assert the empty-body branch also carries an etag and can 304. Catches that branch losing etag support, since it builds its response separately.

Ran locally: `cargo check -p feature-flags`, `cargo clippy -p feature-flags --tests` (clean, one pre-existing warning on master), `cargo fmt`, and the crate's unit tests (35 passed). I could not run the integration tests locally because the sandbox has no Postgres/Redis, so they need CI to verify.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task) from issue #60314. Skills invoked: `/writing-tests`. Key decision: a content-derived per-request etag instead of a Redis-stored one like `/flags/definitions`, because no cache backs this endpoint and the response varies by credential class for encrypted flags, which a single stored etag can't represent. Considered and rejected adding a HyperCache for per-flag payloads as out of scope.

@greptile

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

