### PR TITLE
feat(billing): meter and observe api_queries_read_bytes overage

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -223,6 +223,27 @@ def is_team_limited(team_api_token: str, resource: QuotaResource, cache_key: Quo
     return team_api_token in limited_team_attributes
 
 
+def team_quota_limited_until(team_api_token: str, resource: QuotaResource) -> Optional[int]:
+    """
+    Returns the unix timestamp until which the team is quota-limited for `resource` (the
+    zset score, i.e. the end of the org's billing period), or None when not limited.
+
+    Fails open: any Redis or cache error is treated as "not limited". The slow loop that
+    writes these entries stays authoritative — a cache outage must never block queries.
+    """
+    try:
+        if not is_team_limited(team_api_token, resource, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY):
+            return None
+        score = get_client().zscore(
+            f"{QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY.value}{resource.value}", team_api_token
+        )
+        # The entry can vanish between the membership check and the score read - fail open.
+        return int(score) if score is not None else None
+    except Exception as e:
+        capture_exception(e)
+        return None
+
+
 def dispatch_recordings_remote_config_sync(team_ids: Iterable[int]) -> None:
     """
     Triggers a `RemoteConfig` rebuild for each team after its recordings quota-limit state

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -33,6 +33,7 @@ from ee.billing.quota_limiting import (
     org_quota_limited_until,
     replace_limited_team_tokens,
     set_org_usage_summary,
+    team_quota_limited_until,
     update_all_orgs_billing_quotas,
     update_org_billing_quotas,
     update_organization_usage_fields,
@@ -2844,3 +2845,31 @@ class TestSignalsRefundQuotaOffset(BaseTest):
         with patch("ee.billing.quota_limiting.get_signals_credited_refund_credits_for_org") as mock_offset:
             org_quota_limited_until(self.organization, QuotaResource.EVENTS, [], [])
         mock_offset.assert_not_called()
+
+
+class TestTeamQuotaLimitedUntil(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        get_client().delete(f"{QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY.value}{QuotaResource.API_QUERIES.value}")
+
+    @parameterized.expand(
+        [
+            # name, score offset from now, whether the limit is still active
+            ("active_limit_returns_reset_timestamp", 3600, True),
+            ("expired_limit_reads_as_not_limited", -3600, False),
+        ]
+    )
+    def test_score_semantics(self, _name: str, offset: int, expect_limited: bool) -> None:
+        score = int(timezone.now().timestamp()) + offset
+        add_limited_team_tokens(
+            QuotaResource.API_QUERIES, {self.team.api_token: score}, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+        )
+
+        result = team_quota_limited_until(self.team.api_token, QuotaResource.API_QUERIES)
+
+        assert result == (score if expect_limited else None)
+        assert team_quota_limited_until("phc_token_of_an_unlimited_team", QuotaResource.API_QUERIES) is None
+
+    def test_fails_open_when_redis_unavailable(self) -> None:
+        with patch("ee.billing.quota_limiting.get_client", side_effect=ConnectionError("redis down")):
+            assert team_quota_limited_until(self.team.api_token, QuotaResource.API_QUERIES) is None

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -725,7 +725,7 @@ def _compute_inline_query_results_for_shared_notebook(
     # cache_age_seconds is deliberately unused: blocking-if-stale passes through the whitelist
     # without a throttle override, so there is nothing to thread into process_query_dict here.
     execution_mode = shared_insights_execution_mode(
-        ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+        ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE, team
     ).execution_mode
     for node_id, query in inline_nodes:
         serialized: dict | None = None

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -397,6 +397,9 @@ class QueryTags(BaseModel):
     exported_asset_id: Optional[int] = None
     export_format: Optional[str] = None
     chargeable: Optional[int] = None
+    # Set while the api_queries_read_bytes quota runs observe-only: marks queries that
+    # enforcement would have rejected, so the would-be-limited fleet can be reviewed.
+    api_queries_over_quota: Optional[int] = None
     request_name: Optional[str] = None
     name: Optional[str] = None
     endpoint_version: Optional[int] = None  # Endpoints, the product

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -298,7 +298,34 @@ class SharedExecutionSettings(NamedTuple):
     cache_age_seconds: int | None
 
 
-def shared_insights_execution_mode(execution_mode: ExecutionMode) -> SharedExecutionSettings:
+API_QUERIES_QUOTA_LIMITED_COUNTER = Counter(
+    "posthog_api_queries_quota_limited_total",
+    "Query executions for teams whose organization is over its api_queries_read_bytes quota.",
+    labelnames=["surface", "outcome"],  # surface: api | shared; outcome: enforced | observed
+)
+
+
+def get_api_queries_quota_limited_until(team: Team) -> Optional[datetime]:
+    """When the team's organization is over its API queries (bytes read) quota, returns the
+    moment the limit lifts (the end of the org's billing period); otherwise None.
+
+    Reads the Redis decision cache written by the quota-limiting loop. Fails open: any
+    error reads as "not limited", so an unavailable cache never blocks queries.
+    """
+    if not settings.EE_AVAILABLE:
+        return None
+
+    from ee.billing.quota_limiting import QuotaResource, team_quota_limited_until
+
+    limited_until = team_quota_limited_until(team.api_token, QuotaResource.API_QUERIES)
+    if limited_until is None:
+        return None
+    return datetime.fromtimestamp(limited_until, tz=UTC)
+
+
+def shared_insights_execution_mode(
+    execution_mode: ExecutionMode, team: Optional[Team] = None
+) -> SharedExecutionSettings:
     """Map a requested execution mode to the one allowed on shared/embedded resources.
 
     Returns the mode plus an optional `cache_age_seconds` override for the query runner.
@@ -306,7 +333,14 @@ def shared_insights_execution_mode(execution_mode: ExecutionMode) -> SharedExecu
     staleness threshold: a cached result younger than the window is served as-is, anything
     older (or missing) recomputes synchronously — throttling forced recomputes without a
     separate clock.
+
+    Pass `team` to record when an over-quota organization's shared or embedded resources
+    trigger calculation: shared links are public, so this surface needs its own review
+    metrics before any enforcement decision.
     """
+    if team is not None and get_api_queries_quota_limited_until(team) is not None:
+        API_QUERIES_QUOTA_LIMITED_COUNTER.labels(surface="shared", outcome="observed").inc()
+
     if execution_mode == ExecutionMode.CALCULATE_BLOCKING_ALWAYS:
         return SharedExecutionSettings(
             ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
@@ -1625,6 +1659,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         if self.is_query_service:
             tag_queries(chargeable=1)
+            self._check_api_queries_quota()
 
         with (
             get_materialized_endpoints_rate_limiter().run(
@@ -2051,6 +2086,22 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         feature = self.team.organization.get_available_feature(AvailableFeature.API_QUERIES_CONCURRENCY)
         return feature.get("limit") if feature else None
+
+    def _check_api_queries_quota(self) -> None:
+        """Observe chargeable API queries while the organization is over its
+        api_queries_read_bytes quota.
+
+        Observe-only: the over-quota calculation is counted and tagged in the query log so
+        the would-be-limited fleet can be reviewed; nothing is blocked. Runs at calculation
+        time only, so cached results are never counted — the quota is about ClickHouse reads.
+        """
+        limited_until = get_api_queries_quota_limited_until(self.team)
+        if limited_until is None:
+            return
+
+        # Breadcrumb in the query log so the would-be-limited fleet is reviewable.
+        tag_queries(api_queries_over_quota=1)
+        API_QUERIES_QUOTA_LIMITED_COUNTER.labels(surface="api", outcome="observed").inc()
 
     @abstractmethod
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -46,6 +46,7 @@ from posthog.hogql.database.database import Database
 from posthog.hogql.errors import QueryError, ResolutionError
 
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
+from posthog.clickhouse.query_tagging import get_query_tags, reset_query_tags
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -63,8 +64,10 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team, WeekStartDay
 from posthog.rbac.user_access_control import UserAccessControl, UserAccessControlError
+from posthog.redis import get_client
 
 try:
+    from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, add_limited_team_tokens
     from ee.models.rbac.access_control import AccessControl
 except ImportError:
     pass
@@ -93,6 +96,37 @@ class TheTestQuery(BaseModel):
     tags: QueryLogTags | None = None
 
 
+def make_test_query_runner_class(base: type[QueryRunner] = QueryRunner):
+    """Setup required methods and attributes of the abstract base class."""
+
+    class TestQueryRunner(base):  # type: ignore[misc, valid-type]
+        query: TheTestQuery
+        cached_response: TheTestCachedBasicQueryResponse
+
+        def _calculate(self):
+            return TheTestBasicQueryResponse(
+                results=[
+                    ["row", 1, 2, 3],
+                    (i for i in range(10)),  # Test support of cache.set with iterators
+                ]
+            )
+
+        def _refresh_frequency(self) -> timedelta:
+            return timedelta(minutes=4)
+
+        def _is_stale(self, last_refresh: Optional[datetime], lazy: bool = False, *args, **kwargs) -> bool:
+            if not last_refresh:
+                raise ValueError("Cached results require a last_refresh")
+
+            if lazy:
+                return last_refresh + timedelta(days=1) <= datetime.now(tz=ZoneInfo("UTC"))
+            return last_refresh + timedelta(minutes=10) <= datetime.now(tz=ZoneInfo("UTC"))
+
+    TestQueryRunner.__abstractmethods__ = frozenset()
+
+    return TestQueryRunner
+
+
 class TestQueryRunner(BaseTest):
     maxDiff = None
 
@@ -101,34 +135,7 @@ class TestQueryRunner(BaseTest):
         cache.clear()
 
     def setup_test_query_runner_class(self, base: type[QueryRunner] = QueryRunner):
-        """Setup required methods and attributes of the abstract base class."""
-
-        class TestQueryRunner(base):  # type: ignore[misc, valid-type]
-            query: TheTestQuery
-            cached_response: TheTestCachedBasicQueryResponse
-
-            def _calculate(self):
-                return TheTestBasicQueryResponse(
-                    results=[
-                        ["row", 1, 2, 3],
-                        (i for i in range(10)),  # Test support of cache.set with iterators
-                    ]
-                )
-
-            def _refresh_frequency(self) -> timedelta:
-                return timedelta(minutes=4)
-
-            def _is_stale(self, last_refresh: Optional[datetime], lazy: bool = False, *args, **kwargs) -> bool:
-                if not last_refresh:
-                    raise ValueError("Cached results require a last_refresh")
-
-                if lazy:
-                    return last_refresh + timedelta(days=1) <= datetime.now(tz=ZoneInfo("UTC"))
-                return last_refresh + timedelta(minutes=10) <= datetime.now(tz=ZoneInfo("UTC"))
-
-        TestQueryRunner.__abstractmethods__ = frozenset()
-
-        return TestQueryRunner
+        return make_test_query_runner_class(base)
 
     def test_sync_warning_attach_preserves_other_warning_kinds(self):
         # The accumulator attach replaces the response's warnings with the collected sync warnings.
@@ -1329,6 +1336,67 @@ class TestSharedInsightsExecutionMode(BaseTest):
         result_mode, cache_age_seconds = shared_insights_execution_mode(execution_mode)
         self.assertEqual(result_mode, expected_mode)
         self.assertEqual(cache_age_seconds, expected_cache_age_seconds)
+
+
+@pytest.mark.ee
+class TestAPIQueriesQuotaLimiting(BaseTest):
+    def setUp(self):
+        super().setUp()
+        reset_query_tags()
+        get_client().delete(f"{QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY.value}{QuotaResource.API_QUERIES.value}")
+
+    def _limit_team(self) -> int:
+        limited_until = int(datetime.now(UTC).timestamp()) + 3600
+        add_limited_team_tokens(
+            QuotaResource.API_QUERIES,
+            {self.team.api_token: limited_until},
+            QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY,
+        )
+        return limited_until
+
+    def _make_runner(self, is_query_service: bool) -> QueryRunner:
+        runner_class = make_test_query_runner_class()
+        runner = runner_class(query={"some_attr": "bla"}, team=self.team)
+        runner.is_query_service = is_query_service
+        return runner
+
+    @parameterized.expand(
+        [
+            # name, is_query_service, team_limited, expect_breadcrumb
+            ("over_quota_api_query_observed", True, True, True),
+            ("in_app_query_not_observed", False, True, False),
+            ("unlimited_team_not_observed", True, False, False),
+        ]
+    )
+    def test_over_quota_queries_run_and_leave_review_breadcrumb(
+        self, _name: str, is_query_service: bool, team_limited: bool, expect_breadcrumb: bool
+    ) -> None:
+        if team_limited:
+            self._limit_team()
+        runner = self._make_runner(is_query_service=is_query_service)
+
+        response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+
+        assert isinstance(response, TheTestCachedBasicQueryResponse)
+        assert response.results
+        assert (get_query_tags().api_queries_over_quota == 1) is expect_breadcrumb
+
+    def test_fails_open_when_redis_unavailable(self) -> None:
+        self._limit_team()
+        runner = self._make_runner(is_query_service=True)
+
+        with mock.patch("ee.billing.quota_limiting.get_client", side_effect=ConnectionError("redis down")):
+            response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+
+        assert isinstance(response, TheTestCachedBasicQueryResponse)
+        assert response.results
+
+    def test_shared_surfaces_keep_their_mapping_while_observing(self) -> None:
+        self._limit_team()
+
+        result_mode, _cache_age = shared_insights_execution_mode(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, self.team)
+
+        assert result_mode == ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
 
 
 @pytest.mark.ee

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -396,7 +396,8 @@
          count(1) cnt,
          sum(read_bytes) read_bytes
   FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE type = 'QueryFinish'
+  WHERE type IN ('QueryFinish',
+                 'ExceptionWhileProcessing')
     AND is_initial_query
     AND event_time >= 'today 00:00:00'
     AND event_time < '2022-01-10 23:59:59'

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -64,6 +64,7 @@ from posthog.tasks.usage_report import (
     capture_report,
     get_all_event_metrics_in_period,
     get_instance_metadata,
+    get_teams_with_api_queries_metrics,
     get_teams_with_billable_event_count_in_period,
     get_teams_with_query_metric,
     has_non_zero_usage,
@@ -1376,6 +1377,24 @@ class TestHogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTa
 
 
 class TestQueryUsageReportSQL:
+    @patch("posthog.tasks.usage_report.sync_execute", return_value=[(1, 2, 300)])
+    def test_get_teams_with_api_queries_metrics_meters_failed_chargeable_queries(
+        self, mock_sync_execute: MagicMock
+    ) -> None:
+        begin = datetime(2026, 6, 15, tzinfo=tzutc())
+        end = begin + timedelta(days=1)
+
+        result = get_teams_with_api_queries_metrics(begin=begin, end=end)
+
+        assert result == {"count": [(1, 2)], "read_bytes": [(1, 300)]}
+        query = mock_sync_execute.call_args.args[0]
+        # Failed queries consume bytes and must be metered; ExceptionBeforeStart (validation and
+        # syntax errors, ~0 bytes read) stays free.
+        assert "type IN ('QueryFinish', 'ExceptionWhileProcessing')" in query
+        assert "ExceptionBeforeStart" not in query
+        # Only customer-initiated API access is metered, never PostHog-initiated background work.
+        assert "JSONExtractBool(log_comment, 'chargeable')" in query
+
     @patch("posthog.tasks.usage_report.sync_execute", return_value=[(1, 100)])
     def test_get_teams_with_query_metric_uses_event_time_pruning_window(self, mock_sync_execute: MagicMock) -> None:
         begin = datetime(2026, 6, 15, tzinfo=tzutc())

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1077,10 +1077,13 @@ def get_teams_with_api_queries_metrics(
 ) -> dict[str, list[tuple[int, int]]]:
     # Intentionally uses event_time not query_start_time, the difference between values is on avg 1.5s,
     # the former is part of primary key, the latter not.
+    # Failed queries count too: bytes are consumed regardless of exit status, so
+    # ExceptionWhileProcessing is included. ExceptionBeforeStart is not — validation and
+    # syntax errors read ~0 bytes, keeping mistakes free.
     query = f"""
         SELECT JSONExtractInt(log_comment, 'team_id') team_id, count(1) cnt, sum(read_bytes) read_bytes
         FROM clusterAllReplicas({CLICKHOUSE_CLUSTER}, system.query_log)
-        WHERE type = 'QueryFinish'
+        WHERE type IN ('QueryFinish', 'ExceptionWhileProcessing')
         AND is_initial_query
         AND event_time >= %(begin)s AND event_time < %(end)s
         AND team_id > 0

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1150,9 +1150,10 @@ class InsightSerializer(InsightBasicSerializer):
                     self.context["request"], dashboard_tile, is_shared=is_shared
                 )
 
+                team = self.context["get_team"]()
                 shared_cache_age_seconds: int | None = None
                 if is_shared:
-                    execution_mode, shared_cache_age_seconds = shared_insights_execution_mode(execution_mode)
+                    execution_mode, shared_cache_age_seconds = shared_insights_execution_mode(execution_mode, team)
 
                 # Shared rendering bypasses the FE scene-tag flow, so set product/feature
                 # tags here. No-op overwrite for authenticated paths (same values).
@@ -1184,7 +1185,7 @@ class InsightSerializer(InsightBasicSerializer):
                 with tags_context(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.INSIGHT, **shared_tags):
                     return calculate_for_query_based_insight(
                         insight,
-                        team=self.context["get_team"](),
+                        team=team,
                         dashboard=dashboard,
                         execution_mode=execution_mode,
                         user=request_user,


### PR DESCRIPTION
> [!NOTE]
> Stack 1/3 (metrics) — merge first. Stacked on top: #71746 (dry-run correctness), then #71702 (gated rollout).

## Problem

A small number of free organizations generate a hugely disproportionate share of ClickHouse read volume, typically a personal API key polling HogQL continuously for weeks, unnoticed.
Before we can cap anyone we need trustworthy metrics: correct metering of what over-quota orgs actually read, and visibility into who a limit *would* affect.
Today the `api_queries_read_bytes` usage query filters to `type = 'QueryFinish'`, so queries that fail mid-execution (which still consume bytes, and are exactly the retry-loop pattern to cap) read as free, and nothing records when an over-quota org keeps querying.

Sizing and validation for the wider rollout live in the internal `PostHog/query-performance-analysis` repo (`analysis/2026-07-16-free-tier-limit-sizing.html`).

## Changes

Observe-only — no request is blocked or degraded by this PR:

- `get_teams_with_api_queries_metrics` now counts `ExceptionWhileProcessing` alongside `QueryFinish`, since bytes are consumed regardless of exit status. `ExceptionBeforeStart` (validation and syntax errors, ~0 bytes) stays free, and the `chargeable` filter still scopes metering to customer-initiated API access only.
- New `team_quota_limited_until()` in `ee/billing/quota_limiting.py`: reads the quota-limiter zset and returns the reset timestamp (billing period end). Fails open — any Redis or cache error reads as "not limited", so a cache outage can never block queries.
- Observe instrumentation at calculation time: chargeable API-key queries from over-quota orgs tick `posthog_api_queries_quota_limited_total` (labels `surface`, `outcome`) and get an `api_queries_over_quota` query-log tag; shared/embedded surfaces (insights, dashboards, notebook inline queries) tick the same counter under `surface=shared`. Cache hits are never counted — the quota is about ClickHouse reads.

> [!NOTE]
> Billed `api_queries_read_bytes` usage will tick up for orgs whose chargeable API queries fail mid-execution, since those bytes are now counted. That is the intended fairness semantics — mistakes that never start reading stay free.

## How did you test this code?

The sandbox this was authored in has no Postgres/ClickHouse/Redis, so I could not execute the suite locally — CI validates (the same tests were green on the pre-split branch). `ruff check`/`format` and `py_compile` pass on all changed files. Tests added, each catching a regression nothing else covered:

- `TestQueryUsageReportSQL::test_get_teams_with_api_queries_metrics_meters_failed_chargeable_queries` — reverting the SQL to `type = 'QueryFinish'` (or dropping the `chargeable` filter) would silently make failed-query bytes free again.
- `TestTeamQuotaLimitedUntil` (ee) — score semantics (active vs expired limit) and fail-open on Redis outage; a fail-closed regression would block all API queries fleet-wide during a cache incident once enforcement exists.
- `TestAPIQueriesQuotaLimiting` — over-quota API queries still run and leave the review breadcrumb, in-app and unlimited teams are never tagged (the metering-scope guard), Redis outage fails open, and shared mappings are unchanged while observing.

The `test_usage_report.ambr` snapshot was updated by hand to the new SQL, formatted with the repo-pinned sqlparse 0.5.4 to match what regeneration produces.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No repo docs reference API query quotas today.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) from a written brief; Paul D'Ambra directed the work, including the split of the original single PR into this three-layer stack (metrics → dry-run correctness → rollout).
Skills invoked: `/writing-tests`, `/improving-drf-endpoints`.
This layer deliberately leaves the existing (broken, no-op) concurrency-0 quota branch in `get_api_queries_concurrency_limit` untouched — replacing it belongs to the rollout layer, so this PR stays purely additive observability.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

