### PR TITLE
fix(lemon-ui): pin table header while table scrolls its own content

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -351,6 +351,13 @@
 
 // Stickiness is disabled in snapshots due to flakiness
 body:not(.storybook-test-runner) {
+    // When the table scrolls its own content, pin the header to the top of the scrollport
+    .LemonTable--content-scroll .LemonTable__content > table > thead {
+        position: sticky;
+        top: 0;
+        z-index: 7; // Above sticky/pinned column cells (6), below the scroll-shadow overlay (8)
+    }
+
     .LemonTable__header--sticky,
     .LemonTable__cell--sticky,
     .LemonTable__header--pinned,

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -378,7 +378,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                     rowRibbonColor !== undefined && `LemonTable--with-ribbon`,
                     stealth && 'LemonTable--stealth',
                     !uppercaseHeader && 'LemonTable--lowercase-header',
-                    allowContentScroll && 'h-full min-h-0 overflow-hidden',
+                    allowContentScroll && 'LemonTable--content-scroll h-full min-h-0 overflow-hidden',
                     className
                 )}
                 // eslint-disable-next-line react/forbid-dom-props


### PR DESCRIPTION
## Problem

Put a SQL insight rendered as a table on a dashboard and scroll the results: the header row scrolls out of view, so you lose track of which column is which.

Tables embedded in fixed-height containers scroll inside `LemonTable`'s own `ScrollableShadows` viewport (the `allowContentScroll` prop), but `LemonTable` has no vertical sticky-header support. Its existing `--sticky`/`--pinned` classes only pin columns horizontally (`left: 0`). This affects SQL insight tables and trends legend tables on dashboards, and the alert check history table.

## Changes

When `allowContentScroll` is set, `LemonTable` now adds a `LemonTable--content-scroll` modifier and pins the `thead` to the top of its scrollport with `position: sticky`.

Scrolled dashboard card, before and after:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/PostHog/pr-assets/0048e10de823a8b47a4c953d7ad1d7c791d09f16/2026/07/e0d44036-249b-4b88-b7e7-3e2cb0e9cfc8.png) | ![after](https://raw.githubusercontent.com/PostHog/pr-assets/fc12eae96d3beec7944a37fb9ea690fa1f8ad25f/2026/07/a2dbfd5b-fa40-4d3a-acc7-c5595aa31909.png) |

- z-index 7 keeps the header above pinned/sticky column cells (6) and below the scroll-shadow overlay (8), so the pinned-corner interplay with `firstColumnSticky`/`pinnedColumns` keeps working
- the `th` bottom border was already an inset box-shadow specifically so sticky headers could work, and the `thead` already has an opaque background, so no visual changes were needed there
- same pattern `InsightTooltip.scss` already uses in production to pin a `LemonTable` header
- placed inside the existing `body:not(.storybook-test-runner)` guard, matching how column stickiness is excluded from snapshots

Tables that don't use `allowContentScroll` (page-flow tables) are unaffected.

## How did you test this code?

- Verified against the live app (local dev stack, driven via Playwright): created a SQL insight (`DataVisualizationNode` + `HogQLQuery` returning 200 rows) on a dashboard, scrolled the card's table viewport 400px. Without the fix the `thead` measures 356px above the card and is not visible; with the fix it stays pinned at the top of the scrollport (`position: sticky`, visible while scrolled). Screenshots above are from that run
- Also verified the CSS mechanism headlessly against a replica of the dashboard-card DOM (pinned first column interplay, `elementFromPoint` over the header area returns the `th`)
- `pnpm --filter=@posthog/frontend format` and `hogli ci:preflight --fix`/`--strict` pass
- No tests added: the change is CSS-only and stickiness is deliberately disabled in storybook snapshot runs

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, no documented workflow or API changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) at Andy's request after he hit the unpinned header on a dashboard SQL table. Traced the render path (`InsightCard` → `Query embedded` → `DataVisualization` → `Table` → `LemonTable allowContentScroll`) to establish that the table scrolls in its own viewport with no sticky-header CSS, found the `InsightTooltip` precedent, and fixed it at the `LemonTable` level so all `allowContentScroll` consumers benefit. Considered wiring the unused `--scrollable-shadows-offset-top` hook to move the top scroll shadow below the pinned header, but it offsets the whole overlay without height compensation (would clip the bottom shadow), so left it alone. Skills invoked: superpowers:systematic-debugging, run-posthog.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
