### PR TITLE
fix(data-imports): stop grouping OpenAI costs by api_key_id

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/settings.py
@@ -66,8 +66,8 @@ class OpenAIEndpointConfig:
 _USAGE_GROUP_BY = ["project_id", "user_id", "api_key_id", "model"]
 _COMPLETIONS_GROUP_BY = [*_USAGE_GROUP_BY, "batch", "service_tier"]
 _IMAGES_GROUP_BY = [*_USAGE_GROUP_BY, "size", "source"]
-# The costs endpoint only accepts project_id and line_item, despite the SDK types listing
-# api_key_id — requesting it makes the live API reject the whole request with a 400.
+# The costs endpoint only accepts project_id and line_item. The SDK types also list api_key_id,
+# but requesting it makes the live API reject the whole request with a 400.
 _COSTS_GROUP_BY = ["project_id", "line_item"]
 
 # For 1d buckets the usage endpoints allow at most 31 buckets per page; costs allows 180.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/settings.py
@@ -66,7 +66,9 @@ class OpenAIEndpointConfig:
 _USAGE_GROUP_BY = ["project_id", "user_id", "api_key_id", "model"]
 _COMPLETIONS_GROUP_BY = [*_USAGE_GROUP_BY, "batch", "service_tier"]
 _IMAGES_GROUP_BY = [*_USAGE_GROUP_BY, "size", "source"]
-_COSTS_GROUP_BY = ["project_id", "line_item", "api_key_id"]
+# The costs endpoint only accepts project_id and line_item, despite the SDK types listing
+# api_key_id — requesting it makes the live API reject the whole request with a 400.
+_COSTS_GROUP_BY = ["project_id", "line_item"]
 
 # For 1d buckets the usage endpoints allow at most 31 buckets per page; costs allows 180.
 _USAGE_PAGE_LIMIT = 31

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/tests/test_openai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/tests/test_openai.py
@@ -113,6 +113,13 @@ class TestBucketParams:
         assert params["start_time"] == int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
         assert params["limit"] == 180
 
+    def test_costs_groups_only_by_dimensions_the_api_accepts(self) -> None:
+        # api_key_id grouping is rejected by the live costs endpoint with a 400 that fails the whole
+        # sync, even though the SDK types list it.
+        config = OPENAI_ENDPOINTS["costs"]
+        _, multi = _bucket_params(config, should_use_incremental_field=False, db_incremental_field_last_value=None)
+        assert multi == {"group_by": ["project_id", "line_item"]}
+
 
 class TestFlattenBucketResult:
     def test_flattens_nested_amount_and_converts_bucket_times(self) -> None:


### PR DESCRIPTION
## Problem

Error tracking flagged a live 400 from the OpenAI data-warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019f6d3d-fce8-7ec0-b275-9141ff8627b2)). Every affected org's costs sync failed the same way:

```
HTTPError: 400 Client Error: Bad Request for url:
https://api.openai.com/v1/organization/costs?bucket_width=1d&limit=180&start_time=<redacted>&group_by=project_id&group_by=line_item&group_by=api_key_id
```

The request is built by the shared costs config, so the failure is not caused by anyone's credentials or data. The costs endpoint (`/v1/organization/costs`) only accepts `project_id` and `line_item` as `group_by` dimensions. We also request `api_key_id`, which the live API rejects with a hard 400 that kills the whole costs sync. The `api_key_id` dimension is a usage-endpoint field. It appears in the OpenAI SDK's costs type as well, but the deployed endpoint does not accept it, so the SDK/spec is ahead of the live API here.

## Changes

Drop `api_key_id` from the costs `group_by`, leaving `project_id` and `line_item` — the dimensions the live API accepts. This is a request we control, so the right fix is to correct the request rather than mark the 400 non-retryable (which would permanently disable costs sync for everyone). Per-API-key attribution is still available via the usage endpoints, which do accept `api_key_id`.

## How did you test this code?

Added a case to `TestBucketParams` asserting the costs request groups only by `project_id` and `line_item`. This catches a regression if `api_key_id` (or any dimension the costs endpoint rejects) is added back to the costs `group_by` — the exact param that triggered the 400. No existing test asserted the costs `group_by` contents.

Ran the full source test file locally: `35 passed`. Ruff check and format are clean. I (Claude) did not exercise the live OpenAI API.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) confirmed the issue in error tracking (6 occurrences across 6 orgs in a one-minute window, all on the costs endpoint), traced the 400 to `_fetch_page` raising `raise_for_status` on the costs request, and checked the OpenAI SDK's costs params (which list `api_key_id`, but the live API rejects it). Considered marking the 400 non-retryable and rejected it: the request is one we construct, so correcting it restores costs sync rather than disabling it. Scoped the change to the costs `group_by` only. Invoked the `/writing-tests` skill before adding the regression case.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
