### PR TITLE
chore(devex): streamline codex commands

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,12 +1,12 @@
 developer_instructions = """
-Run commands that depend on PostHog's development environment through
-`bash "$(git rev-parse --show-toplevel)/.codex/with-flox" <command> [args...]`.
+Run commands that depend on PostHog's development environment from the repository
+root through `.codex/with-flox <command> [args...]`.
 This includes hogli, Python and uv, Node.js and pnpm, Rust and Go, and local-stack
 commands. Basic filesystem, Git, and GitHub commands can run directly. Never use
-a dependency executable inherited from another checkout. If the wrapper reports
-that setup or a dependency change needs elevated execution, rerun that same
-wrapper command with elevated permissions. Dependency changes also apply the
-existing dev sandbox.
+a dependency executable inherited from another checkout. Request elevated
+execution on the first attempt for environment preparation, dependency changes,
+and local-stack lifecycle commands. Dependency changes also apply the existing
+dev sandbox.
 """
 
 [sandbox_workspace_write]

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -2,4 +2,4 @@ version = 1
 name = "posthog"
 
 [setup]
-script = "bash .codex/with-flox --prepare true"
+script = ".codex/with-flox --prepare true"

--- a/.codex/with-flox
+++ b/.codex/with-flox
@@ -9,7 +9,7 @@ if [[ "${1:-}" == "--prepare" ]]; then
 fi
 
 if (($# == 0)); then
-    echo "usage: bash .codex/with-flox [--prepare] <command> [args...]" >&2
+    echo "usage: .codex/with-flox [--prepare] <command> [args...]" >&2
     exit 2
 fi
 
@@ -187,7 +187,7 @@ fi
 
 if [[ "$prepare" -eq 0 ]]; then
     if [[ ! -f "$env_file" ]]; then
-        echo "error: Codex environment is not prepared; run 'bash $repo_root/.codex/with-flox --prepare true'" >&2
+        echo "error: Codex environment is not prepared; run '$repo_root/.codex/with-flox --prepare true'" >&2
         exit 1
     fi
 
@@ -221,7 +221,7 @@ if [[ "$prepare" -eq 0 ]]; then
         cached_variables=$((cached_variables + 1))
     done < "$env_file"
     if [[ "$cached_variables" -eq 0 || "$cached_fingerprint" != "$(environment_fingerprint)" ]]; then
-        echo "error: Codex environment is stale; run 'bash $repo_root/.codex/with-flox --prepare true'" >&2
+        echo "error: Codex environment is stale; run '$repo_root/.codex/with-flox --prepare true'" >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Problem

- Follow-up to [fix(devex): make codex worktrees use local flox](https://github.com/PostHog/posthog/pull/70767): the environment is correct, but every wrapped command repeats a long repository-root path and predictably fails once before elevated work.

## Changes

- Make `.codex/with-flox` directly executable from the repository root.
- Request required elevation on the first attempt.
- Preserve environment fingerprinting and sandbox behavior.

## How did you test this code?

- `.codex/with-flox shellcheck .codex/with-flox`
- Direct Node and Python version checks
- `.codex/with-flox hogli ci:preflight --strict`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- Not needed; this only changes repository-local agent configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used the `/wt` skill. Metadata caching was benchmarked and rejected because it weakened stale-input detection without a clear performance win.