### PR TITLE
chore(cymbal): harden exception property boundaries

### DIFF
--- a/rust/cymbal/src/core/symbolication/symbol/local.rs
+++ b/rust/cymbal/src/core/symbolication/symbol/local.rs
@@ -272,7 +272,7 @@ mod test {
             sourcemap::SourcemapProvider,
             Catalog, MockS3Client,
         },
-        types::RawErrProps,
+        types::RawExceptionProperties,
     };
 
     const CHUNK_PATH: &str = "/static/chunk-PGUQKT6S.js";
@@ -362,7 +362,8 @@ mod test {
 
     fn get_test_frame(server: &MockServer) -> RawFrame {
         let exception: ClickHouseEvent = serde_json::from_str(EXAMPLE_EXCEPTION).unwrap();
-        let mut props: RawErrProps = serde_json::from_str(&exception.properties.unwrap()).unwrap();
+        let mut props: RawExceptionProperties =
+            serde_json::from_str(&exception.properties.unwrap()).unwrap();
         let Stacktrace::Raw {
             frames: mut test_stack,
         } = props.exception_list.swap_remove(0).stack.unwrap()

--- a/rust/cymbal/src/core/symbolication/symbol_store/chunk_id.rs
+++ b/rust/cymbal/src/core/symbolication/symbol_store/chunk_id.rs
@@ -358,7 +358,7 @@ mod test {
             sourcemap::{OwnedSourceMapCache, SourcemapProvider},
             Catalog, MockS3Client, Provider,
         },
-        types::RawErrProps,
+        types::RawExceptionProperties,
     };
 
     const EXAMPLE_EXCEPTION: &str =
@@ -404,7 +404,8 @@ mod test {
 
     fn get_example_frame() -> RawJSFrame {
         let event: ClickHouseEvent = serde_json::from_str(EXAMPLE_EXCEPTION).unwrap();
-        let mut props: RawErrProps = serde_json::from_str(&event.properties.unwrap()).unwrap();
+        let mut props: RawExceptionProperties =
+            serde_json::from_str(&event.properties.unwrap()).unwrap();
         let stack = props.exception_list.swap_remove(0).stack.unwrap();
         let Stacktrace::Raw { frames } = stack else {
             panic!("Expected a raw stacktrace");

--- a/rust/cymbal/src/core/types/mod.rs
+++ b/rust/cymbal/src/core/types/mod.rs
@@ -1,5 +1,5 @@
 //! Shared exception/stacktrace domain types used by both run modes. The
-//! processing event model (`RawErrProps`, `OutputErrProps`, the pipeline
+//! processing event model (`RawExceptionProperties`, `ProcessedExceptionProperties`, the pipeline
 //! `Batch`/`Operator` types) lives in `crate::modes::processing::types`.
 
 use serde::{Deserialize, Serialize};

--- a/rust/cymbal/src/core/types/notification.rs
+++ b/rust/cymbal/src/core/types/notification.rs
@@ -6,7 +6,25 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::OutputErrProps;
+use crate::types::ProcessedExceptionProperties;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum NotificationValidationError {
+    #[error(
+        "notification issue id {context_issue_id} does not match processed property issue id {property_issue_id}"
+    )]
+    IssueIdMismatch {
+        context_issue_id: Uuid,
+        property_issue_id: Uuid,
+    },
+    #[error(
+        "notification fingerprint {notification_fingerprint:?} does not match processed property fingerprint {property_fingerprint:?}"
+    )]
+    FingerprintMismatch {
+        notification_fingerprint: String,
+        property_fingerprint: String,
+    },
+}
 
 /// A notification emitted by error-tracking ingestion. Serialized as
 /// internally-tagged JSON (`{"type": "issue_created", ...}`) so new variants can
@@ -59,6 +77,33 @@ impl IngestionNotification {
             }
         }
     }
+
+    pub fn validate(&self) -> Result<(), NotificationValidationError> {
+        let issue = match self {
+            IngestionNotification::IssueCreated(notification) => &notification.issue,
+            IngestionNotification::IssueReopened(notification) => &notification.issue,
+            IngestionNotification::IssueSpiking(notification) => &notification.issue,
+        };
+        let property_issue_id = issue.event_properties.issue_id();
+        if issue.issue_id != property_issue_id {
+            return Err(NotificationValidationError::IssueIdMismatch {
+                context_issue_id: issue.issue_id,
+                property_issue_id,
+            });
+        }
+
+        if let IngestionNotification::IssueCreated(notification) = self {
+            let property_fingerprint = notification.issue.event_properties.fingerprint();
+            if notification.fingerprint != property_fingerprint {
+                return Err(NotificationValidationError::FingerprintMismatch {
+                    notification_fingerprint: notification.fingerprint.clone(),
+                    property_fingerprint: property_fingerprint.to_string(),
+                });
+            }
+        }
+
+        Ok(())
+    }
 }
 
 /// Shared metadata for every ingestion notification.
@@ -76,7 +121,7 @@ pub struct IssueNotificationContext {
     pub issue_id: Uuid,
     pub issue: IssueSnapshot,
     /// Full final exception event properties after Cymbal processing.
-    pub event_properties: OutputErrProps,
+    pub event_properties: ProcessedExceptionProperties,
 }
 
 impl IssueNotificationContext {
@@ -148,16 +193,26 @@ mod tests {
                     status: "active".to_string(),
                     created_at: DateTime::from_timestamp(0, 0).unwrap(),
                 },
-                event_properties: OutputErrProps {
-                    fingerprint: "abc".to_string(),
-                    ..Default::default()
-                },
+                event_properties: serde_json::from_value(serde_json::json!({
+                    "$exception_list": [{"type": "Error", "value": "boom"}],
+                    "$exception_fingerprint": "abc",
+                    "$exception_fingerprint_record": [{"type": "manual"}],
+                    "$exception_issue_id": Uuid::nil(),
+                    "$exception_handled": false,
+                    "$exception_types": ["Error"],
+                    "$exception_values": ["boom"],
+                    "$exception_sources": [],
+                    "$exception_functions": [],
+                }))
+                .unwrap(),
             },
             fingerprint: "abc".to_string(),
             event_uuid: Uuid::nil(),
             event_timestamp: "1970-01-01T00:00:00Z".to_string(),
             assignee: None,
         });
+
+        assert_eq!(notification.validate(), Ok(()));
 
         let json = serde_json::to_value(&notification).unwrap();
         assert_eq!(json["type"], "issue_created");
@@ -168,5 +223,21 @@ mod tests {
         // Round-trips back to the same JSON through the typed enum.
         let decoded: IngestionNotification = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(serde_json::to_value(&decoded).unwrap(), json);
+
+        let mut issue_mismatch = json.clone();
+        issue_mismatch["issue_id"] = serde_json::json!(Uuid::now_v7());
+        let decoded: IngestionNotification = serde_json::from_value(issue_mismatch).unwrap();
+        assert!(matches!(
+            decoded.validate(),
+            Err(NotificationValidationError::IssueIdMismatch { .. })
+        ));
+
+        let mut fingerprint_mismatch = json;
+        fingerprint_mismatch["fingerprint"] = serde_json::json!("different");
+        let decoded: IngestionNotification = serde_json::from_value(fingerprint_mismatch).unwrap();
+        assert!(matches!(
+            decoded.validate(),
+            Err(NotificationValidationError::FingerprintMismatch { .. })
+        ));
     }
 }

