### PR TITLE
feat(signals): show product analytics anomaly source in agent roster

### DIFF
--- a/frontend/src/scenes/inbox/components/config/AgentsRoster.tsx
+++ b/frontend/src/scenes/inbox/components/config/AgentsRoster.tsx
@@ -152,6 +152,7 @@ export function AgentsRoster(): JSX.Element {
         sessionAnalysisConfig,
         conversationsConfig,
         evalReportsConfig,
+        anomalyInvestigationConfig,
         githubIssuesConfig,
         linearIssuesConfig,
         zendeskTicketsConfig,
@@ -160,6 +161,7 @@ export function AgentsRoster(): JSX.Element {
         isSessionAnalysisToggling,
         isConversationsToggling,
         isEvalReportsToggling,
+        isAnomalyInvestigationToggling,
         isErrorTrackingToggling,
         isGithubIssuesToggling,
         isLinearIssuesToggling,
@@ -171,6 +173,7 @@ export function AgentsRoster(): JSX.Element {
         toggleConversations,
         toggleErrorTracking,
         toggleEvalReports,
+        toggleAnomalyInvestigation,
         initiateDataWarehouseSourceToggle,
     } = useActions(signalSourcesLogic)
 
@@ -212,6 +215,13 @@ export function AgentsRoster(): JSX.Element {
                         requiresSetup: false,
                         syncStatus: null,
                     }
+                case 'analytics':
+                    return {
+                        armed: !!anomalyInvestigationConfig?.enabled,
+                        loading: isAnomalyInvestigationToggling,
+                        requiresSetup: false,
+                        syncStatus: anomalyInvestigationConfig?.status,
+                    }
                 case 'github':
                     return dwState(githubIssuesConfig, isGithubIssuesToggling)
                 case 'linear':
@@ -231,6 +241,8 @@ export function AgentsRoster(): JSX.Element {
             isSessionAnalysisToggling,
             evalReportsConfig,
             isEvalReportsToggling,
+            anomalyInvestigationConfig,
+            isAnomalyInvestigationToggling,
             githubIssuesConfig,
             isGithubIssuesToggling,
             linearIssuesConfig,
@@ -257,6 +269,9 @@ export function AgentsRoster(): JSX.Element {
                 case 'llm_analytics':
                     toggleEvalReports()
                     return
+                case 'analytics':
+                    toggleAnomalyInvestigation()
+                    return
                 case 'github':
                     initiateDataWarehouseSourceToggle('Github')
                     return
@@ -276,6 +291,7 @@ export function AgentsRoster(): JSX.Element {
             toggleConversations,
             toggleSessionAnalysis,
             toggleEvalReports,
+            toggleAnomalyInvestigation,
             initiateDataWarehouseSourceToggle,
         ]
     )

--- a/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
+++ b/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
@@ -11,6 +11,7 @@ export type AgentRosterSource =
     | 'conversations'
     | 'session_replay'
     | 'llm_analytics'
+    | 'analytics'
     | 'github'
     | 'linear'
     | 'zendesk'
@@ -74,6 +75,15 @@ export const AGENT_ROSTER_GROUPS: AgentRosterGroup[] = [
                 description: 'Findings from evaluation reports on your LLM traffic.',
                 docsUrl: 'https://posthog.com/docs/ai-evals/evaluations',
                 docsLabel: 'AI observability',
+            },
+            {
+                source: 'analytics',
+                sourceProduct: SignalSourceProduct.Analytics,
+                label: 'Product analytics',
+                description: 'Anomalies and unexpected shifts detected in your product metrics.',
+                docsUrl: 'https://posthog.com/docs/product-analytics',
+                docsLabel: 'Product analytics',
+                alpha: true,
             },
         ],
     },


### PR DESCRIPTION
## Problem

The new Product Analytics Anomaly Investigation signal source wasn't appearing in the Signals scouts config UI under the "PostHog data" category. The source is fully functional on the backend (enum, migration, workflow) and already wired into `signalSourcesLogic` (config selector, toggling flag, toggle action), plus it has an icon and a signal card — but the categorized roster UI is driven by a hand-maintained allowlist (`AGENT_ROSTER_GROUPS`) that it was never added to, so it rendered nowhere.

## Changes

- Add `'analytics'` to the `AgentRosterSource` union and register a "Product analytics" entry in the "PostHog data" group in `agentRosterMeta.ts`.
- Wire the exhaustive `stateFor` and `handleToggle` switches in `AgentsRoster.tsx` to the existing `anomalyInvestigationConfig` / `isAnomalyInvestigationToggling` / `toggleAnomalyInvestigation` plumbing, mirroring the AI observability (`llm_analytics`) entry.

**Why:** the source was invisible in the UI despite being fully built out on the backend — this connects the last mile so users can arm it like every other PostHog-data source.

## How did you test this code?

Not able to run the frontend typecheck in this environment (no `node_modules`). The change mirrors the existing `llm_analytics` entry exactly, and every referenced symbol was verified to exist: `SignalSourceProduct.Analytics` (used in `signalSourcesLogic.ts` and `sourceProductIcons.tsx`) and the three logic selectors/actions. Both switches are exhaustive over `AgentRosterSource`, so a missing case would fail typecheck — the new `analytics` case is present in both. A reviewer should run `pnpm --filter=@posthog/frontend typescript:check` and confirm the card appears under "PostHog data".

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Root cause was traced with an Explore agent: category membership is a static allowlist, not derived from the `SignalSourceProduct` enum, so the source needed three edits (union type + group entry + both switch cases). Chose to mirror the `llm_analytics`/eval-reports entry rather than refactor the allowlist to auto-derive from the enum, keeping the change minimal and low-risk.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784232274769559)*
