### PR TITLE
feat(retention): two-arm first-time scan on the legacy path

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -630,7 +630,28 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             source=ast.Field(chain=["events", "timestamp"])
         )
 
-        event_filters = self._event_filters()
+        two_arm = self._legacy_first_time_two_arm_scan()
+        if two_arm:
+            # Aliasing the UNION as `events` keeps every aggregate expression below identical;
+            # only the entity conditions swap to the arms' role tags.
+            select_from = ast.JoinExpr(
+                table=ast.SelectSetQuery.create_from_queries(
+                    [
+                        self._legacy_scan_arm(self.start_event, "start"),
+                        self._legacy_scan_arm(self.return_event, "return"),
+                    ],
+                    "UNION ALL",
+                ),
+                alias="events",
+            )
+            where: ast.Expr | None = None
+            start_condition: ast.Expr = parse_expr("events.matches_start = 1")
+            return_condition: ast.Expr = parse_expr("events.is_return = 1")
+        else:
+            select_from = ast.JoinExpr(table=ast.Field(chain=["events"]))
+            where = ast.And(exprs=self._event_filters())
+            start_condition = self.start_entity_expr
+            return_condition = self.return_entity_expr
 
         start_event_timestamps = parse_expr(
             """
@@ -644,7 +665,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             """,
             {
                 "start_of_interval_sql": start_of_interval_sql,
-                "start_entity_expr": self.start_entity_expr,
+                "start_entity_expr": start_condition,
                 "filter_timestamp": self.events_timestamp_filter(),
             },
         )
@@ -661,7 +682,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 """,
                 {
                     "start_of_interval_timestamp": start_of_interval_sql,
-                    "returning_entity_expr": self.return_entity_expr,
+                    "returning_entity_expr": return_condition,
                     "filter_timestamp": self.events_timestamp_filter(),
                 },
             ),
@@ -704,12 +725,14 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             return_event_timestamps = self._get_return_event_timestamps_expr(
                 minimum_occurrences=self.minimum_occurrences,
                 start_of_interval_sql=start_of_interval_sql,
-                return_entity_expr=self.return_entity_expr,
+                return_entity_expr=return_condition,
             )
             return_event_values = None
 
         if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
-            min_timestamp_inner_expr = self.get_first_time_anchor_expr(self.start_event)
+            min_timestamp_inner_expr = (
+                self._legacy_two_arm_anchor_expr() if two_arm else self.get_first_time_anchor_expr(self.start_event)
+            )
 
             start_event_timestamps = parse_expr(
                 """
