### PR TITLE
fix(flags): log find_flags_with_enriched_analytics failures

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -945,7 +945,14 @@ def find_flags_with_enriched_analytics() -> None:
     end = datetime.now()
     begin = end - timedelta(hours=12)
 
-    find_flags_with_enriched_analytics(begin, end)
+    try:
+        find_flags_with_enriched_analytics(begin, end)
+    except Exception as e:
+        logger.exception("Find flags with enriched analytics failed", error=e)
+        capture_exception(
+            e, additional_properties={"feature": "feature_flags", "task": "find_flags_with_enriched_analytics"}
+        )
+        raise
 
 
 @shared_task(ignore_result=True)

--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -20,6 +20,7 @@ from django.core.cache import cache
 from posthog import redis
 from posthog.constants import FlagRequestType
 from posthog.models.team.team import Team
+from posthog.tasks.tasks import find_flags_with_enriched_analytics as find_flags_with_enriched_analytics_task
 
 from products.feature_flags.backend.api.feature_flag import _create_usage_dashboard
 from products.feature_flags.backend.flag_analytics import (
@@ -1033,6 +1034,17 @@ class TestEnrichedAnalytics(BaseTest):
         f1.refresh_from_db()
         self.assertEqual(f1.has_enriched_analytics, True)
         self.assertEqual(f1.usage_dashboard, None)
+
+
+class TestFindFlagsWithEnrichedAnalyticsTask(BaseTest):
+    @patch("products.feature_flags.backend.flag_analytics.find_flags_with_enriched_analytics")
+    def test_logs_and_reraises_on_failure(self, mock_find_flags: MagicMock) -> None:
+        mock_find_flags.side_effect = Exception("boom")
+
+        with patch("posthog.tasks.tasks.capture_exception") as mock_capture, self.assertRaises(Exception):
+            find_flags_with_enriched_analytics_task()
+
+        mock_capture.assert_called_once()
 
 
 class TestCrossProjectEvaluations(ClickhouseTestMixin, APIBaseTest):


### PR DESCRIPTION
## Problem

`find_flags_with_enriched_analytics` in posthog/tasks/tasks.py runs twice a day, scanning the last 12 hours of `$feature_view` events in ClickHouse to mark matching feature flags as having enriched analytics. Unlike the sibling task `sync_feature_flag_last_called` in the same file, it has no exception handling at the task level. When the inner call throws, the exception propagates with no application log line, just a bare Prometheus counter increment from Celery's own failure tracking. There's nothing to look at when this fails beyond knowing that it did.

## Changes

Wrapped the task body in a try/except that logs via structlog and calls `capture_exception` before re-raising. This mirrors the pattern `sync_feature_flag_last_called` already uses in the same file. The re-raise keeps Celery and Prometheus failure tracking unchanged, this is only about adding a diagnosable log line.

## How did you test this code?

Added `TestFindFlagsWithEnrichedAnalyticsTask.test_logs_and_reraises_on_failure`, which mocks the inner function to raise and asserts `capture_exception` gets called while the exception still propagates. Ran it locally with `hogli test posthog/test/test_feature_flag_analytics.py::TestFindFlagsWithEnrichedAnalyticsTask`, it passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, config, or documented workflow changed here.