### PR TITLE
feat(retention): scan first-time retention in two arms on the query variant

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -282,10 +282,8 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         # start and return timestamp arrays can be computed in one pass. Property aggregation has a known
         # legacy/variant discrepancy and stays on the UNION; a data-warehouse entity is a genuinely
         # different source and cannot collapse here.
-        # First-time modes also stay on the UNION: they drop the window bound to find each actor's
-        # first-ever start event, and a single scan then reads every column over all history, while
-        # the two arms confine the unbounded scan to the start entity's rows and keep the return arm
-        # window-bounded.
+        # First-time modes also stay on the UNION: their single scan is unbounded in time (first-ever
+        # anchor), so splitting confines the all-time read to the start entity's rows.
         return (
             not self.has_property_aggregation
             and not self.is_first_occurrence_matching_filters
@@ -503,8 +501,6 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         table_name = entity.table_name if entity_is_dwh else "events"
         assert table_name
-        # Arm-scoped filters instead of the OR of both entities: each arm pre-filters to its own
-        # entity's event names, and in first-time modes only the start arm scans all time.
         where_expr = (
             None
             if entity_is_dwh

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -119,17 +119,12 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         if self.is_first_ever_occurrence:
             # First-ever buckets each actor by the breakdown value on their earliest START
-            # event, resolved here via argMinIf(..., start_entity_expr_no_props). The events
-            # return arm can only do that when it shares the events source with the start
-            # entity. When the start entity is a DWH table, start_entity_expr_no_props
-            # collapses to a truthy constant, so on the events return arm argMinIf would
-            # instead read the actor's earliest RETURN event's value. Degrade to the empty
-            # bucket — the start (DWH) arm already emits "", so the outer max() yields "".
-            if (
-                query_kind == "return"
-                and self.start_event.type == EntityType.DATA_WAREHOUSE
-                and self._breakdown_extract_targets_events_table()
-            ):
+            # event. Only the start arm sees the full start-matcher stream, so it is the
+            # sole authority; the return arm's scan is entity-scoped and window-bounded, and
+            # its argMinIf would resolve a later row's value whenever the start matcher
+            # overlaps return rows. Degrade the return arm to the empty bucket — the outer
+            # max() lets the start arm's real value win.
+            if query_kind == "return":
                 return ast.Constant(value="")
             # Bucket each actor by the breakdown value on their earliest start event.
             return parse_expr(
@@ -282,15 +277,23 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         # start and return timestamp arrays can be computed in one pass. Property aggregation has a known
         # legacy/variant discrepancy and stays on the UNION; a data-warehouse entity is a genuinely
         # different source and cannot collapse here.
-        # First-time modes also stay on the UNION: their single scan is unbounded in time (first-ever
-        # anchor), so splitting confines the all-time read to the start entity's rows.
+        # First-time modes stay on the UNION only when the split can shrink the scan: their
+        # single scan is unbounded in time (first-ever anchor), and the two arms confine the
+        # all-time read to the start entity's event names. With identical entities or an
+        # all-events start entity the arms scan the same rows twice, so keep the single pass.
         return (
             not self.has_property_aggregation
-            and not self.is_first_occurrence_matching_filters
-            and not self.is_first_ever_occurrence
+            and not self._first_time_split_shrinks_scan()
             and self.start_event.type != EntityType.DATA_WAREHOUSE
             and self.return_event.type != EntityType.DATA_WAREHOUSE
         )
+
+    def _first_time_split_shrinks_scan(self) -> bool:
+        if not (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            return False
+        if self._start_and_return_entities_are_same():
+            return False
+        return None not in self.runner.get_events_for_entity(self.start_event)
 
     def _build_single_scan_query(
         self,
@@ -501,11 +504,20 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         table_name = entity.table_name if entity_is_dwh else "events"
         assert table_name
-        where_expr = (
-            None
-            if entity_is_dwh
-            else ast.And(exprs=[*self.runner.arm_event_filters(entity, query_kind), *self._cohort_breakdown_filters()])
-        )
+        where_expr: ast.Expr | None = None
+        if not entity_is_dwh:
+            arm_filters = [*self.runner.arm_event_filters(entity, query_kind), *self._cohort_breakdown_filters()]
+            # Push the arm's own entity predicate into WHERE so non-matching rows are pruned
+            # before aggregation. The first-ever start arm must keep no-props rows: its anchor
+            # minIfs and breakdown argMinIf aggregate over the no-props matcher.
+            arm_entity_predicate = (
+                self.entity_expr_no_props(entity)
+                if self.is_first_ever_occurrence and query_kind == "start"
+                else entity_expr
+            )
+            if not (isinstance(arm_entity_predicate, ast.Constant) and arm_entity_predicate.value is True):
+                arm_filters.append(arm_entity_predicate)
+            where_expr = ast.And(exprs=arm_filters)
 
         select_fields: list[ast.Expr] = [
             ast.Alias(alias="actor_id", expr=actor_field),

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -282,8 +282,14 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         # start and return timestamp arrays can be computed in one pass. Property aggregation has a known
         # legacy/variant discrepancy and stays on the UNION; a data-warehouse entity is a genuinely
         # different source and cannot collapse here.
+        # First-time modes also stay on the UNION: they drop the window bound to find each actor's
+        # first-ever start event, and a single scan then reads every column over all history, while
+        # the two arms confine the unbounded scan to the start entity's rows and keep the return arm
+        # window-bounded.
         return (
             not self.has_property_aggregation
+            and not self.is_first_occurrence_matching_filters
+            and not self.is_first_ever_occurrence
             and self.start_event.type != EntityType.DATA_WAREHOUSE
             and self.return_event.type != EntityType.DATA_WAREHOUSE
         )
@@ -497,7 +503,13 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         table_name = entity.table_name if entity_is_dwh else "events"
         assert table_name
-        where_expr = None if entity_is_dwh else ast.And(exprs=self._event_filters())
+        # Arm-scoped filters instead of the OR of both entities: each arm pre-filters to its own
+        # entity's event names, and in first-time modes only the start arm scans all time.
+        where_expr = (
+            None
+            if entity_is_dwh
+            else ast.And(exprs=[*self.runner.arm_event_filters(entity, query_kind), *self._cohort_breakdown_filters()])
+        )
 
         select_fields: list[ast.Expr] = [
             ast.Alias(alias="actor_id", expr=actor_field),
@@ -913,7 +925,9 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
     def _event_filters(self) -> list[ast.Expr]:
-        event_filters = self.global_event_filters.copy()
+        return [*self.global_event_filters, *self._cohort_breakdown_filters()]
+
+    def _cohort_breakdown_filters(self) -> list[ast.Expr]:
         if (
             self.query.breakdownFilter
             and self.query.breakdownFilter.breakdowns
@@ -923,15 +937,15 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             cohort_id = self.query.breakdownFilter.breakdowns[0].property
             # Don't add cohort filter for "all users" (cohort_id = 0)
             if int(cohort_id) != ALL_USERS_COHORT_ID:
-                event_filters.append(
+                return [
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.InCohort,
                         left=ast.Field(chain=["person_id"]),
                         right=ast.Constant(value=int(cohort_id)),
                     )
-                )
+                ]
 
-        return event_filters
+        return []
 
     def _is_valid_start_interval_expr(self, start_event_timestamps_field: str = "start_event_timestamps") -> ast.Expr:
         start_event_timestamps = ast.Field(chain=[start_event_timestamps_field])

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -250,13 +250,15 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return global_event_filters
 
     def arm_event_filters(self, entity: RetentionEntity, query_kind: Literal["start", "return"]) -> list[ast.Expr]:
-        """Filters for one arm of a two-scan retention query, scoped to that arm's entity only."""
+        """Filters for one events-table arm of a two-scan retention query, scoped to that arm's entity only."""
         filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence, entities=[entity]
         )
         if query_kind == "return" and (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
-            # First-time modes need the start arm unbounded to find the first-ever start event,
-            # but return events outside the window never enter any aggregate.
+            # First-time modes need the start arm unbounded to find the first-ever start event.
+            # The return arm's timestamp aggregates are all window-conditioned, and its
+            # first-ever breakdown value is degraded to '', so bounding it drops no rows any
+            # aggregate depends on.
             filters.append(self.events_timestamp_filter())
         if self.group_type_index is not None:
             filters.append(self._group_actor_filter())
@@ -402,8 +404,8 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             entities = [self.start_event, self.return_event]
         events = [event for entity in entities for event in self.get_events_for_entity(entity)]
         unique_events = set(events)
-        # Don't pre-filter if any of them is "All events"
-        if None not in unique_events:
+        # Don't pre-filter if any of them is "All events" or the entity has no events at all
+        if unique_events and None not in unique_events:
             events_where.append(
                 ast.CompareOperation(
                     left=ast.Field(chain=["event"]),

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -250,17 +250,13 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return global_event_filters
 
     def arm_event_filters(self, entity: RetentionEntity, query_kind: Literal["start", "return"]) -> list[ast.Expr]:
-        """
-        Event filters for one arm of a two-scan (UNION ALL) retention query, scoped to
-        that arm's entity instead of the OR of both entities.
-        """
+        """Filters for one arm of a two-scan retention query, scoped to that arm's entity only."""
         filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence, entities=[entity]
         )
         if query_kind == "return" and (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
-            # First-time modes drop the global window bound so the start arm can find the
-            # first-ever start event, but return events outside the window never enter any
-            # aggregate, so the return arm can always be bounded.
+            # First-time modes need the start arm unbounded to find the first-ever start event,
+            # but return events outside the window never enter any aggregate.
             filters.append(self.events_timestamp_filter())
         if self.group_type_index is not None:
             filters.append(self._group_actor_filter())
@@ -383,10 +379,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         is_first_ever_occurrence: bool = False,
         entities: list[RetentionEntity] | None = None,
     ):
-        """
-        Event filters to apply to both start and return events, or to just the given
-        entities when building a per-arm scan.
-        """
+        """Event filters for both start and return events, or just `entities` for a per-arm scan."""
         events_where = []
 
         if self.query.properties is not None and self.query.properties != []:

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from math import ceil
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 from posthog.schema import (
     AggregationType,
@@ -246,18 +246,36 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             global_event_filters.append(is_relevant_event)
 
         if self.group_type_index is not None:
-            global_event_filters.append(
-                ast.Not(
-                    expr=ast.Call(
-                        name="has",
-                        args=[
-                            ast.Array(exprs=[ast.Constant(value="")]),
-                            ast.Field(chain=["events", f"$group_{self.group_type_index}"]),
-                        ],
-                    ),
-                ),
-            )
+            global_event_filters.append(self._group_actor_filter())
         return global_event_filters
+
+    def arm_event_filters(self, entity: RetentionEntity, query_kind: Literal["start", "return"]) -> list[ast.Expr]:
+        """
+        Event filters for one arm of a two-scan (UNION ALL) retention query, scoped to
+        that arm's entity instead of the OR of both entities.
+        """
+        filters = self.events_where_clause(
+            self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence, entities=[entity]
+        )
+        if query_kind == "return" and (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            # First-time modes drop the global window bound so the start arm can find the
+            # first-ever start event, but return events outside the window never enter any
+            # aggregate, so the return arm can always be bounded.
+            filters.append(self.events_timestamp_filter())
+        if self.group_type_index is not None:
+            filters.append(self._group_actor_filter())
+        return filters
+
+    def _group_actor_filter(self) -> ast.Expr:
+        return ast.Not(
+            expr=ast.Call(
+                name="has",
+                args=[
+                    ast.Array(exprs=[ast.Constant(value="")]),
+                    ast.Field(chain=["events", f"$group_{self.group_type_index}"]),
+                ],
+            ),
+        )
 
     def convert_single_breakdown_to_multiple_breakdowns(self):
         assert self.query.breakdownFilter is not None
@@ -359,9 +377,15 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             return action.get_step_events()
         return [entity.id] if isinstance(entity.id, str) else [None]
 
-    def events_where_clause(self, is_first_occurrence_matching_filters: bool, is_first_ever_occurrence: bool = False):
+    def events_where_clause(
+        self,
+        is_first_occurrence_matching_filters: bool,
+        is_first_ever_occurrence: bool = False,
+        entities: list[RetentionEntity] | None = None,
+    ):
         """
-        Event filters to apply to both start and return events
+        Event filters to apply to both start and return events, or to just the given
+        entities when building a per-arm scan.
         """
         events_where = []
 
@@ -381,7 +405,9 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             events_where.append(self.events_timestamp_filter())
 
         # Pre-filter by event name
-        events = self.get_events_for_entity(self.start_event) + self.get_events_for_entity(self.return_event)
+        if entities is None:
+            entities = [self.start_event, self.return_event]
+        events = [event for entity in entities for event in self.get_events_for_entity(entity)]
         unique_events = set(events)
         # Don't pre-filter if any of them is "All events"
         if None not in unique_events:

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
@@ -28,7 +28,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid')))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid')), equals(events.event, 'paid'))
         GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
@@ -80,7 +80,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid', 'posthog_test_warehouse_event_mix_signups')), or(equals(events.event, 'posthog_test_warehouse_event_mix_signups'), equals(events.event, 'paid')))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid')), equals(events.event, 'paid'))
         GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse.ambr
@@ -28,7 +28,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid', 'posthog_test_warehouse_event_mix_signups')), or(equals(events.event, 'posthog_test_warehouse_event_mix_signups'), equals(events.event, 'paid')))
+        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('paid')))
         GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -1434,23 +1434,41 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))], []) AS start_event_timestamps,
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+               if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))], []) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')))
+        GROUP BY actor_id
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))
+        GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1520,23 +1538,41 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))], []) AS start_event_timestamps,
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+               if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))], []) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')))
+        GROUP BY actor_id
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))
+        GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -1454,7 +1454,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')))
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))
         GROUP BY actor_id
         UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
                          [] AS start_event_timestamps,