--- a/rust/cymbal/src/modes/notifications/consumer_loop.rs
+++ b/rust/cymbal/src/modes/notifications/consumer_loop.rs
@@ -57,6 +57,17 @@ async fn handle_notification_batch(
     for result in batch {
         match result {
             Ok((notification, offset)) => {
+                let offset = match validate_notification_with_offset(
+                    &notification,
+                    offset,
+                    Offset::store,
+                    pending_offsets,
+                ) {
+                    Ok(Some(offset)) => offset,
+                    Ok(None) => continue,
+                    Err(e) => panic!("failed to store invalid notification offset: {e}"),
+                };
+
                 log_notification_summary(&notification);
                 metrics::counter!(NOTIFICATIONS_RECEIVED_TOTAL).increment(1);
                 match handle_notification(context, notification).await {
@@ -91,6 +102,23 @@ async fn handle_notification_batch(
             }
         }
     }
+}
+
+fn validate_notification_with_offset<O, E>(
+    notification: &IngestionNotification,
+    offset: O,
+    store_offset: impl FnOnce(O) -> Result<(), E>,
+    pending_offsets: &mut usize,
+) -> Result<Option<O>, E> {
+    if let Err(e) = notification.validate() {
+        warn!(error = %e, "notification validation error (poison pill skipped)");
+        metrics::counter!(NOTIFICATIONS_SKIPPED_TOTAL, "reason" => "validation").increment(1);
+        store_offset(offset)?;
+        *pending_offsets += 1;
+        return Ok(None);
+    }
+
+    Ok(Some(offset))
 }
 
 fn commit_pending_offsets(
@@ -143,5 +171,84 @@ fn log_notification_summary(notification: &IngestionNotification) {
                 "received error-tracking ingestion notification"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn issue_created(issue_id: Uuid, property_issue_id: Uuid) -> IngestionNotification {
+        serde_json::from_value(serde_json::json!({
+            "type": "issue_created",
+            "notification_id": Uuid::nil(),
+            "team_id": 42,
+            "issue_id": issue_id,
+            "issue": {
+                "name": "Example",
+                "description": "Example issue",
+                "status": "active",
+                "created_at": "1970-01-01T00:00:00Z"
+            },
+            "event_properties": {
+                "$exception_list": [{"type": "Error", "value": "boom"}],
+                "$exception_fingerprint": "abc",
+                "$exception_fingerprint_record": [{"type": "manual"}],
+                "$exception_issue_id": property_issue_id,
+                "$exception_handled": false,
+                "$exception_types": ["Error"],
+                "$exception_values": ["boom"],
+                "$exception_sources": [],
+                "$exception_functions": []
+            },
+            "fingerprint": "abc",
+            "event_uuid": Uuid::nil(),
+            "event_timestamp": "1970-01-01T00:00:00Z",
+            "assignee": null
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn invalid_notification_is_stored_and_does_not_block_the_next_valid_item() {
+        let issue_id = Uuid::now_v7();
+        let invalid = issue_created(issue_id, Uuid::now_v7());
+        let valid = issue_created(issue_id, issue_id);
+        let mut pending_offsets = 0;
+        let mut stored = Vec::new();
+        let mut handled = Vec::new();
+
+        let result = validate_notification_with_offset(
+            &invalid,
+            10,
+            |offset| {
+                stored.push(offset);
+                Ok::<_, ()>(())
+            },
+            &mut pending_offsets,
+        )
+        .unwrap();
+        if let Some(offset) = result {
+            handled.push(offset);
+        }
+
+        let result = validate_notification_with_offset(
+            &valid,
+            11,
+            |offset| {
+                stored.push(offset);
+                Ok::<_, ()>(())
+            },
+            &mut pending_offsets,
+        )
+        .unwrap();
+        if let Some(offset) = result {
+            handled.push(offset);
+        }
+
+        assert_eq!(stored, vec![10]);
+        assert_eq!(handled, vec![11]);
+        assert_eq!(pending_offsets, 1);
     }
 }

--- a/rust/cymbal/src/modes/notifications/issue_handler.rs
+++ b/rust/cymbal/src/modes/notifications/issue_handler.rs
@@ -42,7 +42,9 @@ pub async fn handle_issue_created(
         &event_properties,
     )
     .await?;
-    let sentry_integration = event_properties.other.contains_key("$sentry_event_id");
+    let sentry_integration = event_properties
+        .properties()
+        .contains_key("$sentry_event_id");
 
     send_issue_created_internal_event(
         &context.cyclotron_producer,
@@ -157,7 +159,7 @@ pub async fn handle_issue_spiking(
         &context.internal_events_topic,
         meta.notification_id,
         &issue,
-        &event_properties.fingerprint,
+        event_properties.fingerprint(),
         detected_at,
         computed_baseline,
         current_bucket_value,

--- a/rust/cymbal/src/modes/notifications/side_effects.rs
+++ b/rust/cymbal/src/modes/notifications/side_effects.rs
@@ -13,7 +13,7 @@ use crate::metric_consts::FINGERPRINT_EMBEDDING_SKIPPED;
 use crate::modes::notifications::stacktrace::print_stacktrace;
 use crate::modes::notifications::types::NotificationIssue;
 use crate::modes::processing::fingerprinting::FingerprintRecordPart;
-use crate::types::OutputErrProps;
+use crate::types::ProcessedExceptionProperties;
 
 /// SDKs whose fingerprint embeddings we don't generate — they emit too many
 /// distinct issues, so embedding every fingerprint isn't worth the cost.
@@ -24,7 +24,7 @@ struct IssueLifecycleInternalEvent<'a, I: NotificationIssue> {
     notification_id: Uuid,
     issue: &'a I,
     assignee: Option<String>,
-    output_props: &'a OutputErrProps,
+    processed_properties: &'a ProcessedExceptionProperties,
     event_timestamp: &'a DateTime<Utc>,
 }
 
@@ -32,20 +32,20 @@ pub async fn send_new_fingerprint_event<I: NotificationIssue>(
     producer: &FutureProducer<KafkaContext>,
     embedding_worker_topic: &str,
     issue: &I,
-    output_props: &OutputErrProps,
+    processed_properties: &ProcessedExceptionProperties,
 ) -> Result<(), UnhandledError> {
-    if let Some(reason) = skip_fingerprint_embedding_reason(output_props) {
+    if let Some(reason) = skip_fingerprint_embedding_reason(processed_properties) {
         metrics::counter!(FINGERPRINT_EMBEDDING_SKIPPED, "reason" => reason).increment(1);
         debug!(
             team_id = issue.team_id(),
-            fingerprint = %output_props.fingerprint,
+            fingerprint = %processed_properties.fingerprint(),
             reason,
             "skipping fingerprint embedding request"
         );
         return Ok(());
     }
 
-    let request = fingerprint_embedding_request(issue, output_props);
+    let request = fingerprint_embedding_request(issue, processed_properties);
 
     let res = send_iter_to_kafka(producer, embedding_worker_topic, &[request])
         .await
@@ -62,24 +62,29 @@ pub async fn send_new_fingerprint_event<I: NotificationIssue>(
 /// the user controls — manual fingerprints and custom grouping rules — since
 /// embedding-based similarity grouping doesn't apply to them, nor events from
 /// SDKs in `EMBEDDING_DISABLED_LIBS` (they emit too many issues).
-fn skip_fingerprint_embedding_reason(output_props: &OutputErrProps) -> Option<&'static str> {
-    if output_props
-        .fingerprint_record
+fn skip_fingerprint_embedding_reason(
+    processed_properties: &ProcessedExceptionProperties,
+) -> Option<&'static str> {
+    if processed_properties
+        .fingerprint_record()
         .iter()
         .any(|part| matches!(part, FingerprintRecordPart::Manual))
     {
         return Some("manual_fingerprint");
     }
 
-    if output_props
-        .fingerprint_record
+    if processed_properties
+        .fingerprint_record()
         .iter()
         .any(|part| matches!(part, FingerprintRecordPart::Custom { .. }))
     {
         return Some("custom_grouping_rule");
     }
 
-    let lib = output_props.other.get("$lib").and_then(Value::as_str);
+    let lib = processed_properties
+        .properties()
+        .get("$lib")
+        .and_then(Value::as_str);
     if lib.is_some_and(|lib| EMBEDDING_DISABLED_LIBS.contains(&lib)) {
         return Some("disabled_sdk");
     }
@@ -89,16 +94,16 @@ fn skip_fingerprint_embedding_reason(output_props: &OutputErrProps) -> Option<&'
 
 fn fingerprint_embedding_request<I: NotificationIssue>(
     issue: &I,
-    output_props: &OutputErrProps,
+    processed_properties: &ProcessedExceptionProperties,
 ) -> EmbeddingRequest {
     EmbeddingRequest {
         team_id: issue.team_id(),
         product: "error_tracking".to_string(),
         document_type: "fingerprint".to_string(),
         rendering: "type_message_and_stack".to_string(),
-        document_id: output_props.fingerprint.clone(),
+        document_id: processed_properties.fingerprint().to_string(),
         timestamp: issue.created_at(),
-        content: print_stacktrace(output_props, Some(7000)),
+        content: print_stacktrace(processed_properties, Some(7000)),
         models: vec![EmbeddingModel::OpenAITextEmbeddingLarge],
         metadata: Default::default(),
     }
@@ -110,7 +115,7 @@ pub async fn send_issue_created_internal_event<I: NotificationIssue>(
     notification_id: Uuid,
     issue: &I,
     assignee: Option<String>,
-    output_props: &OutputErrProps,
+    processed_properties: &ProcessedExceptionProperties,
     event_timestamp: &DateTime<Utc>,
 ) -> Result<(), UnhandledError> {
     send_internal_event_with_producer(
@@ -121,7 +126,7 @@ pub async fn send_issue_created_internal_event<I: NotificationIssue>(
             notification_id,
             issue,
             assignee,
-            output_props,
+            processed_properties,
             event_timestamp,
         },
     )
@@ -134,7 +139,7 @@ pub async fn send_issue_reopened_internal_event<I: NotificationIssue>(
     notification_id: Uuid,
     issue: &I,
     assignee: Option<String>,
-    output_props: &OutputErrProps,
+    processed_properties: &ProcessedExceptionProperties,
     event_timestamp: &DateTime<Utc>,
 ) -> Result<(), UnhandledError> {
     send_internal_event_with_producer(
@@ -145,7 +150,7 @@ pub async fn send_issue_reopened_internal_event<I: NotificationIssue>(
             notification_id,
             issue,
             assignee,
-            output_props,
+            processed_properties,
             event_timestamp,
         },
     )
@@ -214,7 +219,7 @@ async fn send_internal_event_with_producer<I: NotificationIssue>(
         notification_id,
         issue,
         assignee,
-        output_props,
+        processed_properties,
         event_timestamp,
     } = request;
 
@@ -227,9 +232,9 @@ async fn send_internal_event_with_producer<I: NotificationIssue>(
         .insert_prop("description", issue.description())
         .expect("Strings are serializable");
     event.insert_prop("status", issue.status())?;
-    event.insert_prop("fingerprint", &output_props.fingerprint)?;
+    event.insert_prop("fingerprint", processed_properties.fingerprint())?;
     event.insert_prop("exception_timestamp", event_timestamp)?;
-    event.insert_prop("exception_props", output_props)?;
+    event.insert_prop("exception_props", processed_properties)?;
 
     if let Some(assignee) = assignee {
         event
@@ -273,17 +278,28 @@ async fn send_internal_event_with_producer<I: NotificationIssue>(
 mod tests {
     use super::*;
 
-    fn props_with(record: Vec<FingerprintRecordPart>, lib: Option<&str>) -> OutputErrProps {
-        let mut props = OutputErrProps {
-            fingerprint_record: record,
-            ..Default::default()
-        };
+    fn props_with(
+        record: Vec<FingerprintRecordPart>,
+        lib: Option<&str>,
+    ) -> ProcessedExceptionProperties {
+        let mut value = serde_json::json!({
+            "$exception_list": [{"type": "Error", "value": "boom"}],
+            "$exception_fingerprint": "test-fingerprint",
+            "$exception_fingerprint_record": record,
+            "$exception_issue_id": Uuid::nil(),
+            "$exception_handled": false,
+            "$exception_types": ["Error"],
+            "$exception_values": ["boom"],
+            "$exception_sources": [],
+            "$exception_functions": [],
+        });
         if let Some(lib) = lib {
-            props
-                .other
+            value
+                .as_object_mut()
+                .unwrap()
                 .insert("$lib".to_string(), Value::String(lib.to_string()));
         }
-        props
+        serde_json::from_value(value).unwrap()
     }
 
     #[test]

--- a/rust/cymbal/src/modes/notifications/signals.rs
+++ b/rust/cymbal/src/modes/notifications/signals.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 use crate::metric_consts::{SIGNAL_EMITTED, SIGNAL_EMIT_FAILED, SIGNAL_EMIT_RESPONSE};
 use crate::modes::notifications::stacktrace::print_stacktrace;
 use crate::modes::notifications::types::NotificationIssue;
-use crate::types::OutputErrProps;
+use crate::types::ProcessedExceptionProperties;
 
 /// Signal payload matching the Django internal API contract.
 #[derive(Serialize)]
@@ -22,7 +22,7 @@ pub struct EmitSignalRequest {
 /// Context for building a signal from an issue + its error properties.
 pub struct IssueSignalContext<'a, I: NotificationIssue> {
     pub issue: &'a I,
-    pub props: &'a OutputErrProps,
+    pub props: &'a ProcessedExceptionProperties,
     pub source_type: &'static str,
     /// Brief LLM-facing explanation of what this signal means, e.g. "New issue" or "Issue reopened".
     pub preamble: String,
@@ -80,7 +80,7 @@ impl SignalClient {
     pub async fn emit_issue_created<I: NotificationIssue>(
         &self,
         issue: &I,
-        props: &OutputErrProps,
+        props: &ProcessedExceptionProperties,
     ) {
         let request = EmitSignalRequest::from(IssueSignalContext {
             issue,
@@ -89,7 +89,7 @@ impl SignalClient {
             preamble: "New error tracking issue created - this particular exception was observed for the first time".to_string(),
             weight: 1.0,
             extra: serde_json::json!({
-                "fingerprint": props.fingerprint,
+                "fingerprint": props.fingerprint(),
             }),
         });
         self.send(issue.team_id(), request).await;
@@ -98,7 +98,7 @@ impl SignalClient {
     pub async fn emit_issue_reopened<I: NotificationIssue>(
         &self,
         issue: &I,
-        props: &OutputErrProps,
+        props: &ProcessedExceptionProperties,
     ) {
         let request = EmitSignalRequest::from(IssueSignalContext {
             issue,
@@ -107,7 +107,7 @@ impl SignalClient {
             preamble: "Previously resolved error tracking issue has reappeared - this particular exception was observed previously, and thought to be resolved, but has reappeared".to_string(),
             weight: 1.0,
             extra: serde_json::json!({
-                "fingerprint": props.fingerprint,
+                "fingerprint": props.fingerprint(),
             }),
         });
         self.send(issue.team_id(), request).await;
@@ -116,7 +116,7 @@ impl SignalClient {
     pub async fn emit_issue_spiking<I: NotificationIssue>(
         &self,
         issue: &I,
-        props: &OutputErrProps,
+        props: &ProcessedExceptionProperties,
         computed_baseline: f64,
         current_bucket_value: f64,
     ) {
@@ -132,7 +132,7 @@ impl SignalClient {
             preamble,
             weight: 1.0,
             extra: serde_json::json!({
-                "fingerprint": props.fingerprint,
+                "fingerprint": props.fingerprint(),
             }),
         });
         self.send(issue.team_id(), request).await;
@@ -184,7 +184,7 @@ impl MaybeSignalClient {
         Self(Some(Arc::new(client)))
     }
 
-    pub fn emit_issue_created<I>(&self, issue: &I, props: &OutputErrProps)
+    pub fn emit_issue_created<I>(&self, issue: &I, props: &ProcessedExceptionProperties)
     where
         I: NotificationIssue + Clone + Send + Sync + 'static,
     {
@@ -197,7 +197,7 @@ impl MaybeSignalClient {
         }
     }
 
-    pub fn emit_issue_reopened<I>(&self, issue: &I, props: &OutputErrProps)
+    pub fn emit_issue_reopened<I>(&self, issue: &I, props: &ProcessedExceptionProperties)
     where
         I: NotificationIssue + Clone + Send + Sync + 'static,
     {
@@ -213,7 +213,7 @@ impl MaybeSignalClient {
     pub fn emit_issue_spiking<I>(
         &self,
         issue: &I,
-        props: &OutputErrProps,
+        props: &ProcessedExceptionProperties,
         computed_baseline: f64,
         current_bucket_value: f64,
     ) where

--- a/rust/cymbal/src/modes/notifications/stacktrace.rs
+++ b/rust/cymbal/src/modes/notifications/stacktrace.rs
@@ -1,6 +1,6 @@
 use crate::frames::Frame;
 use crate::tokenizer::CL100K_BPE;
-use crate::types::OutputErrProps;
+use crate::types::ProcessedExceptionProperties;
 
 /// Render exception types, messages, and stack frames as a human-readable string.
 ///
@@ -10,7 +10,7 @@ use crate::types::OutputErrProps;
 /// are kept with a `...` marker between them. If the truncated output is
 /// still over the limit, the string is hard-truncated to exactly `limit`
 /// tokens.
-pub fn print_stacktrace(props: &OutputErrProps, max_tokens: Option<usize>) -> String {
+pub fn print_stacktrace(props: &ProcessedExceptionProperties, max_tokens: Option<usize>) -> String {
     let full = render_stacktrace(props, false);
 
     let Some(limit) = max_tokens else {
@@ -42,10 +42,10 @@ pub fn print_stacktrace(props: &OutputErrProps, max_tokens: Option<usize>) -> St
     }
 }
 
-fn render_stacktrace(props: &OutputErrProps, truncate: bool) -> String {
+fn render_stacktrace(props: &ProcessedExceptionProperties, truncate: bool) -> String {
     let mut content = String::with_capacity(2048);
 
-    for exception in &props.exception_list.0 {
+    for exception in &props.exception_list().0 {
         let type_and_value = format!(
             "{}: {}\n",
             exception.exception_type,

--- a/rust/cymbal/src/modes/processing/fingerprinting/mod.rs
+++ b/rust/cymbal/src/modes/processing/fingerprinting/mod.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::sync::OnceLock;
 
 use crate::frames::Frame;
-use crate::modes::processing::rules::grouping::GroupingRule;
 use crate::types::{Exception, ExceptionList, Stacktrace};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -60,14 +59,6 @@ impl FingerprintBuilder {
 }
 
 impl Fingerprint {
-    pub fn from_rule(rule: GroupingRule) -> Self {
-        let content = format!("custom-rule:{}", rule.id);
-        Fingerprint {
-            value: content,
-            record: vec![FingerprintRecordPart::Custom { rule_id: rule.id }],
-        }
-    }
-
     pub fn from_exception_list(exception_list: &ExceptionList) -> Fingerprint {
         FingerprintVersion::V1
             .strategy()

--- a/rust/cymbal/src/modes/processing/issue_resolution.rs
+++ b/rust/cymbal/src/modes/processing/issue_resolution.rs
@@ -12,7 +12,7 @@ use crate::core::types::notification::{
     IssueSpiking, NotificationMeta,
 };
 use crate::modes::processing::rules::assignment::{Assignee, Assignment};
-use crate::types::OutputErrProps;
+use crate::types::ProcessedExceptionProperties;
 use crate::{app_context::AppContext, error::UnhandledError, metric_consts::ISSUE_REOPENED};
 
 #[derive(Debug, Clone)]
@@ -366,16 +366,16 @@ pub async fn send_issue_created_notification(
     context: &AppContext,
     issue: &Issue,
     assignment: Option<Assignment>,
-    output_props: OutputErrProps,
+    processed_properties: ProcessedExceptionProperties,
     event_uuid: Uuid,
     event_timestamp: &DateTime<Utc>,
 ) -> Result<(), UnhandledError> {
-    let fingerprint = output_props.fingerprint.clone();
+    let fingerprint = processed_properties.fingerprint().to_string();
     publish_ingestion_notification(
         context,
         IngestionNotification::IssueCreated(IssueCreated {
             meta: notification_meta(issue),
-            issue: issue_notification_context(issue, output_props),
+            issue: issue_notification_context(issue, processed_properties),
             fingerprint,
             event_uuid,
             event_timestamp: event_timestamp.to_rfc3339(),
@@ -389,14 +389,14 @@ pub async fn send_issue_reopened_notification(
     context: &AppContext,
     issue: &Issue,
     assignment: Option<Assignment>,
-    output_props: OutputErrProps,
+    processed_properties: ProcessedExceptionProperties,
     event_timestamp: &DateTime<Utc>,
 ) -> Result<(), UnhandledError> {
     publish_ingestion_notification(
         context,
         IngestionNotification::IssueReopened(IssueReopened {
             meta: notification_meta(issue),
-            issue: issue_notification_context(issue, output_props),
+            issue: issue_notification_context(issue, processed_properties),
             event_timestamp: event_timestamp.to_rfc3339(),
             assignee: assignment_to_string(assignment)?,
         }),
@@ -407,7 +407,7 @@ pub async fn send_issue_reopened_notification(
 pub async fn send_issue_spiking_notification(
     context: &AppContext,
     issue: &Issue,
-    output_props: OutputErrProps,
+    processed_properties: ProcessedExceptionProperties,
     computed_baseline: f64,
     current_bucket_value: f64,
 ) -> Result<(), UnhandledError> {
@@ -415,7 +415,7 @@ pub async fn send_issue_spiking_notification(
         context,
         IngestionNotification::IssueSpiking(IssueSpiking {
             meta: notification_meta(issue),
-            issue: issue_notification_context(issue, output_props),
+            issue: issue_notification_context(issue, processed_properties),
             computed_baseline,
             current_bucket_value,
         }),
@@ -432,12 +432,12 @@ fn notification_meta(issue: &Issue) -> NotificationMeta {
 
 fn issue_notification_context(
     issue: &Issue,
-    output_props: OutputErrProps,
+    processed_properties: ProcessedExceptionProperties,
 ) -> IssueNotificationContext {
     IssueNotificationContext {
         issue_id: issue.id,
         issue: issue_snapshot(issue),
-        event_properties: output_props,
+        event_properties: processed_properties,
     }
 }
 

--- a/rust/cymbal/src/modes/processing/rules/assignment.rs
+++ b/rust/cymbal/src/modes/processing/rules/assignment.rs
@@ -12,7 +12,7 @@ use crate::metric_consts::{
 };
 
 use crate::teams::TeamManager;
-use crate::{error::UnhandledError, issue_resolution::Issue, types::OutputErrProps};
+use crate::{error::UnhandledError, issue_resolution::Issue, types::ProcessedExceptionProperties};
 
 #[derive(Debug, Clone)]
 pub struct NewAssignment {
@@ -218,7 +218,7 @@ pub async fn try_assignment_rules(
     con: &mut PgConnection,
     team_manager: &TeamManager,
     issue: Issue,
-    exception_properties: &OutputErrProps,
+    exception_properties: &ProcessedExceptionProperties,
 ) -> Result<Option<NewAssignment>, UnhandledError> {
     let timing = common_metrics::timing_guard(ASSIGNMENT_RULES_PROCESSING_TIME, &[]);
 

--- a/rust/cymbal/src/modes/processing/rules/grouping.rs
+++ b/rust/cymbal/src/modes/processing/rules/grouping.rs
@@ -190,7 +190,7 @@ mod test {
     use sqlx::PgPool;
     use uuid::Uuid;
 
-    use crate::{fingerprinting::Fingerprint, test_utils::create_test_context};
+    use crate::test_utils::create_test_context;
 
     use super::{evaluate_grouping_rules, GroupingRule};
 
@@ -240,7 +240,7 @@ mod test {
         let props = test_props(JsonValue::from("test_value"));
 
         let rule = get_test_rule();
-        let expected_fingerprint = format!("custom-rule:{}", rule.id);
+        let expected_rule_id = rule.id;
         // Insert the rule, so we skip the DB lookup
         ctx.team_manager
             .grouping_rules
@@ -252,9 +252,7 @@ mod test {
             })
             .await
             .unwrap();
-        let fingerprint = Fingerprint::from_rule(matched.expect("rule should match"));
-
-        assert_eq!(fingerprint.value, expected_fingerprint);
+        assert_eq!(matched.expect("rule should match").id, expected_rule_id);
 
         // Insert a different value - simply removing the value would cause the rule to be disabled, since it
         // tries to access an undefined global

--- a/rust/cymbal/src/modes/processing/stages/alerting/spike_alert.rs
+++ b/rust/cymbal/src/modes/processing/stages/alerting/spike_alert.rs
@@ -17,7 +17,7 @@ use crate::{
         batch::Batch,
         exception_event::ExceptionEvent,
         stage::{Stage, StageResult},
-        OutputErrProps,
+        ProcessedExceptionProperties,
     },
 };
 
@@ -42,14 +42,14 @@ impl Stage for SpikeAlertStage {
 
     async fn process(self, batch: Batch<RateCheckedPipelineItem>) -> StageResult<Self> {
         let mut issues: Vec<Issue> = Vec::new();
-        let mut issue_props_by_id: HashMap<Uuid, OutputErrProps> = HashMap::new();
+        let mut issue_props_by_id: HashMap<Uuid, ProcessedExceptionProperties> = HashMap::new();
 
         for res in batch.inner_ref() {
             let Ok(evt) = res else { continue };
             let issue = evt.issue();
-            // Keep one OutputErrProps per issue (they share the same stack shape)
+            // Keep one ProcessedExceptionProperties per issue (they share the same stack shape)
             if let Entry::Vacant(e) = issue_props_by_id.entry(issue.id) {
-                e.insert(evt.to_output());
+                e.insert(evt.processed_properties());
             }
             issues.push(issue.clone());
         }

--- a/rust/cymbal/src/modes/processing/stages/alerting/spike_detection.rs
+++ b/rust/cymbal/src/modes/processing/stages/alerting/spike_detection.rs
@@ -15,7 +15,7 @@ use crate::metric_consts::{
     SPIKE_ISSUES_SPIKING,
 };
 use crate::modes::processing::rules::spike::SpikeDetectionConfig;
-use crate::types::OutputErrProps;
+use crate::types::ProcessedExceptionProperties;
 
 const ISSUE_BUCKET_TTL_SECONDS: usize = 60 * 60;
 const ISSUE_BUCKET_INTERVAL_MINUTES: i64 = 5;
@@ -42,7 +42,7 @@ fn cooldown_key(issue_id: &Uuid) -> String {
 #[derive(Debug, Clone)]
 pub struct SpikingIssue {
     pub issue: Issue,
-    pub props: OutputErrProps,
+    pub props: ProcessedExceptionProperties,
     pub computed_baseline: f64,
     pub current_bucket_value: i64,
 }
@@ -168,7 +168,7 @@ async fn try_increment_team_buckets(
 pub async fn do_spike_detection(
     context: Arc<AppContext>,
     issues_by_id: HashMap<Uuid, Issue>,
-    issue_props_by_id: HashMap<Uuid, OutputErrProps>,
+    issue_props_by_id: HashMap<Uuid, ProcessedExceptionProperties>,
     issue_counts: HashMap<Uuid, u32>,
 ) -> Result<(), UnhandledError> {
     if issue_counts.is_empty() {
@@ -379,7 +379,7 @@ fn is_spiking(current_value: i64, baseline: f64, config: &SpikeDetectionConfig) 
 async fn get_spiking_issues(
     redis: &(dyn Client + Send + Sync),
     issues_by_id: &HashMap<Uuid, Issue>,
-    issue_props_by_id: &HashMap<Uuid, OutputErrProps>,
+    issue_props_by_id: &HashMap<Uuid, ProcessedExceptionProperties>,
     team_configs: &HashMap<i32, SpikeDetectionConfig>,
 ) -> Result<Vec<SpikingIssue>, UnhandledError> {
     if issues_by_id.is_empty() {
@@ -419,12 +419,18 @@ async fn get_spiking_issues(
         })?;
 
         if is_spiking(current_value, baseline, config) {
+            let props = issue_props_by_id
+                .get(&bucket.issue_id)
+                .cloned()
+                .ok_or_else(|| {
+                    UnhandledError::Other(format!(
+                        "No processed exception properties for issue {}",
+                        bucket.issue_id
+                    ))
+                })?;
             spiking.push(SpikingIssue {
                 issue: issue.clone(),
-                props: issue_props_by_id
-                    .get(&bucket.issue_id)
-                    .cloned()
-                    .unwrap_or_default(),
+                props,
                 computed_baseline: baseline,
                 current_bucket_value: current_value,
             });
@@ -529,6 +535,21 @@ mod tests {
         v.to_string().into_bytes()
     }
 
+    fn processed_properties(issue_id: Uuid) -> ProcessedExceptionProperties {
+        serde_json::from_value(serde_json::json!({
+            "$exception_list": [{"type": "Error", "value": "boom"}],
+            "$exception_fingerprint": "test-fingerprint",
+            "$exception_fingerprint_record": [{"type": "manual"}],
+            "$exception_issue_id": issue_id,
+            "$exception_handled": false,
+            "$exception_types": ["Error"],
+            "$exception_values": ["boom"],
+            "$exception_sources": [],
+            "$exception_functions": [],
+        }))
+        .unwrap()
+    }
+
     struct TestContext {
         redis: MockRedisClient,
         issue_id: Uuid,
@@ -604,8 +625,8 @@ mod tests {
 
         async fn get_spiking(&self) -> Vec<SpikingIssue> {
             let configs = HashMap::from([(self.team_id, SpikeDetectionConfig::default())]);
-            let empty_props = HashMap::new();
-            get_spiking_issues(&self.redis, &self.issues_by_id(), &empty_props, &configs)
+            let properties = HashMap::from([(self.issue_id, processed_properties(self.issue_id))]);
+            get_spiking_issues(&self.redis, &self.issues_by_id(), &properties, &configs)
                 .await
                 .unwrap()
         }
@@ -1033,8 +1054,11 @@ mod tests {
             (team_1, SpikeDetectionConfig::default()),
             (team_2, SpikeDetectionConfig::default()),
         ]);
-        let empty_props = HashMap::new();
-        let result = get_spiking_issues(&redis, &issues_by_id, &empty_props, &configs)
+        let properties = issues_by_id
+            .keys()
+            .map(|issue_id| (*issue_id, processed_properties(*issue_id)))
+            .collect();
+        let result = get_spiking_issues(&redis, &issues_by_id, &properties, &configs)
             .await
             .unwrap();
 

--- a/rust/cymbal/src/modes/processing/stages/grouping/fingerprint.rs
+++ b/rust/cymbal/src/modes/processing/stages/grouping/fingerprint.rs
@@ -6,14 +6,16 @@ use uuid::Uuid;
 
 use crate::{
     error::UnhandledError,
-    fingerprinting::{Fingerprint, FingerprintRecordPart, FingerprintVersion},
+    fingerprinting::{Fingerprint, FingerprintVersion},
     issue_resolution::IssueFingerprintOverride,
     metric_consts::{FINGERPRINT_GENERATOR_OPERATOR, FINGERPRINT_LEGACY_VERSION_USED},
     modes::processing::normalization::legacy_wire_order,
     modes::processing::rules::grouping::evaluate_grouping_rules,
     stages::grouping::GroupingStage,
     types::{
-        exception_event::{ExceptionEvent, FingerprintData, Fingerprinted, PipelineItem, Resolved},
+        exception_event::{
+            ExceptionEvent, Fingerprinted, PipelineItem, Resolved, SelectedFingerprint,
+        },
         ExceptionList,
     },
 };
@@ -52,17 +54,12 @@ impl FingerprintGenerator {
         // defer it: `evaluate_grouping_rules` invokes this closure only when rules exist.
         let matched_rule =
             evaluate_grouping_rules(&ctx.connection, input.team_id(), &ctx.team_manager, || {
-                Ok(input.to_grouping_value())
+                Ok(input.grouping_rule_properties())
             })
             .await?;
 
         if let Some(rule) = matched_rule {
-            let fingerprint = Fingerprint::from_rule(rule);
-            return Ok(input.into_fingerprinted(FingerprintData {
-                value: fingerprint.value,
-                version: None,
-                record: fingerprint.record,
-            }));
+            return Ok(input.into_fingerprinted(SelectedFingerprint::custom(rule.id)));
         }
 
         // Legacy fingerprint versions keep issues keyed before wire-order
@@ -86,11 +83,7 @@ impl FingerprintGenerator {
                 .increment(1);
         }
 
-        Ok(input.into_fingerprinted(FingerprintData {
-            value: fingerprint.value,
-            version: Some(version),
-            record: fingerprint.record,
-        }))
+        Ok(input.into_fingerprinted(SelectedFingerprint::automatic(version, fingerprint)))
     }
 
     pub fn name(&self) -> &'static str {
@@ -98,7 +91,7 @@ impl FingerprintGenerator {
     }
 }
 
-fn manual_fingerprint(value: &str) -> FingerprintData {
+fn manual_fingerprint(value: &str) -> SelectedFingerprint {
     let value = if value.len() > 64 {
         let mut hasher = Sha512::default();
         hasher.update(value);
@@ -106,11 +99,7 @@ fn manual_fingerprint(value: &str) -> FingerprintData {
     } else {
         value.to_string()
     };
-    FingerprintData {
-        value,
-        version: None,
-        record: vec![FingerprintRecordPart::Manual],
-    }
+    SelectedFingerprint::manual(value)
 }
 
 // Walks versions newest-first and keeps the first fingerprint that already maps to an issue,

--- a/rust/cymbal/src/modes/processing/stages/http_pipeline.rs
+++ b/rust/cymbal/src/modes/processing/stages/http_pipeline.rs
@@ -50,7 +50,7 @@ fn handle_result(
 ) -> Result<Option<AnyEvent>, UnhandledError> {
     let item: Option<AnyEvent> = match processed {
         Ok(props) => {
-            original.set_properties(props.to_clickhouse_value())?;
+            original.set_properties(props.into_clickhouse_properties())?;
             Some(original)
         }
         Err(err) => match err {

--- a/rust/cymbal/src/modes/processing/stages/linking/issue.rs
+++ b/rust/cymbal/src/modes/processing/stages/linking/issue.rs
@@ -19,7 +19,7 @@ use crate::{
     teams::TeamManager,
     types::{
         exception_event::{ExceptionEvent, Fingerprinted, Linked, PipelineItem},
-        OutputErrProps,
+        ProcessedExceptionProperties,
     },
 };
 
@@ -77,7 +77,7 @@ impl IssueLinker {
         input: ExceptionEvent<Fingerprinted>,
         ctx: LinkingStage,
     ) -> Result<ExceptionEvent<Linked>, UnhandledError> {
-        let key = (input.team_id(), input.fingerprint().value.clone());
+        let key = (input.team_id(), input.fingerprint().value().to_string());
 
         // Wrap the (large) event in an `Arc` so the cache-loader closures capture a cheap
         // refcount bump instead of a full deep clone. The loaders only ever borrow the
@@ -122,7 +122,7 @@ async fn resolve_via_id_cache(
     input: Arc<ExceptionEvent<Fingerprinted>>,
     ctx: &LinkingStage,
 ) -> Result<Issue, UnhandledError> {
-    let fingerprint = input.fingerprint().value.clone();
+    let fingerprint = input.fingerprint().value().to_string();
     let key = (input.team_id(), fingerprint.clone());
 
     // `try_get_with` only returns the cached value (`Uuid`), so we stash the freshly
@@ -215,10 +215,17 @@ async fn load_and_maybe_reopen(
         issue.created_at,
     )
     .await?;
-    let output_props: OutputErrProps = event_properties.to_output(&issue);
+    let processed_properties: ProcessedExceptionProperties =
+        event_properties.processed_properties(&issue);
     drop(conn);
-    send_issue_reopened_notification(context, &issue, assignment, output_props, &event_timestamp)
-        .await?;
+    send_issue_reopened_notification(
+        context,
+        &issue,
+        assignment,
+        processed_properties,
+        &event_timestamp,
+    )
+    .await?;
 
     Ok(Some(issue))
 }
@@ -231,7 +238,7 @@ async fn resolve_issue(
     event_properties: &ExceptionEvent<Fingerprinted>,
 ) -> Result<Issue, UnhandledError> {
     let team_id = event_properties.team_id();
-    let fingerprint = event_properties.fingerprint().value.clone();
+    let fingerprint = event_properties.fingerprint().value().to_string();
 
     let mut conn = context.posthog_pool.acquire().await?;
     // Fast path - just fetch the issue directly, and then reopen it if needed
@@ -255,13 +262,14 @@ async fn resolve_issue(
                 first_seen_for_state,
             )
             .await?;
-            let output_props: OutputErrProps = event_properties.to_output(&issue);
+            let processed_properties: ProcessedExceptionProperties =
+                event_properties.processed_properties(&issue);
             drop(conn);
             send_issue_reopened_notification(
                 context,
                 &issue,
                 assignment,
-                output_props,
+                processed_properties,
                 &event_timestamp,
             )
             .await?;
@@ -331,12 +339,13 @@ async fn resolve_issue(
 
             drop(conn);
 
-            let output_props: OutputErrProps = event_properties.to_output(&issue);
+            let processed_properties: ProcessedExceptionProperties =
+                event_properties.processed_properties(&issue);
             send_issue_reopened_notification(
                 context,
                 &issue,
                 assignment,
-                output_props,
+                processed_properties,
                 &event_timestamp,
             )
             .await?;
@@ -347,7 +356,7 @@ async fn resolve_issue(
             process_event_assignment(&mut txn, &context.team_manager, &issue, event_properties)
                 .await?;
 
-        let output_props = event_properties.to_output(&issue);
+        let processed_properties = event_properties.processed_properties(&issue);
         send_fingerprint_issue_state(
             context,
             &issue,
@@ -364,7 +373,7 @@ async fn resolve_issue(
             context,
             &issue,
             assignment,
-            output_props,
+            processed_properties,
             event_properties.uuid(),
             &event_timestamp,
         )
@@ -380,18 +389,18 @@ async fn process_event_assignment(
     issue: &Issue,
     exception_props: &ExceptionEvent<Fingerprinted>,
 ) -> Result<Option<Assignment>, UnhandledError> {
-    let output_props = exception_props.to_output(issue);
-    process_assignment(conn, team_manager, issue, &output_props).await
+    let processed_properties = exception_props.processed_properties(issue);
+    process_assignment(conn, team_manager, issue, &processed_properties).await
 }
 
 pub async fn process_assignment(
     conn: &mut PgConnection,
     team_manager: &TeamManager,
     issue: &Issue,
-    output_props: &OutputErrProps,
+    processed_properties: &ProcessedExceptionProperties,
 ) -> Result<Option<Assignment>, UnhandledError> {
     let new_assignment =
-        try_assignment_rules(conn, team_manager, issue.clone(), output_props).await?;
+        try_assignment_rules(conn, team_manager, issue.clone(), processed_properties).await?;
 
     let assignment = if let Some(new_assignment) = new_assignment {
         Some(new_assignment.apply(&mut *conn, issue.id).await?)

--- a/rust/cymbal/src/modes/processing/stages/linking/rule_suppression.rs
+++ b/rust/cymbal/src/modes/processing/stages/linking/rule_suppression.rs
@@ -38,7 +38,7 @@ impl ValueOperator for RuleSuppression {
         rules.sort_unstable_by_key(|r| r.order_key);
 
         // Only serialize the event once we know the team has suppression rules.
-        let props_json = input.to_properties_value();
+        let props_json = input.suppression_rule_properties();
 
         for rule in rules {
             match rule.should_suppress(&props_json, &input.uuid()) {

--- a/rust/cymbal/src/modes/processing/stages/rate_limiting/mod.rs
+++ b/rust/cymbal/src/modes/processing/stages/rate_limiting/mod.rs
@@ -545,7 +545,7 @@ fn evaluate_bypass_rules<'a>(
         let Some(rules) = rules_by_team.get(&props.team_id()) else {
             continue;
         };
-        let props_json = props.to_properties_value();
+        let props_json = props.rate_limit_rule_properties();
         for rule in rules {
             if disabled_rules.contains(&rule.id) {
                 continue;
@@ -591,7 +591,7 @@ mod tests {
     use super::*;
     use crate::issue_resolution::{Issue, IssueStatus};
     use crate::modes::processing::types::{
-        exception_event::{FingerprintData, ResolvedMetadata},
+        exception_event::{ResolvedMetadata, SelectedFingerprint},
         ExceptionList,
     };
     use async_trait::async_trait;
@@ -673,11 +673,7 @@ mod tests {
                     handled: false,
                     releases: HashMap::new(),
                 },
-                fingerprint: FingerprintData {
-                    value: "test-fingerprint".to_string(),
-                    version: None,
-                    record: vec![],
-                },
+                fingerprint: SelectedFingerprint::manual("test-fingerprint".to_string()),
                 issue: Issue {
                     id: issue_id.unwrap_or_default(),
                     team_id,

--- a/rust/cymbal/src/modes/processing/types/exception_event.rs
+++ b/rust/cymbal/src/modes/processing/types/exception_event.rs
@@ -6,14 +6,16 @@ use uuid::Uuid;
 
 use crate::{
     error::EventError,
-    fingerprinting::{FingerprintRecordPart, FingerprintVersion},
+    fingerprinting::{Fingerprint, FingerprintRecordPart, FingerprintVersion},
     frames::releases::ReleaseInfo,
     issue_resolution::Issue,
     langs::native::DebugImage,
     modes::processing::normalization::normalize_wire_order,
     recursively_sanitize_properties,
-    types::{event::AnyEvent, ExceptionList, OutputErrProps, RawErrProps},
+    types::{event::AnyEvent, ExceptionList, ProcessedExceptionProperties, RawExceptionProperties},
 };
+
+use super::ProcessedExceptionPropertiesWire;
 
 pub const MAX_EXCEPTION_VALUE_LENGTH: usize = 10_000;
 
@@ -57,22 +59,60 @@ pub struct Resolved {
 }
 
 #[derive(Debug, Clone)]
-pub struct FingerprintData {
-    pub value: String,
-    pub version: Option<FingerprintVersion>,
-    pub record: Vec<FingerprintRecordPart>,
+pub struct SelectedFingerprint {
+    value: String,
+    version: Option<FingerprintVersion>,
+    record: Vec<FingerprintRecordPart>,
+}
+
+impl SelectedFingerprint {
+    pub(crate) fn manual(value: String) -> Self {
+        Self {
+            value,
+            version: None,
+            record: vec![FingerprintRecordPart::Manual],
+        }
+    }
+
+    pub(crate) fn custom(rule_id: Uuid) -> Self {
+        Self {
+            value: format!("custom-rule:{rule_id}"),
+            version: None,
+            record: vec![FingerprintRecordPart::Custom { rule_id }],
+        }
+    }
+
+    pub(crate) fn automatic(version: FingerprintVersion, fingerprint: Fingerprint) -> Self {
+        Self {
+            value: fingerprint.value,
+            version: Some(version),
+            record: fingerprint.record,
+        }
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn version(&self) -> Option<FingerprintVersion> {
+        self.version
+    }
+
+    pub fn record(&self) -> &[FingerprintRecordPart] {
+        &self.record
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct Fingerprinted {
     pub(crate) metadata: ResolvedMetadata,
-    pub(crate) fingerprint: FingerprintData,
+    pub(crate) fingerprint: SelectedFingerprint,
 }
 
 #[derive(Debug, Clone)]
 pub struct Linked {
     pub(crate) metadata: ResolvedMetadata,
-    pub(crate) fingerprint: FingerprintData,
+    pub(crate) fingerprint: SelectedFingerprint,
     pub(crate) issue: Issue,
 }
 
@@ -86,6 +126,11 @@ pub struct Finalized {
     linked: Linked,
 }
 
+/// Internal typestate carrier for a successfully accepted exception event.
+///
+/// The state parameter proves which processing stages have completed. This
+/// carrier intentionally has no serde implementation: wire payloads cannot
+/// prove that resolution, grouping, linking, rate checking, or alerting ran.
 #[derive(Debug, Clone)]
 pub struct ExceptionEvent<S> {
     pub(crate) uuid: Uuid,
@@ -185,7 +230,7 @@ impl ExceptionEvent<Resolved> {
 
     pub(crate) fn into_fingerprinted(
         self,
-        fingerprint: FingerprintData,
+        fingerprint: SelectedFingerprint,
     ) -> ExceptionEvent<Fingerprinted> {
         self.map_state(|state| Fingerprinted {
             metadata: state.metadata,
@@ -193,7 +238,7 @@ impl ExceptionEvent<Resolved> {
         })
     }
 
-    pub fn to_grouping_value(&self) -> Value {
+    pub fn grouping_rule_properties(&self) -> Value {
         let mut map = self.base_resolved_properties(&self.state.metadata);
         map.insert(
             "$exception_fingerprint".into(),
@@ -209,11 +254,7 @@ impl ExceptionEvent<Resolved> {
 }
 
 impl ExceptionEvent<Fingerprinted> {
-    pub fn metadata(&self) -> &ResolvedMetadata {
-        &self.state.metadata
-    }
-
-    pub fn fingerprint(&self) -> &FingerprintData {
+    pub fn fingerprint(&self) -> &SelectedFingerprint {
         &self.state.fingerprint
     }
 
@@ -225,24 +266,16 @@ impl ExceptionEvent<Fingerprinted> {
         })
     }
 
-    pub fn to_properties_value(&self) -> Value {
+    pub fn suppression_rule_properties(&self) -> Value {
         self.properties_with_fingerprint(&self.state.metadata, &self.state.fingerprint, None)
     }
 
-    pub fn to_output(&self, issue: &Issue) -> OutputErrProps {
-        self.build_output(&self.state.metadata, &self.state.fingerprint, issue.id)
+    pub fn processed_properties(&self, issue: &Issue) -> ProcessedExceptionProperties {
+        self.build_processed_properties(&self.state.metadata, &self.state.fingerprint, issue.id)
     }
 }
 
 impl ExceptionEvent<Linked> {
-    pub fn metadata(&self) -> &ResolvedMetadata {
-        &self.state.metadata
-    }
-
-    pub fn fingerprint(&self) -> &FingerprintData {
-        &self.state.fingerprint
-    }
-
     pub fn issue(&self) -> &Issue {
         &self.state.issue
     }
@@ -251,15 +284,7 @@ impl ExceptionEvent<Linked> {
         self.state.issue.id
     }
 
-    pub fn to_output(&self) -> OutputErrProps {
-        self.build_output(
-            &self.state.metadata,
-            &self.state.fingerprint,
-            self.state.issue.id,
-        )
-    }
-
-    pub fn to_properties_value(&self) -> Value {
+    pub fn rate_limit_rule_properties(&self) -> Value {
         self.properties_with_fingerprint(
             &self.state.metadata,
             &self.state.fingerprint,
@@ -273,24 +298,12 @@ impl ExceptionEvent<Linked> {
 }
 
 impl ExceptionEvent<RateChecked> {
-    pub fn metadata(&self) -> &ResolvedMetadata {
-        &self.state.linked.metadata
-    }
-
-    pub fn fingerprint(&self) -> &FingerprintData {
-        &self.state.linked.fingerprint
-    }
-
     pub fn issue(&self) -> &Issue {
         &self.state.linked.issue
     }
 
-    pub fn issue_id(&self) -> Uuid {
-        self.state.linked.issue.id
-    }
-
-    pub fn to_output(&self) -> OutputErrProps {
-        self.build_output(
+    pub fn processed_properties(&self) -> ProcessedExceptionProperties {
+        self.build_processed_properties(
             &self.state.linked.metadata,
             &self.state.linked.fingerprint,
             self.state.linked.issue.id,
@@ -305,53 +318,83 @@ impl ExceptionEvent<RateChecked> {
 }
 
 impl ExceptionEvent<Finalized> {
-    pub fn metadata(&self) -> &ResolvedMetadata {
-        &self.state.linked.metadata
-    }
+    pub fn into_clickhouse_properties(self) -> Value {
+        let ExceptionEvent {
+            exception_list,
+            debug_images,
+            props,
+            proposed_issue_name,
+            proposed_issue_description,
+            state,
+            ..
+        } = self;
+        let Linked {
+            metadata,
+            fingerprint,
+            issue,
+        } = state.linked;
 
-    pub fn fingerprint(&self) -> &FingerprintData {
-        &self.state.linked.fingerprint
-    }
-
-    pub fn issue(&self) -> &Issue {
-        &self.state.linked.issue
-    }
-
-    pub fn issue_id(&self) -> Uuid {
-        self.state.linked.issue.id
-    }
-
-    pub fn to_output(&self) -> OutputErrProps {
-        self.build_output(
-            &self.state.linked.metadata,
-            &self.state.linked.fingerprint,
-            self.state.linked.issue.id,
-        )
-    }
-
-    pub fn to_clickhouse_value(&self) -> Value {
-        let mut value = serde_json::to_value(self.to_output())
-            .expect("final exception properties are serializable");
-        let map = value
-            .as_object_mut()
-            .expect("serialized exception properties are an object");
-        if let Some(name) = &self.proposed_issue_name {
-            map.insert("$issue_name".into(), Value::String(name.clone()));
-        }
-        if let Some(description) = &self.proposed_issue_description {
+        let mut map: Map<String, Value> = props.into_iter().collect();
+        map.insert(
+            "$exception_list".into(),
+            serde_json::to_value(exception_list).expect("exception list is serializable"),
+        );
+        map.insert(
+            "$exception_sources".into(),
+            serde_json::to_value(metadata.sources).expect("exception sources are serializable"),
+        );
+        map.insert(
+            "$exception_types".into(),
+            serde_json::to_value(metadata.types).expect("exception types are serializable"),
+        );
+        map.insert(
+            "$exception_values".into(),
+            serde_json::to_value(metadata.messages).expect("exception messages are serializable"),
+        );
+        map.insert(
+            "$exception_functions".into(),
+            serde_json::to_value(metadata.functions).expect("exception functions are serializable"),
+        );
+        map.insert("$exception_handled".into(), Value::Bool(metadata.handled));
+        if !metadata.releases.is_empty() {
             map.insert(
-                "$issue_description".into(),
-                Value::String(description.clone()),
+                "$exception_releases".into(),
+                serde_json::to_value(metadata.releases)
+                    .expect("exception releases are serializable"),
             );
         }
-        if !self.debug_images.is_empty() {
+        map.insert(
+            "$exception_fingerprint".into(),
+            Value::String(fingerprint.value),
+        );
+        if let Some(version) = fingerprint.version {
+            map.insert(
+                "$exception_fingerprint_version".into(),
+                serde_json::to_value(version).expect("fingerprint version is serializable"),
+            );
+        }
+        map.insert(
+            "$exception_fingerprint_record".into(),
+            serde_json::to_value(fingerprint.record).expect("fingerprint record is serializable"),
+        );
+        map.insert(
+            "$exception_issue_id".into(),
+            Value::String(issue.id.to_string()),
+        );
+        if let Some(name) = proposed_issue_name {
+            map.insert("$issue_name".into(), Value::String(name));
+        }
+        if let Some(description) = proposed_issue_description {
+            map.insert("$issue_description".into(), Value::String(description));
+        }
+        if !debug_images.is_empty() {
             map.insert(
                 "$debug_images".into(),
-                serde_json::to_value(&self.debug_images)
+                serde_json::to_value(debug_images)
                     .expect("debug image properties are serializable"),
             );
         }
-        value
+        Value::Object(map)
     }
 }
 
@@ -409,7 +452,7 @@ impl<S> ExceptionEvent<S> {
     fn properties_with_fingerprint(
         &self,
         metadata: &ResolvedMetadata,
-        fingerprint: &FingerprintData,
+        fingerprint: &SelectedFingerprint,
         issue_id: Option<Uuid>,
     ) -> Value {
         let mut map = self.base_resolved_properties(metadata);
@@ -434,13 +477,13 @@ impl<S> ExceptionEvent<S> {
         Value::Object(map)
     }
 
-    fn build_output(
+    fn build_processed_properties(
         &self,
         metadata: &ResolvedMetadata,
-        fingerprint: &FingerprintData,
+        fingerprint: &SelectedFingerprint,
         issue_id: Uuid,
-    ) -> OutputErrProps {
-        OutputErrProps {
+    ) -> ProcessedExceptionProperties {
+        ProcessedExceptionProperties(ProcessedExceptionPropertiesWire {
             exception_list: self.exception_list.clone(),
             fingerprint: fingerprint.value.clone(),
             fingerprint_version: fingerprint.version,
@@ -453,7 +496,7 @@ impl<S> ExceptionEvent<S> {
             values: metadata.messages.clone(),
             sources: metadata.sources.clone(),
             functions: metadata.functions.clone(),
-        }
+        })
     }
 }
 
@@ -473,7 +516,7 @@ impl TryFrom<AnyEvent> for ExceptionEvent<Parsed> {
             recursively_sanitize_properties(event.uuid, value, 0)?;
         }
 
-        let mut raw: RawErrProps = serde_json::from_value(properties)
+        let mut raw: RawExceptionProperties = serde_json::from_value(properties)
             .map_err(|error| EventError::InvalidProperties(event.uuid, error.to_string()))?;
         if raw.exception_list.is_empty() {
             return Err(EventError::EmptyExceptionList(event.uuid));
@@ -544,5 +587,114 @@ impl TryFrom<Result<ClickHouseEvent, EventError>> for ExceptionEvent<Parsed> {
 
     fn try_from(event: Result<ClickHouseEvent, EventError>) -> Result<Self, Self::Error> {
         event?.try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolved_event() -> ExceptionEvent<Resolved> {
+        ExceptionEvent {
+            uuid: Uuid::now_v7(),
+            team_id: 42,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            exception_list: ExceptionList(vec![crate::types::Exception {
+                exception_id: Some("exception-id".to_string()),
+                exception_type: "Error".to_string(),
+                exception_message: "boom".to_string(),
+                mechanism: None,
+                module: None,
+                thread_id: None,
+                stack: None,
+            }]),
+            debug_images: vec![],
+            props: HashMap::from([("passthrough".to_string(), Value::Bool(true))]),
+            proposed_issue_name: None,
+            proposed_issue_description: None,
+            state: Resolved {
+                metadata: ResolvedMetadata {
+                    sources: vec![],
+                    types: vec!["Error".to_string()],
+                    messages: vec!["boom".to_string()],
+                    functions: vec![],
+                    handled: false,
+                    releases: HashMap::new(),
+                },
+                client_fingerprint: Some("client-fingerprint".to_string()),
+                legacy_order_resolved: None,
+            },
+        }
+    }
+
+    #[test]
+    fn selected_fingerprint_constructors_keep_origin_coherent() {
+        let manual = SelectedFingerprint::manual("manual-value".to_string());
+        assert_eq!(manual.value(), "manual-value");
+        assert_eq!(manual.version(), None);
+        assert!(matches!(manual.record(), [FingerprintRecordPart::Manual]));
+
+        let rule_id = Uuid::now_v7();
+        let custom = SelectedFingerprint::custom(rule_id);
+        assert_eq!(custom.value(), format!("custom-rule:{rule_id}"));
+        assert_eq!(custom.version(), None);
+        assert!(matches!(
+            custom.record(),
+            [FingerprintRecordPart::Custom { rule_id: id }] if *id == rule_id
+        ));
+
+        let automatic = SelectedFingerprint::automatic(
+            FingerprintVersion::V2,
+            Fingerprint {
+                value: "automatic-value".to_string(),
+                record: vec![FingerprintRecordPart::Exception {
+                    id: None,
+                    pieces: vec!["Error".to_string()],
+                }],
+            },
+        );
+        assert_eq!(automatic.value(), "automatic-value");
+        assert_eq!(automatic.version(), Some(FingerprintVersion::V2));
+        assert!(matches!(
+            automatic.record(),
+            [FingerprintRecordPart::Exception { .. }]
+        ));
+    }
+
+    #[test]
+    fn purpose_specific_projections_preserve_issue_id_nullability() {
+        let resolved = resolved_event();
+        let grouping = resolved.grouping_rule_properties();
+        assert_eq!(grouping["$exception_fingerprint"], "client-fingerprint");
+        assert!(grouping["$exception_fingerprint_record"].is_null());
+        assert!(grouping["$exception_issue_id"].is_null());
+
+        let fingerprinted = resolved.into_fingerprinted(SelectedFingerprint::manual(
+            "client-fingerprint".to_string(),
+        ));
+        let suppression = fingerprinted.suppression_rule_properties();
+        assert_eq!(suppression["$exception_fingerprint"], "client-fingerprint");
+        assert_eq!(
+            suppression["$exception_fingerprint_record"],
+            serde_json::json!([{"type": "manual"}])
+        );
+        assert!(suppression["$exception_issue_id"].is_null());
+
+        let issue = Issue {
+            id: Uuid::now_v7(),
+            team_id: 42,
+            status: crate::issue_resolution::IssueStatus::Active,
+            name: None,
+            description: None,
+            created_at: chrono::Utc::now(),
+        };
+        let assignment = serde_json::to_value(fingerprinted.processed_properties(&issue)).unwrap();
+        assert_eq!(assignment["$exception_issue_id"], issue.id.to_string());
+        assert_eq!(assignment["passthrough"], true);
+
+        let linked = fingerprinted.into_linked(issue.clone());
+        let rate_limit = linked.rate_limit_rule_properties();
+        assert_eq!(rate_limit["$exception_issue_id"], issue.id.to_string());
+        assert_eq!(rate_limit["passthrough"], true);
     }
 }

--- a/rust/cymbal/src/modes/processing/types/mod.rs
+++ b/rust/cymbal/src/modes/processing/types/mod.rs
@@ -104,7 +104,7 @@ impl ExceptionList {
 /// Deserialization checks only the wire shape. Sanitization, non-empty list
 /// validation, normalization, and construction of `ExceptionEvent<Parsed>`
 /// happen at the event conversion boundary.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RawExceptionProperties {
     #[serde(rename = "$exception_list")]
     pub exception_list: ExceptionList,
@@ -202,10 +202,6 @@ impl ProcessedExceptionProperties {
         &self.0.fingerprint
     }
 
-    pub fn fingerprint_version(&self) -> Option<FingerprintVersion> {
-        self.0.fingerprint_version
-    }
-
     pub fn fingerprint_record(&self) -> &[FingerprintRecordPart] {
         &self.0.fingerprint_record
     }
@@ -220,10 +216,6 @@ impl ProcessedExceptionProperties {
 
     pub fn is_handled(&self) -> bool {
         self.0.handled
-    }
-
-    pub fn releases(&self) -> &HashMap<String, ReleaseInfo> {
-        &self.0.releases
     }
 
     pub fn types(&self) -> &[String] {

--- a/rust/cymbal/src/modes/processing/types/mod.rs
+++ b/rust/cymbal/src/modes/processing/types/mod.rs
@@ -99,88 +99,148 @@ impl ExceptionList {
     }
 }
 
-// Given a Clickhouse Event's properties, we care about the contents
-// of only a small subset. This struct is used to give us a strongly-typed
-// "view" of those event properties we care about.
+/// Untrusted exception properties accepted from ClickHouse and SDK event payloads.
+///
+/// Deserialization checks only the wire shape. Sanitization, non-empty list
+/// validation, normalization, and construction of `ExceptionEvent<Parsed>`
+/// happen at the event conversion boundary.
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct RawErrProps {
+pub struct RawExceptionProperties {
     #[serde(rename = "$exception_list")]
     pub exception_list: ExceptionList,
     #[serde(
         rename = "$exception_fingerprint",
         skip_serializing_if = "Option::is_none"
     )]
-    pub fingerprint: Option<String>, // Clients can send us fingerprints, which we'll use if present
+    pub fingerprint: Option<String>,
     #[serde(rename = "$issue_name", skip_serializing_if = "Option::is_none")]
-    pub issue_name: Option<String>, // Clients can send us custom issue names, which we'll use if present
+    pub issue_name: Option<String>,
     #[serde(rename = "$issue_description", skip_serializing_if = "Option::is_none")]
-    pub issue_description: Option<String>, // Clients can send us custom issue descriptions, which we'll use if present
+    pub issue_description: Option<String>,
     #[serde(rename = "$exception_handled", skip_serializing_if = "Option::is_none")]
-    pub handled: Option<bool>, // Clients can send us handled status, which we'll use if present
+    pub handled: Option<bool>,
     #[serde(
         rename = "$debug_images",
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub debug_images: Vec<DebugImage>, // Debug images sent by native SDKs (apple, rust) for symbolication
+    pub debug_images: Vec<DebugImage>,
+    /// Properties not interpreted by Cymbal, preserved across processing.
     #[serde(flatten)]
-    // A catch-all for all the properties we don't "care" about, so when we send back to kafka we don't lose any info
     pub other: HashMap<String, Value>,
 }
 
-impl RawErrProps {
-    pub fn add_error_message(&mut self, msg: impl ToString) {
-        let mut errors = match self.other.remove("$cymbal_errors") {
-            Some(serde_json::Value::Array(errors)) => errors,
-            _ => Vec::new(),
-        };
-
-        errors.push(serde_json::Value::String(msg.to_string()));
-
-        self.other.insert(
-            "$cymbal_errors".to_string(),
-            serde_json::Value::Array(errors),
-        );
-    }
-}
-
-// We emit this
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct OutputErrProps {
+/// The stable JSON representation of exception properties after Cymbal processing.
+///
+/// The public wrapper prevents ordinary callers from defaulting or independently
+/// assembling successful pipeline products. This private DTO remains the single
+/// source of truth for the external property names and omission behavior.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct ProcessedExceptionPropertiesWire {
     #[serde(rename = "$exception_list")]
-    pub exception_list: ExceptionList,
+    exception_list: ExceptionList,
     #[serde(rename = "$exception_fingerprint")]
-    pub fingerprint: String,
+    fingerprint: String,
     #[serde(
         rename = "$exception_fingerprint_version",
         skip_serializing_if = "Option::is_none"
     )]
-    pub fingerprint_version: Option<FingerprintVersion>,
+    fingerprint_version: Option<FingerprintVersion>,
     #[serde(rename = "$exception_fingerprint_record")]
-    pub fingerprint_record: Vec<FingerprintRecordPart>,
+    fingerprint_record: Vec<FingerprintRecordPart>,
     #[serde(rename = "$exception_issue_id")]
-    pub issue_id: Uuid,
+    issue_id: Uuid,
     #[serde(flatten)]
-    pub other: HashMap<String, Value>,
-
-    // Metadata
+    other: HashMap<String, Value>,
     #[serde(rename = "$exception_handled")]
-    pub handled: bool,
+    handled: bool,
     #[serde(
         rename = "$exception_releases",
         skip_serializing_if = "HashMap::is_empty",
         default
     )]
-    pub releases: HashMap<String, ReleaseInfo>,
-    // Search metadata (materialized)
+    releases: HashMap<String, ReleaseInfo>,
     #[serde(rename = "$exception_types")]
-    pub types: Vec<String>,
+    types: Vec<String>,
     #[serde(rename = "$exception_values")]
-    pub values: Vec<String>,
+    values: Vec<String>,
     #[serde(rename = "$exception_sources")]
-    pub sources: Vec<String>,
+    sources: Vec<String>,
     #[serde(rename = "$exception_functions")]
-    pub functions: Vec<String>,
+    functions: Vec<String>,
+}
+
+/// Validated processed exception properties used at serialization boundaries.
+///
+/// This is a boundary value, not a pipeline state. Deserializing it does not
+/// construct or imply an `ExceptionEvent<S>` processing state.
+#[derive(Debug, Serialize, Clone)]
+#[serde(transparent)]
+pub struct ProcessedExceptionProperties(ProcessedExceptionPropertiesWire);
+
+impl<'de> Deserialize<'de> for ProcessedExceptionProperties {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = ProcessedExceptionPropertiesWire::deserialize(deserializer)?;
+        if wire.exception_list.is_empty() {
+            return Err(serde::de::Error::custom(
+                "processed exception list must not be empty",
+            ));
+        }
+        Ok(Self(wire))
+    }
+}
+
+impl ProcessedExceptionProperties {
+    pub fn exception_list(&self) -> &ExceptionList {
+        &self.0.exception_list
+    }
+
+    pub fn fingerprint(&self) -> &str {
+        &self.0.fingerprint
+    }
+
+    pub fn fingerprint_version(&self) -> Option<FingerprintVersion> {
+        self.0.fingerprint_version
+    }
+
+    pub fn fingerprint_record(&self) -> &[FingerprintRecordPart] {
+        &self.0.fingerprint_record
+    }
+
+    pub fn issue_id(&self) -> Uuid {
+        self.0.issue_id
+    }
+
+    pub fn properties(&self) -> &HashMap<String, Value> {
+        &self.0.other
+    }
+
+    pub fn is_handled(&self) -> bool {
+        self.0.handled
+    }
+
+    pub fn releases(&self) -> &HashMap<String, ReleaseInfo> {
+        &self.0.releases
+    }
+
+    pub fn types(&self) -> &[String] {
+        &self.0.types
+    }
+
+    pub fn values(&self) -> &[String] {
+        &self.0.values
+    }
+
+    pub fn sources(&self) -> &[String] {
+        &self.0.sources
+    }
+
+    pub fn functions(&self) -> &[String] {
+        &self.0.functions
+    }
 }
 
 // Deduplicates while preserving first-seen order, so derived properties
@@ -196,30 +256,6 @@ where
         .filter_map(key_extractor)
         .filter(|key| seen.insert(key.clone()))
         .collect()
-}
-
-impl OutputErrProps {
-    pub fn add_error_message(&mut self, msg: impl ToString) {
-        let mut errors = match self.other.remove("$cymbal_errors") {
-            Some(serde_json::Value::Array(errors)) => errors,
-            _ => Vec::new(),
-        };
-
-        errors.push(serde_json::Value::String(msg.to_string()));
-
-        self.other.insert(
-            "$cymbal_errors".to_string(),
-            serde_json::Value::Array(errors),
-        );
-    }
-
-    pub fn strip_frame_junk(&mut self) {
-        self.exception_list.iter_mut().for_each(|exception| {
-            if let Some(Stacktrace::Resolved { frames }) = &mut exception.stack {
-                frames.iter_mut().for_each(|frame| frame.junk_drawer = None);
-            }
-        });
-    }
 }
 
 impl Stacktrace {
@@ -267,11 +303,12 @@ impl Stacktrace {
 #[cfg(test)]
 mod test {
     use common_types::ClickHouseEvent;
-    use serde_json::Error;
+    use serde_json::{json, Error, Value};
+    use uuid::Uuid;
 
     use crate::{frames::RawFrame, types::Stacktrace};
 
-    use super::{Exception, ExceptionList, RawErrProps};
+    use super::{Exception, ExceptionList, ProcessedExceptionProperties, RawExceptionProperties};
 
     #[test]
     fn it_deserialises_error_props() {
@@ -279,7 +316,7 @@ mod test {
 
         let raw: ClickHouseEvent = serde_json::from_str(raw).unwrap();
 
-        let props: RawErrProps = serde_json::from_str(&raw.properties.unwrap()).unwrap();
+        let props: RawExceptionProperties = serde_json::from_str(&raw.properties.unwrap()).unwrap();
         let exception_list = &props.exception_list;
 
         assert_eq!(exception_list.len(), 1);
@@ -330,7 +367,7 @@ mod test {
             "$exception_list": []
         }"#;
 
-        let props: Result<RawErrProps, Error> = serde_json::from_str(raw);
+        let props: Result<RawExceptionProperties, Error> = serde_json::from_str(raw);
         assert!(props.is_ok());
         assert_eq!(props.unwrap().exception_list.len(), 0);
 
@@ -341,7 +378,7 @@ mod test {
         }"#;
 
         // We support default values
-        let props: RawErrProps =
+        let props: RawExceptionProperties =
             serde_json::from_str(raw).expect("Can deserialize with missing value");
         assert_eq!(props.exception_list[0].exception_message, "");
 
@@ -352,12 +389,54 @@ mod test {
             }]
         }"#;
 
-        let props: Result<RawErrProps, Error> = serde_json::from_str(raw);
+        let props: Result<RawExceptionProperties, Error> = serde_json::from_str(raw);
         assert!(props.is_err());
         assert_eq!(
             props.unwrap_err().to_string(),
             "missing field `type` at line 5 column 13"
         );
+    }
+
+    fn processed_properties_json(exception_list: Value) -> Value {
+        json!({
+            "$exception_list": exception_list,
+            "$exception_fingerprint": "",
+            "$exception_fingerprint_record": [],
+            "$exception_issue_id": Uuid::nil(),
+            "$exception_handled": false,
+            "$exception_types": ["Error"],
+            "$exception_values": ["boom"],
+            "$exception_sources": [],
+            "$exception_functions": [],
+            "passthrough": {"kept": true},
+        })
+    }
+
+    #[test]
+    fn processed_properties_validate_stable_wire_invariants() {
+        let value = processed_properties_json(json!([{"type": "Error", "value": "boom"}]));
+        let properties: ProcessedExceptionProperties =
+            serde_json::from_value(value.clone()).expect("compatible processed properties");
+
+        assert_eq!(properties.fingerprint(), "");
+        assert!(properties.fingerprint_record().is_empty());
+        assert_eq!(properties.issue_id(), Uuid::nil());
+        assert_eq!(properties.types(), ["Error"]);
+        assert_eq!(properties.values(), ["boom"]);
+        assert_eq!(properties.properties()["passthrough"]["kept"], true);
+        assert_eq!(serde_json::to_value(properties).unwrap(), value);
+
+        let mut empty_manual =
+            processed_properties_json(json!([{"type": "Error", "value": "boom"}]));
+        empty_manual["$exception_fingerprint_record"] = json!([{"type": "manual"}]);
+        let manual: ProcessedExceptionProperties = serde_json::from_value(empty_manual).unwrap();
+        assert_eq!(manual.fingerprint(), "");
+
+        let empty = processed_properties_json(json!([]));
+        let error = serde_json::from_value::<ProcessedExceptionProperties>(empty).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("processed exception list must not be empty"));
     }
 
     #[test]

--- a/rust/cymbal/tests/assignment_rules.rs
+++ b/rust/cymbal/tests/assignment_rules.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::Utc;
 use cymbal::{
     issue_resolution::{Issue, IssueStatus},
@@ -7,7 +5,7 @@ use cymbal::{
     modes::processing::ProcessingConfig,
     stages::linking::issue::process_assignment,
     teams::TeamManager,
-    types::OutputErrProps,
+    types::ProcessedExceptionProperties,
 };
 use serde_json::{json, Value as JsonValue};
 use sqlx::PgPool;
@@ -44,12 +42,20 @@ fn get_test_rule() -> AssignmentRule {
     }
 }
 
-fn test_props() -> OutputErrProps {
-    OutputErrProps {
-        fingerprint: "test value".to_string(),
-        other: HashMap::from([("test_value".to_string(), json!("test_value"))]),
-        ..Default::default()
-    }
+fn test_props() -> ProcessedExceptionProperties {
+    serde_json::from_value(json!({
+        "$exception_list": [{"type": "Error", "value": "test value"}],
+        "$exception_fingerprint": "test value",
+        "$exception_fingerprint_record": [{"type": "manual"}],
+        "$exception_issue_id": Uuid::nil(),
+        "$exception_handled": false,
+        "$exception_types": ["Error"],
+        "$exception_values": ["test value"],
+        "$exception_sources": [],
+        "$exception_functions": [],
+        "test_value": "test_value",
+    }))
+    .unwrap()
 }
 
 fn test_issue() -> Issue {

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -8,7 +8,10 @@ use cymbal::{
     fingerprinting::{Fingerprint, FingerprintVersion},
     frames::Frame,
     symbolication::symbol_store::saving::SymbolSetRecord,
-    types::{event::AnyEvent, Exception, ExceptionList, Mechanism, OutputErrProps, Stacktrace},
+    types::{
+        event::AnyEvent, Exception, ExceptionList, Mechanism, ProcessedExceptionProperties,
+        Stacktrace,
+    },
 };
 use insta::assert_json_snapshot;
 use mockall::predicate;
@@ -140,7 +143,7 @@ fn frame_at(mut frame: Frame, source: &str, line: u32, column: u32) -> Frame {
 struct SuccessResponse(Vec<Option<AnyEvent>>);
 
 impl SuccessResponse {
-    fn take_properties(self) -> OutputErrProps {
+    fn take_properties(self) -> ProcessedExceptionProperties {
         let event = self.0.first().expect("Should have at least one event");
         serde_json::from_value(event.as_ref().unwrap().properties.clone())
             .expect("Should deserialize properties")
@@ -332,9 +335,10 @@ async fn insert_symbol_set_record(db: &PgPool, team_id: i32, chunk_id: &str) {
 // Helper to extract exception list from response
 fn extract_exception_list(response: &SuccessResponse) -> ExceptionList {
     let event = response.first_event();
-    let props: OutputErrProps = serde_json::from_value(event.as_ref().unwrap().properties.clone())
-        .expect("Should deserialize properties");
-    props.exception_list
+    let props: ProcessedExceptionProperties =
+        serde_json::from_value(event.as_ref().unwrap().properties.clone())
+            .expect("Should deserialize properties");
+    props.exception_list().clone()
 }
 
 // Tests
@@ -389,11 +393,11 @@ async fn creates_issue_with_fingerprint(db: PgPool) {
     let (status, body): (_, SuccessResponse) = harness.post_event(&input).await;
 
     assert!(status.is_success(), "Expected success, got {:?}", status);
-    let event: OutputErrProps = body.take_properties();
-    assert!(!event.fingerprint.is_empty());
-    assert_eq!(event.types, vec!["Error".to_string()]);
-    assert_eq!(event.values, vec!["test error message".to_string()]);
-    assert_eq!(harness.get_issue_id().await, event.issue_id);
+    let event: ProcessedExceptionProperties = body.take_properties();
+    assert!(!event.fingerprint().is_empty());
+    assert_eq!(event.types(), ["Error"]);
+    assert_eq!(event.values(), ["test error message"]);
+    assert_eq!(harness.get_issue_id().await, event.issue_id());
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -440,7 +444,7 @@ async fn uses_client_fingerprint_override(db: PgPool) {
 
     let event = body.take_properties();
     assert!(status.is_success());
-    assert_eq!(event.fingerprint, "custom-fingerprint".to_string());
+    assert_eq!(event.fingerprint(), "custom-fingerprint");
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -457,8 +461,8 @@ async fn same_fingerprint_returns_same_issue(db: PgPool) {
     let event1 = body1.take_properties();
     let event2 = body2.take_properties();
 
-    assert_eq!(event1.fingerprint, event2.fingerprint);
-    assert_eq!(event1.issue_id, event2.issue_id);
+    assert_eq!(event1.fingerprint(), event2.fingerprint());
+    assert_eq!(event1.issue_id(), event2.issue_id());
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -468,7 +472,7 @@ async fn suppressed_issue_returns_suppressed_response(db: PgPool) {
 
     let (_, created): (_, SuccessResponse) = harness.post_event(&input).await;
     let body = created.take_properties();
-    let issue_id = body.issue_id;
+    let issue_id = body.issue_id();
     harness.suppress_issue(issue_id).await;
 
     let (status, body): (_, SuccessResponse) = harness.post_event(&input).await;
@@ -511,18 +515,22 @@ async fn extracts_metadata_from_exceptions(db: PgPool) {
     assert!(status.is_success());
     let event = body.take_properties();
 
-    assert_eq!(event.types, vec!["TypeError"]);
-    assert_eq!(
-        event.values,
-        vec!["Cannot read property 'foo' of undefined"]
-    );
-    assert!(event.handled);
+    assert_eq!(event.types(), ["TypeError"]);
+    assert_eq!(event.values(), ["Cannot read property 'foo' of undefined"]);
+    assert!(event.is_handled());
     assert!(event
-        .sources
-        .contains(&"src/components/Button.tsx".to_string()));
-    assert!(event.sources.contains(&"src/App.tsx".to_string()));
-    assert!(event.functions.contains(&"handleClick".to_string()));
-    assert!(event.functions.contains(&"onClick".to_string()));
+        .sources()
+        .iter()
+        .any(|source| source == "src/components/Button.tsx"));
+    assert!(event.sources().iter().any(|source| source == "src/App.tsx"));
+    assert!(event
+        .functions()
+        .iter()
+        .any(|function| function == "handleClick"));
+    assert!(event
+        .functions()
+        .iter()
+        .any(|function| function == "onClick"));
 }
 
 // Frame resolution tests
@@ -662,9 +670,9 @@ fn resolved_stack_event(source: &str) -> AnyEvent {
 }
 
 fn automatic_fingerprint(version: FingerprintVersion, event: &AnyEvent) -> Fingerprint {
-    let props: OutputErrProps = serde_json::from_value(event.properties.clone())
+    let props: ProcessedExceptionProperties = serde_json::from_value(event.properties.clone())
         .expect("event properties should deserialize");
-    version.compute(&props.exception_list)
+    version.compute(props.exception_list())
 }
 
 fn grouping_rule_bytecode() -> JsonValue {

--- a/rust/cymbal/tests/fingerprint_golden.rs
+++ b/rust/cymbal/tests/fingerprint_golden.rs
@@ -9,7 +9,7 @@ use common_types::error_tracking::FrameId;
 use common_types::ClickHouseEvent;
 use cymbal::fingerprinting::Fingerprint;
 use cymbal::frames::Frame;
-use cymbal::types::{Exception, RawErrProps, Stacktrace};
+use cymbal::types::{Exception, RawExceptionProperties, Stacktrace};
 
 #[allow(clippy::too_many_arguments)]
 fn frame(
@@ -240,13 +240,13 @@ fn golden_chained_exceptions() {
 
 #[test]
 fn golden_static_raw_ch_exception_list() {
-    // Real capture-shaped event: `properties` is a JSON string holding RawErrProps.
+    // Real capture-shaped event: `properties` is a JSON string holding RawExceptionProperties.
     let event: ClickHouseEvent =
         serde_json::from_str(include_str!("./static/raw_ch_exception_list.json"))
             .expect("valid ClickHouseEvent fixture");
-    let props: RawErrProps =
+    let props: RawExceptionProperties =
         serde_json::from_str(event.properties.as_deref().expect("fixture has properties"))
-            .expect("valid RawErrProps");
+            .expect("valid RawExceptionProperties");
     snapshot(
         "static_raw_ch_exception_list",
         props.exception_list.iter().cloned().collect(),

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -17,7 +17,7 @@ use cymbal::{
         sourcemap::{OwnedSourceMapCache, SourcemapProvider},
         Catalog, Fetcher, Parser,
     },
-    types::{RawErrProps, Stacktrace},
+    types::{RawExceptionProperties, Stacktrace},
 };
 use httpmock::MockServer;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, SourceAndMap};
@@ -85,7 +85,8 @@ async fn end_to_end_resolver_test() {
     });
 
     let exception: ClickHouseEvent = serde_json::from_str(EXAMPLE_EXCEPTION).unwrap();
-    let mut props: RawErrProps = serde_json::from_str(&exception.properties.unwrap()).unwrap();
+    let mut props: RawExceptionProperties =
+        serde_json::from_str(&exception.properties.unwrap()).unwrap();
     let Stacktrace::Raw {
         frames: mut test_stack,
     } = props.exception_list.swap_remove(0).stack.unwrap()

--- a/rust/cymbal/tests/types.rs
+++ b/rust/cymbal/tests/types.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use common_types::ClickHouseEvent;
 use cymbal::{
     frames::{Frame, RawFrame},
-    types::{RawErrProps, Stacktrace},
+    types::{RawExceptionProperties, Stacktrace},
 };
 use serde_json::Value;
 
@@ -14,7 +14,7 @@ fn serde_passthrough() {
     let raw: ClickHouseEvent = serde_json::from_str(raw).unwrap();
 
     let before_properties: Value = serde_json::from_str(raw.properties.as_ref().unwrap()).unwrap();
-    let properties_parsed: RawErrProps =
+    let properties_parsed: RawExceptionProperties =
         serde_json::from_str(raw.properties.as_ref().unwrap()).unwrap();
 
     let properties_raw = serde_json::to_string(&properties_parsed).unwrap();
@@ -30,7 +30,7 @@ fn serde_passthrough() {
 
 #[test]
 fn python_exceptions() {
-    let props: RawErrProps =
+    let props: RawExceptionProperties =
         serde_json::from_str(include_str!("./static/python_err_props.json")).unwrap();
 
     let frames = props
@@ -57,7 +57,7 @@ fn python_exceptions() {
 
 #[test]
 fn node_exceptions() {
-    let props: RawErrProps =
+    let props: RawExceptionProperties =
         serde_json::from_str(include_str!("./static/node_err_props.json")).unwrap();
 
     let frames = props
@@ -99,7 +99,7 @@ fn node_exceptions() {
 
 #[test]
 fn php_exceptions() {
-    let props: RawErrProps =
+    let props: RawExceptionProperties =
         serde_json::from_str(include_str!("./static/php_err_props.json")).unwrap();
 
     let frames = props


### PR DESCRIPTION
## Problem

> [!IMPORTANT]
> Requires #71601. This PR is stacked on `hp/type-safe-cymbal-processing-pipeline` and should merge after that PR.

The typestate pipeline guarantees coherent resolved metadata, fingerprints, and issue linkage, but its boundary property types still allow impossible successful values through `Default`, public field construction, and independently assembled fingerprint fields. Notification consumers also need stable validation that does not reject compatible payloads during rolling deployments.

## Changes

- Rename the raw and processed exception property types to make their boundary roles explicit.
- Wrap processed properties in a non-defaultable type backed by a private serde wire representation.
- Reject empty processed exception lists and validate notification issue IDs and duplicated fingerprints before side effects.
- Preserve permissive legacy fingerprint handling without recomputing version-dependent metadata or fingerprints.
- Replace `FingerprintData` with `SelectedFingerprint` and origin-specific constructors.
- Add purpose-specific grouping, suppression, rate-limit, assignment, notification, and final property projections.
- Build final ClickHouse properties by consuming the finalized event instead of serializing and reopening an intermediate value.
- Remove obsolete property mutation methods and unused post-link projections.

Before:

```mermaid
flowchart LR
    Pipeline[Typed pipeline] --> Props[Public defaultable properties]
    Props --> Kafka[Kafka notification]
    Kafka --> Deserialize[Deserialize]
    Deserialize --> Effects[Notification side effects]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Pipeline,Effects phYellow;
    class Kafka phBlue;
    class Props,Deserialize phGray;
```

After:

```mermaid
flowchart LR
    Pipeline[Typed pipeline] --> Props[Controlled processed properties]
    Props --> Kafka[Kafka notification]
    Kafka --> Validate[Deserialize and validate stable identity]
    Validate --> Effects[Notification side effects]
    Validate --> Skip[Commit invalid poison pill]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Pipeline,Effects phYellow;
    class Kafka,Validate phBlue;
    class Props phGray;
    class Skip phRed;
```

## How did you test this code?

- `cargo fmt --all --check`
- `cargo clippy -p cymbal --all-targets -- -D warnings`
- `cargo test -p cymbal`
- Targeted notification validation tests catch mismatched issue IDs and fingerprints, verify invalid offsets are stored, and ensure the following valid item remains processable.
- Processed-property tests catch empty exception lists while preserving empty manual fingerprints, empty legacy-compatible records, and serde round trips.
- Fingerprint constructor tests catch incoherent origin, version, and record combinations.
- Existing fingerprint golden, assignment, remote-resolution, suppression, and full processed-property snapshot suites verify behavioral and wire compatibility.
- `./bin/hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation changes are needed. This changes internal Rust types and validation while preserving external property and notification schemas.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using the OpenSpec planning workflow. Skills invoked: `/openspec-explore`, `/openspec-propose`, `/openspec-apply-change`, `/writing-tests`, and `/pr`. A shareable agent-session URL was not available in the CLI.

The design keeps the internal typestate carrier non-deserializable, uses concrete raw and processed boundary types instead of a generic wire typestate, and limits consumer rejection to stable invariants. Metadata and legacy fingerprints are not recomputed because a false mismatch would permanently skip notification side effects.
