### PR TITLE
feat(ci): stamp owning team on per-test CI spans

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -27,6 +27,9 @@
 #   test job fails, downloads that shard's JUnit to list the actual failing tests. The shadow
 #   strips artifact uploads (above), so it has nothing to download and keeps the plain
 #   dependency-result table — depot-exempt for the same reason as the other uploads.
+# - report-test-timings: canonical emits per-test OTLP spans from the uploaded JUnit. The shadow
+#   strips artifact uploads (above) and posts no telemetry, so the whole job is depot-exempt —
+#   changes confined to it (script deps, the reporter's availability guard) need no depot bump.
 # - OpenAPI types: the check-openapi-types job is folded into check-migrations as a
 #   check-only step (drift still fails the run); only its auto-commit side effect is dropped
 # - actions/cache reads/writes route to Depot Cache, not GitHub Actions Cache,

--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -6,7 +6,11 @@
 #   "opentelemetry-api~=1.27",
 #   "opentelemetry-sdk~=1.27",
 #   "opentelemetry-exporter-otlp-proto-http~=1.27",
+#   "posthog-owners",
 # ]
+#
+# [tool.uv.sources]
+# posthog-owners = { path = "../../tools/owners" }
 # ///
 """Emit OTLP traces from Backend CI JUnit XML artifacts.
 
@@ -35,8 +39,10 @@ import hashlib
 import logging
 import secrets
 import argparse
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -48,6 +54,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.trace import Status, StatusCode
+from posthog_owners import OwnersResolver
 
 logger = logging.getLogger("report_test_timings")
 
@@ -69,6 +76,7 @@ class TestCase:
     end: datetime
     outcome: str  # passed | failed | error | skipped | xfailed | rerun_passed
     attempts: int  # 1 + number of pytest-rerunfailures retries before final outcome
+    file: str  # repo-relative test file from JUnit's `file`; '' when absent (external shards)
     selector: str  # runnable 'path/test.py::Class::test' from JUnit's `file`; '' when file is absent
 
 
@@ -284,6 +292,7 @@ def parse_shard(xml_path: Path, info: ArtifactInfo) -> Shard | None:
                 nodeid=to_nodeid(classname, name),
                 classname=classname,
                 name=name,
+                file=file,
                 selector=to_selector(file, classname, name),
                 duration_seconds=duration,
                 start=test_start,
@@ -435,6 +444,31 @@ def job_trace_name(workflow: str, info: ArtifactInfo) -> str:
     return f"{workflow} / {job}"
 
 
+def owner_team_lookup() -> Callable[[str], str]:
+    """Repo-relative test file -> primary owning team slug, '' when unowned.
+
+    Ownership is the repo's own `owners.yaml` tree, read through the shared resolver rather
+    than re-parsed here — one resolver owns the semantics, everything else calls it (see
+    `docs/internal/ownership-model-proposal.md` §5). Resolution is capture-time on purpose:
+    a test is attributed to whoever owned it when it ran.
+
+    A resolver that can't load (an older base checkout predating `tools/owners`) degrades to
+    no stamp, so spans still carry timings and land in the reader's `unowned` bucket.
+    """
+    try:
+        resolver = OwnersResolver()
+    except Exception:
+        logger.exception("owners resolver unavailable; emitting spans without team attribution")
+        return lambda _file: ""
+
+    @cache
+    def lookup(file: str) -> str:
+        owners = resolver.resolve(file).owners if file else None
+        return owners[0] if owners else ""
+
+    return lookup
+
+
 def emit_traces(shards: list[Shard], endpoint: str, token: str) -> None:
     """Emit one trace per job: a `<workflow> / <job>` root span with test children, shipped via OTLP HTTP."""
     run_id = os.environ.get("GITHUB_RUN_ID", "0")
@@ -452,16 +486,17 @@ def emit_traces(shards: list[Shard], endpoint: str, token: str) -> None:
         provider.shutdown()
         return
 
+    owner_of = owner_team_lookup()
     for shard in shards:
         # Mutate the shared generator before each job so its root span (and the test
         # children that inherit the active parent's trace ID) form a distinct trace.
         id_generator.trace_id = deterministic_trace_id(run_id, run_attempt, job_trace_key(shard.info))
-        _emit_shard_span(tracer, shard, job_trace_name(workflow, shard.info))
+        _emit_shard_span(tracer, shard, job_trace_name(workflow, shard.info), owner_of)
 
     provider.shutdown()
 
 
-def _emit_shard_span(tracer: trace.Tracer, shard: Shard, root_name: str) -> bool:
+def _emit_shard_span(tracer: trace.Tracer, shard: Shard, root_name: str, owner_of: Callable[[str], str]) -> bool:
     """Emit the job's root span and its test children. Returns True iff any child has Error."""
     info = shard.info
     shard_span = tracer.start_span(root_name, start_time=_to_ns(shard.start))