@@ -1467,7 +1467,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))
         GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
@@ -1558,7 +1558,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')))
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), equals(events.event, 'target_event'))
         GROUP BY actor_id
         UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
                          [] AS start_event_timestamps,
@@ -1571,7 +1571,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))
         GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
@@ -1599,23 +1599,41 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toIntervalDay(1))], []) AS start_event_timestamps,
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events_json AS events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)), equals(events.event, 'returning_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+               if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toIntervalDay(1))], []) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))
+        GROUP BY actor_id
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))
+        GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1685,23 +1703,41 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))], []) AS start_event_timestamps,
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events_json AS events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+               if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))], []) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), equals(events.event, 'target_event'))
+        GROUP BY actor_id
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))
+        GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -8201,8 +8201,6 @@ class TestRetentionFirstTimeTwoLegScan(APIBaseTest):
         self.assertIn("did_action", return_constants)
         self.assertNotIn("signup", return_constants)
 
-        # The start arm must scan all time to find each actor's first occurrence;
-        # the return arm only ever aggregates within the window, so it stays bounded.
         self.assertFalse(self._where_has_timestamp_bound(start_arm))
         self.assertTrue(self._where_has_timestamp_bound(return_arm))
 

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -8132,3 +8132,81 @@ class TestClickhouseRetentionGroupAggregation(
     #     self.assertIn("USA", breakdown_values)
     #     self.assertNotIn("Canada", breakdown_values)
     #     self.assertIn(BREAKDOWN_OTHER_STRING_LABEL, breakdown_values)  # Canada should be in "Other"
+
+
+class TestRetentionFirstTimeTwoLegScan(APIBaseTest):
+    def _variant_base_query(self, retention_type: str) -> ast.SelectQuery:
+        runner = RetentionQueryRunner(
+            team=self.team,
+            query={
+                "kind": "RetentionQuery",
+                "retentionFilter": {
+                    "retentionType": retention_type,
+                    "targetEntity": {"id": "signup", "type": "events"},
+                    "returningEntity": {"id": "did_action", "type": "events"},
+                },
+            },
+        )
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=True):
+            return RetentionFixedIntervalBaseQueryBuilder(runner).build_base_query()
+
+    @staticmethod
+    def _where_constants(arm: ast.SelectQuery) -> list[Any]:
+        constants: list[Any] = []
+
+        def walk(value: Any) -> None:
+            if isinstance(value, ast.Constant):
+                constants.append(value.value)
+            if hasattr(value, "__dataclass_fields__"):
+                for field_name in value.__dataclass_fields__:
+                    walk(getattr(value, field_name))
+            elif isinstance(value, list | tuple):
+                for item in value:
+                    walk(item)
+
+        walk(arm.where)
+        return constants
+
+    @staticmethod
+    def _where_has_timestamp_bound(arm: ast.SelectQuery) -> bool:
+        found = False
+
+        def walk(value: Any) -> None:
+            nonlocal found
+            if isinstance(value, ast.CompareOperation) and isinstance(value.left, ast.Field):
+                if value.left.chain[-1] == "timestamp":
+                    found = True
+            if hasattr(value, "__dataclass_fields__"):
+                for field_name in value.__dataclass_fields__:
+                    walk(getattr(value, field_name))
+            elif isinstance(value, list | tuple):
+                for item in value:
+                    walk(item)
+
+        walk(arm.where)
+        return found
+
+    @parameterized.expand(["retention_first_time", "retention_first_ever_occurrence"])
+    def test_first_time_modes_scan_two_arms_with_bounded_return_arm(self, retention_type):
+        base_query = self._variant_base_query(retention_type)
+        assert base_query.select_from is not None
+        table = base_query.select_from.table
+        self.assertIsInstance(table, ast.SelectSetQuery)
+        start_arm, return_arm = list(table.select_queries())  # type: ignore[union-attr]
+
+        start_constants = self._where_constants(start_arm)
+        return_constants = self._where_constants(return_arm)
+        self.assertIn("signup", start_constants)
+        self.assertNotIn("did_action", start_constants)
+        self.assertIn("did_action", return_constants)
+        self.assertNotIn("signup", return_constants)
+
+        # The start arm must scan all time to find each actor's first occurrence;
+        # the return arm only ever aggregates within the window, so it stays bounded.
+        self.assertFalse(self._where_has_timestamp_bound(start_arm))
+        self.assertTrue(self._where_has_timestamp_bound(return_arm))
+
+    def test_recurring_mode_keeps_single_scan(self):
+        base_query = self._variant_base_query("retention_recurring")
+        assert base_query.select_from is not None
+        self.assertIsInstance(base_query.select_from.table, ast.Field)

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -2870,6 +2870,47 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             ],
         )
 
