### PR TITLE
feat(retention): two-arm first-time scan on the legacy path

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -610,7 +610,28 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             source=ast.Field(chain=["events", "timestamp"])
         )
 
-        event_filters = self._event_filters()
+        two_arm = self._legacy_first_time_two_arm_scan()
+        if two_arm:
+            # Aliasing the UNION as `events` keeps every aggregate expression below identical;
+            # only the entity conditions swap to the arms' role tags.
+            select_from = ast.JoinExpr(
+                table=ast.SelectSetQuery.create_from_queries(
+                    [
+                        self._legacy_scan_arm(self.start_event, "start"),
+                        self._legacy_scan_arm(self.return_event, "return"),
+                    ],
+                    "UNION ALL",
+                ),
+                alias="events",
+            )
+            where: ast.Expr | None = None
+            start_condition: ast.Expr = parse_expr("events.matches_start = 1")
+            return_condition: ast.Expr = parse_expr("events.is_return = 1")
+        else:
+            select_from = ast.JoinExpr(table=ast.Field(chain=["events"]))
+            where = ast.And(exprs=self._event_filters())
+            start_condition = self.start_entity_expr
+            return_condition = self.return_entity_expr
 
         start_event_timestamps = parse_expr(
             """
@@ -624,7 +645,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             """,
             {
                 "start_of_interval_sql": start_of_interval_sql,
-                "start_entity_expr": self.start_entity_expr,
+                "start_entity_expr": start_condition,
                 "filter_timestamp": self.events_timestamp_filter(),
             },
         )
@@ -641,7 +662,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 """,
                 {
                     "start_of_interval_timestamp": start_of_interval_sql,
-                    "returning_entity_expr": self.return_entity_expr,
+                    "returning_entity_expr": return_condition,
                     "filter_timestamp": self.events_timestamp_filter(),
                 },
             ),
@@ -684,12 +705,14 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             return_event_timestamps = self._get_return_event_timestamps_expr(
                 minimum_occurrences=self.minimum_occurrences,
                 start_of_interval_sql=start_of_interval_sql,
-                return_entity_expr=self.return_entity_expr,
+                return_entity_expr=return_condition,
             )
             return_event_values = None
 
         if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
-            min_timestamp_inner_expr = self.get_first_time_anchor_expr(self.start_event)
+            min_timestamp_inner_expr = (
+                self._legacy_two_arm_anchor_expr() if two_arm else self.get_first_time_anchor_expr(self.start_event)
+            )
 
             start_event_timestamps = parse_expr(
                 """
