### PR TITLE
chore(warehouse_sources): pin version-update PR title scope to warehouse_sources

### DIFF
--- a/.agents/skills/warehouse-source-new-version/SKILL.md
+++ b/.agents/skills/warehouse-source-new-version/SKILL.md
@@ -30,7 +30,7 @@ Use this skill when a vendor has released a new API version and an existing sour
    - Watch for version-dependent column hints/schemas: e.g. Stripe's `external_table_definitions` were built for specific versions. When adding a version whose response shapes differ, gate the canonical column hints to the versions they were built for and let newer versions auto-infer the schema from the data (a set of hint-compatible versions checked where hints are applied).
 4. **Keep old versions working**: do not delete or alter the request path for previously supported versions. Removing a version is an explicit future decision, not part of a version-add PR.
 5. **Tests**: extend the source's tests so both the old and new versions are exercised — at minimum that the version label reaches the client/request layer for each supported version (mock the boundary; parameterize over versions). The registry invariant test picks up declaration mistakes automatically.
-6. **One PR per source.** Conventional title: `feat(<dir>): support <vendor> API version <label>`.
+6. **One PR per source.** Conventional title: `feat(warehouse_sources): support <vendor> API version <label>` — the scope is always `warehouse_sources` (the product), never the source dir/vendor name.
 
 ## Deprecating a version
 


### PR DESCRIPTION
## Problem

The self-updating sources pipeline opens a PR per source when a vendor ships a new API version, and it takes the PR title from this skill. The skill templated the title as `feat(<dir>): ...`, so the pipeline produced titles scoped to the source dir — e.g. `feat(salesforce): support Salesforce API version v67.0`. The scope should be the product, `warehouse_sources`, like the rest of these PRs.

## Changes

One-line fix in the `warehouse-source-new-version` skill: the conventional-title template now pins the scope to `warehouse_sources` and says so explicitly, so the pipeline stops using the vendor/dir name.

```diff
-6. **One PR per source.** Conventional title: `feat(<dir>): support <vendor> API version <label>`.
+6. **One PR per source.** Conventional title: `feat(warehouse_sources): support <vendor> API version <label>` — the scope is always `warehouse_sources` (the product), never the source dir/vendor name.
```

> [!NOTE]
> This only fixes titles generated *from this skill*. If the pipeline's own driver prompt (in the warehouse-sources-admin repo, outside this repo) hardcodes or overrides the title independently, that would need the same change there. The buggy output matched the old `feat(<dir>)` template exactly, so the skill is the likely source.

## How did you test this code?

Docs-only change to a skill markdown file. No code, no tests to run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel spotted the wrong PR title from the pipeline and asked whether it was the skill or the prompt. It was the skill. Split into its own PR off fresh master since #71570 (the source-seeding PR) had already merged.

Skill referenced: `warehouse-source-new-version`.
