### PR TITLE
fix(clickhouse): treat 429 rate-limit as a retryable connect error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -112,6 +112,12 @@ _TRANSIENT_CONNECT_DROP_SUBSTRINGS = (
     "Tunnel connection failed: 502",
     "Tunnel connection failed: 503",
     "Tunnel connection failed: 504",
+    # ClickHouse (or a proxy/gateway in front of it) rate-limited the connect
+    # request with HTTP 429. A rate limit is a "back off and retry" signal, not a
+    # deterministic failure, so a fresh attempt after our short backoff can
+    # recover. We match only 429; the deterministic 404 (wrong endpoint) stays in
+    # the source's NonRetryableErrors.
+    "returned response code 429",
 )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -661,6 +661,8 @@ class TestClickHouseSourceNonRetryableErrors:
             # Transient gateway errors must stay retryable — only 404 is permanent.
             "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 502",
             "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 503",
+            # A 429 rate limit must stay retryable — the correct response is to back off, not stop.
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 429",
         ],
     )
     def test_transient_errors_are_retryable(self, source, error_msg):
@@ -687,6 +689,8 @@ class TestIsTransientConnectDrop:
             "502 Bad gateway'))) executing HTTP request attempt 1",
             "Tunnel connection failed: 503 Service Unavailable",
             "Tunnel connection failed: 504 Gateway Timeout",
+            # A 429 rate limit is a back-off-and-retry signal, so the connect retries.
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 429",
         ],
     )
     def test_matches_transient_drops(self, message):


### PR DESCRIPTION
## Problem

PostHog error tracking flagged a live failure in the ClickHouse data-warehouse import source:

- **Exception:** `ClickHouseConnectionError` wrapping clickhouse-connect's `OperationalError`
- **Message:** `HTTPDriver for <redacted host> returned response code 429`
- **Origin:** `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py` — raised in `_get_client`, reached via `get_clickhouse_row_count` → `clickhouse_source` → `source_for_pipeline`.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f6c8c-4967-7631-98e9-1044bf6f98f0

The customer's ClickHouse endpoint (or a proxy/gateway in front of it) rate-limited our connect request with HTTP 429. `_get_client` caught the driver error but only recognized a fixed set of transient connect failures (TLS drops, and gateway codes 502/503/504) as worth retrying. A 429 matched none of them, so it bubbled up immediately, failing the connect and forcing the whole import activity to restart.

## Changes

A 429 is a "back off and retry" signal, not a permanent error and not a bug on our side, so it should stay retryable. I added `returned response code 429` to `_TRANSIENT_CONNECT_DROP_SUBSTRINGS`, right next to the existing 502/503/504 gateway codes it's a sibling of. Now `_get_client` gives a rate-limited connect a few backed-off retries before giving up, and because it's still not in the source's `NonRetryableErrors`, it also remains retryable at the Temporal activity level if the rate limit outlasts the in-connect backoff.

I deliberately did not add 429 to `NonRetryableErrors` — that would stop retrying, which is the opposite of what a rate limit calls for. The deterministic 404 (wrong endpoint) stays non-retryable as before.

> [!NOTE]
> Scoped strictly to 429. No change to the global retry policy, timeouts, or the other transient/non-retryable classifications.

## How did you test this code?

Automated tests only (I'm an agent and did not run this against a live rate-limited ClickHouse). Added two parametrized cases and ran the affected suites:

- `TestIsTransientConnectDrop::test_matches_transient_drops` — new 429 case. Catches a regression where 429 is dropped from the transient list and a rate-limited connect stops being retried.
- `TestClickHouseSourceNonRetryableErrors::test_transient_errors_are_retryable` — new 429 case. Catches a regression where 429 is mistakenly added to `NonRetryableErrors` and stops being retried at the activity level.

```
uv run pytest .../clickhouse/test_clickhouse.py \
  -k "TransientConnectDrop or NonRetryable or GetClientTransientRetry"
# 35 passed
```

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I confirmed the issue in PostHog error tracking (stack trace, exception type, frequency), traced the raise site into `_get_client`, and classified the 429 as a transient rate-limit rather than a user/config error or a code bug. Chose the transient-connect-retry path over `NonRetryableErrors` because the correct response to a rate limit is to back off and retry, matching the existing 502/503/504 handling.

Skills invoked: `/writing-tests` (to gate the added test cases).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
