### PR TITLE
chore(clickhouse): bump prod-eu kafka_logs_avro consumers to 16

### DIFF
--- a/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
@@ -50,7 +50,7 @@ database "posthog" {
       topic_list           = "kafka_topic_list = 'clickhouse_logs'"
       group_name           = "kafka_group_name = 'clickhouse-logs-avro-new'"
       format               = "kafka_format = 'Avro'"
-      num_consumers        = 8
+      num_consumers        = 16
       skip_broken_messages = 100
       poll_timeout_ms      = 3000
       poll_max_batch_size  = 1000

--- a/posthog/clickhouse/hcl/roles/logs/prod-eu/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/logs/prod-eu/tables.hcl
@@ -121,7 +121,7 @@ database "posthog" {
       topic_list           = "kafka_topic_list = 'clickhouse_logs'"
       group_name           = "kafka_group_name = 'clickhouse-logs-avro-new'"
       format               = "kafka_format = 'Avro'"
-      num_consumers        = 8
+      num_consumers        = 16
       skip_broken_messages = 100
       poll_timeout_ms      = 3000
       poll_max_batch_size  = 1000

--- a/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
@@ -17,7 +17,7 @@ CREATE TABLE posthog.kafka_logs_avro (
   event_name String,
   attributes Map(LowCardinality(String), String),
   bytes_uncompressed Int64
-) ENGINE = Kafka() SETTINGS kafka_broker_list = 'warpstream_logs', kafka_format = 'kafka_format = \'Avro\'', kafka_group_name = 'kafka_group_name = \'clickhouse-logs-avro-new\'', kafka_num_consumers = 8, kafka_poll_max_batch_size = 1000, kafka_poll_timeout_ms = 3000, kafka_skip_broken_messages = 100, kafka_thread_per_consumer = 1, kafka_topic_list = 'kafka_topic_list = \'clickhouse_logs\'';
+) ENGINE = Kafka() SETTINGS kafka_broker_list = 'warpstream_logs', kafka_format = 'kafka_format = \'Avro\'', kafka_group_name = 'kafka_group_name = \'clickhouse-logs-avro-new\'', kafka_num_consumers = 16, kafka_poll_max_batch_size = 1000, kafka_poll_timeout_ms = 3000, kafka_skip_broken_messages = 100, kafka_thread_per_consumer = 1, kafka_topic_list = 'kafka_topic_list = \'clickhouse_logs\'';
 CREATE TABLE posthog.kafka_metrics_avro (
   uuid String,
   trace_id String,


### PR DESCRIPTION
## Problem

Observed some consumer lag on the EU logs Kafka pipeline. The `kafka_logs_avro` consumer group wasn't keeping up.

## Changes

Bumped the consumer count for `kafka_logs_avro` (prod-eu logs) from 8 to 16. Source HCL plus the regenerated `golden`/`sql`.

## How did you test this code?

Already applied to the EU cluster and lag recovered. This just syncs with reality.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label — infra config, no user-facing docs. -->

## 🤖 Agent context