### PR TITLE
feat(billing): enforce api_queries_read_bytes quota

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -52,6 +52,7 @@ from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
 from posthog.event_usage import EventSource, get_request_analytics_properties, report_user_or_team_action
+from posthog.exceptions import QuotaLimitExceeded
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.apply_dashboard_filters import apply_dashboard_filters, apply_dashboard_variables
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -343,6 +344,9 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
             raise
         except ConcurrencyLimitExceeded as c:
             self._raise_concurrency_throttled(c)
+        except QuotaLimitExceeded:
+            # Expected while an org is over quota - a 402 the caller can act on, not error noise.
+            raise
         except Exception as e:
             capture_exception(e)
             raise

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -29,6 +29,15 @@ class QuotaLimitExceeded(APIException):
     default_detail = "Your organization reached its billing limit for this resource. Increase the limits in Billing settings, or ask an org admin to do so."
 
 
+class APIQueriesQuotaExceeded(QuotaLimitExceeded):
+    default_code = "api_queries_quota_exceeded"
+    default_detail = (
+        "Your organization has read more query data over the API than its plan includes for this billing period. "
+        "API queries will be available again when the period resets. "
+        "Upgrade your plan in Billing settings to restore access sooner, or ask an org admin to do so."
+    )
+
+
 class EnterpriseFeatureException(APIException):
     status_code = status.HTTP_402_PAYMENT_REQUIRED
     default_code = "payment_required"

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -107,6 +107,7 @@ from posthog.clickhouse.query_tagging import get_query_tag_value, is_api_key_acc
 from posthog.constants import AvailableFeature
 from posthog.errors import QueryErrorCategory, classify_query_error, clickhouse_error_type
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
+from posthog.exceptions import APIQueriesQuotaExceeded
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.access_controlled_resources import queried_access_controlled_resources
 from posthog.hogql_queries.insights.utils.breakdowns import has_multi_breakdown, has_single_breakdown
