### PR TITLE
feat(mcp): add mcp-output-format flag for toon/json tool output

### DIFF
--- a/products/posthog_ai/eval_harness/README.md
+++ b/products/posthog_ai/eval_harness/README.md
@@ -81,6 +81,9 @@ Sandbox-only flags (`--provider`, `--max-sandboxes`, `--agent-runtime`, `--reaso
 `EXPORT_EVAL_RESULTS=1` additionally appends one structured JSON summary per experiment to `eval_results.jsonl`.
 The full plain-text run transcript is always written without this setting.
 
+`FEATURE_FLAG_OVERRIDES` (a JSON object of flag key → value) is merged into the harness-started MCP server's dev-only flag override seam, on top of the harness defaults.
+Use it to compare flag-gated MCP behavior across runs — e.g. `FEATURE_FLAG_OVERRIDES='{"mcp-output-format":"json"}' hogli evals cli_mcp` scores the agent against JSON tool output instead of the default TOON encoding.
+
 ### Codex runtime
 
 `--agent-runtime codex` runs the same agent-server with OpenAI's Codex harness instead of Claude, defaulting the model to `gpt-5.5`.

--- a/products/posthog_ai/eval_harness/harness/services.py
+++ b/products/posthog_ai/eval_harness/harness/services.py
@@ -100,6 +100,28 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
 
     api_url = live_server_url
 
+    # The MCP server evaluates feature flags via posthog-node, which is disabled
+    # here (no POSTHOG_ANALYTICS_* config), so every flag would resolve false.
+    # Force flag-gated behavior on for evals via the dev/test-only override seam
+    # (honored only when NODE_ENV is explicitly development/test — set below).
+    # product-data-catalog gates the metric-discovery section of the execute-sql
+    # description; the governed-metrics evals exercise that path.
+    flag_overrides: dict[str, object] = {"product-data-catalog": True}
+    # Merge overrides from the caller's environment on top, so an eval run can
+    # force flag-gated behavior without editing this file — e.g.
+    # FEATURE_FLAG_OVERRIDES='{"mcp-output-format":"json"}' to compare JSON vs
+    # TOON tool output.
+    caller_overrides = os.environ.get("FEATURE_FLAG_OVERRIDES")
+    if caller_overrides:
+        try:
+            parsed = json.loads(caller_overrides)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            flag_overrides.update(parsed)
+        else:
+            logger.warning("Ignoring FEATURE_FLAG_OVERRIDES: not a JSON object: %s", caller_overrides)
+
     # The Hono server reads config directly from process env — no wrangler
     # --var wiring needed. PORT picks the listen port; the dev:hono script
     # bundles via esbuild then spawns Node on the bundle.
@@ -111,13 +133,7 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
         "NODE_ENV": "development",
         "PORT": str(MCP_PORT),
         "HOST": "0.0.0.0",
-        # The MCP server evaluates feature flags via posthog-node, which is disabled
-        # here (no POSTHOG_ANALYTICS_* config), so every flag would resolve false.
-        # Force flag-gated behavior on for evals via the dev/test-only override seam
-        # (honored only when NODE_ENV is explicitly development/test — set above).
-        # product-data-catalog gates the metric-discovery section of the execute-sql
-        # description; the governed-metrics evals exercise that path.
-        "FEATURE_FLAG_OVERRIDES": json.dumps({"product-data-catalog": True}),
+        "FEATURE_FLAG_OVERRIDES": json.dumps(flag_overrides),
     }
 
     logger.info("Starting MCP server (Hono runtime) on port %d (API: %s)", MCP_PORT, api_url)

--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -42,6 +42,10 @@ function buildBaseProperties(
         $mcp_consumer: requestContext.mcpConsumer,
         $mcp_mode: requestContext.mode,
         $mcp_region: requestContext.region,
+        // Request-level default from the mcp-output-format flag, so a TOON-vs-JSON
+        // rollout can be sliced in analytics. Per-call overrides (--json,
+        // output_format, tool-level _meta) are not reflected here.
+        $mcp_default_output_format: state.defaultOutputFormat,
         ...(analyticsContext
             ? {
                   $mcp_organization_id: analyticsContext.organizationId,

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -1,12 +1,14 @@
 import type { GroupType } from '@/api/client'
 import { hasScope } from '@/lib/api'
 import { MCPClientProfile } from '@/lib/client-detection'
-import { isCloudApi, isLocalApi, PRODUCT_DATA_CATALOG_FLAG } from '@/lib/constants'
+import { isCloudApi, isLocalApi, MCP_OUTPUT_FORMAT_FLAG, PRODUCT_DATA_CATALOG_FLAG } from '@/lib/constants'
 import { buildMCPAnalyticsGroups } from '@/lib/posthog/analytics'
 import {
     type EvaluatedFlags,
     evaluateFeatureFlags,
     type FlagGroups,
+    type McpDefaultOutputFormat,
+    resolveDefaultOutputFormat,
     resolveFeatureFlagOverrides,
 } from '@/lib/posthog/flags'
 import type { RequestProperties } from '@/lib/request-properties'
@@ -31,6 +33,9 @@ export interface ResolvedState {
     context: Context
     useSingleExec: boolean
     toolFeatureFlags: EvaluatedFlags | undefined
+    // Default text encoding for tool results ('toon' unless the mcp-output-format
+    // flag says 'json'). Per-call output_format and tool-level _meta still win.
+    defaultOutputFormat: McpDefaultOutputFormat
     apiKeyScopes: string[]
     clientProfile: MCPClientProfile
     requestContext: MCPRequestContext
@@ -106,8 +111,11 @@ export class RequestStateResolver {
         }
 
         // PRODUCT_DATA_CATALOG_FLAG gates instructions content (the metric-discovery prompt
-        // section), not a tool, so the tool-definition scan can't discover it.
-        const allFlagKeys = [...new Set([...getRequiredFeatureFlags(), PRODUCT_DATA_CATALOG_FLAG])]
+        // section) and MCP_OUTPUT_FORMAT_FLAG gates result serialization — neither gates a
+        // tool, so the tool-definition scan can't discover them.
+        const allFlagKeys = [
+            ...new Set([...getRequiredFeatureFlags(), PRODUCT_DATA_CATALOG_FLAG, MCP_OUTPUT_FORMAT_FLAG]),
+        ]
 
         const flagAnalyticsContext = await reqCtx.safelyGetAnalyticsContext(context)
         const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
@@ -127,6 +135,7 @@ export class RequestStateResolver {
         // even when no catalog tool referenced it.
         const flagKeysForState = [...new Set([...allFlagKeys, ...Object.keys(overrides)])]
         const toolFeatureFlags = Object.fromEntries(flagKeysForState.map((k) => [k, mergedFlags[k]]))
+        const defaultOutputFormat = resolveDefaultOutputFormat(toolFeatureFlags)
 
         const oauthClientName = (await reqCtx.tokenCache.get('clientName')) || undefined
 
@@ -193,6 +202,7 @@ export class RequestStateResolver {
             context,
             useSingleExec,
             toolFeatureFlags,
+            defaultOutputFormat,
             apiKeyScopes,
             clientProfile,
             requestContext,

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -209,6 +209,7 @@ export class ToolExecutor {
                     toolMeta: tool._meta,
                     toolName: tool.name,
                     params: validation.data,
+                    defaultOutputFormat: state.defaultOutputFormat,
                     suppressStructuredContentForFormattedResults: state.clientProfile.isCliModeEnabled(),
                     distinctId,
                 })
@@ -311,6 +312,8 @@ export class ToolExecutor {
                       toolMeta: resolved._meta,
                       toolName: 'exec',
                       params: validation.data,
+                      // No defaultOutputFormat here: the exec handler already applied it
+                      // (via ExecToolOptions) and returns final serialized text.
                       suppressStructuredContentForFormattedResults: state.clientProfile.isCliModeEnabled(),
                       distinctId: undefined,
                   })
@@ -414,6 +417,7 @@ export class ToolExecutor {
             {
                 isInlineExecUiHost: state.clientProfile.isInlineExecUiHost(),
                 helpCatalog: this.instructionsBuilder.buildExecHelpCatalog(state),
+                defaultOutputFormat: state.defaultOutputFormat,
             }
         )
 

--- a/services/mcp/src/lib/build-tool-result.ts
+++ b/services/mcp/src/lib/build-tool-result.ts
@@ -1,6 +1,7 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 
 import { estimateTokens } from '@/lib/estimate-tokens'
+import type { McpDefaultOutputFormat } from '@/lib/posthog/flags'
 import { formatResponse } from '@/lib/response'
 import { POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY, POSTHOG_META_KEY } from '@/tools/types'
 import { APP_DATA_META_KEY, type AnalyticsMetadata, type WithAnalytics } from '@/ui-apps/types'
@@ -19,6 +20,12 @@ export interface BuildToolResultOptions {
     toolName: string
     /** The input params passed to the tool (used to read `output_format=json` escape hatch). */
     params: unknown
+    /**
+     * Request-level default text encoding, resolved from the `mcp-output-format`
+     * flag. Lowest precedence: an explicit caller `output_format` and a tool-level
+     * `outputFormat` in `_meta` both win. Unset behaves as 'toon'.
+     */
+    defaultOutputFormat?: McpDefaultOutputFormat | undefined
     /** Whether formatted-result text should win over structuredContent for this client profile. */
     suppressStructuredContentForFormattedResults?: boolean | undefined
     /**
@@ -106,6 +113,7 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
         toolMeta,
         toolName,
         params,
+        defaultOutputFormat,
         suppressStructuredContentForFormattedResults,
         forceUiDataToMeta,
         distinctId,
@@ -132,9 +140,11 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
 
     const resourceUri = toolMeta?.ui?.resourceUri
     const hasUiResource = !!resourceUri
-    // Caller's per-call `output_format` wins over the tool's YAML default in `_meta`.
+    // Caller's per-call `output_format` wins over the tool's YAML default in `_meta`,
+    // which wins over the flag-resolved request default.
     const callerOutputFormat = (params as { output_format?: 'optimized' | 'json' } | undefined)?.output_format
-    const effectiveOutputFormat = callerOutputFormat ?? toolMeta?.[POSTHOG_META_KEY]?.outputFormat
+    const effectiveOutputFormat =
+        callerOutputFormat ?? toolMeta?.[POSTHOG_META_KEY]?.outputFormat ?? defaultOutputFormat
     const useJson = effectiveOutputFormat === 'json'
     const callerWantsJson = callerOutputFormat === 'json'
 
@@ -150,7 +160,11 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
         }
     }
 
-    const text = formattedResults ?? (useJson ? JSON.stringify(rawResult) : formatResponse(rawResult))
+    // String results are already final text — JSON-stringifying them would wrap
+    // them in quotes (and double-encode strings that already carry JSON).
+    const text =
+        formattedResults ??
+        (isStringResult ? (rawResult as string) : useJson ? JSON.stringify(rawResult) : formatResponse(rawResult))
 
     // Inline-exec UI-app hosts always drop top-level structuredContent (routed to
     // `_meta` below); other coding-agent clients only drop it when a formatted table

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -25,3 +25,10 @@ export const MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
 // Gates the semantic layer (governed-metrics catalog) — no tool declares it, so it must be
 // joined into the evaluated flag set explicitly; instructions content branches on it.
 export const PRODUCT_DATA_CATALOG_FLAG = 'product-data-catalog'
+
+// Multivariate flag selecting the default text encoding for tool results: variant 'json'
+// switches the default from TOON to JSON; any other value keeps TOON. Like
+// PRODUCT_DATA_CATALOG_FLAG it gates serialization rather than a tool, so no tool declares
+// it and it must be joined into the evaluated flag set explicitly. See
+// `resolveDefaultOutputFormat` in lib/posthog/flags.
+export const MCP_OUTPUT_FORMAT_FLAG = 'mcp-output-format'

--- a/services/mcp/src/lib/posthog/flags.ts
+++ b/services/mcp/src/lib/posthog/flags.ts
@@ -1,3 +1,4 @@
+import { MCP_OUTPUT_FORMAT_FLAG } from '@/lib/constants'
 import { env } from '@/lib/env'
 
 import { getPostHogClient } from './client'
@@ -39,6 +40,21 @@ export async function evaluateFeatureFlags(
         result[key] = allFlags[key] as FlagValue
     }
     return result
+}
+
+/** Request-level default text encoding for tool results, resolved from {@link MCP_OUTPUT_FORMAT_FLAG}. */
+export type McpDefaultOutputFormat = 'toon' | 'json'
+
+/**
+ * Resolves the `mcp-output-format` flag into the default text encoding for tool
+ * results. Only the explicit `'json'` variant switches the default to JSON —
+ * anything else (unset flag, the `'toon'` variant, boolean `true` from local
+ * dev's enable-all, a failed evaluation) keeps TOON, so the flag fails safe to
+ * the shipped default. Per-call `output_format` and tool-level `outputFormat`
+ * in `_meta` both take precedence over this default.
+ */
+export function resolveDefaultOutputFormat(flags: EvaluatedFlags | undefined): McpDefaultOutputFormat {
+    return flags?.[MCP_OUTPUT_FORMAT_FLAG] === 'json' ? 'json' : 'toon'
 }
 
 // Env var (or Cloudflare var) holding a JSON object of flag overrides, e.g.

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -57,6 +57,13 @@ export interface ExecToolOptions {
      * re-homed onto `_meta`. Computed from the client profile at the call site.
      */
     isInlineExecUiHost?: boolean
+    /**
+     * Request-level default text encoding, resolved from the `mcp-output-format`
+     * flag at the call site. 'json' makes bare `call` (no `--json`) JSON-encode
+     * results; `--json`, a stray `output_format`, and tool-level `outputFormat`
+     * in `_meta` still win. Unset behaves as 'toon'.
+     */
+    defaultOutputFormat?: 'toon' | 'json'
 }
 
 function makeExecSchema(commandReference: string): z.ZodObject<{ command: z.ZodString }> {
@@ -486,7 +493,7 @@ export function createExecTool(
                     const useJson =
                         forceJson ||
                         strayOutputFormat === 'json' ||
-                        tool._meta?.[POSTHOG_META_KEY]?.outputFormat === 'json'
+                        (tool._meta?.[POSTHOG_META_KEY]?.outputFormat ?? options.defaultOutputFormat) === 'json'
                     // Fold the flag back into the tool's own `output_format` field when it has
                     // one: formatter-toggle tools then skip the server-side formatter (clean raw
                     // JSON, no `__formatted_results_override` duplication), and tools where the
@@ -548,6 +555,7 @@ export function createExecTool(
                                 toolMeta: tool._meta,
                                 toolName: tool.name,
                                 params: useJson ? { ...input, output_format: 'json' } : input,
+                                defaultOutputFormat: options.defaultOutputFormat,
                                 // Inline-exec UI-app hosts (PostHog Code, Claude Code, Cowork)
                                 // surface `structuredContent` to the model in preference to the
                                 // text content, which would bury the compact formatted table

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -147,7 +147,8 @@ export type PostHogToolMeta = {
      * Output format for the tool response.
      * `'optimized'` surfaces the LLM-friendly formatter output (from `ee/hogai/context/insight/format/`)
      * via `formatted_results` when available; `'json'` returns raw JSON-stringified content. When unset,
-     * the text content is TOON-encoded by default.
+     * the text content follows the request-level default — TOON, unless the `mcp-output-format` flag
+     * resolves to `'json'` (see `resolveDefaultOutputFormat` in `lib/posthog/flags`).
      */
     outputFormat?: 'optimized' | 'json'
 }

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -30,6 +30,7 @@ function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
         } as any,
         useSingleExec: true,
         toolFeatureFlags: undefined,
+        defaultOutputFormat: 'toon',
         apiKeyScopes: [],
         clientProfile: {} as any,
         requestContext: {

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -5,7 +5,10 @@ const { mockSessionStore, mockTokenStore } = vi.hoisted(() => ({
     mockTokenStore: new Map<string, unknown>(),
 }))
 
-vi.mock('@/lib/posthog/flags', () => ({
+vi.mock('@/lib/posthog/flags', async (importOriginal) => ({
+    // Keep pure helpers (e.g. resolveDefaultOutputFormat) real; stub only the
+    // posthog-node-backed evaluation.
+    ...(await importOriginal<typeof import('@/lib/posthog/flags')>()),
     evaluateFeatureFlags: vi.fn(async () => ({})),
     resolveFeatureFlagOverrides: vi.fn(() => ({})),
 }))

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -47,6 +47,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         } as any,
         useSingleExec: false,
         toolFeatureFlags: undefined,
+        defaultOutputFormat: 'toon',
         apiKeyScopes: [],
         clientProfile: {
             capabilities: { supportsInstructions: true },

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -73,6 +73,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         } as any,
         useSingleExec: false,
         toolFeatureFlags: undefined,
+        defaultOutputFormat: 'toon',
         apiKeyScopes: [],
         clientProfile: {
             capabilities: { supportsInstructions: true },

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -50,6 +50,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         } as any,
         useSingleExec: false,
         toolFeatureFlags: undefined,
+        defaultOutputFormat: 'toon',
         apiKeyScopes: [],
         clientProfile: {
             capabilities: { supportsInstructions: true },

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 
 vi.mock('@/resources/internals', () => ({
     fetchContextMillResources: vi.fn().mockRejectedValue(new Error('mocked')),
@@ -46,6 +47,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         } as any,
         useSingleExec: false,
         toolFeatureFlags: undefined,
+        defaultOutputFormat: 'toon',
         apiKeyScopes: [],
         clientProfile: {
             capabilities: { supportsInstructions: true },
@@ -136,6 +138,52 @@ describe('ToolExecutor', () => {
 
             expect(result).not.toBeNull()
             expect(result.content).not.toBeNull()
+        })
+
+        it('JSON-encodes a tools-mode result when state defaultOutputFormat is json', async () => {
+            // The mcp-output-format flag must reach buildToolResultPayload through
+            // callTool; dropping the threading leaves the flag evaluated but ignored.
+            vi.spyOn(catalog, 'getToolByName').mockReturnValueOnce({
+                name: 'fake-format-tool',
+                base: {
+                    schema: z.object({}),
+                    handler: vi.fn().mockResolvedValue({ rows: [{ a: 1 }, { a: 2 }] }),
+                },
+            } as any)
+
+            const result = (await executor.handleToolCall(
+                { name: 'fake-format-tool', arguments: {} },
+                makeState([{ name: 'fake-format-tool' }], { defaultOutputFormat: 'json' })
+            )) as any
+
+            expect(JSON.parse(result.content[0].text)).toEqual({ rows: [{ a: 1 }, { a: 2 }] })
+        })
+
+        it('JSON-encodes an exec call result when state defaultOutputFormat is json', async () => {
+            // Same guard for single-exec mode, where the format rides on ExecToolOptions.
+            // Real catalog name (the instructions builder resolves its definition), fake handler.
+            const fakeTool = {
+                name: 'organization-get',
+                title: 'Organization get',
+                description: 'returns an object',
+                schema: z.object({}),
+                scopes: [],
+                annotations: {
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: false,
+                    readOnlyHint: true,
+                },
+                handler: async () => ({ rows: [{ a: 1 }, { a: 2 }] }),
+            }
+
+            const result = (await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'call organization-get {}' } },
+                makeState([fakeTool] as any, { useSingleExec: true, defaultOutputFormat: 'json' })
+            )) as any
+
+            expect(result.isError).toBeFalsy()
+            expect(JSON.parse(result.content[0].text)).toEqual({ rows: [{ a: 1 }, { a: 2 }] })
         })
 
         it('accepts cached exec calls even when the current session is in tools mode', async () => {

--- a/services/mcp/tests/unit/build-tool-result.test.ts
+++ b/services/mcp/tests/unit/build-tool-result.test.ts
@@ -210,6 +210,56 @@ describe('buildToolResultPayload — non-query use cases', () => {
             _posthogUrl: 'http://...',
         })
     })
+
+    it('JSON-encodes rawResult when defaultOutputFormat=json and neither caller nor tool sets a format', () => {
+        // The mcp-output-format flag resolves to the request-level default; dropping the
+        // fallback in buildToolResultPayload would make the flag a silent no-op.
+        const payload = buildToolResultPayload({
+            handlerResult: { results: [{ a: 1 }], _posthogUrl: 'http://...' },
+            toolMeta: undefined,
+            toolName: 'query-logs',
+            params: {},
+            defaultOutputFormat: 'json',
+            suppressStructuredContentForFormattedResults: true,
+            distinctId: undefined,
+        })
+
+        expect(JSON.parse(payload.content[0]!.text)).toEqual({
+            results: [{ a: 1 }],
+            _posthogUrl: 'http://...',
+        })
+    })
+
+    it('passes string handler results through verbatim even when defaultOutputFormat=json', () => {
+        // Exec and execute-sql return pre-serialized text; JSON-quoting it under a
+        // json rollout would double-encode exec results and mangle SQL tables.
+        const payload = buildToolResultPayload({
+            handlerResult: '{"rows":[1]}',
+            toolMeta: undefined,
+            toolName: 'exec',
+            params: {},
+            defaultOutputFormat: 'json',
+            suppressStructuredContentForFormattedResults: true,
+            distinctId: undefined,
+        })
+
+        expect(payload.content[0]!.text).toBe('{"rows":[1]}')
+    })
+
+    it('formatted override still wins when defaultOutputFormat=json', () => {
+        // A json rollout must not regress optimized tools to raw JSON dumps.
+        const payload = buildToolResultPayload({
+            handlerResult: queryTrendsHandlerResult(),
+            toolMeta: queryTrendsToolMeta,
+            toolName: 'query-trends',
+            params: {},
+            defaultOutputFormat: 'json',
+            suppressStructuredContentForFormattedResults: false,
+            distinctId: 'd',
+        })
+
+        expect(payload.content[0]!.text).toBe(FORMATTED_TABLE)
+    })
 })
 
 describe('isToolCallPayload — nominal brand', () => {

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -173,6 +173,26 @@ describe('exec tool', () => {
             expect(parsed).toEqual({ id: 1, name: 'test', items: [{ a: 1 }, { a: 2 }] })
         })
 
+        it('returns JSON without --json when defaultOutputFormat option is json (mcp-output-format flag)', async () => {
+            const exec = createExec([makeMockTool()], undefined, { defaultOutputFormat: 'json' })
+            const result = await exec.handler(mockContext, { command: 'call mock-tool' })
+            const parsed = JSON.parse(result as string)
+            expect(parsed).toEqual({ id: 1, name: 'test', items: [{ a: 1 }, { a: 2 }] })
+        })
+
+        it('keeps formatted output when tool meta outputFormat=optimized despite defaultOutputFormat=json', async () => {
+            const tool = makeMockTool({
+                _meta: { [POSTHOG_META_KEY]: { outputFormat: 'optimized' } },
+                handler: async () => ({
+                    results: [{ data: [1, 2, 3], count: 6 }],
+                    [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: 'Date|count\n2026-05-07|6',
+                }),
+            })
+            const exec = createExec([tool], undefined, { defaultOutputFormat: 'json' })
+            const result = await exec.handler(mockContext, { command: 'call mock-tool' })
+            expect(result).toBe('Date|count\n2026-05-07|6')
+        })
+
         it('returns ONLY the formatted table when result has __formatted_results_override and mode is optimized', async () => {
             const tool = makeMockTool({
                 handler: async () => ({

--- a/services/mcp/tests/unit/feature-flag-overrides.test.ts
+++ b/services/mcp/tests/unit/feature-flag-overrides.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { resolveFeatureFlagOverrides } from '@/lib/posthog/flags'
+import { MCP_OUTPUT_FORMAT_FLAG } from '@/lib/constants'
+import { resolveDefaultOutputFormat, resolveFeatureFlagOverrides } from '@/lib/posthog/flags'
 
 describe('resolveFeatureFlagOverrides', () => {
     const ORIG_OVERRIDES = process.env.FEATURE_FLAG_OVERRIDES
@@ -52,5 +53,24 @@ describe('resolveFeatureFlagOverrides', () => {
 
     it('returns an empty object when nothing is set', () => {
         expect(resolveFeatureFlagOverrides()).toEqual({})
+    })
+})
+
+describe('resolveDefaultOutputFormat', () => {
+    // Only the explicit 'json' variant may switch the default: inverting the
+    // fail-safe would flip every tool result to JSON whenever flag evaluation
+    // fails or local dev's enable-all returns booleans.
+    it.each([
+        ['json', 'json'],
+        ['toon', 'toon'],
+        [true, 'toon'],
+        [false, 'toon'],
+    ] as const)('resolves flag value %j to %s', (flagValue, expected) => {
+        expect(resolveDefaultOutputFormat({ [MCP_OUTPUT_FORMAT_FLAG]: flagValue })).toBe(expected)
+    })
+
+    it('falls back to toon when flags are missing or the key is unset', () => {
+        expect(resolveDefaultOutputFormat(undefined)).toBe('toon')
+        expect(resolveDefaultOutputFormat({})).toBe('toon')
     })
 })


### PR DESCRIPTION
## TL;DR

TOON ([toonformat.dev](https://toonformat.dev/)) is already the default text encoding for MCP tool results. What was missing is control over it: this PR adds a `mcp-output-format` feature flag that can switch the default to JSON per user/org, an analytics property to slice a rollout by format, and an eval-harness seam to score agents against either format.

ELI5: our MCP server answers agents in a compact table-like format (TOON) instead of JSON to save tokens. That choice was hardcoded. Now a feature flag can flip it, so we can kill-switch it or A/B it and measure whether TOON actually helps.

## Problem

MCP tool results are TOON-encoded by default, with JSON only reachable per call (`output_format=json`, `--json`) or per tool (YAML `use_optimized_output`). There is no central control of the default, so no kill-switch if TOON hurts a client and no way to A/B TOON vs JSON on live traffic or in evals.

## Changes

- New multivariate flag `mcp-output-format`, evaluated once per request alongside the existing flag batch. The `json` variant flips the default encoding to JSON. Anything else (the `toon` variant, booleans, an unset flag, a failed evaluation) keeps TOON, so nothing changes until the flag is created.
- Precedence is unchanged: caller `output_format` beats tool-level `_meta.outputFormat` beats the flag default. Optimized formatted tables keep winning.
- Both dispatch paths honor it: tools mode via `buildToolResultPayload`, single-exec mode via `ExecToolOptions.defaultOutputFormat`.
- `$mcp_default_output_format` is stamped on MCP analytics events.
- Hardening found along the way: `buildToolResultPayload` no longer JSON-stringifies string handler results. Pre-serialized exec output would have been double-encoded under a json default.
- Eval harness: caller-provided `FEATURE_FLAG_OVERRIDES` now merges into the harness-started MCP server env instead of being clobbered, so `FEATURE_FLAG_OVERRIDES='{"mcp-output-format":"json"}' hogli evals cli_mcp` scores agents against JSON output for comparison with a default (TOON) run.

## How did you test this code?

- `services/mcp` unit and hono vitest suites pass locally. The one failing test on my machine (`tests/integration/manifest.test.ts`) fetches GitHub releases over the network and fails identically on a clean tree. `tsgo --noEmit` error count matches the clean-tree baseline, and `ruff` is clean on the harness change.
- New tests, each pinned to a regression: the pure flag-value mapping (an inverted fail-safe would flip all prod output to JSON on a flag-eval blip), the `buildToolResultPayload` fallback and its precedence over formatted tables, string passthrough (double-encoding guard), the exec `call` path with and without per-tool `optimized` meta, and executor threading in both modes (a flag that evaluates but never reaches the serializer is exactly how this would ship dead).
- Not run: the sandboxed agent evals (`hogli evals cli_mcp`). They need Docker, Braintrust, and LLM gateway keys that this environment does not have. The comparison command is documented in the eval harness README.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `products/posthog_ai/eval_harness/README.md` with the `FEATURE_FLAG_OVERRIDES` passthrough. No page under `docs/` documents MCP output encoding today.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via a PostHog Code cloud task, directed by the assignee. Skills invoked: /writing-tests. Key decision: the request was to add a flag enabling TOON output, but TOON turned out to already be the unconditional default, so the flag became a variant-based format selector that fails safe to TOON (no behavior change until the flag exists, kill-switch and A/B in both directions). `callExecTool` deliberately does not pass the default into `buildToolResultPayload` since the exec handler already applied it; a double-encoding test failure surfaced that.

**Why:** enable measuring whether TOON output improves MCP agent performance vs JSON, and keep a kill-switch if it does not.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
