### PR TITLE
feat(replay-vision): lead alert messages with the alert name

### DIFF
--- a/products/replay_vision/backend/temporal/vision_actions/alerts.py
+++ b/products/replay_vision/backend/temporal/vision_actions/alerts.py
@@ -272,11 +272,11 @@ def _persist_recovered(
     window_label = "24 hours" if window_days == 1 else f"{window_days} days"
     # Recovery means the metric sits strictly on the other side of the (inclusive) breach bound.
     cleared_bound = "above" if alert_config.get("direction") == AlertDirection.BELOW else "below"
-    scanner_name = _scanner_display_name(action)
 
     markdown = (
-        f"**Recovered: {scanner_name}** — {metric_label} over the last {window_label} is back at "
-        f"{_format_number(metric_value)}, {cleared_bound} the threshold of {_format_number(threshold)}."
+        f"**Recovered: {_alert_display_name(action)}**{_scanner_clause(action)} — {metric_label} over the last "
+        f"{window_label} is back at {_format_number(metric_value)}, {cleared_bound} the threshold of "
+        f"{_format_number(threshold)}."
     )
     started_at = _breach_started_at(team.id, action.id, run.pk)
     if started_at is not None:
@@ -303,21 +303,30 @@ def _run_url(team_id: int, action_id: str, run_id: str) -> str:
     return f"{settings.SITE_URL}/project/{team_id}/replay-vision/actions/{action_id}/runs/{run_id}"
 
 
-def _scanner_display_name(action: Any) -> str:
-    # Scanner name is free text; strip markdown/mrkdwn control chars so it can't garble the bold
-    # header, plus link syntax chars so it can't break out of the header link's label.
-    raw_name = action.scanner.name if action.scanner_id else ""
-    return re.sub(r"\s+", " ", re.sub(r"[*_`#\[\]()]", "", raw_name)).strip() or "your scanner"
+def _display_name(raw_name: str, fallback: str) -> str:
+    # Names are free text; strip markdown/mrkdwn control chars so they can't garble the bold
+    # header, plus link syntax chars so they can't break out of the header link's label.
+    return re.sub(r"\s+", " ", re.sub(r"[*_`#\[\]()]", "", raw_name)).strip() or fallback
+
+
+def _alert_display_name(action: Any) -> str:
+    return _display_name(action.name or "", "your alert")
+
+
+def _scanner_clause(action: Any) -> str:
+    """The " for scanner <name>" header suffix — empty when the action has no primary scanner, so
+    the header degrades to just the alert name."""
+    if not action.scanner_id:
+        return ""
+    return f" for scanner {_display_name(action.scanner.name, 'your scanner')}"
 
 
 def _linkify_header(markdown: str, action: Any, run_url: str, label: str = "Alert") -> str:
-    """Wrap the header's scanner name in a link to this alert's run page — the alert's own message
+    """Wrap the header's alert name in a link to this alert's run page — the alert's own message
     plus every matching observation (and breadcrumbs back to the scanner). A name the strip pass
     rewrote (e.g. it contained a bare URL, now a code span) won't match the expected header — leave
     it unlinked rather than guess."""
-    if not action.scanner_id:
-        return markdown
-    name = _scanner_display_name(action)
+    name = _alert_display_name(action)
     prefix = f"**{label}: {name}**"
     if not markdown.startswith(prefix):
         return markdown
@@ -337,12 +346,12 @@ def _alert_markdown(
     carry `[obs N]` citation markers — N is the observation's 1-based position in `rows`
     (= `observation_ids` order) — which the Slack pass and the in-app view resolve into links to each
     observation."""
-    scanner_name = _scanner_display_name(action)
+    header = f"**Alert: {_alert_display_name(action)}**{_scanner_clause(action)}"
 
     noun = "observation" if matched_count == 1 else "observations"
     if alert_config.get("frequency", AlertFrequency.ON_BREACH) == AlertFrequency.EVERY_MATCH:
         lines = [
-            f"**Alert: {scanner_name}** — {matched_count} new matching {noun} since the last check.",
+            f"{header} — {matched_count} new matching {noun} since the last check.",
         ]
     else:
         metric = alert_config.get("metric", AlertMetric.COUNT)
@@ -352,7 +361,7 @@ def _alert_markdown(
         window_label = "24 hours" if window_days == 1 else f"{window_days} days"
         bound = "at or below" if alert_config.get("direction") == AlertDirection.BELOW else "at or above"
         lines = [
-            f"**Alert: {scanner_name}** — {metric_label} over the last {window_label} was "
+            f"{header} — {metric_label} over the last {window_label} was "
             f"{_format_number(metric_value)}, {bound} the threshold of {_format_number(threshold)}.",
             "",
             f"{matched_count} {noun} matched in this window.",

--- a/products/replay_vision/backend/tests/test_vision_action_alerts.py
+++ b/products/replay_vision/backend/tests/test_vision_action_alerts.py
@@ -90,7 +90,7 @@ class TestVisionActionAlerts(BaseTest):
         self.assertEqual(result.metric_value, 2.0)
         run.refresh_from_db()
         run_url = f"{settings.SITE_URL}/project/{self.team.id}/replay-vision/actions/{action.id}/runs/{run.pk}"
-        self.assertIn(f"Alert: [watcher]({run_url})", run.synthesized_markdown)
+        self.assertIn(f"Alert: [alert-watcher]({run_url})** for scanner watcher", run.synthesized_markdown)
         self.assertIn("over the last 24 hours", run.synthesized_markdown)
         self.assertIn("at or above the threshold of 2", run.synthesized_markdown)
         self.assertIn("2 observations matched", run.synthesized_markdown)
@@ -99,7 +99,7 @@ class TestVisionActionAlerts(BaseTest):
         self.assertEqual(run.observation_ids, [str(newest.id), str(older.id)])
         self.assertIn("[obs 1]", run.synthesized_markdown)
         self.assertIn("[obs 2]", run.synthesized_markdown)
-        self.assertIn(f"<{run_url}|watcher>", run.output["slack"])
+        self.assertIn(f"<{run_url}|alert-watcher>", run.output["slack"])
         self.assertIn(f"/observations/{newest.id}|[1]>", run.output["slack"])
         self.assertIn(f"/observations/{older.id}|[2]>", run.output["slack"])
         # Every match is already listed, so there's no "see all" overflow link to add noise.
@@ -162,7 +162,7 @@ class TestVisionActionAlerts(BaseTest):
 
         self.assertEqual(recovered.status, AlertStatus.RECOVERED)
         recovery_run.refresh_from_db()
-        self.assertIn("Recovered:", recovery_run.synthesized_markdown)
+        self.assertIn("Recovered: [alert-watcher](", recovery_run.synthesized_markdown)
         self.assertIn("below the threshold of 1", recovery_run.synthesized_markdown)
         self.assertIn("had been firing since", recovery_run.synthesized_markdown)
         self.assertTrue(recovery_run.output["recovered"])


### PR DESCRIPTION
## Problem

Alert messages led with the scanner name, but the alert is its own entity: one scanner can have several alerts with different conditions, and the message never said which one fired.

## Changes

- Fired and recovered message headers are now `**Alert: <alert name>** for scanner <scanner name>`, with the alert name linked to this alert's run page (previously the scanner name carried that link).
- The alert name is free text like the scanner name, so it gets the same markdown/mrkdwn sanitization (shared `_display_name` helper).
- If the action somehow has no primary scanner, the "for scanner" clause is omitted instead of saying "your scanner".

## How did you test this code?

Automated only, no manual testing.
Updated the existing assertions in `test_vision_action_alerts.py` to lock the new header shape for fired and recovered messages, including the Slack rendering (`<run-url|alert-name>`).
Full alert test file (20 tests) green locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude (PostHog Code), directed by Kim ("the alert should include the alert name, linked to the run"). No new tests, only assertion updates on existing ones.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
