### PR TITLE
feat(customer-analytics): instant accounts sort when fully loaded

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AGENTS.md
+++ b/products/customer_analytics/frontend/components/Accounts/AGENTS.md
@@ -76,7 +76,7 @@ How that sort is applied depends on whether the whole matching set is already lo
 
 - **Fully loaded (the common case — one page, no "Load more"):** `canSortClientSide` is true.
   The list query carries **no** `orderBy`, so toggling a header does not change the query and never refetches.
-  Instead `AccountsHogQLTable` reorders the loaded rows in the browser via the DataTable's `dataTableRowsTransformer` context seam, calling `sortAccountRows` (in `accountsSort.ts`) — sorting is instant.
+  Instead the loaded rows are reordered in the browser: the `accountsLogic.sortedRowsTransformer` selector (wrapping `sortAccountRows` from `accountsSort.ts`) is passed by `AccountsHogQLTable` into the DataTable's `dataTableRowsTransformer` context seam — sorting is instant.
   `sortAccountRows` reads each cell by its position in the row's result array (the name tuple sorts by `.name`, relationship/tag arrays join to a string, numbers sort numerically), is stable, and always sinks empty cells to the bottom in both directions.
 - **Paginated (more rows than one page):** `canSortClientSide` is false, so the query carries an `orderBy` and ClickHouse sorts the **entire** set and returns the globally-correct top page; the transformer is inactive (rows are shown in server order). Toggling a header refetches, as before.
 