@@ -334,11 +335,14 @@ def shared_insights_execution_mode(
     older (or missing) recomputes synchronously — throttling forced recomputes without a
     separate clock.
 
-    Pass `team` to record when an over-quota organization's shared or embedded resources
-    trigger calculation: shared links are public, so this surface needs its own review
-    metrics before any enforcement decision.
+    Pass `team` so an organization over its API queries quota degrades to cached-only
+    results: shared links are public, and would otherwise let anyone keep triggering fresh
+    calculations for an over-quota org.
     """
     if team is not None and get_api_queries_quota_limited_until(team) is not None:
+        if settings.API_QUERIES_QUOTA_ENFORCEMENT_ENABLED:
+            API_QUERIES_QUOTA_LIMITED_COUNTER.labels(surface="shared", outcome="enforced").inc()
+            return SharedExecutionSettings(ExecutionMode.CACHE_ONLY_NEVER_CALCULATE, None)
         API_QUERIES_QUOTA_LIMITED_COUNTER.labels(surface="shared", outcome="observed").inc()
 
     if execution_mode == ExecutionMode.CALCULATE_BLOCKING_ALWAYS:
@@ -2065,7 +2069,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
     def get_api_queries_concurrency_limit(self):
         """
-        :return: None - no feature, 0 - rate limited, 1,3,<other> for actual concurrency limit
+        :return: None - no feature, 1,3,<other> for actual concurrency limit
         """
 
         # TODO - remove once no longer needed, as per https://posthog.slack.com/archives/C075D3C5HST/p1766275591753869
@@ -2075,33 +2079,37 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         if not settings.EE_AVAILABLE or not settings.API_QUERIES_ENABLED:
             return None
 
-        from posthog.constants import AvailableFeature
-
-        from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, list_limited_team_attributes
-
-        if self.team.api_token in list_limited_team_attributes(
-            QuotaResource.API_QUERIES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
-        ):
-            return 0
-
         feature = self.team.organization.get_available_feature(AvailableFeature.API_QUERIES_CONCURRENCY)
         return feature.get("limit") if feature else None
 
     def _check_api_queries_quota(self) -> None:
-        """Observe chargeable API queries while the organization is over its
+        """Reject chargeable API queries while the organization is over its
         api_queries_read_bytes quota.
 
-        Observe-only: the over-quota calculation is counted and tagged in the query log so
-        the would-be-limited fleet can be reviewed; nothing is blocked. Runs at calculation
-        time only, so cached results are never counted — the quota is about ClickHouse reads.
+        Runs at calculation time only, so cached results keep being served — the quota caps
+        ClickHouse reads, and serving cache reads nothing. Observe-only unless
+        API_QUERIES_QUOTA_ENFORCEMENT_ENABLED: an over-quota calculation is then counted and
+        tagged in the query log, but never blocked.
         """
         limited_until = get_api_queries_quota_limited_until(self.team)
         if limited_until is None:
             return
 
-        # Breadcrumb in the query log so the would-be-limited fleet is reviewable.
-        tag_queries(api_queries_over_quota=1)
-        API_QUERIES_QUOTA_LIMITED_COUNTER.labels(surface="api", outcome="observed").inc()
+        if not settings.API_QUERIES_QUOTA_ENFORCEMENT_ENABLED:
+            # Breadcrumb in the query log so the would-be-limited fleet is reviewable.
+            tag_queries(api_queries_over_quota=1)
+            API_QUERIES_QUOTA_LIMITED_COUNTER.labels(surface="api", outcome="observed").inc()
+            return
+
+        API_QUERIES_QUOTA_LIMITED_COUNTER.labels(surface="api", outcome="enforced").inc()
+        raise APIQueriesQuotaExceeded(
+            detail=(
+                "Your organization has read more query data over the API than its plan includes for this "
+                f"billing period. API queries will be available again after {limited_until:%Y-%m-%d %H:%M} UTC, "
+                "when the period resets. Upgrade your plan in Billing settings to restore access sooner, "
+                "or ask an org admin to do so."
+            )
+        )
 
     @abstractmethod
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -10,6 +10,7 @@ from unittest import mock
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
+from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
@@ -49,6 +50,7 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tags, reset_query_tags
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError
+from posthog.exceptions import APIQueriesQuotaExceeded
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.query_runner import (
@@ -1362,41 +1364,97 @@ class TestAPIQueriesQuotaLimiting(BaseTest):
 
     @parameterized.expand(
         [
-            # name, is_query_service, team_limited, expect_breadcrumb
-            ("over_quota_api_query_observed", True, True, True),
-            ("in_app_query_not_observed", False, True, False),
-            ("unlimited_team_not_observed", True, False, False),
+            # name, enforcement_enabled, is_query_service, team_limited, expect_rejection
+            ("enforced_api_query_rejected", True, True, True, True),
+            ("observe_only_query_still_runs", False, True, True, False),
+            ("in_app_query_unaffected", True, False, True, False),
+            ("unlimited_team_unaffected", True, True, False, False),
         ]
     )
-    def test_over_quota_queries_run_and_leave_review_breadcrumb(
-        self, _name: str, is_query_service: bool, team_limited: bool, expect_breadcrumb: bool
+    def test_quota_enforcement_matrix(
+        self,
+        _name: str,
+        enforcement_enabled: bool,
+        is_query_service: bool,
+        team_limited: bool,
+        expect_rejection: bool,
     ) -> None:
         if team_limited:
             self._limit_team()
         runner = self._make_runner(is_query_service=is_query_service)
 
-        response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+        with override_settings(API_QUERIES_QUOTA_ENFORCEMENT_ENABLED=enforcement_enabled):
+            if expect_rejection:
+                with self.assertRaises(APIQueriesQuotaExceeded):
+                    runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+            else:
+                response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+                assert isinstance(response, TheTestCachedBasicQueryResponse)
+                assert response.results
 
-        assert isinstance(response, TheTestCachedBasicQueryResponse)
-        assert response.results
-        assert (get_query_tags().api_queries_over_quota == 1) is expect_breadcrumb
+    def test_rejection_names_reset_date_and_upgrade_path(self) -> None:
+        limited_until = self._limit_team()
+        runner = self._make_runner(is_query_service=True)
+
+        with override_settings(API_QUERIES_QUOTA_ENFORCEMENT_ENABLED=True):
+            with self.assertRaises(APIQueriesQuotaExceeded) as ctx:
+                runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+
+        detail = str(ctx.exception.detail)
+        assert f"{datetime.fromtimestamp(limited_until, tz=UTC):%Y-%m-%d %H:%M} UTC" in detail
+        assert "Billing settings" in detail
+        assert ctx.exception.status_code == 402
+        assert ctx.exception.get_codes() == "api_queries_quota_exceeded"
 
     def test_fails_open_when_redis_unavailable(self) -> None:
         self._limit_team()
         runner = self._make_runner(is_query_service=True)
 
-        with mock.patch("ee.billing.quota_limiting.get_client", side_effect=ConnectionError("redis down")):
-            response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+        with override_settings(API_QUERIES_QUOTA_ENFORCEMENT_ENABLED=True):
+            with mock.patch("ee.billing.quota_limiting.get_client", side_effect=ConnectionError("redis down")):
+                response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
 
         assert isinstance(response, TheTestCachedBasicQueryResponse)
         assert response.results
 
-    def test_shared_surfaces_keep_their_mapping_while_observing(self) -> None:
+    def test_observe_mode_leaves_review_breadcrumb_in_query_tags(self) -> None:
         self._limit_team()
+        runner = self._make_runner(is_query_service=True)
 
-        result_mode, _cache_age = shared_insights_execution_mode(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, self.team)
+        response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
 
-        assert result_mode == ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+        assert isinstance(response, TheTestCachedBasicQueryResponse)
+        assert response.results
+        assert get_query_tags().api_queries_over_quota == 1
+
+    @parameterized.expand(
+        [
+            # name, enforcement_enabled, team_limited, expected_mode
+            ("enforced_degrades_to_cache_only", True, True, ExecutionMode.CACHE_ONLY_NEVER_CALCULATE),
+            (
+                "observe_only_keeps_shared_mapping",
+                False,
+                True,
+                ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+            ),
+            (
+                "unlimited_team_keeps_shared_mapping",
+                True,
+                False,
+                ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+            ),
+        ]
+    )
+    def test_shared_surfaces_degrade_to_cached_results(
+        self, _name: str, enforcement_enabled: bool, team_limited: bool, expected_mode: ExecutionMode
+    ) -> None:
+        if team_limited:
+            self._limit_team()
+
+        with override_settings(API_QUERIES_QUOTA_ENFORCEMENT_ENABLED=enforcement_enabled):
+            result_mode, _cache_age = shared_insights_execution_mode(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, self.team)
+
+        assert result_mode == expected_mode
 
 
 @pytest.mark.ee

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -943,6 +943,15 @@ KAFKA_PRODUCE_ACK_TIMEOUT_SECONDS = int(os.getenv("KAFKA_PRODUCE_ACK_TIMEOUT_SEC
 # if `true` we highly increase the rate limit on /query endpoint and limit the number of concurrent queries
 API_QUERIES_ENABLED = get_from_env("API_QUERIES_ENABLED", False, type_cast=str_to_bool)
 
+# Enforcement switch for the `api_queries_read_bytes` quota. When `false` (observe-only),
+# queries from organizations over the quota still run — we only count them in metrics and
+# tag them in the query log so the would-be-limited fleet can be reviewed. When `true`,
+# API queries from over-quota organizations are rejected and shared/embedded resources
+# degrade to serving cached results until the billing period resets.
+API_QUERIES_QUOTA_ENFORCEMENT_ENABLED = get_from_env(
+    "API_QUERIES_QUOTA_ENFORCEMENT_ENABLED", False, type_cast=str_to_bool
+)
+
 ####
 # /api/environments deprecation
 


### PR DESCRIPTION
> [!NOTE]
> Stack 3/3 (rollout). Stacked on #71746 (dry-run correctness), which stacks on #71745 (metrics). Merge those first — this PR's diff is only the enforcement layer.

## Problem

A small number of free organizations generate a hugely disproportionate share of ClickHouse read volume, typically a personal API key polling HogQL continuously for weeks, unnoticed.
With metering and observe-only metrics in place (#71745) and a reviewable dry-run (#71746), this layer adds the actual enforcement, still shipped dark.

It also retires the previous enforcement attempt, which turned out to be a silent no-op: `get_api_queries_concurrency_limit()` returned `0` for quota-limited teams, but `RateLimit.use()` treats `limit=0` as falsy and fell back to the default concurrency, so nothing was ever blocked.

## Changes

Everything is gated behind the new `API_QUERIES_QUOTA_ENFORCEMENT_ENABLED` setting (default off — behavior is identical to the observe-only layer until it's flipped):

```mermaid
flowchart LR
    A([API-key query]) --> Q{over quota?}
    S([shared link load]) --> Q
    Q -->|no| RUN[query runs]
    Q -->|"yes, observe-only (default)"| OBS[counter + query-log tag, query runs]
    Q -->|"yes, enforcement on"| ENF{surface}
    ENF -->|API| REJ[402 with reset date and upgrade path]
    ENF -->|shared| CACHE[serve cached results only]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,S phYellow;
    class Q,ENF phBlue;
    class REJ phRed;
    class RUN,OBS,CACHE phGray;
```

- With enforcement on, chargeable API-key queries from over-quota orgs are rejected at calculation time on both the sync and async (celery) paths with `APIQueriesQuotaExceeded` (402, subclass of `QuotaLimitExceeded`), whose message names the reset date (from the quota zset score, i.e. the billing period end) and the upgrade path. Cached results keep being served — the quota caps ClickHouse reads, and serving cache reads nothing.
- Shared/embedded surfaces (insights, dashboards, notebook inline queries) degrade to `CACHE_ONLY_NEVER_CALCULATE`, so public links can't keep burning reads for a limited org.
- The broken concurrency-0 branch is removed from `get_api_queries_concurrency_limit`; quota and concurrency are now separate concerns.
- `posthog/api/query.py` re-raises `QuotaLimitExceeded` explicitly so expected 402s don't flood error tracking.

> [!WARNING]
> This PR does not turn enforcement on anywhere. Flipping it on requires (1) the billing service giving free plans a finite `api_queries_read_bytes` allowance, (2) a manual review of the observe-only output (`update_billing_quotas --dry-run`, the `posthog_api_queries_quota_limited_total` counter, the `api_queries_over_quota` query-log tag), then (3) setting `API_QUERIES_QUOTA_ENFORCEMENT_ENABLED=1`. The 80% usage-warning emails are computed billing-service-side from the same usage key and need no wiring here.

## How did you test this code?

The sandbox this was authored in has no Postgres/ClickHouse/Redis, so I could not execute the suite locally — CI validates (the same final code was green on the pre-split branch). Tests in this layer extend the observe-only suite from #71745, each catching a regression nothing else covered:

- `test_quota_enforcement_matrix` — the enforced/observed/in-app/unlimited matrix; the enforced case is exactly the falsy-`limit=0` no-op bug this PR fixes, and the in-app and observe cases guard the "majority unaffected, dark by default" requirements.
- `test_rejection_names_reset_date_and_upgrade_path` — the user-facing 402 contract (reset date, guidance, error code).
- `test_fails_open_when_redis_unavailable` — now asserted with enforcement enabled: a Redis outage must never block queries even when the switch is on.
- `test_shared_surfaces_degrade_to_cached_results` — degrade only when limited and enforced; a bug degrading unlimited teams would break every shared dashboard.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No repo docs reference API query quotas today; user-facing quota docs live on posthog.com and only need updating when enforcement is actually enabled.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) from a written brief; Paul D'Ambra directed the work, including converting the original single PR into this three-layer stack (this PR was restacked onto #71746 and now carries only the enforcement diff; its final tree is identical to the previously CI-green single-PR state, plus the argparse fix from #71746).
Skills invoked: `/writing-tests`, `/improving-drf-endpoints`.
Key decisions: enforce at calculation time rather than request time so cached responses keep flowing to limited orgs; a dedicated `APIQueriesQuotaExceeded` subclass so callers and tests can match on the code; the broken concurrency-0 branch was removed rather than "fixed", since a working 0-limit would have produced a 15s retry loop ending in a misleading concurrency error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
