### PR TITLE
fix(postgres): retry source lock_timeout during server-cursor read

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -128,6 +128,14 @@ _MAX_SETUP_CONNECTION_DROPPED_RETRIES = 5
 # as sustained and re-raised for Temporal to retry the whole activity.
 _MAX_INITIAL_READ_DROP_RETRIES = 5
 
+# Bounded in-process retries for a source-side lock_timeout hit while opening the main server-cursor
+# read *before* the first row is yielded — the DECLARE waited past the source's lock_timeout for a
+# lock another transaction held (a concurrent DDL / VACUUM FULL taking ACCESS EXCLUSIVE conflicts
+# with our ACCESS SHARE). It's transient: the lock frees once that transaction ends. At offset 0
+# nothing has been emitted, so re-running the read from scratch is safe for any sync type. Past this
+# the conflict is treated as sustained and re-raised for Temporal to retry the whole activity.
+_MAX_INITIAL_READ_LOCK_TIMEOUT_RETRIES = 5
+
 
 def source_requires_ssl(source: ExternalDataSource, source_config: Any = None) -> bool:
     """Return whether this source must connect over SSL/TLS.
@@ -3512,6 +3520,7 @@ def postgres_source(
                 return
 
             initial_read_drop_retries = 0
+            initial_read_lock_timeout_retries = 0
             while True:
                 offset = 0
                 try:
@@ -3586,6 +3595,26 @@ def postgres_source(
                     )
                     if timeout_error is not None:
                         raise timeout_error from e
+                    raise
+                except psycopg.errors.LockNotAvailable as e:
+                    # The server-cursor DECLARE waited past the source's lock_timeout for a lock
+                    # another transaction holds (a concurrent DDL / VACUUM FULL takes ACCESS
+                    # EXCLUSIVE, which conflicts with our ACCESS SHARE). It's transient — the lock
+                    # frees once that transaction ends — so it must stay retryable and is never a
+                    # NonRetryableError. LockNotAvailable subclasses OperationalError, so this clause
+                    # must precede the connection-dropped handler below. At offset 0 nothing has been
+                    # emitted, so re-running the read from scratch is safe for any sync type; retry in
+                    # process with bounded backoff instead of failing the activity and flooding error
+                    # tracking. Once a row is out, or the conflict is sustained, propagate so Temporal
+                    # retries the whole activity.
+                    if offset == 0 and initial_read_lock_timeout_retries < _MAX_INITIAL_READ_LOCK_TIMEOUT_RETRIES:
+                        initial_read_lock_timeout_retries += 1
+                        logger.debug(
+                            f"Lock timeout before first row ({e}). Retrying read "
+                            f"(attempt {initial_read_lock_timeout_retries}/{_MAX_INITIAL_READ_LOCK_TIMEOUT_RETRIES})."
+                        )
+                        time.sleep(min(2 * initial_read_lock_timeout_retries, 30))
+                        continue
                     raise
                 except _CONNECTION_DROPPED_ERROR_TYPES as e:
                     # The server cursor holds a transaction open across the slow

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -6831,6 +6831,142 @@ class TestGetRowsInitialReadDropRetry:
             self._run(connect_side_effect)
 
 
+class TestGetRowsInitialReadLockTimeoutRetry:
+    # Regression: a source-side lock_timeout hit while opening the server-cursor DECLARE
+    # (cursor.execute) raises psycopg.errors.LockNotAvailable, which subclasses OperationalError and
+    # so was caught by the connection-dropped handler, failed _is_connection_dropped_error, and
+    # re-raised — failing the activity and flooding error tracking with a handled exception for a
+    # transient lock conflict (a concurrent DDL / VACUUM FULL holding ACCESS EXCLUSIVE). It's
+    # transient, so it must stay retryable; before the first row is yielded (offset 0) re-running the
+    # read from scratch is safe, so it should retry in process. Once a chunk is out, replaying it
+    # would duplicate rows, so the lock timeout must still propagate.
+    _LOCK_TIMEOUT = "canceling statement due to lock timeout"
+
+    class _Cursor:
+        def __init__(self, *, batches, lock_on_execute):
+            col = mock.Mock()
+            col.name = "id"
+            self.description = [col]
+            self._batches = list(batches)
+            self._lock_on_execute = lock_on_execute
+
+        def execute(self, *args, **kwargs):
+            if self._lock_on_execute:
+                raise psycopg.errors.LockNotAvailable(TestGetRowsInitialReadLockTimeoutRetry._LOCK_TIMEOUT)
+            return None
+
+        def fetchmany(self, _n):
+            if not self._batches:
+                return []
+            batch = self._batches.pop(0)
+            if isinstance(batch, BaseException):
+                raise batch
+            return batch
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    class _Connection:
+        def __init__(self, *, batches, lock_on_execute):
+            self.autocommit = False
+            self.closed = False
+            self.broken = False
+            self.adapters = mock.Mock()
+            self._batches = batches
+            self._lock_on_execute = lock_on_execute
+
+        def cursor(self, *args, **kwargs):
+            if "name" in kwargs:
+                return TestGetRowsInitialReadLockTimeoutRetry._Cursor(
+                    batches=self._batches, lock_on_execute=self._lock_on_execute
+                )
+            return mock.MagicMock()
+
+        def commit(self):
+            return None
+
+        def close(self):
+            self.closed = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def _run(self, connect_side_effect):
+        @contextmanager
+        def fake_tunnel():
+            yield ("localhost", 5432)
+
+        fake_table = mock.Mock()
+        fake_table.to_arrow_schema.return_value = pa.schema([pa.field("id", pa.int64())])
+        fake_table.type = "table"
+        fake_table.columns = []
+        fake_table.__contains__ = mock.Mock(return_value=False)
+
+        module = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres"
+        with (
+            patch(f"{module}.time.sleep"),
+            patch(f"{module}.psycopg.connect", side_effect=connect_side_effect) as connect_mock,
+            patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(batches=[], lock_on_execute=False)),
+            patch(f"{module}._get_table", return_value=fake_table),
+            patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._get_primary_keys", return_value=["id"]),
+            patch(f"{module}._is_partitioned_table", return_value=False),
+            patch(f"{module}._get_table_chunk_size", return_value=100),
+            patch(f"{module}._get_rows_to_sync", return_value=10),
+            patch(f"{module}._role_subject_to_rls", return_value=False),
+            patch(f"{module}._get_partition_settings", return_value=None),
+        ):
+            response = postgres_source(
+                tunnel=lambda: fake_tunnel(),
+                user="u",
+                password="p",
+                database="db",
+                sslmode="prefer",
+                schema="public",
+                table_names=["companies"],
+                should_use_incremental_field=False,
+                logger=structlog.get_logger(),
+                db_incremental_field_last_value=None,
+                team_id=1,
+            )
+            tables = list(cast(Iterable[Any], response.items()))
+        return tables, connect_mock
+
+    def test_retries_read_when_lock_timeout_before_first_row(self):
+        calls = {"n": 0}
+
+        def connect_side_effect(*args, **kwargs):
+            calls["n"] += 1
+            # First read connect succeeds, but the server-cursor DECLARE hits the source's
+            # lock_timeout; the retry reconnects and serves the rows.
+            lock_on_execute = calls["n"] == 1
+            batches = [] if lock_on_execute else [[(1,), (2,), (3,)]]
+            return self._Connection(batches=batches, lock_on_execute=lock_on_execute)
+
+        tables, connect_mock = self._run(connect_side_effect)
+
+        assert connect_mock.call_count >= 2, "the read should have been retried after the DECLARE-time lock timeout"
+        assert sum(table.num_rows for table in tables) == 3
+
+    def test_reraises_lock_timeout_after_rows_yielded(self):
+        # A lock timeout after a chunk is already out must propagate: an unordered full-table scan
+        # can't resume without duplicating rows, so the in-process retry must not swallow it.
+        def connect_side_effect(*args, **kwargs):
+            return self._Connection(
+                batches=[[(1,), (2,)], psycopg.errors.LockNotAvailable(self._LOCK_TIMEOUT)],
+                lock_on_execute=False,
+            )
+
+        with pytest.raises(psycopg.errors.LockNotAvailable, match="canceling statement due to lock timeout"):
+            self._run(connect_side_effect)
+
+
 class TestPartitionIterationConnectRetry:
     # Regression: the windowed / per-partition read paths opened each window's (or partition's)
     # connection with a bare get_connection(), so a transient drop while establishing it — the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -6843,15 +6843,20 @@ class TestGetRowsInitialReadLockTimeoutRetry:
     _LOCK_TIMEOUT = "canceling statement due to lock timeout"
 
     class _Cursor:
-        def __init__(self, *, batches, lock_on_execute):
+        # The read server cursor. `state["declare_locks_left"]` is how many DECLAREs (cursor.execute)
+        # should hit the source's lock_timeout before one succeeds; it's shared across reconnects so
+        # the in-process retry opens a fresh cursor that finally gets through. Batches drive the
+        # post-DECLARE fetch, and a batch that is an exception is raised mid-stream.
+        def __init__(self, *, batches, state):
             col = mock.Mock()
             col.name = "id"
             self.description = [col]
             self._batches = list(batches)
-            self._lock_on_execute = lock_on_execute
+            self._state = state
 
         def execute(self, *args, **kwargs):
-            if self._lock_on_execute:
+            if self._state["declare_locks_left"] > 0:
+                self._state["declare_locks_left"] -= 1
                 raise psycopg.errors.LockNotAvailable(TestGetRowsInitialReadLockTimeoutRetry._LOCK_TIMEOUT)
             return None
 
@@ -6870,19 +6875,19 @@ class TestGetRowsInitialReadLockTimeoutRetry:
             return False
 
     class _Connection:
-        def __init__(self, *, batches, lock_on_execute):
+        def __init__(self, *, batches, state):
             self.autocommit = False
             self.closed = False
             self.broken = False
             self.adapters = mock.Mock()
             self._batches = batches
-            self._lock_on_execute = lock_on_execute
+            self._state = state
 
         def cursor(self, *args, **kwargs):
+            # Only the named server cursor (the read under test) can hit the lock timeout; the unnamed
+            # setup cursor stays benign so the lock fires on the DECLARE, not on setup.
             if "name" in kwargs:
-                return TestGetRowsInitialReadLockTimeoutRetry._Cursor(
-                    batches=self._batches, lock_on_execute=self._lock_on_execute
-                )
+                return TestGetRowsInitialReadLockTimeoutRetry._Cursor(batches=self._batches, state=self._state)
             return mock.MagicMock()
 
         def commit(self):
@@ -6897,7 +6902,7 @@ class TestGetRowsInitialReadLockTimeoutRetry:
         def __exit__(self, *args):
             return False
 
-    def _run(self, connect_side_effect):
+    def _run(self, *, declare_locks_left, batches):
         @contextmanager
         def fake_tunnel():
             yield ("localhost", 5432)
@@ -6908,11 +6913,17 @@ class TestGetRowsInitialReadLockTimeoutRetry:
         fake_table.columns = []
         fake_table.__contains__ = mock.Mock(return_value=False)
 
+        # Shared across every read connection so the retry's fresh cursor sees the decremented count.
+        state = {"declare_locks_left": declare_locks_left}
+
+        def connect_side_effect(*args, **kwargs):
+            return self._Connection(batches=batches, state=state)
+
         module = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres"
         with (
             patch(f"{module}.time.sleep"),
             patch(f"{module}.psycopg.connect", side_effect=connect_side_effect) as connect_mock,
-            patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(batches=[], lock_on_execute=False)),
+            patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(batches=[], state={"declare_locks_left": 0})),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
@@ -6936,35 +6947,22 @@ class TestGetRowsInitialReadLockTimeoutRetry:
                 team_id=1,
             )
             tables = list(cast(Iterable[Any], response.items()))
-        return tables, connect_mock
+        return tables, connect_mock, state
 
     def test_retries_read_when_lock_timeout_before_first_row(self):
-        calls = {"n": 0}
+        # The first read DECLARE hits the source's lock_timeout; the in-process retry opens a fresh
+        # server cursor that succeeds and serves the rows. If the retry branch were removed the
+        # LockNotAvailable would propagate and no rows would come back.
+        tables, _connect_mock, state = self._run(declare_locks_left=1, batches=[[(1,), (2,), (3,)]])
 
-        def connect_side_effect(*args, **kwargs):
-            calls["n"] += 1
-            # First read connect succeeds, but the server-cursor DECLARE hits the source's
-            # lock_timeout; the retry reconnects and serves the rows.
-            lock_on_execute = calls["n"] == 1
-            batches = [] if lock_on_execute else [[(1,), (2,), (3,)]]
-            return self._Connection(batches=batches, lock_on_execute=lock_on_execute)
-
-        tables, connect_mock = self._run(connect_side_effect)
-
-        assert connect_mock.call_count >= 2, "the read should have been retried after the DECLARE-time lock timeout"
+        assert state["declare_locks_left"] == 0, "the read DECLARE should have hit the lock timeout"
         assert sum(table.num_rows for table in tables) == 3
 
     def test_reraises_lock_timeout_after_rows_yielded(self):
         # A lock timeout after a chunk is already out must propagate: an unordered full-table scan
         # can't resume without duplicating rows, so the in-process retry must not swallow it.
-        def connect_side_effect(*args, **kwargs):
-            return self._Connection(
-                batches=[[(1,), (2,)], psycopg.errors.LockNotAvailable(self._LOCK_TIMEOUT)],
-                lock_on_execute=False,
-            )
-
         with pytest.raises(psycopg.errors.LockNotAvailable, match="canceling statement due to lock timeout"):
-            self._run(connect_side_effect)
+            self._run(declare_locks_left=0, batches=[[(1,), (2,)], psycopg.errors.LockNotAvailable(self._LOCK_TIMEOUT)])
 
 
 class TestPartitionIterationConnectRetry:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `LockNotAvailable` from the Postgres data-warehouse import source:

```
LockNotAvailable: canceling statement due to lock timeout
```

It fires in `get_rows` when we open the main server-side cursor (`DECLARE ... CURSOR FOR SELECT ...`).
The source has a `lock_timeout` set, and our `SELECT` (which needs `ACCESS SHARE`) waited past it for a lock another transaction held.
In practice that is a concurrent DDL or `VACUUM FULL` taking `ACCESS EXCLUSIVE` on the table, which conflicts with our read.

This is transient - the lock frees once the conflicting transaction ends. But `LockNotAvailable` subclasses `OperationalError`, so it landed in the connection-dropped `except` clause, failed the `_is_connection_dropped_error` check, and re-raised.
The result: the whole activity failed and Temporal re-ran it from scratch (schema discovery, count, partition sizing), and every occurrence was captured to error tracking as a handled exception - exactly the noise the source already suppresses for sibling transient conditions.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f6cb3-1899-7000-a241-a4346a41b3ed

## Changes

Decision: this is a transient condition, not a user/upstream config error, so it stays retryable and is **not** added to `NonRetryableErrors`.
The fix closes a graceful-handling gap rather than reclassifying the error.

`get_rows` already retries a transient connection drop in process when it hits the `DECLARE` before the first row is yielded (offset 0), because nothing has been emitted yet so re-running the read from scratch is safe.
A lock timeout at the same point is the same shape, so I added a sibling handler that does the same:

- Catch `psycopg.errors.LockNotAvailable` ahead of the connection-dropped clause (it subclasses `OperationalError`, so ordering matters).
- At offset 0, retry in process with bounded backoff (up to 5 attempts) - safe for any sync type since no rows are out.
- Once a row has been yielded, or retries are exhausted, propagate so Temporal retries the whole activity. Still retryable, never non-retryable.

> [!NOTE]
> A `lock_timeout` raises `LockNotAvailable` (SQLSTATE 55P03), which is distinct from the `QueryCanceled` (57014) a `statement_timeout` raises, so the existing statement-timeout handling never covered it.

## How did you test this code?

Added `TestGetRowsInitialReadLockTimeoutRetry` with two cases (no existing test exercises `LockNotAvailable` - the streaming-loop tests all use `QueryCanceled`, `SerializationFailure`, or connection drops):

- A lock timeout on the `DECLARE` at offset 0 reconnects and serves the rows in process.
- A lock timeout after a chunk is already out propagates (an unordered full-table scan can't resume without duplicating rows).

Ran locally with `uv run pytest`: the two new tests pass, as do the sibling `TestGetRowsInitialReadDropRetry` and the broader retry/timeout/drop slice (217 passed). Four unrelated tests in the file error at setup because they need a live Postgres the sandbox doesn't have - confirmed identical on a clean master checkout. `ruff check` and `ruff format --check` are clean on both files. I (Claude) did not run manual end-to-end testing against a real database.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) pulled the issue's stack trace via the PostHog MCP tools, confirmed the failure originates in `postgres.py:get_rows` at the server-cursor `execute`, and read the source's extensive retryable-vs-non-retryable handling.

Decision path: I ruled out `NonRetryableErrors` because a lock timeout is transient (the guidance is to keep transient infra errors retryable), and ruled out "no change needed" because the source deliberately recovers sibling transient conditions in process and suppresses their error-tracking noise - letting this one escape is an inconsistency. I scoped the fix to the observed offset-0 `DECLARE` case and mirrored the established connection-dropped retry rather than introducing a new abstraction.

Checked for duplicates across open PRs (including the maintainer's own) by exception type, message phrase, and module path. The closest matches (#68441 internal queue-partition DDL lock waits, #68816 `postgres_fdw` connection-refused) are different root causes and code paths. Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
