### PR TITLE
feat(replay-vision): link the summary header to the run page

### DIFF
--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -175,6 +175,9 @@ def _synthesize(inputs: SynthesizeGroupSummaryInputs) -> SynthesizeGroupSummaryR
     markdown = strip_external_links_markdown(
         _summary_header(action, batch.window_start, len(batch.lines), batch.window_total) + markdown
     )
+    # Linkify AFTER the strip pass (like the citation links) so the run URL isn't defanged on
+    # instances whose SITE_URL isn't a posthog.com host (self-hosted, dev).
+    markdown = _linkify_summary_header(markdown, action, _run_url(team.id, str(action.id), str(run.pk)))
     slack_text = _markdown_to_slack(markdown, team_id=team.id, observation_ids=batch.observation_ids)
 
     run.synthesized_markdown = markdown
@@ -360,15 +363,36 @@ def _fetch_observations(team: Team, action: VisionAction, run: VisionActionRun) 
     )
 
 
+def _scanner_display_name(action: VisionAction) -> str:
+    # Scanner name is free-text; strip markdown/mrkdwn control chars so it can't garble the bold header
+    # (in-app Markdown or the Slack `**`→`*` pass), plus link syntax chars so it can't break out of the
+    # header link's label, and collapse any newlines that would break the line.
+    raw_name = action.scanner.name if action.scanner_id else ""
+    return re.sub(r"\s+", " ", re.sub(r"[*_`#\[\]()]", "", raw_name)).strip() or "your scanner"
+
+
+def _run_url(team_id: int, action_id: str, run_id: str) -> str:
+    return f"{settings.SITE_URL}/project/{team_id}/replay-vision/actions/{action_id}/runs/{run_id}"
+
+
+def _linkify_summary_header(markdown: str, action: VisionAction, run_url: str) -> str:
+    """Wrap the header's scanner name in a link to this summary's run page — the full report plus the
+    recordings it covered (with breadcrumbs back to the scanner). Only rewrites the exact expected
+    header; a name the strip pass rewrote (e.g. it contained a bare URL, now a code span) won't match
+    and is left unlinked rather than guessed at."""
+    name = _scanner_display_name(action)
+    prefix = f"**Summary for {name}**"
+    if not markdown.startswith(prefix):
+        return markdown
+    return f"**Summary for [{name}]({run_url})**" + markdown[len(prefix) :]
+
+
 def _summary_header(action: VisionAction, window_start: datetime | None, count: int, window_total: int = 0) -> str:
     """A trusted one-line preface stating which scanner this summary is for, how many recordings it
     covers, and the window's start — the "summary for scans since <prev run>" context the reader needs.
     When the window held more observations than the cap, it says so ("sampled N of M") so the reader
     knows the report covers only a sample of the period, not every observation."""
-    # Scanner name is free-text; strip markdown/mrkdwn control chars so it can't garble the bold header
-    # (in-app Markdown or the Slack `**`→`*` pass) and collapse any newlines that would break the line.
-    raw_name = action.scanner.name if action.scanner_id else ""
-    scanner_name = re.sub(r"\s+", " ", re.sub(r"[*_`#]", "", raw_name)).strip() or "your scanner"
+    scanner_name = _scanner_display_name(action)
     noun = "recording" if count == 1 else "recordings"
     # When the period held more observations than the cap, only `count` were summarized — say so.
     coverage = f"sampled {count} of {window_total:,} {noun}" if window_total > count else f"{count} {noun}"

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -204,12 +204,13 @@ class TestVisionActionSynthesis(BaseTest):
         self._synthesize(action, run, llm_content="# Summary\nThemes.")
 
         run.refresh_from_db()
+        run_url = f"{settings.SITE_URL}/project/{self.team.id}/replay-vision/actions/{action.id}/runs/{run.pk}"
         self.assertTrue(
-            run.synthesized_markdown.startswith("**Summary for summarizer** — 2 recordings since "),
+            run.synthesized_markdown.startswith(f"**Summary for [summarizer]({run_url})** — 2 recordings since "),
             run.synthesized_markdown,
         )
-        # The header rides into the Slack payload too (bold header → *bold*).
-        self.assertIn("*Summary for summarizer*", run.output["slack"])
+        # The header rides into the Slack payload too (bold → *bold*, link → <url|label>).
+        self.assertIn(f"*Summary for <{run_url}|summarizer>*", run.output["slack"])
 
     def test_header_flags_sampling_when_window_exceeds_cap(self) -> None:
         # When the period holds more observations than the cap, the header must say the summary covers
@@ -236,7 +237,7 @@ class TestVisionActionSynthesis(BaseTest):
         self._synthesize(action, run)
 
         run.refresh_from_db()
-        self.assertIn("**Summary for Checkoutflow**", run.synthesized_markdown)
+        self.assertIn("**Summary for [Checkoutflow](", run.synthesized_markdown)
 
     def test_summary_header_defangs_links_in_scanner_name(self) -> None:
         # A scanner name is free text and lands in the header; a name with link/image markdown must not


### PR DESCRIPTION
## Problem

Summary reports lead with "**Summary for {scanner name}**", but nothing in that header is clickable.
In Slack (and on the digest card) the only links are the cited observations - there's no way to click through to the summary run itself or back to the scanner.
Alert messages already link their header to the run page; summaries never got the same treatment.

## Changes

- The scanner name in the summary header is now a link to this summary's run page (`/replay-vision/actions/{id}/runs/{id}`), which shows the full report, every recording it covered, and breadcrumbs back to the scanner. Same target the alert headers link to.
- The link is added after the external-link strip pass (the citation-link pattern), so the run URL isn't defanged on instances whose `SITE_URL` isn't a posthog.com host.
- The Slack payload picks it up automatically via the existing markdown-link conversion (`<url|scanner name>`).
- Scanner-name sanitization for the header now also strips `[]()` so a free-text name can't break out of the link label (mirrors the alert header sanitizer). A name the strip pass rewrote (e.g. one containing a bare URL) won't match the expected header and stays unlinked rather than guessed at.

## How did you test this code?

Automated only, no manual testing.
Updated the existing header assertions in `test_vision_action_synthesis.py` to lock the linked header in both the stored markdown and the Slack rendering; the name-sanitization and link-defang tests cover the new `[]()` stripping unchanged.
Full synthesis test file (39 tests) green locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude (PostHog Code), directed by Kim ("make the scanner clickable or at least allow the user to click through to the summary run itself"). Linked to the run page rather than the scanner page for consistency with the alert headers, which made the same call - the run page carries breadcrumbs back to the scanner, so both destinations are one click away.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
