### PR TITLE
feat(warehouse_sources): promote Slack source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/slack/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/slack/source.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -91,8 +92,7 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], Webhook
             category=DataWarehouseSourceCategory.COMMUNICATION,
             caption="Connect your Slack workspace to sync channels, users, and messages.",
             iconPath="/static/services/slack.png",
-            featureFlag="slack-dwh",
-            releaseStatus="alpha",
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

The Slack data-warehouse source has been running behind the `slack-dwh` feature flag at `releaseStatus="alpha"`. Its production metrics now clear the bar for general availability, so it should ship to everyone.

Current metrics (7-day window):
- Adoption: live 3.1 months (threshold is 100+ teams **or** 3+ months live — the time bar is met).
- Import error rate: 0.0% over the last 7 days (threshold is < 2.5%).

## Changes

- Set `releaseStatus` on the Slack `SourceConfig` to `ReleaseStatus.GA` (using the `ReleaseStatus` enum rather than a bare string literal, per the warehouse-sources convention).
- Removed `featureFlag="slack-dwh"`. Every GA source in the tree ships without a `featureFlag`, and every source that still carries one is at alpha/beta — a rollout flag gates the source to flagged users, which is incompatible with general availability. Dropping it makes the source visible to all teams.

This is a status promotion only. No connector behavior, schemas, or sync logic changed. The webhook template's `status="alpha"` is a separate HogFunction lifecycle field (Stripe's GA source keeps it too), so it was left untouched.

## How did you test this code?

Ran the existing Slack source tests, which pass:

```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/slack/tests/test_slack_source.py
3 passed
```

No test asserted on the old `releaseStatus`/`featureFlag`, so none needed updating. Ran `ruff check` and `ruff format` on the changed file. I (Claude) did not exercise the live Slack API — this change carries no runtime behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) made this change at Tom's direction. Invoked the `/implementing-warehouse-sources` skill to confirm the release-status conventions (use the `ReleaseStatus` enum, GA sources drop the rollout `featureFlag`). Before opening this I checked open PRs — including the maintainer's own — from several angles (source name, "releaseStatus", "promote") and found no existing PR promoting the Slack warehouse source, so this isn't a duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
