### PR TITLE
docs(engineering-analytics): update the insights skill for warehouse views, reviews, and new tools

### DIFF
--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
@@ -4,40 +4,69 @@ description: >
   Converts engineering analytics (PR / CI) data into saved PostHog insights, dashboards, and subscriptions, and
   explains what data the product reads so it can be queried directly with SQL. The engineering analytics dashboard
   and MCP tools run curated HogQL privately over per-team GitHub warehouse tables; this skill teaches discovering
-  those tables via engineering-analytics-sources, replicating the curated column semantics in HogQL, saving the
-  query with insight-create, and scheduling delivery with subscriptions-create. Use when asked to "save this as an
-  insight", "put CI health / merge times on a dashboard", "email me PR throughput weekly", "subscribe to these
-  numbers", "alert on CI success rate", or "what data/tables does engineering analytics read". For ad-hoc CI and
-  merge questions use diagnosing-ci-and-merge-bottlenecks instead.
+  those tables via engineering-analytics-sources, replicating the curated column semantics in HogQL, reading the
+  exposed engineering_analytics_* warehouse views where product logic is involved (CI cost, fingerprinted failure
+  lines, commit attribution), saving the query with insight-create, and scheduling delivery with
+  subscriptions-create. Use when asked to "save this as an insight", "put CI health / merge times on a dashboard",
+  "email me PR throughput weekly", "chart CI cost", "track time to first review", "subscribe to these numbers",
+  "alert on CI success rate", or "what data/tables/views does engineering analytics read". For ad-hoc CI and merge
+  questions use diagnosing-ci-and-merge-bottlenecks; to investigate one specific CI failure use
+  investigating-ci-failures.
 ---
 
 # Turning engineering analytics into insights and subscriptions
 
-The engineering analytics dashboard and MCP tools (`pull-requests`, `workflow-health`, `pr-lifecycle`, …)
+The engineering analytics dashboard and MCP tools (`pull-requests`, `workflow-health`, `pr-lifecycle`, `engineering-analytics-broken-tests`, …)
 run curated HogQL privately: nothing in the UI or the tool output names the underlying tables,
 and the endpoints cannot themselves be saved as insights or subscribed to.
-The data, however, lives in ordinary team-scoped sources you can query yourself:
+The data, however, is queryable directly, through two substrates:
 
