### PR TITLE
feat(replay-vision): call the recording subject a person in the ui

### DIFF
--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -485,7 +485,7 @@ class ReplayObservationFilter(django_filters.FilterSet):
     recording_subject = django_filters.CharFilter(
         field_name="recording_subject_email",
         lookup_expr="icontains",
-        help_text="Filter to observations whose recording subject email contains this value (case-insensitive).",
+        help_text="Filter to observations whose person email contains this value (case-insensitive).",
     )
     labeled = django_filters.BooleanFilter(
         method="_filter_labeled",

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -1387,7 +1387,7 @@ export type VisionObservationsRetrieveParams = {
      */
     order_by?: string
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string
     /**
@@ -1465,7 +1465,7 @@ export type VisionScannersObservationsListParams = {
      */
     order_by?: string
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string
     /**
@@ -1500,7 +1500,7 @@ export type VisionScannersObservationsRetrieveParams = {
      */
     order_by?: string
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string
     /**
@@ -1535,7 +1535,7 @@ export type VisionScannersObservationsStatsRetrieveParams = {
      */
     recent_days?: number
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string
     /**

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -492,7 +492,7 @@ export function ReplayObservationSceneComponent(): JSX.Element {
                                 {observation.session_id}
                             </Link>
                         </LabeledRow>
-                        <LabeledRow label="Recording subject">
+                        <LabeledRow label="Person">
                             {observation.distinct_id ? (
                                 <Link to={urls.personByDistinctId(observation.distinct_id)}>
                                     {observation.recording_subject_email ?? observation.distinct_id}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -132,7 +132,7 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
             ),
         },
         {
-            title: 'Recording subject',
+            title: 'Person',
             key: 'recording_subject',
             sorter: true,
             render: (_, obs) =>
@@ -246,7 +246,7 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
                                 <LemonInput
                                     type="search"
                                     size="small"
-                                    placeholder="Recording subject email"
+                                    placeholder="Person email"
                                     value={observationSubjectFilter}
                                     onChange={setObservationSubjectFilter}
                                     className="w-56"

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -69234,7 +69234,7 @@ export namespace Schemas {
      */
     order_by?: string;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**
@@ -69312,7 +69312,7 @@ export namespace Schemas {
      */
     order_by?: string;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**
@@ -69347,7 +69347,7 @@ export namespace Schemas {
      */
     order_by?: string;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**
@@ -69382,7 +69382,7 @@ export namespace Schemas {
      */
     recent_days?: number;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**
@@ -77961,7 +77961,7 @@ export namespace Schemas {
      */
     order_by?: string;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**
@@ -78039,7 +78039,7 @@ export namespace Schemas {
      */
     order_by?: string;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**
@@ -78074,7 +78074,7 @@ export namespace Schemas {
      */
     order_by?: string;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**
@@ -78109,7 +78109,7 @@ export namespace Schemas {
      */
     recent_days?: number;
     /**
-     * Filter to observations whose recording subject email contains this value (case-insensitive).
+     * Filter to observations whose person email contains this value (case-insensitive).
      */
     recording_subject?: string;
     /**

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -59,7 +59,7 @@ export const VisionObservationsRetrieveQueryParams = /* @__PURE__ */ zod.object(
     recording_subject: zod
         .string()
         .optional()
-        .describe('Filter to observations whose recording subject email contains this value (case-insensitive).'),
+        .describe('Filter to observations whose person email contains this value (case-insensitive).'),
     session_id: zod
         .string()
         .optional()
@@ -421,7 +421,7 @@ export const VisionScannersObservationsListQueryParams = /* @__PURE__ */ zod.obj
     recording_subject: zod
         .string()
         .optional()
-        .describe('Filter to observations whose recording subject email contains this value (case-insensitive).'),
+        .describe('Filter to observations whose person email contains this value (case-insensitive).'),
     session_id: zod
         .string()
         .optional()
@@ -472,7 +472,7 @@ export const VisionScannersObservationsRetrieveQueryParams = /* @__PURE__ */ zod
     recording_subject: zod
         .string()
         .optional()
-        .describe('Filter to observations whose recording subject email contains this value (case-insensitive).'),
+        .describe('Filter to observations whose person email contains this value (case-insensitive).'),
     session_id: zod
         .string()
         .optional()
@@ -522,7 +522,7 @@ export const VisionScannersObservationsStatsRetrieveQueryParams = /* @__PURE__ *
     recording_subject: zod
         .string()
         .optional()
-        .describe('Filter to observations whose recording subject email contains this value (case-insensitive).'),
+        .describe('Filter to observations whose person email contains this value (case-insensitive).'),
     session_id: zod
         .string()
         .optional()


### PR DESCRIPTION
## Problem

The observations UI called the person in a recording the "recording subject".
That reads clinical and is inconsistent with the rest of PostHog replay, which calls them a person.

## Changes

- Observations table column "Recording subject" → "Person", filter placeholder "Recording subject email" → "Person email", observation detail label → "Person".
- The API filter description now says "person email"; generated frontend and MCP types regenerated.
- Deliberately unchanged: the internal field and query param names (`recording_subject_email`, `recording_subject`) since renaming them breaks API compatibility for no user-visible gain, and the model `help_text`, which would generate a wording-only migration.

Copy-only change, no layout or behavior differences, so no screenshots.

## How did you test this code?

Copy-only string changes plus a regenerated OpenAPI pass (`hogli build:openapi`). No tests assert these labels. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude (PostHog Code). Kim asked whether to keep "recording subject" or switch to "user"; Claude recommended "person" for consistency with replay's existing terminology and Kim approved. Skill invoked: /improving-drf-endpoints (for the filter help_text change that flows into generated types).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
