### PR TITLE
feat(flags): expose minimal_flag_called_events in the local-eval blob

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1614,6 +1614,14 @@
             ],
             "label": "Feature flag evaluated at"
         },
+        "$feature_flag_has_experiment": {
+            "description": "Whether the feature flag that was called is linked to a live experiment.",
+            "examples": [
+                "true",
+                "false"
+            ],
+            "label": "Feature flag has experiment"
+        },
         "$feature_flag_id": {
             "description": "The numeric identifier of the feature flag that was called.",
             "examples": [
@@ -6000,6 +6008,14 @@
                 "1732051200000"
             ],
             "label": "Feature flag evaluated at"
+        },
+        "$feature_flag_has_experiment": {
+            "description": "Whether the feature flag that was called is linked to a live experiment.",
+            "examples": [
+                "true",
+                "false"
+            ],
+            "label": "Feature flag has experiment"
         },
         "$feature_flag_id": {
             "description": "The numeric identifier of the feature flag that was called.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1750,6 +1750,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "The numeric identifier of the feature flag that was called.",
             "examples": ["1234"],
         },
+        "$feature_flag_has_experiment": {
+            "label": "Feature flag has experiment",
+            "description": "Whether the feature flag that was called is linked to a live experiment.",
+            "examples": ["true", "false"],
+        },
         "$feature_flag_bootstrapped_response": {
             "label": "Feature flag bootstrapped response",
             "description": "The response value provided to the SDK at initialization via the bootstrap option, before evaluation against PostHog.",

--- a/products/feature_flags/backend/api/staff_team_config.py
+++ b/products/feature_flags/backend/api/staff_team_config.py
@@ -115,12 +115,17 @@ class FeatureFlagsStaffTeamConfigViewSet(viewsets.ViewSet):
 
         # posthog.tasks.team_metadata sits under posthog.tasks, whose __init__ is a celery
         # autoimport aggregator that pulls in every task module — keep that off the API
-        # router's import path by deferring it to call time.
+        # router's import path by deferring it to call time. The local tasks module is
+        # deferred for the same reason (it imports celery machinery).
         from posthog.tasks.team_metadata import update_team_metadata_cache_task  # noqa: PLC0415
 
-        # /flags and /decide read this value out of team_metadata_hypercache, not the DB, so the
-        # write above has no effect until that cache is rebuilt.
+        from products.feature_flags.backend.tasks import update_team_flags_cache  # noqa: PLC0415
+
+        # /flags and /decide read this value out of team_metadata_hypercache, and local-eval
+        # SDKs read it out of the flag-definitions blob — neither reads the DB, so the write
+        # above has no effect until both caches are rebuilt.
         update_team_metadata_cache_task.delay(team.id)
+        update_team_flags_cache.delay(team.id)
 
         logger.info(
             "flags_staff_team_config_updated",

--- a/products/feature_flags/backend/local_evaluation.py
+++ b/products/feature_flags/backend/local_evaluation.py
@@ -53,6 +53,7 @@ from products.feature_flags.backend.flags_cache import (
 )
 from products.feature_flags.backend.models.evaluation_context import EvaluationContext, FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.feature_flags.backend.models.team_feature_flags_config import TeamFeatureFlagsConfig
 from products.feature_flags.backend.types import FlagFilters, FlagProperty, PropertyFilterType
 from products.surveys.backend.models import Survey
 
@@ -523,7 +524,9 @@ def clear_flag_definition_caches(team: Team | int, kinds: list[str] | None = Non
 def _get_flags_response_for_local_evaluation(team: Team) -> dict[str, Any]:
     """Build the local-evaluation response for a single team."""
     results = _get_flags_response_for_local_evaluation_batch([team])
-    return results.get(team.id, {"flags": [], "group_type_mapping": {}, "cohorts": {}})
+    return results.get(
+        team.id, {"flags": [], "group_type_mapping": {}, "cohorts": {}, "minimal_flag_called_events": False}
+    )
 
 
 def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -542,6 +545,15 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
     team_ids = [t.id for t in teams]
     team_by_id = {t.id: t for t in teams}
     project_ids = list({t.project_id for t in teams})
+
+    # Slim $feature_flag_called gate, exposed top-level so local-eval SDKs (which never
+    # call /flags) get the same signal FlagsResponse.minimal_flag_called_events carries.
+    # Absent row → False → SDKs send full events, same fail-safe as the /flags path.
+    minimal_flag_called_events_by_team = dict(
+        TeamFeatureFlagsConfig.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
+        .filter(team_id__in=team_ids)
+        .values_list("team_id", "minimal_flag_called_events")
+    )
 
     # Bulk load survey flag IDs across all teams
     survey_flag_ids: set[int] = set()
@@ -675,6 +687,7 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
             "flags": flags_data,
             "group_type_mapping": gtm_by_project.get(team.project_id, {}),
             "cohorts": cohorts,
+            "minimal_flag_called_events": minimal_flag_called_events_by_team.get(tid, False),
         }
 
         results[tid] = _apply_flag_dependency_transformation(response_data, flag_id_to_key)
@@ -686,6 +699,7 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
                 "flags": [],
                 "group_type_mapping": gtm_by_project.get(team_by_id[tid].project_id, {}),
                 "cohorts": {},
+                "minimal_flag_called_events": minimal_flag_called_events_by_team.get(tid, False),
             }
 
     return results
@@ -818,6 +832,10 @@ def verify_team_flag_definitions(
             diffs.append({"type": "COHORTS_MISMATCH", "flag_key": "cohorts"})
         if cached_data.get("group_type_mapping") != db_data.get("group_type_mapping"):
             diffs.append({"type": "GROUP_TYPE_MAPPING_MISMATCH", "flag_key": "group_type_mapping"})
+        # Default False on both sides so pre-existing blobs without the key don't all
+        # report drift — absent and False mean the same thing to SDKs (full events).
+        if cached_data.get("minimal_flag_called_events", False) != db_data.get("minimal_flag_called_events", False):
+            diffs.append({"type": "MINIMAL_FLAG_CALLED_EVENTS_MISMATCH", "flag_key": "minimal_flag_called_events"})
 
     if not diffs:
         return {"status": "match", "issue": "", "details": ""}
@@ -828,6 +846,7 @@ def verify_team_flag_definitions(
     mismatch_count = sum(1 for d in diffs if d.get("type") == "FIELD_MISMATCH")
     cohorts_mismatch = any(d.get("type") == "COHORTS_MISMATCH" for d in diffs)
     gtm_mismatch = any(d.get("type") == "GROUP_TYPE_MAPPING_MISMATCH" for d in diffs)
+    minimal_ffc_mismatch = any(d.get("type") == "MINIMAL_FLAG_CALLED_EVENTS_MISMATCH" for d in diffs)
 
     summary_parts = []
     if missing_count > 0:
@@ -843,6 +862,8 @@ def verify_team_flag_definitions(
         extra_parts.append("cohorts mismatch")
     if gtm_mismatch:
         extra_parts.append("group_type_mapping mismatch")
+    if minimal_ffc_mismatch:
+        extra_parts.append("minimal_flag_called_events mismatch")
 
     details = "; ".join(filter(None, [flag_summary, ", ".join(extra_parts)]))
 

--- a/products/feature_flags/backend/local_evaluation.py
+++ b/products/feature_flags/backend/local_evaluation.py
@@ -521,12 +521,24 @@ def clear_flag_definition_caches(team: Team | int, kinds: list[str] | None = Non
     flag_definitions_hypercache.clear_cache(team, kinds=kinds)
 
 
+def _local_eval_response(
+    flags: list[dict[str, Any]],
+    group_type_mapping: dict[str, str],
+    cohorts: dict[str, Any],
+    minimal_flag_called_events: bool,
+) -> dict[str, Any]:
+    return {
+        "flags": flags,
+        "group_type_mapping": group_type_mapping,
+        "cohorts": cohorts,
+        "minimal_flag_called_events": minimal_flag_called_events,
+    }
+
+
 def _get_flags_response_for_local_evaluation(team: Team) -> dict[str, Any]:
     """Build the local-evaluation response for a single team."""
     results = _get_flags_response_for_local_evaluation_batch([team])
-    return results.get(
-        team.id, {"flags": [], "group_type_mapping": {}, "cohorts": {}, "minimal_flag_called_events": False}
-    )
+    return results.get(team.id, _local_eval_response([], {}, {}, False))
 
 
 def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -549,10 +561,11 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
     # Slim $feature_flag_called gate, exposed top-level so local-eval SDKs (which never
     # call /flags) get the same signal FlagsResponse.minimal_flag_called_events carries.
     # Absent row → False → SDKs send full events, same fail-safe as the /flags path.
-    minimal_flag_called_events_by_team = dict(
+    minimal_flag_called_events_by_team: defaultdict[int, bool] = defaultdict(
+        bool,
         TeamFeatureFlagsConfig.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
         .filter(team_id__in=team_ids)
-        .values_list("team_id", "minimal_flag_called_events")
+        .values_list("team_id", "minimal_flag_called_events"),
     )
 
     # Bulk load survey flag IDs across all teams
@@ -683,24 +696,24 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
                 FLAG_PROCESSING_ERROR_COUNTER.inc()
                 continue
 
-        response_data: dict[str, Any] = {
-            "flags": flags_data,
-            "group_type_mapping": gtm_by_project.get(team.project_id, {}),
-            "cohorts": cohorts,
-            "minimal_flag_called_events": minimal_flag_called_events_by_team.get(tid, False),
-        }
+        response_data = _local_eval_response(
+            flags_data,
+            gtm_by_project.get(team.project_id, {}),
+            cohorts,
+            minimal_flag_called_events_by_team[tid],
+        )
 
         results[tid] = _apply_flag_dependency_transformation(response_data, flag_id_to_key)
 
     # Ensure every requested team has a result, even if it had no flags
     for tid in team_ids:
         if tid not in results:
-            results[tid] = {
-                "flags": [],
-                "group_type_mapping": gtm_by_project.get(team_by_id[tid].project_id, {}),
-                "cohorts": {},
-                "minimal_flag_called_events": minimal_flag_called_events_by_team.get(tid, False),
-            }
+            results[tid] = _local_eval_response(
+                [],
+                gtm_by_project.get(team_by_id[tid].project_id, {}),
+                {},
+                minimal_flag_called_events_by_team[tid],
+            )
 
     return results
 
@@ -736,6 +749,16 @@ FLAG_DEFINITIONS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     should_skip_write=_skip_write_if_group_mapping_emptied,
     refresh_only_fields=_FLAG_DEFINITIONS_REFRESH_ONLY_FIELDS,
 )
+
+
+# Top-level blob fields (besides "flags", compared separately by key) checked for drift by
+# verify_team_flag_definitions. Each entry is (field, mismatch type, default used when a legacy
+# blob predates the field — None means the field has always been present).
+_TOP_LEVEL_FIELDS_TO_COMPARE: list[tuple[str, str, Any]] = [
+    ("cohorts", "COHORTS_MISMATCH", None),
+    ("group_type_mapping", "GROUP_TYPE_MAPPING_MISMATCH", None),
+    ("minimal_flag_called_events", "MINIMAL_FLAG_CALLED_EVENTS_MISMATCH", False),
+]
 
 
 def verify_team_flag_definitions(
@@ -826,16 +849,12 @@ def verify_team_flag_definitions(
                     diff["field_diffs"] = field_diffs
                 diffs.append(diff)
 
-    # Also compare cohorts and group_type_mapping
+    # Also compare top-level blob fields other than flags (cohorts, group_type_mapping, …).
+    # A default other than None means a legacy blob missing the key isn't reported as drift.
     if cached_data is not None and db_data is not None:
-        if cached_data.get("cohorts") != db_data.get("cohorts"):
-            diffs.append({"type": "COHORTS_MISMATCH", "flag_key": "cohorts"})
-        if cached_data.get("group_type_mapping") != db_data.get("group_type_mapping"):
-            diffs.append({"type": "GROUP_TYPE_MAPPING_MISMATCH", "flag_key": "group_type_mapping"})
-        # Default False on both sides so pre-existing blobs without the key don't all
-        # report drift — absent and False mean the same thing to SDKs (full events).
-        if cached_data.get("minimal_flag_called_events", False) != db_data.get("minimal_flag_called_events", False):
-            diffs.append({"type": "MINIMAL_FLAG_CALLED_EVENTS_MISMATCH", "flag_key": "minimal_flag_called_events"})
+        for field, mismatch_type, default in _TOP_LEVEL_FIELDS_TO_COMPARE:
+            if cached_data.get(field, default) != db_data.get(field, default):
+                diffs.append({"type": mismatch_type, "flag_key": field})
 
     if not diffs:
         return {"status": "match", "issue": "", "details": ""}
@@ -844,9 +863,7 @@ def verify_team_flag_definitions(
     missing_count = sum(1 for d in diffs if d.get("type") == "MISSING_IN_CACHE")
     stale_count = sum(1 for d in diffs if d.get("type") == "STALE_IN_CACHE")
     mismatch_count = sum(1 for d in diffs if d.get("type") == "FIELD_MISMATCH")
-    cohorts_mismatch = any(d.get("type") == "COHORTS_MISMATCH" for d in diffs)
-    gtm_mismatch = any(d.get("type") == "GROUP_TYPE_MAPPING_MISMATCH" for d in diffs)
-    minimal_ffc_mismatch = any(d.get("type") == "MINIMAL_FLAG_CALLED_EVENTS_MISMATCH" for d in diffs)
+    mismatched_types = {d.get("type") for d in diffs}
 
     summary_parts = []
     if missing_count > 0:
@@ -857,13 +874,11 @@ def verify_team_flag_definitions(
         summary_parts.append(f"{mismatch_count} mismatched")
 
     flag_summary = f"{', '.join(summary_parts)} flags" if summary_parts else ""
-    extra_parts = []
-    if cohorts_mismatch:
-        extra_parts.append("cohorts mismatch")
-    if gtm_mismatch:
-        extra_parts.append("group_type_mapping mismatch")
-    if minimal_ffc_mismatch:
-        extra_parts.append("minimal_flag_called_events mismatch")
+    extra_parts = [
+        f"{field} mismatch"
+        for field, mismatch_type, _ in _TOP_LEVEL_FIELDS_TO_COMPARE
+        if mismatch_type in mismatched_types
+    ]
 
     details = "; ".join(filter(None, [flag_summary, ", ".join(extra_parts)]))
 

--- a/products/feature_flags/backend/local_evaluation.py
+++ b/products/feature_flags/backend/local_evaluation.py
@@ -522,6 +522,7 @@ def clear_flag_definition_caches(team: Team | int, kinds: list[str] | None = Non
 
 
 def _local_eval_response(
+    *,
     flags: list[dict[str, Any]],
     group_type_mapping: dict[str, str],
     cohorts: dict[str, Any],
@@ -538,7 +539,10 @@ def _local_eval_response(
 def _get_flags_response_for_local_evaluation(team: Team) -> dict[str, Any]:
     """Build the local-evaluation response for a single team."""
     results = _get_flags_response_for_local_evaluation_batch([team])
-    return results.get(team.id, _local_eval_response([], {}, {}, False))
+    return results.get(
+        team.id,
+        _local_eval_response(flags=[], group_type_mapping={}, cohorts={}, minimal_flag_called_events=False),
+    )
 
 
 def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -697,10 +701,10 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
                 continue
 
         response_data = _local_eval_response(
-            flags_data,
-            gtm_by_project.get(team.project_id, {}),
-            cohorts,
-            minimal_flag_called_events_by_team[tid],
+            flags=flags_data,
+            group_type_mapping=gtm_by_project.get(team.project_id, {}),
+            cohorts=cohorts,
+            minimal_flag_called_events=minimal_flag_called_events_by_team[tid],
         )
 
         results[tid] = _apply_flag_dependency_transformation(response_data, flag_id_to_key)
@@ -709,10 +713,10 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
     for tid in team_ids:
         if tid not in results:
             results[tid] = _local_eval_response(
-                [],
-                gtm_by_project.get(team_by_id[tid].project_id, {}),
-                {},
-                minimal_flag_called_events_by_team[tid],
+                flags=[],
+                group_type_mapping=gtm_by_project.get(team_by_id[tid].project_id, {}),
+                cohorts={},
+                minimal_flag_called_events=minimal_flag_called_events_by_team[tid],
             )
 
     return results

--- a/products/feature_flags/backend/test/test_local_evaluation.py
+++ b/products/feature_flags/backend/test/test_local_evaluation.py
@@ -976,9 +976,13 @@ class TestLocalEvaluationBatch(BaseTest):
         # team reading False, or an ungated/legacy team (no config row) reading anything but
         # False — including on the no-flags fallback path.
         gated_team = self._create_team_with_project("Gated")
+        gated_team_no_flags = self._create_team_with_project("Gated no flags")
         ungated_team = self._create_team_with_project("Ungated")
 
         TeamFeatureFlagsConfig.objects.update_or_create(team=gated_team, defaults={"minimal_flag_called_events": True})
+        TeamFeatureFlagsConfig.objects.update_or_create(
+            team=gated_team_no_flags, defaults={"minimal_flag_called_events": True}
+        )
         TeamFeatureFlagsConfig.objects.filter(team=ungated_team).delete()
 
         FeatureFlag.objects.create(
@@ -987,9 +991,14 @@ class TestLocalEvaluationBatch(BaseTest):
             filters={"groups": [{"rollout_percentage": 100}]},
         )
 
-        results = _get_flags_response_for_local_evaluation_batch([gated_team, ungated_team])
+        results = _get_flags_response_for_local_evaluation_batch([gated_team, gated_team_no_flags, ungated_team])
 
         assert results[gated_team.id]["minimal_flag_called_events"] is True
+        # Gated team with no flags hits the no-flags fallback path, not the main response path.
+        # Without this case, a fallback that hardcodes False instead of threading the gate would
+        # pass unnoticed, since the ungated team's expected False is indistinguishable from that.
+        assert results[gated_team_no_flags.id]["flags"] == []
+        assert results[gated_team_no_flags.id]["minimal_flag_called_events"] is True
         assert results[ungated_team.id]["minimal_flag_called_events"] is False
 
     def test_batch_team_with_no_flags_includes_group_type_mapping(self):

--- a/products/feature_flags/backend/test/test_local_evaluation.py
+++ b/products/feature_flags/backend/test/test_local_evaluation.py
@@ -32,6 +32,7 @@ from products.feature_flags.backend.local_evaluation import (
     verify_team_flag_definitions,
 )
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.feature_flags.backend.models.team_feature_flags_config import TeamFeatureFlagsConfig
 from products.surveys.backend.models import Survey
 
 
@@ -969,6 +970,28 @@ class TestLocalEvaluationBatch(BaseTest):
         assert "group_type_mapping" in results[team_without_flags.id]
         assert "cohorts" in results[team_without_flags.id]
 
+    def test_batch_includes_minimal_flag_called_events_gate(self):
+        # Local-eval SDKs never call /flags, so the blob is their only source of the slim
+        # $feature_flag_called gate. Catches the key being dropped from the payload, a gated
+        # team reading False, or an ungated/legacy team (no config row) reading anything but
+        # False — including on the no-flags fallback path.
+        gated_team = self._create_team_with_project("Gated")
+        ungated_team = self._create_team_with_project("Ungated")
+
+        TeamFeatureFlagsConfig.objects.update_or_create(team=gated_team, defaults={"minimal_flag_called_events": True})
+        TeamFeatureFlagsConfig.objects.filter(team=ungated_team).delete()
+
+        FeatureFlag.objects.create(
+            team=gated_team,
+            key="gated-flag",
+            filters={"groups": [{"rollout_percentage": 100}]},
+        )
+
+        results = _get_flags_response_for_local_evaluation_batch([gated_team, ungated_team])
+
+        assert results[gated_team.id]["minimal_flag_called_events"] is True
+        assert results[ungated_team.id]["minimal_flag_called_events"] is False
+
     def test_batch_team_with_no_flags_includes_group_type_mapping(self):
         team = self._create_team_with_project("GTM Team")
 
@@ -1257,10 +1280,11 @@ class TestLocalEvaluationBatch(BaseTest):
             filters={"groups": [{"rollout_percentage": 100}]},
         )
 
-        with self.assertNumQueries(2):
-            # Expected queries: survey flag IDs and flags (with evaluation
-            # tags via ArrayAgg). Group type mappings are read from
-            # personhog, not SQL. No cohort query should be issued.
+        with self.assertNumQueries(3):
+            # Expected queries: the minimal_flag_called_events gate, survey flag
+            # IDs, and flags (with evaluation tags via ArrayAgg). Group type
+            # mappings are read from personhog, not SQL. No cohort query should
+            # be issued.
             results = _get_flags_response_for_local_evaluation_batch([team])
 
         assert results[team.id]["cohorts"] == {}
@@ -1424,6 +1448,33 @@ class TestVerifyFlagDefinitions(BaseTest):
 
         assert result["status"] == "match"
         assert result["issue"] == ""
+
+    def test_verify_detects_stale_minimal_flag_called_events(self):
+        # A gated team whose blob was cached before the gate flipped must report drift
+        # so verify-and-fix rewrites it; otherwise local-eval SDKs keep the stale gate
+        # until TTL expiry if the staff endpoint's rebuild task was lost.
+        update_flag_definitions_cache(self.team)
+
+        TeamFeatureFlagsConfig.objects.update_or_create(team=self.team, defaults={"minimal_flag_called_events": True})
+
+        result = verify_team_flag_definitions(self.team)
+
+        assert result["status"] == "mismatch"
+        assert "minimal_flag_called_events mismatch" in result["details"]
+
+    def test_verify_treats_absent_gate_key_as_false(self):
+        # Pre-existing blobs written before the key existed must not report drift for
+        # ungated teams — absent and False both mean "full events" to SDKs. Guards
+        # against a fleet-wide rewrite storm on deploy.
+        update_flag_definitions_cache(self.team)
+        cached, _ = flag_definitions_hypercache.get_from_cache_with_source(self.team)
+        assert cached is not None
+        legacy_blob = {k: v for k, v in cached.items() if k != "minimal_flag_called_events"}
+        flag_definitions_hypercache.set_cache_value(self.team, legacy_blob)
+
+        result = verify_team_flag_definitions(self.team)
+
+        assert result["status"] == "match"
 
     def test_verify_returns_mismatch_when_flag_key_renamed(self):
         flag = FeatureFlag.objects.create(

--- a/products/feature_flags/backend/test/test_staff_team_config_api.py
+++ b/products/feature_flags/backend/test/test_staff_team_config_api.py
@@ -74,8 +74,11 @@ class TestFeatureFlagsStaffTeamConfigAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @parameterized.expand([(True,), (False,)])
-    def test_set_updates_db_value_and_enqueues_cache_refresh_task(self, new_value):
-        with patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_task:
+    def test_set_updates_db_value_and_enqueues_cache_refresh_tasks(self, new_value):
+        with (
+            patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_metadata_task,
+            patch("products.feature_flags.backend.tasks.update_team_flags_cache") as mock_flags_task,
+        ):
             response = self.client.post(
                 SET_URL, {"team_id": self.team.id, "minimal_flag_called_events": new_value}, format="json"
             )
@@ -85,9 +88,11 @@ class TestFeatureFlagsStaffTeamConfigAPI(APIBaseTest):
 
         config = TeamFeatureFlagsConfig.objects.get(team=self.team)
         self.assertEqual(config.minimal_flag_called_events, new_value)
-        # /flags and /decide read this value out of team_metadata_hypercache, not the DB, so a
-        # bare write has no effect until that cache is rebuilt.
-        mock_task.delay.assert_called_once_with(self.team.id)
+        # /flags and /decide read this value out of team_metadata_hypercache, and local-eval
+        # SDKs read it out of the flag-definitions blob — a bare DB write has no effect until
+        # both caches are rebuilt.
+        mock_metadata_task.delay.assert_called_once_with(self.team.id)
+        mock_flags_task.delay.assert_called_once_with(self.team.id)
 
     def test_set_returns_404_for_unknown_team(self):
         missing_id = self.team.id + 9999
@@ -99,7 +104,10 @@ class TestFeatureFlagsStaffTeamConfigAPI(APIBaseTest):
         # auto-created row from the team-creation signal.
         TeamFeatureFlagsConfig.objects.filter(team=self.team).delete()
 
-        with patch("posthog.tasks.team_metadata.update_team_metadata_cache_task"):
+        with (
+            patch("posthog.tasks.team_metadata.update_team_metadata_cache_task"),
+            patch("products.feature_flags.backend.tasks.update_team_flags_cache"),
+        ):
             response = self.client.post(
                 SET_URL, {"team_id": self.team.id, "minimal_flag_called_events": True}, format="json"
             )


### PR DESCRIPTION
## Problem

Part of the slim `$feature_flag_called` events work. The team gate already reaches SDKs through the v2 `/flags` response (`minimalFlagCalledEvents`, #69145), but server SDKs running in local-evaluation mode never call `/flags` — they poll the flag-definitions blob. Without the gate in that blob, local-eval SDKs can never send the slim event shape.

Separately, `$feature_flag_has_experiment` (emitted by SDKs since the has_experiment rollout, and an input to the ingestion dedup key) was missing from the taxonomy, so it showed up unlabeled in property filters.

## Changes

- `_get_flags_response_for_local_evaluation_batch` now bulk-loads `TeamFeatureFlagsConfig.minimal_flag_called_events` (one query per batch, not per team) and emits it as a top-level `minimal_flag_called_events` key in the blob. Absent row means `false`, matching the fail-safe of the `/flags` field: any missing signal means SDKs send full events.
- The staff toggle (`/feature_flags/staff`) now also enqueues `update_team_flags_cache` next to the existing team-metadata refresh, since the blob doesn't rebuild on a bare extension write.
- The flag-definitions cache verifier compares the new key, defaulting absent to `false` on both sides so pre-existing blobs don't all report drift for ungated teams (avoids a rewrite storm on deploy) while a gated team with a stale blob still gets fixed.
- Registers `$feature_flag_has_experiment` in `taxonomy.py` (+ regenerated `core-filter-definitions-by-group.json`).

No Rust changes needed: `flag_definitions.rs` serves the blob as untyped JSON, and ETag is derived from content, so polling SDKs pick up the new key on their next cycle.

## How did you test this code?

- New test `test_batch_includes_minimal_flag_called_events_gate`: catches the key being dropped from the blob, a gated team reading false, or a legacy team (no config row) reading anything but false — including on the no-flags fallback path. No existing test covered the gate in the blob.
- New verifier tests: `test_verify_detects_stale_minimal_flag_called_events` (a gated team with a pre-flip blob must report drift so verify-and-fix rewrites it) and `test_verify_treats_absent_gate_key_as_false` (pre-existing blobs without the key must not report drift for ungated teams — guards the deploy-time rewrite storm).
- Extended `test_set_updates_db_value_and_enqueues_cache_refresh_tasks` to assert the second task is enqueued — catches the staff toggle silently going stale for local-eval SDKs.
- Updated the query-count pin in `test_batch_no_cohort_flags_skips_cohort_loading` (2 → 3: the gate load is one constant extra query per batch, not N+1).
- Full `test_local_evaluation.py` (92 passed) and `test_staff_team_config_api.py` (8 passed) run locally via `hogli test`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change: the gate is internal-only (staff toggle) and the blob key is an SDK-facing contract documented with the SDK work.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked: `/improving-drf-endpoints` (before touching the staff viewset — no serializer/schema changes ended up needed), `/writing-tests` (each test above names the regression it catches). The keep/strip contract for the slim event shape was settled in this session from prod property-size measurements (client SDKs are ~97.5% of `$feature_flag_called` payload bytes; the weight is flag-state blobs, not the context envelope) and prior blast-radius analyses; this PR is only the server-side signal plumbing — SDK emission changes land in the SDK repos. Considered omitting the key for ungated teams instead of emitting `false`; emitting it always keeps the blob shape stable and matches `_serialize_team_to_metadata`. Considered leaving the verifier alone; without the compare, a gated team whose staff-toggle rebuild task was lost would keep a stale gate until TTL expiry.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*