### PR TITLE
fix(funnels): correct breakdown bar widths in top-to-bottom layout

### DIFF
--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -11,7 +11,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
-import { type ChartParams, FunnelStepReference, type FunnelStepWithConversionMetrics, StepOrderValue } from '~/types'
+import { type ChartParams, type FunnelStepWithConversionMetrics, StepOrderValue } from '~/types'
 
 import { FunnelBarHorizontalTooltip } from './FunnelBarHorizontalTooltip'
 import {
@@ -63,7 +63,6 @@ export function FunnelBarHorizontalChart({
     const { aggregationLabel } = useValues(groupsModel)
 
     const steps = visibleStepsWithConversionMetrics
-    const stepReference = funnelsFilter?.funnelStepReference || FunnelStepReference.total
     const showPersonsModal = canOpenPersonModal && showPersonsModalProp
     const interactive = showPersonsModal && !inCardView
     const isUnordered = funnelsFilter?.funnelOrderType === StepOrderValue.UNORDERED
@@ -72,14 +71,13 @@ export function FunnelBarHorizontalChart({
 
     const buildOptions = useMemo(
         () => ({
-            stepReference,
             breakdownFilter,
             getColor: getFunnelsColor,
             getLabel: (variant: FunnelStepWithConversionMetrics) =>
                 String(variant.breakdown_value ?? variant.name ?? ''),
             fillerColor,
         }),
-        [stepReference, breakdownFilter, getFunnelsColor, fillerColor]
+        [breakdownFilter, getFunnelsColor, fillerColor]
     )
 
     const stepsData = useMemo(

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -1,4 +1,4 @@
-import { EntityTypes, FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
+import { EntityTypes, type FunnelStepWithConversionMetrics } from '~/types'
 
 import {
     buildFunnelBarHorizontalCompareData,
@@ -43,7 +43,6 @@ function makeStep({
 }
 
 const options = {
-    stepReference: FunnelStepReference.total,
     getColor: () => '#1d4aff',
     getLabel: (variant: FunnelStepWithConversionMetrics) => String(variant.breakdown_value ?? variant.name),
     fillerColor: '#eef0f3',
@@ -212,42 +211,43 @@ describe('buildFunnelBarHorizontalData', () => {
     })
 
     describe('reference step', () => {
-        it.each([
-            { stepReference: FunnelStepReference.total, expected: [100, 50, 20] },
-            { stepReference: FunnelStepReference.previous, expected: [100, 50, 20] },
-        ])(
-            'uses precomputed fromBasisStep for non-breakdown layouts (stepReference=$stepReference)',
-            ({ stepReference, expected }) => {
-                const steps = [
-                    makeStep({ count: 100, fromBasisStep: 1, name: 'Viewed' }),
-                    makeStep({ count: 50, fromBasisStep: 0.5, name: 'Signed up' }),
-                    makeStep({ count: 20, fromBasisStep: 0.2, name: 'Purchased' }),
-                ]
-                const result = buildFunnelBarHorizontalData(steps, { ...options, stepReference })
-                expect(dataAcross(result, 0)).toEqual(expected)
-            }
-        )
-
-        it('honors stepReference.previous as the basis for breakdown fractions', () => {
+        it('sizes breakdown stacks from the precomputed aggregate rate, not the neighboring step count', () => {
+            // Optional steps + "relative to previous step": fromBasisStep is computed against the last
+            // non-optional step, and an optional step can out-count its immediate predecessor. Deriving
+            // the basis from steps[i - 1] here would put step 2 at 130/50 = 260%, clamped to a full bar.
             const steps: FunnelStepWithConversionMetrics[] = [
-                makeStep({ count: 100, fromBasisStep: 1, name: 'Viewed' }),
-                makeStep({ count: 50, fromBasisStep: 0.5, name: 'Signed up' }),
                 makeStep({
-                    count: 30,
-                    fromBasisStep: 0.3,
-                    name: 'Purchased',
+                    count: 2000,
+                    fromBasisStep: 1,
+                    name: 'Viewed',
                     nested_breakdown: [
-                        makeStep({ count: 20, fromBasisStep: 0.4, breakdown_value: 'mobile' }),
-                        makeStep({ count: 10, fromBasisStep: 0.2, breakdown_value: 'desktop' }),
+                        makeStep({ count: 1200, fromBasisStep: 1, breakdown_value: 'mobile' }),
+                        makeStep({ count: 800, fromBasisStep: 1, breakdown_value: 'desktop' }),
+                    ],
+                }),
+                makeStep({
+                    count: 50,
+                    fromBasisStep: 0.025,
+                    name: 'Connected (optional)',
+                    nested_breakdown: [
+                        makeStep({ count: 30, fromBasisStep: 0.025, breakdown_value: 'mobile' }),
+                        makeStep({ count: 20, fromBasisStep: 0.025, breakdown_value: 'desktop' }),
+                    ],
+                }),
+                makeStep({
+                    count: 130,
+                    fromBasisStep: 0.065,
+                    name: 'Pushed (optional)',
+                    nested_breakdown: [
+                        makeStep({ count: 100, fromBasisStep: 0.083, breakdown_value: 'mobile' }),
+                        makeStep({ count: 30, fromBasisStep: 0.0375, breakdown_value: 'desktop' }),
                     ],
                 }),
             ]
-            const result = buildFunnelBarHorizontalData(steps, {
-                ...options,
-                stepReference: FunnelStepReference.previous,
-            })
-            // Step 0 has no nested_breakdown, so the non-breakdown path is taken regardless of stepReference.
-            expect(dataAcross(result, 0)).toEqual([100, 50, 30])
+            const result = buildFunnelBarHorizontalData(steps, options)
+            expect(dataAcross(result, 0)).toEqual([60, 1.5, 5]) // mobile: count share of the aggregate rate
+            expect(dataAcross(result, 1)).toEqual([40, 1, 1.5]) // desktop
+            expect(result.map(stackTotal)).toEqual([100, 100, 100]) // segments + filler always close the track
         })
     })
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -212,9 +212,7 @@ describe('buildFunnelBarHorizontalData', () => {
 
     describe('reference step', () => {
         it('sizes breakdown stacks from the precomputed aggregate rate, not the neighboring step count', () => {
-            // Optional steps + "relative to previous step": fromBasisStep is computed against the last
-            // non-optional step, and an optional step can out-count its immediate predecessor. Deriving
-            // the basis from steps[i - 1] here would put step 2 at 130/50 = 260%, clamped to a full bar.
+            // Optional step 2 out-counts step 1; a steps[i - 1] basis would give 260% and clamp to a full bar.
             const steps: FunnelStepWithConversionMetrics[] = [
                 makeStep({
                     count: 2000,

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -1,9 +1,9 @@
 import type { Series, TooltipContext } from '@posthog/quill-charts'
 
-import { getReferenceStep, getStepBreakdownSeries, hasBreakdown } from 'scenes/funnels/funnelUtils'
+import { getStepBreakdownSeries, hasBreakdown } from 'scenes/funnels/funnelUtils'
 
 import type { BreakdownFilter } from '~/queries/schema/schema-general'
-import { FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
+import { type FunnelStepWithConversionMetrics } from '~/types'
 
 import {
     buildFunnelBarHorizontalDropOff,
@@ -27,7 +27,6 @@ export {
 } from '../shared/funnelBarHorizontalShared'
 
 interface BuildOptions {
-    stepReference: FunnelStepReference
     breakdownFilter?: BreakdownFilter | null
     getColor: (series: FunnelStepWithConversionMetrics) => string
     getLabel: (series: FunnelStepWithConversionMetrics) => string
@@ -66,13 +65,18 @@ function buildBreakdownSegments(
     options: BuildOptions
 ): Series<FunnelBarHorizontalSegmentMeta>[] {
     const step = steps[stepIndex]
-    const basisCount = getReferenceStep(steps, options.stepReference, stepIndex).count
+    // Distribute the step's precomputed aggregate rate across variants by count, so the stacked
+    // total always matches the rate shown in the step footer. Recomputing the basis from the
+    // neighboring step would ignore optional steps: with "relative to previous step", the rates
+    // treat the last non-optional step as previous, and an optional step can out-count its
+    // immediate predecessor — count / previousStep.count then exceeds 100% and clamps to a full bar.
+    const fractionPerCount = step.count > 0 ? step.conversionRates.fromBasisStep / step.count : 0
     const breakdownCount = steps[0].nested_breakdown!.length
     const segments: Series<FunnelBarHorizontalSegmentMeta>[] = []
 
     for (let breakdownIndex = 0; breakdownIndex < breakdownCount; breakdownIndex++) {
         const variant = variantAtStep(step, breakdownIndex)
-        const fraction = variant && basisCount > 0 ? variant.count / basisCount : 0
+        const fraction = variant ? variant.count * fractionPerCount : 0
         // Color and label come from step 0's variant so the same breakdown reads consistently
         // across steps even when a later step is missing that variant.
         const representative = variantAtStep(steps[0], breakdownIndex)!

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -65,11 +65,8 @@ function buildBreakdownSegments(
     options: BuildOptions
 ): Series<FunnelBarHorizontalSegmentMeta>[] {
     const step = steps[stepIndex]
-    // Distribute the step's precomputed aggregate rate across variants by count, so the stacked
-    // total always matches the rate shown in the step footer. Recomputing the basis from the
-    // neighboring step would ignore optional steps: with "relative to previous step", the rates
-    // treat the last non-optional step as previous, and an optional step can out-count its
-    // immediate predecessor — count / previousStep.count then exceeds 100% and clamps to a full bar.
+    // Split the precomputed rate across variants by count so the stack matches the footer.
+    // Deriving the basis from the neighboring step would ignore optional steps and overflow the bar.
     const fractionPerCount = step.count > 0 ? step.conversionRates.fromBasisStep / step.count : 0
     const breakdownCount = steps[0].nested_breakdown!.length
     const segments: Series<FunnelBarHorizontalSegmentMeta>[] = []


### PR DESCRIPTION
## Problem

In a funnel with optional steps and "conversion rate relative to previous step", the top-to-bottom (horizontal bars) layout rendered breakdown bar widths that contradicted the percentages printed under each step: a step with a ~5% conversion could render a full-width bar. The left-to-right layout of the same insight rendered correctly.

**Why:** the breakdown path in the top-to-bottom chart recomputed each segment's basis from the immediately preceding step's count. The precomputed conversion rates treat the last *non-optional* step as "previous", so an optional step that out-counts its immediate (optional) predecessor produced fractions above 100%, clamped to a full bar.

## Changes

- `buildBreakdownSegments` now distributes the step's precomputed aggregate rate (`conversionRates.fromBasisStep`) across breakdown variants by count, so the stacked bar total always equals the rate shown in the step footer — for any step reference, with or without optional steps.
- Removed the now-unused `stepReference` build option (the precomputed rate already encodes it).

## How did you test this code?

- Added a regression test where an optional step out-counts its immediate predecessor with a breakdown: previously the recomputed fraction exceeded 100% and clamped to a full bar; the test asserts segments are sized from the precomputed aggregate rate and the stack always closes the 0–100 track. No existing test covered a breakdown step whose neighbor-derived basis diverges from `fromBasisStep`.
- Removed two tests that existed only to exercise the deleted `stepReference` option.
- Ran the full `funnelBarHorizontalTransforms` Jest suite (32 passed) and the frontend TypeScript check (remaining errors are pre-existing and unrelated).
- Not able to verify visually in a running app in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — rendering bug fix, no behavior/API/config change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from two screenshots of the same funnel in both layouts: bar widths in the top-to-bottom view matched count-over-immediately-preceding-step while the footers matched count-over-last-non-optional-step, which pointed at `buildBreakdownSegments` recomputing the basis via `getReferenceStep` instead of using the precomputed `conversionRates`. Considered threading the optional-steps list into the transform, but deriving segment widths from the already-correct `fromBasisStep` is simpler and keeps the bar consistent with the footer by construction. Skills invoked: /writing-tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