@@ -497,6 +532,9 @@ def _emit_shard_span(tracer: trace.Tracer, shard: Shard, root_name: str) -> bool
             test_span.set_attribute("test.name", test.name)
             if test.selector:
                 test_span.set_attribute("test.selector", test.selector)
+            owner_team = owner_of(test.file)
+            if owner_team:
+                test_span.set_attribute("test.owner_team", owner_team)
             if test.outcome in ("failed", "error"):
                 test_span.set_status(Status(StatusCode.ERROR))
                 has_error = True

--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -448,8 +448,10 @@ def owner_team_lookup() -> Callable[[str], str]:
     """Repo-relative test file -> primary owning team slug, '' when unowned.
 
     Resolution is capture-time on purpose: a test is attributed to whoever owned it when it
-    ran. A resolver that can't load (a base checkout predating `tools/owners`) degrades to no
-    stamp, leaving those spans in the reader's `unowned` bucket rather than losing the emit.
+    ran. Ownership is best-effort next to the timings themselves, so every failure — a resolver
+    that can't load (a base checkout predating `tools/owners`) or one file that won't resolve —
+    degrades to no stamp, leaving those spans in the reader's `unowned` bucket rather than
+    losing the emit.
     """
     try:
         resolver = OwnersResolver()
@@ -461,7 +463,11 @@ def owner_team_lookup() -> Callable[[str], str]:
     def lookup(file: str) -> str:
         if not file:
             return ""
-        owners = resolver.resolve(file).owners
+        try:
+            owners = resolver.resolve(file).owners
+        except Exception:
+            logger.exception("owners resolution failed for %s; emitting span without team attribution", file)
+            return ""
         return owners[0] if owners else ""
 
     return lookup

--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -447,13 +447,9 @@ def job_trace_name(workflow: str, info: ArtifactInfo) -> str:
 def owner_team_lookup() -> Callable[[str], str]:
     """Repo-relative test file -> primary owning team slug, '' when unowned.
 
-    Ownership is the repo's own `owners.yaml` tree, read through the shared resolver rather
-    than re-parsed here — one resolver owns the semantics, everything else calls it (see
-    `docs/internal/ownership-model-proposal.md` §5). Resolution is capture-time on purpose:
-    a test is attributed to whoever owned it when it ran.
-
-    A resolver that can't load (an older base checkout predating `tools/owners`) degrades to
-    no stamp, so spans still carry timings and land in the reader's `unowned` bucket.
+    Resolution is capture-time on purpose: a test is attributed to whoever owned it when it
+    ran. A resolver that can't load (a base checkout predating `tools/owners`) degrades to no
+    stamp, leaving those spans in the reader's `unowned` bucket rather than losing the emit.
     """
     try:
         resolver = OwnersResolver()
@@ -463,7 +459,9 @@ def owner_team_lookup() -> Callable[[str], str]:
 
     @cache
     def lookup(file: str) -> str:
