### PR TITLE
fix(active_campaign): treat rejected API URL as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/source.py
@@ -89,6 +89,11 @@ You can find both in your ActiveCampaign account under **Settings > Developer**.
             "401 Client Error": "Invalid ActiveCampaign credentials. Please check your API URL and key and reconnect.",
             "403 Client Error": "Access forbidden. Please check that your ActiveCampaign API key is valid and reconnect.",
             "Unauthorized for url": "Invalid ActiveCampaign credentials. Please check your API URL and key and reconnect.",
+            # `active_campaign_source` raises this when the configured api_url fails our URL
+            # validation — an unresolvable host (wrong account name), a private/internal host,
+            # or a bad scheme. All are user-config problems retrying can't fix. Match the stable
+            # prefix, not the appended reason (which can embed a resolved IP).
+            "ActiveCampaign API URL is not allowed": "PostHog couldn't reach the ActiveCampaign API URL you entered. Check that it's correct — it should look like https://youraccount.api-us1.com — and reconnect.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/tests/test_active_campaign_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/tests/test_active_campaign_source.py
@@ -73,9 +73,26 @@ class TestActiveCampaignSource:
         assert api_key_field.required is True
         assert api_key_field.secret is True
 
-    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error", "Unauthorized for url"])
+    @pytest.mark.parametrize(
+        "expected_key",
+        ["401 Client Error", "403 Client Error", "Unauthorized for url", "ActiveCampaign API URL is not allowed"],
+    )
     def test_non_retryable_errors(self, expected_key: str) -> None:
         assert expected_key in self.source.get_non_retryable_errors()
+
+    @pytest.mark.parametrize(
+        "raised_message",
+        [
+            # `active_campaign_source` raises `ActiveCampaign API URL is not allowed: {reason}` for
+            # every URL-validation failure; the sync matcher is a substring check, so the stable
+            # prefix must classify each reason as non-retryable regardless of the appended detail.
+            "ActiveCampaign API URL is not allowed: Could not resolve host",
+            "ActiveCampaign API URL is not allowed: Private IP address not allowed",
+        ],
+    )
+    def test_url_not_allowed_is_non_retryable(self, raised_message: str) -> None:
+        keys = self.source.get_non_retryable_errors().keys()
+        assert any(key in raised_message for key in keys)
 
     def test_get_schemas_all_full_refresh(self) -> None:
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

Error tracking surfaced a live `ValueError` on the ActiveCampaign data-warehouse source:

> `ActiveCampaign API URL is not allowed: Could not resolve host`

Issue: https://us.posthog.com/project/2/error_tracking/019f6c68-d954-7d92-9810-c00dd7a1eedc

It's raised in `active_campaign_source` when our defense-in-depth SSRF check (`is_url_allowed`) rejects the customer-configured `api_url`. The "could not resolve host" reason means DNS returned no IPs for the host — for a stable SaaS like ActiveCampaign that's almost always a wrong account name in the URL (`https://youraccount.api-us1.com`) or a closed account. Today that failure is retryable, so the sync keeps retrying against a host that will never resolve.

## Changes

Add `"ActiveCampaign API URL is not allowed"` to the source's `get_non_retryable_errors`, mirroring the Stripe pattern.

Every reason under this message — unresolvable host, private/internal host, disallowed scheme — is a user-config problem that retrying can't fix, so the sync should stop and tell the customer to correct their API URL and reconnect. The code isn't buggy here: it's correctly rejecting a bad URL, so this is a classification fix, not a code-path fix.

I match the stable prefix, not the appended reason. The reason can embed a resolved IP (e.g. `Disallowed target IP: <ip>`), so keeping the match on the prefix avoids depending on volatile data.

Transient read timeouts and connection resets are untouched and stay retryable — only our own URL-validation rejection is classified non-retryable.

## How did you test this code?

Automated only (I'm an agent — no manual sync run):

- Extended `test_non_retryable_errors` with the new key.
- Added `test_url_not_allowed_is_non_retryable`, which mirrors production's substring match: it asserts the real raised messages (`...: Could not resolve host`, `...: Private IP address not allowed`) are classified non-retryable. This guards the exact regression — if the key is renamed so it no longer appears in the raised message, the sync would resume retrying forever against an unresolvable host.
- `uv run pytest .../active_campaign/tests/test_active_campaign_source.py` → 16 passed.
- `ruff check` and `ruff format --check` on both files → clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (`claude-opus-4-8`) via PostHog Code. Confirmed the stack trace originates in `active_campaign_source` (not just serialized log context), read `is_url_allowed` to establish that "could not resolve host" maps to a bad user-supplied host, and confirmed the sync matcher (`external_data_job.py`) is a substring check that sets `should_sync=False` on match.

Decision: user/upstream config error, not a bug — so extend `NonRetryableErrors` rather than change the code path. Considered whether a transient DNS blip could be swallowed; concluded the dominant cause for a stable SaaS host failing to resolve is a wrong account name, and the tradeoff favors stopping the retry storm with a clear "fix your URL" message. Chose to match the broad SSRF-block prefix (covers all validation-failure reasons, all user-config) rather than only the observed reason.

Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
