### PR TITLE
feat(aio): let users set an existing key as the active eval key

### DIFF
--- a/products/ai_observability/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/ai_observability/frontend/settings/LLMProviderKeysSettings.tsx
@@ -754,14 +754,19 @@ export function LLMProviderKeysSettings(): JSX.Element {
     const {
         providerKeys,
         providerKeysLoading,
+        evaluationConfig,
         evaluationConfigLoading,
         editingKey,
         validatingKeyId,
+        settingActiveKeyId,
         keyToDelete,
         dependentConfigs,
         dependentConfigsLoading,
     } = useValues(llmProviderKeysLogic)
-    const { setNewKeyModalOpen, validateProviderKey, setEditingKey, setKeyToDelete } = useActions(llmProviderKeysLogic)
+    const { setNewKeyModalOpen, validateProviderKey, setEditingKey, setKeyToDelete, setActiveKey } =
+        useActions(llmProviderKeysLogic)
+
+    const activeKeyId = evaluationConfig?.active_provider_key?.id ?? null
     const restrictionReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
@@ -775,7 +780,14 @@ export function LLMProviderKeysSettings(): JSX.Element {
                 <div className="flex items-center gap-2">
                     <IconKey className="text-muted" />
                     <div>
-                        <span className="font-medium">{key.name}</span>
+                        <div className="flex items-center gap-2">
+                            <span className="font-medium">{key.name}</span>
+                            {key.id === activeKeyId && (
+                                <Tooltip title="Evaluations without a pinned model use this key.">
+                                    <LemonTag type="success">Active</LemonTag>
+                                </Tooltip>
+                            )}
+                        </div>
                         {key.error_message && (key.state === 'invalid' || key.state === 'error') && (
                             <div className="text-xs text-danger mt-0.5">{key.error_message}</div>
                         )}
@@ -823,9 +835,24 @@ export function LLMProviderKeysSettings(): JSX.Element {
         {
             title: '',
             key: 'actions',
-            width: 150,
+            width: 280,
             render: (_, key) => (
                 <div className="flex gap-1">
+                    {key.id !== activeKeyId && (
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            loading={settingActiveKeyId === key.id}
+                            onClick={() => setActiveKey(key.id)}
+                            disabledReason={
+                                restrictionReason ??
+                                (key.state !== 'ok' ? 'Validate this key before setting it as active' : undefined)
+                            }
+                            tooltip="Use this key for evaluations that don't pin their own model"
+                        >
+                            Set as active
+                        </LemonButton>
+                    )}
                     <LemonButton
                         size="small"
                         type="secondary"

--- a/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
@@ -212,6 +212,7 @@ export interface llmProviderKeysLogicValues {
     providerKeys: LLMProviderKey[]
     providerKeysLoading: boolean
     requiresProviderKey: boolean
+    settingActiveKeyId: string | null
     trialEvalLimit: number
     trialEvalsRemaining: number
     trialEvalsUsed: number
@@ -407,6 +408,9 @@ export interface llmProviderKeysLogicActions {
     setNewlyCreatedKey: (key: LLMProviderKey | null) => {
         key: LLMProviderKey | null
     }
+    setActiveKey: (id: string) => {
+        id: string
+    }
     updateProviderKey: ({ id, payload }: { id: string; payload: UpdateLLMProviderKeyPayload }) => {
         id: string
         payload: UpdateLLMProviderKeyPayload
@@ -484,6 +488,7 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
         setNewlyCreatedKey: (key: LLMProviderKey | null) => ({ key }),
         confirmAssignKey: (evaluationIds: string[], enable: boolean) => ({ evaluationIds, enable }),
         dismissAssignKey: true,
+        setActiveKey: (id: string) => ({ id }),
     }),
 
     reducers({
@@ -505,6 +510,14 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                 validateProviderKey: (_, { id }) => id,
                 validateProviderKeySuccess: () => null,
                 validateProviderKeyFailure: () => null,
+            },
+        ],
+        settingActiveKeyId: [
+            null as string | null,
+            {
+                setActiveKey: (_, { id }) => id,
+                loadEvaluationConfigSuccess: () => null,
+                loadEvaluationConfigFailure: () => null,
             },
         ],
         preValidationResult: [
@@ -808,6 +821,25 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                 lemonToast.error('Failed to assign key to evaluations')
             }
             actions.setNewlyCreatedKey(null)
+        },
+        setActiveKey: async ({ id }) => {
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId) {
+                return
+            }
+            try {
+                // nosemgrep: prefer-codegen-api
+                await api.create(
+                    `/api/environments/${teamId}/llm_analytics/evaluation_config/set_active_key/`,
+                    { key_id: id }
+                )
+                lemonToast.success('Active key updated. Evaluations will now use this key.')
+            } catch (error) {
+                const detail = error instanceof ApiError ? error.detail : null
+                lemonToast.error(`Failed to set active key: ${detail || 'Unknown error'}`)
+            }
+            // Reload either way: on success to reflect the new active key, on failure to clear the spinner.
+            actions.loadEvaluationConfig()
         },
     })),
 

--- a/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
@@ -829,10 +829,9 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
             }
             try {
                 // nosemgrep: prefer-codegen-api
-                await api.create(
-                    `/api/environments/${teamId}/llm_analytics/evaluation_config/set_active_key/`,
-                    { key_id: id }
-                )
+                await api.create(`/api/environments/${teamId}/llm_analytics/evaluation_config/set_active_key/`, {
+                    key_id: id,
+                })
                 lemonToast.success('Active key updated. Evaluations will now use this key.')
             } catch (error) {
                 const detail = error instanceof ApiError ? error.detail : null

--- a/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
@@ -396,6 +396,9 @@ export interface llmProviderKeysLogicActions {
             api_version?: string
         }
     }
