### PR TITLE
chore(ai-observability): document allowed characters for $ai_session_id

### DIFF
--- a/docs/onboarding/ai-observability/_snippets/trace-event.tsx
+++ b/docs/onboarding/ai-observability/_snippets/trace-event.tsx
@@ -52,6 +52,10 @@ export const TraceEvent = (): JSX.Element => {
                                     whatever grouping makes sense for your application (user sessions, workflows,
                                     conversations, or other logical boundaries).
                                     <br />
+                                    Must contain only letters, numbers, and special characters: <code>-</code>,{' '}
+                                    <code>_</code>, <code>~</code>, <code>.</code>, <code>@</code>, <code>(</code>,{' '}
+                                    <code>)</code>, <code>!</code>, <code>'</code>, <code>:</code>, <code>|</code>
+                                    <br />
                                     Example: <code>session-abc-123</code>, <code>conv-user-456</code>
                                 </p>
                             </td>


### PR DESCRIPTION
## Problem

The AI observability trace event onboarding snippet documents the allowed character set for `$ai_trace_id`, but the `$ai_session_id` entry right below it had no equivalent guidance. Since this snippet renders on the traces, generations, spans, and embeddings docs pages, users setting a custom session ID had no way to know which characters are safe.

## Changes

Added the same "must contain only letters, numbers, and special characters" line to the `$ai_session_id` row, mirroring the `$ai_trace_id` entry exactly.

## How did you test this code?

Docs-only content change to a single onboarding snippet. No automated tests were run. I did not manually render the onboarding flow. The edit mirrors the existing, already-shipped `$ai_trace_id` markup verbatim.

## Docs update

Companion to posthog.com PR [#18603](https://github.com/PostHog/posthog.com/pull/18603), which adds the same guidance to the Sessions doc prose.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) at a user's request from a Slack thread. The user asked to replicate the `$ai_trace_id` special-character guidance for `$ai_session_id` across the AI observability docs; this snippet is the shared source for the rendered property tables, so the change belongs here in the monorepo.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784228960193579)*
