### PR TITLE
fix(clickhouse): retry connect-time HTTP 429 rate limits in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -112,6 +112,16 @@ _TRANSIENT_CONNECT_DROP_SUBSTRINGS = (
     "Tunnel connection failed: 502",
     "Tunnel connection failed: 503",
     "Tunnel connection failed: 504",
+    # The ClickHouse host (or a proxy/gateway in front of it) rate-limited the
+    # request with HTTP 429 ("HTTPDriver for <url> returned response code 429").
+    # A 429 is a transient "back off and retry" signal, not a config error.
+    # clickhouse-connect already retries 429 for queries (query_retries), but
+    # the probe it runs while constructing the client passes retries=0, so a
+    # 429 at connect time reaches us with no retry at all — a bounded backoff
+    # retry here recovers the common transient burst. We match only 429; other
+    # HTTP statuses keep their existing handling (404 is non-retryable in the
+    # source, 5xx stay retryable via Temporal).
+    "returned response code 429",
 )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -5,7 +5,7 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
-from clickhouse_connect.driver.exceptions import ClickHouseError
+from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError
 
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -687,6 +687,9 @@ class TestIsTransientConnectDrop:
             "502 Bad gateway'))) executing HTTP request attempt 1",
             "Tunnel connection failed: 503 Service Unavailable",
             "Tunnel connection failed: 504 Gateway Timeout",
+            # HTTP 429 rate-limit at connect time — clickhouse-connect doesn't
+            # retry the client-construction probe, so we retry it in-process.
+            "HTTPDriver for https://host:8443 returned response code 429",
         ],
     )
     def test_matches_transient_drops(self, message):
@@ -721,6 +724,18 @@ class TestGetClientTransientRetry:
         with (
             patch.object(ch_module.time, "sleep"),
             patch.object(ch_module, "get_client", side_effect=[ssl_eof, client]) as mock_get_client,
+        ):
+            assert self._connect() is client
+        assert mock_get_client.call_count == 2
+
+    def test_retries_connect_time_429_then_succeeds(self):
+        # clickhouse-connect raises OperationalError for a 429 exhausted at the
+        # client-construction probe (which runs with retries=0). We retry it.
+        client = MagicMock()
+        rate_limited = OperationalError("HTTPDriver for https://host:8443 returned response code 429")
+        with (
+            patch.object(ch_module.time, "sleep"),
+            patch.object(ch_module, "get_client", side_effect=[rate_limited, client]) as mock_get_client,
         ):
             assert self._connect() is client
         assert mock_get_client.call_count == 2


### PR DESCRIPTION
## Problem

A ClickHouse data-warehouse import failed at connect time with:

```
ClickHouseConnectionError: HTTPDriver for <redacted-host> returned response code 429
```

A 429 (Too Many Requests) is a transient rate-limit from the ClickHouse host (or a proxy/gateway in front of it), not a credentials or config error. It must stay retryable — dropping it into the non-retryable set would permanently fail a sync over a temporary rate-limit.

The failure surfaces from `_get_client` in `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`, raised while clickhouse-connect constructs the client. clickhouse-connect *does* retry 429 for actual queries (`query_retries`), but the small probe it runs during client construction passes `retries=0`, so a connect-time 429 reaches us with **no retry at all**. Our own in-process transient-retry allowlist also didn't cover it. So a transient rate-limit burst during connect failed the activity immediately and only recovered on the next full Temporal activity retry.

## Changes

Add `"returned response code 429"` to `_TRANSIENT_CONNECT_DROP_SUBSTRINGS`, the in-process connect-retry allowlist that already handles transient tunnel gateway statuses (502/503/504). A connect-time 429 now gets a bounded, backed-off in-process retry before the error ever leaves the activity.

> [!NOTE]
> This never makes retryability worse. If the in-process attempts exhaust, the error still propagates and Temporal retries the activity exactly as it does today. Only 429 is matched — 404 stays non-retryable, and other 5xx keep their existing (Temporal-level) retry behavior.

This mirrors both the existing in-process pattern and clickhouse-connect's own treatment of 429 as retryable for queries.

Observed error: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019f6c8b-5994-7272-be7a-37131c09eb53).

## How did you test this code?

Automated tests in `test_clickhouse.py` (run locally, passing):

- `TestIsTransientConnectDrop::test_matches_transient_drops` — added a connect-time 429 message to the matched set. Catches the regression where a 429 stops being classified as a transient, retryable connect failure. The existing `test_does_not_match_deterministic_failures` still asserts 404 is *not* matched, so the two codes stay on opposite sides.
- `TestGetClientTransientRetry::test_retries_connect_time_429_then_succeeds` — a 429 `OperationalError` (the exact type clickhouse-connect raises for a rate-limit exhausted at construction) retries once and succeeds on a fresh attempt. Catches removal of 429 from the in-process retry path.

Ran the full `test_clickhouse.py` file (179 passed; the one unrelated `TestClickHouseReconcileSchemaMetadata` error is a Django-DB fixture that needs Postgres, not available in this sandbox). `ruff check` and `ruff format --check` clean on the changed files. I (Claude) did not run any live-cluster or manual ClickHouse test.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude Opus 4.8), triaging a live error-tracking issue for the ClickHouse import source. Confirmed the stack originates in `clickhouse.py:_get_client` (not just serialized log context), then read clickhouse-connect's `httpclient.py` to establish that 429 is retried for queries but not for the connect-time probe (`retries=0`). Rejected adding 429 to `get_non_retryable_errors` — a rate-limit is transient and that would strand syncs. Chose the smallest scoped change that keeps it retryable and closes the connect-time gap, reusing the existing transient-connect allowlist rather than introducing a new mechanism. Invoked the `/writing-tests` guidance to keep the added tests to two that each catch a named regression.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
