### PR TITLE
fix(personhog): remove obsolete mypy suppression

### DIFF
--- a/posthog/personhog_client/converters.py
+++ b/posthog/personhog_client/converters.py
@@ -68,7 +68,7 @@ def proto_person_to_model(
 
     obj = PersonModel(
         id=person.id,
-        uuid=uuid_mod.UUID(person.uuid) if person.uuid else None,  # type: ignore[misc]
+        uuid=uuid_mod.UUID(person.uuid) if person.uuid else None,
         team_id=person.team_id,
         properties=json.loads(person.properties) if person.properties else {},
         is_identified=person.is_identified,


### PR DESCRIPTION
## Problem

The repo-wide mypy check fails because a suppression on the personhog proto converter is no longer needed.

## Changes

- Remove the obsolete `type: ignore[misc]` comment.
- Preserve converter behavior.

## How did you test this code?

- `uv run mypy --cache-fine-grained .` passed across 14,037 source files.
- `./bin/hogli test posthog/personhog_client/test_converters.py` passed (18 tests).
- Targeted Ruff checks and `./bin/hogli ci:preflight --fix` passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes are needed for a type-check suppression cleanup.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex isolated this cleanup after the repository-wide mypy check for another PR exposed the existing failure. The `running-ci-preflight` skill was used. This remains separate from the feature PR so the original diff stays focused.