### PR TITLE
fix(clickhouse): retry transient 429 rate-limit responses on connect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -119,6 +119,20 @@ def _is_transient_connect_drop(error_message: str) -> bool:
     return any(substring in error_message for substring in _TRANSIENT_CONNECT_DROP_SUBSTRINGS)
 
 
+# clickhouse-connect surfaces an upstream rate-limit as a full HTTP response
+# ("HTTPDriver for <url> returned response code 429"), not a dropped connection:
+# the request reached the server (or a proxy in front of it) and it told us to
+# slow down. A 429 is explicitly "retry later", so a brief backed-off re-attempt
+# often clears a short rate-limit burst; if it doesn't, the failing Temporal
+# activity stays retryable and recovers later. We match only 429 — other 4xx
+# response codes are deterministic (e.g. 404 stays non-retryable).
+_TRANSIENT_RATE_LIMIT_SUBSTRING = "returned response code 429"
+
+
+def _is_retryable_connect_error(error_message: str) -> bool:
+    return _is_transient_connect_drop(error_message) or _TRANSIENT_RATE_LIMIT_SUBSTRING in error_message
+
+
 def _get_client(
     *,
     host: str,
@@ -163,9 +177,9 @@ def _get_client(
             # the request.
             attempt += 1
             message = str(e)
-            if attempt < _MAX_CONNECT_ATTEMPTS and _is_transient_connect_drop(message):
+            if attempt < _MAX_CONNECT_ATTEMPTS and _is_retryable_connect_error(message):
                 structlog.get_logger().warning(
-                    "Transient ClickHouse connection drop during connect; retrying",
+                    "Transient ClickHouse connect error; retrying",
                     attempt=attempt,
                     max_attempts=_MAX_CONNECT_ATTEMPTS,
                     exc_info=e,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -5,7 +5,7 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
-from clickhouse_connect.driver.exceptions import ClickHouseError
+from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError
 
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -661,6 +661,8 @@ class TestClickHouseSourceNonRetryableErrors:
             # Transient gateway errors must stay retryable — only 404 is permanent.
             "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 502",
             "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 503",
+            # 429 Too Many Requests is a rate-limit ("retry later"), not a permanent error.
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 429",
         ],
     )
     def test_transient_errors_are_retryable(self, source, error_msg):
@@ -734,6 +736,16 @@ class TestGetClientTransientRetry:
             with pytest.raises(ClickHouseConnectionError):
                 self._connect()
         assert mock_get_client.call_count == _MAX_CONNECT_ATTEMPTS
+
+    def test_retries_rate_limit_then_succeeds(self):
+        client = MagicMock()
+        rate_limited = OperationalError("HTTPDriver for https://host:8443 returned response code 429")
+        with (
+            patch.object(ch_module.time, "sleep"),
+            patch.object(ch_module, "get_client", side_effect=[rate_limited, client]) as mock_get_client,
+        ):
+            assert self._connect() is client
+        assert mock_get_client.call_count == 2
 
     def test_does_not_retry_deterministic_failure(self):
         cert_error = ClickHouseError("certificate verify failed")


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `ClickHouseConnectionError` from the ClickHouse data-warehouse import source: `HTTPDriver for <redacted host> returned response code 429`. It originates in this source's code — `_get_client` (`products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`) — raised via the synchronous schema-discovery path (`incremental_fields` → `get_schemas` → `_get_client`).

A 429 is "Too Many Requests" — a transient rate-limit from the upstream ClickHouse HTTP interface (or a proxy in front of it) that explicitly means "retry later". clickhouse-connect raises it as a full HTTP response (an `OperationalError`) which `_get_client` catches, but its in-process connect-retry loop only recognized connection drops and transient gateway blips (502/503/504). So a 429 was wrapped as `ClickHouseConnectionError` and raised immediately, with no retry.

On the sync/import path this was already retryable (429 isn't in `NonRetryableErrors`, so Temporal backs off and retries). But the schema-discovery path is a plain synchronous request with no retry layer, so a single transient burst surfaced to the user and generated error-tracking noise.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f6c8f-182e-7150-b5a3-448b81d734b2

## Changes

- Recognize a 429 response code as a retryable connect error in `_get_client`, so a brief backed-off in-process re-attempt can clear a short rate-limit window. Matches how the same function already retries transient gateway blips.
- 429 deliberately stays **out** of `NonRetryableErrors` — a rate-limit must remain retryable, so the Temporal pipeline path keeps its exponential-backoff safety net. Only 429 is matched; other 4xx codes (e.g. 404) remain non-retryable.

## How did you test this code?

Automated only (agent did not run the app manually):

- `test_retries_rate_limit_then_succeeds` (new) — asserts `_get_client` retries a 429 `OperationalError` then succeeds. Catches a regression where the retry predicate stops recognizing 429 and the synchronous schema-discovery path surfaces a transient rate-limit immediately instead of retrying. No existing test exercised the 429 connect path.
- Added a 429 case to `test_transient_errors_are_retryable` — locks in that 429 is never treated as non-retryable (a regression that added it to `NonRetryableErrors` would stop the sync path from retrying a transient rate-limit).
- Ran the source's test module: all cases pass (`ruff check`/`format` clean). One unrelated DB-backed test errors in this sandbox because Postgres isn't available.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Investigated the issue and full stack trace via the PostHog error-tracking tools, confirmed the failure originates in `_get_client`, and read the source + shared helper. Classified the 429 as a transient rate-limit (not a user/upstream permanent error, so not a `NonRetryableErrors` addition) and chose a bounded in-process retry consistent with the existing 502/503/504 handling. Checked open PRs (including the maintainer's) to rule out a duplicate — the adjacent egress-proxy PR handles CONNECT-tunnel 502/504 and 404, not a 429 response. Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