+    setActiveKey: (id: string) => {
+        id: string
+    }
     setEditingKey: (key: LLMProviderKey | null) => {
         key: LLMProviderKey | null
     }
@@ -407,9 +410,6 @@ export interface llmProviderKeysLogicActions {
     }
     setNewlyCreatedKey: (key: LLMProviderKey | null) => {
         key: LLMProviderKey | null
-    }
-    setActiveKey: (id: string) => {
-        id: string
     }
     updateProviderKey: ({ id, payload }: { id: string; payload: UpdateLLMProviderKeyPayload }) => {
         id: string


### PR DESCRIPTION
## Problem

Evaluations decide whether they can run entirely off `EvaluationConfig.active_provider_key`. When that field is null (and the team isn't grandfathered into the trial), the AI observability UI shows the "add a provider API key" / bring-your-own-key banner and evals stay disabled.

The catch: the provider-keys settings page only ever populated `active_provider_key` when adding the *first* key (`set_as_active` on create). If a team already had keys but ended up with no active one — for example after deleting the active key while others remained, or keys created outside that flow — there was no way in the UI to designate one. So a user could be staring at a perfectly valid provider key while evals kept telling them to bring a key. The only workaround was to delete and re-add the key.

This came up from a user who had an OpenRouter key configured but still hit the bring-your-own-key error on the Evaluations page. Context in the [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784221694340279?thread_ts=1784221694.340279&cid=C087XQ7K9K7).

## Changes

The backend already had everything needed — the `evaluation_config/set_active_key` endpoint and its scoping were in place — the settings UI just never called it. This wires it up:

- Show an **Active** tag next to whichever key is the current eval key, so the active key is visible at all.
- Add a **Set as active** action on the other keys (disabled with a reason until a key is in the `ok` state), calling `set_active_key` and reloading the config.

No backend, schema, or API changes.

> [!NOTE]
> This does not touch the separate `no_default_model` gap: an active key for a provider with no entry in `DEFAULT_MODEL_BY_PROVIDER` (OpenRouter, Fireworks, Azure, etc.) still needs the eval to pin a model explicitly. That's a distinct error path from the bring-your-own-key banner and left for a follow-up.

## How did you test this code?

No manual testing — this session had no frontend dev server or `node_modules`, so I (Claude, via the PostHog Slack app) could not run the app, typecheck, or Jest. Reviewer should run `pnpm --filter=@posthog/frontend typescript:check` and click through the AI observability provider-keys settings.

The change is a thin listener (POST + reload) plus table rendering. I extended the manual type interfaces in `llmProviderKeysLogic.ts` by hand since the file uses `MakeLogicType` rather than live typegen. No new automated test was added — the existing `llmProviderKeysLogic.test.ts` only covers the pure `normalizeLLMProvider` helper and doesn't mount the logic, and a logic-mount test for this thin listener wouldn't catch a regression the type checker doesn't.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by a PostHog engineer via the PostHog Slack app and approved before opening. I traced the bring-your-own-key path from a Replay Vision observation of the affected session down through `model_resolution.py` (`provider_key_required` fires only when `active_provider_key is None`) and found the UI had no affordance to set an existing key active despite the backend `set_active_key` endpoint existing. Chose to wire up that existing endpoint rather than change resolution semantics or auto-promote keys on delete, since those carry product decisions. Left unassigned because I could not verify the requester's GitHub handle this session — owning team should assign the DRI on triage.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784221694340279?thread_ts=1784221694.340279&cid=C087XQ7K9K7)*
