### PR TITLE
chore(insights): remove product-analytics-quill-legend flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -428,7 +428,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_QUARTER_YEAR_INTERVALS: 'product-analytics-quarter-year-intervals', // owner: @sampennington #team-product-analytics, gates quarter/year interval selection on insights
     PRODUCT_ANALYTICS_QUILL_DATE_FILTER: 'product-analytics-quill-date-filter', // owner: @sampennington #team-product-analytics, swaps the insight date filter for the chip-based quill date filter (lemon-skinned)
-    PRODUCT_ANALYTICS_QUILL_LEGEND: 'product-analytics-quill-legend', // owner: #team-product-analytics, gates the in-chart quill legend replacing the legacy side InsightLegend
     PRODUCT_ANALYTICS_QUILL_SQL_CHARTS: 'product-analytics-quill-sql-charts', // owner: #team-data-tools, gates rendering DataVisualization line/area charts via @posthog/quill-charts
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_DWH: 'retention-dwh', // owner: @thmsobrmlr #team-product-analytics

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -4,7 +4,6 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import userEvent from '@testing-library/user-event'
 import { BindLogic, Provider } from 'kea'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -135,11 +134,11 @@ describe('InsightDisplayConfig', () => {
                     ],
                     displayItems: [
                         'Show values on series',
-                        'Show legend',
                         'Show alert threshold lines',
                         'Show multiple Y-axes',
                         'Show trend lines',
                         'Show annotations',
+                        'Show legendBottom',
                     ],
                 },
             ],
@@ -151,11 +150,11 @@ describe('InsightDisplayConfig', () => {
                     displayItems: [
                         'Show values on series',
                         'Show as % of total',
-                        'Show legend',
                         'Show alert threshold lines',
                         'Show multiple Y-axes',
                         'Show trend lines',
                         'Show annotations',
+                        'Show legendBottom',
                     ],
                 },
             ],
@@ -167,11 +166,11 @@ describe('InsightDisplayConfig', () => {
                     displayItems: [
                         'Show values on series',
                         'Show as % of total',
-                        'Show legend',
                         'Show alert threshold lines',
                         'Show multiple Y-axes',
                         'Show trend lines',
                         'Show annotations',
+                        'Show legendBottom',
                     ],
                 },
             ],
@@ -231,7 +230,7 @@ describe('InsightDisplayConfig', () => {
                 makeStickinessQuery(),
                 {
                     sections: ['Display'],
-                    displayItems: ['Show values on series', 'Show legend', 'Show multiple Y-axes'],
+                    displayItems: ['Show values on series', 'Show multiple Y-axes', 'Show legendBottom'],
                 },
             ],
             [
@@ -334,7 +333,7 @@ describe('InsightDisplayConfig', () => {
             await openOptionsMenu()
 
             const items = getDisplaySectionItems()
-            expect(items).toContain('Show legend')
+            expect(items.some((item) => item.includes('Show legend'))).toBe(true)
             expect(items).toContain('Show values on series')
             expect(items).toContain('Show alert threshold lines')
             expect(items).toContain('Show trend lines')
@@ -365,13 +364,7 @@ describe('InsightDisplayConfig', () => {
         })
     })
 
-    describe('line graph display options with the quill legend flag', () => {
-        beforeEach(() => {
-            featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]: true,
-            })
-        })
-
+    describe('in-chart legend position options', () => {
         it('keeps the "Show legend" checkbox and adds a position select on the same row', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.ActionsLineGraph))
             await openOptionsMenu()

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -63,7 +63,6 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     } = useValues(trendsDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
     const hideWeekendsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]
-    const quillLegendEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]
     const styleRefreshEnabled = !!featureFlags[FEATURE_FLAGS.QUILL_CHART_STYLE_REFRESH]
 
     // The slope graph shows the first vs last interval, so it drops the options that need the points
@@ -95,7 +94,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     // of the legacy show/hide checkbox. usesInChartLegend is the single source of truth (same
     // selector used by InsightVizDisplay to suppress the side legend). Funnel trends with breakdown
     // also get the position selector since they render the quill legend via config.legend.