+    def test_retention_first_time_ever_breakdown_with_overlapping_action_target(self):
+        """First-ever breakdown must come from the actor's first-ever start event, not a later
+        return event whose row also matches the start entity (overlapping action steps)."""
+        action = Action.objects.create(
+            team=self.team,
+            name="any signup",
+            steps_json=[{"event": "signup_a"}, {"event": "signup_b"}],
+        )
+        _create_person(team_id=self.team.pk, distinct_ids=["person1"])
+        # First-ever action-matching event: signup_b with plan "a"; later in-window return
+        # events (signup_a) carry plan "z", which sorts higher and must not win the bucket.
+        _create_events(self.team, [("person1", _date(1), {"plan": "a"})], "signup_b")
+        _create_events(
+            self.team, [("person1", _date(2), {"plan": "z"}), ("person1", _date(4), {"plan": "z"})], "signup_a"
+        )
+        flush_persons_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": _date(0), "date_to": _date(7)},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 7,
+                    "retentionType": RETENTION_FIRST_EVER_OCCURRENCE,
+                    "targetEntity": {"id": action.id, "type": TREND_FILTER_TYPE_ACTIONS},
+                    "returningEntity": {"id": "signup_a", "name": "signup_a", "type": TREND_FILTER_TYPE_EVENTS},
+                },
+                "breakdownFilter": {
+                    "breakdown": "plan",
+                    "breakdown_type": "event",
+                },
+            }
+        )
+
+        buckets = {row.get("breakdown_value") for row in result}
+        self.assertIn("a", buckets)
+        self.assertNotIn("z", buckets)
+        bucket_a = [row for row in result if row.get("breakdown_value") == "a"]
+        # Cohorted on day 1, returned via signup_a on days 2 and 4 (intervals 1 and 3).
+        self.assertEqual(pluck(bucket_a, "values", "count")[1][:4], [1, 1, 0, 1])
+
     def test_retention_first_time_ever_with_event_breakdown(self):
         """Test first time ever retention with event property breakdown"""
         _create_person(team_id=self.team.pk, distinct_ids=["person1"])
