### PR TITLE
fix(billing): correct update_billing_quotas dry-run flags and output

### DIFF
--- a/posthog/management/commands/update_billing_quotas.py
+++ b/posthog/management/commands/update_billing_quotas.py
@@ -9,8 +9,10 @@ class Command(BaseCommand):
     help = "Update billing rate limiting for all organizations"
 
     def add_arguments(self, parser):
-        parser.add_argument("--dry-run", type=bool, help="Print information instead of storing it")
-        parser.add_argument("--print-reports", type=bool, help="Print the reports in full")
+        # store_true, not type=bool: argparse applies bool() to the raw string, so
+        # `--dry-run false` would silently parse as True.
+        parser.add_argument("--dry-run", action="store_true", help="Print information instead of storing it")
+        parser.add_argument("--print-reports", action="store_true", help="Print the reports in full")
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
@@ -25,13 +27,15 @@ class Command(BaseCommand):
 
         if dry_run:
             print("Dry run so not stored.")  # noqa T201
-        else:
-            print(f"{len(quota_limited_orgs['events'])} orgs rate limited for events")  # noqa T201
-            print(  # noqa T201
-                f"{len(quota_limiting_suspended_orgs['events'])} orgs rate limiting suspended for events"  # noqa T201
-            )  # noqa T201
-            print(f"{len(quota_limited_orgs['recordings'])} orgs rate limited for recordings")  # noqa T201
-            print(  # noqa T201
-                f"{len(quota_limiting_suspended_orgs['recordings'])} orgs rate limiting suspended for recordings"  # noqa T201
-            )  # noqa T201
+
+        for resource, limited in quota_limited_orgs.items():
+            if limited:
+                print(f"{len(limited)} orgs {'would be ' if dry_run else ''}rate limited for {resource}")  # noqa T201
+        for resource, suspended in quota_limiting_suspended_orgs.items():
+            if suspended:
+                print(  # noqa T201
+                    f"{len(suspended)} orgs {'would have ' if dry_run else ''}rate limiting suspended for {resource}"
+                )
+
+        if not dry_run:
             print("Done!")  # noqa T201


### PR DESCRIPTION
> [!NOTE]
> Stack 2/3 (dry-run correctness). Stacked on #71745 (metrics); the gated rollout in #71702 stacks on top of this.

## Problem

The observe-first rollout of the `api_queries_read_bytes` quota needs a trustworthy review path: run the quota cron in dry-run mode and read off which orgs a limit would touch.
The `update_billing_quotas` command has two problems there.
Its flags use `type=bool`, and argparse applies `bool()` to the raw string, so `--dry-run false` silently parses as `True` and the bare `--dry-run` flag form is rejected outright.
And its summary output hardcodes events and recordings, so the resource this rollout is about never appears.

## Changes

- `--dry-run` and `--print-reports` are now `store_true` flags.
- The summary prints would-be-limited and would-be-suspended org counts for every quota resource with any entries, in both dry-run and real runs, with dry-run phrasing ("would be rate limited") so output can't be mistaken for an applied run.

## How did you test this code?

No new tests: flag parsing is argparse framework behavior and the print loop is presentation only — a test would be a change detector. `ruff check`/`format` pass; the command is exercised manually via `python manage.py update_billing_quotas --dry-run --print-reports` during the observe-only review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal management command.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task); Paul D'Ambra directed the work, including the split into a three-layer stack.
The argparse `store_true` fix was added during the split: the layer is named "dry run correctness", and the broken bool coercion is the correctness bug in that path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