-| What the product shows                           | Where the data actually lives                                                        | Can it back an insight?               |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------- |
-| PR list, merge times, CI status, workflow health | Data warehouse tables `<prefix>github_pull_requests`, `<prefix>github_workflow_runs` | **Yes** (SQL insight over the tables) |
-| Job durations, runner tiers, CI cost             | `<prefix>github_workflow_jobs` (optional; plus a cost model in product code)         | Partially (durations yes, cost no)    |
-| CI failure logs for a PR                         | Logs product (`service_name = 'github-ci-logs'`), short retention                    | No (use the MCP tool ad hoc)          |
-| Flaky test leaderboard                           | CI trace spans + ranking logic in product code                                       | No (use the MCP tool ad hoc)          |
+- **Raw warehouse tables** — `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, and (when synced)
+  `<prefix>github_workflow_jobs` and `<prefix>github_reviews` — ordinary team-scoped tables you query with HogQL.
+- **Three curated warehouse views** with fixed names — `engineering_analytics_job_costs`,
+  `engineering_analytics_ci_job_history`, `engineering_analytics_ci_failures` — provisioned per team once a GitHub
+  source has both the `workflow_runs` and `workflow_jobs` endpoints synced (they appear together or not at all).
+  Non-materialized: computed at query time, always current, and they back insights and subscriptions like any table.
+
+The views exist for exactly one reason: they render **product code** into SQL — the runner-tier cost model, the
+failure-fingerprint recipe, the jobs↔runs commit-attribution rules — logic that would silently drift if hand-rolled,
+re-rendered into the team's view whenever the code changes. Everything else is just table data, and **pure HogQL over
+the raw tables is always enough**: never create additional warehouse views for engineering analytics data, and never
+re-derive in SQL what the three views already encode.
+
+| What the product shows                              | Where the data actually lives                                                         | Can it back an insight?                       |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| PR list, merge times, CI status, workflow health    | Data warehouse tables `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`  | **Yes** (SQL insight over the tables)          |
+| Reviews and approvals                               | `<prefix>github_reviews` (optional; webhook-fed, no history backfill)                 | **Yes** (SQL insight; window from first data)  |
+| Job durations, queue times, runner tiers            | `<prefix>github_workflow_jobs` (optional)                                              | **Yes**                                        |
+| CI cost (runner-tier price ladder)                  | `engineering_analytics_job_costs` view                                                | **Yes** (query the view, never recompute cost) |
+| Per-job CI history with commit attribution          | `engineering_analytics_ci_job_history` view                                           | **Yes**                                        |
+| Grouped (fingerprinted) CI failure lines            | `engineering_analytics_ci_failures` view (reads the Logs product, short retention)    | **Yes**, for short recent windows              |
+| Thinned CI failure logs for a PR or run             | Logs product (`service_name = 'github-ci-logs'`) + thinning logic                     | No (use the MCP tools ad hoc)                  |
+| Flaky-test leaderboard, broken-tests triage, team CI health | CI trace spans + ranking/classification logic in product code                 | No (use the MCP tools ad hoc)                  |
 
 So the job splits cleanly:
-warehouse-backed metrics become SQL insights (then dashboards, then subscriptions);
-everything computed by product logic stays on the MCP tools, delivered recurringly via an AI subscription if needed.
+warehouse-backed metrics (raw tables or the three views) become SQL insights (then dashboards, then subscriptions);
+everything computed by product logic at request time stays on the MCP tools, delivered recurringly via an AI subscription if needed.
 
 ## Step 1: discover the team's tables
 
 Warehouse table names carry a user-chosen prefix, so never hardcode them.
 Call the `engineering-analytics-sources` MCP tool: each connected GitHub source returns its `id`, `repo`, and `prefix`.
-The tables are `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, and (when the job-level sync is enabled) `<prefix>github_workflow_jobs`;
+The tables are `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, and — when the corresponding endpoint is synced — `<prefix>github_workflow_jobs` and `<prefix>github_reviews`;
 an empty prefix means the plain `github_*` names.
+The sources tool does not report which optional endpoints are synced; probe an optional table with a `LIMIT 1` query.
 With multiple sources, ask which repo the user means; each source is one repo.
 
+The three `engineering_analytics_*` views need no discovery: their names are fixed (no prefix), and each unions every
+qualifying source, carrying `repo_owner` / `repo_name` columns (`repo` on `ci_failures`) to filter down to one repo.
+If querying a view fails with an unknown table, the team's job-level source isn't synced yet — the views only exist
+alongside `<prefix>github_workflow_jobs`.
+
 ## Step 2: write HogQL that carries the curated semantics
+
+First check whether one of the three views already answers the question — cost, per-job history and commit
+attribution, fingerprinted failure lines — and query it directly; the rules below are for the raw tables.
 
 The raw tables land GitHub's JSON verbatim, so a naive `SELECT` gets the domain rules wrong.
 Copy the base subqueries from [references/hogql-recipes.md](references/hogql-recipes.md) (they mirror the product's own curated builders) and follow these rules:
@@ -48,6 +77,7 @@ Copy the base subqueries from [references/hogql-recipes.md](references/hogql-rec
 - **Bot detection**: `author_handle LIKE '%[bot]' OR author_handle IN ('dependabot', 'github-actions', 'posthog-bot', 'renovate')`. Exclude bots and drafts from throughput / merge-time metrics by default.
 - **Honest names.** `merged_at - created_at` is `open_to_merge_seconds` (it fuses draft and review time); never label an insight "cycle time" or "review time".
 - **Conclusions can be stale.** The runs sync watermarks on `created_at`; a run that completes late can show a stale conclusion. Compute rates over `status = 'completed'` rows only.
+- **Reviews have no history by default.** `github_reviews` is fed by the `pull_request_review` webhook; rows exist only from when the source was connected (with reviews enabled), unless a deliberate one-off backfill was run. Baseline any review metric's window on the earliest `submitted_at` present. `state` is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` (pending drafts are dropped at sync), and the injected `pr_number` joins to the PR table's `number`.
 
 Test the query with the `execute-sql` MCP tool (or the SQL editor) before saving anything.
 
@@ -80,16 +110,24 @@ Offer a scheduled subscription instead, or a threshold check inside a prompt-kin
 
 ## What NOT to rebuild in SQL
 
-CI **cost** (runner-tier price ladder), the **flaky-test ranking**, and **failure-log thinning** are product logic, not table columns;
+The **flaky-test ranking**, **broken-tests classification**, **team CI health rollup**, and **failure-log thinning** are product logic over data an insight can't reach (CI trace spans, raw log bodies);
 hand-rolled SQL versions will silently drift from what the dashboard shows.
 For a recurring report on those, create a prompt-kind AI subscription (see the `creating-ai-subscription` skill) whose prompt asks for the relevant engineering analytics reading each period,
