### PR TITLE
fix(google_search_console): retry transient token-refresh 502 inline

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -11,6 +11,7 @@ from django.db import OperationalError, close_old_connections
 
 import requests
 import structlog
+from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.credentials import Credentials as OAuthCredentials
 
@@ -272,6 +273,24 @@ def _is_server_error(response: requests.Response) -> bool:
     return response.status_code >= 500
 
 
+def _is_transient_refresh_error(error: RefreshError) -> bool:
+    """Whether an OAuth token-refresh failure is a transient server-side blip worth retrying.
+
+    `AuthorizedSession` refreshes the access token before the Search Analytics request, so a
+    failing token endpoint raises `RefreshError` from `session.post` before any response object
+    exists — the 5xx handling on the response never sees it. google-auth flags 500/503/504/408/429
+    (and JSON `server_error`/`temporarily_unavailable`) as retryable, but omits 502 from its
+    retryable status codes, so a Bad Gateway from the token endpoint surfaces as a
+    `RefreshError(retryable=False)` carrying an HTML error page. Treat those as transient too.
+    Permanent failures (`invalid_grant`, `invalid_scope`) stay non-transient so they bubble up to
+    `get_non_retryable_errors`.
+    """
+    if getattr(error, "retryable", False):
+        return True
+    message = str(error)
+    return "502" in message and "Server Error" in message
+
+
 def _quota_backoff_seconds(response: requests.Response, attempt: int) -> float:
     """Seconds to wait before retrying a quota error: honor `Retry-After`, else exponential."""
     retry_after = response.headers.get("Retry-After")
