### PR TITLE
fix(temporalio): ride out transient h2 transport errors in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
@@ -65,6 +65,19 @@ _MAX_TRANSIENT_RPC_ATTEMPTS = 6
 
 _RETRYABLE_RPC_STATUSES = frozenset({RPCStatusCode.RESOURCE_EXHAUSTED, RPCStatusCode.DEADLINE_EXCEEDED})
 
+# tonic/hyper surface a mid-stream HTTP/2 transport interruption (a reset stream or a response
+# body read cut short) as an RPCError with status UNKNOWN and an "h2 protocol error" message,
+# rather than one of the transient statuses above. It's a connection blip, not the server
+# rejecting the request, so ride it out the same way. Match the stable transport phrase, not the
+# whole UNKNOWN status, so genuine server-side UNKNOWN failures still surface.
+_RETRYABLE_RPC_MESSAGES = ("h2 protocol error",)
+
+
+def _is_retryable_rpc_error(error: RPCError) -> bool:
+    if error.status in _RETRYABLE_RPC_STATUSES:
+        return True
+    return any(phrase in error.message for phrase in _RETRYABLE_RPC_MESSAGES)
+
 
 async def _with_transient_rpc_retry(
     operation: Callable[[], Awaitable[T]],
@@ -78,7 +91,7 @@ async def _with_transient_rpc_retry(
             return await operation()
         except RPCError as e:
             attempt += 1
-            if attempt >= max_attempts or e.status not in _RETRYABLE_RPC_STATUSES:
+            if attempt >= max_attempts or not _is_retryable_rpc_error(e):
                 raise
             backoff = min(2 * attempt, 30)
             logger.debug(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -111,6 +111,9 @@ class TestTransientRPCRetry:
         [
             ("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED),
             ("downstream duration timeout", RPCStatusCode.DEADLINE_EXCEEDED),
+            # A mid-stream HTTP/2 transport interruption surfaces as UNKNOWN, not one of the
+            # transient statuses above — it must still be ridden out in-process.
+            ("h2 protocol error: error reading a body from connection", RPCStatusCode.UNKNOWN),
         ],
     )
     @patch(
@@ -154,13 +157,21 @@ class TestTransientRPCRetry:
         # Bounded attempts leave Temporal to retry; backs off between attempts but not after the last.
         assert sleep.await_args_list == [call(2), call(4), call(6)]
 
+    @pytest.mark.parametrize(
+        "message,status",
+        [
+            ("workflow execution not found for", RPCStatusCode.NOT_FOUND),
+            # UNKNOWN alone must not be retried — only UNKNOWN carrying a transport signature is.
+            ("internal server error", RPCStatusCode.UNKNOWN),
+        ],
+    )
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.temporalio.temporalio.asyncio.sleep",
         new_callable=AsyncMock,
     )
-    async def test_non_transient_rpc_error_is_not_retried(self, sleep):
+    async def test_non_transient_rpc_error_is_not_retried(self, sleep, message, status):
         async def operation():
-            raise _rpc_error("workflow execution not found for", RPCStatusCode.NOT_FOUND)
+            raise _rpc_error(message, status)
 
         with pytest.raises(RPCError):
             await _with_transient_rpc_retry(operation, MagicMock())


### PR DESCRIPTION
## Problem

Error tracking surfaced an `RPCError` from the Temporal.io data-warehouse source:

> h2 protocol error: error reading a body from connection

It's raised inside `_with_transient_rpc_retry` in `temporalio.py` while paging through workflows / fetching workflow histories. The exception value is `(2, 'h2 protocol error: ...', b'')` — gRPC status `2` is `UNKNOWN`.

This is a mid-stream HTTP/2 transport interruption (a reset stream or a response body read cut short), not the server rejecting the request. It's transient: a short backoff clears it. But `_with_transient_rpc_retry` only rode out `RESOURCE_EXHAUSTED` and `DEADLINE_EXCEEDED`, so an `UNKNOWN`-status transport blip was re-raised immediately. That fails the whole import activity (which rebuilds the client and restarts pagination) and shows up as error-tracking noise — exactly what this helper was written to avoid.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f6d8f-cfeb-7363-80d9-ea1840efcfa8

## Changes

I treat a transient HTTP/2 transport interruption as retryable in the same in-process retry loop. The helper now retries when either the gRPC status is one of the existing transient statuses **or** the message carries a stable transport signature (`h2 protocol error`).

Matching the message phrase rather than the whole `UNKNOWN` status keeps the scope tight: a genuine server-side `UNKNOWN` failure still surfaces and isn't silently retried. This is not added to `NonRetryableErrors` — a connection blip should stay retryable, just ridden out locally first.

## How did you test this code?

Automated only (no manual/live testing):

- Extended `test_rides_out_transient_error` with a `(h2 protocol error…, UNKNOWN)` case — catches a regression where the transport signature stops being ridden out and the activity fails on a blip again.
- Parameterized `test_non_transient_rpc_error_is_not_retried` to add an `UNKNOWN` status with a non-transport message — guards against over-widening to blanket-retry every `UNKNOWN`.
- `uv run pytest .../temporalio/test_temporalio.py` → 23 passed. `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I read the issue and a representative event via the PostHog error-tracking tools, confirmed the failure originates in this source's `_with_transient_rpc_retry`, and decided it's a fragility (transient transport error not ridden out) rather than a user/upstream error — so it stays retryable and does not belong in `NonRetryableErrors`. Considered doing nothing and leaving it to Temporal's activity-level retry, but the in-process helper exists precisely to absorb these blips without restarting pagination or generating noise, so I extended it. Invoked the `/writing-tests` skill before touching the test file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