-or just call the MCP tools (`engineering-analytics-pr-cost`, `engineering-analytics-flaky-tests`, `engineering-analytics-ci-failure-logs`) ad hoc.
+or just call the MCP tools (`engineering-analytics-flaky-tests`, `engineering-analytics-broken-tests`, `engineering-analytics-team-ci-health`, `engineering-analytics-ci-failure-logs`, `engineering-analytics-run-failure-logs`) ad hoc.
+
+CI **cost** used to be on this list; it no longer is. The cost model is rendered into the
+`engineering_analytics_job_costs` view (parity-tested against the product's own model, re-rendered when the model
+changes), so cost insights are plain SQL over the view — and the cost MCP tools (`engineering-analytics-pr-cost`,
+`engineering-analytics-workflow-runner-costs`) read that same rendered SELECT, so the numbers agree. What remains
+true: never recompute dollar cost from runner labels yourself.
 
 ## Caveats to carry into every insight
 
 Name these in the insight description so future readers inherit them:
 `open_to_merge_seconds` is coarse (draft + review fused);
 CI conclusions can lag until the run's webhook settles;
-reviews, approvals, and deploys are not in the data yet;
+reviews start at source-connect (webhook-fed, no history backfill), and deploys and PR state transitions (draft↔ready) are not in the data yet;
+`estimated_cost_usd` NULL means non-billable or still running, never zero — disambiguate via `provider` vs `completed_at`;
+`ci_failures` is pytest-only and failure-only, so its counts are absolute signal, never rates;
 bots and drafts are excluded (or not: say which).
 And never build per-author leaderboards or cross-author rankings; per-developer surveillance is an explicit product non-goal.

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
@@ -35,17 +35,17 @@ re-rendered into the team's view whenever the code changes. Everything else is j
 the raw tables is always enough**: never create additional warehouse views for engineering analytics data, and never
 re-derive in SQL what the three views already encode.
 
-| What the product shows                              | Where the data actually lives                                                         | Can it back an insight?                       |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| PR list, merge times, CI status, workflow health    | Data warehouse tables `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`  | **Yes** (SQL insight over the tables)          |
-| Reviews and approvals                               | `<prefix>github_reviews`                                                              | **Yes**                                        |
-| Team-level PR metrics (author→team attribution)     | `<prefix>github_team_members` semi-joined against the PR authors                      | **Yes** (team aggregates only)                 |
-| Job durations, queue times, runner tiers            | `<prefix>github_workflow_jobs`                                                        | **Yes**                                        |
-| CI cost (runner-tier price ladder)                  | `engineering_analytics_job_costs` view                                                | **Yes** (query the view, never recompute cost) |
-| Per-job CI history with commit attribution          | `engineering_analytics_ci_job_history` view                                           | **Yes**                                        |
-| Grouped (fingerprinted) CI failure lines            | `engineering_analytics_ci_failures` view (reads the Logs product, short retention)    | **Yes**, for short recent windows              |
-| Thinned CI failure logs for a PR or run             | Logs product (`service_name = 'github-ci-logs'`) + thinning logic                     | No (use the MCP tools ad hoc)                  |
-| Flaky-test leaderboard, broken-tests triage, team CI health | CI trace spans + ranking/classification logic in product code                 | No (use the MCP tools ad hoc)                  |
+| What the product shows                                      | Where the data actually lives                                                        | Can it back an insight?                        |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| PR list, merge times, CI status, workflow health            | Data warehouse tables `<prefix>github_pull_requests`, `<prefix>github_workflow_runs` | **Yes** (SQL insight over the tables)          |
+| Reviews and approvals                                       | `<prefix>github_reviews`                                                             | **Yes**                                        |
+| Team-level PR metrics (author→team attribution)             | `<prefix>github_team_members` semi-joined against the PR authors                     | **Yes** (team aggregates only)                 |
+| Job durations, queue times, runner tiers                    | `<prefix>github_workflow_jobs`                                                       | **Yes**                                        |
+| CI cost (runner-tier price ladder)                          | `engineering_analytics_job_costs` view                                               | **Yes** (query the view, never recompute cost) |
+| Per-job CI history with commit attribution                  | `engineering_analytics_ci_job_history` view                                          | **Yes**                                        |
+| Grouped (fingerprinted) CI failure lines                    | `engineering_analytics_ci_failures` view (reads the Logs product, short retention)   | **Yes**, for short recent windows              |
+| Thinned CI failure logs for a PR or run                     | Logs product (`service_name = 'github-ci-logs'`) + thinning logic                    | No (use the MCP tools ad hoc)                  |
+| Flaky-test leaderboard, broken-tests triage, team CI health | CI trace spans + ranking/classification logic in product code                        | No (use the MCP tools ad hoc)                  |
 
 So the job splits cleanly:
 warehouse-backed metrics (raw tables or the three views) become SQL insights (then dashboards, then subscriptions);

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
@@ -21,11 +21,11 @@ run curated HogQL privately: nothing in the UI or the tool output names the unde
 and the endpoints cannot themselves be saved as insights or subscribed to.
 The data, however, is queryable directly, through two substrates:
 
