### PR TITLE
fix(clickhouse): stop capturing transient rate-limit noise in partition probe

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -899,6 +899,24 @@ def _get_incremental_row_count(
     return int(count) if count is not None else None
 
 
+# clickhouse-connect surfaces a non-2xx HTTP status from the server (or a
+# proxy/LB in front of it) as `HTTPDriver for <url> returned response code <N>`.
+# 429 (rate limited) and the transient gateway codes mean the endpoint can't
+# serve us right now, not that anything we sent was wrong — they clear on their
+# own. A real ClickHouse query error carries a `Code: NNN` instead. We match
+# only these transient statuses so genuine failures still surface.
+_TRANSIENT_HTTP_RESPONSE_SUBSTRINGS: tuple[str, ...] = (
+    "returned response code 429",
+    "returned response code 502",
+    "returned response code 503",
+    "returned response code 504",
+)
+
+
+def _is_transient_http_response(message: str) -> bool:
+    return any(substring in message for substring in _TRANSIENT_HTTP_RESPONSE_SUBSTRINGS)
+
+
 def _get_partition_settings(
     client: ClickHouseClient, database: str, table_name: str, logger: FilteringBoundLogger
 ) -> PartitionSettings | None:
@@ -920,7 +938,12 @@ def _get_partition_settings(
             parameters={"database": database, "table": table_name},
         )
     except ClickHouseError as e:
-        capture_exception(e)
+        # Partitioning is a best-effort optimization; any failure here degrades
+        # to default partitioning. A transient rate-limit/gateway response from
+        # the source isn't actionable on our side, so don't add error-tracking
+        # noise for it — genuine errors are still captured.
+        if not _is_transient_http_response(str(e)):
+            capture_exception(e)
         logger.debug(f"_get_partition_settings: failed: {e}")
         return None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -18,6 +18,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse
     _build_query,
     _get_client,
     _get_incremental_row_count,
+    _get_partition_settings,
     _has_duplicate_primary_keys,
     _is_transient_connect_drop,
     _parse_mv_target,
@@ -1010,6 +1011,40 @@ class TestGetIncrementalRowCount:
         result.result_rows = [(None,)]
         client.query.return_value = result
         assert _get_incremental_row_count(client, "db", "t", "id", 0, self._logger()) is None
+
+
+class TestGetPartitionSettings:
+    def _logger(self):
+        return MagicMock()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "HTTPDriver for https://example.invalid:443 returned response code 429",
+            "HTTPDriver for https://example.invalid:443 returned response code 502",
+            "HTTPDriver for https://example.invalid:443 returned response code 503",
+            "HTTPDriver for https://example.invalid:443 returned response code 504",
+        ],
+    )
+    def test_transient_http_response_not_captured(self, error_msg):
+        client = MagicMock()
+        client.query.side_effect = ClickHouseError(error_msg)
+
+        with patch.object(ch_module, "capture_exception") as mock_capture:
+            # Falls back to default partitioning without adding error-tracking
+            # noise — the source rate-limiting us isn't actionable on our side.
+            assert _get_partition_settings(client, "db", "t", self._logger()) is None
+
+        mock_capture.assert_not_called()
+
+    def test_unexpected_error_is_captured(self):
+        client = MagicMock()
+        client.query.side_effect = ClickHouseError("Code: 62. DB::Exception: Syntax error")
+
+        with patch.object(ch_module, "capture_exception") as mock_capture:
+            assert _get_partition_settings(client, "db", "t", self._logger()) is None
+
+        mock_capture.assert_called_once()
 
 
 class TestGetRowsBatching:


### PR DESCRIPTION
## Problem

Error tracking surfaced a handled `OperationalError` from the ClickHouse data-warehouse import source:

> `HTTPDriver for <redacted host> returned response code 429`

The exception originates in `_get_partition_settings` in `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`.
That function is a best-effort optimization: it reads `system.tables.total_bytes` to size Delta partitions, and on any failure it already falls back to default partitioning and returns `None`.

The problem is that its `except ClickHouseError` block calls `capture_exception` on every failure, including a transient HTTP 429 (rate limited) from the source (or a proxy/LB in front of it).
The sync itself does not fail here, the error is caught and recovered from (`$exception_handled: true`).
So the only effect is error-tracking noise for something that is not actionable on our side and clears on its own.

This is the same class of issue the sibling duplicate-primary-key probe already handles via its expected-probe-failure allowlist.

## Changes

`_get_partition_settings` now skips `capture_exception` for transient HTTP responses (429 and the gateway codes 502/503/504), while still capturing any other unexpected `ClickHouseError`.
Behavior is otherwise unchanged: it still logs at debug and returns `None`, so the pipeline continues with default partitioning.

A `Code: NNN` from a real ClickHouse query error does not match the transient-status substrings, so genuine failures still surface.

This is deliberately not a `NonRetryableErrors` change: the error is swallowed inside a best-effort probe and never reaches the pipeline retry machinery, and transient rate limits should stay retryable everywhere else.

## How did you test this code?

Added `TestGetPartitionSettings` with two cases:

- transient HTTP responses (429/502/503/504) return `None` **without** calling `capture_exception` — this is the regression the fix targets, and no existing test covered `_get_partition_settings` capture behavior.
- a genuine `Code: 62` error still calls `capture_exception` — guards against over-suppressing real failures.

Ran locally:

```
pytest .../clickhouse/test_clickhouse.py::TestGetPartitionSettings          # 5 passed
pytest .../clickhouse/test_clickhouse.py::TestHasDuplicatePrimaryKeys \
       ::TestGetIncrementalRowCount ::TestClickHouseSourceNonRetryableErrors # 31 passed
ruff check + ruff format --check                                            # clean
```

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I confirmed the issue in error tracking (pulled the stack trace, exception type, and that it was handled), traced the call path into `_get_partition_settings`, and confirmed via the `clickhouse-connect` exception hierarchy that `OperationalError` is a `ClickHouseError` subclass so it hits that `except` block.

Decision: this is a fixable bug (over-eager capture in a graceful-fallback path), not a `NonRetryableErrors` case, because the error is already swallowed and transient rate limits should remain retryable. Chose to mirror the file's existing `_is_expected_probe_failure` pattern rather than remove capturing entirely, so genuine unexpected errors still surface. Checked open PRs (including the maintainer's) for a matching fix and found none.

Invoked the `/writing-tests` skill before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
