### PR TITLE
fix(flags): skip NUL-byte flag keys in last-called sync

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1381,11 +1381,13 @@ def sync_feature_flag_last_called(self: PushGatewayTask) -> None:
             )
             return
 
-        # Build lookup map from merged results
+        # Build lookup map from merged results. Skip flag keys containing NUL bytes:
+        # Postgres can't store them, so they can never match a real FeatureFlag.key,
+        # and passing one into the key__in query below raises psycopg.DataError.
         flag_updates: dict[tuple[int, str], datetime] = {}
-        for key, (ts, _count) in merged_results.items():
-            if ts is not None:
-                flag_updates[key] = ts
+        for (team_id, flag_key), (ts, _count) in merged_results.items():
+            if ts is not None and "\x00" not in flag_key:
+                flag_updates[(team_id, flag_key)] = ts
 
         if not flag_updates:
             redis_client.set(FEATURE_FLAG_LAST_CALLED_SYNC_KEY, current_sync_timestamp.isoformat())

--- a/products/feature_flags/backend/test/test_feature_flag_sync.py
+++ b/products/feature_flags/backend/test/test_feature_flag_sync.py
@@ -168,6 +168,25 @@ class TestSyncFeatureFlagLastCalled(BaseTest):
     @freeze_time("2024-06-15 12:00:00")
     @patch("posthog.clickhouse.client.sync_execute")
     @patch("posthog.tasks.tasks.get_client")
+    def test_skips_flag_keys_with_nul_bytes(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
+        """A ClickHouse-sourced flag key containing a NUL byte must not reach the Postgres query,
+        since psycopg rejects NUL bytes in query parameters."""
+        redis_mock = mock_redis_client()
+        mock_get_client.return_value = redis_mock
+
+        mock_sync_execute.return_value = [
+            (self.team.pk, self.flag1.key, tz.make_aware(datetime(2024, 6, 15, 11, 0, 0)), 100),
+            (self.team.pk, "bad-flag-\x00-key", tz.make_aware(datetime(2024, 6, 15, 11, 0, 0)), 50),
+        ]
+
+        sync_feature_flag_last_called()  # must not raise
+
+        self.flag1.refresh_from_db()
+        assert self.flag1.last_called_at is not None
+
+    @freeze_time("2024-06-15 12:00:00")
+    @patch("posthog.clickhouse.client.sync_execute")
+    @patch("posthog.tasks.tasks.get_client")
     @override_settings(FEATURE_FLAG_LAST_CALLED_AT_SYNC_BATCH_SIZE=2)
     def test_bulk_update_respects_batch_size(self, mock_get_client: MagicMock, mock_sync_execute: MagicMock) -> None:
         """Bulk updates should respect configured batch size"""


### PR DESCRIPTION
## Problem

`sync_feature_flag_last_called` syncs `last_called_at` timestamps from ClickHouse `$feature_flag_called` events into the `FeatureFlag` table. It builds the set of flag keys directly from ClickHouse's `JSONExtractString(properties, '$feature_flag')` and passes it into `FeatureFlag.objects.filter(key__in=flag_keys)`.

The `$feature_flag` property value is client controlled. If it contains an embedded NUL byte, the Postgres query fails with `psycopg.DataError: PostgreSQL text fields cannot contain NUL (0x00) bytes`. That's not a ClickHouse error, so it isn't covered by the task's `autoretry_for=CH_TRANSIENT_ERRORS`, it's a hard failure that kills the whole sync run and loses the `last_called_at` update for every team in that cycle, not just the one bad key.

This isn't hypothetical: production logs show this exact crash happening repeatedly over several hours on 2026-07-14, roughly every 30 minutes. Because the sync only advances its checkpoint on success, every retry hit the same offending event until the checkpoint's staleness cap eventually pushed the query window past it — the failures stopped on their own, but no `last_called_at` updates landed for any team during that window.

## Changes

Skip any flag key containing a NUL byte before it reaches the Postgres query. Postgres can never store a NUL byte in a text column, so such a key could never match a real `FeatureFlag.key` anyway, dropping it changes nothing about correct data and avoids the crash.

## How did you test this code?

Added `test_skips_flag_keys_with_nul_bytes` to `TestSyncFeatureFlagLastCalled`. It feeds a ClickHouse row with a NUL byte in the flag key through `sync_feature_flag_last_called()` and asserts the run completes and a normal flag in the same batch still gets its `last_called_at` updated.

This test runs against the real test Postgres database. I confirmed it reproduces the exact `psycopg.DataError` when run against the code before this fix, and passes cleanly after.

Ran the full file: `hogli test products/feature_flags/backend/test/test_feature_flag_sync.py`, 21 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, internal Celery task with no user-facing or documented behavior change.