@@ -777,8 +800,8 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         inner_query = ast.SelectQuery(
             select=select_fields,
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
-            where=ast.And(exprs=event_filters),
+            select_from=select_from,
+            where=where,
             group_by=[ast.Field(chain=["actor_id"])],
             having=ast.And(
                 exprs=[
@@ -805,6 +828,73 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
         return inner_query
+
+    def _legacy_first_time_two_arm_scan(self) -> bool:
+        # The tag-column arms carry no event properties, so any per-row property read in the
+        # outer query (value breakdowns, property aggregation) keeps the single scan.
+        return (
+            self._first_time_split_shrinks_scan()
+            and not self.has_property_aggregation
+            and not has_breakdown_filter(self.query.breakdownFilter)
+        )
+
+    def _first_time_split_shrinks_scan(self) -> bool:
+        if not (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            return False
+        if self._start_and_return_entities_are_same():
+            return False
+        return None not in self.runner.get_events_for_entity(self.start_event)
+
+    def _legacy_scan_arm(self, entity: RetentionEntity, query_kind: Literal["start", "return"]) -> ast.SelectQuery:
+        filters = [*self.runner.arm_event_filters(entity, query_kind)]
+        if query_kind == "start":
+            # The first-ever anchor needs the no-props stream, so property matching moves into
+            # the matches_start column instead of the WHERE.
+            arm_predicate = (
+                self.entity_expr_no_props(entity)
+                if self.is_first_ever_occurrence
+                else self.entity_expr_with_props(entity)
+            )
+            matches_start: ast.Expr = (
+                self.entity_expr_with_props(entity) if self.is_first_ever_occurrence else ast.Constant(value=1)
+            )
+            is_start, is_return = 1, 0
+        else:
+            arm_predicate = self.entity_expr_with_props(entity)
+            matches_start = ast.Constant(value=0)
+            is_start, is_return = 0, 1
+        if not (isinstance(arm_predicate, ast.Constant) and arm_predicate.value is True):
+            filters.append(arm_predicate)
+
+        return ast.SelectQuery(
+            select=[
+                ast.Alias(
+                    alias=self.aggregation_target_events_column,
+                    expr=ast.Field(chain=["events", self.aggregation_target_events_column]),
+                ),
+                ast.Alias(alias="timestamp", expr=ast.Field(chain=["events", "timestamp"])),
+                ast.Alias(alias="is_start", expr=ast.Constant(value=is_start)),
+                ast.Alias(alias="matches_start", expr=matches_start),
+                ast.Alias(alias="is_return", expr=ast.Constant(value=is_return)),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(exprs=filters) if filters else None,
+        )
+
+    def _legacy_two_arm_anchor_expr(self) -> ast.Expr:
+        # Mirrors get_first_time_anchor_expr with the arms' tags standing in for the entity matchers.
+        if self.is_first_ever_occurrence:
+            return parse_expr(
+                """
+                if(
+                    minIf(events.timestamp, events.is_start = 1)
+                        = minIf(events.timestamp, events.matches_start = 1),
+                    minIf(events.timestamp, events.is_start = 1),
+                    NULL
+                )
+                """
+            )
+        return parse_expr("minIf(events.timestamp, events.matches_start = 1)")
 
     def _get_minimum_occurrences_aliases(self, minimum_occurrences: int, with_dupes_expr: ast.Expr) -> list[ast.Alias]:
         """

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from math import ceil
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 from posthog.schema import (
     AggregationType,
@@ -246,18 +246,33 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             global_event_filters.append(is_relevant_event)
 
         if self.group_type_index is not None:
-            global_event_filters.append(
-                ast.Not(
-                    expr=ast.Call(
-                        name="has",
-                        args=[
-                            ast.Array(exprs=[ast.Constant(value="")]),
-                            ast.Field(chain=["events", f"$group_{self.group_type_index}"]),
-                        ],
-                    ),
-                ),
-            )
+            global_event_filters.append(self._group_actor_filter())
         return global_event_filters
+
+    def arm_event_filters(self, entity: RetentionEntity, query_kind: Literal["start", "return"]) -> list[ast.Expr]:
+        """Filters for one events-table arm of a two-scan retention query, scoped to that arm's entity only."""
+        filters = self.events_where_clause(
+            self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence, entities=[entity]
+        )
+        if query_kind == "return" and (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            # First-time modes need the start arm unbounded to find the first-ever start event.
+            # The return arm's timestamp aggregates are all window-conditioned, so bounding it
+            # drops no rows any aggregate depends on.
+            filters.append(self.events_timestamp_filter())
+        if self.group_type_index is not None:
+            filters.append(self._group_actor_filter())
+        return filters
+
+    def _group_actor_filter(self) -> ast.Expr:
+        return ast.Not(
+            expr=ast.Call(
+                name="has",
+                args=[
+                    ast.Array(exprs=[ast.Constant(value="")]),
+                    ast.Field(chain=["events", f"$group_{self.group_type_index}"]),
+                ],
+            ),
+        )
 
     def convert_single_breakdown_to_multiple_breakdowns(self):
         assert self.query.breakdownFilter is not None
@@ -359,10 +374,13 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             return action.get_step_events()
         return [entity.id] if isinstance(entity.id, str) else [None]
 
-    def events_where_clause(self, is_first_occurrence_matching_filters: bool, is_first_ever_occurrence: bool = False):
-        """
-        Event filters to apply to both start and return events
-        """
+    def events_where_clause(
+        self,
+        is_first_occurrence_matching_filters: bool,
+        is_first_ever_occurrence: bool = False,
+        entities: list[RetentionEntity] | None = None,
+    ):
+        """Event filters for both start and return events, or just `entities` for a per-arm scan."""
         events_where = []
 
         if self.query.properties is not None and self.query.properties != []:
@@ -381,10 +399,12 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             events_where.append(self.events_timestamp_filter())
 
         # Pre-filter by event name
-        events = self.get_events_for_entity(self.start_event) + self.get_events_for_entity(self.return_event)
+        if entities is None:
+            entities = [self.start_event, self.return_event]
+        events = [event for entity in entities for event in self.get_events_for_entity(entity)]
         unique_events = set(events)
-        # Don't pre-filter if any of them is "All events"
-        if None not in unique_events:
+        # Don't pre-filter if any of them is "All events" or the entity has no events at all
+        if unique_events and None not in unique_events:
             events_where.append(
                 ast.CompareOperation(
                     left=ast.Field(chain=["event"]),

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -1391,23 +1391,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(events.timestamp, equals(events.matches_start, 1)), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               1 AS matches_start,
+               0 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1477,23 +1497,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(events.timestamp, equals(events.is_start, 1)), minIf(events.timestamp, equals(events.matches_start, 1))), minIf(events.timestamp, equals(events.is_start, 1)), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)) AS matches_start,
+               0 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), equals(events.event, 'target_event'))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1606,23 +1646,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(events.timestamp, equals(events.is_start, 1)), minIf(events.timestamp, equals(events.matches_start, 1))), minIf(events.timestamp, equals(events.is_start, 1)), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events_json AS events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)) AS matches_start,
+               0 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), equals(events.event, 'target_event'))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -1692,23 +1752,43 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0))), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+    (SELECT events.person_id AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.matches_start, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(events.timestamp, equals(events.matches_start, 1)), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
-            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arraySort(groupUniqArrayIf(toStartOfDay(events.timestamp), and(equals(events.is_return, 1), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM events_json AS events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)), equals(events.event, 'returning_event')))
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               1 AS is_start,
+               1 AS matches_start,
+               0 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('target_event')), and(equals(events.event, 'target_event'), ifNull(equals(if(notEquals(toJSONString(events.properties.^prop), '{}'), toJSONString(events.properties.^prop), if(isNull(events.properties.prop), NULL, if(startsWith(dynamicType(events.properties.prop), 'DateTime'), replaceOne(toString(events.properties.prop), ' ', 'T'), if(or(startsWith(dynamicType(events.properties.prop), 'Array'), startsWith(dynamicType(events.properties.prop), 'Map'), startsWith(dynamicType(events.properties.prop), 'Tuple')), toJSONString(events.properties.prop), toString(events.properties.prop))))), 'correct'), 0)))
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                         0 AS is_start,
+                         0 AS matches_start,
+                         1 AS is_return
+        FROM events_json AS events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), equals(events.event, 'returning_event'))) AS events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -8132,3 +8132,145 @@ class TestClickhouseRetentionGroupAggregation(
     #     self.assertIn("USA", breakdown_values)
     #     self.assertNotIn("Canada", breakdown_values)
     #     self.assertIn(BREAKDOWN_OTHER_STRING_LABEL, breakdown_values)  # Canada should be in "Other"
+
+
+class TestRetentionLegacyFirstTimeTwoArmScan(APIBaseTest):
+    def _legacy_base_query(
+        self,
+        retention_type: str,
+        target: dict | None = None,
+        returning: dict | None = None,
+        breakdown_filter: dict | None = None,
+        aggregation_property: str | None = None,
+        aggregation_group_type_index: int | None = None,
+    ) -> ast.SelectQuery:
+        query: dict = {
+            "kind": "RetentionQuery",
+            "retentionFilter": {
+                "retentionType": retention_type,
+                "targetEntity": target or {"id": "signup", "type": "events"},
+                "returningEntity": returning or {"id": "did_action", "type": "events"},
+            },
+        }
+        if breakdown_filter is not None:
+            query["breakdownFilter"] = breakdown_filter
+        if aggregation_property is not None:
+            query["retentionFilter"]["aggregationType"] = "sum"
+            query["retentionFilter"]["aggregationProperty"] = aggregation_property
+        if aggregation_group_type_index is not None:
+            query["aggregation_group_type_index"] = aggregation_group_type_index
+        runner = RetentionQueryRunner(team=self.team, query=query)
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=False):
+            return RetentionFixedIntervalBaseQueryBuilder(runner).build_base_query()
+
+    @staticmethod
+    def _where_constants(arm: ast.SelectQuery) -> list[Any]:
+        constants: list[Any] = []
+
+        def walk(value: Any) -> None:
+            if isinstance(value, ast.Constant):
+                constants.append(value.value)
+            if hasattr(value, "__dataclass_fields__"):
+                for field_name in value.__dataclass_fields__:
+                    walk(getattr(value, field_name))
+            elif isinstance(value, list | tuple):
+                for item in value:
+                    walk(item)
+
+        walk(arm.where)
+        return constants
+
+    @staticmethod
+    def _where_has_timestamp_bound(arm: ast.SelectQuery) -> bool:
+        found = False
+
+        def walk(value: Any) -> None:
+            nonlocal found
+            if isinstance(value, ast.CompareOperation) and isinstance(value.left, ast.Field):
+                if value.left.chain[-1] == "timestamp":
+                    found = True
+            if hasattr(value, "__dataclass_fields__"):
+                for field_name in value.__dataclass_fields__:
+                    walk(getattr(value, field_name))
+            elif isinstance(value, list | tuple):
+                for item in value:
+                    walk(item)
+
+        walk(arm.where)
+        return found
+
+    @parameterized.expand(["retention_first_time", "retention_first_ever_occurrence"])
+    def test_first_time_modes_scan_two_arms_with_bounded_return_arm(self, retention_type):
+        base_query = self._legacy_base_query(retention_type)
+        assert base_query.select_from is not None
+        self.assertEqual(base_query.select_from.alias, "events")
+        table = base_query.select_from.table
+        self.assertIsInstance(table, ast.SelectSetQuery)
+        start_arm, return_arm = list(table.select_queries())  # type: ignore[union-attr]
+
+        start_constants = self._where_constants(start_arm)
+        return_constants = self._where_constants(return_arm)
+        self.assertIn("signup", start_constants)
+        self.assertNotIn("did_action", start_constants)
+        self.assertIn("did_action", return_constants)
+        self.assertNotIn("signup", return_constants)
+
+        self.assertFalse(self._where_has_timestamp_bound(start_arm))
+        self.assertTrue(self._where_has_timestamp_bound(return_arm))
+
+    @parameterized.expand(
+        [
+            ("recurring", "retention_recurring", None, None, None, None),
+            (
+                "same_entity",
+                "retention_first_time",
+                {"id": "signup", "type": "events"},
+                {"id": "signup", "type": "events"},
+                None,
+                None,
+            ),
+            ("all_events_target", "retention_first_time", {"id": None, "type": "events"}, None, None, None),
+            (
+                "breakdown",
+                "retention_first_time",
+                None,
+                None,
+                {"breakdowns": [{"type": "event", "property": "plan"}]},
+                None,
+            ),
+            ("property_aggregation", "retention_first_time", None, None, None, "revenue"),
+        ]
+    )
+    def test_keeps_single_scan_when_split_cannot_apply(
+        self, _name, retention_type, target, returning, breakdown_filter, aggregation_property
+    ):
+        base_query = self._legacy_base_query(
+            retention_type,
+            target=target,
+            returning=returning,
+            breakdown_filter=breakdown_filter,
+            aggregation_property=aggregation_property,
+        )
+        assert base_query.select_from is not None
+        self.assertIsInstance(base_query.select_from.table, ast.Field)
+
+    def test_first_time_group_aggregation_filters_both_arms(self):
+        base_query = self._legacy_base_query("retention_first_time", aggregation_group_type_index=0)
+        assert base_query.select_from is not None
+        table = base_query.select_from.table
+        self.assertIsInstance(table, ast.SelectSetQuery)
+
+        def collect_chains(value, chains):
+            if isinstance(value, ast.Field):
+                chains.append(value.chain)
+            if hasattr(value, "__dataclass_fields__"):
+                for field_name in value.__dataclass_fields__:
+                    collect_chains(getattr(value, field_name), chains)
+            elif isinstance(value, list | tuple):
+                for item in value:
+                    collect_chains(item, chains)
+
+        for arm in table.select_queries():  # type: ignore[union-attr]
+            chains: list = []
+            collect_chains(arm.where, chains)
+            self.assertIn(["events", "$group_0"], chains)


