### PR TITLE
fix(agent-platform): lazy-load seed secret contract

### DIFF
--- a/.github/workflows/cd-agent-builder-seed.yml
+++ b/.github/workflows/cd-agent-builder-seed.yml
@@ -55,9 +55,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  sparse-checkout: |
-                      products/agent_platform/services/agent-tests/src/examples
-                      products/agent_platform/backend/logic/trigger_required_secrets.generated.json
+                  sparse-checkout: products/agent_platform/services/agent-tests/src/examples
                   sparse-checkout-cone-mode: false
 
             - name: Seed the agent-builder bundle

--- a/.github/workflows/cd-agent-builder-seed.yml
+++ b/.github/workflows/cd-agent-builder-seed.yml
@@ -55,7 +55,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  sparse-checkout: products/agent_platform/services/agent-tests/src/examples
+                  sparse-checkout: |
+                      products/agent_platform/services/agent-tests/src/examples
+                      products/agent_platform/backend/logic/trigger_required_secrets.generated.json
                   sparse-checkout-cone-mode: false
 
             - name: Seed the agent-builder bundle

--- a/products/agent_platform/services/agent-tests/src/cases/example-agent-builder.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/example-agent-builder.test.ts
@@ -13,15 +13,19 @@
  * Faux net — wiring, not inference quality.
  */
 
-import { readdir, readFile } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { cp, mkdir, mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
 
 import { AgentSpecSchema } from '@posthog/agent-shared'
 import { listNativeTools } from '@posthog/agent-tools'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const BUNDLE_ROOT = resolve(__dirname, '../examples/agent-builder')
+const execFileAsync = promisify(execFile)
 
 async function loadBundle(): Promise<{ spec: Record<string, unknown>; files: Record<string, string> }> {
     const spec = JSON.parse(await readFile(join(BUNDLE_ROOT, 'spec.json'), 'utf-8')) as Record<string, unknown>
@@ -181,5 +185,23 @@ describe('example: agent-builder bundle', () => {
         expect(src).toContain('def per_file_sha256(')
         // The bundle now SHIPS an MCP — the seeder must never blank mcps[].
         expect(src).not.toContain('spec["mcps"] = []')
+    })
+
+    it('the shared example seeder starts from the production sparse checkout', async () => {
+        const tempRoot = await mkdtemp(join(tmpdir(), 'agent-builder-seed-'))
+        const sparseExamplesRoot = join(tempRoot, 'products/agent_platform/services/agent-tests/src/examples')
+
+        try {
+            await mkdir(dirname(sparseExamplesRoot), { recursive: true })
+            await cp(resolve(__dirname, '../examples'), sparseExamplesRoot, { recursive: true })
+
+            const { stdout } = await execFileAsync('python3', [join(sparseExamplesRoot, 'seed.py'), '--list'], {
+                env: { ...process.env, SEED_DUMMY_SECRETS: '0' },
+            })
+
+            expect(stdout).toContain('agent-builder')
+        } finally {
+            await rm(tempRoot, { recursive: true, force: true })
+        }
     })
 })

--- a/products/agent_platform/services/agent-tests/src/examples/seed.py
+++ b/products/agent_platform/services/agent-tests/src/examples/seed.py
@@ -128,14 +128,13 @@ def _load_trigger_required_secrets() -> dict[str, list[str]]:
     }
 
 
-TRIGGER_REQUIRED_SECRETS: dict[str, list[str]] = _load_trigger_required_secrets()
-
 # Opt-in: set obviously-fake placeholder values for any secret an agent requires
 # (declared `spec.secrets[]` + per-trigger required keys) that isn't already
 # set, so secret-gated agents (slack, …) can promote in local dev. The agents
 # won't actually function — Slack signature checks etc. will fail — but they go
 # live + visible in the console. Never overwrites an existing value.
 SEED_DUMMY_SECRETS = os.environ.get("SEED_DUMMY_SECRETS") == "1"
+TRIGGER_REQUIRED_SECRETS: dict[str, list[str]] = _load_trigger_required_secrets() if SEED_DUMMY_SECRETS else {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Agent Builder seed workflow is the automation that keeps the canonical production Agent Builder aligned with the checked-in bundle and current kernel skills. It runs after relevant changes merge and on a daily schedule to pick up backend-delivered kernel skills and correct deployment drift.

The shared seed script began eagerly loading a generated backend secret contract during startup. The production workflow intentionally checks out only the example bundles, so that contract was absent and every seed run crashed before making an API request. As a result, Agent Builder changes could merge without reaching production, kernel-skill updates could not converge after backend deployment, and the scheduled drift-repair path was [failing](https://github.com/PostHog/posthog/actions/runs/29535216730). Production remained on its previous live revision until I noticed and seeded it manually.

The generated contract is needed only by the opt-in local `SEED_DUMMY_SECRETS=1` mode. Normal production seeding should not depend on it.

## Changes

Load the trigger-secret contract only when `SEED_DUMMY_SECRETS=1`. Keep the production workflow's narrow sparse checkout unchanged.

Add a regression test that copies only the production sparse-checkout subtree and verifies the shared seeder starts successfully.