--- a/products/customer_analytics/frontend/components/Accounts/AGENTS.md
+++ b/products/customer_analytics/frontend/components/Accounts/AGENTS.md
@@ -69,7 +69,22 @@ Negative operators (is not / doesn't contain / doesn't match regex) are wrapped 
 Filters for deleted definitions or with incomplete values compile to nothing rather than breaking the query, and only validated UUID keys are ever interpolated (quoted via the shared `escapePropertyAsHogQLIdentifier`).
 Value suggestions load from`GET /api/projects/:team_id/custom_property_definitions/values/?key=<definition-id>&value=<search>`(the group's`valuesEndpoint`): select → option labels, boolean → true/false, text/numeric → distinct active values; date pickers need no suggestions.
 
-Sort safety: removing the sorted column drops the sort (`clearSortIfColumnRemoved`), else the backend gets an `orderBy` referencing a missing alias.
+### Sorting (hybrid client / server)
+
+Clicking a column header toggles `accountsLogic.sortOrder` (asc → desc → off, `toggleSort`).
+How that sort is applied depends on whether the whole matching set is already loaded, tracked by the `canSortClientSide` selector (`!listHasMoreData && !listPaginated`):
+
+- **Fully loaded (the common case — one page, no "Load more"):** `canSortClientSide` is true.
+  The list query carries **no** `orderBy`, so toggling a header does not change the query and never refetches.
+  Instead `AccountsHogQLTable` reorders the loaded rows in the browser via the DataTable's `dataTableRowsTransformer` context seam, calling `sortAccountRows` (in `accountsSort.ts`) — sorting is instant.
+  `sortAccountRows` reads each cell by its position in the row's result array (the name tuple sorts by `.name`, relationship/tag arrays join to a string, numbers sort numerically), is stable, and always sinks empty cells to the bottom in both directions.
+- **Paginated (more rows than one page):** `canSortClientSide` is false, so the query carries an `orderBy` and ClickHouse sorts the **entire** set and returns the globally-correct top page; the transformer is inactive (rows are shown in server order). Toggling a header refetches, as before.
+
+`listPaginated` is what makes this safe: it is set when the user pages past the first page (`loadNextData`, connected from the list `dataNodeLogic`) and reset on every fresh load (`loadData`).
+Without it, paging to the end of a large list would flip `listHasMoreData` to false mid-session, drop the `orderBy`, and reset the query back to page one — discarding the accumulated rows.
+Resetting on fresh load lets a filtered-down set (now ≤ one page) return to instant client-side sort.
+
+Sort safety: removing the sorted column drops the sort (`clearSortIfColumnRemoved`); otherwise a server-side sort would reference a missing SELECT alias.
 
 ## The expanded row
 

--- a/products/customer_analytics/frontend/components/Accounts/AGENTS.md
+++ b/products/customer_analytics/frontend/components/Accounts/AGENTS.md
@@ -85,7 +85,22 @@ Value suggestions load from`GET /api/projects/:team_id/custom_property_definitio
 
 **Tile display** (title / subtitle / value format). A tile also carries two optional presentation fields, independent of the metric: `caption` (custom subtitle) and `format` (`TileValueFormat` = `unit`/`currency`/`percentage`, a subset of `OverviewGrid`'s `WebAnalyticsItemKind` so `format ?? 'unit'` maps 1:1 to the render `kind`). `tileCaption(tile)` resolves the subtitle: the trimmed custom `caption` when set, else `autoCaption(tile)` (the derived `agg of col × n` / `col op val` text; `count` has no derived caption, so a custom one is the only subtitle it can show). The editor edits `caption` (empty → `undefined`) and `format` (`unit` → `undefined`); both flow through the row's `emit(patch)` merge so a metric edit never drops them. Render formatting lives in `OverviewGrid.formatItem`: `currency` uses the team `baseCurrency`, `percentage` treats the value as already in percent units (`85` → "85%", combine with `scale × 100` for a 0-1 fraction). Both fields ride along in `properties.tiles` (no backend/schema/migration) and default cleanly for older saved/legacy tiles.
 
-Sort safety: removing the sorted column drops the sort (`clearSortIfColumnRemoved`), else the backend gets an `orderBy` referencing a missing alias.
+### Sorting (hybrid client / server)
+
+Clicking a column header toggles `accountsLogic.sortOrder` (asc → desc → off, `toggleSort`).
+How that sort is applied depends on whether the whole matching set is already loaded, tracked by the `canSortClientSide` selector (`!listHasMoreData && !listPaginated`):
+
+- **Fully loaded (the common case — one page, no "Load more"):** `canSortClientSide` is true.
+  The list query carries **no** `orderBy`, so toggling a header does not change the query and never refetches.
+  Instead `AccountsHogQLTable` reorders the loaded rows in the browser via the DataTable's `dataTableRowsTransformer` context seam, calling `sortAccountRows` (in `accountsSort.ts`) — sorting is instant.
+  `sortAccountRows` reads each cell by its position in the row's result array (the name tuple sorts by `.name`, relationship/tag arrays join to a string, numbers sort numerically), is stable, and always sinks empty cells to the bottom in both directions.
+- **Paginated (more rows than one page):** `canSortClientSide` is false, so the query carries an `orderBy` (built via `orderByExpression`, so numeric custom properties sort numerically server-side too) and ClickHouse sorts the **entire** set and returns the globally-correct top page; the transformer is inactive (rows are shown in server order). Toggling a header refetches, as before.
+
+`listPaginated` is what makes this safe: it is set when the user pages past the first page (`loadNextData`, connected from the list `dataNodeLogic`) and reset on every fresh load (`loadData`).
+Without it, paging to the end of a large list would flip `listHasMoreData` to false mid-session, drop the `orderBy`, and reset the query back to page one — discarding the accumulated rows.
+Resetting on fresh load lets a filtered-down set (now ≤ one page) return to instant client-side sort.
+
+Sort safety: removing the sorted column drops the sort (`clearSortIfColumnRemoved`); otherwise a server-side sort would reference a missing SELECT alias.
 
 ## The expanded row
 

--- a/products/customer_analytics/frontend/components/Accounts/AGENTS.md
+++ b/products/customer_analytics/frontend/components/Accounts/AGENTS.md
@@ -92,7 +92,7 @@ How that sort is applied depends on whether the whole matching set is already lo
 
 - **Fully loaded (the common case — one page, no "Load more"):** `canSortClientSide` is true.
   The list query carries **no** `orderBy`, so toggling a header does not change the query and never refetches.
-  Instead `AccountsHogQLTable` reorders the loaded rows in the browser via the DataTable's `dataTableRowsTransformer` context seam, calling `sortAccountRows` (in `accountsSort.ts`) — sorting is instant.
+  Instead the loaded rows are reordered in the browser: the `accountsLogic.sortedRowsTransformer` selector (wrapping `sortAccountRows` from `accountsSort.ts`) is passed by `AccountsHogQLTable` into the DataTable's `dataTableRowsTransformer` context seam — sorting is instant.
   `sortAccountRows` reads each cell by its position in the row's result array (the name tuple sorts by `.name`, relationship/tag arrays join to a string, numbers sort numerically), is stable, and always sinks empty cells to the bottom in both directions.
 - **Paginated (more rows than one page):** `canSortClientSide` is false, so the query carries an `orderBy` (built via `orderByExpression`, so numeric custom properties sort numerically server-side too) and ClickHouse sorts the **entire** set and returns the globally-correct top page; the transformer is inactive (rows are shown in server order). Toggling a header refetches, as before.
 

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -32,6 +32,7 @@ import { AccountNotebooksExpansion } from './AccountNotebooksExpansion'
 import { ACCOUNTS_NAME_COLUMN, LEGACY_ROLE_COLUMNS, accountsColumnConfigLogic } from './accountsColumnConfigLogic'
 import { accountsExpansionLogic } from './accountsExpansionLogic'
 import { accountsLogic, savingRoleKey } from './accountsLogic'
+import { sortAccountRows } from './accountsSort'
 import { AccountsEvents } from './constants'
 
 // Shape the backend emits for the `name` column — see accounts_query_runner._calculate.
@@ -328,6 +329,21 @@ function useContextColumns(): Record<string, QueryContextColumn> {
     }, [visibleColumnNames, aliasToDefinition, aliasToRelationshipDefinition])
 }
 
+// Client-side sort of the loaded rows, wired through the DataTable's rows
+// transformer. Active only when the whole matching set is loaded (`canSortClientSide`);
+// while the list is paginated the query carries an `orderBy` and the server returns
+// rows already globally sorted, so we leave them in place.
+function useSortedRowsTransformer(): QueryContext<DataTableNode>['dataTableRowsTransformer'] {
+    const { sortOrder, canSortClientSide } = useValues(accountsLogic)
+    const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
+    return useMemo(() => {
+        if (!canSortClientSide || !sortOrder) {
+            return undefined
+        }
+        return (rows) => sortAccountRows(rows, sortOrder, visibleColumnNames)
+    }, [canSortClientSide, sortOrder, visibleColumnNames])
+}
+
 function useExpandable(): QueryContext<DataTableNode>['expandable'] {
     const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
     const { expandedAccountIds } = useValues(accountsExpansionLogic)
@@ -424,6 +440,7 @@ export function AccountsHogQLTable(): JSX.Element {
     const { responseLoading, response } = useValues(dataNodeLogic)
     const contextColumns = useContextColumns()
     const expandable = useExpandable()
+    const dataTableRowsTransformer = useSortedRowsTransformer()
     // A null source means the query is still waiting on the relationship
     // definitions — same skeleton as the initial fetch, not an empty table.
     if ((responseLoading || !accountsQuerySource) && !response) {
@@ -440,6 +457,7 @@ export function AccountsHogQLTable(): JSX.Element {
                 context={{
                     columns: contextColumns,
                     expandable,
+                    dataTableRowsTransformer,
                     dataNodeLogicKey: ACCOUNTS_HOGQL_DATA_NODE_KEY,
                     emptyStateHeading: 'There are no matching accounts for this query',
                     emptyStateDetail: 'Try adjusting the filters or refreshing',

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -32,7 +32,6 @@ import { AccountNotebooksExpansion } from './AccountNotebooksExpansion'
 import { ACCOUNTS_NAME_COLUMN, LEGACY_ROLE_COLUMNS, accountsColumnConfigLogic } from './accountsColumnConfigLogic'
 import { accountsExpansionLogic } from './accountsExpansionLogic'
 import { accountsLogic, savingRoleKey } from './accountsLogic'
-import { sortAccountRows } from './accountsSort'
 import { AccountsEvents } from './constants'
 
 // Shape the backend emits for the `name` column — see accounts_query_runner._calculate.
@@ -329,21 +328,6 @@ function useContextColumns(): Record<string, QueryContextColumn> {
     }, [visibleColumnNames, aliasToDefinition, aliasToRelationshipDefinition])
 }
 
-// Client-side sort of the loaded rows, wired through the DataTable's rows
-// transformer. Active only when the whole matching set is loaded (`canSortClientSide`);
-// while the list is paginated the query carries an `orderBy` and the server returns
-// rows already globally sorted, so we leave them in place.
-function useSortedRowsTransformer(): QueryContext<DataTableNode>['dataTableRowsTransformer'] {
-    const { sortOrder, canSortClientSide } = useValues(accountsLogic)
-    const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
-    return useMemo(() => {
-        if (!canSortClientSide || !sortOrder) {
-            return undefined
-        }
-        return (rows) => sortAccountRows(rows, sortOrder, visibleColumnNames)
-    }, [canSortClientSide, sortOrder, visibleColumnNames])
-}
-
 function useExpandable(): QueryContext<DataTableNode>['expandable'] {
     const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
     const { expandedAccountIds } = useValues(accountsExpansionLogic)
@@ -436,11 +420,10 @@ function AccountsHogQLSkeleton(): JSX.Element {
 }
 
 export function AccountsHogQLTable(): JSX.Element {
-    const { hogqlQuery, accountsQuerySource } = useValues(accountsLogic)
+    const { hogqlQuery, accountsQuerySource, sortedRowsTransformer } = useValues(accountsLogic)
     const { responseLoading, response } = useValues(dataNodeLogic)
     const contextColumns = useContextColumns()
     const expandable = useExpandable()
-    const dataTableRowsTransformer = useSortedRowsTransformer()
     // A null source means the query is still waiting on the relationship
     // definitions — same skeleton as the initial fetch, not an empty table.
     if ((responseLoading || !accountsQuerySource) && !response) {
@@ -457,7 +440,7 @@ export function AccountsHogQLTable(): JSX.Element {
                 context={{
                     columns: contextColumns,
                     expandable,
-                    dataTableRowsTransformer,
+                    dataTableRowsTransformer: sortedRowsTransformer,
                     dataNodeLogicKey: ACCOUNTS_HOGQL_DATA_NODE_KEY,
                     emptyStateHeading: 'There are no matching accounts for this query',
                     emptyStateDetail: 'Try adjusting the filters or refreshing',

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -41,6 +41,7 @@ import {
 } from './accountsColumnConfigLogic'
 import { AccountExpansionTab, accountsExpansionLogic } from './accountsExpansionLogic'
 import { accountsLogic, savingRoleKey } from './accountsLogic'
+import { sortAccountRows } from './accountsSort'
 import { AccountsEvents } from './constants'
 
 // Shape the backend emits for the `name` column — see accounts_query_runner._calculate.
@@ -504,6 +505,21 @@ function useContextColumns(): Record<string, QueryContextColumn> {
     }, [visibleColumnNames, aliasToDefinition, aliasToRelationshipDefinition, displayByAlias])
 }
 
+// Client-side sort of the loaded rows, wired through the DataTable's rows
+// transformer. Active only when the whole matching set is loaded (`canSortClientSide`);
+// while the list is paginated the query carries an `orderBy` and the server returns
+// rows already globally sorted, so we leave them in place.
+function useSortedRowsTransformer(): QueryContext<DataTableNode>['dataTableRowsTransformer'] {
+    const { sortOrder, canSortClientSide } = useValues(accountsLogic)
+    const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
+    return useMemo(() => {
+        if (!canSortClientSide || !sortOrder) {
+            return undefined
+        }
+        return (rows) => sortAccountRows(rows, sortOrder, visibleColumnNames)
+    }, [canSortClientSide, sortOrder, visibleColumnNames])
+}
+
 function useExpandable(): QueryContext<DataTableNode>['expandable'] {
     const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
     const { expandedAccountIds } = useValues(accountsExpansionLogic)
@@ -600,6 +616,7 @@ export function AccountsHogQLTable(): JSX.Element {
     const { responseLoading, response } = useValues(dataNodeLogic)
     const contextColumns = useContextColumns()
     const expandable = useExpandable()
+    const dataTableRowsTransformer = useSortedRowsTransformer()
     // A null source means the query is still waiting on the relationship
     // definitions — same skeleton as the initial fetch, not an empty table.
     if ((responseLoading || !accountsQuerySource) && !response) {
@@ -616,6 +633,7 @@ export function AccountsHogQLTable(): JSX.Element {
                 context={{
                     columns: contextColumns,
                     expandable,
+                    dataTableRowsTransformer,
                     dataNodeLogicKey: ACCOUNTS_HOGQL_DATA_NODE_KEY,
                     emptyStateHeading: 'There are no matching accounts for this query',
                     emptyStateDetail: 'Try adjusting the filters or refreshing',

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -41,7 +41,6 @@ import {
 } from './accountsColumnConfigLogic'
 import { AccountExpansionTab, accountsExpansionLogic } from './accountsExpansionLogic'
 import { accountsLogic, savingRoleKey } from './accountsLogic'
-import { sortAccountRows } from './accountsSort'
 import { AccountsEvents } from './constants'
 
 // Shape the backend emits for the `name` column — see accounts_query_runner._calculate.
@@ -505,21 +504,6 @@ function useContextColumns(): Record<string, QueryContextColumn> {
     }, [visibleColumnNames, aliasToDefinition, aliasToRelationshipDefinition, displayByAlias])
 }
 
-// Client-side sort of the loaded rows, wired through the DataTable's rows
-// transformer. Active only when the whole matching set is loaded (`canSortClientSide`);
-// while the list is paginated the query carries an `orderBy` and the server returns
-// rows already globally sorted, so we leave them in place.
-function useSortedRowsTransformer(): QueryContext<DataTableNode>['dataTableRowsTransformer'] {
-    const { sortOrder, canSortClientSide } = useValues(accountsLogic)
-    const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
-    return useMemo(() => {
-        if (!canSortClientSide || !sortOrder) {
-            return undefined
-        }
-        return (rows) => sortAccountRows(rows, sortOrder, visibleColumnNames)
-    }, [canSortClientSide, sortOrder, visibleColumnNames])
-}
-
 function useExpandable(): QueryContext<DataTableNode>['expandable'] {
     const { visibleColumnNames } = useValues(accountsColumnConfigLogic)
     const { expandedAccountIds } = useValues(accountsExpansionLogic)
@@ -612,11 +596,10 @@ function AccountsHogQLSkeleton(): JSX.Element {
 }
 
 export function AccountsHogQLTable(): JSX.Element {
-    const { hogqlQuery, accountsQuerySource } = useValues(accountsLogic)
+    const { hogqlQuery, accountsQuerySource, sortedRowsTransformer } = useValues(accountsLogic)
     const { responseLoading, response } = useValues(dataNodeLogic)
     const contextColumns = useContextColumns()
     const expandable = useExpandable()
-    const dataTableRowsTransformer = useSortedRowsTransformer()
     // A null source means the query is still waiting on the relationship
     // definitions — same skeleton as the initial fetch, not an empty table.
     if ((responseLoading || !accountsQuerySource) && !response) {
@@ -633,7 +616,7 @@ export function AccountsHogQLTable(): JSX.Element {
                 context={{
                     columns: contextColumns,
                     expandable,
-                    dataTableRowsTransformer,
+                    dataTableRowsTransformer: sortedRowsTransformer,
                     dataNodeLogicKey: ACCOUNTS_HOGQL_DATA_NODE_KEY,
                     emptyStateHeading: 'There are no matching accounts for this query',
                     emptyStateDetail: 'Try adjusting the filters or refreshing',

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
@@ -363,6 +363,7 @@ describe('accountsLogic', () => {
             expect(logic.values.canSortClientSide).toBe(true)
             logic.actions.toggleSort('notebook_count')
             expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
+            expect(logic.values.sortedRowsTransformer).toEqual(expect.any(Function))
             logic.actions.toggleSort('notebook_count') // desc
             expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
         })
@@ -371,6 +372,7 @@ describe('accountsLogic', () => {
             logic.actions.listLoadNextData()
             expect(logic.values.canSortClientSide).toBe(false)
             logic.actions.toggleSort('notebook_count')
+            expect(logic.values.sortedRowsTransformer).toBeUndefined()
             expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['notebook_count'])
             logic.actions.toggleSort('notebook_count') // desc
             expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['notebook_count DESC'])

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
@@ -337,7 +337,6 @@ describe('accountsLogic', () => {
         it('toggleSort on a fresh column starts ascending', () => {
             logic.actions.toggleSort('notebook_count')
             expect(logic.values.sortOrder).toEqual({ column: 'notebook_count', direction: 'asc' })
-            expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['notebook_count'])
         })
 
         it('toggleSort cycles asc -> desc -> null on repeated clicks', () => {
@@ -345,10 +344,8 @@ describe('accountsLogic', () => {
             expect(logic.values.sortOrder?.direction).toBe('asc')
             logic.actions.toggleSort('notebook_count')
             expect(logic.values.sortOrder).toEqual({ column: 'notebook_count', direction: 'desc' })
-            expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['notebook_count DESC'])
             logic.actions.toggleSort('notebook_count')
             expect(logic.values.sortOrder).toBeNull()
-            expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
         })
 
         it('toggleSort on a different column resets to ascending', () => {
@@ -356,17 +353,41 @@ describe('accountsLogic', () => {
             logic.actions.toggleSort('notebook_count') // desc
             logic.actions.toggleSort('csm')
             expect(logic.values.sortOrder).toEqual({ column: 'csm', direction: 'asc' })
-            expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['csm'])
         })
 
-        it('arbitrary column sorts by its alias directly', () => {
+        // Hybrid sort: while the whole matching set is loaded the query stays free of
+        // orderBy, so toggling a header re-sorts the loaded rows client-side without a
+        // refetch. Once the list is paginated ("Load more") the query carries orderBy so
+        // ClickHouse returns the globally-sorted page.
+        it('leaves orderBy off while the full list is loaded, for instant client-side sort', () => {
+            expect(logic.values.canSortClientSide).toBe(true)
+            logic.actions.toggleSort('notebook_count')
+            expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
+            logic.actions.toggleSort('notebook_count') // desc
+            expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
+        })
+
+        it('adds orderBy once the list is paginated, for a global server-side sort', () => {
+            logic.actions.listLoadNextData()
+            expect(logic.values.canSortClientSide).toBe(false)
+            logic.actions.toggleSort('notebook_count')
+            expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['notebook_count'])
+            logic.actions.toggleSort('notebook_count') // desc
+            expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['notebook_count DESC'])
+        })
+
+        it('returns to client-side sort after a fresh load re-evaluates pagination', () => {
+            logic.actions.listLoadNextData()
             logic.actions.toggleSort('name')
             expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['name'])
-            logic.actions.toggleSort('name')
-            expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['name DESC'])
+            // A fresh load (filter change / refresh) resets the paginated flag.
+            logic.actions.listLoadData()
+            expect(logic.values.canSortClientSide).toBe(true)
+            expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
         })
 
-        it('skips the orderBy when the sorted role column has no matching definition', () => {
+        it('skips the server orderBy when the sorted role column has no matching definition', () => {
+            logic.actions.listLoadNextData()
             logic.actions.toggleSort('csm')
             accountsColumnConfigLogic.findMounted()?.actions.loadRelationshipDefinitionsSuccess([])
             expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
@@ -401,6 +422,9 @@ describe('accountsLogic', () => {
                 'sorts a %s column by its value cast to a float',
                 (displayType) => {
                     selectCustomProperty(displayType)
+                    // Server-side orderBy only applies when the list is paginated; otherwise
+                    // the fully-loaded rows sort client-side and carry no orderBy.
+                    logic.actions.listLoadNextData()
                     logic.actions.toggleSort(alias)
                     expect(orderByOf(logic.values.hogqlQuery.source)).toEqual([floatExpr])
                     logic.actions.toggleSort(alias) // desc
@@ -410,6 +434,7 @@ describe('accountsLogic', () => {
 
             it('sorts a non-numeric custom property lexically by its alias', () => {
                 selectCustomProperty('text')
+                logic.actions.listLoadNextData()
                 logic.actions.toggleSort(alias)
                 expect(orderByOf(logic.values.hogqlQuery.source)).toEqual([alias])
             })

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.test.ts
@@ -355,10 +355,6 @@ describe('accountsLogic', () => {
             expect(logic.values.sortOrder).toEqual({ column: 'csm', direction: 'asc' })
         })
 
-        // Hybrid sort: while the whole matching set is loaded the query stays free of
-        // orderBy, so toggling a header re-sorts the loaded rows client-side without a
-        // refetch. Once the list is paginated ("Load more") the query carries orderBy so
-        // ClickHouse returns the globally-sorted page.
         it('leaves orderBy off while the full list is loaded, for instant client-side sort', () => {
             expect(logic.values.canSortClientSide).toBe(true)
             logic.actions.toggleSort('notebook_count')
@@ -382,7 +378,6 @@ describe('accountsLogic', () => {
             logic.actions.listLoadNextData()
             logic.actions.toggleSort('name')
             expect(orderByOf(logic.values.hogqlQuery.source)).toEqual(['name'])
-            // A fresh load (filter change / refresh) resets the paginated flag.
             logic.actions.listLoadData()
             expect(logic.values.canSortClientSide).toBe(true)
             expect(orderByOf(logic.values.hogqlQuery.source)).toBeUndefined()
@@ -424,8 +419,6 @@ describe('accountsLogic', () => {
                 'sorts a %s column by its value cast to a float',
                 (displayType) => {
                     selectCustomProperty(displayType)
-                    // Server-side orderBy only applies when the list is paginated; otherwise
-                    // the fully-loaded rows sort client-side and carry no orderBy.
                     logic.actions.listLoadNextData()
                     logic.actions.toggleSort(alias)
                     expect(orderByOf(logic.values.hogqlQuery.source)).toEqual([floatExpr])

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -10,8 +10,8 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
-import { AccountsQuery, DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { type DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { AccountsQuery, DataNode, DataTableNode, NodeKind, RefreshType } from '~/queries/schema/schema-general'
 import type { AccountCustomPropertyFilter, UserBasicType } from '~/types'
 
 import {
@@ -172,6 +172,7 @@ export interface accountsLogicValues {
     overviewMetrics: string[] // accountsOverviewTilesLogic
     tileFilter: TileFilter | null // accountsOverviewTilesLogic
     mineOnly: boolean // customerAnalyticsSceneLogic
+    listHasMoreData: boolean // dataNodeLogic
     currentTeamId: number | null // teamLogic
     user: UserType | null // userLogic
     accountIdFilter: string | null
@@ -180,10 +181,12 @@ export interface accountsLogicValues {
     allRolesUnassigned: boolean
     assignedToCurrentUser: boolean
     assignedToFilter: RoleFilterValue
+    canSortClientSide: boolean
     currentUserId: number | null
     customPropertyFilters: AccountCustomPropertyFilter[]
     hogqlQuery: DataTableNode
     isRoleSaving: (accountId: string, column: string) => boolean
+    listPaginated: boolean
     metricsQuery: AccountsQuery | null
     relationshipOverrides: Record<string, number[]>
     savingRoles: Record<string, true>
@@ -228,6 +231,17 @@ export interface accountsLogicActions {
     setMineOnly: (mineOnly: boolean) => {
         mineOnly: boolean
     } // customerAnalyticsSceneLogic
+    listLoadData: (
+        refresh?: RefreshType | undefined,
+        alreadyRunningQueryId?: string | undefined,
+        overrideQuery?: DataNode<Record<string, any>> | undefined
+    ) => {
+        overrideQuery: DataNode<Record<string, any>> | undefined
+        pollOnly: boolean
+        queryId: string
+        refresh: RefreshType | undefined
+    } // dataNodeLogic
+    listLoadNextData: () => any // dataNodeLogic
     ensureAllMembersLoaded: () => {
         value: true
     } // membersLogic
@@ -349,6 +363,7 @@ export interface accountsLogicMeta {
             tileFilter: TileFilter | null,
             customPropertyFilters: AccountCustomPropertyFilter[]
         ) => AccountsViewUrlState
+        canSortClientSide: (listHasMoreData: boolean, listPaginated: boolean) => boolean
         hogqlQuery: (
             searchQuery: string,
             tagsFilter: string[],
@@ -357,6 +372,7 @@ export interface accountsLogicMeta {
             accountIdFilter: string | null,
             tileFilter: TileFilter | null,
             sortOrder: AccountSortOrder,
+            canSortClientSide: boolean,
             querySelectColumns: string[],
             visibleColumnNames: string[],
             customPropertyFilters: AccountCustomPropertyFilter[],
@@ -409,6 +425,10 @@ export const accountsLogic = kea<accountsLogicType>([
             ['metrics as overviewMetrics', 'tileFilter'],
             customerAnalyticsSceneLogic,
             ['mineOnly'],
+            // Pagination state of the list rows, to decide whether the whole
+            // matching set is loaded (sort client-side) or not (sort server-side).
+            dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
+            ['hasMoreData as listHasMoreData'],
         ],
         actions: [
             accountsColumnConfigLogic,
@@ -423,6 +443,10 @@ export const accountsLogic = kea<accountsLogicType>([
             ['loadUserSuccess'],
             membersLogic,
             ['ensureAllMembersLoaded'],
+            // List load lifecycle — a fresh load resets the paginated flag, "Load
+            // more" sets it (see the listPaginated reducer).
+            dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
+            ['loadData as listLoadData', 'loadNextData as listLoadNextData'],
         ],
     })),
     actions({
@@ -512,6 +536,18 @@ export const accountsLogic = kea<accountsLogicType>([
             null as AccountSortOrder,
             {
                 setSortOrder: (_, { sortOrder }) => sortOrder,
+            },
+        ],
+        // True when the currently-loaded rows were built by paging past the first
+        // page ("Load more"). Keeps the list in server-side sort mode so paginating
+        // to the end never drops the query's `orderBy` (which would reset back to
+        // page one and discard the accumulated rows). Reset on every fresh load, so
+        // a filtered-down set is re-evaluated and can return to instant client sort.
+        listPaginated: [
+            false,
+            {
+                listLoadData: () => false,
+                listLoadNextData: () => true,
             },
         ],
         savingRoles: [
@@ -625,6 +661,13 @@ export const accountsLogic = kea<accountsLogicType>([
                 return state
             },
         ],
+        // When the whole matching set is already loaded in the browser, sorting can
+        // happen client-side (instant, no refetch). Otherwise the query carries an
+        // `orderBy` so ClickHouse sorts the full set and returns the global top page.
+        canSortClientSide: [
+            (s) => [s.listHasMoreData, s.listPaginated],
+            (listHasMoreData: boolean, listPaginated: boolean): boolean => !listHasMoreData && !listPaginated,
+        ],
         hogqlQuery: [
             (s) => [
                 s.searchQuery,
@@ -634,6 +677,7 @@ export const accountsLogic = kea<accountsLogicType>([
                 s.accountIdFilter,
                 s.tileFilter,
                 s.sortOrder,
+                s.canSortClientSide,
                 s.querySelectColumns,
                 s.visibleColumnNames,
                 s.customPropertyFilters,
@@ -648,6 +692,7 @@ export const accountsLogic = kea<accountsLogicType>([
                 accountIdFilter: string | null,
                 tileFilter: TileFilter | null,
                 sortOrder: AccountSortOrder,
+                canSortClientSide: boolean,
                 querySelectColumns: string[],
                 visibleColumnNames: string[],
                 customPropertyFilters: AccountCustomPropertyFilter[],
@@ -669,10 +714,14 @@ export const accountsLogic = kea<accountsLogicType>([
                     customPropertyFilters,
                     customPropertyDefinitionsById,
                 })
+                // Only sort on the server when the list is paginated — otherwise the
+                // rows are all loaded and the table sorts them client-side (instant, no
+                // refetch), so leaving `orderBy` off keeps the query semantically stable
+                // and toggling sort doesn't re-fetch.
                 // HogQL ORDER BY resolves SELECT aliases by name, so the visible column
                 // name works directly. Skip sorts on columns the translation dropped
                 // (a legacy role with no matching definition) — the alias wouldn't resolve.
-                if (sortOrder && visibleColumnNames.includes(sortOrder.column)) {
+                if (sortOrder && !canSortClientSide && visibleColumnNames.includes(sortOrder.column)) {
                     const expr = orderByExpression(sortOrder.column, aliasToDefinition)
                     source.orderBy = [sortOrder.direction === 'asc' ? expr : `${expr} DESC`]
                 }

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -433,8 +433,6 @@ export const accountsLogic = kea<accountsLogicType>([
             ['metrics as overviewMetrics', 'tileFilter'],
             customerAnalyticsSceneLogic,
             ['mineOnly'],
-            // Pagination state of the list rows, to decide whether the whole
-            // matching set is loaded (sort client-side) or not (sort server-side).
             dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
             ['hasMoreData as listHasMoreData'],
         ],
@@ -451,8 +449,6 @@ export const accountsLogic = kea<accountsLogicType>([
             ['loadUserSuccess'],
             membersLogic,
             ['ensureAllMembersLoaded'],
-            // List load lifecycle — a fresh load resets the paginated flag, "Load
-            // more" sets it (see the listPaginated reducer).
             dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
             ['loadData as listLoadData', 'loadNextData as listLoadNextData'],
         ],
@@ -546,11 +542,8 @@ export const accountsLogic = kea<accountsLogicType>([
                 setSortOrder: (_, { sortOrder }) => sortOrder,
             },
         ],
-        // True when the currently-loaded rows were built by paging past the first
-        // page ("Load more"). Keeps the list in server-side sort mode so paginating
-        // to the end never drops the query's `orderBy` (which would reset back to
-        // page one and discard the accumulated rows). Reset on every fresh load, so
-        // a filtered-down set is re-evaluated and can return to instant client sort.
+        // Keeps server-side sort while paging, so reaching the last page never drops the
+        // orderBy and collapses the accumulated rows back to page one.
         listPaginated: [
             false,
             {
@@ -669,15 +662,10 @@ export const accountsLogic = kea<accountsLogicType>([
                 return state
             },
         ],
-        // When the whole matching set is already loaded in the browser, sorting can
-        // happen client-side (instant, no refetch). Otherwise the query carries an
-        // `orderBy` so ClickHouse sorts the full set and returns the global top page.
         canSortClientSide: [
             (s) => [s.listHasMoreData, s.listPaginated],
             (listHasMoreData: boolean, listPaginated: boolean): boolean => !listHasMoreData && !listPaginated,
         ],
-        // Passed to the DataTable's `dataTableRowsTransformer` context seam; undefined
-        // while the list is paginated (the server already returned globally sorted rows).
         sortedRowsTransformer: [
             (s) => [s.canSortClientSide, s.sortOrder, s.visibleColumnNames],
             (
@@ -735,10 +723,6 @@ export const accountsLogic = kea<accountsLogicType>([
                     customPropertyFilters,
                     customPropertyDefinitionsById,
                 })
-                // Only sort on the server when the list is paginated — otherwise the
-                // rows are all loaded and the table sorts them client-side (instant, no
-                // refetch), so leaving `orderBy` off keeps the query semantically stable
-                // and toggling sort doesn't re-fetch.
                 // HogQL ORDER BY resolves SELECT aliases by name, so the visible column
                 // name works directly. Skip sorts on columns the translation dropped
                 // (a legacy role with no matching definition) — the alias wouldn't resolve.

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -194,8 +194,8 @@ export interface accountsLogicValues {
     savingRoles: Record<string, true>
     searchInput: string
     searchQuery: string
-    sortedRowsTransformer: ((rows: DataTableRow[]) => DataTableRow[]) | undefined
     sortOrder: AccountSortOrder
+    sortedRowsTransformer: ((rows: DataTableRow[]) => DataTableRow[]) | undefined
     tagsFilter: string[]
     viewUrlState: AccountsViewUrlState
 }

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -11,6 +11,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { type DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import type { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 import { AccountsQuery, DataNode, DataTableNode, NodeKind, RefreshType } from '~/queries/schema/schema-general'
 import type { AccountCustomPropertyFilter, UserBasicType } from '~/types'
 
@@ -38,6 +39,7 @@ import {
     DEFAULT_ACCOUNT_TAB,
 } from './accountsExpansionLogic'
 import { accountsOverviewTilesLogic, TileFilter } from './accountsOverviewTilesLogic'
+import { sortAccountRows } from './accountsSort'
 import { normalizeRoleFilter } from './accountsViewState'
 import { AccountsEvents } from './constants'
 
@@ -192,6 +194,7 @@ export interface accountsLogicValues {
     savingRoles: Record<string, true>
     searchInput: string
     searchQuery: string
+    sortedRowsTransformer: ((rows: DataTableRow[]) => DataTableRow[]) | undefined
     sortOrder: AccountSortOrder
     tagsFilter: string[]
     viewUrlState: AccountsViewUrlState
@@ -364,6 +367,11 @@ export interface accountsLogicMeta {
             customPropertyFilters: AccountCustomPropertyFilter[]
         ) => AccountsViewUrlState
         canSortClientSide: (listHasMoreData: boolean, listPaginated: boolean) => boolean
+        sortedRowsTransformer: (
+            canSortClientSide: boolean,
+            sortOrder: AccountSortOrder,
+            visibleColumnNames: string[]
+        ) => ((rows: DataTableRow[]) => DataTableRow[]) | undefined
         hogqlQuery: (
             searchQuery: string,
             tagsFilter: string[],
@@ -667,6 +675,19 @@ export const accountsLogic = kea<accountsLogicType>([
         canSortClientSide: [
             (s) => [s.listHasMoreData, s.listPaginated],
             (listHasMoreData: boolean, listPaginated: boolean): boolean => !listHasMoreData && !listPaginated,
+        ],
+        // Passed to the DataTable's `dataTableRowsTransformer` context seam; undefined
+        // while the list is paginated (the server already returned globally sorted rows).
+        sortedRowsTransformer: [
+            (s) => [s.canSortClientSide, s.sortOrder, s.visibleColumnNames],
+            (
+                canSortClientSide: boolean,
+                sortOrder: AccountSortOrder,
+                visibleColumnNames: string[]
+            ): ((rows: DataTableRow[]) => DataTableRow[]) | undefined =>
+                canSortClientSide && sortOrder
+                    ? (rows: DataTableRow[]): DataTableRow[] => sortAccountRows(rows, sortOrder, visibleColumnNames)
+                    : undefined,
         ],
         hogqlQuery: [
             (s) => [

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -11,8 +11,8 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
-import { AccountsQuery, DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { type DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { AccountsQuery, DataNode, DataTableNode, NodeKind, RefreshType } from '~/queries/schema/schema-general'
 import type { AccountCustomPropertyFilter, UserBasicType } from '~/types'
 
 import {
@@ -190,6 +190,7 @@ export interface accountsLogicValues {
     overviewMetrics: string[] // accountsOverviewTilesLogic
     tileFilter: TileFilter | null // accountsOverviewTilesLogic
     mineOnly: boolean // customerAnalyticsSceneLogic
+    listHasMoreData: boolean // dataNodeLogic
     currentTeamId: number | null // teamLogic
     user: UserType | null // userLogic
     accountIdFilter: string | null
@@ -198,10 +199,12 @@ export interface accountsLogicValues {
     allRolesUnassigned: boolean
     assignedToCurrentUser: boolean
     assignedToFilter: RoleFilterValue
+    canSortClientSide: boolean
     currentUserId: number | null
     customPropertyFilters: AccountCustomPropertyFilter[]
     hogqlQuery: DataTableNode
     isRoleSaving: (accountId: string, column: string) => boolean
+    listPaginated: boolean
     metricsQuery: AccountsQuery | null
     relationshipOverrides: Record<string, number[]>
     savingRoles: Record<string, true>
@@ -256,6 +259,17 @@ export interface accountsLogicActions {
     setMineOnly: (mineOnly: boolean) => {
         mineOnly: boolean
     } // customerAnalyticsSceneLogic
+    listLoadData: (
+        refresh?: RefreshType | undefined,
+        alreadyRunningQueryId?: string | undefined,
+        overrideQuery?: DataNode<Record<string, any>> | undefined
+    ) => {
+        overrideQuery: DataNode<Record<string, any>> | undefined
+        pollOnly: boolean
+        queryId: string
+        refresh: RefreshType | undefined
+    } // dataNodeLogic
+    listLoadNextData: () => any // dataNodeLogic
     ensureAllMembersLoaded: () => {
         value: true
     } // membersLogic
@@ -378,6 +392,7 @@ export interface accountsLogicMeta {
             customPropertyFilters: AccountCustomPropertyFilter[],
             columnDisplay: AccountColumnDisplayState
         ) => AccountsViewUrlState
+        canSortClientSide: (listHasMoreData: boolean, listPaginated: boolean) => boolean
         hogqlQuery: (
             searchQuery: string,
             tagsFilter: string[],
@@ -386,6 +401,7 @@ export interface accountsLogicMeta {
             accountIdFilter: string | null,
             tileFilter: TileFilter | null,
             sortOrder: AccountSortOrder,
+            canSortClientSide: boolean,
             querySelectColumns: string[],
             visibleColumnNames: string[],
             customPropertyFilters: AccountCustomPropertyFilter[],
@@ -439,6 +455,10 @@ export const accountsLogic = kea<accountsLogicType>([
             ['metrics as overviewMetrics', 'tileFilter'],
             customerAnalyticsSceneLogic,
             ['mineOnly'],
+            // Pagination state of the list rows, to decide whether the whole
+            // matching set is loaded (sort client-side) or not (sort server-side).
+            dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
+            ['hasMoreData as listHasMoreData'],
         ],
         actions: [
             accountsColumnConfigLogic,
@@ -461,6 +481,10 @@ export const accountsLogic = kea<accountsLogicType>([
             ['loadUserSuccess'],
             membersLogic,
             ['ensureAllMembersLoaded'],
+            // List load lifecycle — a fresh load resets the paginated flag, "Load
+            // more" sets it (see the listPaginated reducer).
+            dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
+            ['loadData as listLoadData', 'loadNextData as listLoadNextData'],
         ],
     })),
     actions({
@@ -550,6 +574,18 @@ export const accountsLogic = kea<accountsLogicType>([
             null as AccountSortOrder,
             {
                 setSortOrder: (_, { sortOrder }) => sortOrder,
+            },
+        ],
+        // True when the currently-loaded rows were built by paging past the first
+        // page ("Load more"). Keeps the list in server-side sort mode so paginating
+        // to the end never drops the query's `orderBy` (which would reset back to
+        // page one and discard the accumulated rows). Reset on every fresh load, so
+        // a filtered-down set is re-evaluated and can return to instant client sort.
+        listPaginated: [
+            false,
+            {
+                listLoadData: () => false,
+                listLoadNextData: () => true,
             },
         ],
         savingRoles: [
@@ -668,6 +704,13 @@ export const accountsLogic = kea<accountsLogicType>([
                 return state
             },
         ],
+        // When the whole matching set is already loaded in the browser, sorting can
+        // happen client-side (instant, no refetch). Otherwise the query carries an
+        // `orderBy` so ClickHouse sorts the full set and returns the global top page.
+        canSortClientSide: [
+            (s) => [s.listHasMoreData, s.listPaginated],
+            (listHasMoreData: boolean, listPaginated: boolean): boolean => !listHasMoreData && !listPaginated,
+        ],
         hogqlQuery: [
             (s) => [
                 s.searchQuery,
@@ -677,6 +720,7 @@ export const accountsLogic = kea<accountsLogicType>([
                 s.accountIdFilter,
                 s.tileFilter,
                 s.sortOrder,
+                s.canSortClientSide,
                 s.querySelectColumns,
                 s.visibleColumnNames,
                 s.customPropertyFilters,
@@ -691,6 +735,7 @@ export const accountsLogic = kea<accountsLogicType>([
                 accountIdFilter: string | null,
                 tileFilter: TileFilter | null,
                 sortOrder: AccountSortOrder,
+                canSortClientSide: boolean,
                 querySelectColumns: string[],
                 visibleColumnNames: string[],
                 customPropertyFilters: AccountCustomPropertyFilter[],
@@ -712,10 +757,14 @@ export const accountsLogic = kea<accountsLogicType>([
                     customPropertyFilters,
                     customPropertyDefinitionsById,
                 })
+                // Only sort on the server when the list is paginated — otherwise the
+                // rows are all loaded and the table sorts them client-side (instant, no
+                // refetch), so leaving `orderBy` off keeps the query semantically stable
+                // and toggling sort doesn't re-fetch.
                 // HogQL ORDER BY resolves SELECT aliases by name, so the visible column
                 // name works directly. Skip sorts on columns the translation dropped
                 // (a legacy role with no matching definition) — the alias wouldn't resolve.
-                if (sortOrder && visibleColumnNames.includes(sortOrder.column)) {
+                if (sortOrder && !canSortClientSide && visibleColumnNames.includes(sortOrder.column)) {
                     const expr = orderByExpression(sortOrder.column, aliasToDefinition)
                     source.orderBy = [sortOrder.direction === 'asc' ? expr : `${expr} DESC`]
                 }

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -212,8 +212,8 @@ export interface accountsLogicValues {
     savingRoles: Record<string, true>
     searchInput: string
     searchQuery: string
-    sortedRowsTransformer: ((rows: DataTableRow[]) => DataTableRow[]) | undefined
     sortOrder: AccountSortOrder
+    sortedRowsTransformer: ((rows: DataTableRow[]) => DataTableRow[]) | undefined
     tagsFilter: string[]
     viewUrlState: AccountsViewUrlState
 }

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -12,6 +12,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { type DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import type { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 import { AccountsQuery, DataNode, DataTableNode, NodeKind, RefreshType } from '~/queries/schema/schema-general'
 import type { AccountCustomPropertyFilter, UserBasicType } from '~/types'
 
@@ -40,6 +41,7 @@ import {
     DEFAULT_ACCOUNT_TAB,
 } from './accountsExpansionLogic'
 import { accountsOverviewTilesLogic, TileFilter } from './accountsOverviewTilesLogic'
+import { sortAccountRows } from './accountsSort'
 import { normalizeRoleFilter } from './accountsViewState'
 import { AccountsEvents } from './constants'
 
@@ -210,6 +212,7 @@ export interface accountsLogicValues {
     savingRoles: Record<string, true>
     searchInput: string
     searchQuery: string
+    sortedRowsTransformer: ((rows: DataTableRow[]) => DataTableRow[]) | undefined
     sortOrder: AccountSortOrder
     tagsFilter: string[]
     viewUrlState: AccountsViewUrlState
@@ -393,6 +396,11 @@ export interface accountsLogicMeta {
             columnDisplay: AccountColumnDisplayState
         ) => AccountsViewUrlState
         canSortClientSide: (listHasMoreData: boolean, listPaginated: boolean) => boolean
+        sortedRowsTransformer: (
+            canSortClientSide: boolean,
+            sortOrder: AccountSortOrder,
+            visibleColumnNames: string[]
+        ) => ((rows: DataTableRow[]) => DataTableRow[]) | undefined
         hogqlQuery: (
             searchQuery: string,
             tagsFilter: string[],
@@ -710,6 +718,19 @@ export const accountsLogic = kea<accountsLogicType>([
         canSortClientSide: [
             (s) => [s.listHasMoreData, s.listPaginated],
             (listHasMoreData: boolean, listPaginated: boolean): boolean => !listHasMoreData && !listPaginated,
+        ],
+        // Passed to the DataTable's `dataTableRowsTransformer` context seam; undefined
+        // while the list is paginated (the server already returned globally sorted rows).
+        sortedRowsTransformer: [
+            (s) => [s.canSortClientSide, s.sortOrder, s.visibleColumnNames],
+            (
+                canSortClientSide: boolean,
+                sortOrder: AccountSortOrder,
+                visibleColumnNames: string[]
+            ): ((rows: DataTableRow[]) => DataTableRow[]) | undefined =>
+                canSortClientSide && sortOrder
+                    ? (rows: DataTableRow[]): DataTableRow[] => sortAccountRows(rows, sortOrder, visibleColumnNames)
+                    : undefined,
         ],
         hogqlQuery: [
             (s) => [

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -463,8 +463,6 @@ export const accountsLogic = kea<accountsLogicType>([
             ['metrics as overviewMetrics', 'tileFilter'],
             customerAnalyticsSceneLogic,
             ['mineOnly'],
-            // Pagination state of the list rows, to decide whether the whole
-            // matching set is loaded (sort client-side) or not (sort server-side).
             dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
             ['hasMoreData as listHasMoreData'],
         ],
@@ -489,8 +487,6 @@ export const accountsLogic = kea<accountsLogicType>([
             ['loadUserSuccess'],
             membersLogic,
             ['ensureAllMembersLoaded'],
-            // List load lifecycle — a fresh load resets the paginated flag, "Load
-            // more" sets it (see the listPaginated reducer).
             dataNodeLogic({ key: ACCOUNTS_HOGQL_DATA_NODE_KEY } as DataNodeLogicProps),
             ['loadData as listLoadData', 'loadNextData as listLoadNextData'],
         ],
@@ -584,11 +580,8 @@ export const accountsLogic = kea<accountsLogicType>([
                 setSortOrder: (_, { sortOrder }) => sortOrder,
             },
         ],
-        // True when the currently-loaded rows were built by paging past the first
-        // page ("Load more"). Keeps the list in server-side sort mode so paginating
-        // to the end never drops the query's `orderBy` (which would reset back to
-        // page one and discard the accumulated rows). Reset on every fresh load, so
-        // a filtered-down set is re-evaluated and can return to instant client sort.
+        // Keeps server-side sort while paging, so reaching the last page never drops the
+        // orderBy and collapses the accumulated rows back to page one.
         listPaginated: [
             false,
             {
@@ -712,15 +705,10 @@ export const accountsLogic = kea<accountsLogicType>([
                 return state
             },
         ],
-        // When the whole matching set is already loaded in the browser, sorting can
-        // happen client-side (instant, no refetch). Otherwise the query carries an
-        // `orderBy` so ClickHouse sorts the full set and returns the global top page.
         canSortClientSide: [
             (s) => [s.listHasMoreData, s.listPaginated],
             (listHasMoreData: boolean, listPaginated: boolean): boolean => !listHasMoreData && !listPaginated,
         ],
-        // Passed to the DataTable's `dataTableRowsTransformer` context seam; undefined
-        // while the list is paginated (the server already returned globally sorted rows).
         sortedRowsTransformer: [
             (s) => [s.canSortClientSide, s.sortOrder, s.visibleColumnNames],
             (
@@ -778,10 +766,6 @@ export const accountsLogic = kea<accountsLogicType>([
                     customPropertyFilters,
                     customPropertyDefinitionsById,
                 })
-                // Only sort on the server when the list is paginated — otherwise the
-                // rows are all loaded and the table sorts them client-side (instant, no
-                // refetch), so leaving `orderBy` off keeps the query semantically stable
-                // and toggling sort doesn't re-fetch.
                 // HogQL ORDER BY resolves SELECT aliases by name, so the visible column
                 // name works directly. Skip sorts on columns the translation dropped
                 // (a legacy role with no matching definition) — the alias wouldn't resolve.

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -581,7 +581,10 @@ export const accountsLogic = kea<accountsLogicType>([
             },
         ],
         // Keeps server-side sort while paging, so reaching the last page never drops the
-        // orderBy and collapses the accumulated rows back to page one.
+        // orderBy and collapses the accumulated rows back to page one. Resetting on every
+        // listLoadData is deliberate even for the refetch a sort-while-paginated triggers:
+        // that request already carries the new orderBy, and its response replaces the
+        // accumulated pages with one server-sorted page that is safe to client-sort next.
         listPaginated: [
             false,
             {

--- a/products/customer_analytics/frontend/components/Accounts/accountsSort.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsSort.test.ts
@@ -1,0 +1,90 @@
+import type { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
+
+import type { AccountSortOrder } from './accountsLogic'
+import { sortAccountRows } from './accountsSort'
+
+// Rows are result-arrays aligned to the visible column names, matching what the
+// accounts query runner emits: the name column is a { name, external_id, id } tuple,
+// relationship columns are arrays of assignee ids, everything else is a primitive.
+const COLUMNS = ['name', 'notebook_count', 'csm']
+
+const buildRow = ({
+    name,
+    count = 0,
+    csm = [],
+}: {
+    name: string
+    count?: number | null
+    csm?: number[]
+}): DataTableRow => ({
+    result: [{ name, external_id: name, id: name }, count, csm],
+})
+
+const cellAt = (row: DataTableRow, index: number): unknown => (row.result as unknown[])[index]
+const names = (rows: DataTableRow[]): string[] => rows.map((r) => (cellAt(r, 0) as { name: string }).name)
+const counts = (rows: DataTableRow[]): unknown[] => rows.map((r) => cellAt(r, 1))
+
+describe('sortAccountRows', () => {
+    it.each([
+        ['there is no active sort', null as AccountSortOrder],
+        ['the sorted column is not visible', { column: 'missing', direction: 'asc' } as AccountSortOrder],
+    ])('returns the same rows untouched when %s', (_label, sortOrder) => {
+        const rows = [buildRow({ name: 'B' }), buildRow({ name: 'A' })]
+        expect(sortAccountRows(rows, sortOrder, COLUMNS)).toBe(rows)
+    })
+
+    it('sorts the name tuple column by its name, case-insensitively, in both directions', () => {
+        const rows = [buildRow({ name: 'Charlie' }), buildRow({ name: 'alpha' }), buildRow({ name: 'Bravo' })]
+        expect(names(sortAccountRows(rows, { column: 'name', direction: 'asc' }, COLUMNS))).toEqual([
+            'alpha',
+            'Bravo',
+            'Charlie',
+        ])
+        expect(names(sortAccountRows(rows, { column: 'name', direction: 'desc' }, COLUMNS))).toEqual([
+            'Charlie',
+            'Bravo',
+            'alpha',
+        ])
+    })
+
+    it('sorts a numeric column numerically, not lexically', () => {
+        const rows = [
+            buildRow({ name: 'a', count: 2 }),
+            buildRow({ name: 'b', count: 10 }),
+            buildRow({ name: 'c', count: 1 }),
+        ]
+        expect(counts(sortAccountRows(rows, { column: 'notebook_count', direction: 'asc' }, COLUMNS))).toEqual([
+            1, 2, 10,
+        ])
+    })
+
+    it.each([['asc'], ['desc']] as const)('always sorts empty cells last when %s', (direction) => {
+        const rows = [
+            buildRow({ name: 'a', count: null }),
+            buildRow({ name: 'b', count: 5 }),
+            buildRow({ name: 'c', count: null }),
+        ]
+        expect(counts(sortAccountRows(rows, { column: 'notebook_count', direction }, COLUMNS))).toEqual([5, null, null])
+    })
+
+    it('treats an empty relationship array as an empty cell (sorts last)', () => {
+        const rows = [buildRow({ name: 'unassigned', csm: [] }), buildRow({ name: 'assigned', csm: [42] })]
+        expect(names(sortAccountRows(rows, { column: 'csm', direction: 'asc' }, COLUMNS))).toEqual([
+            'assigned',
+            'unassigned',
+        ])
+    })
+
+    it('keeps equal-keyed rows in their incoming order (stable)', () => {
+        const rows = [
+            buildRow({ name: 'first', count: 5 }),
+            buildRow({ name: 'second', count: 5 }),
+            buildRow({ name: 'third', count: 5 }),
+        ]
+        expect(names(sortAccountRows(rows, { column: 'notebook_count', direction: 'asc' }, COLUMNS))).toEqual([
+            'first',
+            'second',
+            'third',
+        ])
+    })
+})

--- a/products/customer_analytics/frontend/components/Accounts/accountsSort.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsSort.test.ts
@@ -3,9 +3,6 @@ import type { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 import type { AccountSortOrder } from './accountsLogic'
 import { sortAccountRows } from './accountsSort'
 
-// Rows are result-arrays aligned to the visible column names, matching what the
-// accounts query runner emits: the name column is a { name, external_id, id } tuple,
-// relationship columns are arrays of assignee ids, everything else is a primitive.
 const COLUMNS = ['name', 'notebook_count', 'csm']
 
 const buildRow = ({

--- a/products/customer_analytics/frontend/components/Accounts/accountsSort.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsSort.ts
@@ -1,0 +1,95 @@
+import type { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
+
+import type { AccountSortOrder } from './accountsLogic'
+
+// Client-side sort for the accounts list, applied while the whole matching set is
+// loaded in the browser (`canSortClientSide`). Toggling a column header then reorders
+// the already-loaded rows instead of refetching — sorting is instant, because the
+// query carries no `orderBy` and stays semantically stable. When the list is
+// paginated the query instead carries an `orderBy` and ClickHouse returns globally
+// sorted rows, so this transformer is not applied. The backend's default order is
+// created_at DESC; this reorders whatever has been loaded.
+
+// A cell counts as empty (and always sorts last, in both directions) when it has no
+// value to compare: null/undefined, the empty string, or an empty array (e.g. an
+// unassigned relationship column). `0` and `false` are real values, not empty.
+function isEmptyCell(value: unknown): boolean {
+    if (value === null || value === undefined || value === '') {
+        return true
+    }
+    return Array.isArray(value) && value.length === 0
+}
+
+// Reduce a raw cell to something comparable. The `name` column arrives as a
+// `{ name, external_id, id }` tuple, relationship/tag columns as arrays; everything
+// else is already a primitive (number, or a string — including numeric custom
+// properties stored as strings).
+function sortKey(value: unknown): number | string {
+    if (typeof value === 'number') {
+        return value
+    }
+    if (Array.isArray(value)) {
+        return value.join(',')
+    }
+    if (value && typeof value === 'object') {
+        const name = (value as { name?: unknown }).name
+        return typeof name === 'string' ? name : String(value)
+    }
+    return String(value)
+}
+
+// Ascending comparison of two non-empty cells. Numbers compare numerically; anything
+// else compares as a string with natural (numeric-aware, case-insensitive) collation,
+// which also orders numeric strings ("2" before "10") correctly.
+function compareNonEmpty(a: unknown, b: unknown): number {
+    const ka = sortKey(a)
+    const kb = sortKey(b)
+    if (typeof ka === 'number' && typeof kb === 'number') {
+        return ka < kb ? -1 : ka > kb ? 1 : 0
+    }
+    return String(ka).localeCompare(String(kb), undefined, { numeric: true, sensitivity: 'base' })
+}
+
+function cellAt(row: DataTableRow, index: number): unknown {
+    return Array.isArray(row.result) ? row.result[index] : undefined
+}
+
+/**
+ * Reorder the loaded table rows by the active sort. Returns the input untouched when
+ * there is no sort, or when the sorted column isn't currently visible (its values
+ * aren't in the row arrays). The sort is stable: rows with equal keys keep their
+ * incoming (server default) order, and empty cells always sort last.
+ */
+export function sortAccountRows(
+    rows: DataTableRow[],
+    sortOrder: AccountSortOrder,
+    visibleColumnNames: string[]
+): DataTableRow[] {
+    if (!sortOrder) {
+        return rows
+    }
+    // Every column — including the name column — sorts by its visible name, which is
+    // the position of its cell within each row's result array.
+    const index = visibleColumnNames.indexOf(sortOrder.column)
+    if (index < 0) {
+        return rows
+    }
+    const direction = sortOrder.direction === 'desc' ? -1 : 1
+    return rows
+        .map((row, position) => ({ row, position }))
+        .sort((a, b) => {
+            const av = cellAt(a.row, index)
+            const bv = cellAt(b.row, index)
+            const aEmpty = isEmptyCell(av)
+            const bEmpty = isEmptyCell(bv)
+            if (aEmpty || bEmpty) {
+                if (aEmpty && bEmpty) {
+                    return a.position - b.position
+                }
+                return aEmpty ? 1 : -1
+            }
+            const cmp = compareNonEmpty(av, bv)
+            return cmp !== 0 ? cmp * direction : a.position - b.position
+        })
+        .map(({ row }) => row)
+}

--- a/products/customer_analytics/frontend/components/Accounts/accountsSort.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsSort.ts
@@ -2,17 +2,7 @@ import type { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 
 import type { AccountSortOrder } from './accountsLogic'
 
-// Client-side sort for the accounts list, applied while the whole matching set is
-// loaded in the browser (`canSortClientSide`). Toggling a column header then reorders
-// the already-loaded rows instead of refetching — sorting is instant, because the
-// query carries no `orderBy` and stays semantically stable. When the list is
-// paginated the query instead carries an `orderBy` and ClickHouse returns globally
-// sorted rows, so this transformer is not applied. The backend's default order is
-// created_at DESC; this reorders whatever has been loaded.
-
-// A cell counts as empty (and always sorts last, in both directions) when it has no
-// value to compare: null/undefined, the empty string, or an empty array (e.g. an
-// unassigned relationship column). `0` and `false` are real values, not empty.
+// `0` and `false` are real values, not empty
 function isEmptyCell(value: unknown): boolean {
     if (value === null || value === undefined || value === '') {
         return true
@@ -20,10 +10,7 @@ function isEmptyCell(value: unknown): boolean {
     return Array.isArray(value) && value.length === 0
 }
 
-// Reduce a raw cell to something comparable. The `name` column arrives as a
-// `{ name, external_id, id }` tuple, relationship/tag columns as arrays; everything
-// else is already a primitive (number, or a string — including numeric custom
-// properties stored as strings).
+// The name column arrives as a { name, external_id, id } tuple, relationship/tag columns as arrays
 function sortKey(value: unknown): number | string {
     if (typeof value === 'number') {
         return value
@@ -38,15 +25,13 @@ function sortKey(value: unknown): number | string {
     return String(value)
 }
 
-// Ascending comparison of two non-empty cells. Numbers compare numerically; anything
-// else compares as a string with natural (numeric-aware, case-insensitive) collation,
-// which also orders numeric strings ("2" before "10") correctly.
 function compareNonEmpty(a: unknown, b: unknown): number {
     const ka = sortKey(a)
     const kb = sortKey(b)
     if (typeof ka === 'number' && typeof kb === 'number') {
         return ka < kb ? -1 : ka > kb ? 1 : 0
     }
+    // numeric-aware collation so "2" sorts before "10"
     return String(ka).localeCompare(String(kb), undefined, { numeric: true, sensitivity: 'base' })
 }
 
@@ -54,12 +39,6 @@ function cellAt(row: DataTableRow, index: number): unknown {
     return Array.isArray(row.result) ? row.result[index] : undefined
 }
 
-/**
- * Reorder the loaded table rows by the active sort. Returns the input untouched when
- * there is no sort, or when the sorted column isn't currently visible (its values
- * aren't in the row arrays). The sort is stable: rows with equal keys keep their
- * incoming (server default) order, and empty cells always sort last.
- */
 export function sortAccountRows(
     rows: DataTableRow[],
     sortOrder: AccountSortOrder,
@@ -68,8 +47,6 @@ export function sortAccountRows(
     if (!sortOrder) {
         return rows
     }
-    // Every column — including the name column — sorts by its visible name, which is
-    // the position of its cell within each row's result array.
     const index = visibleColumnNames.indexOf(sortOrder.column)
     if (index < 0) {
         return rows
@@ -86,6 +63,7 @@ export function sortAccountRows(
                 if (aEmpty && bEmpty) {
                     return a.position - b.position
                 }
+                // empty cells sort last in both directions
                 return aEmpty ? 1 : -1
             }
             const cmp = compareNonEmpty(av, bv)

--- a/products/customer_analytics/frontend/components/Accounts/accountsSort.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsSort.ts
@@ -11,7 +11,7 @@ function isEmptyCell(value: unknown): boolean {
 }
 
 // The name column arrives as a { name, external_id, id } tuple, relationship/tag columns as arrays
-function sortKey(value: unknown): number | string {
+function getSortKey(value: unknown): number | string {
     if (typeof value === 'number') {
         return value
     }
@@ -26,8 +26,8 @@ function sortKey(value: unknown): number | string {
 }
 
 function compareNonEmpty(a: unknown, b: unknown): number {
-    const ka = sortKey(a)
-    const kb = sortKey(b)
+    const ka = getSortKey(a)
+    const kb = getSortKey(b)
     if (typeof ka === 'number' && typeof kb === 'number') {
         return ka < kb ? -1 : ka > kb ? 1 : 0
     }
@@ -35,7 +35,7 @@ function compareNonEmpty(a: unknown, b: unknown): number {
     return String(ka).localeCompare(String(kb), undefined, { numeric: true, sensitivity: 'base' })
 }
 
-function cellAt(row: DataTableRow, index: number): unknown {
+function getCellAt(row: DataTableRow, index: number): unknown {
     return Array.isArray(row.result) ? row.result[index] : undefined
 }
 
@@ -52,22 +52,15 @@ export function sortAccountRows(
         return rows
     }
     const direction = sortOrder.direction === 'desc' ? -1 : 1
-    return rows
-        .map((row, position) => ({ row, position }))
-        .sort((a, b) => {
-            const av = cellAt(a.row, index)
-            const bv = cellAt(b.row, index)
-            const aEmpty = isEmptyCell(av)
-            const bEmpty = isEmptyCell(bv)
-            if (aEmpty || bEmpty) {
-                if (aEmpty && bEmpty) {
-                    return a.position - b.position
-                }
-                // empty cells sort last in both directions
-                return aEmpty ? 1 : -1
-            }
-            const cmp = compareNonEmpty(av, bv)
-            return cmp !== 0 ? cmp * direction : a.position - b.position
-        })
-        .map(({ row }) => row)
+    return [...rows].sort((a, b) => {
+        const av = getCellAt(a, index)
+        const bv = getCellAt(b, index)
+        const aEmpty = isEmptyCell(av)
+        const bEmpty = isEmptyCell(bv)
+        if (aEmpty || bEmpty) {
+            // empty cells sort last in both directions
+            return aEmpty === bEmpty ? 0 : aEmpty ? 1 : -1
+        }
+        return compareNonEmpty(av, bv) * direction
+    })
 }


### PR DESCRIPTION
## Problem

Sorting the accounts list re-queried the backend on every column-header click. It always attached an `orderBy` to the HogQL query, so each sort triggered a ClickHouse round-trip and the table dimmed into a loading state before reordering. For the common case where the whole list is already loaded in the browser, that round-trip is pure latency. Sorting should feel instant.

## Changes

Sorting is now a hybrid, chosen by whether the whole matching set is already loaded (the `canSortClientSide` selector):

- **Fully loaded** (one page, no "Load more" — the common case): the query carries no `orderBy`, so toggling a header doesn't change the query and nothing refetches. The loaded rows are reordered in the browser through the DataTable's `dataTableRowsTransformer` seam, via a new pure `sortAccountRows`. Sorting is instant.
- **Paginated** (more than one page): the query keeps its `orderBy`, so ClickHouse sorts the entire set and returns the globally-correct top page. Same as before.

A `listPaginated` flag (set when the user pages past the first page, reset on each fresh load) switches the two modes and keeps paging to the end of a large list from dropping the `orderBy` and collapsing the accumulated rows back to page one.

No visual change (same table, same sort indicators), so no screenshots.

`sortAccountRows` compares numeric-looking values numerically, matching the server-side numeric sort of custom-property columns from #72288, so both sort modes order numbers by magnitude.

## How did you test this code?

Automated only. I am an agent and did not run the app in a browser.

- New `accountsSort.test.ts` covers the pure `sortAccountRows`: name-tuple sorting, numeric vs lexical ordering, empty cells always last in both directions, empty relationship arrays, stability, and the no-op guards. The module is new, so none of this was previously covered.
- Updated the `sortOrder` block in `accountsLogic.test.ts` to assert the hybrid: `orderBy` stays off while the list is fully loaded (catches a regression back to refetch-on-sort), appears once the list is paginated (catches losing the globally-correct sort for large lists), and resets after a fresh load.
- Ran the full Accounts jest suite after rebasing on current master: 17 suites, 225 tests, all pass.
- `tsgo` typecheck clean for the changed files. oxlint and oxfmt clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated the Accounts area dev guide (`AGENTS.md`) with a "Sorting (hybrid client / server)" section. No customer-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @jakesciotto.

Built with Claude Code (Opus 4.8). Skill invoked: `/writing-tests`.

The list is server-paginated at 100 rows with a globally-correct server sort, so a naive "just sort client-side" would only reorder the loaded page and surface the wrong top result for teams with more than one page of accounts. I (Claude) surfaced that trade-off and the chosen behavior was "instant when fully loaded, accurate when paginated" — hence the hybrid rather than pure client-side. The `listPaginated` flag is intentionally sticky within a loaded view (set on "Load more", reset on fresh load) to avoid an oscillation where paging a large list to the end flips `hasMoreData` to false, drops the `orderBy`, and resets pagination. The client transformer is left inactive in server mode to avoid a flash from client vs ClickHouse collation differences. In a follow-up session I (Claude) rebased the branch onto current master, resolved the `AGENTS.md` doc conflict, and confirmed the hybrid composes with the server-side numeric sort from #72288.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

