### PR TITLE
revert: restore archive-completeness check in the MCP manifest test

### DIFF
--- a/services/mcp/tests/integration/manifest.test.ts
+++ b/services/mcp/tests/integration/manifest.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { fetchContextMillResources, loadManifestFromArchive } from '@/resources/internals'
 
 describe('Context-Mill Manifest Integration', () => {
-    it('should fetch, unzip, and validate available resources from GitHub releases', async () => {
+    it('should fetch, unzip, and validate the manifest from GitHub releases', async () => {
         const archive = await fetchContextMillResources()
 
         // Verify archive is not empty
@@ -16,19 +16,19 @@ describe('Context-Mill Manifest Integration', () => {
         expect(validatedManifest.version).toBe('1.0')
         expect(Array.isArray(validatedManifest.resources)).toBe(true)
 
-        // The manifest may include resources that are not part of the aggregate archive.
-        const availableResources = validatedManifest.resources.filter((entry) => !entry.file || archive[entry.file])
+        // Verify we have actual resources
+        expect(validatedManifest.resources.length).toBeGreaterThan(0)
 
-        // Verify the archive contains actual resources
-        expect(availableResources.length).toBeGreaterThan(0)
-
-        // Verify each available resource has required fields
-        for (const entry of availableResources) {
+        // Verify each resource has required fields and its file exists in archive
+        for (const entry of validatedManifest.resources) {
             expect(entry.id).toBeTruthy()
             expect(entry.name).toBeTruthy()
             expect(entry.resource).toBeTruthy()
             expect(entry.resource.mimeType).toBeTruthy()
             expect(entry.resource.text).toBeTruthy()
+            if (entry.file) {
+                expect(archive[entry.file]).toBeTruthy()
+            }
         }
     }, 30000)
 })


### PR DESCRIPTION
Reverts test updated in [#248](https://github.com/PostHog/context-mill/pull/248). Fixed at source (context mill)