### PR TITLE
fix(data-imports): treat Fly.io 400 Bad Request as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/source.py
@@ -95,6 +95,12 @@ Create an organization-scoped token with `fly tokens create org` (or from the **
             # the sync. Match the stable status text and base host, not the per-request path.
             "401 Client Error: Unauthorized for url: https://api.machines.dev": "Your Fly.io API token is invalid or expired. Create a new token with `fly tokens create org` and reconnect.",
             "403 Client Error: Forbidden for url: https://api.machines.dev": "Your Fly.io API token does not have access to this organization or resource. Check the token's scope and reconnect.",
+            # Fly.io accepts the token (auth is checked before anything else, so a bad token is a
+            # 401/403 handled above) but rejects the request itself. The org slug validates against
+            # the apps endpoint yet the org-scoped machines/volumes endpoints refuse it, so the
+            # request is deterministically bad and retrying just resends it. Match the stable status
+            # text and base host, not the per-request path (which carries the org slug).
+            "400 Client Error: Bad Request for url: https://api.machines.dev": "Fly.io rejected the request for this organization. Check that the organization slug is correct (find it with `fly orgs list`) and that your token can access that organization, then reconnect.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/tests/test_fly_io_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/tests/test_fly_io_source.py
@@ -104,6 +104,12 @@ class TestNonRetryableErrors:
         [
             ("unauthorized", "401 Client Error: Unauthorized for url: https://api.machines.dev/v1/orgs/acme/machines"),
             ("forbidden", "403 Client Error: Forbidden for url: https://api.machines.dev/v1/apps?org_slug=acme"),
+            # A 400 on the org-scoped machines/volumes endpoint is a permanent rejection (auth passed,
+            # since a bad token is a 401/403); retrying resends the same doomed request.
+            (
+                "bad_request",
+                "400 Client Error: Bad Request for url: https://api.machines.dev/v1/orgs/acme/machines?limit=1000",
+            ),
         ]
     )
     def test_credential_errors_are_non_retryable(self, _name: str, observed_error: str) -> None:


### PR DESCRIPTION
## Problem

The Fly.io data-warehouse import surfaces this in error tracking:

- Exception: `HTTPError`
- Message: `400 Client Error: Bad Request for url: https://api.machines.dev/v1/orgs/<org>/machines?limit=1000`
- Origin: `_fetch_page` in `products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/fly_io.py`, hit while syncing the org-scoped `machines` (and `volumes`) streams.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f6c7c-8fe6-7ba2-aac3-d2b2c404bad6

A 400 here is not in `get_non_retryable_errors`, so it re-raises and Temporal keeps retrying the activity. Each attempt hits the same deterministic 400 and re-reports to error tracking, which is pure noise since retrying can never succeed.

## Changes

Classify a Fly.io `400 Bad Request` as non-retryable, alongside the existing `401`/`403` credential entries, and give the user an actionable message.

Why this is the right bucket, not a code bug in the request we build:

- The request is spec-compliant. The Fly Machines API OpenAPI spec documents the org-scoped `GET /v1/orgs/{org_slug}/machines` and `/volumes` endpoints, and `limit` is a valid query param with a documented max of 1000. The `?limit=1000` in the message is just the URL that `raise_for_status()` echoes, not a rejected param.
- Auth is checked first. Every unauthenticated request to these endpoints returns `401` before any param validation (verified against the live API). A `400` therefore means the token was accepted, so this is not a revoked or expired token (those are `401`/`403`, already handled).
- It is deterministic. The same org slug and params get sent every sync, so a `400` will keep failing. The most likely trigger is the org slug: it passes credential validation (which probes the `apps` endpoint via `?org_slug=`) yet the org-path `machines`/`volumes` endpoints reject it, for example when the personal-org alias doesn't resolve on the org-path form.

This mirrors the existing 401/403 entries: match the stable status text and base host (`https://api.machines.dev`), never the per-request path, which carries the customer's org slug.

> [!NOTE]
> This stops the retry-and-report noise and gives the user something to act on. A deeper follow-up could align credential validation with the endpoints the sync actually calls (or resolve the personal-org alias), so a slug that will 400 gets caught at connect time instead.

## How did you test this code?

Automated only (I am an agent and did not run a live Fly.io sync):

- Extended the parameterized `TestNonRetryableErrors` in `test_fly_io_source.py` with a realistic `400 Client Error: Bad Request ...` message and assert it is classified non-retryable. The existing `test_transient_errors_remain_retryable` (read timeout, 500) still passes, so this doesn't swallow retryable failures.
- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/tests/` — 16 passed.
- `ruff check` and `ruff format --check` clean on both files.

I also confirmed against the live Fly Machines API that unauthenticated calls to these endpoints return `401` (auth precedes param validation) and against the OpenAPI spec that the org-scoped endpoints and `limit` param are documented.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of a live error-tracking issue in the data-warehouse import pipeline, done by Claude (Claude Code). I traced the stack trace to the Fly.io source, read the source and settings, and checked the decision both ways (fixable request bug vs upstream/config error). I ruled out a request bug by confirming the endpoints and the `limit=1000` param against Fly's OpenAPI spec and probing the live API to establish that auth is validated before params (so a 400 implies a valid token). Landed on non-retryable, matching the established pattern in this file for 401/403.

Skills/tools: PostHog error-tracking MCP tools to pull the issue and stack trace; `WebFetch`/`WebSearch` and direct `curl` against the Fly API and its OpenAPI spec; `ruff` and `pytest` for lint and tests. No migrations or DRF/serializer changes involved.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
