### PR TITLE
fix(error-tracking): stop flagging search typing as kea router url loops

### DIFF
--- a/frontend/src/lib/logic/scenes/urlChangeTracker.test.ts
+++ b/frontend/src/lib/logic/scenes/urlChangeTracker.test.ts
@@ -69,7 +69,7 @@ describe('getUrlChangeTracker', () => {
         const insightsTracker = getUrlChangeTracker('insightsLogic')
 
         for (let i = 0; i < 6; i++) {
-            webTracker.recordChange(`/web?v=${i}`, 'webAnalyticsLogic', 'setFilters')
+            webTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
         }
 
         expect(webTracker.isRapidlyChanging()).toBe(true)
@@ -136,12 +136,22 @@ describe('UrlChangeTracker', () => {
             { count: 4, expected: false },
             { count: 5, expected: true },
             { count: 10, expected: true },
-        ])('returns $expected when $count changes recorded', ({ count, expected }) => {
+        ])('flags a loop re-setting the same URL: $expected at $count changes', ({ count, expected }) => {
             for (let i = 0; i < count; i++) {
-                tracker.recordChange(`/web?v=${i}`, 'webAnalyticsLogic', 'setFilters')
+                tracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
             }
 
             expect(tracker.isRapidlyChanging()).toBe(expected)
+        })
+
+        it('does not flag a burst of distinct URLs, e.g. typing into a search box', () => {
+            // Each keystroke syncs a new search term to the query string, so every URL differs.
+            // This is legitimate navigation, not the infinite loop the tracker exists to catch.
+            for (let i = 0; i < 10; i++) {
+                tracker.recordChange(`/dashboard?search=${i}`, 'dashboardsLogic', 'setSearch')
+            }
+
+            expect(tracker.isRapidlyChanging()).toBe(false)
         })
     })
 
@@ -239,11 +249,11 @@ describe('UrlChangeTracker', () => {
                 maxChangesPerSecond: 2,
             })
 
-            customTracker.recordChange('/web?v=1', 'webAnalyticsLogic', 'setFilters')
-            customTracker.recordChange('/web?v=2', 'webAnalyticsLogic', 'setFilters')
+            customTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
+            customTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
             expect(customTracker.isRapidlyChanging()).toBe(false)
 
-            customTracker.recordChange('/web?v=3', 'webAnalyticsLogic', 'setFilters')
+            customTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
             expect(customTracker.isRapidlyChanging()).toBe(true)
         })
 

--- a/frontend/src/lib/logic/scenes/urlChangeTracker.test.ts
+++ b/frontend/src/lib/logic/scenes/urlChangeTracker.test.ts
@@ -153,6 +153,17 @@ describe('UrlChangeTracker', () => {
 
             expect(tracker.isRapidlyChanging()).toBe(false)
         })
