### PR TITLE
fix(data-management): make virtual property definition pages load instead of 404

### DIFF
--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -46,13 +46,15 @@ import { getEventDefinitionIcon, getPropertyDefinitionIcon } from '../events/Def
 export const scene: SceneExport<DefinitionLogicProps> = {
     component: DefinitionEdit,
     logic: definitionLogic,
-    paramsToProps: ({ params: { id } }) => ({ id }),
+    paramsToProps: ({ params: { id } }) => ({ id: id ? decodeURIComponent(id) : id }),
 }
 
-export function DefinitionEdit(props: DefinitionLogicProps): JSX.Element {
+export function DefinitionEdit(rawProps: DefinitionLogicProps): JSX.Element {
+    // The app renders scene components with raw route params, so decode the id like paramsToProps does
+    const props = { ...rawProps, id: rawProps.id ? decodeURIComponent(rawProps.id) : rawProps.id }
     const logic = definitionEditLogic(props)
     const definitionLogicInstance = definitionLogic(props)
-    const { definitionLoading, definitionMissing, isProperty } = useValues(definitionLogicInstance)
+    const { definitionLoading, definitionMissing, isProperty, singular } = useValues(definitionLogicInstance)
     const { editDefinition } = useValues(logic)
     const { saveDefinition } = useActions(logic)
     const { tags, tagsLoading } = useValues(tagsModel)
@@ -80,7 +82,7 @@ export function DefinitionEdit(props: DefinitionLogicProps): JSX.Element {
     const mediaPreviewDragTarget = createRef<HTMLDivElement>()
 
     if (definitionMissing) {
-        return <NotFound object="event" />
+        return <NotFound object={singular} />
     }
     return (
         <Form logic={definitionEditLogic} props={props} formKey="editDefinition">

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -26,7 +26,11 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { getPrimaryPropertyForEvent, hasTaxonomyPrimaryProperty } from 'lib/utils/events'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { definitionEditLogic } from 'scenes/data-management/definition/definitionEditLogic'
-import { DefinitionLogicProps, definitionLogic } from 'scenes/data-management/definition/definitionLogic'
+import {
+    DefinitionLogicProps,
+    decodeDefinitionId,
+    definitionLogic,
+} from 'scenes/data-management/definition/definitionLogic'
 import { PropertyAccessControl } from 'scenes/data-management/definition/PropertyAccessControl'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -46,12 +50,12 @@ import { getEventDefinitionIcon, getPropertyDefinitionIcon } from '../events/Def
 export const scene: SceneExport<DefinitionLogicProps> = {
     component: DefinitionEdit,
     logic: definitionLogic,
-    paramsToProps: ({ params: { id } }) => ({ id: id ? decodeURIComponent(id) : id }),
+    paramsToProps: ({ params: { id } }) => ({ id: decodeDefinitionId(id) }),
 }
 
 export function DefinitionEdit(rawProps: DefinitionLogicProps): JSX.Element {
     // The app renders scene components with raw route params, so decode the id like paramsToProps does
-    const props = { ...rawProps, id: rawProps.id ? decodeURIComponent(rawProps.id) : rawProps.id }
+    const props = { ...rawProps, id: decodeDefinitionId(rawProps.id) }
     const logic = definitionEditLogic(props)
     const definitionLogicInstance = definitionLogic(props)
     const { definitionLoading, definitionMissing, isProperty, singular } = useValues(definitionLogicInstance)

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -19,7 +19,11 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { getPrimaryPropertyForEvent } from 'lib/utils/events'
-import { DefinitionLogicProps, definitionLogic } from 'scenes/data-management/definition/definitionLogic'
+import {
+    DefinitionLogicProps,
+    decodeDefinitionId,
+    definitionLogic,
+} from 'scenes/data-management/definition/definitionLogic'
 import { EventDefinitionExperiments } from 'scenes/data-management/events/EventDefinitionExperiments'
 import { EventDefinitionInsights } from 'scenes/data-management/events/EventDefinitionInsights'
 import { EventDefinitionProperties } from 'scenes/data-management/events/EventDefinitionProperties'
@@ -35,7 +39,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { Query } from '~/queries/Query/Query'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { getCoreFilterDefinition, getFilterLabel, getFirstFilterTypeFor } from '~/taxonomy/helpers'
+import { getCoreFilterDefinition, getFilterLabel, getVirtualPropertyDefinition } from '~/taxonomy/helpers'
 import {
     EventDefinition,
     FilterLogicalOperator,
@@ -48,7 +52,7 @@ import { getEventDefinitionIcon, getPropertyDefinitionIcon } from '../events/Def
 export const scene: SceneExport<DefinitionLogicProps> = {
     component: DefinitionView,
     logic: definitionLogic,
-    paramsToProps: ({ params: { id } }) => ({ id: id ? decodeURIComponent(id) : id }),
+    paramsToProps: ({ params: { id } }) => ({ id: decodeDefinitionId(id) }),
 }
 
 type StatusProps = {
@@ -124,7 +128,7 @@ function PrimaryPropertyDetail({ definition }: { definition: EventDefinition }):
 
 export function DefinitionView(rawProps: DefinitionLogicProps): JSX.Element {
     // The app renders scene components with raw route params, so decode the id like paramsToProps does
-    const props = { ...rawProps, id: rawProps.id ? decodeURIComponent(rawProps.id) : rawProps.id }
+    const props = { ...rawProps, id: decodeDefinitionId(rawProps.id) }
     const logic = definitionLogic(props)
     const { definition, definitionLoading, definitionMissing, singular, isEvent, isProperty, metrics, metricsLoading } =
         useValues(logic)
@@ -166,17 +170,16 @@ export function DefinitionView(rawProps: DefinitionLogicProps): JSX.Element {
     const statusProps = getStatusProps(isProperty)
 
     const isVirtual = 'virtual' in definition && !!definition.virtual
-    // Virtual properties can live in the person or group taxonomy, so look up their label across groups
-    const propertyLabelGroup = isVirtual
-        ? (getFirstFilterTypeFor(definition.name) ?? TaxonomicFilterGroupType.EventProperties)
-        : TaxonomicFilterGroupType.EventProperties
+    // Resolve label and description from the same taxonomy group the definition came from, so they can't disagree
+    const virtualProperty = isVirtual ? getVirtualPropertyDefinition(definition.id) : null
+    const propertyLabelGroup = virtualProperty?.group ?? TaxonomicFilterGroupType.EventProperties
     const formattedName = getFilterLabel(
         definition.name,
         isEvent ? TaxonomicFilterGroupType.Events : propertyLabelGroup
     )
     // Taxonomy descriptions can be rich (links, code), so render them directly for virtual definitions
-    const description = isVirtual
-        ? getCoreFilterDefinition(definition.name, propertyLabelGroup)?.description
+    const description = virtualProperty
+        ? getCoreFilterDefinition(definition.name, virtualProperty.group)?.description
         : definition.description
 
     return (
@@ -246,8 +249,8 @@ export function DefinitionView(rawProps: DefinitionLogicProps): JSX.Element {
                                                         in the database.
                                                     </p>
                                                     <p>
-                                                        This definition will be recreated if the ${singular} is ever
-                                                        seen again in the event stream.
+                                                        This definition will be recreated if the {singular} is ever seen
+                                                        again in the event stream.
                                                     </p>
                                                 </>
                                             ),
@@ -308,7 +311,12 @@ export function DefinitionView(rawProps: DefinitionLogicProps): JSX.Element {
                 )}
                 <h5>Description</h5>
                 <div className="definition-description my-2" data-attr="definition-description-view">
-                    {description || <span className="text-muted italic">Add a description for this {singular}</span>}
+                    {description ||
+                        (isVirtual ? (
+                            <span className="text-muted italic">No description</span>
+                        ) : (
+                            <span className="text-muted italic">Add a description for this {singular}</span>
+                        ))}
                 </div>
                 {definition.tags && definition.tags.length > 0 && (
                     <ObjectTags

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -35,7 +35,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { Query } from '~/queries/Query/Query'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { getFilterLabel } from '~/taxonomy/helpers'
+import { getCoreFilterDefinition, getFilterLabel, getFirstFilterTypeFor } from '~/taxonomy/helpers'
 import {
     EventDefinition,
     FilterLogicalOperator,
@@ -48,7 +48,7 @@ import { getEventDefinitionIcon, getPropertyDefinitionIcon } from '../events/Def
 export const scene: SceneExport<DefinitionLogicProps> = {
     component: DefinitionView,
     logic: definitionLogic,
-    paramsToProps: ({ params: { id } }) => ({ id }),
+    paramsToProps: ({ params: { id } }) => ({ id: id ? decodeURIComponent(id) : id }),
 }
 
 type StatusProps = {
@@ -122,7 +122,9 @@ function PrimaryPropertyDetail({ definition }: { definition: EventDefinition }):
     )
 }
 
-export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
+export function DefinitionView(rawProps: DefinitionLogicProps): JSX.Element {
+    // The app renders scene components with raw route params, so decode the id like paramsToProps does
+    const props = { ...rawProps, id: rawProps.id ? decodeURIComponent(rawProps.id) : rawProps.id }
     const logic = definitionLogic(props)
     const { definition, definitionLoading, definitionMissing, singular, isEvent, isProperty, metrics, metricsLoading } =
         useValues(logic)
@@ -156,17 +158,26 @@ export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
     }
 
     if (definitionMissing) {
-        return <NotFound object="event" />
+        return <NotFound object={singular} />
     }
 
     const definitionStatus = definition.verified ? 'verified' : definition.hidden ? 'hidden' : 'visible'
 
     const statusProps = getStatusProps(isProperty)
 
+    const isVirtual = 'virtual' in definition && !!definition.virtual
+    // Virtual properties can live in the person or group taxonomy, so look up their label across groups
+    const propertyLabelGroup = isVirtual
+        ? (getFirstFilterTypeFor(definition.name) ?? TaxonomicFilterGroupType.EventProperties)
+        : TaxonomicFilterGroupType.EventProperties
     const formattedName = getFilterLabel(
         definition.name,
-        isEvent ? TaxonomicFilterGroupType.Events : TaxonomicFilterGroupType.EventProperties
+        isEvent ? TaxonomicFilterGroupType.Events : propertyLabelGroup
     )
+    // Taxonomy descriptions can be rich (links, code), so render them directly for virtual definitions
+    const description = isVirtual
+        ? getCoreFilterDefinition(definition.name, propertyLabelGroup)?.description
+        : definition.description
 
     return (
         <SceneContent>
@@ -210,63 +221,67 @@ export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
                                 data-attr="event-definition-view-recordings"
                             />
                         )}
-                        <LemonButton
-                            data-attr="delete-definition"
-                            type="secondary"
-                            status="danger"
-                            size="small"
-                            onClick={() =>
-                                LemonDialog.open({
-                                    title: `Delete this ${singular} definition?`,
-                                    description: (
-                                        <>
-                                            <p>
-                                                <strong>
-                                                    {getFilterLabel(
-                                                        definition.name,
-                                                        isEvent
-                                                            ? TaxonomicFilterGroupType.Events
-                                                            : TaxonomicFilterGroupType.EventProperties
-                                                    )}
-                                                </strong>{' '}
-                                                will no longer appear in selectors. Associated data will remain in the
-                                                database.
-                                            </p>
-                                            <p>
-                                                This definition will be recreated if the ${singular} is ever seen again
-                                                in the event stream.
-                                            </p>
-                                        </>
-                                    ),
-                                    primaryButton: {
-                                        status: 'danger',
-                                        children: 'Delete definition',
-                                        onClick: () => deleteDefinition(),
-                                    },
-                                    secondaryButton: {
-                                        children: 'Cancel',
-                                    },
-                                    width: 448,
-                                })
-                            }
-                            tooltip="Delete this definition. Associated data will remain."
-                        >
-                            Delete
-                        </LemonButton>
-                        <LemonButton
-                            data-attr="edit-definition"
-                            type="secondary"
-                            size="small"
-                            onClick={() => {
-                                if (isProperty) {
-                                    router.actions.push(urls.propertyDefinitionEdit(definition.id))
-                                } else {
-                                    router.actions.push(urls.eventDefinitionEdit(definition.id))
-                                }
-                            }}
-                        >
-                            Edit
-                        </LemonButton>
+                        {!isVirtual && (
+                            <>
+                                <LemonButton
+                                    data-attr="delete-definition"
+                                    type="secondary"
+                                    status="danger"
+                                    size="small"
+                                    onClick={() =>
+                                        LemonDialog.open({
+                                            title: `Delete this ${singular} definition?`,
+                                            description: (
+                                                <>
+                                                    <p>
+                                                        <strong>
+                                                            {getFilterLabel(
+                                                                definition.name,
+                                                                isEvent
+                                                                    ? TaxonomicFilterGroupType.Events
+                                                                    : TaxonomicFilterGroupType.EventProperties
+                                                            )}
+                                                        </strong>{' '}
+                                                        will no longer appear in selectors. Associated data will remain
+                                                        in the database.
+                                                    </p>
+                                                    <p>
+                                                        This definition will be recreated if the ${singular} is ever
+                                                        seen again in the event stream.
+                                                    </p>
+                                                </>
+                                            ),
+                                            primaryButton: {
+                                                status: 'danger',
+                                                children: 'Delete definition',
+                                                onClick: () => deleteDefinition(),
+                                            },
+                                            secondaryButton: {
+                                                children: 'Cancel',
+                                            },
+                                            width: 448,
+                                        })
+                                    }
+                                    tooltip="Delete this definition. Associated data will remain."
+                                >
+                                    Delete
+                                </LemonButton>
+                                <LemonButton
+                                    data-attr="edit-definition"
+                                    type="secondary"
+                                    size="small"
+                                    onClick={() => {
+                                        if (isProperty) {
+                                            router.actions.push(urls.propertyDefinitionEdit(definition.id))
+                                        } else {
+                                            router.actions.push(urls.eventDefinitionEdit(definition.id))
+                                        }
+                                    }}
+                                >
+                                    Edit
+                                </LemonButton>
+                            </>
+                        )}
                     </>
                 }
                 forceBackTo={
@@ -293,9 +308,7 @@ export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
                 )}
                 <h5>Description</h5>
                 <div className="definition-description my-2" data-attr="definition-description-view">
-                    {definition.description || (
-                        <span className="text-muted italic">Add a description for this {singular}</span>
-                    )}
+                    {description || <span className="text-muted italic">Add a description for this {singular}</span>}
                 </div>
                 {definition.tags && definition.tags.length > 0 && (
                     <ObjectTags
@@ -374,6 +387,19 @@ export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
                         </div>
                         <p className="italic text-secondary text-xs mt-1 mb-0">
                             {statusProps[definitionStatus].tooltip}
+                        </p>
+                    </div>
+                )}
+
+                {isVirtual && (
+                    <div className="flex flex-col flex-1 basis-48 min-w-48">
+                        <h5>Source</h5>
+                        <div>
+                            <LemonTag type="highlight">Virtual</LemonTag>
+                        </div>
+                        <p className="italic text-secondary text-xs mt-1 mb-0">
+                            This property is computed at query time rather than stored, so it can't be edited or
+                            deleted.
                         </p>
                     </div>
                 )}

--- a/frontend/src/scenes/data-management/definition/definitionLogic.test.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.test.ts
@@ -65,5 +65,21 @@ describe('definitionLogic', () => {
                     definition: createNewDefinition(false),
                 })
         })
+
+        it('resolves virtual property definitions from the taxonomy instead of the API', async () => {
+            router.actions.push(urls.propertyDefinition('$builtin_$virt_bot_name'))
+            logic = definitionLogic({ id: '$builtin_$virt_bot_name' })
+            logic.mount()
+            await expectLogic(logic)
+                .toDispatchActions(['loadDefinition', 'loadDefinitionSuccess'])
+                .toMatchValues({
+                    definition: expect.objectContaining({
+                        id: '$builtin_$virt_bot_name',
+                        name: '$virt_bot_name',
+                        virtual: true,
+                    }),
+                    definitionMissing: false,
+                })
+        })
     })
 })

--- a/frontend/src/scenes/data-management/definition/definitionLogic.test.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.test.ts
@@ -1,7 +1,11 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
-import { createNewDefinition, definitionLogic } from 'scenes/data-management/definition/definitionLogic'
+import {
+    createNewDefinition,
+    decodeDefinitionId,
+    definitionLogic,
+} from 'scenes/data-management/definition/definitionLogic'
 import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
@@ -64,6 +68,12 @@ describe('definitionLogic', () => {
                 .toMatchValues({
                     definition: createNewDefinition(false),
                 })
+        })
+
+        it('decodes route ids without throwing on malformed percent sequences', () => {
+            expect(decodeDefinitionId('%24builtin_%24virt_bot_name')).toBe('$builtin_$virt_bot_name')
+            expect(decodeDefinitionId('100%off')).toBe('100%off')
+            expect(decodeDefinitionId(undefined)).toBeUndefined()
         })
 
         it('resolves virtual property definitions from the taxonomy instead of the API', async () => {

--- a/frontend/src/scenes/data-management/definition/definitionLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.ts
@@ -9,16 +9,10 @@ import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { updatePropertyDefinitions } from '~/models/propertyDefinitionsModel'
-import { getFilterLabel } from '~/taxonomy/helpers'
+import { getFilterLabel, getFirstFilterTypeFor, getVirtualPropertyDefinition } from '~/taxonomy/helpers'
 import { Breadcrumb, Definition, EventDefinitionMetrics, ObjectMediaPreview, PropertyDefinition } from '~/types'
 
-import type {
-    PropertyDefinitionType,
-    PropertyType,
-    SchemaEnforcementMode,
-    UserBasicType,
-    WarehousePropertyOrigin,
-} from '../../../types'
+import type { SchemaEnforcementMode, UserBasicType } from '../../../types'
 import { DataManagementTab } from '../DataManagementScene'
 import { eventDefinitionsTableLogic } from '../events/eventDefinitionsTableLogic'
 import { propertyDefinitionsTableLogic } from '../properties/propertyDefinitionsTableLogic'
@@ -130,6 +124,7 @@ export interface definitionLogicActions {
     }
     loadDefinitionSuccess: (
         definition:
+            | PropertyDefinition
             | {
                   created_at?: string | undefined
                   default_columns?: string[] | undefined
@@ -151,34 +146,13 @@ export interface definitionLogicActions {
                   verified?: boolean | undefined
                   verified_at?: string | undefined
                   verified_by?: string | undefined
-              }
-            | {
-                  created_at?: string | undefined
-                  description?: string | undefined
-                  example?: string | undefined
-                  hidden?: boolean | undefined
-                  id: string
-                  is_action?: boolean | undefined
-                  is_numerical?: boolean | undefined
-                  is_seen_on_filtered_events?: boolean | undefined
-                  last_seen_at?: string | undefined
-                  name: string
-                  property_type?: PropertyType | undefined
-                  tags?: string[] | undefined
-                  type?: PropertyDefinitionType | undefined
-                  updated_at?: string | undefined
-                  updated_by?: UserBasicType | null | undefined
-                  verified?: boolean | undefined
-                  verified_at?: string | undefined
-                  verified_by?: string | undefined
-                  virtual?: boolean | undefined
-                  warehouse_origin?: WarehousePropertyOrigin | null | undefined
               },
         payload?: {
             id: string
         }
     ) => {
         definition:
+            | PropertyDefinition
             | {
                   created_at?: string | undefined
                   default_columns?: string[] | undefined
@@ -200,28 +174,6 @@ export interface definitionLogicActions {
                   verified?: boolean | undefined
                   verified_at?: string | undefined
                   verified_by?: string | undefined
-              }
-            | {
-                  created_at?: string | undefined
-                  description?: string | undefined
-                  example?: string | undefined
-                  hidden?: boolean | undefined
-                  id: string
-                  is_action?: boolean | undefined
-                  is_numerical?: boolean | undefined
-                  is_seen_on_filtered_events?: boolean | undefined
-                  last_seen_at?: string | undefined
-                  name: string
-                  property_type?: PropertyType | undefined
-                  tags?: string[] | undefined
-                  type?: PropertyDefinitionType | undefined
-                  updated_at?: string | undefined
-                  updated_by?: UserBasicType | null | undefined
-                  verified?: boolean | undefined
-                  verified_at?: string | undefined
-                  verified_by?: string | undefined
-                  virtual?: boolean | undefined
-                  warehouse_origin?: WarehousePropertyOrigin | null | undefined
               }
         payload?: {
             id: string
@@ -351,6 +303,13 @@ export const definitionLogic = kea<definitionLogicType>([
                     (merge ? { ...values.definition, ...definition } : definition) as Definition,
                 loadDefinition: async ({ id }, breakpoint) => {
                     let definition = { ...values.definition }
+                    if (values.isProperty) {
+                        // Virtual properties have no database row to fetch, so resolve them from the taxonomy
+                        const virtualDefinition = getVirtualPropertyDefinition(id)
+                        if (virtualDefinition) {
+                            return virtualDefinition
+                        }
+                    }
                     try {
                         if (values.isEvent) {
                             // Event Definition
@@ -439,6 +398,11 @@ export const definitionLogic = kea<definitionLogicType>([
         breadcrumbs: [
             (s) => [s.definition, s.isEvent],
             (definition: Definition, isEvent: boolean): Breadcrumb[] => {
+                // Virtual properties can live in the person or group taxonomy, so look up their label across groups
+                const propertyLabelGroup =
+                    'virtual' in definition && definition.virtual
+                        ? (getFirstFilterTypeFor(definition.name) ?? TaxonomicFilterGroupType.EventProperties)
+                        : TaxonomicFilterGroupType.EventProperties
                 return [
                     {
                         key: Scene.DataManagement,
@@ -458,9 +422,7 @@ export const definitionLogic = kea<definitionLogicType>([
                             definition?.id !== 'new'
                                 ? getFilterLabel(
                                       definition?.name,
-                                      isEvent
-                                          ? TaxonomicFilterGroupType.Events
-                                          : TaxonomicFilterGroupType.EventProperties
+                                      isEvent ? TaxonomicFilterGroupType.Events : propertyLabelGroup
                                   ) || 'Untitled'
                                 : 'Untitled',
                         iconType: isEvent ? 'event_definition' : 'property_definition',
@@ -471,6 +433,15 @@ export const definitionLogic = kea<definitionLogicType>([
     }),
     listeners(({ actions, values }) => ({
         loadDefinitionSuccess: () => {
+            // Virtual definitions are taxonomy-defined and read-only, so bounce off the edit page
+            if (
+                'virtual' in values.definition &&
+                values.definition.virtual &&
+                router.values.location.pathname.endsWith('/edit')
+            ) {
+                router.actions.replace(urls.propertyDefinition(values.definition.id))
+                return
+            }
             if (values.isEvent && values.definition.id && values.definition.id !== 'new') {
                 actions.loadPreviews()
             }

--- a/frontend/src/scenes/data-management/definition/definitionLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.ts
@@ -1,15 +1,16 @@
 import { MakeLogicType, actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { tryDecodeURIComponent } from 'lib/utils/url'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { updatePropertyDefinitions } from '~/models/propertyDefinitionsModel'
-import { getFilterLabel, getFirstFilterTypeFor, getVirtualPropertyDefinition } from '~/taxonomy/helpers'
+import { getFilterLabel, getVirtualPropertyDefinition } from '~/taxonomy/helpers'
 import { Breadcrumb, Definition, EventDefinitionMetrics, ObjectMediaPreview, PropertyDefinition } from '~/types'
 
 import type { SchemaEnforcementMode, UserBasicType } from '../../../types'
@@ -271,6 +272,13 @@ export type definitionLogicType = MakeLogicType<
     definitionLogicMeta
 >
 
+// Route params arrive percent-encoded (virtual ids contain `$`); tryDecodeURIComponent keeps malformed ids
+// from throwing, letting them fall through to the API's graceful 404. Both the scenes' paramsToProps and the
+// component bodies must use this so the two definitionLogic build paths agree on one logic key.
+export function decodeDefinitionId(id: string | undefined): string | undefined {
+    return id ? tryDecodeURIComponent(id) : id
+}
+
 export const definitionLogic = kea<definitionLogicType>([
     path(['scenes', 'data-management', 'definition', 'definitionViewLogic']),
     props({} as DefinitionLogicProps),
@@ -305,9 +313,9 @@ export const definitionLogic = kea<definitionLogicType>([
                     let definition = { ...values.definition }
                     if (values.isProperty) {
                         // Virtual properties have no database row to fetch, so resolve them from the taxonomy
-                        const virtualDefinition = getVirtualPropertyDefinition(id)
-                        if (virtualDefinition) {
-                            return virtualDefinition
+                        const virtualProperty = getVirtualPropertyDefinition(id)
+                        if (virtualProperty) {
+                            return virtualProperty.definition
                         }
                     }
                     try {
@@ -398,11 +406,12 @@ export const definitionLogic = kea<definitionLogicType>([
         breadcrumbs: [
             (s) => [s.definition, s.isEvent],
             (definition: Definition, isEvent: boolean): Breadcrumb[] => {
-                // Virtual properties can live in the person or group taxonomy, so look up their label across groups
+                // Resolve virtual definitions' label from the same taxonomy group the definition came from
                 const propertyLabelGroup =
-                    'virtual' in definition && definition.virtual
-                        ? (getFirstFilterTypeFor(definition.name) ?? TaxonomicFilterGroupType.EventProperties)
-                        : TaxonomicFilterGroupType.EventProperties
+                    ('virtual' in definition &&
+                        definition.virtual &&
+                        getVirtualPropertyDefinition(definition.id)?.group) ||
+                    TaxonomicFilterGroupType.EventProperties
                 return [
                     {
                         key: Scene.DataManagement,
@@ -457,6 +466,20 @@ export const definitionLogic = kea<definitionLogicType>([
         },
         deleteMediaPreviewFailure: () => {
             lemonToast.error('Failed to delete image')
+        },
+    })),
+    // Covers client-side navigation to the edit URL while this logic is already mounted, where
+    // loadDefinition (and therefore the loadDefinitionSuccess bounce above) does not re-fire
+    urlToAction(({ values, props }) => ({
+        [urls.propertyDefinitionEdit(':id')]: ({ id }) => {
+            if (
+                id &&
+                decodeDefinitionId(id) === props.id &&
+                'virtual' in values.definition &&
+                values.definition.virtual
+            ) {
+                router.actions.replace(urls.propertyDefinition(values.definition.id))
+            }
         },
     })),
     afterMount(({ actions, values, props }) => {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -696,7 +696,7 @@ export const redirects: Record<
 
     '/events/actions': urls.actions(),
     '/events/properties': urls.propertyDefinitions(),
-    '/events/properties/:id': ({ id }) => urls.propertyDefinition(id),
+    '/events/properties/:id': ({ id }) => urls.propertyDefinition(decodeURIComponent(id)),
     '/events/stats': urls.eventDefinitions(),
     '/events/stats/:id': ({ id }) => urls.eventDefinition(id),
     // The scene lives at /feature_flags (underscore); catch the hyphenated variant so it doesn't 404

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -2,6 +2,7 @@ import { combineUrl } from 'kea-router'
 
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { tryDecodeURIComponent } from 'lib/utils/url'
 import { getDefaultEventsSceneQuery } from 'scenes/activity/explore/defaults'
 import { Params, Scene, SceneConfig, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -696,7 +697,7 @@ export const redirects: Record<
 
     '/events/actions': urls.actions(),
     '/events/properties': urls.propertyDefinitions(),
-    '/events/properties/:id': ({ id }) => urls.propertyDefinition(decodeURIComponent(id)),
+    '/events/properties/:id': ({ id }) => urls.propertyDefinition(tryDecodeURIComponent(id)),
     '/events/stats': urls.eventDefinitions(),
     '/events/stats/:id': ({ id }) => urls.eventDefinition(id),
     // The scene lives at /feature_flags (underscore); catch the hyphenated variant so it doesn't 404

--- a/frontend/src/scenes/urls.test.ts
+++ b/frontend/src/scenes/urls.test.ts
@@ -5,6 +5,16 @@ describe('urls', () => {
         expect(urls.webAnalyticsRecap()).toEqual('/web/recap')
     })
 
+    it('percent-encodes property definition ids so virtual ($builtin_*) ids survive route matching', () => {
+        expect(urls.propertyDefinition('$builtin_$virt_bot_name')).toEqual(
+            '/data-management/properties/%24builtin_%24virt_bot_name'
+        )
+        expect(urls.propertyDefinitionEdit('$builtin_$virt_bot_name')).toEqual(
+            '/data-management/properties/%24builtin_%24virt_bot_name/edit'
+        )
+        expect(urls.propertyDefinition(':id')).toEqual('/data-management/properties/:id')
+    })
+
     it.each(['Postgres', 'MySQL', 'Snowflake'] as const)(
         'includes direct access method when opening the new %s source wizard in direct mode',
         (sourceType) => {

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -42,10 +42,11 @@ export const urls = {
     eventDefinitionEdit: (id: string | number): string => `/data-management/events/${id}/edit`,
     propertyDefinitions: (type?: string): string => combineUrl('/data-management/properties', type ? { type } : {}).url,
     // Virtual property ids contain `$`, which kea-router's segment charset rejects, so encode real ids
+    // (`:param` placeholders pass through untouched for route registration)
     propertyDefinition: (id: string | number): string =>
-        `/data-management/properties/${id === ':id' ? id : encodeURIComponent(id)}`,
+        `/data-management/properties/${typeof id === 'string' && id.startsWith(':') ? id : encodeURIComponent(id)}`,
     propertyDefinitionEdit: (id: string | number): string =>
-        `/data-management/properties/${id === ':id' ? id : encodeURIComponent(id)}/edit`,
+        `/data-management/properties/${typeof id === 'string' && id.startsWith(':') ? id : encodeURIComponent(id)}/edit`,
     schemaManagement: (): string => '/data-management/schema',
     dataManagementHistory: (): string => '/data-management/history',
     database: (): string => '/data-management/database',

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -41,8 +41,11 @@ export const urls = {
     eventDefinition: (id: string | number): string => `/data-management/events/${id}`,
     eventDefinitionEdit: (id: string | number): string => `/data-management/events/${id}/edit`,
     propertyDefinitions: (type?: string): string => combineUrl('/data-management/properties', type ? { type } : {}).url,
-    propertyDefinition: (id: string | number): string => `/data-management/properties/${id}`,
-    propertyDefinitionEdit: (id: string | number): string => `/data-management/properties/${id}/edit`,
+    // Virtual property ids contain `$`, which kea-router's segment charset rejects, so encode real ids
+    propertyDefinition: (id: string | number): string =>
+        `/data-management/properties/${id === ':id' ? id : encodeURIComponent(id)}`,
+    propertyDefinitionEdit: (id: string | number): string =>
+        `/data-management/properties/${id === ':id' ? id : encodeURIComponent(id)}/edit`,
     schemaManagement: (): string => '/data-management/schema',
     dataManagementHistory: (): string => '/data-management/history',
     database: (): string => '/data-management/database',

--- a/frontend/src/taxonomy/helpers.ts
+++ b/frontend/src/taxonomy/helpers.ts
@@ -1,7 +1,7 @@
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { surveyQuestionLabelsLogic } from 'scenes/surveys/surveyQuestionLabelsLogic'
 
-import { CoreFilterDefinition } from '~/types'
+import { CoreFilterDefinition, PropertyDefinition, PropertyType } from '~/types'
 
 import { CORE_FILTER_DEFINITIONS_BY_GROUP, CoreFilterDefinitionsGroup } from './taxonomy'
 
@@ -113,6 +113,39 @@ export function getCoreFilterDefinition(
                 label: `Feature Interaction: ${featureFlagKey}`,
                 description: `Whether the user has interacted with "${featureFlagKey}".`,
                 examples: ['true', 'false'],
+            }
+        }
+    }
+    return null
+}
+
+/** Prefix of the synthetic ids the property definitions API gives virtual (query-time computed) properties. */
+export const VIRTUAL_PROPERTY_DEFINITION_ID_PREFIX = '$builtin_'
+
+const VIRTUAL_PROPERTY_DEFINITION_GROUPS = [
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.PersonProperties,
+    TaxonomicFilterGroupType.GroupsPrefix,
+]
+
+/** Virtual properties have no database row, so their definition is built from the taxonomy. */
+export function getVirtualPropertyDefinition(id: string): PropertyDefinition | null {
+    if (!id.startsWith(VIRTUAL_PROPERTY_DEFINITION_ID_PREFIX)) {
+        return null
+    }
+    const name = id.slice(VIRTUAL_PROPERTY_DEFINITION_ID_PREFIX.length)
+    for (const group of VIRTUAL_PROPERTY_DEFINITION_GROUPS) {
+        const coreDefinition = getCoreFilterDefinition(name, group)
+        if (coreDefinition?.virtual) {
+            return {
+                id,
+                name,
+                description: typeof coreDefinition.description === 'string' ? coreDefinition.description : undefined,
+                is_numerical: coreDefinition.type === PropertyType.Numeric,
+                property_type: coreDefinition.type,
+                verified: false,
+                hidden: false,
+                virtual: true,
             }
         }
     }

--- a/frontend/src/taxonomy/helpers.ts
+++ b/frontend/src/taxonomy/helpers.ts
@@ -128,8 +128,14 @@ const VIRTUAL_PROPERTY_DEFINITION_GROUPS = [
     TaxonomicFilterGroupType.GroupsPrefix,
 ]
 
+export interface VirtualPropertyDefinitionMatch {
+    definition: PropertyDefinition
+    /** The taxonomy group the definition was resolved from; use it for label/description lookups so they can't disagree. */
+    group: TaxonomicFilterGroupType
+}
+
 /** Virtual properties have no database row, so their definition is built from the taxonomy. */
-export function getVirtualPropertyDefinition(id: string): PropertyDefinition | null {
+export function getVirtualPropertyDefinition(id: string): VirtualPropertyDefinitionMatch | null {
     if (!id.startsWith(VIRTUAL_PROPERTY_DEFINITION_ID_PREFIX)) {
         return null
     }
@@ -138,14 +144,18 @@ export function getVirtualPropertyDefinition(id: string): PropertyDefinition | n
         const coreDefinition = getCoreFilterDefinition(name, group)
         if (coreDefinition?.virtual) {
             return {
-                id,
-                name,
-                description: typeof coreDefinition.description === 'string' ? coreDefinition.description : undefined,
-                is_numerical: coreDefinition.type === PropertyType.Numeric,
-                property_type: coreDefinition.type,
-                verified: false,
-                hidden: false,
-                virtual: true,
+                definition: {
+                    id,
+                    name,
+                    description:
+                        typeof coreDefinition.description === 'string' ? coreDefinition.description : undefined,
+                    is_numerical: coreDefinition.type === PropertyType.Numeric,
+                    property_type: coreDefinition.type,
+                    verified: false,
+                    hidden: false,
+                    virtual: true,
+                },
+                group,
             }
         }
     }


### PR DESCRIPTION
## Problem

The property definitions page lists virtual properties (Bot name, Traffic type, Initial channel type, Total MRR, ...), but clicking any of them lands on "Page not found". Reported in [this Slack thread](https://posthog.slack.com/archives/C09ALCCKESZ/p1784246592950579).

Two layers were broken:

1. Virtual property ids look like `$builtin_$virt_bot_name`, and kea-router's url-pattern matcher rejects `$` in path segments (its charset is `a-zA-Z0-9-_~ %`), so the detail route never even matched and users hit the app-level 404.
2. Even with routing fixed, the detail page fetches the definition from the API by id, and virtual properties have no database row (they're fabricated inside the list endpoint from `CORE_FILTER_DEFINITIONS_BY_GROUP`), so the fetch 404s.

## Changes

**Routing**

- `urls.propertyDefinition` / `urls.propertyDefinitionEdit` percent-encode the id (the `:id` route registration passes through raw), following the existing `urls.site` pattern. Encoding is a no-op for real UUID ids.
- Both definition scenes decode the id in `paramsToProps` and in the component. The component half matters because `App.tsx` passes raw route params to scene components while `BindLogic` gets the `paramsToProps` output; decoding in only one place produces two logic instances with different keys.
- The legacy `/events/properties/:id` redirect decodes before re-encoding to avoid double encoding.

**Virtual property detail page**

- New `getVirtualPropertyDefinition` in `taxonomy/helpers.ts` resolves `$builtin_*` ids into a read-only definition from the taxonomy (event, then person, then group properties, mirroring the backend's injection groups).
- `definitionLogic` short-circuits to it before calling the API, and bounces the `/edit` URL back to the view.
- `DefinitionView` hides delete/edit for virtual definitions, shows a "Source: Virtual" block explaining the property is computed at query time, resolves labels across taxonomy groups (so `$virt_initial_channel_type` titles as "Initial channel type"), and renders rich taxonomy descriptions (links work).
- The definition not-found page now says "Property not found" instead of "Event not found" on property routes.

**Screenshots**

The virtual property page for "Bot name" (`$virt_bot_name`), with the Source: Virtual panel and no edit/delete actions:

![pr-virt-bot-name](https://raw.githubusercontent.com/PostHog/pr-assets/cb4ff65eb03ce2a2632ff8c48125ce1a35b61293/2026/07/98eb0904-d4ab-40d4-922f-af4c7ff02119.png)

A person-taxonomy virtual property ("Initial channel type") resolving its label and rich linked description:

![pr-virt-initial-channel-type](https://raw.githubusercontent.com/PostHog/pr-assets/f7e938ff4ea15b8b9f04e70ea842f7f70d373a1c/2026/07/cf127377-a6cd-4527-af66-c9b230e8a16e.png)

## How did you test this code?

Verified in the local dev app end to end (I drove it via Claude with a headless browser):

- Properties list -> click "Bot name" -> detail page renders label, description, type, and the Virtual tag, with no delete/edit buttons.
- `$builtin_$virt_initial_channel_type` (person taxonomy) resolves the right label and renders its linked description.
- Direct navigation to the `/edit` URL of a virtual property redirects to the read-only view.
- Real property and event definition pages are unchanged (delete/edit intact, API loading as before).

Automated tests added:

- `definitionLogic.test.ts`: a `$builtin_*` id resolves from the taxonomy without an API call. Catches removal of the loader short-circuit, which would regress the page to a 404 toast.
- `urls.test.ts`: encode round-trip for property definition ids, plus the `:id` passthrough. Catches someone "simplifying" the `encodeURIComponent` away, which would break routing for every virtual property link.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed. This fixes broken navigation rather than changing documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-kea-logics, /adopting-generated-api-types, /writing-tests.

Decisions along the way: I first assumed the 404 came from the API detail fetch and planned a frontend-only taxonomy short-circuit. Live verification showed the route itself never matched because of the `$` charset issue, which is why the encode/decode plumbing exists. I chose a frontend-only fix over teaching the backend `retrieve()` about `$builtin_*` ids since the REST 404 for a non-record is arguably correct, and nothing else consumes those ids by detail fetch today. The dual decode (paramsToProps plus component) copies the established `Site.tsx` pattern for ids that need encoding.

