### PR TITLE
fix(mssql): treat Azure SQL firewall block as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -30,12 +30,21 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mssql.mssq
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
+_FIREWALL_BLOCKED_ERROR = (
+    "Your SQL Server's firewall is blocking PostHog. Add a firewall rule allowing PostHog's IP "
+    "addresses to reach the server (on Azure SQL, use the portal or sp_set_firewall_rule), then "
+    "try again. New rules can take a few minutes to take effect."
+)
+
 MSSQLErrors = {
     # SQL Server error 18456 is an authentication failure (wrong username/password, or the login is
     # disabled), not a problem with the database field. Surface the same wording the sibling SQL
     # sources use and match the stable prefix, not the volatile "'<username>'." that follows it.
     "Login failed for user": "Invalid user or password",
     "Adaptive Server is unavailable or does not exist": "Could not connect to SQL server - check server host and port",
+    # Azure SQL error 40615 — the server-level firewall rejected the connecting client IP. The full
+    # message echoes the server name and client IP, so match the stable, distinctive phrase instead.
+    "is not allowed to access the server": _FIREWALL_BLOCKED_ERROR,
     "connection timed out": "Could not connect to SQL server - check server firewall settings",
 }
 
@@ -54,6 +63,11 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
+            # Azure SQL error 40615 — the server-level firewall rejected PostHog's client IP. This
+            # also surfaces "Adaptive Server connection failed" below, but that generic entry has no
+            # message; keep this first so the actionable firewall guidance wins. Match the stable
+            # phrase, not the volatile server name / client IP the rest of the message echoes.
+            "is not allowed to access the server": _FIREWALL_BLOCKED_ERROR,
             "Adaptive Server connection failed": None,
             # pymssql DB-Lib error 20009 — the server host can't be reached for the whole
             # connection attempt. On a managed instance this is a persistent connectivity issue

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -21,7 +21,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mssql.mssq
     retry_on_deadlock,
     retry_on_transient_connection_error,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.mssql.source import MSSQLSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.mssql.source import (
+    _FIREWALL_BLOCKED_ERROR,
+    MSSQLSource,
+)
 from products.warehouse_sources.backend.types import IncrementalFieldType
 
 
@@ -590,6 +593,23 @@ class TestMSSQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Azure SQL error 40615 — the server firewall rejected the client IP. Redacted shape;
+            # the server name / client IP are volatile, the matched phrase is not.
+            "Cannot open server 'example' requested by the login. Client with IP address "
+            "'203.0.113.10' is not allowed to access the server.",
+        ],
+    )
+    def test_firewall_block_is_non_retryable(self, error_msg):
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        matches = [msg for pattern, msg in non_retryable.items() if pattern in error_msg]
+        assert matches, error_msg
+        # The actionable firewall guidance must win over the generic catch-all, so the first match
+        # can't be the message-less entry.
+        assert matches[0] is not None
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Real pymssql MSSQLDatabaseException for SQL Server error 229 on a table.
             "SQL Server message 229, severity 14, state 5, procedure b'', line 1:\n"
             "b\"The SELECT permission was denied on the object 'ExistenciasProductoMagiQ', "
@@ -660,6 +680,30 @@ class TestMSSQLSourceNonRetryableErrors:
 
         non_retryable = MSSQLSource().get_non_retryable_errors()
         assert any(pattern in str(exc_info.value) for pattern in non_retryable.keys())
+
+
+class TestMSSQLSourceValidateCredentials:
+    @pytest.fixture
+    def source(self):
+        return MSSQLSource()
+
+    def test_firewall_block_returns_actionable_message_without_capturing(self, source, mocker):
+        capture = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mssql.source.capture_exception"
+        )
+        mocker.patch.object(source, "is_database_host_valid", return_value=(True, None))
+        # Redacted Azure SQL error 40615 — real server name and client IP are volatile.
+        firewall_error = pymssql.OperationalError(
+            "Cannot open server 'example' requested by the login. Client with IP address "
+            "'203.0.113.10' is not allowed to access the server."
+        )
+        mocker.patch.object(source, "get_schemas", side_effect=firewall_error)
+
+        valid, error = source.validate_credentials(_make_config(), team_id=1)
+
+        assert valid is False
+        assert error == _FIREWALL_BLOCKED_ERROR
+        capture.assert_not_called()
 
 
 class TestIsTransientConnectionError:


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError` from the MSSQL data-warehouse source: Azure SQL error **40615**, `Cannot open server '<redacted>' requested by the login. Client with IP address '<redacted>' is not allowed to access the server.` The server-level firewall rejected the connecting client IP.

This is a customer config issue. Retrying can't fix it. The customer has to allow PostHog's IP addresses through their Azure SQL firewall.

The event fired from the schema-discovery path (`validate_credentials`). That path matches errors against a small `MSSQLErrors` dict that didn't recognize 40615, so the firewall block fell through to `capture_exception` (error-tracking noise) and returned a generic "Could not connect to MS SQL. Please check all connection details are valid." with no hint about the real cause.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f6c46-7feb-78e1-99c1-3ef366bfaa65

## Changes

Recognize the stable phrase `is not allowed to access the server` (Azure SQL 40615) in the MSSQL source:

- **Validation** (`MSSQLErrors`): returns actionable guidance instead of the generic message, and no longer captures it as an unexpected error.
- **Sync** (`get_non_retryable_errors`): the error was already non-retryable via the generic `Adaptive Server connection failed` catch-all (which carries no message), but now surfaces the actionable firewall guidance. The new entry is placed first so it wins the friendly-message lookup.

Both share one message constant. The match is on the stable phrase only, not the volatile server name or client IP the rest of the message echoes.

> [!NOTE]
> Decision: user/upstream config error, so it belongs in the non-retryable set rather than being a code bug to fix. The connectivity itself was already non-retryable during sync; the gap was the noisy, unhelpful validation path.

## How did you test this code?

Automated tests (all run locally, `uv run pytest` on the mssql test file, 91 passed):

- `TestMSSQLSourceValidateCredentials::test_firewall_block_returns_actionable_message_without_capturing` — guards the observed regression: a firewall `OperationalError` during validation returns the actionable message and does not call `capture_exception`.
- `TestMSSQLSourceNonRetryableErrors::test_firewall_block_is_non_retryable` — a firewall-only message (without the generic `Adaptive Server connection failed` text) is classified non-retryable, and the actionable message wins over the message-less catch-all.

Both use redacted, non-customer values (a placeholder server name and a `203.0.113.0/24` documentation IP).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the issue via the PostHog error-tracking MCP tools, traced the capture to `validate_credentials` in the MSSQL source, and classified it as a user/upstream config error. Invoked `/writing-tests` before adding tests. Chose to match the stable phrase `is not allowed to access the server` rather than the error code or the volatile server/IP fragments.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