-- **Raw warehouse tables** — `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, and (when synced)
-  `<prefix>github_workflow_jobs` and `<prefix>github_reviews` — ordinary team-scoped tables you query with HogQL.
+- **Raw warehouse tables** — `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`,
+  `<prefix>github_workflow_jobs`, and `<prefix>github_reviews` — ordinary team-scoped tables you query with HogQL.
 - **Three curated warehouse views** with fixed names — `engineering_analytics_job_costs`,
-  `engineering_analytics_ci_job_history`, `engineering_analytics_ci_failures` — provisioned per team once a GitHub
-  source has both the `workflow_runs` and `workflow_jobs` endpoints synced (they appear together or not at all).
+  `engineering_analytics_ci_job_history`, `engineering_analytics_ci_failures` — provisioned per team from the
+  connected GitHub source(s).
   Non-materialized: computed at query time, always current, and they back insights and subscriptions like any table.
 
 The views exist for exactly one reason: they render **product code** into SQL — the runner-tier cost model, the
@@ -37,8 +37,8 @@ re-derive in SQL what the three views already encode.
 | What the product shows                              | Where the data actually lives                                                         | Can it back an insight?                       |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | PR list, merge times, CI status, workflow health    | Data warehouse tables `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`  | **Yes** (SQL insight over the tables)          |
-| Reviews and approvals                               | `<prefix>github_reviews` (optional; webhook-fed, no history backfill)                 | **Yes** (SQL insight; window from first data)  |
-| Job durations, queue times, runner tiers            | `<prefix>github_workflow_jobs` (optional)                                              | **Yes**                                        |
+| Reviews and approvals                               | `<prefix>github_reviews`                                                              | **Yes**                                        |
+| Job durations, queue times, runner tiers            | `<prefix>github_workflow_jobs`                                                        | **Yes**                                        |
 | CI cost (runner-tier price ladder)                  | `engineering_analytics_job_costs` view                                                | **Yes** (query the view, never recompute cost) |
 | Per-job CI history with commit attribution          | `engineering_analytics_ci_job_history` view                                           | **Yes**                                        |
 | Grouped (fingerprinted) CI failure lines            | `engineering_analytics_ci_failures` view (reads the Logs product, short retention)    | **Yes**, for short recent windows              |
@@ -53,15 +53,12 @@ everything computed by product logic at request time stays on the MCP tools, del
 
 Warehouse table names carry a user-chosen prefix, so never hardcode them.
 Call the `engineering-analytics-sources` MCP tool: each connected GitHub source returns its `id`, `repo`, and `prefix`.
-The tables are `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, and — when the corresponding endpoint is synced — `<prefix>github_workflow_jobs` and `<prefix>github_reviews`;
+The tables are `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, `<prefix>github_workflow_jobs`, and `<prefix>github_reviews`;
 an empty prefix means the plain `github_*` names.
-The sources tool does not report which optional endpoints are synced; probe an optional table with a `LIMIT 1` query.
 With multiple sources, ask which repo the user means; each source is one repo.
 
 The three `engineering_analytics_*` views need no discovery: their names are fixed (no prefix), and each unions every
-qualifying source, carrying `repo_owner` / `repo_name` columns (`repo` on `ci_failures`) to filter down to one repo.
-If querying a view fails with an unknown table, the team's job-level source isn't synced yet — the views only exist
-alongside `<prefix>github_workflow_jobs`.
+connected source, carrying `repo_owner` / `repo_name` columns (`repo` on `ci_failures`) to filter down to one repo.
 
 ## Step 2: write HogQL that carries the curated semantics
 
@@ -77,7 +74,7 @@ Copy the base subqueries from [references/hogql-recipes.md](references/hogql-rec
 - **Bot detection**: `author_handle LIKE '%[bot]' OR author_handle IN ('dependabot', 'github-actions', 'posthog-bot', 'renovate')`. Exclude bots and drafts from throughput / merge-time metrics by default.
 - **Honest names.** `merged_at - created_at` is `open_to_merge_seconds` (it fuses draft and review time); never label an insight "cycle time" or "review time".
 - **Conclusions can be stale.** The runs sync watermarks on `created_at`; a run that completes late can show a stale conclusion. Compute rates over `status = 'completed'` rows only.
-- **Reviews have no history by default.** `github_reviews` is fed by the `pull_request_review` webhook; rows exist only from when the source was connected (with reviews enabled), unless a deliberate one-off backfill was run. Baseline any review metric's window on the earliest `submitted_at` present. `state` is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` (pending drafts are dropped at sync), and the injected `pr_number` joins to the PR table's `number`.
+- **Reviews join by `pr_number`.** In `github_reviews`, `state` is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` (pending drafts are dropped at sync), and the injected `pr_number` joins to the PR table's `number`.
 
 Test the query with the `execute-sql` MCP tool (or the SQL editor) before saving anything.
 
@@ -115,18 +112,17 @@ hand-rolled SQL versions will silently drift from what the dashboard shows.
 For a recurring report on those, create a prompt-kind AI subscription (see the `creating-ai-subscription` skill) whose prompt asks for the relevant engineering analytics reading each period,
 or just call the MCP tools (`engineering-analytics-flaky-tests`, `engineering-analytics-broken-tests`, `engineering-analytics-team-ci-health`, `engineering-analytics-ci-failure-logs`, `engineering-analytics-run-failure-logs`) ad hoc.
 
-CI **cost** used to be on this list; it no longer is. The cost model is rendered into the
+CI **cost** is not on that list because its product logic is rendered into the
 `engineering_analytics_job_costs` view (parity-tested against the product's own model, re-rendered when the model
 changes), so cost insights are plain SQL over the view — and the cost MCP tools (`engineering-analytics-pr-cost`,
-`engineering-analytics-workflow-runner-costs`) read that same rendered SELECT, so the numbers agree. What remains
-true: never recompute dollar cost from runner labels yourself.
+`engineering-analytics-workflow-runner-costs`) read that same rendered SELECT, so the numbers agree. Still: never
+recompute dollar cost from runner labels yourself.
 
 ## Caveats to carry into every insight
 
 Name these in the insight description so future readers inherit them:
 `open_to_merge_seconds` is coarse (draft + review fused);
 CI conclusions can lag until the run's webhook settles;
-reviews start at source-connect (webhook-fed, no history backfill), and deploys and PR state transitions (draft↔ready) are not in the data yet;
 `estimated_cost_usd` NULL means non-billable or still running, never zero — disambiguate via `provider` vs `completed_at`;
 `ci_failures` is pytest-only and failure-only, so its counts are absolute signal, never rates;
 bots and drafts are excluded (or not: say which).

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
@@ -59,8 +59,9 @@ The tables are `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, `
 an empty prefix means the plain `github_*` names.
 With multiple sources, ask which repo the user means; each source is one repo.
 
-The three `engineering_analytics_*` views need no discovery: their names are fixed (no prefix), and each unions every
-connected source, carrying `repo_owner` / `repo_name` columns (`repo` on `ci_failures`) to filter down to one repo.
+The three `engineering_analytics_*` views need no discovery: their names are fixed (no prefix), and they cover all of
+the team's GitHub sources at once — filter on `repo_owner` / `repo_name` (`job_costs`, `ci_job_history`) or `repo`
+(`ci_failures`, which reads the Logs product rather than the per-source tables) to scope down to one repo.
 
 ## Step 2: write HogQL that carries the curated semantics
 

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
@@ -22,7 +22,8 @@ and the endpoints cannot themselves be saved as insights or subscribed to.
 The data, however, is queryable directly, through two substrates:
 
 - **Raw warehouse tables** — `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`,
-  `<prefix>github_workflow_jobs`, and `<prefix>github_reviews` — ordinary team-scoped tables you query with HogQL.
+  `<prefix>github_workflow_jobs`, `<prefix>github_reviews`, and `<prefix>github_teams` /
+  `<prefix>github_team_members` (org team membership — the author→team map) — ordinary team-scoped tables you query with HogQL.
 - **Three curated warehouse views** with fixed names — `engineering_analytics_job_costs`,
   `engineering_analytics_ci_job_history`, `engineering_analytics_ci_failures` — provisioned per team from the
   connected GitHub source(s).
@@ -38,6 +39,7 @@ re-derive in SQL what the three views already encode.
 | --------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | PR list, merge times, CI status, workflow health    | Data warehouse tables `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`  | **Yes** (SQL insight over the tables)          |
 | Reviews and approvals                               | `<prefix>github_reviews`                                                              | **Yes**                                        |
+| Team-level PR metrics (author→team attribution)     | `<prefix>github_team_members` semi-joined against the PR authors                      | **Yes** (team aggregates only)                 |
 | Job durations, queue times, runner tiers            | `<prefix>github_workflow_jobs`                                                        | **Yes**                                        |
 | CI cost (runner-tier price ladder)                  | `engineering_analytics_job_costs` view                                                | **Yes** (query the view, never recompute cost) |
 | Per-job CI history with commit attribution          | `engineering_analytics_ci_job_history` view                                           | **Yes**                                        |
@@ -53,7 +55,7 @@ everything computed by product logic at request time stays on the MCP tools, del
 
 Warehouse table names carry a user-chosen prefix, so never hardcode them.
 Call the `engineering-analytics-sources` MCP tool: each connected GitHub source returns its `id`, `repo`, and `prefix`.
-The tables are `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, `<prefix>github_workflow_jobs`, and `<prefix>github_reviews`;
+The tables are `<prefix>github_pull_requests`, `<prefix>github_workflow_runs`, `<prefix>github_workflow_jobs`, `<prefix>github_reviews`, and `<prefix>github_teams` / `<prefix>github_team_members`;
 an empty prefix means the plain `github_*` names.
 With multiple sources, ask which repo the user means; each source is one repo.
 
