### PR TITLE
fix(clickhouse): tolerate readonly source profiles rejecting settings

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -13,7 +13,7 @@ import pyarrow as pa
 import structlog
 from clickhouse_connect import get_client
 from clickhouse_connect.driver.client import Client as ClickHouseClient
-from clickhouse_connect.driver.exceptions import ClickHouseError
+from clickhouse_connect.driver.exceptions import ClickHouseError, ProgrammingError
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from structlog.types import FilteringBoundLogger
 
@@ -143,6 +143,28 @@ def _is_retryable_connect_error(error_message: str) -> bool:
     return _is_transient_connect_drop(error_message) or _TRANSIENT_RATE_LIMIT_SUBSTRING in error_message
 
 
+def _apply_session_settings(client: ClickHouseClient, settings: dict[str, Any]) -> None:
+    """Apply session settings, tolerating a server that reports one as readonly.
+
+    Our settings are performance and Arrow-output tuning hints. A readonly user
+    profile (common on managed ClickHouse) reports every setting as readonly, and
+    clickhouse-connect refuses to send those — raising ProgrammingError ("Setting
+    <x> is unknown or readonly"). Passing them at client construction turns that
+    into a fatal connect error that fails the whole sync. Applying them one by one
+    lets us keep the settings the server accepts and fall back to the server
+    default for the rest.
+    """
+    for key, value in settings.items():
+        try:
+            client.set_client_setting(key, value)
+        except ProgrammingError as e:
+            structlog.get_logger().warning(
+                "ClickHouse rejected session setting; falling back to server default",
+                setting=key,
+                exc_info=e,
+            )
+
+
 def _get_client(
     *,
     host: str,
@@ -165,7 +187,7 @@ def _get_client(
     attempt = 0
     while True:
         try:
-            return get_client(
+            client = get_client(
                 host=host,
                 port=port,
                 database=database,
@@ -177,7 +199,6 @@ def _get_client(
                 connect_timeout=CONNECT_TIMEOUT_SECONDS,
                 send_receive_timeout=query_timeout,
                 query_limit=0,  # we manage limits ourselves
-                settings=settings or {},
                 compress=True,
             )
         except (ClickHouseError, OSError, ssl.SSLError) as e:
@@ -197,6 +218,12 @@ def _get_client(
                 time.sleep(attempt)
                 continue
             raise ClickHouseConnectionError(message) from e
+
+        # Apply tuning settings after connect, not at construction, so a readonly
+        # source profile that rejects one degrades to the server default instead
+        # of failing the whole connection.
+        _apply_session_settings(client, settings or {})
+        return client
 
 
 def _strip_type_modifiers(type_name: str) -> tuple[str, bool]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -5,7 +5,7 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
-from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError
+from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError, ProgrammingError
 
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -773,6 +773,46 @@ class TestGetClientTransientRetry:
                 self._connect()
         assert mock_get_client.call_count == 1
         mock_sleep.assert_not_called()
+
+
+class TestGetClientSessionSettings:
+    """`_get_client` applies tuning settings after connect, tolerating a
+    readonly source profile that rejects them instead of failing the sync."""
+
+    def _connect(self, settings):
+        return _get_client(
+            host="h",
+            port=8443,
+            database="default",
+            user="default",
+            password=None,
+            secure=True,
+            verify=True,
+            settings=settings,
+        )
+
+    def test_readonly_setting_does_not_fail_connection(self):
+        client = MagicMock()
+
+        def set_setting(key, _value):
+            if key == "max_block_size":
+                raise ProgrammingError("Setting max_block_size is unknown or readonly")
+
+        client.set_client_setting.side_effect = set_setting
+        with patch.object(ch_module, "get_client", return_value=client):
+            result = self._connect({"max_block_size": 20000, "optimize_read_in_order": 1})
+
+        assert result is client
+        # The rejected setting is skipped; the accepted one is still applied.
+        client.set_client_setting.assert_any_call("optimize_read_in_order", 1)
+
+    def test_settings_applied_after_connect_not_at_construction(self):
+        client = MagicMock()
+        with patch.object(ch_module, "get_client", return_value=client) as mock_get_client:
+            self._connect({"max_block_size": 20000})
+
+        assert "settings" not in mock_get_client.call_args.kwargs
+        client.set_client_setting.assert_called_once_with("max_block_size", 20000)
 
 
 class TestTranslateError:


### PR DESCRIPTION
## Problem

The ClickHouse data-warehouse import source crashes at connect time for customers whose ClickHouse user has a readonly profile, which is common on managed offerings. Error tracking surfaced it as `ClickHouseConnectionError: Setting max_block_size is unknown or readonly`, raised from `_get_client`.

Root cause: `get_rows` opens the streaming client with a batch of performance and Arrow-output tuning settings (`max_block_size`, `output_format_arrow_string_as_string`, `optimize_read_in_order`, and so on) passed at client construction. On a readonly profile, `system.settings` reports every setting as readonly, so clickhouse-connect refuses to send them and raises `ProgrammingError` ("Setting `<x>` is unknown or readonly"). Since that happens during construction, `_get_client`'s connect-error handler rewraps it as a fatal `ClickHouseConnectionError` and the whole sync fails.

These settings are tuning hints, not correctness requirements (modern ClickHouse defaults already match what we ask for). The sync should degrade to the server defaults, not die. The other settings-bearing paths in this file (`_has_duplicate_primary_keys`, `_get_incremental_row_count`) already catch `ClickHouseError` and fall back. Only client construction was unguarded.

## Changes

Apply the tuning settings after connect via `set_client_setting`, one at a time, tolerating a per-setting readonly rejection and logging a warning instead of failing. Settings the server accepts still take effect; the rest fall back to the server default.

```diff
- return get_client(..., settings=settings or {}, compress=True)
+ client = get_client(..., compress=True)
+ ...
+ _apply_session_settings(client, settings or {})  # skips readonly-rejected settings
+ return client
```

## How did you test this code?

Added `TestGetClientSessionSettings` with two cases, both of which I confirmed fail on the pre-fix code and pass after:

- `test_readonly_setting_does_not_fail_connection` — a client whose `set_client_setting` raises `ProgrammingError` for one setting no longer fails the connection, and the accepted settings are still applied. This is the exact regression from the error-tracking issue.
- `test_settings_applied_after_connect_not_at_construction` — guards that tuning settings are applied post-connect (where they can be dropped individually) rather than at construction (where one readonly setting kills the whole connect).

I (Claude) ran the source's unit tests locally: all pass except one pre-existing DB-backed test (`TestClickHouseReconcileSchemaMetadata`) that needs Postgres, unrelated to this change. `ruff check` and `ruff format --check` are clean on both files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from a PostHog error-tracking issue for the ClickHouse import source. I (Claude) confirmed the issue in error tracking, traced the stack (`get_rows` → `_get_client` → clickhouse-connect's `_validate_settings`), read the clickhouse-connect internals to confirm the default `invalid_setting_action='error'` behavior and that `system.settings.readonly` reflects the user profile, and judged this a fixable fragility rather than a user/upstream error worth adding to `NonRetryableErrors` (the settings are optional tuning; we should degrade, not stop retrying). Considered flipping the process-global `invalid_setting_action` to `drop` but rejected it — `clickhouse_connect` is also used for our internal ClickHouse in `posthog/clickhouse/client/connection.py`, so a global change would weaken validation there. The per-setting `set_client_setting` approach keeps the fix scoped to this source. Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
