### PR TITLE
fix(clickhouse): retry connect-time 429 rate limits in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -112,6 +112,14 @@ _TRANSIENT_CONNECT_DROP_SUBSTRINGS = (
     "Tunnel connection failed: 502",
     "Tunnel connection failed: 503",
     "Tunnel connection failed: 504",
+    # The upstream ClickHouse endpoint (or a gateway in front of it) answered
+    # our connect-time handshake query with a 429 Too Many Requests
+    # ("HTTPDriver for <url> returned response code 429"). This is transient
+    # rate-limiting that clears on its own, so a fresh attempt after a short
+    # pause recovers; if it persists past our attempts we re-raise and Temporal
+    # retries with longer backoff. We match only 429 — deterministic codes like
+    # 404 stay out of the retry path (that one is non-retryable in source.py).
+    "returned response code 429",
 )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -661,6 +661,8 @@ class TestClickHouseSourceNonRetryableErrors:
             # Transient gateway errors must stay retryable — only 404 is permanent.
             "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 502",
             "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 503",
+            # 429 Too Many Requests is upstream rate-limiting that clears on its own.
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 429",
         ],
     )
     def test_transient_errors_are_retryable(self, source, error_msg):
@@ -687,6 +689,8 @@ class TestIsTransientConnectDrop:
             "502 Bad gateway'))) executing HTTP request attempt 1",
             "Tunnel connection failed: 503 Service Unavailable",
             "Tunnel connection failed: 504 Gateway Timeout",
+            # The upstream endpoint rate-limited our connect-time handshake query.
+            "HTTPDriver for https://host:8443 returned response code 429",
         ],
     )
     def test_matches_transient_drops(self, message):


### PR DESCRIPTION
## Problem

Error tracking surfaced a live failure on the ClickHouse data-warehouse source: `ClickHouseConnectionError: HTTPDriver for <redacted host> returned response code 429`, raised in `clickhouse.py:_get_client` ([issue](https://us.posthog.com/project/2/error_tracking/019f6c8c-3391-78d0-978d-aee416045b91)).

A 429 is Too Many Requests. The upstream ClickHouse endpoint (or a gateway in front of it) rate-limited the handshake query that `clickhouse-connect` runs while constructing the client. That `OperationalError` is caught by `_get_client` and re-wrapped into `ClickHouseConnectionError`, which failed the whole import attempt on the spot and was captured as a handled exception. The occurrences in the issue are a short burst inside a single sync's retry window — a textbook transient rate-limit.

## Changes

Add `"returned response code 429"` to `_TRANSIENT_CONNECT_DROP_SUBSTRINGS`, the allowlist that `_get_client` already uses to retry transient connect failures in-process (up to `_MAX_CONNECT_ATTEMPTS`, with a short pause between tries). This puts 429 alongside the transient gateway codes (502/503/504) that already live there.

Behavior after the change:

- A brief rate-limit burst self-heals within one activity attempt instead of failing it and spamming error tracking.
- If the limit persists past our in-process attempts, we re-raise and Temporal retries the activity with its longer backoff — unchanged.
- 429 stays out of `NonRetryableErrors`. That's deliberate: rate limits clear, so marking them non-retryable would permanently disable a sync (`should_sync=False`) that would otherwise recover. Only deterministic upstream codes like 404 are non-retryable.

> [!NOTE]
> This is scoped strictly to the observed connect-time 429. A 429 raised mid-stream (during the data read) is not touched here and remains retryable via Temporal, same as before.

## How did you test this code?

Extended two existing parameterized tests in `test_clickhouse.py` and ran them (`22 passed`):

- `TestIsTransientConnectDrop.test_matches_transient_drops` — a 429 message now matches the in-process retry allowlist. Catches a regression where someone drops 429 from the retry path.
- `TestClickHouseSourceNonRetryableErrors.test_transient_errors_are_retryable` — locks in that 429 is never classified as non-retryable. Catches a regression where someone adds 429 to `NonRetryableErrors` and permanently disables syncs on a transient limit.

Both are cheap pure-function cases added to existing tests rather than new functions. No manual/live testing was performed by me (the agent).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Claude Opus 4.8) from an error-tracking triage task. Skills invoked: `/writing-tests` (to gate the test additions).

Triage decision: this is a transient upstream rate-limit, not a bug in our code and not a user/credentials error. Two options were considered and rejected. (1) Adding 429 to `NonRetryableErrors` — wrong, it would stop retrying a self-healing condition and disable the sync. (2) Doing nothing — Temporal already retries, but each attempt is captured as error-tracking noise and burns a full attempt. Chosen: reuse the source's existing in-process transient-connect-retry mechanism, which mirrors how 502/503/504 are already handled and lets short bursts recover silently.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