-    const useQuillLegendOptions = usesInChartLegend || (quillLegendEnabled && showFunnelLegendConfig)
+    const useQuillLegendOptions = usesInChartLegend || showFunnelLegendConfig
 
     const showDisplaySection =
         (isTrends && !isCalendarHeatmap) || isRetention || isTrendsFunnel || isStickiness || isLifecycle

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -1085,7 +1085,6 @@ export interface insightVizDataLogicMeta {
             display: ChartDisplayType | null | undefined
         ) => boolean
         usesInChartLegend: (
-            featureFlags: FeatureFlagsSet,
             isTrends: boolean,
             isStickiness: boolean,
             isLifecycle: boolean,
@@ -2223,20 +2222,16 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         // side legend) instead of the legacy show/hide checkbox. Single source of truth shared by
         // InsightDisplayConfig (which control to show) and InsightVizDisplay (suppress side legend).
         usesInChartLegend: [
-            (s) => [s.featureFlags, s.isTrends, s.isStickiness, s.isLifecycle, s.display],
+            (s) => [s.isTrends, s.isStickiness, s.isLifecycle, s.display],
             (
-                featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet,
                 isTrends: boolean,
                 isStickiness: boolean,
                 isLifecycle: boolean,
                 display: ChartDisplayType | null | undefined
             ): boolean => {
-                // Lifecycle always uses config.legend inside TimeSeriesBarChart — no flag gate needed.
+                // Lifecycle always uses config.legend inside TimeSeriesBarChart.
                 if (isLifecycle) {
                     return true
-                }
-                if (!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]) {
-                    return false
                 }
                 return (isTrends || isStickiness) && (!display || DISPLAYS_WITH_IN_CHART_LEGEND.includes(display))
             },

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -4,8 +4,6 @@ import { cleanup, configure, screen, waitFor } from '@testing-library/react'
 
 import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildStickinessQuery, chart, personsModal, renderInsight } from '~/test/insight-testing'
 import { ChartDisplayType } from '~/types'
@@ -93,8 +91,7 @@ describe('StickinessBarChart', () => {
         expect(personsModal.title()).toMatch(/Pageview/)
     })
 