### PR DESCRIPTION
## Problem

First-time and first-ever retention are the most expensive insight queries in the query log. In those modes the base scan has no timestamp bound, because the first-occurrence anchor has to look at all history, and when the returning entity is "All events" it has no event-name prefilter either. The result is one merged scan that reads every aggregate input column over the team's entire event history.

Only a small slice of those rows needs to be read that wide. The start entity's rows are the only ones the anchor needs all-time, and they need very few columns. Everything else is only consumed inside window-bounded aggregates. Bounding the whole scan with an OR doesn't help, since ClickHouse still reads every referenced column for every granule the unbounded branch can match.

## Changes

Inside `build_base_query_legacy`, when the split can shrink the scan, the single `FROM events` is replaced by a `UNION ALL` of two lean arms:

- the start arm scans all-time but only the start entity's event names, emitting just the actor, the timestamp, and role tags
- the return arm is scoped to the returning entity and bounded to the query window

The union is aliased back as `events` with tag columns (`is_start`, `matches_start`, `is_return`), so every aggregate expression in the outer query stays byte-identical and only the entity conditions swap to tag comparisons. A row matching both entities appears once per arm and contributes to exactly the aggregates it did before.

The rewrite applies only when it can pay for itself and stay provably equivalent:

- first-time or first-ever mode, concrete start event names, start and return entities differ
- no value breakdown and no property aggregation, since those read event properties in the outer query and the tag arms don't carry them