-        owners = resolver.resolve(file).owners if file else None
+        if not file:
+            return ""
+        owners = resolver.resolve(file).owners
         return owners[0] if owners else ""
 
     return lookup

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -29,12 +29,14 @@ def _testcase(
     duration: float = 1.0,
     start: datetime | None = None,
     name: str = "t",
+    file: str = "m.py",
 ) -> report_test_timings.TestCase:  # type: ignore[name-defined]
     test_start = start if start is not None else datetime(2026, 5, 4, 10, 0, 0, tzinfo=UTC)
     return report_test_timings.TestCase(
         nodeid=f"m::{name}",
         classname="m",
         name=name,
+        file=file,
         selector=f"m.py::{name}",
         duration_seconds=duration,
         start=test_start,
@@ -343,6 +345,10 @@ def _noop_use_span(span: _FakeSpan, end_on_exit: bool = False) -> Iterator[None]
     yield
 
 
+def _no_owner(file: str) -> str:
+    return ""
+
+
 def test_emit_shard_span_uses_stored_test_windows(monkeypatch: pytest.MonkeyPatch) -> None:
     start = datetime(2026, 5, 4, 10, 0, 0, tzinfo=UTC)
     shard = report_test_timings.Shard(
@@ -371,7 +377,7 @@ def test_emit_shard_span_uses_stored_test_windows(monkeypatch: pytest.MonkeyPatc
     tracer = _FakeTracer()
     monkeypatch.setattr(report_test_timings.trace, "use_span", _noop_use_span)
 
-    has_error = report_test_timings._emit_shard_span(tracer, shard, "Backend CI / core (1)")
+    has_error = report_test_timings._emit_shard_span(tracer, shard, "Backend CI / core (1)", _no_owner)
 
     assert has_error is True
     assert [span.name for span in tracer.spans] == ["Backend CI / core (1)", "m::slow", "m::fail"]
@@ -408,7 +414,7 @@ def test_emit_shard_span_emits_setup_span_when_setup_seconds_positive(monkeypatc
     tracer = _FakeTracer()
     monkeypatch.setattr(report_test_timings.trace, "use_span", _noop_use_span)
 
-    report_test_timings._emit_shard_span(tracer, shard, "Backend CI / core (1)")
+    report_test_timings._emit_shard_span(tracer, shard, "Backend CI / core (1)", _no_owner)
 
     assert [span.name for span in tracer.spans] == ["Backend CI / core (1)", "setup", "m::slow"]
     setup_span = tracer.spans[1]
@@ -416,6 +422,39 @@ def test_emit_shard_span_emits_setup_span_when_setup_seconds_positive(monkeypatc
     assert setup_span.end_time == report_test_timings._to_ns(start + timedelta(seconds=3.5))
     assert setup_span.attributes["shard.setup_seconds"] == pytest.approx(3.5)
     assert tracer.spans[0].attributes["shard.setup_seconds"] == pytest.approx(3.5)
+
+
+# `test.owner_team` is the whole contract the team CI health rollup reads: an unstamped span
+# aggregates as `unowned`. An unowned file must stay unstamped rather than carry an empty
+# attribute, so the reader's coalesce sees a missing key either way.
+def test_emit_shard_span_stamps_owner_team_only_for_owned_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    start = datetime(2026, 5, 4, 10, 0, 0, tzinfo=UTC)
+    shard = report_test_timings.Shard(
+        info=report_test_timings.ArtifactInfo(
+            path=Path("junit-results-backend-core-1"),
+            suite="backend",
+            segment="core",
+            group=1,
+            total=1,
+        ),
+        junit_filename="junit-core.xml",
+        start=start,
+        end=start + timedelta(seconds=10),
+        testcase_seconds=2.0,
+        overhead_seconds=8.0,
+        tests=[
+            _testcase(name="owned", file="products/x/test_a.py"),
+            _testcase(name="unowned", file="stray/test_b.py", start=start + timedelta(seconds=1)),
+        ],
+    )
+    tracer = _FakeTracer()
+    monkeypatch.setattr(report_test_timings.trace, "use_span", _noop_use_span)
+
+    owners = {"products/x/test_a.py": "team-devex"}
+    report_test_timings._emit_shard_span(tracer, shard, "Backend CI / core (1)", lambda f: owners.get(f, ""))
+
+    assert tracer.spans[1].attributes["test.owner_team"] == "team-devex"
+    assert "test.owner_team" not in tracer.spans[2].attributes
 
 
 # ---------- workflow context ----------

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -424,9 +424,8 @@ def test_emit_shard_span_emits_setup_span_when_setup_seconds_positive(monkeypatc
     assert tracer.spans[0].attributes["shard.setup_seconds"] == pytest.approx(3.5)
 
 
-# `test.owner_team` is the whole contract the team CI health rollup reads: an unstamped span
-# aggregates as `unowned`. An unowned file must stay unstamped rather than carry an empty
-# attribute, so the reader's coalesce sees a missing key either way.
+# `test.owner_team` is the contract the team CI health rollup reads: an unstamped span
+# aggregates as `unowned`, so an unowned file must stay unstamped rather than carry an empty one.
 def test_emit_shard_span_stamps_owner_team_only_for_owned_files(monkeypatch: pytest.MonkeyPatch) -> None:
     start = datetime(2026, 5, 4, 10, 0, 0, tzinfo=UTC)
     shard = report_test_timings.Shard(

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3488,8 +3488,7 @@ jobs:
               if: github.run_attempt == '1'
               shell: bash
               run: |
-                  # tools/owners is the reporter's ownership resolver, declared as a path
-                  # dependency — a base ref predating it can't resolve the script's deps at all.
+                  # tools/owners is a path dep of the reporter, so a base ref predating it can't resolve its deps.
                   if [[ -f .github/scripts/report_test_timings.py && -d tools/owners ]]; then
                     echo "available=true" >> "$GITHUB_OUTPUT"
                   else

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3488,7 +3488,9 @@ jobs:
               if: github.run_attempt == '1'
               shell: bash
               run: |
-                  if [[ -f .github/scripts/report_test_timings.py ]]; then
+                  # tools/owners is the reporter's ownership resolver, declared as a path
+                  # dependency — a base ref predating it can't resolve the script's deps at all.
+                  if [[ -f .github/scripts/report_test_timings.py && -d tools/owners ]]; then
                     echo "available=true" >> "$GITHUB_OUTPUT"
                   else
                     echo "available=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -35,9 +35,10 @@ jobs:
               with:
                   python-version-file: pyproject.toml
 
-            # defusedxml + opentelemetry are report_test_timings.py's script deps.
+            # defusedxml + opentelemetry + tools/owners (the ownership resolver the reporter
+            # stamps spans from) are report_test_timings.py's script deps.
             - name: Install pytest
-              run: python -m pip install --quiet pytest defusedxml==0.7.1 opentelemetry-sdk==1.33.1 opentelemetry-exporter-otlp-proto-http==1.33.1
+              run: python -m pip install --quiet pytest defusedxml==0.7.1 opentelemetry-sdk==1.33.1 opentelemetry-exporter-otlp-proto-http==1.33.1 ./tools/owners
 
             # `-c /dev/null` skips the repo pytest.ini (its --reuse-db addopt needs
             # pytest-django, which we don't install here). `--noconftest` skips the

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -35,8 +35,7 @@ jobs:
               with:
                   python-version-file: pyproject.toml
 
-            # defusedxml + opentelemetry + tools/owners (the ownership resolver the reporter
-            # stamps spans from) are report_test_timings.py's script deps.
+            # defusedxml + opentelemetry + tools/owners are report_test_timings.py's script deps.
             - name: Install pytest
               run: python -m pip install --quiet pytest defusedxml==0.7.1 opentelemetry-sdk==1.33.1 opentelemetry-exporter-otlp-proto-http==1.33.1 ./tools/owners
 


### PR DESCRIPTION
## Problem

- The engineering analytics Teams tab shows a single "Unowned" row. Everything buckets there.
- The reader ([team CI health surfaces](https://github.com/PostHog/posthog/pull/70840)) reads `test.owner_team` off each span, but nothing ever wrote it. The two halves crossed: the [owners.yaml resolver](https://github.com/PostHog/posthog/pull/68872) landed a day before the reader.

## Changes

- The CI reporter now resolves each test's JUnit `file` through `tools/owners` and stamps `test.owner_team`. Unowned paths stay unstamped, so they keep aggregating as `unowned`.
- Two workflow prerequisites: `ci-scripts.yml` hand-installs the reporter's deps, and `ci-backend.yml` checks out `base.sha`, so a base predating `tools/owners` now skips the emit instead of failing dependency resolution.

> [!NOTE]
> The Unowned row won't vanish. 828 of 3750 Python test files (22%) genuinely resolve to unowned, mostly under `posthog/` and `ee/`. Existing spans stay unowned until Traces retention rolls over.

## How did you test this code?

- 34 pass in `.github/scripts/test_report_test_timings.py`. One new case catches a dropped or misapplied stamp, the exact regression behind this bug. No existing test covered it.
- I (actually Claude) ran the reporter against a synthetic JUnit file with real repo paths: an engineering analytics test resolved to `team-devex`, a core temporal test resolved to unowned.
- No manual CI run. The emit path only runs post-merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. Internal CI plumbing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 4.8). Skills invoked: `/writing-tests` (gated the new test), `/simplify` (second commit).
- Rejected read-time resolution (sync the ownership map to the warehouse, join in HogQL). The GitHub source only syncs API resources, not repo file contents, and the sole gain is retroactivity, which self-heals inside the 14 day default window.
- Used a uv path dependency rather than `sys.path` so the resolver is consumed as designed. The cost is the base-ref guard above.