@@ -797,8 +820,8 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         inner_query = ast.SelectQuery(
             select=select_fields,
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
-            where=ast.And(exprs=event_filters),
+            select_from=select_from,
+            where=where,
             group_by=[ast.Field(chain=["actor_id"])],
             having=ast.And(
                 exprs=[
@@ -825,6 +848,66 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
         return inner_query
+
+    def _legacy_first_time_two_arm_scan(self) -> bool:
+        # The tag-column arms carry no event properties, so any per-row property read in the
+        # outer query (value breakdowns, property aggregation) keeps the single scan.
+        return (
+            self._first_time_split_shrinks_scan()
+            and not self.has_property_aggregation
+            and not has_breakdown_filter(self.query.breakdownFilter)
+        )
+
+    def _legacy_scan_arm(self, entity: RetentionEntity, query_kind: Literal["start", "return"]) -> ast.SelectQuery:
+        filters = [*self.runner.arm_event_filters(entity, query_kind)]
+        if query_kind == "start":
+            # The first-ever anchor needs the no-props stream, so property matching moves into
+            # the matches_start column instead of the WHERE.
+            arm_predicate = (
+                self.entity_expr_no_props(entity)
+                if self.is_first_ever_occurrence
+                else self.entity_expr_with_props(entity)
+            )
+            matches_start: ast.Expr = (
+                self.entity_expr_with_props(entity) if self.is_first_ever_occurrence else ast.Constant(value=1)
+            )
+            is_start, is_return = 1, 0
+        else:
+            arm_predicate = self.entity_expr_with_props(entity)
+            matches_start = ast.Constant(value=0)
+            is_start, is_return = 0, 1
+        if not (isinstance(arm_predicate, ast.Constant) and arm_predicate.value is True):
+            filters.append(arm_predicate)
+
+        return ast.SelectQuery(
+            select=[
+                ast.Alias(
+                    alias=self.aggregation_target_events_column,
+                    expr=ast.Field(chain=["events", self.aggregation_target_events_column]),
+                ),
+                ast.Alias(alias="timestamp", expr=ast.Field(chain=["events", "timestamp"])),
+                ast.Alias(alias="is_start", expr=ast.Constant(value=is_start)),
+                ast.Alias(alias="matches_start", expr=matches_start),
+                ast.Alias(alias="is_return", expr=ast.Constant(value=is_return)),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(exprs=filters) if filters else None,
+        )
+
+    def _legacy_two_arm_anchor_expr(self) -> ast.Expr:
+        # Mirrors get_first_time_anchor_expr with the arms' tags standing in for the entity matchers.
+        if self.is_first_ever_occurrence:
+            return parse_expr(
+                """
+                if(
+                    minIf(events.timestamp, events.is_start = 1)
+                        = minIf(events.timestamp, events.matches_start = 1),
+                    minIf(events.timestamp, events.is_start = 1),
+                    NULL
+                )
+                """
+            )
+        return parse_expr("minIf(events.timestamp, events.matches_start = 1)")
 
     def _get_minimum_occurrences_aliases(self, minimum_occurrences: int, with_dupes_expr: ast.Expr) -> list[ast.Alias]:
         """

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -1391,23 +1391,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(events.timestamp, equals(events.matches_start, 1)), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               1 AS matches_start,
+               0 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1495,23 +1515,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(events.timestamp, equals(events.is_start, 1)), minIf(events.timestamp, equals(events.matches_start, 1))), minIf(events.timestamp, equals(events.is_start, 1)), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)) AS matches_start,
+               0 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), equals(events.event, 'target_event'))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1660,23 +1700,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(events.timestamp, equals(events.is_start, 1)), minIf(events.timestamp, equals(events.matches_start, 1))), minIf(events.timestamp, equals(events.is_start, 1)), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events_json AS events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)) AS matches_start,
+               0 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), equals(events.event, 'target_event'))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1764,23 +1824,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(events.timestamp, equals(events.matches_start, 1)), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events_json AS events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)), equals(events.event, 'returning_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               1 AS matches_start,
+               0 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -8287,3 +8287,83 @@ class TestRetentionFirstTimeTwoLegScan(APIBaseTest):
             chains: list = []
             collect_chains(arm.where, chains)
             self.assertIn(["events", "$group_0"], chains)
+
+    def _legacy_base_query(
+        self,
+        retention_type: str,
+        target: dict | None = None,
+        returning: dict | None = None,
+        breakdown_filter: dict | None = None,
+        aggregation_property: str | None = None,
+    ) -> ast.SelectQuery:
+        query: dict = {
+            "kind": "RetentionQuery",
+            "retentionFilter": {
+                "retentionType": retention_type,
+                "targetEntity": target or {"id": "signup", "type": "events"},
+                "returningEntity": returning or {"id": "did_action", "type": "events"},
+            },
+        }
+        if breakdown_filter is not None:
+            query["breakdownFilter"] = breakdown_filter
+        if aggregation_property is not None:
+            query["retentionFilter"]["aggregationType"] = "sum"
+            query["retentionFilter"]["aggregationProperty"] = aggregation_property
+        runner = RetentionQueryRunner(team=self.team, query=query)
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=False):
+            return RetentionFixedIntervalBaseQueryBuilder(runner).build_base_query()
+
+    @parameterized.expand(["retention_first_time", "retention_first_ever_occurrence"])
+    def test_legacy_first_time_modes_scan_two_arms_with_bounded_return_arm(self, retention_type):
+        base_query = self._legacy_base_query(retention_type)
+        assert base_query.select_from is not None
+        self.assertEqual(base_query.select_from.alias, "events")
+        table = base_query.select_from.table
+        self.assertIsInstance(table, ast.SelectSetQuery)
+        start_arm, return_arm = list(table.select_queries())  # type: ignore[union-attr]
+
+        start_constants = self._where_constants(start_arm)
+        return_constants = self._where_constants(return_arm)
+        self.assertIn("signup", start_constants)
+        self.assertNotIn("did_action", start_constants)
+        self.assertIn("did_action", return_constants)
+        self.assertNotIn("signup", return_constants)
+
+        self.assertFalse(self._where_has_timestamp_bound(start_arm))
+        self.assertTrue(self._where_has_timestamp_bound(return_arm))
+
+    @parameterized.expand(
+        [
+            ("recurring", "retention_recurring", None, None, None, None),
+            (
+                "same_entity",
+                "retention_first_time",
+                {"id": "signup", "type": "events"},
+                {"id": "signup", "type": "events"},
+                None,
+                None,
+            ),
+            ("all_events_target", "retention_first_time", {"id": None, "type": "events"}, None, None, None),
+            (
+                "breakdown",
+                "retention_first_time",
+                None,
+                None,
+                {"breakdowns": [{"type": "event", "property": "plan"}]},
+                None,
+            ),
+            ("property_aggregation", "retention_first_time", None, None, None, "revenue"),
+        ]
+    )
+    def test_legacy_keeps_single_scan_when_split_cannot_apply(
+        self, _name, retention_type, target, returning, breakdown_filter, aggregation_property
+    ):
+        base_query = self._legacy_base_query(
+            retention_type,
+            target=target,
+            returning=returning,
+            breakdown_filter=breakdown_filter,
+            aggregation_property=aggregation_property,
+        )
+        assert base_query.select_from is not None
+        self.assertIsInstance(base_query.select_from.table, ast.Field)


### PR DESCRIPTION
## Problem

PR #71787 restructured first-time retention into a two-arm scan on the DWH-capable variant builder, but the flag that routes events-only retention to that builder does not exist yet, so production events-only traffic still runs `build_base_query_legacy`. That is the path behind the most expensive retention queries we see in the query log today: in first-time modes the legacy scan has no timestamp bound (the first-occurrence anchor needs all history), and when the returning entity is "All events" it has no event-name prefilter either, so one merged scan reads every aggregate input column over the team's entire event history.

Only a small slice of those rows needs to be read that wide. The start entity's rows are the only ones the anchor needs all-time, and they need very few columns. Everything else is only consumed inside window-bounded aggregates.

## Changes

Inside `build_base_query_legacy`, when the split can shrink the scan, the single `FROM events` is replaced by a `UNION ALL` of two lean arms:

- the start arm scans all-time but only the start entity's event names, emitting just the actor, the timestamp, and role tags
- the return arm is scoped to the returning entity and bounded to the query window

The union is aliased back as `events` with tag columns (`is_start`, `matches_start`, `is_return`), so every aggregate expression in the outer query stays byte-identical and only the entity conditions swap to tag comparisons. A row matching both entities appears once per arm and contributes to exactly the aggregates it did before.

The rewrite applies only when it can pay for itself and stay provably equivalent:

- first-time or first-ever mode, concrete start event names, start and return entities differ (`_first_time_split_shrinks_scan`, shared with #71787)
- no value breakdown and no property aggregation, since those read event properties in the outer query and the tag arms don't carry them

Everything else emits exactly the same SQL as before (existing snapshots prove this mechanically). Recurring retention, breakdowns, property aggregation, cohorts, and the DWH-routed variant are untouched.

## How did you test this code?

- New AST-shape tests (written first, verified failing): first-time and first-ever modes produce the two-arm union with an unbounded entity-scoped start arm and a bounded return arm; recurring, same-entity, all-events-target, breakdown, and property-aggregation shapes keep the single scan. These catch a regression where the gate silently widens or the arms lose their bounds, which no existing test pinned for the legacy path.
- Full retention suite passes in both events-schema modes (198 tests each), including the legacy-vs-variant comparison harness which asserts result parity on every test, so all existing first-time behavioral tests now exercise the new SQL end to end.
- Benchmarked the generated SQL against a production first-time retention query (concrete start event, all-events return, person and event property filters, test-account filters), interleaved runs with condition/uncompressed caches off and direct IO: about 231x fewer bytes read, 18x less CPU, 6x lower latency, 7x less memory, byte-identical result rows on both interleaved pairs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in the same session as #71787. Skills invoked: /writing-tests, /query-clickhouse-via-metabase (for the production benchmark), plus the superpowers TDD and debugging skills.

Decisions along the way:

- We considered routing the beneficial shapes to the variant builder instead (one-line routing change), but chose to optimize legacy in place: the variant's rollout flag doesn't exist yet, and swapping whales onto a whole different builder inherits every divergence the parity suite might still miss. This change alters one dimension of the live path (the scan structure) and keeps legacy's own aggregation and breakdown code.
- Design choice: raw row-stream arms with role tags plus an unchanged outer query, rather than the variant's per-arm pre-aggregation. This sidesteps the breakdown-authority bug class QA found in #71787 (arms disagreeing on a per-actor value before the outer collapse) because per-actor resolution still happens in one place.
- Breakdown and property-aggregation shapes are deliberately excluded rather than ported, keeping the equivalence argument airtight; they can follow if the query log shows expensive queries of that shape.