### PR TITLE
fix(flags): log team metadata fan-out failures

### DIFF
--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -72,15 +72,24 @@ def update_related_teams_metadata_cache_task(organization_id: int | None = None,
     the signal enqueues a single task no matter how many teams the org or project owns, and each
     per-team update runs as its own task so the work spreads across workers.
     """
-    if organization_id is not None:
-        team_ids = Team.objects.filter(organization_id=organization_id).values_list("id", flat=True)
-    elif project_id is not None:
-        team_ids = Team.objects.filter(project_id=project_id).values_list("id", flat=True)
-    else:
-        return
+    try:
+        if organization_id is not None:
+            team_ids = Team.objects.filter(organization_id=organization_id).values_list("id", flat=True)
+        elif project_id is not None:
+            team_ids = Team.objects.filter(project_id=project_id).values_list("id", flat=True)
+        else:
+            return
 
-    for team_id in team_ids:
-        update_team_metadata_cache_task.delay(team_id)
+        for team_id in team_ids:
+            update_team_metadata_cache_task.delay(team_id)
+    except Exception as e:
+        logger.exception(
+            "Failed to fan out related team metadata cache refresh",
+            organization_id=organization_id,
+            project_id=project_id,
+            error=str(e),
+        )
+        raise
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)

--- a/posthog/tasks/test/test_team_metadata_signals.py
+++ b/posthog/tasks/test/test_team_metadata_signals.py
@@ -106,6 +106,17 @@ class TestRelatedTeamsMetadataFanoutTask(BaseTest):
 
         mock_update.delay.assert_not_called()
 
+    def test_logs_and_reraises_on_failure(self) -> None:
+        with (
+            patch("posthog.tasks.team_metadata.update_team_metadata_cache_task") as mock_update,
+            patch("posthog.tasks.team_metadata.logger") as mock_logger,
+            self.assertRaises(Exception),
+        ):
+            mock_update.delay.side_effect = Exception("broker down")
+            update_related_teams_metadata_cache_task(organization_id=self.organization.id)
+
+        mock_logger.exception.assert_called_once()
+
 
 @override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
 class TestOrgProjectDeleteCascadesToTeamClear(BaseTest):


### PR DESCRIPTION
## Problem

`update_related_teams_metadata_cache_task` fans out a per-team metadata cache refresh whenever an organization or project gets renamed. It had no exception handling at all, unlike its sibling tasks in the same file (`refresh_expiring_team_metadata_cache_entries`, `cleanup_stale_expiry_tracking_task`), which both wrap their body in try/except and log via `logger.exception`. When this task fails, there's nothing to diagnose beyond a bare Prometheus counter increment.

## Changes

Wrapped the fan-out body in the same try/except pattern its siblings already use. On failure it logs via `logger.exception(...)` with the organization/project ID for context, then re-raises so Celery's failure tracking and retry behavior stay exactly the same. This is an observability fix only, not a resilience change.

## How did you test this code?

Added `test_logs_and_reraises_on_failure` to `TestRelatedTeamsMetadataFanoutTask` in `posthog/tasks/test/test_team_metadata_signals.py`. It mocks a broker failure on `.delay()` and asserts the exception is logged and still propagates.

Ran the full file locally: `hogli test posthog/tasks/test/test_team_metadata_signals.py`, 12 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior changed here, this is internal observability only.