### PR TITLE
fix(cohort-seeder): set new KafkaConfig producer fields

### DIFF
--- a/rust/cohort-seeder/src/config.rs
+++ b/rust/cohort-seeder/src/config.rs
@@ -219,6 +219,8 @@ impl Config {
             kafka_producer_topic_metadata_refresh_interval_ms: None,
             kafka_producer_message_max_bytes: None,
             kafka_producer_sticky_partitioning_linger_ms: None,
+            kafka_producer_acks: None,
+            kafka_producer_retries: None,
         }
     }
 


### PR DESCRIPTION
## Problem

`cohort-seeder` fails to compile on master. #70557 added two required fields (`kafka_producer_acks`, `kafka_producer_retries`) to the shared `common_kafka::config::KafkaConfig`, but `cohort-seeder`'s exhaustive `build_kafka_config()` initializer was not updated and doesn't use `..Default::default()`. cohort-seeder wasn't in that PR's affected set, so the break landed on master (tip `070b8e29`).

CI builds every PR as its head merged with master, so this now fails Rust lint/build for effectively every open PR, not just cohort-seeder's.

## Changes

- Default `kafka_producer_acks` and `kafka_producer_retries` to `None` in `cohort-seeder`'s `build_kafka_config()`, matching every other kafka caller. `None` means "let librdkafka pick its default", so runtime behavior is unchanged.

## How did you test this code?

Automated only (agent, no manual testing):

- `cargo fmt -p cohort-seeder -- --check` clean.
- `cargo clippy -p cohort-seeder --all-targets --all-features -- -D warnings` passes (previously `E0063`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via the Cursor agent) found this while triaging Rust CI failures on an unrelated rate-limiter PR: the merge-with-master build failed at `cohort-seeder` with `E0063` for the two new `KafkaConfig` fields. Confirmed master tip is broken and that cohort-seeder is the only `common_kafka::KafkaConfig` initializer missing the fields (all others already set them; `kafka-assigner` has its own unrelated local `KafkaConfig` type). Chose explicit `None` over `..Default::default()` to match the surrounding style. Directed by Eli Reisman.
