### PR TITLE
fix(replay): drop the opted-in team filter from the score export query

### DIFF
--- a/posthog/temporal/session_replay/surfacing_score_export_sweep/activities.py
+++ b/posthog/temporal/session_replay/surfacing_score_export_sweep/activities.py
@@ -1,10 +1,12 @@
 """Activities: plan the (day × hash bucket) fan-out, then per partition fetch → pseudonymize → Parquet → S3 put.
 
-Only AI-training opted-in orgs are exported (the ML mirror's gate), with the
-mirror's exact pseudonym scheme, so exported ids join onto `block-metadata`
-and nothing else. Object keys are deterministic, so retries and the re-export
-window overwrite; an empty partition still writes an empty object so deleted
-sessions drop out rather than going stale.
+All scored sessions are exported, pseudonymized with the ML mirror's exact
+pseudonym scheme, so exported ids join onto `block-metadata` — which only
+exists for AI-training opted-in orgs (the mirror's gate) — and nothing else.
+Rows from non-opted-in teams are opaque pseudonyms that join to nothing.
+Object keys are deterministic, so retries and the re-export window overwrite;
+an empty partition still writes an empty object so deleted sessions drop out
+rather than going stale.
 """
 
 from __future__ import annotations
@@ -23,7 +25,6 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from posthog.clickhouse.client import sync_execute
-from posthog.models import Team
 from posthog.temporal.session_replay.surfacing_score_export_sweep import sql as export_sql
 from posthog.temporal.session_replay.surfacing_score_export_sweep.constants import (
     CH_EXPORT_QUERY_MAX_MEMORY_BYTES,
@@ -102,10 +103,6 @@ _PARQUET_FIELDS: list[pa.Field[Any]] = [
 _PARQUET_SCHEMA = pa.schema(_PARQUET_FIELDS)
 
 
-def _opted_in_team_ids() -> list[int]:
-    return list(Team.objects.filter(organization__is_ai_training_opted_in=True).values_list("id", flat=True))
-
-
 # (team_id, session_id, started_at, score)
 _ScoredRow = tuple[int, str, datetime, float]
 
@@ -114,7 +111,7 @@ _Cursor = tuple[str, int]
 _FIRST_PAGE: _Cursor = ("", 0)
 
 
-def _fetch_page(spec: ExportPartitionSpec, team_ids: list[int], cursor: _Cursor) -> list[_ScoredRow]:
+def _fetch_page(spec: ExportPartitionSpec, cursor: _Cursor) -> list[_ScoredRow]:
     return cast(
         list[_ScoredRow],
         sync_execute(
@@ -122,7 +119,6 @@ def _fetch_page(spec: ExportPartitionSpec, team_ids: list[int], cursor: _Cursor)
             {
                 "of_chunks": spec.of_chunks,
                 "chunk_id": spec.chunk_id,
-                "team_ids": team_ids,
                 "day_start": f"{spec.day} 00:00:00",
                 "cursor_session_id": cursor[0],
                 "cursor_team_id": cursor[1],
@@ -175,15 +171,14 @@ async def export_scores_partition_activity(spec: ExportPartitionSpec) -> ExportP
         raise ApplicationError(str(e), type=type(e).__name__, non_retryable=True) from e
 
     activity.heartbeat({"phase": "fetch", "day": spec.day, "chunk_id": spec.chunk_id})
-    team_ids = await sync_to_async(_opted_in_team_ids, thread_sensitive=False)()
 
     sink = io.BytesIO()
     writer = pq.ParquetWriter(sink, _PARQUET_SCHEMA, compression="snappy")
     cursor = _FIRST_PAGE
     rows_total = 0
     try:
-        while team_ids:
-            rows = await sync_to_async(_fetch_page, thread_sensitive=False)(spec, team_ids, cursor)
+        while True:
+            rows = await sync_to_async(_fetch_page, thread_sensitive=False)(spec, cursor)
             if rows:
                 table = await sync_to_async(_page_table, thread_sensitive=False)(rows, secret)
                 await sync_to_async(writer.write_table, thread_sensitive=False)(table)

--- a/posthog/temporal/session_replay/surfacing_score_export_sweep/sql.py
+++ b/posthog/temporal/session_replay/surfacing_score_export_sweep/sql.py
@@ -5,9 +5,15 @@ SESSION_REPLAY_EVENTS_TABLE = "session_replay_events"
 
 def fetch_scored_sessions_page_sql(replay_events_table: str = SESSION_REPLAY_EVENTS_TABLE) -> str:
     """One keyset-paginated page of a (day, hash bucket) export slice.
-    Bound parameters: %(of_chunks)s, %(chunk_id)s, %(team_ids)s,
+    Bound parameters: %(of_chunks)s, %(chunk_id)s,
     %(day_start)s ('YYYY-MM-DD 00:00:00', UTC), %(cursor_session_id)s,
     %(cursor_team_id)s, %(page_size)s.
+
+    There is deliberately no opted-in-team filter: exported rows are
+    pseudonymized and only ever joined downstream against session data that
+    exists solely for opted-in teams, so rows from other teams join to
+    nothing. Inlining the opted-in id list here (twice) also blew past
+    ClickHouse's 1 MiB max_query_size once enough teams opted in.
 
     The cursor predicate and ORDER BY use the same (session_id, team_id) tuple,
     so pages tile the partition exactly; a page shorter than page_size means
@@ -31,7 +37,6 @@ SELECT
     max(surfacing_score) AS score
 FROM {replay_events_table}
 WHERE cityHash64(session_id) %% %(of_chunks)s = %(chunk_id)s
-  AND team_id IN %(team_ids)s
   AND (session_id, team_id) > (%(cursor_session_id)s, %(cursor_team_id)s)
   AND min_first_timestamp >= toDateTime(%(day_start)s, 'UTC')
   AND min_first_timestamp < toDateTime(%(day_start)s, 'UTC') + toIntervalDay(2)
@@ -39,7 +44,6 @@ WHERE cityHash64(session_id) %% %(of_chunks)s = %(chunk_id)s
     SELECT team_id, session_id
     FROM {replay_events_table}
     WHERE cityHash64(session_id) %% %(of_chunks)s = %(chunk_id)s
-      AND team_id IN %(team_ids)s
       AND min_first_timestamp >= toDateTime(%(day_start)s, 'UTC')
       AND is_deleted = 1
   )


### PR DESCRIPTION
## Problem

The surfacing-score export sweep's page query inlined the full list of AI-training opted-in team ids into the SQL text, twice (once in the main `WHERE`, once in the `GLOBAL NOT IN` deletion-marker subquery). `clickhouse_driver` substitutes `%(team_ids)s` client-side, so the rendered query grows linearly with the number of opted-in orgs. In production it crossed ClickHouse's 1 MiB `max_query_size` and every export partition began failing at parse with `Code: 62 ... Max query size exceeded ... failed at position 1048577` (`ExceptionBeforeStart`, verified in `system.query_log` with `source_file = surfacing_score_export_sweep/activities.py`). The sweep's workflow still reported success, so nothing surfaced (that observability gap is [#71571](https://github.com/PostHog/posthog/pull/71571)).

## Changes

Remove the filter entirely rather than restructure how the ids are shipped. It was never load-bearing:

- Exported rows are pseudonymized (HMAC) with the ML mirror's exact scheme, and their only consumer joins them against `block-metadata` in the ML bucket — data that exists solely for opted-in orgs (the mirror applies the opt-in gate at ingestion). A scored session from a non-opted-in team exports as opaque pseudonyms that join to nothing.
- With the filter gone the query no longer references any team list, so its size is constant no matter how many orgs opt in — the failure mode is removed rather than pushed further out.

Mechanical fallout: `_opted_in_team_ids()` and the `Team` import are deleted, `_fetch_page` loses its `team_ids` parameter, and the paging loop gate becomes `while True:` (it already exits on the first short page; the old `while team_ids:` only guarded the zero-opted-in-teams case, which now degenerates naturally to an empty first page).

> [!NOTE]
> Behavior change: the export now includes pseudonymized score rows for *all* scored teams, not just opted-in ones. This is deliberate — see rationale above and the updated module docstring. The rows carry only pseudonymized ids, a start timestamp, and a score.

Alternatives considered: [#70607](https://github.com/PostHog/posthog/pull/70607) and [#71468](https://github.com/PostHog/posthog/pull/71468) both keep the filter and ship the ids out-of-band as a query-scoped external data table. That works, but requires forwarding `external_tables` through the HTTP transport in `posthog/clickhouse/client/connection.py` — shared client code this approach leaves untouched. If this lands, both can close.

## How did you test this code?

Automated only, run by me (Claude):

- `hogli test posthog/temporal/tests/session_replay/surfacing_score_export_sweep/` — 9 passed.
- `ruff check` / `ruff format` / `ty check` clean (via lint-staged on commit).

No new tests: the change is a pure removal, and the one assertable property ("SQL contains no team-id list") would be a change-detector. The existing export tests cover paging and parquet output through the public interface.

I have not run this against production data.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Robbie) directed this; Claude Code wrote it. We first verified the failure was real rather than inferred: pulled `system.query_log` from production ClickHouse (via the internal Metabase API) and confirmed the exact code-62 parse rejections attributed to this sweep's `source_file`, starting when the sweep first ran. We then chose removal over the external-table approach in #70607/#71468 because the filter is redundant given the downstream join target is already opt-in-gated, and removal avoids touching shared ClickHouse client code. The `while True:` loop-gate change was checked against the zero-teams edge case (degenerates to an empty first page). No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