+
+        it('flags an extreme burst of distinct URLs as a loop', () => {
+            // A runaway loop that mutates the URL each iteration (e.g. an incrementing counter) never
+            // repeats a URL, so the duplicate heuristic alone would miss it. The sheer volume - far
+            // beyond human typing - must still be caught.
+            for (let i = 0; i < 60; i++) {
+                tracker.recordChange(`/web?loop=${i}`, 'webAnalyticsLogic', 'setFilters')
+            }
+
+            expect(tracker.isRapidlyChanging()).toBe(true)
+        })
     })
 
     describe('warning throttle', () => {

--- a/frontend/src/lib/logic/scenes/urlChangeTracker.ts
+++ b/frontend/src/lib/logic/scenes/urlChangeTracker.ts
@@ -84,7 +84,16 @@ class UrlChangeTracker {
     }
 
     isRapidlyChanging(): boolean {
-        return this.changes.length > this.config.maxChangesPerSecond
+        if (this.changes.length <= this.config.maxChangesPerSecond) {
+            return false
+        }
+        // A genuine infinite loop re-sets the same handful of URLs over and over, so the burst is
+        // dominated by duplicates. Legitimate rapid navigation - e.g. a user typing into a search
+        // box that syncs each keystroke to the query string - produces a stream of mostly-distinct
+        // URLs and must not be flagged as a loop. Only treat the burst as rapid when at most half of
+        // the recorded changes are distinct URLs.
+        const uniqueUrls = new Set(this.changes.map((c) => c.url)).size
+        return uniqueUrls * 2 <= this.changes.length
     }
 
     canWarn(): boolean {

--- a/frontend/src/lib/logic/scenes/urlChangeTracker.ts
+++ b/frontend/src/lib/logic/scenes/urlChangeTracker.ts
@@ -56,12 +56,17 @@ interface UrlChangeTrackerConfig {
     maxChangesPerSecond: number
     windowMs: number
     throttleWarningMs: number
+    loopBurstThreshold: number
 }
 
 const DEFAULT_CONFIG: UrlChangeTrackerConfig = {
     maxChangesPerSecond: 4,
     windowMs: 3000,
     throttleWarningMs: 60000,
+    // Above this many changes in the window we always treat the burst as a loop, even when every URL
+    // is distinct. ~16 changes/sec sustained over the window is far beyond human typing but trivially
+    // reached by a runaway router loop, so this catches loops that mutate the URL each iteration.
+    loopBurstThreshold: 50,
 }
 
 class UrlChangeTracker {
@@ -87,9 +92,15 @@ class UrlChangeTracker {
         if (this.changes.length <= this.config.maxChangesPerSecond) {
             return false
         }
-        // A genuine infinite loop re-sets the same handful of URLs over and over, so the burst is
-        // dominated by duplicates. Legitimate rapid navigation - e.g. a user typing into a search
-        // box that syncs each keystroke to the query string - produces a stream of mostly-distinct
+        // A runaway loop fires updates far faster and for longer than any human could, so an extreme
+        // burst is always a loop - including one that mutates the URL each iteration (an incrementing
+        // counter, timestamp, or re-serialized param) and so never repeats a URL.
+        if (this.changes.length >= this.config.loopBurstThreshold) {
+            return true
+        }
+        // Below that ceiling, a genuine loop re-sets the same handful of URLs over and over, so the
+        // burst is dominated by duplicates. Legitimate rapid navigation - e.g. a user typing into a
+        // search box that syncs each keystroke to the query string - produces a stream of mostly-distinct
         // URLs and must not be flagged as a loop. Only treat the burst as rapid when at most half of
         // the recorded changes are distinct URLs.
         const uniqueUrls = new Set(this.changes.map((c) => c.url)).size


### PR DESCRIPTION
## Problem

PostHog's frontend reports `Rapid URL changes detected in kea router` to error tracking as a high-volume, handled warning. It's one of our loudest active error-tracking issues (split across 25+ fingerprints), overwhelmingly from the dashboards page.

The kea router runs a guard that flags a burst of URL changes as a potential infinite loop. But the guard only counted how *many* changes happened in the window — it didn't care whether the URLs were the same. Type-to-filter inputs that sync each keystroke to the query string (the dashboards filter bar being the main offender: `LemonInput.onChange` → `DashboardsFiltersBar` → `trackedActionToUrl` → `trackUrlChange`) produce a burst of mostly-*distinct* URLs, which is legitimate navigation, not a loop — and it got flagged anyway.

A previous fix ([#71088](https://github.com/PostHog/posthog/pull/71088)) addressed one specific flavor (the AI-observability trace search stack overflow) but not this general path. The broad fix for `urlChangeTracker.ts` was drafted earlier but never merged, so the warning kept firing at full volume on the latest builds.

## Changes

`isRapidlyChanging()` now only treats a burst as a loop when it is dominated by duplicate URLs — at most half the recorded changes are distinct. A genuine re-navigation loop re-sets the same handful of URLs repeatedly; typing into a search box produces a stream of distinct URLs and is no longer flagged.

## How did you test this code?

Updated `urlChangeTracker.test.ts`:
- Added a regression test asserting a burst of 10 distinct URLs (the search-typing shape) is **not** flagged — this is the exact regression the PR fixes; no existing test covered distinct-URL bursts.
- Updated the existing loop tests to re-set the *same* URL, since a loop is now defined by duplicate URLs rather than raw count.

Note: this environment has no `node_modules`, so I (the agent) could not run jest, typecheck, or lint locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated an error-tracking alert via the PostHog MCP error-tracking tools (`query-error-tracking-issues-list`, `query-error-tracking-issue-events`, `execute-sql`), which showed the warning still firing at full volume on the newest build, overwhelmingly from the dashboards filter bar. Traced prior work to a merged AIO-scoped fix and an unmerged general fix, then re-applied the general `urlChangeTracker.ts` change here. Skills invoked: `/investigating-error-issue`, `/writing-tests`.

The duplicate-ratio heuristic was chosen over alternatives (e.g. debouncing every URL-syncing input) because it fixes the root cause in one shared place and covers all the split fingerprints at once, rather than per-component.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1784230191642049?thread_ts=1784230191.642049&cid=C0A006STKHR)*
