### PR TITLE
fix(mcp): support ID-JAG authorization metadata

### DIFF
--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -112,9 +112,9 @@ export class RequestStateResolver {
         const flagAnalyticsContext = await reqCtx.safelyGetAnalyticsContext(context)
         const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
 
-        const [allFlags, _apiKey, distinctId] = await Promise.all([
+        const [allFlags, authorizationMetadata, distinctId] = await Promise.all([
             this.resolveAllFlags(reqCtx, allFlagKeys, flagGroups),
-            context.stateManager.getApiKey(),
+            context.stateManager.getAuthorizationMetadata(),
             reqCtx.getDistinctId(),
         ])
 
@@ -152,8 +152,8 @@ export class RequestStateResolver {
         reqCtx.setMcpContexts(requestContext, sessionContext)
         props.mode = resolvedMode
 
-        const apiKeyScopes = _apiKey?.scopes ?? []
-        const apiKeyScopedTeams = _apiKey?.scoped_teams ?? []
+        const authorizationScopes = authorizationMetadata.scopes
+        const authorizationScopedTeams = authorizationMetadata.scoped_teams
         const aiConsentGiven = await context.stateManager.getAiConsentGiven()
         const availableFeatures = await context.stateManager.getAvailableFeatures()
         const isCloud = isCloudApi()
@@ -171,18 +171,18 @@ export class RequestStateResolver {
             excludeTools,
             readOnly,
             featureFlags: toolFeatureFlags,
-            scopedTeams: apiKeyScopedTeams,
+            scopedTeams: authorizationScopedTeams,
             aiConsentGiven: aiConsentGiven ?? undefined,
             availableFeatures,
             isCloud,
         }
-        const allTools = this.catalog.getFilteredTools({ ...filterOptions, scopes: apiKeyScopes })
+        const allTools = this.catalog.getFilteredTools({ ...filterOptions, scopes: authorizationScopes })
         // Scope-gated hints are only consumed by the exec `search` command, which
         // only exists in single-exec mode — skip the extra scan otherwise.
-        const scopeGatedTools = useSingleExec ? getScopeGatedTools(apiKeyScopes, filterOptions) : []
+        const scopeGatedTools = useSingleExec ? getScopeGatedTools(authorizationScopes, filterOptions) : []
 
         const [groupTypes, metadata] = await Promise.all([
-            cachedProjectId && hasScope(apiKeyScopes, 'group:read')
+            cachedProjectId && hasScope(authorizationScopes, 'group:read')
                 ? context.stateManager.getOrFetchGroupTypes(cachedProjectId).catch(() => undefined)
                 : undefined,
             context.stateManager.getEnvironmentPrompt(),
@@ -193,7 +193,7 @@ export class RequestStateResolver {
             context,
             useSingleExec,
             toolFeatureFlags,
-            apiKeyScopes,
+            apiKeyScopes: authorizationScopes,
             clientProfile,
             requestContext,
             sessionContext,

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -49,6 +49,11 @@ export class StateManager {
         return this._user
     }
 
+    /**
+     * Resolve the scopes and tenant restrictions used to build the MCP tool catalog.
+     * User authentication only establishes who the bearer represents; this metadata
+     * separately determines which tools that bearer is allowed to see and call.
+     */
     private async _fetchAuthorizationMetadata(): Promise<NonNullable<State['authorizationMetadata']>> {
         const token = this._api.config.apiToken
         if (isIdJagAccessToken(token)) {

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -9,6 +9,7 @@ import {
     wrapError,
 } from '@/lib/errors'
 import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
+import { isIdJagAccessToken, readIdJagAuthorizationMetadata } from '@/lib/id-jag'
 import { getPostHogClient } from '@/lib/posthog'
 import { sanitizeHeaderValue } from '@/lib/utils'
 import type { ApiUser } from '@/schema/api'
@@ -49,6 +50,23 @@ export class StateManager {
     }
 
     private async _fetchApiKey(): Promise<NonNullable<State['apiKey']>> {
+        const token = this._api.config.apiToken
+        if (isIdJagAccessToken(token)) {
+            // `/oauth/introspect` only supports database-backed OAuth tokens.
+            // Authenticate the ID-JAG JWT through PostHog first, then read the
+            // already-validated scope and organization claims locally.
+            await this.getUser()
+            const metadata = readIdJagAuthorizationMetadata(token)
+            if (!metadata) {
+                throw new Error(ErrorCode.INVALID_API_KEY)
+            }
+            return {
+                scopes: metadata.scopes,
+                scoped_teams: [],
+                scoped_organizations: metadata.scopedOrganizations,
+            }
+        }
+
         const apiKeyResult = await this._api.apiKeys().current()
         if (apiKeyResult.success) {
             const { scopes, scoped_teams, scoped_organizations } = apiKeyResult.data
@@ -61,7 +79,7 @@ export class StateManager {
             }
         }
 
-        const introspectionResult = await this._api.oauth().introspect({ token: this._api.config.apiToken })
+        const introspectionResult = await this._api.oauth().introspect({ token })
 
         if (!introspectionResult.success) {
             throw new Error(ErrorCode.INVALID_API_KEY)

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -49,7 +49,7 @@ export class StateManager {
         return this._user
     }
 
-    private async _fetchApiKey(): Promise<NonNullable<State['apiKey']>> {
+    private async _fetchAuthorizationMetadata(): Promise<NonNullable<State['authorizationMetadata']>> {
         const token = this._api.config.apiToken
         if (isIdJagAccessToken(token)) {
             // ID-JAG access tokens are valid PostHog API bearers, but they are stateless JWTs:
@@ -104,15 +104,15 @@ export class StateManager {
         }
     }
 
-    async getApiKey(): Promise<NonNullable<State['apiKey']>> {
-        let _apiKey = await this._cache.get('apiKey')
+    async getAuthorizationMetadata(): Promise<NonNullable<State['authorizationMetadata']>> {
+        let authorizationMetadata = await this._cache.get('authorizationMetadata')
 
-        if (!_apiKey) {
-            _apiKey = await this._fetchApiKey()
-            await this._cache.set('apiKey', _apiKey)
+        if (!authorizationMetadata) {
+            authorizationMetadata = await this._fetchAuthorizationMetadata()
+            await this._cache.set('authorizationMetadata', authorizationMetadata)
         }
 
-        return _apiKey
+        return authorizationMetadata
     }
 
     async getDistinctId(): Promise<NonNullable<State['distinctId']>> {
@@ -142,7 +142,10 @@ export class StateManager {
         organizationId?: string
         projectId?: number
     }> {
-        const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([this.getApiKey(), this.getUser()])
+        const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([
+            this.getAuthorizationMetadata(),
+            this.getUser(),
+        ])
         const { organization: activeOrganization, team: activeTeam } = user
 
         // Team-scoped key: prefer the active team if the scope allows it,
@@ -348,11 +351,14 @@ export class StateManager {
     }
 
     async getCachedOrFetchOrg(): Promise<CachedOrg | undefined> {
-        const apiKey = await this.getApiKey()
+        const authorizationMetadata = await this.getAuthorizationMetadata()
         // `/api/organizations/{id}/` is not project-nested. Backend permission
         // checks reject project-scoped tokens there even when they carry
         // `organization:read` or `*`, so skip the best-effort fetch entirely.
-        if (apiKey.scoped_teams.length > 0 || !hasScope(apiKey.scopes, 'organization:read')) {
+        if (
+            authorizationMetadata.scoped_teams.length > 0 ||
+            !hasScope(authorizationMetadata.scopes, 'organization:read')
+        ) {
             return undefined
         }
 

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -52,9 +52,10 @@ export class StateManager {
     private async _fetchApiKey(): Promise<NonNullable<State['apiKey']>> {
         const token = this._api.config.apiToken
         if (isIdJagAccessToken(token)) {
-            // `/oauth/introspect` only supports database-backed OAuth tokens.
-            // Authenticate the ID-JAG JWT through PostHog first, then read the
-            // already-validated scope and organization claims locally.
+            // ID-JAG access tokens are valid PostHog API bearers, but they are stateless JWTs:
+            // neither the personal-key endpoint nor OAuth introspection can describe them.
+            // Authenticate the token through PostHog first, then read the already-validated
+            // scope and organization claims locally.
             await this.getUser()
             const metadata = readIdJagAuthorizationMetadata(token)
             if (!metadata) {

--- a/services/mcp/src/lib/id-jag.ts
+++ b/services/mcp/src/lib/id-jag.ts
@@ -29,3 +29,35 @@ export function isIdJagAccessToken(token: string): boolean {
         return false
     }
 }
+
+export interface IdJagAuthorizationMetadata {
+    scopes: string[]
+    scopedOrganizations: string[]
+}
+
+/**
+ * Read authorization metadata from an ID-JAG access token after the PostHog
+ * API has authenticated that same token via `/api/users/@me/`.
+ *
+ * This helper does not verify the JWT signature. Callers must first authenticate
+ * the token with PostHog, which is the resource server and source of truth for
+ * signature, expiry, audience, membership, and entitlement validation.
+ */
+export function readIdJagAuthorizationMetadata(token: string): IdJagAuthorizationMetadata | null {
+    if (!isIdJagAccessToken(token)) {
+        return null
+    }
+    try {
+        const payloadRaw = token.split('.')[1]
+        if (!payloadRaw) {
+            return null
+        }
+        const payloadJson = atob(base64UrlToBase64(payloadRaw))
+        const payload = JSON.parse(payloadJson) as { scope?: unknown; org_id?: unknown }
+        const scopes = typeof payload.scope === 'string' ? payload.scope.split(/\s+/).filter(Boolean) : []
+        const scopedOrganizations = typeof payload.org_id === 'string' && payload.org_id ? [payload.org_id] : []
+        return { scopes, scopedOrganizations }
+    } catch {
+        return null
+    }
+}

--- a/services/mcp/src/schema/api.ts
+++ b/services/mcp/src/schema/api.ts
@@ -35,7 +35,7 @@ export interface ApiUser {
 
 // `scoped_teams` and `scoped_organizations` arrive from the API as either an
 // array or `null` (DRF serializer default). Callers must normalize null to []
-// at the wire boundary (see `StateManager._fetchApiKey`); this type represents
+// at the wire boundary (see `StateManager._fetchAuthorizationMetadata`); this type represents
 // the post-normalization shape that the rest of the codebase consumes.
 export interface ApiRedactedPersonalApiKey {
     scopes: string[]

--- a/services/mcp/src/tools/agentPlatform/resolveResource.ts
+++ b/services/mcp/src/tools/agentPlatform/resolveResource.ts
@@ -40,7 +40,7 @@ export const resolveResourceHandler: ToolBase<typeof schema, Result>['handler'] 
     // a missing/erroring key just renders the flat list with required scopes.
     let scopes: string[] | undefined
     try {
-        scopes = (await context.stateManager.getApiKey()).scopes
+        scopes = (await context.stateManager.getAuthorizationMetadata()).scopes
     } catch {
         scopes = undefined
     }

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -149,8 +149,8 @@ export const getToolsFromContext = async (
         }
     })
 
-    const apiKey = await context.stateManager.getApiKey()
-    const scopes = apiKey?.scopes ?? []
+    const authorizationMetadata = await context.stateManager.getAuthorizationMetadata()
+    const scopes = authorizationMetadata.scopes
 
     return tools.filter((tool) => hasScopes(scopes, tool.scopes))
 }

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -24,7 +24,7 @@ export type State = {
     orgId: string | undefined
     distinctId: string | undefined
     region: CloudRegion | undefined
-    apiKey: ApiRedactedPersonalApiKey | undefined
+    authorizationMetadata: ApiRedactedPersonalApiKey | undefined
     clientName: string | undefined
     mcpClientName: string | undefined
     mcpClientVersion: string | undefined

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -53,7 +53,11 @@ vi.mock('@/hono/request-context', () => {
                 getContext: vi.fn(async () => ({
                     stateManager: {
                         setDefaultOrganizationAndProject: vi.fn(async () => {}),
-                        getAuthorizationMetadata: vi.fn(async () => ({ scopes: ['*'], scoped_teams: [] })),
+                        getAuthorizationMetadata: vi.fn(async () => ({
+                            scopes: ['*'],
+                            scoped_teams: [],
+                            scoped_organizations: [],
+                        })),
                         getAiConsentGiven: vi.fn(async () => undefined),
                         getOrFetchGroupTypes: vi.fn(async () => undefined),
                         getEnvironmentPrompt: vi.fn(async () => undefined),

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -53,7 +53,7 @@ vi.mock('@/hono/request-context', () => {
                 getContext: vi.fn(async () => ({
                     stateManager: {
                         setDefaultOrganizationAndProject: vi.fn(async () => {}),
-                        getApiKey: vi.fn(async () => ({ scopes: ['*'], scoped_teams: [] })),
+                        getAuthorizationMetadata: vi.fn(async () => ({ scopes: ['*'], scoped_teams: [] })),
                         getAiConsentGiven: vi.fn(async () => undefined),
                         getOrFetchGroupTypes: vi.fn(async () => undefined),
                         getEnvironmentPrompt: vi.fn(async () => undefined),

--- a/services/mcp/tests/integration/feature-routing.test.ts
+++ b/services/mcp/tests/integration/feature-routing.test.ts
@@ -17,7 +17,7 @@ const createMockContext = (): Context => ({
         POSTHOG_UI_APPS_TOKEN: undefined,
     },
     stateManager: {
-        getApiKey: async () => ({ scopes: ['*'] }),
+        getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
         getAiConsentGiven: async () => undefined,
     } as any,
     sessionManager: new SessionManager({} as any),

--- a/services/mcp/tests/integration/feature-routing.test.ts
+++ b/services/mcp/tests/integration/feature-routing.test.ts
@@ -17,7 +17,7 @@ const createMockContext = (): Context => ({
         POSTHOG_UI_APPS_TOKEN: undefined,
     },
     stateManager: {
-        getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
+        getAuthorizationMetadata: async () => ({ scopes: ['*'], scoped_teams: [], scoped_organizations: [] }),
         getAiConsentGiven: async () => undefined,
     } as any,
     sessionManager: new SessionManager({} as any),

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -61,6 +61,29 @@ describe('StateManager', () => {
         })
     })
 
+    describe('getApiKey', () => {
+        it('uses validated ID-JAG claims instead of OAuth introspection', async () => {
+            const header = Buffer.from(JSON.stringify({ typ: 'at+jwt', alg: 'RS256' })).toString('base64url')
+            const payload = Buffer.from(
+                JSON.stringify({ scope: 'user:read agents:read agents:write', org_id: 'org-1' })
+            ).toString('base64url')
+            const token = `${header}.${payload}.signature`
+            const api = {
+                config: { apiToken: token },
+                users: () => ({ me: async () => ({ success: true, data: mockUser }) }),
+                apiKeys: () => ({ current: async () => ({ success: false }) }),
+                oauth: () => ({ introspect: async () => ({ success: false }) }),
+            } as unknown as ApiClient
+            stateManager = new StateManager(cache, api)
+
+            await expect(stateManager.getApiKey()).resolves.toEqual({
+                scopes: ['user:read', 'agents:read', 'agents:write'],
+                scoped_teams: [],
+                scoped_organizations: ['org-1'],
+            })
+        })
+    })
+
     describe('getDistinctId', () => {
         it('should get distinct ID from cache if available', async () => {
             await cache.set('distinctId', 'cached-distinct-id')

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -83,7 +83,7 @@ describe('StateManager', () => {
         })
     })
 
-    describe('getApiKey', () => {
+    describe('getAuthorizationMetadata', () => {
         it('bootstraps ID-JAG metadata without personal-key lookup or OAuth introspection', async () => {
             const token = createIdJagAccessToken('user:read agents:read agents:write')
             const getUser = vi.fn().mockResolvedValue({ success: true, data: mockUser })
@@ -97,7 +97,7 @@ describe('StateManager', () => {
             } as unknown as ApiClient
             stateManager = new StateManager(cache, api)
 
-            await expect(stateManager.getApiKey()).resolves.toEqual({
+            await expect(stateManager.getAuthorizationMetadata()).resolves.toEqual({
                 scopes: ['user:read', 'agents:read', 'agents:write'],
                 scoped_teams: [],
                 scoped_organizations: ['org-1'],
@@ -121,7 +121,7 @@ describe('StateManager', () => {
             } as unknown as ApiClient
             stateManager = new StateManager(cache, api)
 
-            await expect(stateManager.getApiKey()).rejects.toThrow('Failed to get user: Unauthorized')
+            await expect(stateManager.getAuthorizationMetadata()).rejects.toThrow('Failed to get user: Unauthorized')
         })
     })
 
@@ -152,7 +152,7 @@ describe('StateManager', () => {
                 scoped_teams: [456],
             }
 
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(teamScopedApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(teamScopedApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
 
             const result = await stateManager.setDefaultOrganizationAndProject()
@@ -167,7 +167,7 @@ describe('StateManager', () => {
                 scoped_teams: [123, 456, 789],
             }
 
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(multiTeamApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(multiTeamApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
 
             const result = await stateManager.setDefaultOrganizationAndProject()
@@ -183,7 +183,7 @@ describe('StateManager', () => {
                 scoped_teams: [123, 789],
             }
 
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(multiTeamApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(multiTeamApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
 
             const result = await stateManager.setDefaultOrganizationAndProject()
@@ -194,7 +194,7 @@ describe('StateManager', () => {
         })
 
         it("should use user's active org and team when no scoped restrictions", async () => {
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(mockApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(mockApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
 
             const result = await stateManager.setDefaultOrganizationAndProject()
@@ -211,7 +211,7 @@ describe('StateManager', () => {
                 scoped_organizations: ['org-2', 'org-1'],
             }
 
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(scopedOrgApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(scopedOrgApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
 
             const result = await stateManager.setDefaultOrganizationAndProject()
@@ -227,7 +227,7 @@ describe('StateManager', () => {
             }
 
             const mockApi = stateManager as any
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(scopedOrgApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(scopedOrgApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
 
             // Mock the API client organization projects list call
@@ -255,7 +255,7 @@ describe('StateManager', () => {
             }
 
             const mockApi = stateManager as any
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(scopedOrgApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(scopedOrgApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
 
             mockApi._api = {
@@ -288,7 +288,7 @@ describe('StateManager', () => {
             }
             const userWithoutCurrent: ApiUser = { ...mockUser, team: null, organization: null }
 
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(teamScopedApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(teamScopedApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(userWithoutCurrent)
 
             const result = await stateManager.setDefaultOrganizationAndProject()
@@ -307,7 +307,7 @@ describe('StateManager', () => {
             const userWithoutCurrent: ApiUser = { ...mockUser, team: null, organization: null }
 
             const mockApi = stateManager as any
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(scopedOrgApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(scopedOrgApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(userWithoutCurrent)
 
             mockApi._api = {
@@ -330,7 +330,7 @@ describe('StateManager', () => {
             // missing-context state rather than crash or fabricate an org id.
             const userWithoutCurrent: ApiUser = { ...mockUser, team: null, organization: null }
 
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(mockApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(mockApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(userWithoutCurrent)
 
             const result = await stateManager.setDefaultOrganizationAndProject()
@@ -346,7 +346,7 @@ describe('StateManager', () => {
             }
 
             const mockApi = stateManager as any
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(scopedOrgApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(scopedOrgApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
             const reportSpy = vi.spyOn(stateManager as any, '_reportException').mockImplementation(() => {})
 
@@ -380,7 +380,7 @@ describe('StateManager', () => {
             }
 
             const mockApi = stateManager as any
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(scopedOrgApiKey)
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue(scopedOrgApiKey)
             vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
             const reportSpy = vi.spyOn(stateManager as any, '_reportException').mockImplementation(() => {})
 
@@ -494,7 +494,7 @@ describe('StateManager', () => {
         it('returns undefined when no org can be resolved (does not throw)', async () => {
             // Preserves the best-effort contract used by getEnvironmentPrompt and
             // consent checks: if no org is in scope, the call is a no-op.
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue({
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue({
                 scopes: ['organization:read'],
                 scoped_organizations: [],
                 scoped_teams: [],
@@ -517,7 +517,7 @@ describe('StateManager', () => {
             // HTTP call so no exception is captured and the org is treated as
             // best-effort missing.
             await cache.set('orgId', 'org-1')
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue({
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue({
                 scopes: ['project:read', 'insight:read'],
                 scoped_organizations: [],
                 scoped_teams: [456],
@@ -537,7 +537,7 @@ describe('StateManager', () => {
             'skips the org fetch for project-scoped API keys even when they carry %s',
             async (scope) => {
                 await cache.set('orgId', 'org-1')
-                vi.spyOn(stateManager, 'getApiKey').mockResolvedValue({
+                vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue({
                     scopes: [scope],
                     scoped_organizations: [],
                     scoped_teams: [456],
@@ -555,7 +555,7 @@ describe('StateManager', () => {
         )
 
         it('skips org resolution for project-scoped API keys', async () => {
-            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue({
+            vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue({
                 scopes: ['*'],
                 scoped_organizations: [],
                 scoped_teams: [456],
@@ -579,7 +579,7 @@ describe('StateManager', () => {
             'fetches the org when the API key carries %s',
             async (scope) => {
                 await cache.set('orgId', 'org-1')
-                vi.spyOn(stateManager, 'getApiKey').mockResolvedValue({
+                vi.spyOn(stateManager, 'getAuthorizationMetadata').mockResolvedValue({
                     scopes: [scope],
                     scoped_organizations: [],
                     scoped_teams: [],

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -68,11 +68,13 @@ describe('StateManager', () => {
                 JSON.stringify({ scope: 'user:read agents:read agents:write', org_id: 'org-1' })
             ).toString('base64url')
             const token = `${header}.${payload}.signature`
+            const getUser = vi.fn().mockResolvedValue({ success: true, data: mockUser })
+            const introspect = vi.fn().mockRejectedValue(new Error('ID-JAG tokens must not be introspected'))
             const api = {
                 config: { apiToken: token },
-                users: () => ({ me: async () => ({ success: true, data: mockUser }) }),
+                users: () => ({ me: getUser }),
                 apiKeys: () => ({ current: async () => ({ success: false }) }),
-                oauth: () => ({ introspect: async () => ({ success: false }) }),
+                oauth: () => ({ introspect }),
             } as unknown as ApiClient
             stateManager = new StateManager(cache, api)
 
@@ -81,6 +83,29 @@ describe('StateManager', () => {
                 scoped_teams: [],
                 scoped_organizations: ['org-1'],
             })
+            expect(getUser).toHaveBeenCalledOnce()
+            expect(introspect).not.toHaveBeenCalled()
+        })
+
+        it('rejects ID-JAG claims when PostHog does not authenticate the token', async () => {
+            const header = Buffer.from(JSON.stringify({ typ: 'at+jwt', alg: 'RS256' })).toString('base64url')
+            const payload = Buffer.from(JSON.stringify({ scope: 'agents:write', org_id: 'org-1' })).toString(
+                'base64url'
+            )
+            const token = `${header}.${payload}.signature`
+            const api = {
+                config: { apiToken: token },
+                users: () => ({ me: async () => ({ success: false, error: { message: 'Unauthorized' } }) }),
+                apiKeys: () => ({ current: async () => ({ success: false }) }),
+                oauth: () => ({
+                    introspect: async () => {
+                        throw new Error('ID-JAG tokens must not be introspected')
+                    },
+                }),
+            } as unknown as ApiClient
+            stateManager = new StateManager(cache, api)
+
+            await expect(stateManager.getApiKey()).rejects.toThrow('Failed to get user: Unauthorized')
         })
     })
 

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -27,6 +27,28 @@ describe('StateManager', () => {
         scoped_teams: [],
     }
 
+    const createIdJagAccessToken = (scope: string): string => {
+        const header = Buffer.from(JSON.stringify({ typ: 'at+jwt', alg: 'RS256', kid: 'test-key' })).toString(
+            'base64url'
+        )
+        const payload = Buffer.from(
+            JSON.stringify({
+                iss: 'https://us.posthog.com',
+                sub: 'posthog-code:test@example.com',
+                email: 'test@example.com',
+                aud: 'https://us.posthog.com',
+                client_id: 'posthog-code',
+                scope,
+                app_org: 'posthog-code',
+                org_id: 'org-1',
+                jti: 'test-token',
+                iat: 1_700_000_000,
+                exp: 1_700_000_300,
+            })
+        ).toString('base64url')
+        return `${header}.${payload}.signature`
+    }
+
     beforeEach(async () => {
         cache = new MemoryCache('test-user')
         await cache.clear()
@@ -63,11 +85,7 @@ describe('StateManager', () => {
 
     describe('getApiKey', () => {
         it('bootstraps ID-JAG metadata without personal-key lookup or OAuth introspection', async () => {
-            const header = Buffer.from(JSON.stringify({ typ: 'at+jwt', alg: 'RS256' })).toString('base64url')
-            const payload = Buffer.from(
-                JSON.stringify({ scope: 'user:read agents:read agents:write', org_id: 'org-1' })
-            ).toString('base64url')
-            const token = `${header}.${payload}.signature`
+            const token = createIdJagAccessToken('user:read agents:read agents:write')
             const getUser = vi.fn().mockResolvedValue({ success: true, data: mockUser })
             const getCurrentApiKey = vi.fn().mockRejectedValue(new Error('ID-JAG tokens are not personal API keys'))
             const introspect = vi.fn().mockRejectedValue(new Error('ID-JAG tokens must not be introspected'))
@@ -90,11 +108,7 @@ describe('StateManager', () => {
         })
 
         it('rejects ID-JAG claims when PostHog does not authenticate the token', async () => {
-            const header = Buffer.from(JSON.stringify({ typ: 'at+jwt', alg: 'RS256' })).toString('base64url')
-            const payload = Buffer.from(JSON.stringify({ scope: 'agents:write', org_id: 'org-1' })).toString(
-                'base64url'
-            )
-            const token = `${header}.${payload}.signature`
+            const token = createIdJagAccessToken('agents:write')
             const api = {
                 config: { apiToken: token },
                 users: () => ({ me: async () => ({ success: false, error: { message: 'Unauthorized' } }) }),

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -62,18 +62,19 @@ describe('StateManager', () => {
     })
 
     describe('getApiKey', () => {
-        it('uses validated ID-JAG claims instead of OAuth introspection', async () => {
+        it('bootstraps ID-JAG metadata without personal-key lookup or OAuth introspection', async () => {
             const header = Buffer.from(JSON.stringify({ typ: 'at+jwt', alg: 'RS256' })).toString('base64url')
             const payload = Buffer.from(
                 JSON.stringify({ scope: 'user:read agents:read agents:write', org_id: 'org-1' })
             ).toString('base64url')
             const token = `${header}.${payload}.signature`
             const getUser = vi.fn().mockResolvedValue({ success: true, data: mockUser })
+            const getCurrentApiKey = vi.fn().mockRejectedValue(new Error('ID-JAG tokens are not personal API keys'))
             const introspect = vi.fn().mockRejectedValue(new Error('ID-JAG tokens must not be introspected'))
             const api = {
                 config: { apiToken: token },
                 users: () => ({ me: getUser }),
-                apiKeys: () => ({ current: async () => ({ success: false }) }),
+                apiKeys: () => ({ current: getCurrentApiKey }),
                 oauth: () => ({ introspect }),
             } as unknown as ApiClient
             stateManager = new StateManager(cache, api)
@@ -84,6 +85,7 @@ describe('StateManager', () => {
                 scoped_organizations: ['org-1'],
             })
             expect(getUser).toHaveBeenCalledOnce()
+            expect(getCurrentApiKey).not.toHaveBeenCalled()
             expect(introspect).not.toHaveBeenCalled()
         })
 

--- a/services/mcp/tests/unit/agent-resolve-resource.test.ts
+++ b/services/mcp/tests/unit/agent-resolve-resource.test.ts
@@ -17,8 +17,8 @@ const PLAYBOOKS_DIR = resolve(__dirname, '../../playbooks')
 
 // Context whose api key carries the given scopes (drives the live tool surface).
 const ctxWithScopes = (scopes: string[]): Context =>
-    ({ stateManager: { getApiKey: async () => ({ scopes }) } }) as unknown as Context
-// No stateManager → getApiKey throws → handler renders the flat (scope-unknown) surface.
+    ({ stateManager: { getAuthorizationMetadata: async () => ({ scopes }) } }) as unknown as Context
+// No stateManager → getAuthorizationMetadata throws → handler renders the flat (scope-unknown) surface.
 const ctx = {} as Context
 
 describe('agent-resolve-resource', () => {

--- a/services/mcp/tests/unit/agent-resolve-resource.test.ts
+++ b/services/mcp/tests/unit/agent-resolve-resource.test.ts
@@ -17,7 +17,11 @@ const PLAYBOOKS_DIR = resolve(__dirname, '../../playbooks')
 
 // Context whose api key carries the given scopes (drives the live tool surface).
 const ctxWithScopes = (scopes: string[]): Context =>
-    ({ stateManager: { getAuthorizationMetadata: async () => ({ scopes }) } }) as unknown as Context
+    ({
+        stateManager: {
+            getAuthorizationMetadata: async () => ({ scopes, scoped_teams: [], scoped_organizations: [] }),
+        },
+    }) as unknown as Context
 // No stateManager → getAuthorizationMetadata throws → handler renders the flat (scope-unknown) surface.
 const ctx = {} as Context
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -860,7 +860,11 @@ describe('exec tool', () => {
                     POSTHOG_UI_APPS_TOKEN: undefined,
                 },
                 stateManager: {
-                    getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
+                    getAuthorizationMetadata: async () => ({
+                        scopes: ['*'],
+                        scoped_teams: [],
+                        scoped_organizations: [],
+                    }),
                     getAiConsentGiven: async () => true,
                 } as any,
                 sessionManager: new SessionManager({} as any),
@@ -926,7 +930,11 @@ describe('exec tool', () => {
                     POSTHOG_UI_APPS_TOKEN: undefined,
                 },
                 stateManager: {
-                    getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
+                    getAuthorizationMetadata: async () => ({
+                        scopes: ['*'],
+                        scoped_teams: [],
+                        scoped_organizations: [],
+                    }),
                     getAiConsentGiven: async () => true,
                 } as any,
                 sessionManager: new SessionManager({} as any),
@@ -1139,7 +1147,11 @@ describe('exec tool', () => {
                     POSTHOG_UI_APPS_TOKEN: undefined,
                 },
                 stateManager: {
-                    getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
+                    getAuthorizationMetadata: async () => ({
+                        scopes: ['*'],
+                        scoped_teams: [],
+                        scoped_organizations: [],
+                    }),
                     getAiConsentGiven: async () => true,
                 } as any,
                 sessionManager: new SessionManager({} as any),

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -860,7 +860,7 @@ describe('exec tool', () => {
                     POSTHOG_UI_APPS_TOKEN: undefined,
                 },
                 stateManager: {
-                    getApiKey: async () => ({ scopes: ['*'] }),
+                    getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
                     getAiConsentGiven: async () => true,
                 } as any,
                 sessionManager: new SessionManager({} as any),
@@ -926,7 +926,7 @@ describe('exec tool', () => {
                     POSTHOG_UI_APPS_TOKEN: undefined,
                 },
                 stateManager: {
-                    getApiKey: async () => ({ scopes: ['*'] }),
+                    getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
                     getAiConsentGiven: async () => true,
                 } as any,
                 sessionManager: new SessionManager({} as any),
@@ -1139,7 +1139,7 @@ describe('exec tool', () => {
                     POSTHOG_UI_APPS_TOKEN: undefined,
                 },
                 stateManager: {
-                    getApiKey: async () => ({ scopes: ['*'] }),
+                    getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
                     getAiConsentGiven: async () => true,
                 } as any,
                 sessionManager: new SessionManager({} as any),

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -248,7 +248,7 @@ const createMockContext = (scopes: string[]): Context => ({
         POSTHOG_UI_APPS_TOKEN: undefined,
     },
     stateManager: {
-        getAuthorizationMetadata: async () => ({ scopes }),
+        getAuthorizationMetadata: async () => ({ scopes, scoped_teams: [], scoped_organizations: [] }),
         getAiConsentGiven: async () => undefined,
     } as any,
     sessionManager: new SessionManager({} as any),
@@ -522,7 +522,7 @@ describe('Tool Filtering - AI Consent', () => {
                 POSTHOG_UI_APPS_TOKEN: undefined,
             },
             stateManager: {
-                getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
+                getAuthorizationMetadata: async () => ({ scopes: ['*'], scoped_teams: [], scoped_organizations: [] }),
                 getAiConsentGiven: async () => false,
             } as any,
             sessionManager: new SessionManager({} as any),
@@ -549,7 +549,7 @@ describe('Tool Filtering - AI Consent', () => {
                 POSTHOG_UI_APPS_TOKEN: undefined,
             },
             stateManager: {
-                getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
+                getAuthorizationMetadata: async () => ({ scopes: ['*'], scoped_teams: [], scoped_organizations: [] }),
                 getAiConsentGiven: async () => true,
             } as any,
             sessionManager: new SessionManager({} as any),

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -248,7 +248,7 @@ const createMockContext = (scopes: string[]): Context => ({
         POSTHOG_UI_APPS_TOKEN: undefined,
     },
     stateManager: {
-        getApiKey: async () => ({ scopes }),
+        getAuthorizationMetadata: async () => ({ scopes }),
         getAiConsentGiven: async () => undefined,
     } as any,
     sessionManager: new SessionManager({} as any),
@@ -522,7 +522,7 @@ describe('Tool Filtering - AI Consent', () => {
                 POSTHOG_UI_APPS_TOKEN: undefined,
             },
             stateManager: {
-                getApiKey: async () => ({ scopes: ['*'] }),
+                getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
                 getAiConsentGiven: async () => false,
             } as any,
             sessionManager: new SessionManager({} as any),
@@ -549,7 +549,7 @@ describe('Tool Filtering - AI Consent', () => {
                 POSTHOG_UI_APPS_TOKEN: undefined,
             },
             stateManager: {
-                getApiKey: async () => ({ scopes: ['*'] }),
+                getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
                 getAiConsentGiven: async () => true,
             } as any,
             sessionManager: new SessionManager({} as any),

--- a/services/mcp/tests/unit/tool-schema-snapshots.test.ts
+++ b/services/mcp/tests/unit/tool-schema-snapshots.test.ts
@@ -23,7 +23,7 @@ function createMockContext(): Context {
             POSTHOG_UI_APPS_TOKEN: undefined,
         },
         stateManager: {
-            getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
+            getAuthorizationMetadata: async () => ({ scopes: ['*'], scoped_teams: [], scoped_organizations: [] }),
             getAiConsentGiven: async () => true,
         } as any,
         sessionManager: new SessionManager({} as any),

--- a/services/mcp/tests/unit/tool-schema-snapshots.test.ts
+++ b/services/mcp/tests/unit/tool-schema-snapshots.test.ts
@@ -23,7 +23,7 @@ function createMockContext(): Context {
             POSTHOG_UI_APPS_TOKEN: undefined,
         },
         stateManager: {
-            getApiKey: async () => ({ scopes: ['*'] }),
+            getAuthorizationMetadata: async () => ({ scopes: ['*'] }),
             getAiConsentGiven: async () => true,
         } as any,
         sessionManager: new SessionManager({} as any),


### PR DESCRIPTION
## Problem

> [!NOTE]
> The ID-JAG token is already valid and PostHog successfully authenticates it. This PR does not make the token valid. It fixes how MCP obtains the token's permissions when building the tool catalog.

MCP startup needs two separate answers:

1. **Authentication:** Who does this token represent?
2. **Authorization:** Which scopes, organizations, and tools may that user access?

Authentication already worked through `/api/users/@me/`. Authorization metadata did not.

The old authorization path assumed every credential was either a personal API key or a database-backed OAuth token:

```text
Valid ID-JAG token
  -> personal API key lookup: not found
  -> OAuth introspection: 403 because the JWT has no OAuth database row
  -> no scopes returned
  -> MCP cannot build the scoped tool catalog
  -> PostHog tools are missing
```

ID-JAG access tokens are signed, short-lived JWTs. Their scopes and organization restriction are encoded in the token itself rather than stored in the OAuth token table.

## Changes

For ID-JAG access tokens, MCP now:

```text
Valid ID-JAG token
  -> authenticate the token through PostHog
  -> read scope and organization claims from that validated token
  -> return authorization metadata without calling OAuth introspection
  -> pass the scopes into tool catalog filtering
  -> expose the PostHog tools allowed by those scopes
```

The important behavior change is the early authorization-metadata return. Calling `/api/users/@me/` alone would only verify the token and would not fix the missing tools.

The resolver is also named `getAuthorizationMetadata()` rather than `getApiKey()` so it is clear that it supports personal API keys, OAuth tokens, and ID-JAG tokens.

## How did you test this code?

- Added StateManager regressions using the real ID-JAG access-token claim shape. They prove that validated ID-JAG scopes and organization restrictions are returned without personal-key lookup or OAuth introspection, and that claims are rejected when PostHog authentication fails.
- `pnpm --dir services/mcp test --run tests/unit/StateManager.test.ts` – 59 tests pass.
- Focused MCP unit suites covering authorization metadata and scope-based tool filtering – 149 tests pass.
- `pnpm --dir services/mcp typecheck`
- `pnpm --dir services/mcp lint`
- `pnpm --dir services/mcp format:check`

`hogli ci:preflight --fix` was unavailable in this checkout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change. This restores the existing ID-JAG authentication and authorization contract for MCP clients.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI traced the credential from agent ingress into MCP and inspected the authorization bootstrap path. It used the `/security-audit`, `/writing-tests`, and `/exploring-mcp-sessions` skills.

The key design decision is to keep PostHog as the authentication trust boundary. MCP only reads authorization claims after PostHog has accepted the same token, then uses those claims instead of the database-backed OAuth introspection path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