@@ -317,6 +336,22 @@ def _query_search_analytics(
             wait = QUOTA_BACKOFF_BASE_SECONDS * (2**attempt)
             logger.warning(
                 "GSC request connection error, backing off",
+                site_url=site_url,
+                attempt=attempt,
+                wait_seconds=wait,
+            )
+            time.sleep(wait)
+            continue
+        except RefreshError as e:
+            # A transient 5xx from Google's OAuth token endpoint (notably a 502, which google-auth
+            # doesn't count as retryable) is raised here while AuthorizedSession refreshes the access
+            # token. It clears on its own, so retry inline like a 5xx; permanent failures
+            # (invalid_grant / invalid_scope) bubble up so get_non_retryable_errors can stop the sync.
+            if not _is_transient_refresh_error(e) or attempt == QUOTA_MAX_RETRIES:
+                raise
+            wait = QUOTA_BACKOFF_BASE_SECONDS * (2**attempt)
+            logger.warning(
+                "GSC token refresh transient error, backing off",
                 site_url=site_url,
                 attempt=attempt,
                 wait_seconds=wait,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -6,6 +6,7 @@ from unittest import mock
 from django.db import OperationalError
 
 import requests
+from google.auth.exceptions import RefreshError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
     GoogleSearchConsoleSourceConfig,
@@ -25,6 +26,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_sea
     _is_daily_quota_error,
     _is_quota_error,
     _is_server_error,
+    _is_transient_refresh_error,
     _iter_dates,
     _query_search_analytics,
     _quota_backoff_seconds,
@@ -411,6 +413,30 @@ def test_is_server_error(response, expected):
     assert _is_server_error(response) is expected
 
 
+# A Bad Gateway from Google's OAuth token endpoint arrives as an HTML page, not JSON.
+_HTML_502_BODY = (
+    "<!DOCTYPE html>\n<html lang=en>\n  <title>Error 502 (Server Error)!!1</title>\n"
+    "  <p><b>502.</b> That's an error.\n  <p>The server encountered a temporary error "
+    "and could not complete your request."
+)
+
+
+@pytest.mark.parametrize(
+    "error,expected",
+    [
+        # 502 gateway page: google-auth omits 502 from its retryable status codes, but it's transient.
+        (RefreshError(_HTML_502_BODY), True),
+        # google-auth flags 500/503/504/408/429 (and JSON server errors) retryable itself.
+        (RefreshError("temporarily_unavailable: try again later", retryable=True), True),
+        # Revoked/expired refresh token — permanent, must not be retried inline.
+        (RefreshError("invalid_grant: Token has been expired or revoked."), False),
+        (RefreshError("invalid_scope: Bad Request"), False),
+    ],
+)
+def test_is_transient_refresh_error(error, expected):
+    assert _is_transient_refresh_error(error) is expected
+
+
 def test_quota_backoff_prefers_retry_after_header():
     resp = _fake_response(403, _QUOTA_BODY, headers={"Retry-After": "30"})
     assert _quota_backoff_seconds(resp, attempt=0) == 30.0
@@ -542,6 +568,38 @@ def test_query_connection_error_bubbles_after_max_retries(monkeypatch):
         _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
 
     assert session.post.call_count == QUOTA_MAX_RETRIES + 1
+
+
+def test_query_retries_transient_token_refresh_error_then_succeeds(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    session = mock.MagicMock()
+    session.post.side_effect = [
+        # AuthorizedSession raises RefreshError from post() when the token endpoint 502s mid-refresh.
+        RefreshError(_HTML_502_BODY),
+        _fake_response(200, {"rows": [{"keys": ["2026-04-15"], "clicks": 1}]}),
+    ]
+
+    rows = _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert rows == [{"keys": ["2026-04-15"], "clicks": 1}]
+    assert session.post.call_count == 2
+
+
+def test_query_permanent_token_refresh_error_bubbles_without_retry(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    session = mock.MagicMock()
+    session.post.side_effect = RefreshError("invalid_grant: Token has been expired or revoked.")
+
+    # A revoked/expired refresh token never recovers, so it must bubble on the first attempt
+    # (matching get_non_retryable_errors' "invalid_grant") rather than burning the inline budget.
+    with pytest.raises(RefreshError, match="invalid_grant"):
+        _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert session.post.call_count == 1
 
 
 def test_throttle_spaces_requests_per_site(monkeypatch):


### PR DESCRIPTION
## Problem

Error tracking surfaced a `RefreshError` from the Google Search Console import source. The message is Google's HTML "Error 502 (Server Error)" page, raised out of `google.auth.exceptions` at `_query_search_analytics` (`session.post`).

`AuthorizedSession` refreshes the OAuth access token before the Search Analytics request, so when Google's token endpoint returns a 502 mid-refresh, google-auth raises a `RefreshError` *before* any response object exists. Two things then line up badly:

- google-auth's retryable status codes are `(500, 503, 504, 408, 429)` — **502 is not in the list**, so it doesn't retry the refresh internally and raises `RefreshError(retryable=False)`.
- `_query_search_analytics` only catches `requests.ConnectionError` and inspects 5xx *responses*. A `RefreshError` is neither, so it slips through every inline retry branch and bubbles out.

A 502 is a textbook transient gateway blip ("Please try again in 30 seconds"). Today it fails the activity and forces a full Temporal restart, when the same request would almost certainly succeed a couple of seconds later. The function already absorbs the analogous blips (connection resets, 5xx responses) inline precisely to avoid restarting the whole sync on a hiccup. The token-refresh 502 just fell through that net.

## Changes

Handle transient token-refresh errors inline in `_query_search_analytics`, mirroring the existing `ConnectionError` handling:

- New `_is_transient_refresh_error` classifier: transient if google-auth already flagged it `retryable` (500/503/504/408/429 and JSON server errors), **or** the message is a 502 gateway page (the case google-auth misses).
- Transient ones back off and retry inline; once the inline budget is spent they bubble so Temporal retries the activity (resuming from the last saved date).
- Permanent failures (`invalid_grant`, `invalid_scope`) are left non-transient so they bubble immediately and still match `get_non_retryable_errors` — no wasted retries, no masking of a real "reconnect" condition.

This is scoped to this one error path. It does not touch the global retry policy or `NonRetryableErrors`.

> [!NOTE]
> This is a transient upstream error, so it stays retryable by design — it was not added to `get_non_retryable_errors`. The change just recovers from it more cheaply (a short inline backoff instead of a full activity restart).

## How did you test this code?

Automated only (I'm an agent — no manual sync run). Added to `test_google_search_console.py` and ran the full file (83 passed), plus ruff check/format:

- `test_is_transient_refresh_error` (parameterized) — locks in that a 502 HTML page is transient, that google-auth's `retryable` flag is honored, and that `invalid_grant` / `invalid_scope` are **not** classified transient. Catches a regression where 502 detection is dropped or the classifier is broadened to swallow permanent auth failures.
- `test_query_retries_transient_token_refresh_error_then_succeeds` — a 502 `RefreshError` from `session.post` followed by a 200 yields the rows after one retry. Catches removal or mis-wiring of the new inline branch.
- `test_query_permanent_token_refresh_error_bubbles_without_retry` — an `invalid_grant` `RefreshError` bubbles on the first attempt (`call_count == 1`). Catches over-broadening that would burn the retry budget on a permanent, reconnect-required failure.

No existing test exercised a `RefreshError` out of `session.post` — the existing retry tests cover quota, 5xx responses, and connection errors only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `google_search_console` source. I confirmed the issue in error tracking (single occurrence, `RefreshError` / `google.auth.exceptions`, top in-app frame `_query_search_analytics`), traced the raise path through `AuthorizedSession`'s token refresh, and read google-auth to confirm 502 is excluded from its retryable status codes. Decided this is a transient upstream error (keep retryable, not a `NonRetryableErrors` addition) but with a genuine code gap worth fixing: the inline retry loop didn't cover token-refresh 5xx. Considered doing nothing (Temporal already retries it) but chose the inline fix to match the function's existing intent of absorbing transient blips without a full activity restart.

Skills invoked: `/writing-tests`. Checked for duplicate open PRs (including the maintainer's own) — none address this path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
