### PR TITLE
fix(mcp): flatten union tool input schemas for client compatibility

### DIFF
--- a/services/mcp/src/hono/tool-catalog.ts
+++ b/services/mcp/src/hono/tool-catalog.ts
@@ -25,6 +25,43 @@ export type { PreBuiltTool }
 
 const EMPTY_OBJECT_JSON_SCHEMA = { type: 'object' as const, properties: {} }
 
+type JsonSchema = Record<string, unknown>
+
+/**
+ * Merge a top-level anyOf/oneOf of object variants into a single object schema,
+ * or return null if any variant is not a plain object schema.
+ *
+ * A root union keyword breaks clients that translate tool schemas into a
+ * restricted JSON Schema subset: GitHub Copilot Chat rejects the whole tool at
+ * registration with "object has unsupported top-level schema keyword 'anyOf'".
+ * The merge is advertisement-only and lossy (a variant's extra requirements are
+ * not enforced by the merged schema); call-time validation in the executor still
+ * runs against the original zod union, so invalid variant mixes are rejected.
+ */
+function flattenTopLevelUnion(variants: JsonSchema[]): JsonSchema | null {
+    if (variants.length === 0 || !variants.every((v) => v['type'] === 'object' && v['properties'])) {
+        return null
+    }
+    const properties: Record<string, JsonSchema> = {}
+    for (const variant of variants) {
+        for (const [name, prop] of Object.entries(variant['properties'] as Record<string, JsonSchema>)) {
+            const existing = properties[name]
+            if (!existing) {
+                properties[name] = prop
+            } else if (Array.isArray(existing['enum']) && Array.isArray(prop['enum'])) {
+                // Discriminator fields carry one enum value per variant; merge them
+                // so every variant stays expressible.
+                properties[name] = { ...existing, enum: [...new Set([...existing['enum'], ...prop['enum']])] }
+            }
+        }
+    }
+    // Only fields required by every variant stay required.
+    const required = variants
+        .map((v) => (Array.isArray(v['required']) ? (v['required'] as string[]) : []))
+        .reduce((acc, r) => acc.filter((field) => r.includes(field)))
+    return { type: 'object', properties, ...(required.length > 0 ? { required } : {}) }
+}
+
 /**
  * Convert a tool's zod schema to the MCP `inputSchema` wire shape. Single source
  * for every advertised schema (catalog entries and the `render-ui` umbrella entry)
@@ -36,10 +73,11 @@ export function toMcpInputSchema(schema: ZodObjectAny): McpTool['inputSchema'] {
     delete jsonSchema['additionalProperties']
     // MCP requires inputSchema.type === 'object'. Top-level discriminated unions
     // (e.g. `oneOf` on a polymorphic request body) come back without a root `type`.
-    // Add it so the schema satisfies the MCP tool contract; the union constraint
-    // still applies via the nested anyOf/oneOf.
+    // Flatten object-variant unions (see flattenTopLevelUnion); for anything else,
+    // add the root `type` so the schema satisfies the MCP tool contract.
     if (!jsonSchema['type'] && (Array.isArray(jsonSchema['anyOf']) || Array.isArray(jsonSchema['oneOf']))) {
-        jsonSchema = { type: 'object', ...jsonSchema }
+        const variants = (jsonSchema['anyOf'] ?? jsonSchema['oneOf']) as JsonSchema[]
+        jsonSchema = flattenTopLevelUnion(variants) ?? { type: 'object', ...jsonSchema }
     }
     return jsonSchema as McpTool['inputSchema']
 }

--- a/services/mcp/tests/unit/tool-catalog.test.ts
+++ b/services/mcp/tests/unit/tool-catalog.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
-import { ToolCatalog } from '@/hono/tool-catalog'
+import { ToolCatalog, toMcpInputSchema } from '@/hono/tool-catalog'
 import type { ToolBase, ZodObjectAny } from '@/tools/types'
 
 type FakeDefinition = {
@@ -100,6 +100,44 @@ describe('ToolCatalog', () => {
 
     beforeEach(async () => {
         catalog = new ToolCatalog()
+    })
+
+    describe('toMcpInputSchema', () => {
+        // GitHub Copilot Chat rejects tools whose inputSchema has a root union
+        // keyword ("object has unsupported top-level schema keyword 'anyOf'"),
+        // so polymorphic request bodies must advertise as one flat object.
+        it('flattens a top-level union of object variants into a single object schema', () => {
+            const union = z.union([
+                z.object({
+                    model: z.enum(['events']),
+                    file: z.object({ format: z.string() }),
+                    include: z.array(z.string()).optional(),
+                }),
+                z.object({
+                    model: z.enum(['persons']),
+                    file: z.object({ format: z.string() }),
+                }),
+            ]) as unknown as ZodObjectAny
+
+            const result = toMcpInputSchema(union) as Record<string, unknown>
+
+            expect(result.anyOf).toBeUndefined()
+            expect(result.oneOf).toBeUndefined()
+            expect(result.type).toBe('object')
+            const properties = result.properties as Record<string, Record<string, unknown>>
+            expect(properties.model!.enum).toEqual(['events', 'persons'])
+            expect(Object.keys(properties)).toEqual(['model', 'file', 'include'])
+            // `include` only exists on one variant, so it must not be required.
+            expect(result.required).toEqual(['model', 'file'])
+        })
+
+        it('keeps a root type of object when union variants are not all objects', () => {
+            const union = z.union([z.object({ a: z.string() }), z.string()]) as unknown as ZodObjectAny
+
+            const result = toMcpInputSchema(union) as Record<string, unknown>
+
+            expect(result.type).toBe('object')
+        })
     })
 
     describe('warmup', () => {


### PR DESCRIPTION
## Problem

A customer reported that the `file-download-batch-exports-create` MCP tool fails to load in GitHub Copilot Chat with:

```
Tool mcp_posthog_file-download-batch-exports-create failed validation: object has unsupported top-level schema keyword 'anyOf'
```

The failure happens client side, at tool registration, before any call is made. Copilot Chat translates MCP tool schemas into a restricted JSON Schema subset that requires the root of `inputSchema` to be a plain object. A union keyword (`anyOf`/`oneOf`) at the root gets the whole tool rejected, so it's unusable from Copilot Chat entirely.

Our schema ends up with a root `anyOf` through this chain:

1. The backend endpoint declares its request body with drf-spectacular's `PolymorphicProxySerializer` (three variants: `events`, `persons`, `sessions`, discriminated on `model`), so the OpenAPI spec describes the body as a union of object schemas.
2. Codegen carries that through faithfully: the generated `FileDownloadBatchExportsCreateBody` is a `zod.union`, used directly as the tool's schema.
3. `toMcpInputSchema` converts it to JSON Schema for `tools/list`, producing a top-level `anyOf`. An earlier fix (#60474) made the generated handler send union bodies correctly, and a partial workaround spliced in `type: 'object'` next to the `anyOf` to satisfy the MCP spec, but the root `anyOf` remained and that's exactly what Copilot rejects.

Today only this one tool has a union body, but any future polymorphic endpoint would hit the same wall.

## Changes

In `toMcpInputSchema`, when the converted schema is a root `anyOf`/`oneOf` whose variants are all object schemas, merge them into one flat object schema instead of splicing `type: 'object'` next to the union:

- properties are unioned across variants
- discriminator-style fields (same property, different single-value enums per variant) get their enums merged, so `model` advertises as `enum: ['events', 'persons', 'sessions']`
- `required` keeps only the fields required by every variant

If any variant isn't a plain object, the previous `type: 'object'` splice remains as the fallback.

> [!NOTE]
> The flatten is advertisement-only and intentionally lossy (variant-specific requirements like "only the events model accepts `include`/`exclude`" are no longer schema-enforced). Call-time validation in the executor still parses arguments against the original zod union, so invalid variant mixes are rejected server side before reaching the API. The backend serializer and generated files are untouched; the precise union stays the source of truth everywhere else.

## How did you test this code?

- Added two vitest cases to `tests/unit/tool-catalog.test.ts`. The first catches the regression where a union body would again advertise a root `anyOf` (asserts flat object shape, merged discriminator enum, intersected `required`). The second guards the fallback so non-object-variant unions still advertise `type: 'object'`. No existing test covered the advertised wire shape of union schemas.
- Ran a throwaway test against the real generated `FileDownloadBatchExportsCreateBody` and verified the advertised schema comes out as a flat object with all six properties, the merged `model` enum, and no root union keyword (deleted afterwards, since the unit tests cover the logic).
- `pnpm --filter=@posthog/mcp run typecheck` and the tool-catalog, render-ui, and exec unit suites all pass.
- I did not manually verify against a live Copilot Chat session.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover the MCP tool schema wire format, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and implemented with Claude Code (Fable 5). The `/writing-tests` skill was invoked before adding the unit tests.

Two approaches were considered: flattening in codegen (`generate-tools.ts`) so the tool's zod schema itself becomes a flat object, versus flattening at advertisement time in `toMcpInputSchema`. I (well, Claude) chose the latter because it keeps strict call-time validation against the original union, avoids generated-file churn, and automatically covers any future polymorphic tool. The formatter incidentally rewrote unrelated generated `api.ts` files during the run; those were reverted to keep the diff scoped to the two files.
