### PR TITLE
fix(oauth): keep consent actions above mobile browser chrome

### DIFF
--- a/frontend/src/scenes/oauth/OAuthAuthorize.tsx
+++ b/frontend/src/scenes/oauth/OAuthAuthorize.tsx
@@ -242,7 +242,7 @@ export const OAuthAuthorize = (): JSX.Element => {
 
     return (
         <div className="min-h-full overflow-y-auto">
-            <div className="max-w-2xl mx-auto py-8 px-4 sm:py-12 sm:px-6">
+            <div className="max-w-2xl mx-auto px-4 pt-8 pb-[calc(2rem+max(env(safe-area-inset-bottom),80px))] sm:py-12 sm:px-6">
                 <div className="text-center mb-4 sm:mb-8">
                     {oauthApplication.logo_uri && (
                         <div className="w-16 h-16 mx-auto mb-3 rounded-full border border-border bg-bg-light p-3 flex items-center justify-center">


### PR DESCRIPTION
## Problem

On iOS, floating browser chrome can overlap the action row at the end of a long OAuth consent form. Because the action row is already at the end of the scrollable content, users cannot move it fully above the browser controls and only the unobscured upper portion remains easy to tap.

## Changes

The OAuth consent container now keeps its existing 2rem mobile content padding and adds clearance for `safe-area-inset-bottom`, with PostHog's existing 80px mobile Safari fallback. Layout at the `sm` breakpoint and above still uses the existing 3rem vertical padding.

![OAuth consent actions clear of mobile browser chrome](https://raw.githubusercontent.com/graycreate/posthog/925ce54c74b6b136a6624e0fcf021a907f3d0d64/pr-assets/oauth-mobile-padding.png)

## How did you test this code?

- Ran `oxfmt --check` and `oxlint` on `OAuthAuthorize.tsx`.
- Ran `./bin/hogli ci:preflight --fix`; it passed with no triggered failure classes.
- Opened the existing `ManyOptionalScopes` Storybook story at 390x844 and 844x390 browser viewports.
- Verified computed bottom padding is 112px in the narrow viewport and remains the existing 48px at the `sm` breakpoint.
- Measured the rendered button and used real coordinate clicks at its lower edge and immediately outside it in both viewports. The lower edge submitted and the first pixel outside did not, confirming the `LemonButton` hit target is aligned with its DOM box and does not need a global button change.

`pnpm --filter=@posthog/frontend typescript:check` does not pass in this clean checkout because generated Kea `*Type` modules are absent and the checkout reports unrelated workspace type errors. This CSS-only change does not add or modify TypeScript behavior.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This changes mobile layout spacing without changing OAuth behavior, copy, or a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed Codex to investigate and prepare this fix. Codex used the `/pr` workflow and `browser:control-in-app-browser` skill; no public session link is available.

The initial report suggested both insufficient bottom space and a vertically shifted button hit target. Browser geometry and coordinate-click testing showed the button target itself is aligned, so I kept the change scoped to the consent container. The padding formula follows the mobile Safari fallback already used by PostHog navigation instead of introducing a new global button rule.
