### PR TITLE
fix(shortcuts): match ⌘⌥ shortcuts by layout-aware key, not physical position

### DIFF
--- a/frontend/src/lib/components/Shortcuts/shortcutLogic.test.ts
+++ b/frontend/src/lib/components/Shortcuts/shortcutLogic.test.ts
@@ -1,0 +1,60 @@
+import { initKeaTests } from '~/test/init'
+
+import { shortcutLogic } from './shortcutLogic'
+
+jest.mock('lib/posthog-typed', () => ({
+    __esModule: true,
+    default: { __loaded: true, capture: jest.fn() },
+}))
+
+// The ⌘⌥ matching path branches on isMac(), which is captured once at module load.
+jest.mock('lib/utils/dom', () => ({
+    ...jest.requireActual('lib/utils/dom'),
+    isMac: () => true,
+}))
+
+describe('shortcutLogic', () => {
+    let logic: ReturnType<typeof shortcutLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = shortcutLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    function register(name: string, keybind: string[][]): jest.Mock {
+        const callback = jest.fn()
+        logic.actions.registerShortcut({ name, keybind, intent: name, interaction: 'function', callback })
+        return callback
+    }
+
+    function press(init: KeyboardEventInit): void {
+        window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }))
+    }
+
+    it('matches ⌘⌥ shortcuts by the layout-aware key, not the physical key position', () => {
+        const onC = register('c-action', [['command', 'option', 'c']])
+        const onI = register('i-action', [['command', 'option', 'i']])
+
+        // On Dvorak the key labelled "c" sits where QWERTY has "i": event.code is "KeyI"
+        // but event.key is the true letter "c". Matching must follow the letter, not the position.
+        press({ key: 'c', code: 'KeyI', metaKey: true, altKey: true })
+
+        expect(onC).toHaveBeenCalledTimes(1)
+        expect(onI).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the physical key only when Option turns event.key into a non-letter glyph', () => {
+        const onK = register('k-action', [['command', 'option', 'k']])
+
+        // macOS US layout: ⌥K produces the glyph "˚" as event.key, so the physical code is the
+        // only reliable source of the intended letter.
+        press({ key: '˚', code: 'KeyK', metaKey: true, altKey: true })
+
+        expect(onK).toHaveBeenCalledTimes(1)
+    })
+})

--- a/frontend/src/lib/components/Shortcuts/shortcutLogic.test.ts
+++ b/frontend/src/lib/components/Shortcuts/shortcutLogic.test.ts
@@ -2,12 +2,8 @@ import { initKeaTests } from '~/test/init'
 
 import { shortcutLogic } from './shortcutLogic'
 
-jest.mock('lib/posthog-typed', () => ({
-    __esModule: true,
-    default: { __loaded: true, capture: jest.fn() },
-}))
-
-// The ⌘⌥ matching path branches on isMac(), which is captured once at module load.
+// The ⌘⌥ matching path branches on isMac(), captured once at module load. Force it so the
+// modifier resolves to 'command' regardless of the host platform running the test.
 jest.mock('lib/utils/dom', () => ({
     ...jest.requireActual('lib/utils/dom'),
     isMac: () => true,
@@ -17,7 +13,7 @@ describe('shortcutLogic', () => {
     let logic: ReturnType<typeof shortcutLogic.build>
 
     beforeEach(() => {
-        initKeaTests()
+        initKeaTests(false)
         logic = shortcutLogic()
         logic.mount()
     })

--- a/frontend/src/lib/components/Shortcuts/shortcutLogic.tsx
+++ b/frontend/src/lib/components/Shortcuts/shortcutLogic.tsx
@@ -187,9 +187,14 @@ export const shortcutLogic = kea<shortcutLogicType>([
                     pressedKeys.push('option')
                 }
 
-                // Handle Alt key combinations - event.key can change with Alt held
+                // event.key is layout-aware, so it stays correct on non-QWERTY layouts (Dvorak,
+                // AZERTY, etc.) where the physical event.code position does not match the letter.
+                // Prefer it. The only reason to consult the physical event.code is the macOS quirk
+                // where holding Option turns event.key into a special glyph or dead key (e.g. ⌥K
+                // becomes "˚"); fall back to event.code only in that case, never when event.key
+                // already gives us a usable letter or digit.
                 let keyToAdd = event.key.toLowerCase()
-                if (event.altKey) {
+                if (event.altKey && !/^[a-z0-9]$/.test(keyToAdd)) {
                     const codeMatch = event.code.match(/^Key([A-Z])$/)
                     if (codeMatch) {
                         keyToAdd = codeMatch[1].toLowerCase()


### PR DESCRIPTION
## Problem

On non-QWERTY keyboard layouts (Dvorak, AZERTY, etc.), `⌘⌥` (command+option) shortcuts fired the wrong action because the shortcut engine resolved the pressed letter from the **physical key position** (`event.code`) instead of the layout-aware `event.key`. On Dvorak the key labelled "C" sits where QWERTY has "I", so a `⌘⌥C` press was matched as if it were `⌘⌥I` — landing the user on the wrong destination.

Since every app shortcut uses `command+option` (`baseModifier`), this affected all of them on non-QWERTY layouts.

## Changes

`shortcutLogic` now prefers `event.key` (correct on every layout) when matching the `⌘⌥` chord. It only consults the physical `event.code` for the macOS quirk the branch was originally written for — where holding Option turns `event.key` into a special glyph or dead key (e.g. `⌥K` → "˚") — and never when `event.key` already gives a usable letter or digit. This brings the engine in line with the older `useKeyboardHotkeys` hook, which already matches on `event.key`.

## How did you test this code?

Added `shortcutLogic.test.ts` with two cases:
- **Layout-aware matching** — a Dvorak-style event (`event.key: 'c'`, `event.code: 'KeyI'`) triggers the `⌘⌥C` shortcut and not `⌘⌥I`. This fails if the engine reverts to matching on `event.code`.
- **macOS Option-glyph fallback** — an event whose `event.key` is the glyph "˚" with `event.code: 'KeyK'` still triggers `⌘⌥K`. This fails if the physical-key fallback is dropped, which would break Option shortcuts on macOS.

No existing test covered `shortcutLogic`, so neither regression was previously caught. I was unable to run the JS test suite in this environment (no `node_modules`/toolchain available) — CI will execute the tests.

## Docs update

No docs change — internal keyboard-handling behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Traced the regression: the current shortcut engine (`shortcutLogic`, introduced in #41677) reimplemented keyboard handling from scratch and reintroduced physical-key (`event.code`) matching in its Option branch, whereas the older `useKeyboardHotkeys` hook it sits alongside matches on the layout-aware `event.key`. Fix keeps the macOS Option-dead-key fallback (the branch's original purpose) but gates it so it only triggers when `event.key` isn't already a usable letter/digit.

Skill invoked: `/writing-tests` (to gate the added regression tests).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1784230051235469)*