## How did you test this code?

- New AST-shape tests (written first, verified failing): first-time and first-ever modes produce the two-arm union with an unbounded entity-scoped start arm and a bounded return arm; recurring, same-entity, all-events-target, breakdown, and property-aggregation shapes keep the single scan; group aggregation carries the `$group_N` filter into both arms. These catch a regression where the gate silently widens or the arms lose their bounds, which no existing test pinned.
- Full retention suite passes in both events-schema modes, so all existing first-time behavioral tests exercise the new SQL end to end.
- Benchmarked the generated SQL against a production first-time retention query (concrete start event with person and event property filters, all-events return with an event-name exclusion, test-account filters, 8 day intervals). Interleaved runs on production replicas with condition and uncompressed caches off and direct IO, results byte-identical on both pairs:

| metric | before (single scan) | after (two arms) | ratio |
| --- | --- | --- | --- |
| bytes read | 2.44 TiB | 10.79 GiB | 231x |
| CPU time | 165 s | 9.1 s | 18x |
| wall time | 4.8 s | 0.8 s | 6x |
| peak memory | 3.5 GiB | 0.5 GiB | 7x |

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: /writing-tests, /query-clickhouse-via-metabase (for the production benchmark), plus the superpowers TDD and debugging skills.

Decisions along the way:

- Design choice: raw row-stream arms with role tags plus an unchanged outer query, rather than per-arm pre-aggregation. Per-actor resolution (first-occurrence anchor, interval indexing) still happens in one place, which keeps the equivalence argument simple and avoids arms disagreeing on per-actor values.
- The first-ever anchor compares a no-props minimum against a with-props minimum, so the start arm filters on the props-stripped matcher and evaluates the full matcher into the `matches_start` column instead.
- Breakdown and property-aggregation shapes are deliberately excluded rather than ported, keeping the equivalence argument airtight; they can follow if the query log shows expensive queries of that shape.
