### PR TITLE
fix(mcp): handle resources absent from aggregate archive

### DIFF
--- a/services/mcp/tests/integration/manifest.test.ts
+++ b/services/mcp/tests/integration/manifest.test.ts
@@ -16,19 +16,19 @@ describe('Context-Mill Manifest Integration', () => {
         expect(validatedManifest.version).toBe('1.0')
         expect(Array.isArray(validatedManifest.resources)).toBe(true)
 
-        // Verify we have actual resources
-        expect(validatedManifest.resources.length).toBeGreaterThan(0)
+        // Context-mill may list resources distributed separately from the aggregate archive.
+        const availableResources = validatedManifest.resources.filter((entry) => !entry.file || archive[entry.file])
 
-        // Verify each resource has required fields and its file exists in archive
-        for (const entry of validatedManifest.resources) {
+        // Verify the archive contains actual resources
+        expect(availableResources.length).toBeGreaterThan(0)
+
+        // Verify each available resource has required fields
+        for (const entry of availableResources) {
             expect(entry.id).toBeTruthy()
             expect(entry.name).toBeTruthy()
             expect(entry.resource).toBeTruthy()
             expect(entry.resource.mimeType).toBeTruthy()
             expect(entry.resource.text).toBeTruthy()
-            if (entry.file) {
-                expect(archive[entry.file]).toBeTruthy()
-            }
         }
     }, 30000)
 })

--- a/services/mcp/tests/integration/manifest.test.ts
+++ b/services/mcp/tests/integration/manifest.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { fetchContextMillResources, loadManifestFromArchive } from '@/resources/internals'
 
 describe('Context-Mill Manifest Integration', () => {
-    it('should fetch, unzip, and validate the manifest from GitHub releases', async () => {
+    it('should fetch, unzip, and validate available resources from GitHub releases', async () => {
         const archive = await fetchContextMillResources()
 
         // Verify archive is not empty
@@ -16,7 +16,7 @@ describe('Context-Mill Manifest Integration', () => {
         expect(validatedManifest.version).toBe('1.0')
         expect(Array.isArray(validatedManifest.resources)).toBe(true)
 
-        // Context-mill may list resources distributed separately from the aggregate archive.
+        // The manifest may include resources that are not part of the aggregate archive.
         const availableResources = validatedManifest.resources.filter((entry) => !entry.file || archive[entry.file])
 
         // Verify the archive contains actual resources


### PR DESCRIPTION
## Problem

**Why:** The live Context Mill manifest test assumed every referenced resource file was embedded in the aggregate archive. Current Context Mill releases can retain manifest entries that are not part of that archive, so unrelated MCP CI runs fail even though the loader already skips unavailable entries.

## Changes

Validate the resources that are actually available in the aggregate archive while preserving schema and content checks.

## How did you test this code?

- Reproduced the failure against Context Mill `v1.30.1` and confirmed `v1.30.2` has the same aggregate archive shape.
- Ran `pnpm --filter=@posthog/mcp exec vitest run tests/integration/manifest.test.ts` 20 consecutive times, then reran it after clarifying the test contract.
- Ran `uv run --project tools/hogli python -m hogli ci:preflight --fix`.
- `pnpm --filter=@posthog/mcp run typecheck` could not complete in the partial workspace install because generated UI app dependencies such as React and Quill were unavailable.

This test guards against rejecting usable aggregate archives when the upstream manifest also contains entries unavailable from that archive.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update is needed because this only aligns an integration test with the existing loader behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI investigated and implemented this change using `/fixing-flaky-tests` and `/writing-tests`. The failure was initially reported as a flake, but release comparison showed a deterministic upstream packaging change: `v1.30.0` embedded every referenced file, while later releases retained entries that were not included in the aggregate archive. The test now checks the usable archive contract instead of requiring the aggregate ZIP to mirror the full manifest.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*