### PR TITLE
feat(warehouse_sources): support Lightspeed Retail API version 2026-01

### DIFF
--- a/products/warehouse_sources/backend/migrations/0092_repin_lightspeed_retail_api_version.py
+++ b/products/warehouse_sources/backend/migrations/0092_repin_lightspeed_retail_api_version.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+# Lightspeed Retail (X-Series) deprecated the legacy 2.0 version; deprecated endpoints increasingly
+# return 410 Gone before an eventual retirement. Repin source-level pins onto the current 2026-01
+# date-based version. The endpoints/fields this source reads carry no documented breaking changes
+# across the two versions (it auto-infers its schema and reads the same `version` keyset cursor), so
+# the repin needs no data/schema transform — only the pin moves.
+LIGHTSPEED_RETAIL_SOURCE_TYPE = "LightspeedRetail"
+DEPRECATED_VERSION = "2.0"
+TARGET_VERSION = "2026-01"
+
+
+def repin_lightspeed_retail_api_version(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+
+    # Only touch source-level pins still on the deprecated version. NULL pins already resolve to the
+    # source's `default_version` (now 2026-01), so they need no update. Filtering on the exact old
+    # value keeps this idempotent — a re-run matches nothing. Schema-level overrides
+    # (`ExternalDataSchema.api_version`) are intentionally customer-pinned and are left untouched.
+    ExternalDataSource.objects.filter(source_type=LIGHTSPEED_RETAIL_SOURCE_TYPE, api_version=DEPRECATED_VERSION).update(
+        api_version=TARGET_VERSION
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources", "0091_alter_externaldatasource_source_type_and_more"),
+    ]
+
+    operations = [
+        # Reverse is a no-op: once repinned, these rows are indistinguishable from natively-created
+        # ones, so a blanket downgrade would clobber legitimate 2026-01 pins.
+        migrations.RunPython(repin_lightspeed_retail_api_version, migrations.RunPython.noop, elidable=False),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0091_alter_externaldatasource_source_type_and_more
+0092_repin_lightspeed_retail_api_version

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/constants.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/constants.py
@@ -1,0 +1,5 @@
+# Lightspeed Retail (X-Series) API versions are date-based snapshots (YYYY-MM), replacing the
+# legacy semantic labels. One constant per version so the source's version declaration and the
+# request layer (the `/api/<version>` path segment) share a single label — never parsed or ordered.
+LIGHTSPEED_RETAIL_API_VERSION_2_0 = "2.0"
+LIGHTSPEED_RETAIL_API_VERSION_2026_01 = "2026-01"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
@@ -38,8 +38,9 @@ def _clean_domain_prefix(domain_prefix: str) -> str:
     return prefix
 
 
-def _base_url(domain_prefix: str) -> str:
-    return f"https://{_clean_domain_prefix(domain_prefix)}.retail.lightspeed.app/api/2.0"
+def _base_url(domain_prefix: str, api_version: str) -> str:
+    # X-Series carries the pinned vendor version as the `/api/<version>` path segment.
+    return f"https://{_clean_domain_prefix(domain_prefix)}.retail.lightspeed.app/api/{api_version}"
 
 
 def _to_version(value: Any) -> Optional[int]:
@@ -116,6 +117,7 @@ def lightspeed_retail_source(
     team_id: int,
     job_id: str,
     resumable_source_manager: ResumableSourceManager[LightspeedRetailResumeConfig],
+    api_version: str,
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
@@ -123,7 +125,7 @@ def lightspeed_retail_source(
 
     rest_config: RESTAPIConfig = {
         "client": {
-            "base_url": _base_url(domain_prefix),
+            "base_url": _base_url(domain_prefix, api_version),
             # Bearer auth via the framework so the token is redacted from logs and errors.
             "auth": {"type": "bearer", "token": api_token},
             "paginator": LightspeedRetailPaginator(),
@@ -184,10 +186,10 @@ def lightspeed_retail_source(
     )
 
 
-def validate_credentials(domain_prefix: str, api_token: str) -> bool:
+def validate_credentials(domain_prefix: str, api_token: str, api_version: str) -> bool:
     """Confirm the token and store subdomain are valid with a cheap outlets probe."""
     try:
-        url = f"{_base_url(domain_prefix)}/outlets?page_size=1"
+        url = f"{_base_url(domain_prefix, api_version)}/outlets?page_size=1"
     except ValueError:
         # A malformed domain prefix can't be validated — reject without a request.
         return False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/source.py
@@ -13,7 +13,11 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     SourceInputs,
     SourceResponse,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
+    FieldType,
+    ResumableSource,
+    VersionDeprecation,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
@@ -25,6 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sch
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.lightspeedretail import (
     LightspeedRetailSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.constants import (
+    LIGHTSPEED_RETAIL_API_VERSION_2_0,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_01,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
     LightspeedRetailResumeConfig,
@@ -40,8 +48,12 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 @SourceRegistry.register
 class LightspeedRetailSource(ResumableSource[LightspeedRetailSourceConfig, LightspeedRetailResumeConfig]):
-    supported_versions = ("2.0",)
-    default_version = "2.0"
+    supported_versions = (LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01)
+    default_version = LIGHTSPEED_RETAIL_API_VERSION_2026_01
+    api_docs_url = "https://x-series-api.lightspeedhq.com/docs/introduction"
+    # X-Series deprecated the legacy 2.0 version; no firm sunset date is published (deprecated
+    # endpoints increasingly return 410 Gone before an eventual retirement).
+    deprecated_versions = (VersionDeprecation(version=LIGHTSPEED_RETAIL_API_VERSION_2_0, sunset_at=None),)
 
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 
@@ -66,6 +78,8 @@ class LightspeedRetailSource(ResumableSource[LightspeedRetailSourceConfig, Light
         return {
             "401 Client Error: Unauthorized for url": "Lightspeed Retail authentication failed. Please check your personal token and store domain prefix.",
             "403 Client Error: Forbidden for url": "Lightspeed Retail denied access. Please check that your personal token has the required permissions.",
+            # A retired API version answers 410 forever — retrying can't recover it.
+            "410 Client Error: Gone for url": "Lightspeed Retail no longer serves this API version. Please update the source to a supported API version.",
         }
 
     @property
@@ -113,6 +127,7 @@ Your domain prefix is the first part of your store URL — for `mystore.retail.l
         force_refresh: bool = False,
         api_version: str | None = None,
     ) -> list[SourceSchema]:
+        # Static endpoint catalog — identical across supported versions, so no vendor call to pin.
         return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
@@ -122,7 +137,10 @@ Your domain prefix is the first part of your store URL — for `mystore.retail.l
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        if validate_lightspeed_credentials(config.domain_prefix, config.api_token):
+        # The probe URL carries the version path segment, so a pinned source must probe its own pin.
+        if validate_lightspeed_credentials(
+            config.domain_prefix, config.api_token, self.resolve_api_version(api_version)
+        ):
             return True, None
 
         return False, "Invalid Lightspeed Retail credentials"
@@ -145,6 +163,7 @@ Your domain prefix is the first part of your store URL — for `mystore.retail.l
             team_id=inputs.team_id,
             job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            api_version=self.resolve_api_version(inputs.api_version),
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
@@ -7,6 +7,10 @@ from unittest import mock
 
 from requests import Response
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.constants import (
+    LIGHTSPEED_RETAIL_API_VERSION_2_0,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_01,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
     LightspeedRetailResumeConfig,
     _base_url,
@@ -54,7 +58,9 @@ def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, 
 
     def _prepare(request: Any) -> mock.MagicMock:
         param_snapshots.append(dict(request.params or {}))
-        return mock.MagicMock()
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
 
     session.prepare_request.side_effect = _prepare
     session.send.side_effect = responses
@@ -62,6 +68,7 @@ def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, 
 
 
 def _run(manager: mock.MagicMock, endpoint: str = "sales", **kwargs: Any) -> list[Any]:
+    kwargs.setdefault("api_version", LIGHTSPEED_RETAIL_API_VERSION_2026_01)
     response = lightspeed_retail_source(
         "mystore", "token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs
     )
@@ -87,8 +94,9 @@ class TestCleanDomainPrefix:
         with pytest.raises(ValueError):
             _clean_domain_prefix(value)
 
-    def test_base_url(self):
-        assert _base_url("mystore") == "https://mystore.retail.lightspeed.app/api/2.0"
+    @pytest.mark.parametrize("api_version", [LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01])
+    def test_base_url_carries_the_version_path_segment(self, api_version):
+        assert _base_url("mystore", api_version) == f"https://mystore.retail.lightspeed.app/api/{api_version}"
 
 
 class TestToVersion:
@@ -123,17 +131,27 @@ class TestValidateCredentials:
         response.status_code = status_code
         mock_session.return_value.get.return_value = response
 
-        assert validate_credentials("mystore", "token") is expected
+        assert validate_credentials("mystore", "token", LIGHTSPEED_RETAIL_API_VERSION_2026_01) is expected
+
+    @pytest.mark.parametrize("api_version", [LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01])
+    @mock.patch(LR_SESSION_PATCH)
+    def test_validate_credentials_probes_the_pinned_version(self, mock_session, api_version):
+        mock_session.return_value.get.return_value.status_code = 200
+
+        assert validate_credentials("mystore", "token", api_version) is True
+
+        url = mock_session.return_value.get.call_args.args[0]
+        assert url.startswith(f"https://mystore.retail.lightspeed.app/api/{api_version}/outlets")
 
     @mock.patch(LR_SESSION_PATCH)
     def test_validate_credentials_rejects_bad_prefix_without_request(self, mock_session):
-        assert validate_credentials("my store!", "token") is False
+        assert validate_credentials("my store!", "token", LIGHTSPEED_RETAIL_API_VERSION_2026_01) is False
         mock_session.return_value.get.assert_not_called()
 
     @mock.patch(LR_SESSION_PATCH)
     def test_validate_credentials_swallows_transport_error(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("mystore", "token") is False
+        assert validate_credentials("mystore", "token", LIGHTSPEED_RETAIL_API_VERSION_2026_01) is False
 
 
 class TestGetRows:
@@ -235,6 +253,16 @@ class TestGetRows:
         assert session.send.call_count == 2
         assert params[1]["after"] == 0
 
+    @pytest.mark.parametrize("api_version", [LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2026_01])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_requests_target_the_pinned_version(self, mock_session, api_version):
+        session = mock_session.return_value
+        _wire(session, [_response([])])
+
+        _run(_make_manager(), api_version=api_version)
+
+        assert session.send.call_args.args[0].url == f"https://mystore.retail.lightspeed.app/api/{api_version}/sales"
+
 
 class TestLightspeedRetailSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
@@ -243,7 +271,13 @@ class TestLightspeedRetailSourceResponse:
         mock_session.return_value.headers = {}
         config = LIGHTSPEED_RETAIL_ENDPOINTS[endpoint]
         response = lightspeed_retail_source(
-            "mystore", "token", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager()
+            "mystore",
+            "token",
+            endpoint,
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
+            api_version=LIGHTSPEED_RETAIL_API_VERSION_2026_01,
         )
 
         assert response.name == endpoint

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail_source.py
@@ -7,6 +7,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.lightspeedretail import (
     LightspeedRetailSourceConfig,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.constants import (
+    LIGHTSPEED_RETAIL_API_VERSION_2_0,
+    LIGHTSPEED_RETAIL_API_VERSION_2026_01,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
     LightspeedRetailResumeConfig,
 )
@@ -110,7 +114,26 @@ class TestLightspeedRetailSource:
 
         assert is_valid is expected_valid
         assert error_message == expected_message
-        mock_validate.assert_called_once_with(self.config.domain_prefix, self.config.api_token)
+        mock_validate.assert_called_once_with(
+            self.config.domain_prefix, self.config.api_token, LIGHTSPEED_RETAIL_API_VERSION_2026_01
+        )
+
+    @pytest.mark.parametrize(
+        "pinned, expected",
+        [
+            (None, LIGHTSPEED_RETAIL_API_VERSION_2026_01),
+            (LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2_0),
+        ],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.source.validate_lightspeed_credentials"
+    )
+    def test_validate_credentials_probes_the_pinned_version(self, mock_validate, pinned, expected):
+        mock_validate.return_value = True
+
+        self.source.validate_credentials(self.config, self.team_id, api_version=pinned)
+
+        assert mock_validate.call_args.args[2] == expected
 
     def test_get_resumable_source_manager_binds_resume_config(self):
         inputs = mock.MagicMock()
@@ -127,6 +150,7 @@ class TestLightspeedRetailSource:
         inputs.schema_name = "sales"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = 999
+        inputs.api_version = LIGHTSPEED_RETAIL_API_VERSION_2026_01
         manager = mock.MagicMock()
 
         self.source.source_for_pipeline(self.config, manager, inputs)
@@ -141,6 +165,27 @@ class TestLightspeedRetailSource:
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == 999
+        assert kwargs["api_version"] == LIGHTSPEED_RETAIL_API_VERSION_2026_01
+
+    @pytest.mark.parametrize(
+        "pinned, expected",
+        [
+            (None, LIGHTSPEED_RETAIL_API_VERSION_2026_01),
+            (LIGHTSPEED_RETAIL_API_VERSION_2_0, LIGHTSPEED_RETAIL_API_VERSION_2_0),
+        ],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.source.lightspeed_retail_source"
+    )
+    def test_source_for_pipeline_syncs_on_the_pinned_version(self, mock_lightspeed_source, pinned, expected):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "sales"
+        inputs.should_use_incremental_field = False
+        inputs.api_version = pinned
+
+        self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
+
+        assert mock_lightspeed_source.call_args.kwargs["api_version"] == expected
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.lightspeed_retail.source.lightspeed_retail_source"


### PR DESCRIPTION
## Problem

Lightspeed Retail (X-Series) moved from semantic API versions to date-based versioning (`YYYY-MM`). The legacy `2.0` version this source implements is deprecated, and deprecated endpoints increasingly answer `410 Gone` before an eventual retirement. The source needs to support the current `2026-01` version and steer customers off `2.0`, without moving anyone who is pinned to a supported version.

Vendor references: [introduction](https://x-series-api.lightspeedhq.com/docs/introduction), [versioning strategy](https://x-series-api.lightspeedhq.com/reference/versioning-strategy).

## Changes

- **New version `2026-01`** in `LightspeedRetailSource.supported_versions`, with `default_version` flipped to it so new sources start there. Pinned rows keep their pin.
- **Dispatch.** X-Series carries the version as an `/api/<version>` URL path segment, not a header, so the rest_source client's `base_url` is built from the resolved pin. `source_for_pipeline` passes `self.resolve_api_version(inputs.api_version)` into `lightspeed_retail_source`, which builds `_base_url(domain_prefix, api_version)`. No per-version modules: response shapes, the `version` keyset cursor, and pagination are identical across the two versions.
- **The credential probe now uses the pin too.** `validate_credentials` takes the resolved version and probes `/api/<pin>/outlets`. Previously it built its URL from a default, so a source pinned to `2.0` was validated against the wrong base URL. `get_schemas` is a static endpoint catalog with no vendor call, so it stays version independent.
- **Deprecation.** `2.0` goes into `deprecated_versions` with `sunset_at=None`, since the vendor publishes no firm date. The in-product warning and the API fields come from that metadata, so there is no source-specific UI work. I also added `410 Client Error: Gone` to `get_non_retryable_errors`, because a retired version answers 410 forever and would otherwise retry until the source looks merely slow.
- **Migration** `0092_repin_lightspeed_retail_api_version`, written and not run. Idempotent `RunPython` that repins source-level `ExternalDataSource.api_version` from `2.0` to `2026-01`, filtered on the exact old value. `NULL` pins already resolve to the new default, so they are left alone. The reverse is a no-op, since a blanket downgrade would clobber rows natively created on the new default. Schema-level `ExternalDataSchema.api_version` overrides are customer-managed and are not touched.

The source auto-infers its schema and no read field, cursor, or pagination behavior differs between the versions, so the repin needs no data or schema transform. Only the pin moves.

> [!NOTE]
> I (actually Claude) rewrote this branch from scratch on current master. The earlier version of this PR threaded `api_version` through hand-rolled helpers (`_build_url`, a custom `get_rows` generator) that the rest_source migration on master deleted, so the branch was conflicting against code that no longer exists. The migration was renumbered from 0079 to 0092 against the current leaf.

## How did you test this code?

Automated tests, all run locally in the Flox env and green:

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/lightspeed_retail/` (70 passed)
- `pytest .../sources/tests/test_source_versions.py` (1246 passed, the registry-wide version invariants)
- `python manage.py makemigrations warehouse_sources --check --dry-run` (no changes detected, so the migration graph is consistent)
- `mypy --cache-fine-grained .` repo-wide (clean), since the request-layer signatures changed
- ruff check and ruff format

What the new tests catch:

- Both request paths honor the pin instead of a hardcoded or defaulted version: the sync path (`base_url` reaching the actual request URL) and the credential probe (`/api/<pin>/outlets`). Parameterized over `2.0` and `2026-01`. The probe case is the bug this PR fixes, so it is the one test I would not drop.
- `source_for_pipeline` and `validate_credentials` resolve a `None` pin to the new default and pass a present pin verbatim. Existing tests covered neither, since neither surface took a version before.

I did not run the migration, and I did not sync against a live Lightspeed account. There are no stored credentials for this vendor here, so the version semantics are verified against the vendor docs only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8) did the rewrite at my direction. Skills invoked: `/warehouse-source-new-version`, `/django-migrations`, `/writing-tests`.

The starting point was the stale branch, and the call we made early was to not salvage it. The hand-rolled URL builders it patched are gone from master, so a merge would have been a reconstruction anyway. Reimplementing on rest_source kept the diff to the two places the version actually matters: the client `base_url` and the probe URL.

Two deltas from the earlier attempt, both deliberate. The probe now takes the resolved pin rather than defaulting, which fixes a pinned `2.0` source being validated against the `2026-01` base URL. And `_base_url` takes the version as a required argument rather than a defaulted one, so a future caller cannot silently fall back to the newest version.