@@ -75,6 +77,7 @@ Copy the base subqueries from [references/hogql-recipes.md](references/hogql-rec
 - **Honest names.** `merged_at - created_at` is `open_to_merge_seconds` (it fuses draft and review time); never label an insight "cycle time" or "review time".
 - **Conclusions can be stale.** The runs sync watermarks on `created_at`; a run that completes late can show a stale conclusion. Compute rates over `status = 'completed'` rows only.
 - **Reviews join by `pr_number`.** In `github_reviews`, `state` is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` (pending drafts are dropped at sync), and the injected `pr_number` joins to the PR table's `number`.
+- **Author→team attribution is a membership semi-join.** Filter `author_handle IN (SELECT member_handle FROM …)` against `github_team_members` (see the team recipe) — the shape the product's own team merge trend uses. A person can belong to several GitHub teams, so a plain JOIN would double-count their PRs across teams; and only team-level aggregates leave the query, never per-member figures.
 
 Test the query with the `execute-sql` MCP tool (or the SQL editor) before saving anything.
 
@@ -127,3 +130,4 @@ CI conclusions can lag until the run's webhook settles;
 `ci_failures` is pytest-only and failure-only, so its counts are absolute signal, never rates;
 bots and drafts are excluded (or not: say which).
 And never build per-author leaderboards or cross-author rankings; per-developer surveillance is an explicit product non-goal.
+When a team-level split is wanted, group through the `github_team_members` membership semi-join instead.

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
@@ -2,7 +2,8 @@
 
 These base subqueries mirror the product's curated builders
 (`products/engineering_analytics/backend/logic/views/`), so an insight built on them matches what the dashboard and MCP tools report.
-Replace `github_pull_requests` / `github_workflow_runs` with the team's real table names from `engineering-analytics-sources` (`prefix` + `github_<endpoint>`).
+Replace `github_pull_requests` / `github_workflow_runs` / `github_reviews` with the team's real table names from `engineering-analytics-sources` (`prefix` + `github_<endpoint>`).
+The `engineering_analytics_*` views used below have fixed names — no prefix, no discovery.
 
 ## The PR base
 
@@ -165,4 +166,70 @@ A `pending`-heavy result can be sync staleness, not real in-flight CI; treat pen
 
 `<prefix>github_workflow_jobs` may not be synced; check `engineering-analytics-sources` output or probe with a `LIMIT 1`.
 Durations and queue times are honest SQL (`started_at - created_at` is queue wait, `completed_at - started_at` is run time; all string timestamps, parse them).
-**Do not** recompute dollar cost from labels: the runner-tier price ladder lives in product code and drifts; use the `engineering-analytics-pr-cost` / `engineering-analytics-workflow-runner-costs` MCP tools for cost figures.
+**Do not** recompute dollar cost from labels: the runner-tier price ladder lives in product code and drifts; query the `engineering_analytics_job_costs` view instead (below), which renders that model into SQL and is parity-tested against it.
+
+## Recipe: weekly CI cost by workflow (job_costs view)
+
+```sql
+SELECT
+    toStartOfWeek(created_at) AS week,
+    workflow_name,
+    round(sum(estimated_cost_usd), 2) AS estimated_cost_usd
+FROM engineering_analytics_job_costs
+WHERE created_at >= now() - INTERVAL 60 DAY
+GROUP BY week, workflow_name
+ORDER BY week, estimated_cost_usd DESC
+```
+
+Grain is one row per job attempt, so `sum` is correct across retries.
+`estimated_cost_usd` is NULL (skipped by `sum`) for non-billable jobs (github-hosted, non-Linux, unclassifiable labels) and for jobs still running; disambiguate a NULL via `provider` (non-billable) vs `completed_at` (unsettled).
+Add `WHERE pr_number = <n>` for one PR's cost — it matches `engineering-analytics-pr-cost`, since the tool reads the same rendered cost SELECT.
+With several connected sources, filter `repo_owner` / `repo_name`.
+
+## Review recipes (optional table)
+
+`<prefix>github_reviews` is webhook-fed with no history backfill: rows start when the source was connected with reviews enabled, so clamp windows to the earliest `submitted_at` present.
+Pending drafts are dropped at sync; `state` is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED`, and the injected `pr_number` joins to the PR base's `number`.
+
+Weekly time to first review:
+
+```sql
+WITH prs AS (<PR base>),
+first_review AS (
+    SELECT pr_number, min(parseDateTimeBestEffort(submitted_at)) AS first_review_at
+    FROM github_reviews
+    GROUP BY pr_number
+)
+SELECT
+    toStartOfWeek(prs.created_at) AS week,
+    median(dateDiff('second', prs.created_at, fr.first_review_at)) / 3600 AS p50_hours,
+    quantile(0.95)(dateDiff('second', prs.created_at, fr.first_review_at)) / 3600 AS p95_hours,
+    count() AS reviewed_prs
+FROM prs
+INNER JOIN first_review fr ON prs.number = fr.pr_number
+WHERE prs.created_at >= now() - INTERVAL 90 DAY
+  AND NOT prs.is_bot
+GROUP BY week
+ORDER BY week
+```
+
+Name it "open to first review", not "time in review": there is no ready-for-review timestamp, so draft time is fused in, same caveat as `open_to_merge_seconds`.
+The reviewer handle is `ifNull(JSONExtractString(user, 'login'), '')` when needed (e.g. to exclude self-reviews by comparing against `author_handle`) — but never build per-reviewer leaderboards.
+
+## Recipe: distinct CI failures per day (ci_failures view)
+
+```sql
+SELECT
+    toStartOfDay(timestamp) AS day,
+    uniq(fingerprint) AS distinct_failures,
+    count() AS failed_test_lines
+FROM engineering_analytics_ci_failures
+WHERE timestamp >= now() - INTERVAL 14 DAY
+GROUP BY day
+ORDER BY day
+```
+
+The view reads the Logs product, so its reach is bounded by the short logs retention — fine for a recent-window tile, wrong for long trends.
+Fingerprinting is pytest-only, and the data is failure-only (passing runs are absent), so report absolute counts, never rates.
+To chase a specific failure to a culprit, hand off to the `investigating-ci-failures` skill, which works from this view plus `engineering_analytics_ci_job_history`.
+When windowing `engineering_analytics_ci_job_history`, pair the precise `created_at >= …` filter with a coarse raw floor (`created_at_raw >= '<YYYY-MM-DD>'`, a day below the window) so the parquet scan can prune; a computed-column predicate alone forces a full scan.

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
@@ -214,6 +214,34 @@ ORDER BY week
 Name it "open to first review", not "time in review": there is no ready-for-review timestamp, so draft time is fused in, same caveat as `open_to_merge_seconds`.
 The reviewer handle is `ifNull(JSONExtractString(user, 'login'), '')` when needed (e.g. to exclude self-reviews by comparing against `author_handle`) — but never build per-reviewer leaderboards.
 
+## Recipe: a team's weekly merge time (team_members table)
+
+`<prefix>github_team_members` maps PR authors to GitHub org teams (every column lands Nullable; drop empty logins — they would match deleted-account authors).
+Attribute PRs to a team with a membership **semi-join**, the shape the product's own team merge trend uses — a plain JOIN would double-count authors who belong to several teams:
+
+```sql
+WITH prs AS (<PR base>),
+members AS (
+    SELECT ifNull(login, '') AS member_handle
+    FROM github_team_members
+    WHERE ifNull(team_slug, '') = 'my-team'
+      AND ifNull(login, '') != ''
+)
+SELECT
+    toStartOfWeek(merged_at) AS week,
+    median(open_to_merge_seconds) / 3600 AS p50_hours,
+    count() AS merged_prs
+FROM prs
+WHERE merged_at >= now() - INTERVAL 90 DAY
+  AND NOT is_bot
+  AND author_handle IN (SELECT member_handle FROM members)
+GROUP BY week
+ORDER BY week
+```
+
+Only team-level aggregates leave the query — no per-member figures, no cross-team rankings.
+Note the namespace: these are GitHub org team slugs, while the `engineering-analytics-team-ci-health` tool groups by the repo's ownership map (`products/*/product.yaml` + CODEOWNERS); a team whose slugs differ across the two won't line up between such insights and that tool.
+
 ## Recipe: distinct CI failures per day (ci_failures view)
 
 ```sql

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
@@ -2,7 +2,7 @@
 
 These base subqueries mirror the product's curated builders
 (`products/engineering_analytics/backend/logic/views/`), so an insight built on them matches what the dashboard and MCP tools report.
-Replace `github_pull_requests` / `github_workflow_runs` / `github_reviews` with the team's real table names from `engineering-analytics-sources` (`prefix` + `github_<endpoint>`).
+Replace every `github_*` table name (`github_pull_requests`, `github_workflow_runs`, `github_workflow_jobs`, `github_reviews`, `github_team_members`) with the team's real table name from `engineering-analytics-sources` (`prefix` + `github_<endpoint>`).
 The `engineering_analytics_*` views used below have fixed names — no prefix, no discovery.
 
 ## The PR base

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/references/hogql-recipes.md
@@ -162,10 +162,9 @@ WHERE prs.state = 'open' AND ci.failing > 0
 Drafts and bots stay included here, matching the product's failing-CI card (`ci_cards` only excludes them from the stuck count); add `AND NOT prs.is_draft` only if the user explicitly wants non-draft PRs, and say the number then diverges from the dashboard.
 A `pending`-heavy result can be sync staleness, not real in-flight CI; treat pending as unsettled, never as failure.
 
-## Job-level recipes (optional table)
+## Job-level recipes
 
-`<prefix>github_workflow_jobs` may not be synced; check `engineering-analytics-sources` output or probe with a `LIMIT 1`.
-Durations and queue times are honest SQL (`started_at - created_at` is queue wait, `completed_at - started_at` is run time; all string timestamps, parse them).
+Durations and queue times are honest SQL over `<prefix>github_workflow_jobs` (`started_at - created_at` is queue wait, `completed_at - started_at` is run time; all string timestamps, parse them).
 **Do not** recompute dollar cost from labels: the runner-tier price ladder lives in product code and drifts; query the `engineering_analytics_job_costs` view instead (below), which renders that model into SQL and is parity-tested against it.
 
 ## Recipe: weekly CI cost by workflow (job_costs view)
@@ -186,10 +185,9 @@ Grain is one row per job attempt, so `sum` is correct across retries.
 Add `WHERE pr_number = <n>` for one PR's cost — it matches `engineering-analytics-pr-cost`, since the tool reads the same rendered cost SELECT.
 With several connected sources, filter `repo_owner` / `repo_name`.
 
-## Review recipes (optional table)
+## Review recipes
 
-`<prefix>github_reviews` is webhook-fed with no history backfill: rows start when the source was connected with reviews enabled, so clamp windows to the earliest `submitted_at` present.
-Pending drafts are dropped at sync; `state` is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED`, and the injected `pr_number` joins to the PR base's `number`.
+In `<prefix>github_reviews`, pending drafts are dropped at sync; `state` is `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED`, and the injected `pr_number` joins to the PR base's `number`.
 
 Weekly time to first review:
 


### PR DESCRIPTION
## Problem

The `turning-engineering-analytics-into-insights` skill predates several things engineering analytics now exposes, so agents following it give stale answers:

- It claims CI **cost** cannot back an insight — but the cost model is now rendered into the `engineering_analytics_job_costs` warehouse view, so cost insights are plain SQL.
- It doesn't mention the other two exposed views (`engineering_analytics_ci_job_history`, `engineering_analytics_ci_failures` — the fingerprinted/grouped CI failure lines).
- It says reviews are "not in the data yet" — the `github_reviews` warehouse table now exists (webhook-fed).
- It names only the original MCP tools, missing `broken-tests`, `run-failure-logs`, `team-ci-health`, and the `investigating-ci-failures` sibling skill.

It also never states the design rule for the views: they exist **only** where product code (cost model, fingerprint recipe, commit attribution) must be rendered into SQL so it can't drift; for everything else, pure HogQL over the raw tables is always enough and no further views should be created or requested.

## Changes

- Rework the SKILL.md intro into the two-substrate model (raw tables + the three fixed-name views), with the views-from-code rule stated explicitly, and update the "what backs an insight" table (cost and grouped failure lines move to **yes**).
- Extend table discovery with `github_reviews`, the optional-endpoint probe, and the views' no-prefix / union-all-sources / gating behavior.
- Move cost out of "What NOT to rebuild in SQL" (point at the view instead) and refresh the product-logic list and MCP tool names.
- Add recipes: weekly CI cost by workflow (`job_costs` view), time to first review (`github_reviews`), distinct failures per day (`ci_failures` view), plus the `created_at_raw` scan-pruning floor for `ci_job_history`.
- Refresh the caveats list (reviews start at source-connect; NULL cost semantics; failure counts are absolute, never rates).

## How did you test this code?

Docs-only change. Cross-checked every claim against the current code: `mcp/tools.yaml` (enabled tools and their descriptions), `backend/facade/warehouse_views.py` and `backend/logic/views/{job_costs,ci_job_history,ci_failures}.py` (view names, gating, column contracts, NULL semantics), SPEC.md §"Exposed warehouse views", and the GitHub source's `settings.py` (reviews endpoint: webhook-fed, `pr_number` injection, PENDING drop, no history backfill).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Fully autonomous

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*