### PR TITLE
fix(kafka-deduplicator): deflake test_simple_batch_kafka_consumer

### DIFF
--- a/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
@@ -236,58 +236,41 @@ async fn test_simple_batch_kafka_consumer() -> Result<()> {
         .expect("Timeout waiting for partition assignment")
         .expect("ready_tx was dropped without sending");
 
-    // Schedule shutdown after a short delay to allow the consumer to poll messages
-    let _shutdown_handle = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(500)).await;
-        let _ = shutdown_tx.send(());
-    });
-
-    // Retry loop to wait for messages with timeout
+    // Collect batches until every message has been received. Waiting on the
+    // channel with a per-iteration timeout (rather than sleeping a fixed amount)
+    // lets a slow consumer — cold start, rebalance — catch up without failing
+    // the test spuriously.
     let mut msgs_recv = 0;
-    let max_attempts = 10;
-    let wait_duration = Duration::from_millis(500);
-
-    for attempt in 0..max_attempts {
-        // Try to receive all available batches without blocking
-        loop {
-            match batch_rx.try_recv() {
-                Ok(batch_result) => {
-                    let (msgs, errs) = batch_result.unpack();
-                    if !errs.is_empty() {
-                        panic!("Errors in batch: {errs:?}");
-                    }
-                    assert!(
-                        msgs.len() <= 3,
-                        "Batch size should be at most 3, got: {}",
-                        msgs.len()
-                    );
-                    msgs_recv += msgs.len();
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while msgs_recv < expected_msg_count && std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(200), batch_rx.recv()).await {
+            Ok(Some(batch_result)) => {
+                let (msgs, errs) = batch_result.unpack();
+                if !errs.is_empty() {
+                    panic!("Errors in batch: {errs:?}");
                 }
-                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break, // No more messages right now
-                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break, // Channel closed
+                assert!(
+                    msgs.len() <= batch_size,
+                    "Batch size should be at most {batch_size}, got: {}",
+                    msgs.len()
+                );
+                msgs_recv += msgs.len();
             }
-        }
-
-        // If we've received all messages, break early
-        if msgs_recv >= expected_msg_count {
-            break;
-        }
-
-        // Wait before next attempt (unless this is the last attempt)
-        if attempt < max_attempts - 1 {
-            tokio::time::sleep(wait_duration).await;
+            Ok(None) => break, // channel closed
+            Err(_) => {}       // nothing this interval; keep polling until the deadline
         }
     }
 
     assert_eq!(
-        msgs_recv,
-        expected_msg_count,
-        "Should have received all messages after {} attempts (waited up to {}ms), got: {msgs_recv}",
-        max_attempts,
-        (max_attempts - 1) * wait_duration.as_millis()
+        msgs_recv, expected_msg_count,
+        "Should have received all {expected_msg_count} messages within the deadline, got: {msgs_recv}"
     );
 
-    // Wait for graceful shutdown
+    // Shut down only AFTER all messages are received. The previous version armed
+    // a fixed 500ms timer to send shutdown, which raced message delivery: on a
+    // slow runner the consumer could be torn down before any batch arrived
+    // (msgs_recv == 0). Signalling here makes shutdown causally follow receipt.
+    let _ = shutdown_tx.send(());
     let _ = consumer_handle.await;
 
     Ok(())


### PR DESCRIPTION
## Problem

`test_simple_batch_kafka_consumer` in `kafka-deduplicator` is timing-dependent and flakes in CI. It armed a fixed 500ms timer that sent the consumer its shutdown signal regardless of whether the 9 expected messages had been consumed. On a slow runner the consumer got torn down before delivering any batch, so the test saw `msgs_recv == 0` and failed the final assertion.

This is unrelated to any feature work. It's an isolated test-only fix off `master` to stop the intermittent red.

## Changes

- Drop the spawned fixed-500ms shutdown timer.
- Collect batches until all expected messages arrive (bounded by a 15s deadline), waiting on the channel with a short per-iteration timeout instead of `try_recv` + fixed sleeps.
- Send `shutdown_tx` only after every message is received, so shutdown causally follows receipt.

This matches the "consume everything, then shut down" pattern the other tests in this same file already use (`test_offset_commits_with_routing_processor`, `test_seek_partitions_rewinds_consumer`).

No production code changes — the edit is confined to the test file.

## How did you test this code?

Ran locally against a live Kafka broker (`localhost:9092`):

- `cargo clippy -p kafka-deduplicator --tests --all-features -- -D warnings` — clean.
- `cargo test -p kafka-deduplicator --test batch_consumer_integration_tests test_simple_batch_kafka_consumer` — passed 3 consecutive runs.

The regression this guards: a consumer shut down mid-consumption before any batch is delivered. The old fixed-timer version could pass or fail depending purely on runner speed; the new version fails only if messages genuinely never arrive within the deadline.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Eli directed this as an isolated deflake, split out from an unrelated rate-limiter change stack so it can land on its own. I (Cursor agent, Opus) diagnosed the shutdown-vs-consumption race, applied the fix, and verified it locally against a running Kafka broker. No skills were invoked. No migrations or schema changes.