-    describe('quill in-chart legend (PRODUCT_ANALYTICS_QUILL_LEGEND on)', () => {
-        const quillLegendFlag = { [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]: true }
+    describe('quill in-chart legend', () => {
         const twoSeriesBar = stickinessBar({
             series: [
                 { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
@@ -107,7 +104,7 @@ describe('StickinessBarChart', () => {
             container.querySelector<HTMLElement>('[data-attr="hog-chart-timeseries-bar-legend"]')!
 
         it('humanizes core event names in the legend, leaving custom events as-is', async () => {
-            const { container } = renderInsight({ query: twoSeriesBar, featureFlags: quillLegendFlag })
+            const { container } = renderInsight({ query: twoSeriesBar })
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/chart with 2 data series/i)).toBeInTheDocument()

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -50,7 +50,6 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
     const tooltipConfig = STICKINESS_TOOLTIP_CONFIG
 
     const legendConfig = useInsightsLegendConfig({ insightProps })
-    const quillLegendEnabled = !!legendConfig
 
     const {
         indexedResults,
@@ -58,7 +57,6 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
         interval,
         yAxisScaleType,
         getTrendsColor,
-        getTrendsHidden,
         currentPeriodResult,
         breakdownFilter,
         trendsFilter,
@@ -97,13 +95,13 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
         () =>
             buildStickinessBarSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
                 getColor: getTrendsColor,
-                // With the quill legend on, hidden series stay listed (dimmed) and are excluded via
-                // config.legend.hiddenKeys instead of being dropped here, so the legend can restore them.
-                getHidden: quillLegendEnabled ? undefined : getTrendsHidden,
+                // Hidden series stay listed (dimmed) and are excluded via config.legend.hiddenKeys
+                // instead of being dropped here, so the legend can restore them.
+                getHidden: undefined,
                 getLabel,
                 buildMeta: buildTrendsSeriesMeta,
             }),
-        [indexedResults, getTrendsColor, getTrendsHidden, getLabel, quillLegendEnabled]
+        [indexedResults, getTrendsColor, getLabel]
     )
 
     const chartConfig: TimeSeriesBarChartConfig = useChartConfig(

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -4,8 +4,6 @@ import { cleanup, configure, screen, waitFor } from '@testing-library/react'
 
 import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-
 import { ExportType } from '~/exporter/types'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildStickinessQuery, chart, personsModal, renderInsight } from '~/test/insight-testing'
@@ -100,8 +98,7 @@ describe('StickinessLineChart', () => {
         })
     })
 
-    describe('quill in-chart legend (PRODUCT_ANALYTICS_QUILL_LEGEND on)', () => {
-        const quillLegendFlag = { [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]: true }
+    describe('quill in-chart legend', () => {
         const twoSeriesLine = buildStickinessQuery({
             series: [
                 { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
@@ -114,7 +111,7 @@ describe('StickinessLineChart', () => {
             container.querySelector<HTMLElement>('[data-attr="hog-chart-timeseries-line-legend"]')!
 
         it('humanizes core event names in the legend, leaving custom events as-is', async () => {
-            const { container } = renderInsight({ query: twoSeriesLine, featureFlags: quillLegendFlag })
+            const { container } = renderInsight({ query: twoSeriesLine })
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/chart with 2 data series/i)).toBeInTheDocument()

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -51,7 +51,6 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
     const tooltipConfig = STICKINESS_TOOLTIP_CONFIG
 
     const legendConfig = useInsightsLegendConfig({ insightProps })
-    const quillLegendEnabled = !!legendConfig
 
     const {
         indexedResults,
@@ -60,7 +59,6 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         yAxisScaleType,
         showMultipleYAxes,
         getTrendsColor,
-        getTrendsHidden,
         currentPeriodResult,
         breakdownFilter,
         trendsFilter,
@@ -101,13 +99,13 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
                 showMultipleYAxes: showMultipleYAxes ?? undefined,
                 display: display ?? undefined,
                 getColor: getTrendsColor,
-                // With the quill legend on, hidden series stay listed (dimmed) and are excluded via
-                // config.legend.hiddenKeys instead of being dropped here, so the legend can restore them.
-                getHidden: quillLegendEnabled ? undefined : getTrendsHidden,
+                // Hidden series stay listed (dimmed) and are excluded via config.legend.hiddenKeys
+                // instead of being dropped here, so the legend can restore them.
+                getHidden: undefined,
                 getLabel,
                 buildMeta: buildTrendsSeriesMeta,
             }),
-        [indexedResults, display, getTrendsColor, getTrendsHidden, getLabel, showMultipleYAxes, quillLegendEnabled]
+        [indexedResults, display, getTrendsColor, getLabel, showMultipleYAxes]
     )
 
     const chartConfig: TimeSeriesLineChartConfig = useChartConfig(

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -4,8 +4,6 @@ import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
 
 import { dimensions, setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-
 import { ExportType } from '~/exporter/types'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildTrendsQuery, chart, getHogChart, personsModal, renderInsight } from '~/test/insight-testing'
@@ -560,8 +558,7 @@ describe('TrendsBarChart overlays', () => {
         }
     )
 
-    describe('quill in-chart legend (PRODUCT_ANALYTICS_QUILL_LEGEND on)', () => {
-        const quillLegendFlag = { [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]: true }
+    describe('quill in-chart legend', () => {
         const twoSeriesBar = trendsBar({
             series: [
                 { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
@@ -574,7 +571,7 @@ describe('TrendsBarChart overlays', () => {
             container.querySelector<HTMLElement>('[data-attr="hog-chart-timeseries-bar-legend"]')!
 
         it('renders the in-chart legend with a row per series', async () => {
-            const { container } = renderInsight({ query: twoSeriesBar, featureFlags: quillLegendFlag })
+            const { container } = renderInsight({ query: twoSeriesBar })
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/chart with 2 data series/i)).toBeInTheDocument()

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -122,7 +122,6 @@ export function TrendsBarChart({
 
     const isAggregated = display === ChartDisplayType.ActionsBarValue
     const isGrouped = display === ChartDisplayType.ActionsUnstackedBar
-    const quillLegendEnabled = !isAggregated && !!legendConfig
     const isPercentStackView = !isAggregated && !!showPercentStackView && !!supportsPercentStackView
     // Per-series y-axes are only meaningful for grouped (unstacked) bars — stacked layouts share
     // one axis. Mirrors the legacy ActionsLineGraph, which assigns y0/y1/… per dataset.
@@ -173,9 +172,9 @@ export function TrendsBarChart({
         }
         const timeSeries = buildTrendsBarTimeSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
             getColor: getTrendsColor,
-            // With the quill legend on, hidden series stay listed (dimmed) and are excluded via
-            // config.legend.hiddenKeys instead of being dropped here, so the legend can restore them.
-            getHidden: quillLegendEnabled ? undefined : getTrendsHidden,
+            // Hidden series stay listed (dimmed) and are excluded via config.legend.hiddenKeys
+            // instead of being dropped here, so the legend can restore them.
+            getHidden: undefined,
             getLabel,
             buildMeta: buildTrendsSeriesMeta,
             showMultipleYAxes: applyMultipleYAxes,
@@ -195,7 +194,6 @@ export function TrendsBarChart({
         getAggregatedDisplayLabel,
         getLabel,
         applyMultipleYAxes,
-        quillLegendEnabled,
     ])
 
     const valueLabelFormatter = useCallback(

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -616,8 +616,7 @@ describe('TrendsLineChart', () => {
         })
     })
 
-    describe('quill in-chart legend (PRODUCT_ANALYTICS_QUILL_LEGEND on)', () => {
-        const quillLegendFlag = { [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]: true }
+    describe('quill in-chart legend', () => {
         const twoSeriesQuery = buildTrendsQuery({
             series: [
                 { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
@@ -630,7 +629,7 @@ describe('TrendsLineChart', () => {
             container.querySelector<HTMLElement>('[data-attr="hog-chart-timeseries-line-legend"]')!
 
         it('renders the in-chart legend and suppresses the legacy side legend', async () => {
-            const { container } = renderInsight({ query: twoSeriesQuery, featureFlags: quillLegendFlag })
+            const { container } = renderInsight({ query: twoSeriesQuery })
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/chart with 2 data series/i)).toBeInTheDocument()
@@ -642,7 +641,7 @@ describe('TrendsLineChart', () => {
         })
 
         it('keeps a toggled-off series listed and dimmed in the legend but out of the tooltip', async () => {
-            const { container } = renderInsight({ query: twoSeriesQuery, featureFlags: quillLegendFlag })
+            const { container } = renderInsight({ query: twoSeriesQuery })
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/chart with 2 data series/i)).toBeInTheDocument()
@@ -668,7 +667,6 @@ describe('TrendsLineChart', () => {
         it('renders a static, non-interactive legend in shared mode', async () => {
             const { container } = renderInsight({
                 query: twoSeriesQuery,
-                featureFlags: quillLegendFlag,
                 inSharedMode: true,
             })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -47,7 +47,6 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
     const { insightProps, insight } = useValues(insightLogic)
 
     const legendConfig = useInsightsLegendConfig({ insightProps, inSharedMode })
-    const quillLegendEnabled = !!legendConfig
 
     const {
         indexedResults,
@@ -213,9 +212,9 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                 incompletenessOffsetFromEnd,
                 isStickiness,
                 getColor: getTrendsColor,
-                // With the quill legend on, hidden series are listed (dimmed) and excluded via
-                // config.legend.hiddenKeys instead of being dropped here, so the legend can restore them.
-                getHidden: quillLegendEnabled ? undefined : getTrendsHidden,
+                // Hidden series are listed (dimmed) and excluded via config.legend.hiddenKeys instead
+                // of being dropped here, so the legend can restore them.
+                getHidden: undefined,
                 getLabel,
                 buildMeta: buildTrendsSeriesMeta,
             }),
@@ -226,9 +225,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             incompletenessOffsetFromEnd,
             isStickiness,
             getTrendsColor,
-            getTrendsHidden,
             getLabel,
-            quillLegendEnabled,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import { BindLogic } from 'kea'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -23,15 +22,9 @@ const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
     </BindLogic>
 )
 
-function setup({
-    trendsFilter,
-    flagEnabled = true,
-}: { trendsFilter?: TrendsFilter; flagEnabled?: boolean } = {}): void {
+function setup({ trendsFilter }: { trendsFilter?: TrendsFilter } = {}): void {
     initKeaTests()
     featureFlagLogic.mount()
-    featureFlagLogic.actions.setFeatureFlags([], {
-        [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]: flagEnabled,
-    })
 
     dataNodeLogic({ key: 'InsightViz.new', query: {} as DataNode }).mount()
     insightDataLogic(insightProps).mount()
@@ -43,14 +36,6 @@ function setup({
 }
 
 describe('useInsightsLegendConfig', () => {
-    it('returns undefined when the quill legend flag is off', () => {
-        setup({ flagEnabled: false, trendsFilter: { showLegend: true } })
-
-        const { result } = renderHook(() => useInsightsLegendConfig({ insightProps }), { wrapper })
-
-        expect(result.current).toBeUndefined()
-    })
-
     it.each([
         { legendPosition: 'left', expected: 'left' },
         { legendPosition: 'right', expected: 'right' },

--- a/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.tsx
@@ -3,8 +3,6 @@ import { useMemo, type ReactNode } from 'react'
 
 import type { ChartLegendConfig, LegendItem } from '@posthog/quill-charts'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
@@ -18,16 +16,13 @@ interface UseInsightsLegendConfigOptions {
     inSharedMode?: boolean
 }
 
-/** Builds the quill in-chart legend config for trends-family charts. Returns `undefined` when the
- *  quill-legend flag is off. Wires toggle persistence and the isolate/show-all context menu through
- *  trendsDataLogic. Lifecycle and funnel charts build their legend config inline (they don't read
- *  from trendsDataLogic or need the flag gate). */
+/** Builds the quill in-chart legend config for trends-family charts. Wires toggle persistence and the
+ *  isolate/show-all context menu through trendsDataLogic. Lifecycle and funnel charts build their
+ *  legend config inline (they don't read from trendsDataLogic). */
 export function useInsightsLegendConfig({
     insightProps,
     inSharedMode = false,
-}: UseInsightsLegendConfigOptions): ChartLegendConfig | undefined {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const quillLegendEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]
+}: UseInsightsLegendConfigOptions): ChartLegendConfig {
     const { canEditInsight } = useValues(insightLogic)
     const { indexedResults, getTrendsHidden, showLegend, legendPosition, legendSeriesIsolationMenuEligible } =
         useValues(trendsDataLogic(insightProps))
@@ -41,11 +36,7 @@ export function useInsightsLegendConfig({
 
     const legendInteractive = canEditInsight && !inSharedMode
 
-    return useMemo<ChartLegendConfig | undefined>(() => {
-        if (!quillLegendEnabled) {
-            return undefined
-        }
-
+    return useMemo<ChartLegendConfig>(() => {
         const hiddenKeys = (indexedResults ?? []).filter((r) => getTrendsHidden(r)).map((r) => String(r.id))
         const showContextMenu = legendInteractive && legendSeriesIsolationMenuEligible
         return {
@@ -74,7 +65,6 @@ export function useInsightsLegendConfig({
                 : undefined,
         }
     }, [
-        quillLegendEnabled,
         indexedResults,
         getTrendsHidden,
         showLegend,


### PR DESCRIPTION
## Problem

The in-chart quill legend for trends and stickiness charts has been behind the `product-analytics-quill-legend` flag. It's ready to be the default, so the flag is now just dead weight gating the rollout.

## Changes

Roll the quill in-chart legend out to everyone by removing the flag and making it the default for trends and stickiness charts.

- Drop the `PRODUCT_ANALYTICS_QUILL_LEGEND` constant.
- `usesInChartLegend` no longer reads the flag; `useInsightsLegendConfig` always returns a config instead of `undefined` when the flag was off.
- Remove the now-dead legacy-legend branches in the trends/stickiness chart components (hidden series are always handled via `config.legend.hiddenKeys`, not dropped from the series).
- Tests that flipped the flag on now assert the same behavior as the default.

No visual change for anyone who already had the flag on. The only behavior change is that everyone else now gets the in-chart legend that previously required the flag.

## How did you test this code?

Automated only (I'm Claude, agent-assisted — no manual browser testing). I ran locally:

- The six affected Jest suites plus `InsightVizDisplay` and `insightVizDataLogic` (the selector I changed): all pass (~320 tests).
- `oxlint` + `oxfmt`: clean.
- `tsgo --noEmit`: no errors in any file this PR touches.

The test edits are maintenance, not new coverage: I removed the "flag off returns undefined" case (that path no longer exists) and updated the option-menu ordering assertions in `InsightDisplayConfig.test.tsx`, since the legend option now renders as an in-chart position select at the end of the Display section rather than a mid-list checkbox.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sam asked to clean up the quill-legend flag and roll it out. I (Claude) traced every reference to the flag, removed the gate, and collapsed the resulting dead branches rather than just hardcoding the flag to `true`. Invoked the `/writing-tests` skill before touching tests to keep the changes to genuine behavior-preserving maintenance. Left the legacy `InsightLegend` component in place since it's still used by pie/table/box-plot charts and the exporter — only the trends/stickiness gate is gone.

The `product-analytics-quill-legend` feature flag object itself can be deleted once this ships.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