@@ -8135,18 +8176,24 @@ class TestClickhouseRetentionGroupAggregation(
 
 
 class TestRetentionFirstTimeTwoLegScan(APIBaseTest):
-    def _variant_base_query(self, retention_type: str) -> ast.SelectQuery:
-        runner = RetentionQueryRunner(
-            team=self.team,
-            query={
-                "kind": "RetentionQuery",
-                "retentionFilter": {
-                    "retentionType": retention_type,
-                    "targetEntity": {"id": "signup", "type": "events"},
-                    "returningEntity": {"id": "did_action", "type": "events"},
-                },
+    def _variant_base_query(
+        self,
+        retention_type: str,
+        target: dict | None = None,
+        returning: dict | None = None,
+        aggregation_group_type_index: int | None = None,
+    ) -> ast.SelectQuery:
+        query: dict = {
+            "kind": "RetentionQuery",
+            "retentionFilter": {
+                "retentionType": retention_type,
+                "targetEntity": target or {"id": "signup", "type": "events"},
+                "returningEntity": returning or {"id": "did_action", "type": "events"},
             },
-        )
+        }
+        if aggregation_group_type_index is not None:
+            query["aggregation_group_type_index"] = aggregation_group_type_index
+        runner = RetentionQueryRunner(team=self.team, query=query)
         with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=True):
             return RetentionFixedIntervalBaseQueryBuilder(runner).build_base_query()
 
@@ -8208,3 +8255,35 @@ class TestRetentionFirstTimeTwoLegScan(APIBaseTest):
         base_query = self._variant_base_query("retention_recurring")
         assert base_query.select_from is not None
         self.assertIsInstance(base_query.select_from.table, ast.Field)
+
+    @parameterized.expand(
+        [
+            ("same_entity", {"id": "signup", "type": "events"}, {"id": "signup", "type": "events"}),
+            ("all_events_target", {"id": None, "type": "events"}, {"id": "did_action", "type": "events"}),
+        ]
+    )
+    def test_first_time_keeps_single_scan_when_split_cannot_shrink_the_scan(self, _name, target, returning):
+        base_query = self._variant_base_query("retention_first_time", target=target, returning=returning)
+        assert base_query.select_from is not None
+        self.assertIsInstance(base_query.select_from.table, ast.Field)
+
+    def test_first_time_group_aggregation_filters_both_arms(self):
+        base_query = self._variant_base_query("retention_first_time", aggregation_group_type_index=0)
+        assert base_query.select_from is not None
+        table = base_query.select_from.table
+        self.assertIsInstance(table, ast.SelectSetQuery)
+
+        def collect_chains(value, chains):
+            if isinstance(value, ast.Field):
+                chains.append(value.chain)
+            if hasattr(value, "__dataclass_fields__"):
+                for field_name in value.__dataclass_fields__:
+                    collect_chains(getattr(value, field_name), chains)
+            elif isinstance(value, list | tuple):
+                for item in value:
+                    collect_chains(item, chains)
+
+        for arm in table.select_queries():  # type: ignore[union-attr]
+            chains: list = []
+            collect_chains(arm.where, chains)
+            self.assertIn(["events", "$group_0"], chains)


### PR DESCRIPTION
## Problem

First-time retention (first occurrence matching filters, and first-ever occurrence) has to find each actor's first-ever start event, so the runner deliberately drops the window bound from the events WHERE clause. On the single-scan shape that means one scan over the team's entire event history, and because the start and return entity conditions sit in a single OR, ClickHouse has to decode the expensive columns (`person_properties`, property maps) for every historical row just to evaluate the filter. Column reads don't short-circuit through an OR.

Replaying a representative production first-time retention insight (8-day window, refreshed several times a day) with direct IO and the condition/uncompressed caches disabled: it reads 2.44 TiB and burns ~192 CPU-seconds per run. Retention is currently the single largest CPU consumer among user-facing query patterns.

## Changes

All on the flag-gated dwh-variant path (`retention-fixed-interval-base-query-dwh-variant`); the legacy default path is untouched.

- `_can_single_scan` now excludes first-time modes, so they build the two-arm UNION ALL shape instead of one unbounded scan.
- Each events arm's WHERE is scoped to its own entity via the new `RetentionQueryRunner.arm_event_filters` instead of sharing the global OR-of-both-entities filter:
  - the start arm scans all time (required for the first-occurrence anchor) but pre-filters to the start entity's event names, so the sort key prunes granules and the expensive columns are only decoded near those rows,
  - the return arm is always bounded to the query window on raw `events.timestamp` (return events outside the window never enter any aggregate, in every retention mode), and since it emits `[] AS start_event_timestamps` it never references start-entity expressions at all.
- `events_where_clause` gains an optional `entities` parameter so the event-name pre-filter can be built per arm; the cohort-breakdown filter is extracted into `_cohort_breakdown_filters` and applied per arm.

Benchmark on the production query above, byte-identical results on every run:

| shape | wall | CPU | read | memory |
|---|---|---|---|---|
| single scan (today) | 5.0 s | 192 s | 2.44 TiB | 3.5 GiB |
| two arms, per-arm WHERE | 1.4 s | 12.7 s | 17 GiB | 630 MB |

A control arm that only added the window bound inside the OR (keeping one scan) read the same 2.4 TiB, confirming the scan split is what matters, not the filter logic.

> [!WARNING]
> Two rollout facts reviewers should know. First, the gating flag `retention-fixed-interval-base-query-dwh-variant` does not exist yet in the internal flag project, so the events-only two-arm path in this PR is unreachable in production until the retention team creates and ramps that flag. Second, retention queries with a data warehouse entity route to the variant builder unconditionally, so the per-arm WHERE rewrite here ships to that surface on deploy regardless of the flag, and turning the flag off does not fully revert this change (a code revert does).

### Multi-agent QA review

A six-reviewer QA pass (database, performance, data-integrity, reliability, two generalists) on the initial version of this branch surfaced findings that are now fixed in follow-up commits:

- First-ever retention with a breakdown could silently mis-bucket actors: per-arm narrowing broke the invariant that both arms resolve the same `argMinIf` breakdown value before the outer `max()` collapse (reproduced empirically with an overlapping action target). The return arm now always degrades its first-ever breakdown value to the empty bucket, making the start arm the sole authority, and a red-green parity test pins it.
- The per-arm filters had dropped the entity property predicate from arm WHERE clauses, un-pruning selective filters on the unbounded start arm. Each arm now pushes its own mode-safe predicate (no-props on the first-ever start arm, with-props elsewhere).
- Same-entity and all-events start entities gained nothing from the split while paying for two scans and two override joins, so `_can_single_scan` now keeps the single pass whenever the split cannot shrink the scan (which also revives the single-scan first-time path for those shapes).
- A zero-step action entity could produce `event IN tuple()` and silently blank the insight; the event-name prefilter is now skipped when an entity resolves to no events.

## How did you test this code?

- Full `test_retention_query_runner.py` suite (145 passed): every test in it runs both the legacy and the variant path and asserts equal results, so the changed variant is checked against the unchanged legacy output across recurring, first-time, first-ever, breakdowns, groups, actions, minimum occurrences, and sampling.
- `test_retention_data_warehouse.py` (21 passed) for the arm construction shared with data-warehouse entities.
- `test_retention_first_time_ever_breakdown_with_overlapping_action_target`: parity + behavioral test for the first-ever breakdown fix, verified to fail without the fix and pass with it.
- New `TestRetentionFirstTimeTwoLegScan` AST-shape tests: first-time modes must produce the two-arm shape with an unbounded start arm and a bounded return arm scoped to their own event names, recurring mode must keep the single scan, same-entity and all-events first-time shapes must keep the single scan (the carve-out), and group-aggregated first-time queries must carry the `$group_N` filter in both arms. No existing test pinned the scan topology, which is the thing this PR changes and the thing a future refactor could silently regress.
- Two SQL snapshots updated; the diff shows exactly the intended structure change.
- Production benchmark: replayed the heaviest real first-time retention query from the query log with the rewritten shape via readonly Metabase access, three arm variants, interleaved runs, caches disabled, identical result matrices.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: no user-facing behavior change, query results are identical.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, directed by the assignee, following a query-pain analysis that ranked RetentionQuery as the top fleet CPU pattern. The investigation went: pull the heaviest retention runs from the query log, read the generated SQL, find the unbounded scan, then benchmark three rewrites against production before touching the runner. A bound-inside-the-OR fix was tried first and rejected with data (no read reduction). The two-arm implementation reuses the existing variant UNION architecture rather than adding a new path, and ships behind the same variant flag, so rollout and parity verification ride the existing migration. The `/query-clickhouse-via-metabase` and `/writing-tests` skills were used along the way.
