### PR TITLE
refactor(data-warehouse): migrate coda, aiven, asana, clickup, clockify to rest_source (batch 11)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/aiven.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/aiven.py
@@ -1,9 +1,5 @@
-from collections.abc import Iterator
+from collections.abc import Callable
 from typing import Any
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.aiven.settings import (
@@ -11,161 +7,257 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.aiven.sett
     AivenEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 AIVEN_BASE_URL = "https://api.aiven.io/v1"
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
+
+# Aiven list endpoints return the whole collection in one JSON response with no pagination params,
+# so every resource is a single unpaginated GET.
+_SINGLE_PAGE = SinglePagePaginator
+
+# Parent list endpoints each fan-out mode iterates. `field` is the parent row key bound into the
+# child path (also injected into child rows so composite primary keys stay unique table-wide).
+_PROJECT_PARENT = {"name": "projects", "path": "/project", "data_key": "projects", "field": "project_name"}
+_ORG_PARENT = {
+    "name": "organizations",
+    "path": "/organizations",
+    "data_key": "organizations",
+    "field": "organization_id",
+}
 
 
-class AivenRetryableError(Exception):
-    pass
-
-
-def _get_headers(api_token: str) -> dict[str, str]:
+def _auth_header_value(api_token: str) -> str:
     # Aiven expects the literal `aivenv1` prefix before the token, not `Bearer`.
+    return f"aivenv1 {api_token}"
+
+
+def _client_config(api_token: str) -> ClientConfig:
+    # The credential travels via framework api_key auth (not a hand-built header) so its value is
+    # registered for redaction wherever it surfaces in logs; only non-secret headers go here.
     return {
-        "Authorization": f"aivenv1 {api_token}",
-        "Accept": "application/json",
+        "base_url": AIVEN_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {
+            "type": "api_key",
+            "api_key": _auth_header_value(api_token),
+            "name": "Authorization",
+            "location": "header",
+        },
     }
 
 
-def _make_session(api_token: str) -> requests.Session:
-    # Redact the token everywhere it could surface: the `aivenv1 <token>` scheme is
-    # non-standard, so the tracked transport's name-based scrubbers can't recognise it.
-    return make_tracked_session(redact_values=(api_token,))
-
-
-@retry(
-    retry=retry_if_exception_type((AivenRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch(
-    url: str, headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Aiven does not publish rate limits; treat 429 and transient 5xx as retryable and let the
-    # exponential backoff handle spacing. Everything else (401/403/404) is surfaced immediately.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AivenRetryableError(f"Aiven API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Never log the raw body: these are authenticated third-party responses whose error
-        # payloads can echo tenant metadata or request details into centralized logs.
-        logger.error(f"Aiven API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _list(
-    path: str, data_key: str, headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> list[dict[str, Any]]:
-    """Fetch a single unpaginated Aiven list endpoint and return the rows under ``data_key``.
-
-    Aiven list endpoints return the whole collection in one JSON response (``{"<data_key>": [...]}``)
-    with no pagination params documented or accepted, so a single GET is the complete result.
+def _stamp_parent_field(
+    parent_name: str, parent_field: str, target: str, *, overwrite: bool
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Remap the `_{parent}_{field}` key that ``include_from_parent`` lands onto the clean column the
+    row carried before the migration. ``overwrite`` mirrors the old injection: parent keys the child
+    never has (``project_name``, ``invoice_number``) are set unconditionally; ``organization_id`` is a
+    ``setdefault`` so a row that already carries a real org id keeps it.
     """
-    data = _fetch(f"{AIVEN_BASE_URL}{path}", headers, logger, session)
-    rows = data.get(data_key) or []
-    return rows if isinstance(rows, list) else []
+    source_key = f"_{parent_name}_{parent_field}"
+
+    def _map(row: dict[str, Any]) -> dict[str, Any]:
+        value = row.pop(source_key, None)
+        if value is None:
+            return row
+        if overwrite or target not in row:
+            row[target] = value
+        return row
+
+    return _map
 
 
-def _iter_rows(
-    config: AivenEndpointConfig, headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> Iterator[list[dict[str, Any]]]:
-    """Yield one batch of rows per upstream request, fanning out over parents as needed.
+def _standard_resource(config: AivenEndpointConfig, client_config: ClientConfig, team_id: int, job_id: str) -> Resource:
+    # A missing/empty/non-list data key yields no rows (the old `_list` returned []); the selector is
+    # deliberately non-required so a changed shape degrades to 0 rows rather than failing loud.
+    rest_config: RESTAPIConfig = {
+        "client": client_config,
+        "resources": [
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path_template,
+                    "data_selector": config.data_key,
+                    "paginator": _SINGLE_PAGE(),
+                },
+            }
+        ],
+    }
+    return rest_api_resource(rest_config, team_id, job_id, None)
 
-    Child rows get their parent identifiers injected as top-level fields so composite primary
-    keys stay unique table-wide and rows remain traceable to their parent resource.
+
+def _single_parent_resource(
+    config: AivenEndpointConfig,
+    parent: dict[str, str],
+    placeholder: str,
+    target: str,
+    client_config: ClientConfig,
+    team_id: int,
+    job_id: str,
+    *,
+    overwrite: bool,
+) -> Resource:
+    """Fan out one request per parent (project or organization), stamping the parent id into each row."""
+    rest_config: RESTAPIConfig = {
+        "client": client_config,
+        "resources": [
+            {
+                "name": parent["name"],
+                "endpoint": {
+                    "path": parent["path"],
+                    "data_selector": parent["data_key"],
+                    "paginator": _SINGLE_PAGE(),
+                },
+            },
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path_template,
+                    "params": {placeholder: {"type": "resolve", "resource": parent["name"], "field": parent["field"]}},
+                    "data_selector": config.data_key,
+                    "paginator": _SINGLE_PAGE(),
+                },
+                "include_from_parent": [parent["field"]],
+                "data_map": _stamp_parent_field(parent["name"], parent["field"], target, overwrite=overwrite),
+            },
+        ],
+    }
+    resources = rest_api_resources(rest_config, team_id, job_id, None)
+    return next(r for r in resources if r.name == config.name)
+
+
+def _invoice_lines_resource(
+    config: AivenEndpointConfig, client_config: ClientConfig, team_id: int, job_id: str
+) -> Resource:
+    """Two-level fan-out: organization -> invoice -> lines.
+
+    The intermediate invoices resource carries its organization id down (``include_from_parent``) so
+    the lines path can bind both ``{organization_id}`` and ``{invoice_number}`` from the same invoice
+    row. Line rows get ``organization_id`` (setdefault) and ``invoice_number`` (overwrite) — the exact
+    shape the old two-level loop produced.
     """
+    rest_config: RESTAPIConfig = {
+        "client": client_config,
+        "resources": [
+            {
+                "name": "organizations",
+                "endpoint": {
+                    "path": _ORG_PARENT["path"],
+                    "data_selector": _ORG_PARENT["data_key"],
+                    "paginator": _SINGLE_PAGE(),
+                },
+            },
+            {
+                "name": "invoices",
+                "endpoint": {
+                    "path": "/organization/{organization_id}/invoices",
+                    "params": {
+                        "organization_id": {"type": "resolve", "resource": "organizations", "field": "organization_id"}
+                    },
+                    "data_selector": "invoices",
+                    "paginator": _SINGLE_PAGE(),
+                },
+                "include_from_parent": ["organization_id"],
+                # Land the grandparent org id as a clean column so the lines resource can resolve it.
+                "data_map": _stamp_parent_field("organizations", "organization_id", "organization_id", overwrite=True),
+            },
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path_template,
+                    "params": {
+                        "organization_id": {"type": "resolve", "resource": "invoices", "field": "organization_id"},
+                        "invoice_number": {"type": "resolve", "resource": "invoices", "field": "invoice_number"},
+                    },
+                    "data_selector": config.data_key,
+                    "paginator": _SINGLE_PAGE(),
+                },
+                "include_from_parent": ["organization_id", "invoice_number"],
+                "data_map": _compose(
+                    _stamp_parent_field("invoices", "organization_id", "organization_id", overwrite=False),
+                    _stamp_parent_field("invoices", "invoice_number", "invoice_number", overwrite=True),
+                ),
+            },
+        ],
+    }
+    resources = rest_api_resources(rest_config, team_id, job_id, None)
+    return next(r for r in resources if r.name == config.name)
+
+
+def _compose(
+    *maps: Callable[[dict[str, Any]], dict[str, Any]],
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    def _map(row: dict[str, Any]) -> dict[str, Any]:
+        for m in maps:
+            row = m(row)
+        return row
+
+    return _map
+
+
+def _build_resource(config: AivenEndpointConfig, api_token: str, team_id: int, job_id: str) -> Resource:
+    client_config = _client_config(api_token)
+
     if config.fan_out == "none":
-        rows = _list(config.path_template, config.data_key, headers, logger, session)
-        if rows:
-            yield rows
-        return
-
+        return _standard_resource(config, client_config, team_id, job_id)
     if config.fan_out == "project":
-        for project in _list("/project", "projects", headers, logger, session):
-            project_name = project["project_name"]
-            path = config.path_template.format(project=project_name)
-            rows = _list(path, config.data_key, headers, logger, session)
-            for row in rows:
-                row["project_name"] = project_name
-            if rows:
-                yield rows
-        return
-
+        return _single_parent_resource(
+            config, _PROJECT_PARENT, "project", "project_name", client_config, team_id, job_id, overwrite=True
+        )
     if config.fan_out == "organization":
-        for org in _list("/organizations", "organizations", headers, logger, session):
-            organization_id = org["organization_id"]
-            path = config.path_template.format(organization_id=organization_id)
-            rows = _list(path, config.data_key, headers, logger, session)
-            for row in rows:
-                row.setdefault("organization_id", organization_id)
-            if rows:
-                yield rows
-        return
-
+        return _single_parent_resource(
+            config,
+            _ORG_PARENT,
+            "organization_id",
+            "organization_id",
+            client_config,
+            team_id,
+            job_id,
+            overwrite=False,
+        )
     if config.fan_out == "invoice":
-        for org in _list("/organizations", "organizations", headers, logger, session):
-            organization_id = org["organization_id"]
-            invoices = _list(f"/organization/{organization_id}/invoices", "invoices", headers, logger, session)
-            for invoice in invoices:
-                invoice_number = invoice["invoice_number"]
-                path = config.path_template.format(organization_id=organization_id, invoice_number=invoice_number)
-                rows = _list(path, config.data_key, headers, logger, session)
-                for row in rows:
-                    row.setdefault("organization_id", organization_id)
-                    row["invoice_number"] = invoice_number
-                if rows:
-                    yield rows
-        return
+        return _invoice_lines_resource(config, client_config, team_id, job_id)
 
     raise ValueError(f"Unknown fan_out mode: {config.fan_out}")
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = AIVEN_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-    # One session for the whole run so fan-out requests reuse pooled connections.
-    session = _make_session(api_token)
-    yield from _iter_rows(config, headers, logger, session)
-
-
-def validate_credentials(api_token: str) -> bool:
-    """Confirm the token is valid. ``/me`` reflects the token itself and needs no resource scope."""
-    try:
-        response = _make_session(api_token).get(
-            f"{AIVEN_BASE_URL}/me",
-            headers=_get_headers(api_token),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
 
 
 def aiven_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     config = AIVEN_ENDPOINTS[endpoint]
+    resource = _build_resource(config, api_token, team_id, job_id)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_token=api_token, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_token: str) -> bool:
+    """Confirm the token is valid. ``/me`` reflects the token itself and needs no resource scope."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{AIVEN_BASE_URL}/me",
+        headers={"Authorization": _auth_header_value(api_token), "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/source.py
@@ -27,7 +27,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AivenSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -94,22 +97,12 @@ Billing tables (billing groups, invoices, invoice lines) and organization member
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=AIVEN_ENDPOINTS[endpoint].should_sync_default,
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            should_sync_default={name: cfg.should_sync_default for name, cfg in AIVEN_ENDPOINTS.items()},
+        )
 
     def validate_credentials(
         self, config: AivenSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -123,5 +116,6 @@ Billing tables (billing groups, invoices, invoice lines) and organization member
         return aiven_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/tests/test_aiven.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/tests/test_aiven.py
@@ -1,221 +1,213 @@
-from typing import Any, cast
+import json
+from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, patch
 
 import requests
 from parameterized import parameterized
-from tenacity import stop_after_attempt, wait_none
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.aiven import aiven
 from products.warehouse_sources.backend.temporal.data_imports.sources.aiven.aiven import (
-    _fetch,
-    _get_headers,
-    _iter_rows,
-    _list,
+    AIVEN_BASE_URL,
+    _auth_header_value,
     aiven_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.aiven.settings import AIVEN_ENDPOINTS
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the aiven module.
+AIVEN_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.aiven.aiven.make_tracked_session"
+)
 
-def _response(status_code: int, body: dict[str, Any] | None = None) -> MagicMock:
-    resp = MagicMock(spec=requests.Response)
+
+def _response(status_code: int, body: Any) -> requests.Response:
+    resp = requests.Response()
     resp.status_code = status_code
-    resp.ok = status_code < 400
-    resp.text = ""
-    resp.json.return_value = body or {}
-
-    def _raise() -> None:
-        if not resp.ok:
-            raise requests.HTTPError(
-                f"{status_code} Client Error: for url: https://api.aiven.io/v1/x",
-                response=cast(requests.Response, resp),
-            )
-
-    resp.raise_for_status.side_effect = _raise
+    resp._content = json.dumps(body).encode()
     return resp
 
 
-class TestGetHeaders:
+def _wire(session: MagicMock, responses_by_path: dict[str, requests.Response]) -> list[str]:
+    """Wire a mock session that dispatches each request to a response by its (formatted) path.
+
+    Fan-out issues one request per parent row in a deterministic order, but keying by path keeps the
+    test robust to ordering. Returns the list of paths requested, in call order.
+    """
+    session.headers = {}
+    requested_paths: list[str] = []
+
+    def _prepare(request: Any) -> MagicMock:
+        prepared = MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    def _send(prepared: Any, **kwargs: Any) -> requests.Response:
+        path = prepared.url.replace(AIVEN_BASE_URL, "")
+        requested_paths.append(path)
+        return responses_by_path[path]
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = _send
+    return requested_paths
+
+
+def _rows(endpoint: str) -> list[dict[str, Any]]:
+    response = aiven_source("tok", endpoint, team_id=1, job_id="j")
+    return [row for page in response.items() for row in page]
+
+
+class TestAuthHeader:
     def test_uses_aivenv1_scheme_not_bearer(self) -> None:
-        headers = _get_headers("tok-123")
         # Aiven requires the literal `aivenv1` prefix; a `Bearer` prefix is rejected by the API.
-        assert headers["Authorization"] == "aivenv1 tok-123"
-        assert "Bearer" not in headers["Authorization"]
+        value = _auth_header_value("tok-123")
+        assert value == "aivenv1 tok-123"
+        assert "Bearer" not in value
 
 
-class TestFetch:
-    def test_success_returns_json(self) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(200, {"projects": [{"project_name": "p1"}]})
-        result = _fetch("https://api.aiven.io/v1/project", {}, MagicMock(), session)
-        assert result == {"projects": [{"project_name": "p1"}]}
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_retry_then_raise(self, _name: str, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status)
-        # tenacity attaches `retry_with` to the wrapped fn at runtime; the type stub omits it.
-        fetch = _fetch.retry_with(stop=stop_after_attempt(3), wait=wait_none())  # type: ignore[attr-defined]
-        with pytest.raises(aiven.AivenRetryableError):
-            fetch("https://api.aiven.io/v1/project", {}, MagicMock(), session)
-        assert session.get.call_count == 3
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_immediately_without_retry(self, _name: str, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch("https://api.aiven.io/v1/project", {}, MagicMock(), session)
-        # Credential/permission failures must not burn retries.
-        assert session.get.call_count == 1
-
-
-class TestList:
+class TestListExtraction:
     @parameterized.expand(
         [
             ("present", {"projects": [{"project_name": "p1"}]}, [{"project_name": "p1"}]),
             ("missing_key", {"other": []}, []),
             ("null_value", {"projects": None}, []),
-            ("non_list", {"projects": {"nested": 1}}, []),
+            ("empty_list", {"projects": []}, []),
         ]
     )
-    def test_extracts_rows_under_data_key(self, _name: str, body: dict[str, Any], expected: list) -> None:
-        with patch.object(aiven, "_fetch", return_value=body):
-            assert _list("/project", "projects", {}, MagicMock(), MagicMock()) == expected
+    @patch(CLIENT_SESSION_PATCH)
+    def test_extracts_rows_under_data_key(
+        self, _name: str, body: dict[str, Any], expected: list, MockSession: MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, {"/project": _response(200, body)})
+        assert _rows("projects") == expected
 
 
 class TestFanOut:
-    def test_fan_out_none_yields_single_batch(self) -> None:
-        with patch.object(aiven, "_fetch", return_value={"clouds": [{"cloud_name": "aws-x"}]}):
-            batches = list(_iter_rows(AIVEN_ENDPOINTS["clouds"], {}, MagicMock(), MagicMock()))
-        assert batches == [[{"cloud_name": "aws-x"}]]
+    @patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_none_yields_rows(self, MockSession: MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, {"/clouds": _response(200, {"clouds": [{"cloud_name": "aws-x"}]})})
+        assert _rows("clouds") == [{"cloud_name": "aws-x"}]
 
-    def test_fan_out_project_injects_parent_project_name(self) -> None:
+    @patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_project_injects_parent_project_name(self, MockSession: MagicMock) -> None:
         # `services` items carry no project field, so the parent's `project_name` must be injected
         # to keep the composite primary key unique across projects.
-        responses = {
-            "/project": {"projects": [{"project_name": "p1"}, {"project_name": "p2"}]},
-            "/project/p1/service": {"services": [{"service_name": "s1"}]},
-            "/project/p2/service": {"services": [{"service_name": "s2"}]},
-        }
-
-        def fake_fetch(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            return responses[url.replace(aiven.AIVEN_BASE_URL, "")]
-
-        with patch.object(aiven, "_fetch", side_effect=fake_fetch):
-            batches = list(_iter_rows(AIVEN_ENDPOINTS["services"], {}, MagicMock(), MagicMock()))
-
-        assert batches == [
-            [{"service_name": "s1", "project_name": "p1"}],
-            [{"service_name": "s2", "project_name": "p2"}],
-        ]
-
-    def test_fan_out_organization_injects_org_without_overwriting(self) -> None:
-        responses = {
-            "/organizations": {"organizations": [{"organization_id": "org1"}]},
-            "/organization/org1/user": {"users": [{"user_id": "u1"}]},
-        }
-
-        def fake_fetch(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            return responses[url.replace(aiven.AIVEN_BASE_URL, "")]
-
-        with patch.object(aiven, "_fetch", side_effect=fake_fetch):
-            batches = list(_iter_rows(AIVEN_ENDPOINTS["organization_users"], {}, MagicMock(), MagicMock()))
-
-        assert batches == [[{"user_id": "u1", "organization_id": "org1"}]]
-
-    def test_fan_out_organization_setdefault_keeps_existing_org_id(self) -> None:
-        # billing_groups already carry organization_id; injection must not clobber it.
-        responses = {
-            "/organizations": {"organizations": [{"organization_id": "org1"}]},
-            "/organization/org1/billing-groups": {
-                "billing_groups": [{"billing_group_id": "bg1", "organization_id": "org-real"}]
+        session = MockSession.return_value
+        _wire(
+            session,
+            {
+                "/project": _response(200, {"projects": [{"project_name": "p1"}, {"project_name": "p2"}]}),
+                "/project/p1/service": _response(200, {"services": [{"service_name": "s1"}]}),
+                "/project/p2/service": _response(200, {"services": [{"service_name": "s2"}]}),
             },
-        }
-
-        def fake_fetch(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            return responses[url.replace(aiven.AIVEN_BASE_URL, "")]
-
-        with patch.object(aiven, "_fetch", side_effect=fake_fetch):
-            batches = list(_iter_rows(AIVEN_ENDPOINTS["billing_groups"], {}, MagicMock(), MagicMock()))
-
-        assert batches[0][0]["organization_id"] == "org-real"
-
-    def test_fan_out_invoice_two_levels_injects_org_and_invoice(self) -> None:
-        responses = {
-            "/organizations": {"organizations": [{"organization_id": "org1"}]},
-            "/organization/org1/invoices": {"invoices": [{"invoice_number": "inv1"}, {"invoice_number": "inv2"}]},
-            "/organization/org1/invoice/inv1/lines": {"lines": [{"line_type": "usage"}]},
-            "/organization/org1/invoice/inv2/lines": {"lines": [{"line_type": "credit"}]},
-        }
-
-        def fake_fetch(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            return responses[url.replace(aiven.AIVEN_BASE_URL, "")]
-
-        with patch.object(aiven, "_fetch", side_effect=fake_fetch):
-            batches = list(_iter_rows(AIVEN_ENDPOINTS["invoice_lines"], {}, MagicMock(), MagicMock()))
-
-        assert batches == [
-            [{"line_type": "usage", "organization_id": "org1", "invoice_number": "inv1"}],
-            [{"line_type": "credit", "organization_id": "org1", "invoice_number": "inv2"}],
+        )
+        assert _rows("services") == [
+            {"service_name": "s1", "project_name": "p1"},
+            {"service_name": "s2", "project_name": "p2"},
         ]
 
-    def test_empty_batches_are_not_yielded(self) -> None:
-        responses: dict[str, dict[str, Any]] = {
-            "/project": {"projects": [{"project_name": "p1"}, {"project_name": "p2"}]},
-            "/project/p1/service": {"services": []},
-            "/project/p2/service": {"services": [{"service_name": "s2"}]},
-        }
+    @patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_organization_injects_org(self, MockSession: MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            {
+                "/organizations": _response(200, {"organizations": [{"organization_id": "org1"}]}),
+                "/organization/org1/user": _response(200, {"users": [{"user_id": "u1"}]}),
+            },
+        )
+        assert _rows("organization_users") == [{"user_id": "u1", "organization_id": "org1"}]
 
-        def fake_fetch(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            return responses[url.replace(aiven.AIVEN_BASE_URL, "")]
+    @patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_organization_setdefault_keeps_existing_org_id(self, MockSession: MagicMock) -> None:
+        # billing_groups already carry organization_id; injection must not clobber it.
+        session = MockSession.return_value
+        _wire(
+            session,
+            {
+                "/organizations": _response(200, {"organizations": [{"organization_id": "org1"}]}),
+                "/organization/org1/billing-groups": _response(
+                    200, {"billing_groups": [{"billing_group_id": "bg1", "organization_id": "org-real"}]}
+                ),
+            },
+        )
+        rows = _rows("billing_groups")
+        assert rows == [{"billing_group_id": "bg1", "organization_id": "org-real"}]
 
-        with patch.object(aiven, "_fetch", side_effect=fake_fetch):
-            batches = list(_iter_rows(AIVEN_ENDPOINTS["services"], {}, MagicMock(), MagicMock()))
+    @patch(CLIENT_SESSION_PATCH)
+    def test_fan_out_invoice_two_levels_injects_org_and_invoice(self, MockSession: MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            {
+                "/organizations": _response(200, {"organizations": [{"organization_id": "org1"}]}),
+                "/organization/org1/invoices": _response(
+                    200, {"invoices": [{"invoice_number": "inv1"}, {"invoice_number": "inv2"}]}
+                ),
+                "/organization/org1/invoice/inv1/lines": _response(200, {"lines": [{"line_type": "usage"}]}),
+                "/organization/org1/invoice/inv2/lines": _response(200, {"lines": [{"line_type": "credit"}]}),
+            },
+        )
+        assert _rows("invoice_lines") == [
+            {"line_type": "usage", "organization_id": "org1", "invoice_number": "inv1"},
+            {"line_type": "credit", "organization_id": "org1", "invoice_number": "inv2"},
+        ]
 
-        assert batches == [[{"service_name": "s2", "project_name": "p2"}]]
+    @patch(CLIENT_SESSION_PATCH)
+    def test_empty_child_batches_are_not_yielded(self, MockSession: MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            {
+                "/project": _response(200, {"projects": [{"project_name": "p1"}, {"project_name": "p2"}]}),
+                "/project/p1/service": _response(200, {"services": []}),
+                "/project/p2/service": _response(200, {"services": [{"service_name": "s2"}]}),
+            },
+        )
+        assert _rows("services") == [{"service_name": "s2", "project_name": "p2"}]
 
 
-class TestValidateCredentials:
-    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("server_error", 500, False)])
-    def test_maps_status_to_bool(self, _name: str, status: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status)
-        with patch.object(aiven, "make_tracked_session", return_value=session):
-            assert validate_credentials("tok") is expected
-
-    def test_network_error_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(aiven, "make_tracked_session", return_value=session):
-            assert validate_credentials("tok") is False
+class TestFailLoud:
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    @patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_surface(self, _name: str, status: int, MockSession: MagicMock) -> None:
+        # A 4xx is non-retryable and must fail the sync loudly rather than syncing 0 rows silently.
+        session = MockSession.return_value
+        _wire(session, {"/project": _response(status, {"message": "nope"})})
+        with pytest.raises(requests.HTTPError):
+            _rows("projects")
 
 
-class TestAivenSource:
-    def test_get_rows_uses_single_tracked_session(self) -> None:
-        session = MagicMock()
-        with (
-            patch.object(aiven, "make_tracked_session", return_value=session) as make_session,
-            patch.object(aiven, "_iter_rows", return_value=iter([])) as iter_rows,
-        ):
-            list(get_rows("tok", "projects", MagicMock()))
-        make_session.assert_called_once()
-        # The one session is threaded into the fan-out so requests reuse pooled connections.
-        assert iter_rows.call_args.args[3] is session
-
+class TestSourceResponse:
     @parameterized.expand(list(AIVEN_ENDPOINTS.keys()))
-    def test_source_response_matches_endpoint_settings(self, endpoint: str) -> None:
+    @patch(CLIENT_SESSION_PATCH)
+    def test_source_response_matches_endpoint_settings(self, endpoint: str, MockSession: MagicMock) -> None:
         config = AIVEN_ENDPOINTS[endpoint]
-        response = aiven_source("tok", endpoint, MagicMock())
+        response = aiven_source("tok", endpoint, team_id=1, job_id="j")
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
         if config.partition_key:
             assert response.partition_mode == "datetime"
+            assert response.partition_format == "week"
             assert response.partition_keys == [config.partition_key]
         else:
             assert response.partition_mode is None
             assert response.partition_keys is None
+
+
+class TestValidateCredentials:
+    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("server_error", 500, False)])
+    @patch(AIVEN_SESSION_PATCH)
+    def test_maps_status_to_bool(self, _name: str, status: int, expected: bool, mock_session: MagicMock) -> None:
+        mock_session.return_value.get.return_value = MagicMock(status_code=status)
+        assert validate_credentials("tok") is expected
+
+    @patch(AIVEN_SESSION_PATCH)
+    def test_network_error_is_false(self, mock_session: MagicMock) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("tok") is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/tests/test_aiven_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aiven/tests/test_aiven_source.py
@@ -66,12 +66,15 @@ class TestSourceForPipeline:
     def test_passes_token_and_schema_through(self) -> None:
         inputs = MagicMock()
         inputs.schema_name = "invoices"
+        inputs.team_id = 7
+        inputs.job_id = "job-1"
         with patch.object(source_module, "aiven_source", return_value=MagicMock()) as aiven_source:
             AivenSource().source_for_pipeline(_config(), inputs)
         kwargs = aiven_source.call_args.kwargs
         assert kwargs["api_token"] == "tok"
         assert kwargs["endpoint"] == "invoices"
-        assert kwargs["logger"] is inputs.logger
+        assert kwargs["team_id"] == 7
+        assert kwargs["job_id"] == "job-1"
 
 
 class TestDocsAndErrors:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/asana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/asana.py
@@ -1,11 +1,5 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.asana.settings import (
@@ -14,214 +8,165 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.asana.sett
     AsanaEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 ASANA_BASE_URL = "https://app.asana.com/api/1.0"
 # Asana caps list pages at 100 items.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
 
-
-class AsanaRetryableError(Exception):
-    pass
+# Asana list responses carry the next-page link in the body under `next_page.uri` (a self-contained
+# absolute URL). A null `next_page` ends pagination.
+NEXT_URL_PATH = "next_page.uri"
 
 
 @dataclasses.dataclass
 class AsanaResumeConfig:
-    # Initial request URLs (one per parent for fan-out endpoints) not yet started.
-    remaining_urls: list[str]
-    # The next page URL to fetch for the in-progress request, or None when finished.
-    current_url: Optional[str]
+    # Legacy fields from the hand-rolled fan-out. Kept (now with defaults) so state saved by the
+    # previous implementation still deserializes via `ResumableSourceManager._load_json`.
+    remaining_urls: list[str] = dataclasses.field(default_factory=list)
+    current_url: Optional[str] = None
+    # Framework paginator / fan-out resume snapshot for the current endpoint. When only the legacy
+    # fields are present (old saved state) this is None and that part of the sync starts fresh —
+    # a re-fetch, which the merge dedupes on `gid`.
+    paginator_state: Optional[dict[str, Any]] = None
 
 
-def _get_headers(access_token: str) -> dict[str, str]:
+def _paginator() -> JSONResponsePaginator:
+    return JSONResponsePaginator(next_url_path=NEXT_URL_PATH)
+
+
+def _resource(name: str, path: str, params: dict[str, Any]) -> dict[str, Any]:
     return {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json",
+        "name": name,
+        "endpoint": {
+            "path": path,
+            "params": params,
+            "data_selector": "data",
+            "paginator": _paginator(),
+        },
     }
 
 
-def _with_query(path: str, params: dict[str, Any]) -> str:
-    """Append query params to a relative path that may already carry a `?workspace=` filter."""
-    clean = {key: value for key, value in params.items() if value is not None}
-    if not clean:
-        return f"{ASANA_BASE_URL}{path}"
-    separator = "&" if "?" in path else "?"
-    return f"{ASANA_BASE_URL}{path}{separator}{urlencode(clean)}"
+def _workspaces_parent(*, filter_organizations: bool) -> dict[str, Any]:
+    """Workspaces list used only to resolve child gids. `is_organization` is opted in so the
+    organization-only fan-out (teams) can drop non-organization workspaces."""
+    resource = _resource("workspaces", "/workspaces", {"limit": PAGE_SIZE, "opt_fields": "is_organization"})
+    if filter_organizations:
+        # `/organizations/{gid}/teams` is only valid for organization workspaces; returning [] drops
+        # the row so the child fan-out never requests it.
+        resource["data_map"] = lambda workspace: workspace if workspace.get("is_organization") else []
+    return resource
 
 
-def _list_params(config: AsanaEndpointConfig) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE}
+def _projects_parent() -> dict[str, Any]:
+    """Projects list (one request per workspace) used only to resolve project gids for the
+    project-level fan-out (tasks, sections)."""
+    return _resource(
+        "projects",
+        "/projects?workspace={workspace_gid}",
+        {"limit": PAGE_SIZE, "workspace_gid": {"type": "resolve", "resource": "workspaces", "field": "gid"}},
+    )
+
+
+def _build_resources(config: AsanaEndpointConfig) -> list[dict[str, Any]]:
+    """Build the rest_source resource chain for an endpoint, fanning out over parents as needed.
+    Only the last (target) resource's rows are surfaced; parents exist solely to resolve gids."""
+    target_params: dict[str, Any] = {"limit": PAGE_SIZE}
     if config.opt_fields:
-        params["opt_fields"] = ",".join(config.opt_fields)
-    return params
-
-
-@retry(
-    retry=retry_if_exception_type((AsanaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch_page(
-    url: str, headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Asana rate-limits at 150 req/min (free) / 1500 (paid) and returns 429 with a Retry-After
-    # header; exponential backoff is sufficient and avoids parsing the header here.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AsanaRetryableError(f"Asana API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Asana API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _iter_items(
-    start_url: str, headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> Iterator[dict[str, Any]]:
-    """Fully paginate a single list request, yielding individual records (used for discovery)."""
-    url: Optional[str] = start_url
-    while url is not None:
-        data = _fetch_page(url, headers, logger, session)
-        yield from data.get("data") or []
-        next_page = data.get("next_page")
-        url = next_page.get("uri") if isinstance(next_page, dict) else None
-
-
-def _list_workspaces(
-    headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> list[dict[str, Any]]:
-    url = _with_query("/workspaces", {"limit": PAGE_SIZE, "opt_fields": "is_organization"})
-    return list(_iter_items(url, headers, logger, session))
-
-
-def _list_projects(
-    headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> Iterator[dict[str, Any]]:
-    for workspace in _list_workspaces(headers, logger, session):
-        gid = workspace["gid"]
-        yield from _iter_items(
-            _with_query(f"/projects?workspace={gid}", {"limit": PAGE_SIZE}), headers, logger, session
-        )
-
-
-def _build_initial_urls(
-    config: AsanaEndpointConfig, headers: dict[str, str], logger: FilteringBoundLogger, session: requests.Session
-) -> list[str]:
-    """Resolve the set of request URLs for an endpoint, fanning out over parents as needed."""
-    params = _list_params(config)
+        target_params["opt_fields"] = ",".join(config.opt_fields)
 
     if config.fan_out == "none":
-        return [_with_query(config.path_template, params)]
+        return [_resource(config.name, config.path, target_params)]
 
     if config.fan_out in ("workspace", "organization"):
-        urls = []
-        for workspace in _list_workspaces(headers, logger, session):
-            if config.fan_out == "organization" and not workspace.get("is_organization"):
-                # `/organizations/{gid}/teams` is only valid for organization workspaces.
-                continue
-            urls.append(_with_query(config.path_template.format(gid=workspace["gid"]), params))
-        return urls
+        target_params["workspace_gid"] = {"type": "resolve", "resource": "workspaces", "field": "gid"}
+        return [
+            _workspaces_parent(filter_organizations=config.fan_out == "organization"),
+            _resource(config.name, config.path, target_params),
+        ]
 
     if config.fan_out == "project":
+        target_params["project_gid"] = {"type": "resolve", "resource": "projects", "field": "gid"}
         return [
-            _with_query(config.path_template.format(gid=project["gid"]), params)
-            for project in _list_projects(headers, logger, session)
+            _workspaces_parent(filter_organizations=False),
+            _projects_parent(),
+            _resource(config.name, config.path, target_params),
         ]
 
     raise ValueError(f"Unknown fan_out mode: {config.fan_out}")
 
 
-def validate_credentials(access_token: str) -> bool:
-    """Confirm the personal access token is valid. /users/me needs no extra scopes."""
-    try:
-        response = make_tracked_session().get(
-            f"{ASANA_BASE_URL}/users/me",
-            headers=_get_headers(access_token),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    access_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AsanaResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = ASANA_ENDPOINTS[endpoint]
-    headers = _get_headers(access_token)
-    # One session for the whole run so pagination and fan-out reuse pooled connections.
-    session = make_tracked_session()
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        remaining = list(resume_config.remaining_urls)
-        current = resume_config.current_url
-        logger.debug(f"Asana: resuming {endpoint} from URL: {current}")
-    else:
-        remaining = _build_initial_urls(config, headers, logger, session)
-        current = remaining.pop(0) if remaining else None
-
-    while current is not None:
-        data = _fetch_page(current, headers, logger, session)
-        items = data.get("data") or []
-
-        next_page = data.get("next_page")
-        next_url = next_page.get("uri") if isinstance(next_page, dict) else None
-
-        # Advance: continue the current request's page chain, else move to the next parent URL.
-        if next_url:
-            new_current: Optional[str] = next_url
-            new_remaining = remaining
-        elif remaining:
-            new_current = remaining[0]
-            new_remaining = remaining[1:]
-        else:
-            new_current = None
-            new_remaining = []
-
-        if items:
-            yield items
-
-        # Save AFTER yielding (and only while there's more to fetch) so a crash re-yields the
-        # last batch — merge dedupes on gid — rather than skipping it.
-        if new_current is not None:
-            resumable_source_manager.save_state(
-                AsanaResumeConfig(remaining_urls=new_remaining, current_url=new_current)
-            )
-
-        current = new_current
-        remaining = new_remaining
-
-
 def asana_source(
     access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AsanaResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = ASANA_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ASANA_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so the token is redacted from
+            # logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": access_token},
+            "paginator": _paginator(),
+        },
+        "resources": _build_resources(config),
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.paginator_state is not None:
+            initial_paginator_state = resume.paginator_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while there's more to fetch; the framework saves AFTER a page is yielded so a
+        # crash re-yields the last page (merge dedupes on gid) rather than skipping it. Multi-level
+        # (project) fan-out disables resume entirely, so this is never called for those endpoints.
+        if state:
+            resumable_source_manager.save_state(AsanaResumeConfig(paginator_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    target = next(resource for resource in resources if resource.name == endpoint)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            access_token=access_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: target,
         primary_keys=[PRIMARY_KEY],
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=target.column_hints,
     )
+
+
+def validate_credentials(access_token: str) -> bool:
+    """Confirm the personal access token is valid. /users/me needs no extra scopes."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_token,)),
+        f"{ASANA_BASE_URL}/users/me",
+        headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/settings.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional
 
 from products.warehouse_sources.backend.types import IncrementalField
 
-# How an endpoint's request URLs are derived:
+# How an endpoint's request URLs are derived (drives the rest_source resource chain):
 #   "none"          -> a single top-level list endpoint (no parent fan-out)
 #   "workspace"     -> one request per workspace the token can see
 #   "organization"  -> one request per workspace that is an organization
@@ -15,9 +15,10 @@ FanOut = Literal["none", "workspace", "organization", "project"]
 class AsanaEndpointConfig:
     name: str
     fan_out: FanOut
-    # Relative path appended to the API base. Contains a single ``{gid}`` placeholder for
-    # fan-out endpoints (the parent resource id), and no placeholder for top-level ones.
-    path_template: str
+    # Relative path appended to the API base. Fan-out endpoints carry a single ``{workspace_gid}``
+    # or ``{project_gid}`` placeholder that the framework binds from the parent row per request;
+    # top-level endpoints carry no placeholder.
+    path: str
     # Asana list endpoints return compact records ({gid, name, resource_type}) by default.
     # ``opt_fields`` opts extra properties into the response — keep the partition key here.
     opt_fields: list[str] = field(default_factory=list)
@@ -33,19 +34,19 @@ ASANA_ENDPOINTS: dict[str, AsanaEndpointConfig] = {
     "workspaces": AsanaEndpointConfig(
         name="workspaces",
         fan_out="none",
-        path_template="/workspaces",
+        path="/workspaces",
         opt_fields=["name", "email_domains", "is_organization", "resource_type"],
     ),
     "users": AsanaEndpointConfig(
         name="users",
         fan_out="none",
-        path_template="/users",
+        path="/users",
         opt_fields=["name", "email", "photo", "workspaces", "resource_type"],
     ),
     "projects": AsanaEndpointConfig(
         name="projects",
         fan_out="workspace",
-        path_template="/projects?workspace={gid}",
+        path="/projects?workspace={workspace_gid}",
         opt_fields=[
             "name",
             "created_at",
@@ -74,7 +75,7 @@ ASANA_ENDPOINTS: dict[str, AsanaEndpointConfig] = {
     "tasks": AsanaEndpointConfig(
         name="tasks",
         fan_out="project",
-        path_template="/tasks?project={gid}",
+        path="/tasks?project={project_gid}",
         opt_fields=[
             "name",
             "created_at",
@@ -102,27 +103,27 @@ ASANA_ENDPOINTS: dict[str, AsanaEndpointConfig] = {
     "tags": AsanaEndpointConfig(
         name="tags",
         fan_out="workspace",
-        path_template="/tags?workspace={gid}",
+        path="/tags?workspace={workspace_gid}",
         opt_fields=["name", "created_at", "color", "notes", "workspace", "permalink_url", "resource_type"],
         partition_key="created_at",
     ),
     "sections": AsanaEndpointConfig(
         name="sections",
         fan_out="project",
-        path_template="/projects/{gid}/sections",
+        path="/projects/{project_gid}/sections",
         opt_fields=["name", "created_at", "project", "resource_type"],
         partition_key="created_at",
     ),
     "teams": AsanaEndpointConfig(
         name="teams",
         fan_out="organization",
-        path_template="/organizations/{gid}/teams",
+        path="/organizations/{workspace_gid}/teams",
         opt_fields=["name", "description", "organization", "permalink_url", "visibility", "resource_type"],
     ),
     "custom_fields": AsanaEndpointConfig(
         name="custom_fields",
         fan_out="workspace",
-        path_template="/workspaces/{gid}/custom_fields",
+        path="/workspaces/{workspace_gid}/custom_fields",
         opt_fields=[
             "name",
             "description",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/source.py
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AsanaSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -103,21 +106,7 @@ Grant these read scopes so every table can sync:
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in list(ENDPOINTS)
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: AsanaSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -139,6 +128,8 @@ Grant these read scopes so every table can sync:
         return asana_source(
             access_token=config.access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Asana endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/tests/test_asana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/tests/test_asana.py
@@ -1,19 +1,33 @@
+import json
 from typing import Any, Optional
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana import (
     ASANA_BASE_URL,
     AsanaResumeConfig,
-    _build_initial_urls,
-    _list_params,
-    _with_query,
     asana_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.asana.settings import ASANA_ENDPOINTS, ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the asana module.
+ASANA_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana.make_tracked_session"
+)
+
+
+def _page(items: list[dict[str, Any]], next_uri: Optional[str] = None) -> Response:
+    body: dict[str, Any] = {"data": items, "next_page": {"uri": next_uri, "offset": "tok"} if next_uri else None}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: Optional[AsanaResumeConfig] = None) -> mock.MagicMock:
@@ -23,167 +37,212 @@ def _make_manager(resume_state: Optional[AsanaResumeConfig] = None) -> mock.Magi
     return manager
 
 
-def _page(items: list[dict[str, Any]], next_uri: Optional[str]) -> dict[str, Any]:
-    return {"data": items, "next_page": {"uri": next_uri, "offset": "tok"} if next_uri else None}
+def _wire(session: mock.MagicMock, routes: list[tuple[str, Response]]) -> list[str]:
+    """Wire a mock session that dispatches each request to the first still-unconsumed route whose
+    substring appears in the fully-prepared URL. Returns the list of URLs sent, in order.
+
+    Real ``Request.prepare()`` builds the URL (merging path-embedded query with the params dict and
+    applying Bearer auth) so fan-out over parents and multi-page pagination route deterministically.
+    """
+    session.headers = {}
+    sent_urls: list[str] = []
+    remaining = list(routes)
+
+    def _prepare(request: Any) -> Any:
+        return request.prepare()
+
+    def _send(prepared: Any, **kwargs: Any) -> Response:
+        sent_urls.append(prepared.url)
+        for i, (substr, response) in enumerate(remaining):
+            if substr in prepared.url:
+                remaining.pop(i)
+                return response
+        raise AssertionError(f"no route for {prepared.url}")
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = _send
+    return sent_urls
 
 
-def _ok_response(payload: dict[str, Any]) -> mock.MagicMock:
-    resp = mock.MagicMock(status_code=200, ok=True)
-    resp.json.return_value = payload
-    return resp
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
-class TestWithQuery:
-    def test_appends_with_question_mark_when_no_existing_query(self):
-        assert _with_query("/workspaces", {"limit": 100}) == f"{ASANA_BASE_URL}/workspaces?limit=100"
-
-    def test_appends_with_ampersand_when_query_present(self):
-        url = _with_query("/projects?workspace=1", {"limit": 100})
-        assert url == f"{ASANA_BASE_URL}/projects?workspace=1&limit=100"
-
-    def test_drops_none_values(self):
-        assert _with_query("/workspaces", {"limit": None}) == f"{ASANA_BASE_URL}/workspaces"
-
-    def test_encodes_comma_separated_opt_fields(self):
-        url = _with_query("/workspaces", {"opt_fields": "name,created_at"})
-        assert "opt_fields=name%2Ccreated_at" in url
+def _source(endpoint: str, manager: mock.MagicMock) -> Any:
+    return asana_source("token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
 
 
-class TestListParams:
-    def test_includes_limit_and_opt_fields(self):
-        params = _list_params(ASANA_ENDPOINTS["projects"])
-        assert params["limit"] == 100
-        assert params["opt_fields"] == ",".join(ASANA_ENDPOINTS["projects"].opt_fields)
-        assert "created_at" in params["opt_fields"]
+class TestTopLevelPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_next_page_uri_and_checkpoints(self, MockSession) -> None:
+        session = MockSession.return_value
+        next_uri = f"{ASANA_BASE_URL}/workspaces?offset=tok2"
+        urls = _wire(
+            session,
+            [
+                ("/workspaces?", _page([{"gid": "1"}, {"gid": "2"}], next_uri=next_uri)),
+                ("offset=tok2", _page([{"gid": "3"}])),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("workspaces", manager))
+
+        assert [r["gid"] for r in rows] == ["1", "2", "3"]
+        # First request carries the page size and opted-in fields.
+        assert "limit=100" in urls[0]
+        assert "opt_fields=" in urls[0]
+        # Checkpoint saved after the first page (points at the next link); the terminal page saves nothing.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == AsanaResumeConfig(paginator_state={"next_url": next_uri})
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        urls = _wire(session, [("/workspaces", _page([{"gid": "1"}]))])
+
+        manager = _make_manager()
+        rows = _rows(_source("workspaces", manager))
+
+        assert [r["gid"] for r in rows] == ["1"]
+        assert len(urls) == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_yields_nothing_and_saves_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [("/workspaces", _page([]))])
+
+        manager = _make_manager()
+        rows = _rows(_source("workspaces", manager))
+
+        assert rows == []
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_next_url(self, MockSession) -> None:
+        session = MockSession.return_value
+        resume_url = f"{ASANA_BASE_URL}/workspaces?offset=resume"
+        urls = _wire(session, [("offset=resume", _page([{"gid": "9"}]))])
+
+        manager = _make_manager(AsanaResumeConfig(paginator_state={"next_url": resume_url}))
+        _rows(_source("workspaces", manager))
+
+        assert urls[0] == resume_url
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_saved_state_starts_from_base_path(self, MockSession) -> None:
+        session = MockSession.return_value
+        urls = _wire(session, [("/workspaces", _page([{"gid": "1"}]))])
+
+        # State written by the previous hand-rolled implementation deserializes (compat) but carries
+        # no framework paginator snapshot, so the sync restarts from the base path (a re-fetch).
+        legacy = AsanaResumeConfig(remaining_urls=[f"{ASANA_BASE_URL}/x"], current_url=f"{ASANA_BASE_URL}/y")
+        assert legacy.paginator_state is None
+        manager = _make_manager(legacy)
+        _rows(_source("workspaces", manager))
+
+        assert "offset=" not in urls[0]
+        assert "/workspaces" in urls[0]
+
+
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_workspace_fan_out_drains_every_parent(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                ("/workspaces?", _page([{"gid": "W1"}, {"gid": "W2"}])),
+                ("workspace=W1", _page([{"gid": "a"}])),
+                ("workspace=W2", _page([{"gid": "b"}])),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("projects", manager))
+
+        assert [r["gid"] for r in rows] == ["a", "b"]
+        # Single-hop fan-out keeps resume: the dependent resource checkpoints per-parent progress.
+        assert manager.save_state.called
+        assert "completed" in manager.save_state.call_args.args[0].paginator_state
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_parents_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        urls = _wire(session, [("/workspaces", _page([]))])
+
+        manager = _make_manager()
+        rows = _rows(_source("projects", manager))
+
+        assert rows == []
+        assert len(urls) == 1  # only the (empty) parent list is fetched
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_organization_fan_out_skips_non_org_workspaces(self, MockSession) -> None:
+        session = MockSession.return_value
+        sent = _wire(
+            session,
+            [
+                (
+                    "/workspaces?",
+                    _page([{"gid": "W1", "is_organization": True}, {"gid": "W2", "is_organization": False}]),
+                ),
+                ("/organizations/W1/teams", _page([{"gid": "team1"}])),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("teams", manager))
+
+        assert [r["gid"] for r in rows] == ["team1"]
+        # The non-organization workspace never triggers a teams request.
+        assert not any("/organizations/W2/" in url for url in sent)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_project_level_chain_yields_grandchild_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                ("/workspaces?", _page([{"gid": "W1"}])),
+                ("workspace=W1", _page([{"gid": "P1"}, {"gid": "P2"}])),
+                ("project=P1", _page([{"gid": "t1"}])),
+                ("project=P2", _page([{"gid": "t2"}])),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("tasks", manager))
+
+        assert [r["gid"] for r in rows] == ["t1", "t2"]
+        # Multi-level fan-out disables resume (one shared hook can't checkpoint two levels);
+        # retries re-fetch and the merge dedupes on gid.
+        manager.save_state.assert_not_called()
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana.make_tracked_session")
-    def test_status_mapping(self, mock_session, status_code, expected):
+    @mock.patch(ASANA_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status_code, expected) -> None:
         response = mock.MagicMock()
         response.status_code = status_code
         mock_session.return_value.get.return_value = response
         assert validate_credentials("token") is expected
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana.make_tracked_session")
-    def test_swallows_exceptions(self, mock_session):
+    @mock.patch(ASANA_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("token") is False
 
 
-class TestBuildInitialUrls:
-    def test_top_level_endpoint_yields_single_url(self):
-        urls = _build_initial_urls(ASANA_ENDPOINTS["workspaces"], {}, mock.MagicMock(), mock.MagicMock())
-        assert urls == [
-            f"{ASANA_BASE_URL}/workspaces?limit=100&opt_fields=name%2Cemail_domains%2Cis_organization%2Cresource_type"
-        ]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana._list_workspaces")
-    def test_workspace_fan_out_one_url_per_workspace(self, mock_list_workspaces):
-        mock_list_workspaces.return_value = [{"gid": "1"}, {"gid": "2"}]
-        urls = _build_initial_urls(ASANA_ENDPOINTS["projects"], {}, mock.MagicMock(), mock.MagicMock())
-        assert len(urls) == 2
-        assert all(url.startswith(f"{ASANA_BASE_URL}/projects?workspace=") for url in urls)
-        assert "workspace=1" in urls[0]
-        assert "workspace=2" in urls[1]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana._list_workspaces")
-    def test_organization_fan_out_skips_non_org_workspaces(self, mock_list_workspaces):
-        mock_list_workspaces.return_value = [
-            {"gid": "1", "is_organization": True},
-            {"gid": "2", "is_organization": False},
-        ]
-        urls = _build_initial_urls(ASANA_ENDPOINTS["teams"], {}, mock.MagicMock(), mock.MagicMock())
-        assert len(urls) == 1
-        assert urls[0].startswith(f"{ASANA_BASE_URL}/organizations/1/teams")
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana._list_projects")
-    def test_project_fan_out_one_url_per_project(self, mock_list_projects):
-        mock_list_projects.return_value = iter([{"gid": "p1"}, {"gid": "p2"}])
-        urls = _build_initial_urls(ASANA_ENDPOINTS["tasks"], {}, mock.MagicMock(), mock.MagicMock())
-        assert [u.split("project=")[1].split("&")[0] for u in urls] == ["p1", "p2"]
-
-
-class TestGetRows:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana.make_tracked_session")
-    def test_paginates_via_next_page_uri(self, mock_session):
-        pages = [
-            _ok_response(_page([{"gid": "1"}, {"gid": "2"}], f"{ASANA_BASE_URL}/workspaces?offset=tok2")),
-            _ok_response(_page([{"gid": "3"}], None)),
-        ]
-        mock_session.return_value.get.side_effect = pages
-
-        manager = _make_manager()
-        batches = list(get_rows("token", "workspaces", mock.MagicMock(), manager))
-
-        assert [item["gid"] for batch in batches for item in batch] == ["1", "2", "3"]
-        # Saved once: after the first page (which has a next uri); not after the terminal page.
-        manager.save_state.assert_called_once()
-        saved = manager.save_state.call_args.args[0]
-        assert saved.current_url == f"{ASANA_BASE_URL}/workspaces?offset=tok2"
-        assert saved.remaining_urls == []
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana.make_tracked_session")
-    def test_resumes_from_saved_state(self, mock_session):
-        mock_session.return_value.get.return_value = _ok_response(_page([{"gid": "9"}], None))
-
-        resume_url = f"{ASANA_BASE_URL}/workspaces?offset=resume"
-        manager = _make_manager(AsanaResumeConfig(remaining_urls=[], current_url=resume_url))
-
-        list(get_rows("token", "workspaces", mock.MagicMock(), manager))
-
-        assert mock_session.return_value.get.call_args_list[0].args[0] == resume_url
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana._build_initial_urls")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana.make_tracked_session")
-    def test_drains_remaining_parent_urls(self, mock_session, mock_build_urls):
-        # Two parents, each a single page with no next_page — the generator must advance to
-        # the second parent URL once the first finishes.
-        mock_build_urls.return_value = [
-            f"{ASANA_BASE_URL}/tasks?project=p1",
-            f"{ASANA_BASE_URL}/tasks?project=p2",
-        ]
-        mock_session.return_value.get.side_effect = [
-            _ok_response(_page([{"gid": "a"}], None)),
-            _ok_response(_page([{"gid": "b"}], None)),
-        ]
-
-        manager = _make_manager()
-        batches = list(get_rows("token", "tasks", mock.MagicMock(), manager))
-
-        assert [item["gid"] for batch in batches for item in batch] == ["a", "b"]
-        assert mock_session.return_value.get.call_count == 2
-        # After draining the first parent, state advances to the second parent URL.
-        saved = manager.save_state.call_args.args[0]
-        assert saved.current_url == f"{ASANA_BASE_URL}/tasks?project=p2"
-        assert saved.remaining_urls == []
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana._build_initial_urls")
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana.make_tracked_session")
-    def test_empty_single_endpoint_yields_nothing_and_saves_nothing(self, mock_session, mock_build_urls):
-        mock_build_urls.return_value = [f"{ASANA_BASE_URL}/workspaces?limit=100"]
-        mock_session.return_value.get.return_value = _ok_response(_page([], None))
-
-        manager = _make_manager()
-        batches = list(get_rows("token", "workspaces", mock.MagicMock(), manager))
-
-        assert batches == []
-        manager.save_state.assert_not_called()
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.asana.asana._build_initial_urls")
-    def test_no_parents_yields_nothing(self, mock_build_urls):
-        mock_build_urls.return_value = []
-        manager = _make_manager()
-        assert list(get_rows("token", "projects", mock.MagicMock(), manager)) == []
-        manager.save_state.assert_not_called()
-
-
 class TestAsanaSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata_per_endpoint(self, MockSession, endpoint) -> None:
         config = ASANA_ENDPOINTS[endpoint]
-        response = asana_source("token", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == ["gid"]
@@ -196,7 +255,7 @@ class TestAsanaSourceResponse:
             assert response.partition_keys is None
 
     @pytest.mark.parametrize("config", list(ASANA_ENDPOINTS.values()))
-    def test_partition_keys_are_stable_creation_fields(self, config):
+    def test_partition_keys_are_stable_creation_fields(self, config) -> None:
         if config.partition_key:
             assert config.partition_key == "created_at"
             # The partition field must be opted into the response, else partitioning fails.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickup/clickup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickup/clickup.py
@@ -2,32 +2,37 @@ import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Optional
-from urllib.parse import urlencode
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.clickup.settings import CLICKUP_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 CLICKUP_BASE_URL = "https://api.clickup.com/api/v2"
 
 # Get Filtered Team Tasks is the only paginated endpoint; ClickUp caps it at 100 rows/page.
 TASKS_PAGE_SIZE = 100
-# Hard caps to bound fan-out scans; ClickUp workspaces rarely approach these.
-MAX_SPACES = 1000
-MAX_FOLDERS_PER_SPACE = 1000
 
 # ClickUp returns these task timestamps as epoch-milliseconds strings. We normalize them to
 # ISO 8601 so they land as proper datetime columns and can drive partitioning / incremental sync.
 TASK_DATE_FIELDS = ("date_created", "date_updated", "date_closed", "date_done", "start_date", "due_date")
-
-
-class ClickUpRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -82,17 +87,290 @@ def _to_epoch_ms(value: Any) -> Optional[int]:
         return None
 
 
-def _build_url(path: str, params: dict[str, Any] | None = None) -> str:
-    url = f"{CLICKUP_BASE_URL}{path}"
-    if not params:
-        return url
-    return f"{url}?{urlencode(params)}"
+class ClickUpTaskPaginator(BasePaginator):
+    """Page-number pagination for Get Filtered Team Tasks.
+
+    ClickUp signals the final page in three ways, any of which stops the walk: an empty page, a
+    ``last_page: true`` flag, or a short (< page size) page. It reports neither a total count nor a
+    next-page link, so no built-in paginator fits.
+
+    Resume checkpoints the page just yielded (not the next one): on a crash we re-fetch and re-yield
+    it, and merge on the primary key dedupes the overlap.
+    """
+
+    def __init__(self, page: int = 0, page_size: int = TASKS_PAGE_SIZE) -> None:
+        super().__init__()
+        self.page = page
+        self.page_size = page_size
+        # The page most recently fetched — what resume must re-fetch. Distinct from self.page,
+        # which update_state advances to point at the next page to request.
+        self._current_page = page
+
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        self._current_page = self.page
+
+        if not data:
+            self._has_next_page = False
+            return
+
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+
+        if body.get("last_page") is True or len(data) < self.page_size:
+            self._has_next_page = False
+            return
+
+        self.page += 1
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"page": self._current_page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._current_page = int(page)
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"ClickUpTaskPaginator(page={self.page})"
+
+
+def _client_config(api_key: str) -> ClientConfig:
+    return {
+        "base_url": CLICKUP_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        # Personal tokens (pk_...) and OAuth2 access tokens both go in the raw Authorization
+        # header with no "Bearer" prefix. Framework auth redacts the value from logs.
+        "auth": {"type": "api_key", "api_key": api_key, "name": "Authorization", "location": "header"},
+        # Every endpoint except tasks returns its whole result in one un-paginated response.
+        "paginator": SinglePagePaginator(),
+    }
+
+
+def _flat_resource(name: str, path: str, data_key: str) -> EndpointResource:
+    return {
+        "name": name,
+        "endpoint": {
+            "path": path,
+            "data_selector": data_key,
+        },
+    }
+
+
+def _tasks_resource(
+    api_key: str,
+    workspace_id: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[ClickUpResumeConfig],
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+) -> Resource:
+    params: dict[str, Any] = {
+        # Order by created (immutable) so pagination stays stable as tasks are updated mid-sync.
+        "order_by": "created",
+        # Closed tasks and subtasks are excluded by default — opt in so we capture everything.
+        "include_closed": "true",
+        "subtasks": "true",
+    }
+    if should_use_incremental_field:
+        params["date_updated_gt"] = {
+            "type": "incremental",
+            "cursor_path": "date_updated",
+            "convert": _to_epoch_ms,
+        }
+
+    config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": "tasks",
+                "endpoint": {
+                    "path": f"/team/{workspace_id}/task",
+                    "params": params,
+                    "data_selector": "tasks",
+                    "paginator": ClickUpTaskPaginator(),
+                },
+                "data_map": _normalize_task,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(ClickUpResumeConfig(page=int(state["page"])))
+
+    return rest_api_resource(
+        config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _space_children_resource(
+    api_key: str, workspace_id: str, resource_path: str, data_key: str, team_id: int, job_id: str
+) -> Resource:
+    """Fan out over every space in the workspace and yield rows from a per-space resource."""
+    config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            _flat_resource("spaces", f"/team/{workspace_id}/space", "spaces"),
+            {
+                "name": data_key,
+                "endpoint": {
+                    "path": f"/space/{{space_id}}/{resource_path}",
+                    "params": {"space_id": {"type": "resolve", "resource": "spaces", "field": "id"}},
+                    "data_selector": data_key,
+                },
+            },
+        ],
+    }
+    resources = {r.name: r for r in rest_api_resources(config, team_id, job_id, None)}
+    return resources[data_key]
+
+
+def _lists_resources(api_key: str, workspace_id: str, team_id: int, job_id: str) -> list[Resource]:
+    """Lists live in two places: directly under a space (folderless) and under folders."""
+    config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            _flat_resource("spaces", f"/team/{workspace_id}/space", "spaces"),
+            {
+                "name": "folderless_lists",
+                "endpoint": {
+                    "path": "/space/{space_id}/list",
+                    "params": {"space_id": {"type": "resolve", "resource": "spaces", "field": "id"}},
+                    "data_selector": "lists",
+                },
+            },
+            {
+                "name": "folders",
+                "endpoint": {
+                    "path": "/space/{space_id}/folder",
+                    "params": {"space_id": {"type": "resolve", "resource": "spaces", "field": "id"}},
+                    "data_selector": "folders",
+                },
+            },
+            {
+                "name": "folder_lists",
+                "endpoint": {
+                    "path": "/folder/{folder_id}/list",
+                    "params": {"folder_id": {"type": "resolve", "resource": "folders", "field": "id"}},
+                    "data_selector": "lists",
+                },
+            },
+        ],
+    }
+    resources = {r.name: r for r in rest_api_resources(config, team_id, job_id, None)}
+    return [resources["folderless_lists"], resources["folder_lists"]]
+
+
+def _chain_resources(resources: list[Resource]) -> Iterator[list[dict[str, Any]]]:
+    for resource in resources:
+        yield from resource
+
+
+def clickup_source(
+    api_key: str,
+    workspace_id: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[ClickUpResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = CLICKUP_ENDPOINTS[endpoint]
+
+    items: Any
+    if config.kind == "tasks":
+        resource = _tasks_resource(
+            api_key,
+            workspace_id,
+            team_id,
+            job_id,
+            resumable_source_manager,
+            should_use_incremental_field,
+            db_incremental_field_last_value,
+        )
+        items = lambda: resource
+    elif config.kind == "workspaces":
+        resource = rest_api_resource(
+            {"client": _client_config(api_key), "resources": [_flat_resource("workspaces", "/team", config.data_key)]},
+            team_id,
+            job_id,
+            None,
+        )
+        items = lambda: resource
+    elif config.kind == "team_scoped":
+        path = f"/team/{workspace_id}/{config.resource_path}"
+        resource = rest_api_resource(
+            {"client": _client_config(api_key), "resources": [_flat_resource(endpoint, path, config.data_key)]},
+            team_id,
+            job_id,
+            None,
+        )
+        items = lambda: resource
+    elif config.kind == "space_children":
+        resource = _space_children_resource(
+            api_key, workspace_id, config.resource_path or "", config.data_key, team_id, job_id
+        )
+        items = lambda: resource
+    elif config.kind == "lists":
+        list_resources = _lists_resources(api_key, workspace_id, team_id, job_id)
+        items = lambda: _chain_resources(list_resources)
+    else:
+        raise ValueError(f"Unknown ClickUp endpoint kind: {config.kind}")
+
+    return SourceResponse(
+        name=endpoint,
+        items=items,
+        primary_keys=config.primary_keys,
+        # Tasks are fetched newest-first (default ClickUp order). With sort_mode="desc" the
+        # pipeline only commits the cursor watermark once a sync fully completes, so a mid-sync
+        # crash never advances the cursor past unfetched rows. The `date_updated_gt` server
+        # filter (not row ordering) is what bounds each incremental fetch. Live ordering
+        # semantics were not verified against the API as no test credentials were available.
+        sort_mode="desc" if config.kind == "tasks" else "asc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+    )
 
 
 def validate_credentials(api_key: str, workspace_id: str | None) -> tuple[bool, str | None]:
     """Confirm the token is genuine and (when provided) can see the configured workspace."""
     try:
-        response = make_tracked_session().get(f"{CLICKUP_BASE_URL}/team", headers=_get_headers(api_key), timeout=10)
+        response = make_tracked_session(redact_values=(api_key,)).get(
+            f"{CLICKUP_BASE_URL}/team", headers=_get_headers(api_key), timeout=10
+        )
     except requests.exceptions.RequestException as e:
         return False, str(e)
 
@@ -107,175 +385,3 @@ def validate_credentials(api_key: str, workspace_id: str | None) -> tuple[bool, 
             return False, f"Workspace '{workspace_id}' is not accessible with this token"
 
     return True, None
-
-
-@retry(
-    retry=retry_if_exception_type((ClickUpRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict[str, Any]:
-    response = make_tracked_session().get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ClickUpRetryableError(f"ClickUp API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"ClickUp API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _list_space_ids(workspace_id: str, headers: dict[str, str], logger: FilteringBoundLogger) -> list[str]:
-    spaces = _fetch(_build_url(f"/team/{workspace_id}/space"), headers, logger).get("spaces", [])
-    if len(spaces) >= MAX_SPACES:
-        logger.warning(f"ClickUp: hit space cap ({MAX_SPACES}) for workspace {workspace_id}; some spaces skipped")
-    return [str(space["id"]) for space in spaces[:MAX_SPACES]]
-
-
-def _iter_tasks(
-    workspace_id: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ClickUpResumeConfig],
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> Iterator[list[dict[str, Any]]]:
-    base_params: dict[str, Any] = {
-        # Order by created (immutable) so pagination stays stable as tasks are updated mid-sync.
-        "order_by": "created",
-        # Closed tasks and subtasks are excluded by default — opt in so we capture everything.
-        "include_closed": "true",
-        "subtasks": "true",
-    }
-    if should_use_incremental_field:
-        cutoff_ms = _to_epoch_ms(db_incremental_field_last_value)
-        if cutoff_ms is not None:
-            base_params["date_updated_gt"] = cutoff_ms
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume is not None else 0
-    if resume is not None:
-        logger.debug(f"ClickUp: resuming tasks from page {page}")
-
-    while True:
-        data = _fetch(_build_url(f"/team/{workspace_id}/task", {**base_params, "page": page}), headers, logger)
-        tasks = data.get("tasks", [])
-        if not tasks:
-            break
-
-        yield [_normalize_task(task) for task in tasks]
-        # Checkpoint the page we just yielded (not the next one): on a crash we re-fetch and
-        # re-yield it, and merge on the primary key dedupes the overlap.
-        resumable_source_manager.save_state(ClickUpResumeConfig(page=page))
-
-        # ClickUp signals the final page either via `last_page` or a short (< page size) page.
-        if data.get("last_page") is True or len(tasks) < TASKS_PAGE_SIZE:
-            break
-        page += 1
-
-
-def _iter_space_children(
-    workspace_id: str, resource_path: str, data_key: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> Iterator[list[dict[str, Any]]]:
-    """Fan out over every space in the workspace and yield rows from a per-space resource."""
-    for space_id in _list_space_ids(workspace_id, headers, logger):
-        data = _fetch(_build_url(f"/space/{space_id}/{resource_path}"), headers, logger)
-        rows = data.get(data_key, [])
-        if rows:
-            yield rows
-
-
-def _iter_lists(
-    workspace_id: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> Iterator[list[dict[str, Any]]]:
-    """Lists live in two places: directly under a space (folderless) and under folders."""
-    for space_id in _list_space_ids(workspace_id, headers, logger):
-        folderless = _fetch(_build_url(f"/space/{space_id}/list"), headers, logger).get("lists", [])
-        if folderless:
-            yield folderless
-
-        folders = _fetch(_build_url(f"/space/{space_id}/folder"), headers, logger).get("folders", [])
-        if len(folders) >= MAX_FOLDERS_PER_SPACE:
-            logger.warning(f"ClickUp: hit folder cap ({MAX_FOLDERS_PER_SPACE}) for space {space_id}; some skipped")
-        for folder in folders[:MAX_FOLDERS_PER_SPACE]:
-            folder_lists = _fetch(_build_url(f"/folder/{folder['id']}/list"), headers, logger).get("lists", [])
-            if folder_lists:
-                yield folder_lists
-
-
-def get_rows(
-    api_key: str,
-    workspace_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ClickUpResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CLICKUP_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-
-    if config.kind == "tasks":
-        yield from _iter_tasks(
-            workspace_id,
-            headers,
-            logger,
-            resumable_source_manager,
-            should_use_incremental_field,
-            db_incremental_field_last_value,
-        )
-    elif config.kind == "workspaces":
-        rows = _fetch(_build_url("/team"), headers, logger).get(config.data_key, [])
-        if rows:
-            yield rows
-    elif config.kind == "team_scoped":
-        path = f"/team/{workspace_id}/{config.resource_path}"
-        rows = _fetch(_build_url(path), headers, logger).get(config.data_key, [])
-        if rows:
-            yield rows
-    elif config.kind == "space_children":
-        yield from _iter_space_children(workspace_id, config.resource_path or "", config.data_key, headers, logger)
-    elif config.kind == "lists":
-        yield from _iter_lists(workspace_id, headers, logger)
-    else:
-        raise ValueError(f"Unknown ClickUp endpoint kind: {config.kind}")
-
-
-def clickup_source(
-    api_key: str,
-    workspace_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ClickUpResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Optional[Any] = None,
-) -> SourceResponse:
-    config = CLICKUP_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            workspace_id=workspace_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
-        primary_keys=config.primary_keys,
-        # Tasks are fetched newest-first (default ClickUp order). With sort_mode="desc" the
-        # pipeline only commits the cursor watermark once a sync fully completes, so a mid-sync
-        # crash never advances the cursor past unfetched rows. The `date_updated_gt` server
-        # filter (not row ordering) is what bounds each incremental fetch. Live ordering
-        # semantics were not verified against the API as no test credentials were available.
-        sort_mode="desc" if config.kind == "tasks" else "asc",
-        partition_count=1,
-        partition_size=1,
-        partition_mode="datetime" if config.partition_key else None,
-        partition_format="week" if config.partition_key else None,
-        partition_keys=[config.partition_key] if config.partition_key else None,
-    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickup/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickup/source.py
@@ -19,8 +19,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.clickup.cl
     validate_credentials as validate_clickup_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.clickup.settings import (
-    CLICKUP_ENDPOINTS,
     ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
@@ -28,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ClickUpSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -111,19 +114,8 @@ The **Workspace ID** is the numeric ID in your ClickUp URL: `https://app.clickup
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=CLICKUP_ENDPOINTS[endpoint].supports_incremental,
-                supports_append=False,
-                incremental_fields=CLICKUP_ENDPOINTS[endpoint].incremental_fields,
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Only tasks exposes an incremental field; ClickUp endpoints are all full-refresh, never append.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names, merge_only=ENDPOINTS)
 
     def validate_credentials(
         self, config: ClickUpSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -143,7 +135,8 @@ The **Workspace ID** is the numeric ID in your ClickUp URL: `https://app.clickup
             api_key=config.api_key,
             workspace_id=config.workspace_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickup/tests/test_clickup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickup/tests/test_clickup.py
@@ -1,17 +1,18 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.clickup.clickup import (
     ClickUpResumeConfig,
-    _build_url,
     _ms_to_iso,
     _normalize_task,
     _to_epoch_ms,
     clickup_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.clickup.settings import (
@@ -19,7 +20,19 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.clickup.se
     ENDPOINTS,
 )
 
-SESSION_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.clickup.clickup.make_tracked_session"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the clickup module.
+CLICKUP_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.clickup.clickup.make_tracked_session"
+)
+
+
+def _response(payload: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(payload).encode()
+    return resp
 
 
 def _make_manager(resume_state: ClickUpResumeConfig | None = None) -> mock.MagicMock:
@@ -29,12 +42,30 @@ def _make_manager(resume_state: ClickUpResumeConfig | None = None) -> mock.Magic
     return manager
 
 
-def _response(payload: dict[str, Any], status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.status_code = status_code
-    resp.ok = 200 <= status_code < 300
-    resp.json.return_value = payload
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return clickup_source("pk", "9", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestMsToIso:
@@ -83,15 +114,6 @@ class TestToEpochMs:
         assert _to_epoch_ms(value) == expected
 
 
-class TestBuildUrl:
-    def test_no_params(self) -> None:
-        assert _build_url("/team") == "https://api.clickup.com/api/v2/team"
-
-    def test_encodes_params(self) -> None:
-        url = _build_url("/team/9/task", {"page": 0, "include_closed": "true"})
-        assert url == "https://api.clickup.com/api/v2/team/9/task?page=0&include_closed=true"
-
-
 class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected_valid",
@@ -102,13 +124,13 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(SESSION_PATH)
+    @mock.patch(CLICKUP_SESSION_PATCH)
     def test_status_mapping(self, mock_session: mock.MagicMock, status_code: int, expected_valid: bool) -> None:
         mock_session.return_value.get.return_value = _response({"teams": [{"id": "9"}]}, status_code=status_code)
         valid, _ = validate_credentials("pk_token", workspace_id=None)
         assert valid is expected_valid
 
-    @mock.patch(SESSION_PATH)
+    @mock.patch(CLICKUP_SESSION_PATCH)
     def test_workspace_must_be_accessible(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.return_value = _response({"teams": [{"id": "9"}]})
 
@@ -119,7 +141,7 @@ class TestValidateCredentials:
         assert bad is False
         assert message is not None and "404" in message
 
-    @mock.patch(SESSION_PATH)
+    @mock.patch(CLICKUP_SESSION_PATCH)
     def test_request_exception_returns_error(self, mock_session: mock.MagicMock) -> None:
         import requests
 
@@ -129,82 +151,81 @@ class TestValidateCredentials:
         assert message == "boom"
 
 
-class TestGetRowsTasks:
-    @mock.patch(SESSION_PATH)
-    def test_paginates_until_short_page(self, mock_session: mock.MagicMock) -> None:
+class TestTasks:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         full_page = {"tasks": [{"id": str(i), "date_updated": "1567785250202"} for i in range(100)]}
         short_page = {"tasks": [{"id": "100", "date_updated": "1567785250202"}]}
-        mock_session.return_value.get.side_effect = [_response(full_page), _response(short_page)]
+        snapshots = _wire(session, [_response(full_page), _response(short_page)])
 
         manager = _make_manager()
-        batches = list(get_rows("pk", "9", "tasks", mock.MagicMock(), manager))
+        rows = _rows(_source("tasks", manager))
 
-        assert mock_session.return_value.get.call_count == 2
-        assert sum(len(b) for b in batches) == 101
-        # date fields normalized to ISO on the way out
-        assert batches[0][0]["date_updated"].startswith("2019-09-06T")
-        # State saved after each yielded page.
-        assert manager.save_state.call_count == 2
-        assert manager.save_state.call_args_list[0].args[0].page == 0
-        assert manager.save_state.call_args_list[1].args[0].page == 1
+        assert session.send.call_count == 2
+        assert len(rows) == 101
+        # Date fields normalized to ISO on the way out.
+        assert rows[0]["date_updated"].startswith("2019-09-06T")
+        assert snapshots[0]["params"]["page"] == 0
+        assert snapshots[1]["params"]["page"] == 1
+        # Checkpoint the page just yielded so a crash re-fetches it (merge dedupes). The final short
+        # page has no next page, so no checkpoint follows it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == ClickUpResumeConfig(page=0)
 
-    @mock.patch(SESSION_PATH)
-    def test_last_page_flag_stops_pagination(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_last_page_flag_stops_pagination(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         page = {"tasks": [{"id": str(i)} for i in range(100)], "last_page": True}
-        mock_session.return_value.get.return_value = _response(page)
+        _wire(session, [_response(page)])
 
-        list(get_rows("pk", "9", "tasks", mock.MagicMock(), _make_manager()))
-        assert mock_session.return_value.get.call_count == 1
+        _rows(_source("tasks", _make_manager()))
+        assert session.send.call_count == 1
 
-    @mock.patch(SESSION_PATH)
-    def test_empty_first_page_yields_nothing(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response({"tasks": []})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"tasks": []})])
+
         manager = _make_manager()
-
-        batches = list(get_rows("pk", "9", "tasks", mock.MagicMock(), manager))
-        assert batches == []
+        rows = _rows(_source("tasks", manager))
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(SESSION_PATH)
-    def test_resumes_from_saved_page(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response({"tasks": [{"id": "1"}]})
-        manager = _make_manager(ClickUpResumeConfig(page=4))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"tasks": [{"id": "1"}]})])
 
-        list(get_rows("pk", "9", "tasks", mock.MagicMock(), manager))
+        _rows(_source("tasks", _make_manager(ClickUpResumeConfig(page=4))))
+        assert snapshots[0]["params"]["page"] == 4
 
-        url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "page=4" in url
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_adds_date_updated_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"tasks": [{"id": "1"}]})])
 
-    @mock.patch(SESSION_PATH)
-    def test_incremental_adds_date_updated_filter(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response({"tasks": [{"id": "1"}]})
-
-        list(
-            get_rows(
-                "pk",
-                "9",
+        _rows(
+            _source(
                 "tasks",
-                mock.MagicMock(),
                 _make_manager(),
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2019, 9, 6, 15, 54, 10, 202000, tzinfo=UTC),
             )
         )
+        assert snapshots[0]["params"]["date_updated_gt"] == 1567785250202
 
-        url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "date_updated_gt=1567785250202" in url
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_omits_date_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"tasks": [{"id": "1"}]})])
 
-    @mock.patch(SESSION_PATH)
-    def test_full_refresh_omits_date_filter(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response({"tasks": [{"id": "1"}]})
-
-        list(get_rows("pk", "9", "tasks", mock.MagicMock(), _make_manager(), should_use_incremental_field=False))
-
-        url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "date_updated_gt" not in url
+        _rows(_source("tasks", _make_manager(), should_use_incremental_field=False))
+        assert "date_updated_gt" not in snapshots[0]["params"]
 
 
-class TestGetRowsTeamScoped:
+class TestTeamScoped:
     @pytest.mark.parametrize(
         "endpoint, expected_path",
         [
@@ -213,48 +234,59 @@ class TestGetRowsTeamScoped:
             ("goals", "/team/9/goal"),
         ],
     )
-    @mock.patch(SESSION_PATH)
-    def test_team_scoped_endpoints(self, mock_session: mock.MagicMock, endpoint: str, expected_path: str) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_team_scoped_endpoints(self, MockSession: mock.MagicMock, endpoint: str, expected_path: str) -> None:
+        session = MockSession.return_value
         data_key = CLICKUP_ENDPOINTS[endpoint].data_key
-        mock_session.return_value.get.return_value = _response({data_key: [{"id": "1"}, {"id": "2"}]})
+        snapshots = _wire(session, [_response({data_key: [{"id": "1"}, {"id": "2"}]})])
 
-        batches = list(get_rows("pk", "9", endpoint, mock.MagicMock(), _make_manager()))
+        rows = _rows(_source(endpoint, _make_manager()))
 
-        called_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert called_url.endswith(expected_path)
-        assert [item["id"] for batch in batches for item in batch] == ["1", "2"]
+        assert snapshots[0]["url"].endswith(expected_path)
+        assert [row["id"] for row in rows] == ["1", "2"]
 
 
-class TestGetRowsFanOut:
-    @mock.patch(SESSION_PATH)
-    def test_folders_fan_out_over_spaces(self, mock_session: mock.MagicMock) -> None:
-        spaces = _response({"spaces": [{"id": "s1"}, {"id": "s2"}]})
-        s1_folders = _response({"folders": [{"id": "f1"}]})
-        s2_folders = _response({"folders": [{"id": "f2"}]})
-        mock_session.return_value.get.side_effect = [spaces, s1_folders, s2_folders]
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_folders_fan_out_over_spaces(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"spaces": [{"id": "s1"}, {"id": "s2"}]}),
+                _response({"folders": [{"id": "f1"}]}),
+                _response({"folders": [{"id": "f2"}]}),
+            ],
+        )
 
-        batches = list(get_rows("pk", "9", "folders", mock.MagicMock(), _make_manager()))
+        rows = _rows(_source("folders", _make_manager()))
+        assert [row["id"] for row in rows] == ["f1", "f2"]
 
-        assert [item["id"] for batch in batches for item in batch] == ["f1", "f2"]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_lists_combine_folderless_and_folder_lists(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        # Folderless lists are fetched first (space -> list), then folder lists (space -> folder ->
+        # list); the space list is re-fetched to drive each of the two fan-outs.
+        _wire(
+            session,
+            [
+                _response({"spaces": [{"id": "s1"}]}),
+                _response({"lists": [{"id": "l1"}]}),
+                _response({"spaces": [{"id": "s1"}]}),
+                _response({"folders": [{"id": "f1"}]}),
+                _response({"lists": [{"id": "l2"}]}),
+            ],
+        )
 
-    @mock.patch(SESSION_PATH)
-    def test_lists_combine_folderless_and_folder_lists(self, mock_session: mock.MagicMock) -> None:
-        spaces = _response({"spaces": [{"id": "s1"}]})
-        folderless = _response({"lists": [{"id": "l1"}]})
-        folders = _response({"folders": [{"id": "f1"}]})
-        folder_lists = _response({"lists": [{"id": "l2"}]})
-        mock_session.return_value.get.side_effect = [spaces, folderless, folders, folder_lists]
-
-        batches = list(get_rows("pk", "9", "lists", mock.MagicMock(), _make_manager()))
-
-        assert [item["id"] for batch in batches for item in batch] == ["l1", "l2"]
+        rows = _rows(_source("lists", _make_manager()))
+        assert [row["id"] for row in rows] == ["l1", "l2"]
 
 
 class TestClickUpSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint: str) -> None:
         config = CLICKUP_ENDPOINTS[endpoint]
-        response = clickup_source("pk", "9", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -266,10 +298,10 @@ class TestClickUpSourceResponse:
             assert response.partition_keys is None
 
     def test_tasks_use_desc_sort_mode(self) -> None:
-        assert clickup_source("pk", "9", "tasks", mock.MagicMock(), _make_manager()).sort_mode == "desc"
+        assert _source("tasks", _make_manager()).sort_mode == "desc"
 
     def test_non_task_endpoints_use_asc_sort_mode(self) -> None:
-        assert clickup_source("pk", "9", "spaces", mock.MagicMock(), _make_manager()).sort_mode == "asc"
+        assert _source("spaces", _make_manager()).sort_mode == "asc"
 
     @pytest.mark.parametrize("config", list(CLICKUP_ENDPOINTS.values()))
     def test_partition_keys_are_stable_creation_fields(self, config: Any) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/clockify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/clockify.py
@@ -1,49 +1,75 @@
 import dataclasses
-from collections.abc import Callable, Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.clockify.settings import (
-    CLOCKIFY_ENDPOINTS,
-    ClockifyEndpointConfig,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.clockify.settings import CLOCKIFY_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    rename_parent_fields,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    EndpointResource,
+    IncrementalConfig,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # Global host. Clockify also serves regional hosts (euc1/use2/euw2/apse2); the global host
 # resolves to the user's region, so a single base URL works for every key.
 CLOCKIFY_BASE_URL = "https://api.clockify.me/api/v1"
 
+# Single-level fan-out endpoints: one GET per workspace. Two-level ones (tasks, time_entries)
+# chain a second parent (projects/users) and are handled explicitly below.
+_WORKSPACE_CHILD_ENDPOINTS = ("users", "clients", "projects", "tags")
 
-class ClockifyRetryableError(Exception):
-    pass
+
+class ClockifyPageNumberPaginator(PageNumberPaginator):
+    """Page/`page-size` pagination over Clockify's bare JSON arrays.
+
+    Clockify exposes no total count, so — like the hand-rolled loop this replaces — a page shorter
+    than the requested size (or an empty page) is the last page. Stopping on a short page avoids the
+    extra empty-page request the plain ``PageNumberPaginator`` would pay.
+    """
+
+    def __init__(self, page_size: int) -> None:
+        super().__init__(base_page=1, page_param="page")
+        self._page_size = page_size
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and data is not None and len(data) < self._page_size:
+            self._has_next_page = False
 
 
 @dataclasses.dataclass
 class ClockifyResumeConfig:
-    # The fan-out scope (workspace + optional parent project/user) and the 1-based page we were
-    # reading when the last batch was yielded. Stable ids, not positional indexes, so scopes
-    # added/removed between a crash and the retry can't resume us into the wrong place.
+    # Opaque paginator/fan-out state handed back by the rest_source framework (paginator page for
+    # workspaces, per-parent completed-path progress for single-level fan-out). Retained as a single
+    # blob so the shape can evolve without a state-format migration.
+    fanout_state: dict[str, Any] | None = None
+    # Legacy fields from the hand-rolled resume format. Kept (with defaults) so an old saved state
+    # still parses via ``dataclass(**saved)``; a run resumed from one starts fan-out fresh (a re-read
+    # the merge dedupes) rather than mis-mapping the old positional scope onto the new state.
     workspace_id: str | None = None
     parent_id: str | None = None
     page: int = 1
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {"X-Api-Key": api_key, "Accept": "application/json"}
-
-
-def _build_url(base_url: str, params: dict[str, Any]) -> str:
-    if not params:
-        return base_url
-    return f"{base_url}?{urlencode(params)}"
+def _headers() -> dict[str, str]:
+    # Auth (the X-Api-Key header) is supplied via the framework auth config so its value is redacted
+    # from logs; only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def _format_datetime_z(value: Any) -> str:
@@ -83,47 +109,6 @@ def _clamp_future_value_to_now(value: Any) -> Any:
     return value
 
 
-def validate_credentials(api_key: str) -> bool:
-    """A Clockify API key is user-scoped (no per-endpoint scopes), so one cheap `/user` probe
-    confirms the key is genuine for everything it can reach."""
-    try:
-        response = make_tracked_session().get(f"{CLOCKIFY_BASE_URL}/user", headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type((ClockifyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[dict[str, Any]]:
-    """Fetch one page. Clockify list endpoints return a bare JSON array.
-
-    429s (rate limited; Clockify sends no reset header, so we back off) and 5xx are retried;
-    a non-list body or 4xx auth error is surfaced via `raise_for_status()`.
-    """
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ClockifyRetryableError(f"Clockify API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Clockify API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    if not isinstance(data, list):
-        # Every list endpoint we hit returns an array; a dict here is an unexpected error shape.
-        logger.error(f"Clockify API returned a non-list body: url={url}, body={response.text}")
-        return []
-    return data
-
-
 def _flatten_time_entry(item: dict[str, Any]) -> dict[str, Any]:
     """Surface the nested `timeInterval` object as top-level columns so the interval start can be
     used as the incremental cursor and partition key."""
@@ -135,220 +120,190 @@ def _flatten_time_entry(item: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
-def _get_item_mapper(endpoint: str) -> Callable[[dict[str, Any]], dict[str, Any]] | None:
-    if endpoint == "time_entries":
-        return _flatten_time_entry
-    return None
+# Fan-out injects the parent id under the framework's ``_<parent>_<field>`` naming; rename it back to
+# the flat ``workspace_id`` / ``project_id`` / ``user_id`` columns the tables have always exposed.
+_rename_workspace = rename_parent_fields("workspaces", {"id": "workspace_id"})
+_rename_task_parents = rename_parent_fields("projects", {"workspace_id": "workspace_id", "id": "project_id"})
+_rename_time_entry_parents = rename_parent_fields("users", {"workspace_id": "workspace_id", "id": "user_id"})
 
 
-def _list_ids(
-    session: requests.Session, headers: dict[str, str], base_path: str, page_size: int, logger: FilteringBoundLogger
-) -> Iterator[str]:
-    """Page through a workspace-scoped list endpoint, yielding each row's id. Used to enumerate
-    the parents (projects/users) a two-level fan-out walks over."""
-    page = 1
-    while True:
-        data = _fetch_page(session, _build_url(base_path, {"page": page, "page-size": page_size}), headers, logger)
-        if not data:
-            break
-        for item in data:
-            yield item["id"]
-        if len(data) < page_size:
-            break
-        page += 1
+def _time_entry_map(row: dict[str, Any]) -> dict[str, Any]:
+    return _rename_time_entry_parents(_flatten_time_entry(row))
 
 
-def _list_workspace_ids(session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger) -> list[str]:
-    data = _fetch_page(session, f"{CLOCKIFY_BASE_URL}/workspaces", headers, logger)
-    return [workspace["id"] for workspace in data]
+def _incremental_config(
+    should_use_incremental_field: bool, db_incremental_field_last_value: Any
+) -> IncrementalConfig | None:
+    """Server-side `start` filter for time_entries, only when we have a cursor to filter on.
 
-
-def _build_scopes(
-    session: requests.Session,
-    headers: dict[str, str],
-    config: ClockifyEndpointConfig,
-    logger: FilteringBoundLogger,
-) -> list[tuple[str, str | None, str]]:
-    """Materialize the (workspace_id, parent_id, full_url) tuples this endpoint iterates.
-
-    Built up front so resume can match the saved scope by id. For single-level fan-out
-    parent_id is None; for two-level fan-out we enumerate the parent endpoint per workspace.
+    Mirrors the old behaviour: no filter on a first (full) sync, and the persisted watermark is
+    clamped to now and formatted the way Clockify's `start` expects.
     """
-    scopes: list[tuple[str, str | None, str]] = []
-    for workspace_id in _list_workspace_ids(session, headers, logger):
-        if config.fan_out_parent is None:
-            scopes.append((workspace_id, None, CLOCKIFY_BASE_URL + config.path.format(workspace_id=workspace_id)))
-            continue
-
-        assert config.parent_id_placeholder is not None  # set whenever fan_out_parent is
-        parent_config = CLOCKIFY_ENDPOINTS[config.fan_out_parent]
-        parent_path = CLOCKIFY_BASE_URL + parent_config.path.format(workspace_id=workspace_id)
-        for parent_id in _list_ids(session, headers, parent_path, parent_config.page_size, logger):
-            url = CLOCKIFY_BASE_URL + config.path.format(
-                **{"workspace_id": workspace_id, config.parent_id_placeholder: parent_id}
-            )
-            scopes.append((workspace_id, parent_id, url))
-    return scopes
+    if not should_use_incremental_field or db_incremental_field_last_value is None:
+        return None
+    return {
+        "start_param": "start",
+        "cursor_path": "time_interval_start",
+        "convert": lambda value: _format_datetime_z(_clamp_future_value_to_now(value)),
+    }
 
 
-def _find_scope_index(
-    scopes: list[tuple[str, str | None, str]], workspace_id: str | None, parent_id: str | None
-) -> int | None:
-    for index, (scope_workspace_id, scope_parent_id, _url) in enumerate(scopes):
-        if scope_workspace_id == workspace_id and scope_parent_id == parent_id:
-            return index
-    return None
+def _workspaces_resource() -> EndpointResource:
+    config = CLOCKIFY_ENDPOINTS["workspaces"]
+    return {
+        "name": "workspaces",
+        "endpoint": {
+            "path": config.path,
+            "params": {"page-size": config.page_size},
+            "paginator": ClockifyPageNumberPaginator(config.page_size),
+            "data_selector_required": True,
+        },
+    }
 
 
-def _paginate_scope(
-    session: requests.Session,
-    headers: dict[str, str],
-    base_url: str,
-    config: ClockifyEndpointConfig,
-    batcher: Batcher,
-    manager: ResumableSourceManager[ClockifyResumeConfig],
-    logger: FilteringBoundLogger,
-    mapper: Callable[[dict[str, Any]], dict[str, Any]] | None,
-    workspace_id: str | None,
-    parent_id: str | None,
-    start_page: int,
-    inject: dict[str, str],
-    extra_params: dict[str, Any],
-) -> Iterator[Any]:
-    """Page through one scope, batching rows. Saves resume state AFTER yielding each batch so a
-    crash re-reads the current page (merge dedupes on the primary key) rather than skipping it."""
-    page = start_page
-    while True:
-        params: dict[str, Any] = {"page": page, "page-size": config.page_size, **extra_params}
-        data = _fetch_page(session, _build_url(base_url, params), headers, logger)
-        if not data:
-            break
-
-        for item in data:
-            row = mapper(item) if mapper else item
-            row.update(inject)
-            batcher.batch(row)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                manager.save_state(ClockifyResumeConfig(workspace_id=workspace_id, parent_id=parent_id, page=page))
-
-        # A short page (fewer rows than asked for) is the last page.
-        if len(data) < config.page_size:
-            break
-        page += 1
+def _workspace_child_resource(endpoint: str) -> EndpointResource:
+    config = CLOCKIFY_ENDPOINTS[endpoint]
+    return {
+        "name": endpoint,
+        "include_from_parent": ["id"],
+        "endpoint": {
+            "path": config.path,
+            "params": {
+                "workspace_id": {"type": "resolve", "resource": "workspaces", "field": "id"},
+                "page-size": config.page_size,
+            },
+            "paginator": ClockifyPageNumberPaginator(config.page_size),
+            "data_selector_required": True,
+        },
+        "data_map": _rename_workspace,
+    }
 
 
-def get_rows(
+def _tasks_resource() -> EndpointResource:
+    config = CLOCKIFY_ENDPOINTS["tasks"]
+    return {
+        "name": "tasks",
+        "include_from_parent": ["workspace_id", "id"],
+        "endpoint": {
+            "path": config.path,
+            "params": {
+                "workspace_id": {"type": "resolve", "resource": "projects", "field": "workspace_id"},
+                "project_id": {"type": "resolve", "resource": "projects", "field": "id"},
+                "page-size": config.page_size,
+            },
+            "paginator": ClockifyPageNumberPaginator(config.page_size),
+            "data_selector_required": True,
+        },
+        "data_map": _rename_task_parents,
+    }
+
+
+def _time_entries_resource(incremental: IncrementalConfig | None) -> EndpointResource:
+    config = CLOCKIFY_ENDPOINTS["time_entries"]
+    endpoint: dict[str, Any] = {
+        "path": config.path,
+        "params": {
+            "workspace_id": {"type": "resolve", "resource": "users", "field": "workspace_id"},
+            "user_id": {"type": "resolve", "resource": "users", "field": "id"},
+            "page-size": config.page_size,
+        },
+        "paginator": ClockifyPageNumberPaginator(config.page_size),
+        "data_selector_required": True,
+    }
+    if incremental is not None:
+        endpoint["incremental"] = incremental
+    return {
+        "name": "time_entries",
+        "include_from_parent": ["workspace_id", "id"],
+        "endpoint": endpoint,
+        "data_map": _time_entry_map,
+    }
+
+
+def _resources_for(endpoint: str, incremental: IncrementalConfig | None) -> list[EndpointResource]:
+    if endpoint == "workspaces":
+        return [_workspaces_resource()]
+    if endpoint in _WORKSPACE_CHILD_ENDPOINTS:
+        return [_workspaces_resource(), _workspace_child_resource(endpoint)]
+    if endpoint == "tasks":
+        return [_workspaces_resource(), _workspace_child_resource("projects"), _tasks_resource()]
+    if endpoint == "time_entries":
+        return [_workspaces_resource(), _workspace_child_resource("users"), _time_entries_resource(incremental)]
+    raise ValueError(f"Unknown Clockify endpoint: {endpoint}")
+
+
+def _build_rest_config(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ClockifyResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = CLOCKIFY_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    session = make_tracked_session()
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    mapper = _get_item_mapper(endpoint)
-
-    # Workspaces is the one non-fan-out endpoint.
-    if not config.workspace_scoped:
-        resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-        start_page = resume.page if resume is not None else 1
-        yield from _paginate_scope(
-            session,
-            headers,
-            CLOCKIFY_BASE_URL + config.path,
-            config,
-            batcher,
-            resumable_source_manager,
-            logger,
-            mapper,
-            workspace_id=None,
-            parent_id=None,
-            start_page=start_page,
-            inject={},
-            extra_params={},
-        )
-        if batcher.should_yield(include_incomplete_chunk=True):
-            yield batcher.get_table()
-        return
-
-    # Server-side incremental filter (time_entries only). `incremental_field` is the user's chosen
-    # cursor; we only have a filter param when the endpoint declares one.
-    extra_params: dict[str, Any] = {}
-    if should_use_incremental_field and db_incremental_field_last_value and config.incremental_param:
-        cursor_value = _clamp_future_value_to_now(db_incremental_field_last_value)
-        extra_params[config.incremental_param] = _format_datetime_z(cursor_value)
-
-    scopes = _build_scopes(session, headers, config, logger)
-
-    # Resolve resume to a starting scope + page. If the bookmarked scope no longer exists, start
-    # from the beginning — merge dedupes the re-pulled rows on the primary key.
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_index = 0
-    resume_page = 1
-    if resume is not None:
-        matched = _find_scope_index(scopes, resume.workspace_id, resume.parent_id)
-        if matched is not None:
-            start_index = matched
-            resume_page = resume.page
-            logger.debug(f"Clockify: resuming {endpoint} from scope index {matched}, page {resume_page}")
-
-    for index in range(start_index, len(scopes)):
-        workspace_id, parent_id, url = scopes[index]
-        inject: dict[str, str] = {"workspace_id": workspace_id}
-        if parent_id is not None and config.parent_id_placeholder is not None:
-            inject[config.parent_id_placeholder] = parent_id
-        yield from _paginate_scope(
-            session,
-            headers,
-            url,
-            config,
-            batcher,
-            resumable_source_manager,
-            logger,
-            mapper,
-            workspace_id=workspace_id,
-            parent_id=parent_id,
-            start_page=resume_page if index == start_index else 1,
-            inject=inject,
-            extra_params=extra_params,
-        )
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+) -> RESTAPIConfig:
+    incremental = _incremental_config(should_use_incremental_field, db_incremental_field_last_value)
+    return {
+        "client": {
+            "base_url": CLOCKIFY_BASE_URL,
+            "headers": _headers(),
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-Api-Key", "location": "header"},
+        },
+        "resource_defaults": {},
+        "resources": _resources_for(endpoint, incremental),
+    }
 
 
 def clockify_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ClockifyResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
-    incremental_field: str | None = None,
 ) -> SourceResponse:
-    endpoint_config = CLOCKIFY_ENDPOINTS[endpoint]
+    config = CLOCKIFY_ENDPOINTS[endpoint]
+    rest_config = _build_rest_config(api_key, endpoint, should_use_incremental_field, db_incremental_field_last_value)
+
+    initial_paginator_state: dict[str, Any] | None = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded so a crash re-yields the last page (merge dedupes) rather
+        # than skipping it. A ``None`` state means no page remains — nothing to persist. Never fires
+        # for the two-level fan-outs (tasks/time_entries), where the framework disables resume.
+        if state is not None:
+            resumable_source_manager.save_state(ClockifyResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    resource: Resource = next(r for r in resources if r.name == endpoint)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
-        primary_keys=endpoint_config.primary_keys,
-        sort_mode=endpoint_config.sort_mode,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        sort_mode=config.sort_mode,
         partition_count=1,
         partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="week" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """A Clockify API key is user-scoped (no per-endpoint scopes), so one cheap `/user` probe
+    confirms the key is genuine for everything it can reach."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{CLOCKIFY_BASE_URL}/user",
+        headers={"X-Api-Key": api_key, **_headers()},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/source.py
@@ -19,7 +19,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.clockify.c
     validate_credentials as validate_clockify_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.clockify.settings import (
-    CLOCKIFY_ENDPOINTS,
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
@@ -29,7 +28,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ClockifySourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -94,22 +96,8 @@ The key is user-scoped — it can read exactly what your Clockify user can. Use 
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            # Only time_entries has a server-side timestamp filter; everything else is full refresh.
-            has_incremental = len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=has_incremental,
-                supports_append=has_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=CLOCKIFY_ENDPOINTS[endpoint].should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Only time_entries has a server-side timestamp filter; everything else is full refresh.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: ClockifySourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -131,11 +119,11 @@ The key is user-scoped — it can read exactly what your Clockify user can. Use 
         return clockify_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,
-            incremental_field=inputs.incremental_field,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/tests/test_clockify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/tests/test_clockify.py
@@ -1,30 +1,74 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock
+from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
-from products.warehouse_sources.backend.temporal.data_imports.sources.clockify import clockify
 from products.warehouse_sources.backend.temporal.data_imports.sources.clockify.clockify import (
     CLOCKIFY_BASE_URL,
+    ClockifyPageNumberPaginator,
     ClockifyResumeConfig,
-    _build_url,
     _clamp_future_value_to_now,
     _flatten_time_entry,
     _format_datetime_z,
-    _get_item_mapper,
     clockify_source,
-    get_rows,
+    validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.clockify.settings import (
-    CLOCKIFY_ENDPOINTS,
-    ClockifyEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.clockify.settings import CLOCKIFY_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the clockify module.
+CLOCKIFY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.clockify.clockify.make_tracked_session"
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+
+def _response(body: Any) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: ClockifyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session; capture each request's (url, params) AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so snapshot a copy when each request
+    is prepared instead of inspecting it after the run.
+    """
+    session.headers = {}
+    snapshots: list[tuple[str, dict[str, Any]]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append((request.url, dict(request.params or {})))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return clockify_source(
+        api_key="key", endpoint=endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs
+    )
 
 
 class TestFormatDatetimeZ:
@@ -46,7 +90,6 @@ class TestFormatDatetimeZ:
 class TestClampFutureValueToNow:
     @parameterized.expand(
         [
-            # Future cursor caps at now; anything at/before now (and non-ISO strings) passes through.
             ("future_datetime", datetime(2027, 2, 5, tzinfo=UTC), datetime(2026, 6, 15, 12, tzinfo=UTC)),
             ("past_datetime", datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC), datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC)),
             ("non_iso_string_passthrough", "cursor", "cursor"),
@@ -57,17 +100,6 @@ class TestClampFutureValueToNow:
     @freeze_time("2026-06-15T12:00:00Z")
     def test_clamp(self, _name: str, value: Any, expected: Any) -> None:
         assert _clamp_future_value_to_now(value) == expected
-
-
-class TestBuildUrl:
-    @parameterized.expand(
-        [
-            ("no_params", f"{CLOCKIFY_BASE_URL}/workspaces", {}, f"{CLOCKIFY_BASE_URL}/workspaces"),
-            ("with_params", "http://x/y", {"page": 1, "page-size": 1000}, "http://x/y?page=1&page-size=1000"),
-        ]
-    )
-    def test_build_url(self, _name: str, base: str, params: dict, expected: str) -> None:
-        assert _build_url(base, params) == expected
 
 
 class TestFlattenTimeEntry:
@@ -86,239 +118,242 @@ class TestFlattenTimeEntry:
         row = _flatten_time_entry({"id": "T1"})
         assert "time_interval_start" not in row
 
-    @parameterized.expand([("time_entries", True), ("clients", False), ("workspaces", False)])
-    def test_get_item_mapper(self, endpoint: str, has_mapper: bool) -> None:
-        assert (_get_item_mapper(endpoint) is not None) == has_mapper
 
+class TestPaginator:
+    def _paginator(self) -> ClockifyPageNumberPaginator:
+        paginator = ClockifyPageNumberPaginator(page_size=2)
+        request = mock.MagicMock()
+        request.params = {}
+        paginator.init_request(request)
+        assert request.params == {"page": 1}
+        return paginator
 
-class _FakeManager(ResumableSourceManager[ClockifyResumeConfig]):
-    """In-memory stand-in: overrides __init__ to skip Redis wiring, records saved state."""
+    def test_full_page_advances_to_next_page(self) -> None:
+        paginator = self._paginator()
+        paginator.update_state(_response([{"id": "a"}, {"id": "b"}]), [{"id": "a"}, {"id": "b"}])
+        assert paginator.has_next_page is True
+        request = mock.MagicMock()
+        request.params = {}
+        paginator.update_request(request)
+        assert request.params == {"page": 2}
 
-    def __init__(self, state: ClockifyResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[ClockifyResumeConfig] = []
+    def test_short_page_terminates(self) -> None:
+        paginator = self._paginator()
+        paginator.update_state(_response([{"id": "a"}]), [{"id": "a"}])
+        assert paginator.has_next_page is False
 
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> ClockifyResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: ClockifyResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class _FakeFetcher:
-    """Stand-in for `_fetch_page` keyed by exact request URL; records every URL fetched."""
-
-    def __init__(self, pages: dict[str, list[dict]]) -> None:
-        self.pages = pages
-        self.urls: list[str] = []
-
-    def __call__(self, session: Any, url: str, headers: dict, logger: Any) -> list[dict]:
-        self.urls.append(url)
-        if url not in self.pages:
-            raise AssertionError(f"Unexpected URL fetched: {url}")
-        return self.pages[url]
-
-
-def _collect(
-    manager: _FakeManager, monkeypatch: Any, fetcher: _FakeFetcher, endpoint: str, **kwargs: Any
-) -> list[dict]:
-    monkeypatch.setattr(clockify, "_fetch_page", fetcher)
-    rows: list[dict] = []
-    for table in get_rows(
-        api_key="key", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=manager, **kwargs
-    ):
-        rows.extend(table.to_pylist())
-    return rows
+    def test_empty_page_terminates(self) -> None:
+        paginator = self._paginator()
+        paginator.update_state(_response([]), [])
+        assert paginator.has_next_page is False
 
 
 class TestWorkspacesEndpoint:
-    def test_top_level_pagination_and_no_fan_out(self, monkeypatch: Any) -> None:
-        fetcher = _FakeFetcher(
-            {f"{CLOCKIFY_BASE_URL}/workspaces?page=1&page-size=1000": [{"id": "W1", "name": "A"}, {"id": "W2"}]}
-        )
-        rows = _collect(_FakeManager(), monkeypatch, fetcher, "workspaces")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_top_level_pagination_and_no_fan_out(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": "W1", "name": "A"}, {"id": "W2"}])])
+
+        rows = _rows(_source("workspaces", _make_manager()))
+
         assert [r["id"] for r in rows] == ["W1", "W2"]
-        # Workspaces is its own endpoint — it must NOT also enumerate workspaces for a fan-out.
-        assert fetcher.urls == [f"{CLOCKIFY_BASE_URL}/workspaces?page=1&page-size=1000"]
+        # Workspaces is its own endpoint — one request, and it must NOT fan out over workspaces.
+        assert len(snapshots) == 1
+        assert snapshots[0][0] == f"{CLOCKIFY_BASE_URL}/workspaces"
+        assert snapshots[0][1] == {"page": 1, "page-size": 1000}
 
 
 class TestSingleLevelFanOut:
-    def _pages(self) -> dict[str, list[dict]]:
-        return {
-            f"{CLOCKIFY_BASE_URL}/workspaces": [{"id": "W1"}, {"id": "W2"}],
-            f"{CLOCKIFY_BASE_URL}/workspaces/W1/clients?page=1&page-size=1000": [{"id": "C1", "name": "Acme"}],
-            f"{CLOCKIFY_BASE_URL}/workspaces/W2/clients?page=1&page-size=1000": [{"id": "C2"}],
-        }
+    def _responses(self) -> list[Response]:
+        return [
+            _response([{"id": "W1"}, {"id": "W2"}]),
+            _response([{"id": "C1", "name": "Acme"}]),
+            _response([{"id": "C2"}]),
+        ]
 
-    def test_fans_out_over_workspaces_and_injects_workspace_id(self, monkeypatch: Any) -> None:
-        rows = _collect(_FakeManager(), monkeypatch, _FakeFetcher(self._pages()), "clients")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_over_workspaces_and_injects_workspace_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, self._responses())
+
+        rows = _rows(_source("clients", _make_manager()))
+
         assert [(r["id"], r["workspace_id"]) for r in rows] == [("C1", "W1"), ("C2", "W2")]
+        assert [url for url, _ in snapshots] == [
+            f"{CLOCKIFY_BASE_URL}/workspaces",
+            f"{CLOCKIFY_BASE_URL}/workspaces/W1/clients",
+            f"{CLOCKIFY_BASE_URL}/workspaces/W2/clients",
+        ]
 
-    def test_resume_skips_to_saved_workspace(self, monkeypatch: Any) -> None:
-        manager = _FakeManager(ClockifyResumeConfig(workspace_id="W2", parent_id=None, page=1))
-        rows = _collect(manager, monkeypatch, _FakeFetcher(self._pages()), "clients")
-        # W1 is skipped; only W2's clients are pulled.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_workspace(self, MockSession) -> None:
+        session = MockSession.return_value
+        # W1 already fully synced last run — only workspaces (re-enumerated) and W2 are fetched.
+        snapshots = _wire(session, [_response([{"id": "W1"}, {"id": "W2"}]), _response([{"id": "C2"}])])
+        resume = ClockifyResumeConfig(
+            fanout_state={"completed": [f"/workspaces/W1/clients"], "current": None, "child_state": None}
+        )
+
+        rows = _rows(_source("clients", _make_manager(resume)))
+
         assert [r["id"] for r in rows] == ["C2"]
+        assert [url for url, _ in snapshots] == [
+            f"{CLOCKIFY_BASE_URL}/workspaces",
+            f"{CLOCKIFY_BASE_URL}/workspaces/W2/clients",
+        ]
 
-    def test_resume_from_missing_workspace_restarts_from_beginning(self, monkeypatch: Any) -> None:
-        manager = _FakeManager(ClockifyResumeConfig(workspace_id="GONE", parent_id=None, page=1))
-        rows = _collect(manager, monkeypatch, _FakeFetcher(self._pages()), "clients")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_resume_state_restarts_from_beginning(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, self._responses())
+        # An old-format saved state (no fanout_state) parses but resumes nothing — a full re-read the
+        # merge dedupes, rather than mis-mapping the old positional scope onto the new fan-out state.
+        rows = _rows(_source("clients", _make_manager(ClockifyResumeConfig(workspace_id="GONE"))))
+
         assert [r["id"] for r in rows] == ["C1", "C2"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoint_records_completed_child_path(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "W1"}]), _response([{"id": "C1"}])])
+        manager = _make_manager()
+
+        _rows(_source("clients", manager))
+
+        assert manager.save_state.called
+        last_saved = manager.save_state.call_args.args[0]
+        assert isinstance(last_saved, ClockifyResumeConfig)
+        assert last_saved.fanout_state is not None
+        assert last_saved.fanout_state["completed"] == [f"/workspaces/W1/clients"]
 
 
 class TestTwoLevelFanOutTasks:
-    def test_fans_out_workspace_then_project_and_injects_both_ids(self, monkeypatch: Any) -> None:
-        pages = {
-            f"{CLOCKIFY_BASE_URL}/workspaces": [{"id": "W1"}],
-            f"{CLOCKIFY_BASE_URL}/workspaces/W1/projects?page=1&page-size=1000": [{"id": "P1"}, {"id": "P2"}],
-            f"{CLOCKIFY_BASE_URL}/workspaces/W1/projects/P1/tasks?page=1&page-size=1000": [{"id": "TK1"}],
-            f"{CLOCKIFY_BASE_URL}/workspaces/W1/projects/P2/tasks?page=1&page-size=1000": [{"id": "TK2"}],
-        }
-        rows = _collect(_FakeManager(), monkeypatch, _FakeFetcher(pages), "tasks")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_workspace_then_project_and_injects_both_ids(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "W1"}]),
+                _response([{"id": "P1"}, {"id": "P2"}]),
+                _response([{"id": "TK1"}]),
+                _response([{"id": "TK2"}]),
+            ],
+        )
+
+        rows = _rows(_source("tasks", _make_manager()))
+
         assert rows == [
             {"id": "TK1", "workspace_id": "W1", "project_id": "P1"},
             {"id": "TK2", "workspace_id": "W1", "project_id": "P2"},
         ]
+        assert [url for url, _ in snapshots] == [
+            f"{CLOCKIFY_BASE_URL}/workspaces",
+            f"{CLOCKIFY_BASE_URL}/workspaces/W1/projects",
+            f"{CLOCKIFY_BASE_URL}/workspaces/W1/projects/P1/tasks",
+            f"{CLOCKIFY_BASE_URL}/workspaces/W1/projects/P2/tasks",
+        ]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_chained_fan_out_disables_resume(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "W1"}]), _response([{"id": "P1"}]), _response([{"id": "TK1"}])])
+        manager = _make_manager()
+
+        _rows(_source("tasks", manager))
+
+        # Two dependent resources -> the framework disables resume so a shared hook can't corrupt state.
+        manager.save_state.assert_not_called()
 
 
 class TestTwoLevelFanOutTimeEntries:
-    def _pages(self) -> dict[str, list[dict]]:
-        return {
-            f"{CLOCKIFY_BASE_URL}/workspaces": [{"id": "W1"}],
-            f"{CLOCKIFY_BASE_URL}/workspaces/W1/users?page=1&page-size=1000": [{"id": "U1"}],
-        }
+    def _base_responses(self, entries: list[dict[str, Any]]) -> list[Response]:
+        return [_response([{"id": "W1"}]), _response([{"id": "U1"}]), _response(entries)]
 
-    def test_flattens_interval_and_injects_workspace_and_user(self, monkeypatch: Any) -> None:
-        pages = self._pages()
-        pages[f"{CLOCKIFY_BASE_URL}/workspaces/W1/user/U1/time-entries?page=1&page-size=1000"] = [
-            {"id": "TE1", "timeInterval": {"start": "2026-03-04T00:00:00Z", "end": None, "duration": None}}
-        ]
-        rows = _collect(_FakeManager(), monkeypatch, _FakeFetcher(pages), "time_entries")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_flattens_interval_and_injects_workspace_and_user(self, MockSession) -> None:
+        session = MockSession.return_value
+        entry = {"id": "TE1", "timeInterval": {"start": "2026-03-04T00:00:00Z", "end": None, "duration": None}}
+        snapshots = _wire(session, self._base_responses([entry]))
+
+        rows = _rows(_source("time_entries", _make_manager()))
+
         assert rows[0]["workspace_id"] == "W1"
         assert rows[0]["user_id"] == "U1"
         assert rows[0]["time_interval_start"] == "2026-03-04T00:00:00Z"
+        assert snapshots[-1][0] == f"{CLOCKIFY_BASE_URL}/workspaces/W1/user/U1/time-entries"
 
-    def test_incremental_passes_start_filter(self, monkeypatch: Any) -> None:
-        pages = self._pages()
-        # The exact URL carries the urlencoded `start`; match it by recording fetched URLs instead.
-        fetcher = _FakeFetcher(pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_passes_start_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, self._base_responses([]))
 
-        def fetch(session: Any, url: str, headers: dict, logger: Any) -> list[dict]:
-            fetcher.urls.append(url)
-            if "time-entries" in url:
-                return []
-            return pages[url]
-
-        monkeypatch.setattr(clockify, "_fetch_page", fetch)
-        list(
-            get_rows(
-                api_key="key",
-                endpoint="time_entries",
-                logger=MagicMock(),
-                resumable_source_manager=_FakeManager(),
+        _rows(
+            _source(
+                "time_entries",
+                _make_manager(),
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
-                incremental_field="time_interval_start",
             )
         )
-        time_entry_urls = [u for u in fetcher.urls if "time-entries" in u]
-        assert time_entry_urls and "start=2026-03-04T02%3A58%3A14Z" in time_entry_urls[0]
+
+        # The server-side `start` filter is only applied to the time-entries request.
+        time_entry_params = snapshots[-1][1]
+        assert time_entry_params["start"] == "2026-03-04T02:58:14Z"
+        # Parent enumeration requests carry no incremental filter.
+        assert "start" not in snapshots[0][1]
+        assert "start" not in snapshots[1][1]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_start_filter_on_full_refresh(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, self._base_responses([]))
+
+        _rows(_source("time_entries", _make_manager(), should_use_incremental_field=False))
+
+        assert "start" not in snapshots[-1][1]
 
 
-class TestPaginateScope:
-    def test_short_page_terminates_pagination(self, monkeypatch: Any) -> None:
-        config = ClockifyEndpointConfig(name="t", path="/p", primary_keys=["id"], page_size=2)
-        # First page returns a full page (2) -> fetch page 2; second returns 1 (< page_size) -> stop.
-        pages = {
-            "http://x/p?page=1&page-size=2": [{"id": "a"}, {"id": "b"}],
-            "http://x/p?page=2&page-size=2": [{"id": "c"}],
-        }
-        fetcher = _FakeFetcher(pages)
-        monkeypatch.setattr(clockify, "_fetch_page", fetcher)
-        batcher = Batcher(logger=MagicMock(), chunk_size=1)
-        manager = _FakeManager()
-        rows: list[dict] = []
-        for table in clockify._paginate_scope(
-            MagicMock(),
-            {},
-            "http://x/p",
-            config,
-            batcher,
-            manager,
-            MagicMock(),
-            None,
-            "W1",
-            None,
-            1,
-            {"workspace_id": "W1"},
-            {},
-        ):
-            rows.extend(table.to_pylist())
-        if batcher.should_yield(include_incomplete_chunk=True):
-            rows.extend(batcher.get_table().to_pylist())
-        assert [r["id"] for r in rows] == ["a", "b", "c"]
-        assert fetcher.urls == ["http://x/p?page=1&page-size=2", "http://x/p?page=2&page-size=2"]
+class TestFailLoud:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A 200 body that is not a list means the response shape changed — fail loud, not 0 rows.
+        _wire(session, [_response({"error": "unexpected"})])
 
-    def test_saves_state_after_each_yielded_batch(self, monkeypatch: Any) -> None:
-        config = ClockifyEndpointConfig(name="t", path="/p", primary_keys=["id"], page_size=10)
-        pages = {"http://x/p?page=1&page-size=10": [{"id": "a"}, {"id": "b"}]}
-        monkeypatch.setattr(clockify, "_fetch_page", _FakeFetcher(pages))
-        batcher = Batcher(logger=MagicMock(), chunk_size=1)  # every row is a full chunk -> yields + saves
-        manager = _FakeManager()
-        list(
-            clockify._paginate_scope(
-                MagicMock(), {}, "http://x/p", config, batcher, manager, MagicMock(), None, "W1", "P1", 1, {}, {}
-            )
-        )
-        # State is saved after each yield, pointing at the page being read so a crash re-reads it.
-        assert manager.saved == [
-            ClockifyResumeConfig(workspace_id="W1", parent_id="P1", page=1),
-            ClockifyResumeConfig(workspace_id="W1", parent_id="P1", page=1),
-        ]
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source("workspaces", _make_manager()))
 
 
 class TestClockifySourceResponse:
     @parameterized.expand([(name,) for name in CLOCKIFY_ENDPOINTS])
     def test_primary_keys_and_sort_mode_match_config(self, endpoint: str) -> None:
-        response = clockify_source(
-            api_key="key", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=_FakeManager()
-        )
+        response = _source(endpoint, _make_manager())
         config = CLOCKIFY_ENDPOINTS[endpoint]
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
         assert response.sort_mode == config.sort_mode
 
     def test_time_entries_is_desc_and_partitioned(self) -> None:
-        response = clockify_source(
-            api_key="key", endpoint="time_entries", logger=MagicMock(), resumable_source_manager=_FakeManager()
-        )
+        response = _source("time_entries", _make_manager())
         assert response.sort_mode == "desc"
         assert response.partition_keys == ["time_interval_start"]
         assert response.partition_mode == "datetime"
 
     def test_full_refresh_endpoint_has_no_partition(self) -> None:
-        response = clockify_source(
-            api_key="key", endpoint="clients", logger=MagicMock(), resumable_source_manager=_FakeManager()
-        )
+        response = _source("clients", _make_manager())
         assert response.partition_keys is None
         assert response.partition_mode is None
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status,expected", [(200, True), (401, False), (403, False)])
-    def test_status_maps_to_validity(self, status: int, expected: bool, monkeypatch: Any) -> None:
-        response = MagicMock()
-        response.status_code = status
-        session = MagicMock()
-        session.get.return_value = response
-        monkeypatch.setattr(clockify, "make_tracked_session", lambda *a, **k: session)
-        assert clockify.validate_credentials("key") is expected
+    def test_status_maps_to_validity(self, status: int, expected: bool) -> None:
+        with mock.patch(CLOCKIFY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+            assert validate_credentials("key") is expected
 
-    def test_network_error_is_invalid(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        monkeypatch.setattr(clockify, "make_tracked_session", lambda *a, **k: session)
-        assert clockify.validate_credentials("key") is False
+    def test_network_error_is_invalid(self) -> None:
+        with mock.patch(CLOCKIFY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.side_effect = Exception("boom")
+            assert validate_credentials("key") is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coda/coda.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coda/coda.py
@@ -1,149 +1,143 @@
-import time
-from collections.abc import Iterator
-from typing import Any, Optional
-from urllib.parse import quote, urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from collections.abc import Callable
+from typing import Any
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.coda.settings import CODA_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CODA_BASE_URL = "https://coda.io/apis/v1"
 PAGE_SIZE = 100
 ROWS_PAGE_SIZE = 200
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
-# Coda's rate limits are per endpoint family: doc listing allows only
-# 4 req/6s, while reads allow 100 req/6s — space requests accordingly.
-DOC_LIST_INTERVAL_SECONDS = 1.6
-READ_INTERVAL_SECONDS = 0.07
 
 
-class CodaRetryableError(Exception):
-    pass
+def _cursor_paginator() -> JSONResponseCursorPaginator:
+    # Coda hands back an opaque `nextPageToken` in the body and expects it echoed as `pageToken`;
+    # a page without a token ends the stream, so an empty intermediate page (token present) keeps going.
+    return JSONResponseCursorPaginator(cursor_path="nextPageToken", cursor_param="pageToken")
 
 
-def _get_session(api_token: str) -> requests.Session:
-    return make_tracked_session(headers={"Authorization": f"Bearer {api_token}"}, redact_values=(api_token,))
+def _rename(renames: dict[str, str]) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    # include_from_parent names carried fields `_<parent>_<field>`; rename them back to the flat
+    # `_doc_id` / `_table_id` keys the composite primary keys and downstream schema expect.
+    def _mapper(row: dict[str, Any]) -> dict[str, Any]:
+        for src, dst in renames.items():
+            if src in row:
+                row[dst] = row.pop(src)
+        return row
+
+    return _mapper
 
 
-def validate_credentials(api_token: str) -> bool:
-    """Confirm the API token is valid with the whoami endpoint."""
-    try:
-        response = _get_session(api_token).get(
-            f"{CODA_BASE_URL}/whoami",
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+def _docs_resource() -> EndpointResource:
+    return {
+        "name": "docs",
+        "endpoint": {
+            "path": "/docs",
+            "params": {"limit": PAGE_SIZE},
+            "data_selector": "items",
+            "paginator": _cursor_paginator(),
+        },
+    }
 
 
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    session = _get_session(api_token)
+def _tables_resource() -> EndpointResource:
+    return {
+        "name": "tables",
+        "endpoint": {
+            "path": "/docs/{doc_id}/tables",
+            "params": {
+                "doc_id": {"type": "resolve", "resource": "docs", "field": "id"},
+                "limit": PAGE_SIZE,
+            },
+            "data_selector": "items",
+            "paginator": _cursor_paginator(),
+        },
+        # Carry the parent doc id into every table row so ids that are only unique within a doc
+        # get a composite primary key.
+        "include_from_parent": ["id"],
+        "data_map": _rename({"_docs_id": "_doc_id"}),
+    }
 
-    @retry(
-        retry=retry_if_exception_type((CodaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=5, max=120),
-        reraise=True,
-    )
-    def fetch(path: str, params: dict[str, Any]) -> dict[str, Any]:
-        url = f"{CODA_BASE_URL}{path}"
-        if params:
-            url = f"{url}?{urlencode(params)}"
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
 
-        if response.status_code == 429 or response.status_code >= 500:
-            raise CodaRetryableError(f"Coda API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"Coda API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    def iterate_pages(
-        path: str, page_size: int, interval: float, extra: dict[str, Any] | None = None
-    ) -> Iterator[list[dict[str, Any]]]:
-        token: Optional[str] = None
-        while True:
-            params: dict[str, Any] = {"limit": page_size, **(extra or {})}
-            if token:
-                # pageToken supersedes other params on continuation requests.
-                params = {"pageToken": token}
-            # Proactive pacing sits outside fetch's @retry boundary so tenacity
-            # backoff isn't compounded by this sleep on every retry attempt.
-            time.sleep(interval)
-            data = fetch(path, params)
-            items = data.get("items", []) or []
-            if items:
-                yield items
-            token = data.get("nextPageToken")
-            # Continue while Coda hands back a continuation token, even if this
-            # page was empty — intermediate empty pages still precede more data.
-            if not token:
-                return
-
-    def doc_ids() -> list[str]:
-        # Direct access on the primary key so malformed API data fails fast
-        # rather than silently dropping docs from the sync.
-        return [doc["id"] for page in iterate_pages("/docs", PAGE_SIZE, DOC_LIST_INTERVAL_SECONDS) for doc in page]
-
-    if endpoint == "docs":
-        yield from iterate_pages("/docs", PAGE_SIZE, DOC_LIST_INTERVAL_SECONDS)
-        return
-
-    if endpoint == "tables":
-        for doc_id in doc_ids():
-            for page in iterate_pages(f"/docs/{quote(doc_id)}/tables", PAGE_SIZE, READ_INTERVAL_SECONDS):
-                yield [{**table, "_doc_id": doc_id} for table in page]
-        return
-
-    if endpoint != "rows":
-        raise ValueError(f"Unknown Coda endpoint: {endpoint!r}")
-
-    # rows: fan out docs → tables → rows.
-    for doc_id in doc_ids():
-        tables: list[str] = []
-        for page in iterate_pages(f"/docs/{quote(doc_id)}/tables", PAGE_SIZE, READ_INTERVAL_SECONDS):
-            # Direct access on the primary key so malformed API data fails fast.
-            tables.extend(table["id"] for table in page)
-
-        for table_id in tables:
-            for page in iterate_pages(
-                f"/docs/{quote(doc_id)}/tables/{quote(table_id)}/rows",
-                ROWS_PAGE_SIZE,
-                READ_INTERVAL_SECONDS,
+def _rows_resource() -> EndpointResource:
+    return {
+        "name": "rows",
+        "endpoint": {
+            "path": "/docs/{doc_id}/tables/{table_id}/rows",
+            "params": {
+                # Both path params bind fields of the same parent table row (doc_id is carried in
+                # from the tables resource via include_from_parent above).
+                "doc_id": {"type": "resolve", "resource": "tables", "field": "_doc_id"},
+                "table_id": {"type": "resolve", "resource": "tables", "field": "id"},
+                "limit": ROWS_PAGE_SIZE,
                 # Column names instead of opaque column ids in `values`.
-                extra={"useColumnNames": "true"},
-            ):
-                yield [{**row, "_doc_id": doc_id, "_table_id": table_id} for row in page]
+                "useColumnNames": "true",
+            },
+            "data_selector": "items",
+            "paginator": _cursor_paginator(),
+        },
+        "include_from_parent": ["_doc_id", "id"],
+        "data_map": _rename({"_tables__doc_id": "_doc_id", "_tables_id": "_table_id"}),
+    }
+
+
+def _resource_chain(endpoint: str) -> list[EndpointResource]:
+    # Rows fan out docs → tables → rows; each endpoint's chain is the resources up to and including
+    # it, so iterating the leaf drives its parents lazily. Fresh dicts per call — config setup mutates.
+    if endpoint == "docs":
+        return [_docs_resource()]
+    if endpoint == "tables":
+        return [_docs_resource(), _tables_resource()]
+    if endpoint == "rows":
+        return [_docs_resource(), _tables_resource(), _rows_resource()]
+    raise ValueError(f"Unknown Coda endpoint: {endpoint!r}")
 
 
 def coda_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
+    resource_chain = _resource_chain(endpoint)
     config = CODA_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CODA_BASE_URL,
+            "auth": {"type": "bearer", "token": api_token},
+        },
+        "resource_defaults": {},
+        "resources": resource_chain,
+    }
+
+    resources = rest_api_resources(rest_config, team_id, job_id, None)
+    resource = next(r for r in resources if r.name == endpoint)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         sort_mode="asc",
     )
+
+
+def validate_credentials(api_token: str) -> bool:
+    """Confirm the API token is valid with the whoami endpoint."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{CODA_BASE_URL}/whoami",
+        headers={"Authorization": f"Bearer {api_token}"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coda/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coda/settings.py
@@ -25,3 +25,6 @@ CODA_ENDPOINTS: dict[str, CodaEndpointConfig] = {
 }
 
 ENDPOINTS = tuple(CODA_ENDPOINTS.keys())
+
+# Coda's list endpoints have no updated-since filters, so no stream is incremental.
+INCREMENTAL_FIELDS: dict[str, list] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coda/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coda/source.py
@@ -17,13 +17,16 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.coda.coda 
     coda_source,
     validate_credentials as validate_coda_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.coda.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.coda.settings import ENDPOINTS, INCREMENTAL_FIELDS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CodaSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -89,21 +92,7 @@ You can generate an API token in [Coda account settings](https://coda.io/account
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Coda's list endpoints have no updated-since filters; full refresh only.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CodaSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -117,5 +106,6 @@ You can generate an API token in [Coda account settings](https://coda.io/account
         return coda_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coda/tests/test_coda.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coda/tests/test_coda.py
@@ -1,34 +1,52 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 import pytest
 from unittest import mock
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.coda.coda import (
-    coda_source,
-    get_rows,
-    validate_credentials,
-)
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.coda.coda import coda_source, validate_credentials
 from products.warehouse_sources.backend.temporal.data_imports.sources.coda.settings import CODA_ENDPOINTS, ENDPOINTS
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.coda.coda"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the coda module.
+CODA_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.coda.coda.make_tracked_session"
 
 
-def _response(items: list[dict[str, Any]], next_token: str | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
+def _response(items: list[dict[str, Any]], next_token: str | None = None) -> Response:
     body: dict[str, Any] = {"items": items}
     if next_token:
         body["nextPageToken"] = next_token
-    resp.json.return_value = body
+    resp = Response()
     resp.status_code = 200
-    resp.ok = True
+    resp._content = json.dumps(body).encode()
     return resp
 
 
-@pytest.fixture(autouse=True)
-def _no_sleep():
-    with mock.patch(f"{_MODULE}.time.sleep"):
-        yield
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session, capturing each request's url + params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared instead of inspecting it after the run.
+    """
+    session.headers = {}
+    request_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        request_snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return request_snapshots
+
+
+def _rows(endpoint: str) -> list[dict[str, Any]]:
+    response = coda_source("token", endpoint, team_id=1, job_id="j")
+    return [row for page in response.items() for row in page]
 
 
 class TestValidateCredentials:
@@ -41,106 +59,106 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(CODA_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
-        response = mock.MagicMock()
-        response.status_code = status_code
-        mock_session.return_value.get.return_value = response
-
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("token") is expected
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(CODA_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("token") is False
 
 
 class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_docs_paginate_via_page_token(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "doc1"}], next_token="tok1"),
-            _response([{"id": "doc2"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_docs_paginate_via_page_token(self, MockSession):
+        requests = _wire(
+            MockSession.return_value,
+            [_response([{"id": "doc1"}], next_token="tok1"), _response([{"id": "doc2"}])],
+        )
 
-        batches = list(get_rows("token", "docs", mock.MagicMock()))
+        rows = _rows("docs")
 
-        assert [item["id"] for batch in batches for item in batch] == ["doc1", "doc2"]
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert parse_qs(urlparse(second_url).query)["pageToken"] == ["tok1"]
+        assert [r["id"] for r in rows] == ["doc1", "doc2"]
+        # The next page echoes the body's nextPageToken back as the pageToken query param.
+        assert requests[1]["params"]["pageToken"] == "tok1"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_intermediate_page_does_not_halt_pagination(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "doc1"}], next_token="tok1"),
-            _response([], next_token="tok2"),
-            _response([{"id": "doc2"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_intermediate_page_does_not_halt_pagination(self, MockSession):
+        _wire(
+            MockSession.return_value,
+            [
+                _response([{"id": "doc1"}], next_token="tok1"),
+                _response([], next_token="tok2"),
+                _response([{"id": "doc2"}]),
+            ],
+        )
 
-        batches = list(get_rows("token", "docs", mock.MagicMock()))
+        rows = _rows("docs")
 
-        assert [item["id"] for batch in batches for item in batch] == ["doc1", "doc2"]
+        assert [r["id"] for r in rows] == ["doc1", "doc2"]
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_tables_fan_out_over_docs(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "doc1"}]),
-            _response([{"id": "grid-1", "name": "Tasks"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tables_fan_out_over_docs(self, MockSession):
+        requests = _wire(
+            MockSession.return_value,
+            [_response([{"id": "doc1"}]), _response([{"id": "grid-1", "name": "Tasks"}])],
+        )
 
-        batches = list(get_rows("token", "tables", mock.MagicMock()))
+        rows = _rows("tables")
 
-        flat = [item for batch in batches for item in batch]
-        assert [(t["id"], t["_doc_id"]) for t in flat] == [("grid-1", "doc1")]
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert urlparse(urls[1]).path == "/apis/v1/docs/doc1/tables"
+        assert [(t["id"], t["_doc_id"]) for t in rows] == [("grid-1", "doc1")]
+        assert urlparse(requests[1]["url"]).path == "/apis/v1/docs/doc1/tables"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_rows_fan_out_docs_tables_rows(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "doc1"}]),  # docs
-            _response([{"id": "grid-1"}]),  # tables for doc1
-            _response([{"id": "i-1", "values": {"Name": "x"}}]),  # rows for grid-1
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rows_fan_out_docs_tables_rows(self, MockSession):
+        requests = _wire(
+            MockSession.return_value,
+            [
+                _response([{"id": "doc1"}]),  # docs
+                _response([{"id": "grid-1"}]),  # tables for doc1
+                _response([{"id": "i-1", "values": {"Name": "x"}}]),  # rows for grid-1
+            ],
+        )
 
-        batches = list(get_rows("token", "rows", mock.MagicMock()))
+        rows = _rows("rows")
 
-        flat = [item for batch in batches for item in batch]
-        assert [(r["id"], r["_doc_id"], r["_table_id"]) for r in flat] == [("i-1", "doc1", "grid-1")]
-        rows_url = mock_session.return_value.get.call_args_list[2].args[0]
-        parsed = urlparse(rows_url)
+        assert [(r["id"], r["_doc_id"], r["_table_id"]) for r in rows] == [("i-1", "doc1", "grid-1")]
+        parsed = urlparse(requests[2]["url"])
         assert parsed.path == "/apis/v1/docs/doc1/tables/grid-1/rows"
-        assert parse_qs(parsed.query)["useColumnNames"] == ["true"]
+        assert requests[2]["params"]["useColumnNames"] == "true"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_table_without_id_fails_fast_in_rows(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "doc1"}]),
-            _response([{"name": "broken"}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_table_without_id_fails_fast_in_rows(self, MockSession):
+        _wire(
+            MockSession.return_value,
+            [_response([{"id": "doc1"}]), _response([{"name": "broken"}])],
+        )
 
-        with pytest.raises(KeyError):
-            list(get_rows("token", "rows", mock.MagicMock()))
+        # A table row missing its primary key can't be bound into the rows path — fail loud
+        # rather than silently dropping the table.
+        with pytest.raises(ValueError, match="expects a field 'id'"):
+            _rows("rows")
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_workspace_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_workspace_yields_nothing(self, MockSession):
+        MockSession.return_value.headers = {}
+        MockSession.return_value.prepare_request.side_effect = lambda request: mock.MagicMock()
+        MockSession.return_value.send.return_value = _response([])
 
-        assert list(get_rows("token", "rows", mock.MagicMock())) == []
+        assert _rows("rows") == []
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_unknown_endpoint_raises(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
-
+    def test_unknown_endpoint_raises(self):
         with pytest.raises(ValueError, match="Unknown Coda endpoint"):
-            list(get_rows("token", "nonsense", mock.MagicMock()))
+            coda_source("token", "nonsense", team_id=1, job_id="j")
 
 
 class TestCodaSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = CODA_ENDPOINTS[endpoint]
-        response = coda_source("token", endpoint, mock.MagicMock())
+        response = coda_source("token", endpoint, team_id=1, job_id="j")
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -149,5 +167,5 @@ class TestCodaSourceResponse:
         assert response.partition_keys is None
 
     def test_rows_have_composite_primary_key(self):
-        response = coda_source("token", "rows", mock.MagicMock())
+        response = coda_source("token", "rows", team_id=1, job_id="j")
         assert response.primary_keys == ["_doc_id", "_table_id", "id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -120,7 +120,7 @@ def rest_api_resources(
 def _make_paginate_dependent_resource(
     *,
     client: RESTClient,
-    resolved_param: ResolvedParam,
+    resolved_param: ResolvedParam | list[ResolvedParam],
     include_from_parent: list[str],
     default_columns_config: Optional[Any],
     incremental_object: Optional[Incremental],
@@ -219,7 +219,7 @@ def create_resources(
     client_config: ClientConfig,
     dependency_graph: graphlib.TopologicalSorter,
     endpoint_resource_map: dict[str, EndpointResource],
-    resolved_param_map: dict[str, Optional[ResolvedParam]],
+    resolved_param_map: dict[str, Optional[list[ResolvedParam]]],
     team_id: int,
     job_id: str,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -230,8 +230,14 @@ def create_resources(
 
     # Resume is routed to the dependent (child) resource in a fan-out; the parent list is re-fetched
     # each run (see _make_paginate_dependent_resource). So when any resource is dependent, the
-    # non-dependent resources in the same config don't consume the resume hook.
-    has_dependent_resource = any(rp is not None for rp in resolved_param_map.values())
+    # non-dependent resources in the same config don't consume the resume hook. With MULTIPLE
+    # dependent resources (a chained/multi-level fan-out), no resource gets resume — one shared
+    # hook consumed at several levels would corrupt the saved state; retries re-fetch and the
+    # merge dedupes.
+    dependent_count = sum(1 for rp in resolved_param_map.values() if rp is not None)
+    has_dependent_resource = dependent_count > 0
+    dependent_resume_hook = resume_hook if dependent_count == 1 else None
+    dependent_initial_state = initial_paginator_state if dependent_count == 1 else None
 
     for resource_name in dependency_graph.static_order():
         resource_name = cast(str, resource_name)
@@ -241,10 +247,10 @@ def create_resources(
         request_json = endpoint_config.get("json", None)
         paginator = create_paginator(endpoint_config.get("paginator"))
 
-        resolved_param: ResolvedParam | None = resolved_param_map[resource_name]
+        resolved_params: list[ResolvedParam] | None = resolved_param_map[resource_name]
 
         include_from_parent: list[str] = endpoint_resource.get("include_from_parent") or []
-        if not resolved_param and include_from_parent:
+        if not resolved_params and include_from_parent:
             raise ValueError(
                 f"Resource {resource_name} has include_from_parent but is not dependent on another resource"
             )
@@ -284,7 +290,7 @@ def create_resources(
             )
         }
 
-        if resolved_param is None:
+        if resolved_params is None:
 
             def paginate_resource(
                 method: HTTPMethodBasic,
@@ -347,21 +353,21 @@ def create_resources(
             )
 
         else:
-            predecessor = resources[resolved_param.resolve_config["resource"]]
+            predecessor = resources[resolved_params[0].resolve_config["resource"]]
 
-            base_params = exclude_keys(request_params, {resolved_param.param_name})
+            base_params = exclude_keys(request_params, {rp.param_name for rp in resolved_params})
 
             paginate_fn = _make_paginate_dependent_resource(
                 client=client,
-                resolved_param=resolved_param,
+                resolved_param=resolved_params,
                 include_from_parent=include_from_parent,
                 default_columns_config=columns_config,
                 incremental_object=incremental_object,
                 incremental_param=incremental_param,
                 incremental_cursor_transform=incremental_cursor_transform,
                 db_incremental_field_last_value=db_incremental_field_last_value,
-                resume_hook=resume_hook,
-                initial_state=initial_paginator_state,
+                resume_hook=dependent_resume_hook,
+                initial_state=dependent_initial_state,
                 data_selector_required=bool(endpoint_config.get("data_selector_required")),
             )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
@@ -214,7 +214,7 @@ def build_resource_dependency_graph(
 ) -> tuple[Any, dict[str, EndpointResource], dict[str, Optional[ResolvedParam]]]:
     dependency_graph: graphlib.TopologicalSorter[str] = graphlib.TopologicalSorter()
     endpoint_resource_map: dict[str, EndpointResource] = {}
-    resolved_param_map: dict[str, Optional[ResolvedParam]] = {}
+    resolved_param_map: dict[str, Optional[list[ResolvedParam]]] = {}
 
     for resource_kwargs in resource_list:
         if isinstance(resource_kwargs, dict):
@@ -235,17 +235,23 @@ def build_resource_dependency_graph(
     for resource_name, endpoint_resource in endpoint_resource_map.items():
         assert isinstance(endpoint_resource["endpoint"], dict)
         resolved_params = _find_resolved_params(endpoint_resource["endpoint"])
-        if len(resolved_params) > 1:
-            raise ValueError(f"Multiple resolved params for resource {resource_name}: {resolved_params}")
-        elif len(resolved_params) == 1:
-            resolved_param = resolved_params[0]
-            predecessor = resolved_param.resolve_config["resource"]
+        if len(resolved_params) >= 1:
+            # Multiple resolved params are allowed when they all bind fields of the SAME parent
+            # row (e.g. /docs/{doc_id}/tables/{table_id}/rows where the tables rows carry doc_id
+            # via include_from_parent). Different parent resources per param are not supported.
+            parents = {p.resolve_config["resource"] for p in resolved_params}
+            if len(parents) > 1:
+                raise ValueError(
+                    f"Resolved params for resource {resource_name} must all reference the same "
+                    f"parent resource, got {sorted(parents)}"
+                )
+            predecessor = next(iter(parents))
             if predecessor not in endpoint_resource_map:
                 raise ValueError(
-                    f"A transformer resource {resource_name} refers to non existing parent resource {predecessor} on {resolved_param}"
+                    f"A transformer resource {resource_name} refers to non existing parent resource {predecessor} on {resolved_params[0]}"
                 )
             dependency_graph.add(resource_name, predecessor)
-            resolved_param_map[resource_name] = resolved_param
+            resolved_param_map[resource_name] = resolved_params
         else:
             dependency_graph.add(resource_name)
             resolved_param_map[resource_name] = None
@@ -379,19 +385,24 @@ def create_response_hooks(
 def process_parent_data_item(
     path: str,
     item: dict[str, Any],
-    resolved_param: ResolvedParam,
+    resolved_param: ResolvedParam | list[ResolvedParam],
     include_from_parent: list[str],
 ) -> tuple[str, dict[str, Any]]:
-    parent_resource_name = resolved_param.resolve_config["resource"]
+    # Accept one or many resolved params — all bound from fields of the same parent row
+    # (multi-param paths like /docs/{doc_id}/tables/{table_id}/rows).
+    resolved_params = resolved_param if isinstance(resolved_param, list) else [resolved_param]
+    parent_resource_name = resolved_params[0].resolve_config["resource"]
 
-    field_values = find_values(resolved_param.field_path, item)
-
-    if not field_values:
-        field_path = resolved_param.resolve_config["field"]
-        raise ValueError(
-            f"Transformer expects a field '{field_path}' to be present in the incoming data from resource {parent_resource_name} in order to bind it to path param {resolved_param.param_name}. Available parent fields are {', '.join(item.keys())}"
-        )
-    bound_path = path.format(**{resolved_param.param_name: field_values[0]})
+    bindings: dict[str, Any] = {}
+    for rp in resolved_params:
+        field_values = find_values(rp.field_path, item)
+        if not field_values:
+            field_path = rp.resolve_config["field"]
+            raise ValueError(
+                f"Transformer expects a field '{field_path}' to be present in the incoming data from resource {parent_resource_name} in order to bind it to path param {rp.param_name}. Available parent fields are {', '.join(item.keys())}"
+            )
+        bindings[rp.param_name] = field_values[0]
+    bound_path = path.format(**bindings)
 
     parent_record: dict[str, Any] = {}
     if include_from_parent:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_multilevel_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_multilevel_fanout.py
@@ -1,7 +1,7 @@
 from typing import Any
-from unittest.mock import patch
 
 import pytest
+from unittest.mock import patch
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import rest_api_resources
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.config_setup import (

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_multilevel_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_multilevel_fanout.py
@@ -1,0 +1,140 @@
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import rest_api_resources
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.config_setup import (
+    build_resource_dependency_graph,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
+
+
+def _paginate_stub(pages_by_path: dict[str, list[dict[str, Any]]]):
+    def paginate(
+        self,
+        *,
+        path="",
+        method="get",
+        params=None,
+        json=None,
+        paginator=None,
+        data_selector=None,
+        hooks=None,
+        resume_hook=None,
+        initial_paginator_state=None,
+        data_selector_required=False,
+    ):
+        yield pages_by_path[path]
+
+    return paginate
+
+
+class TestMultiParamResolution:
+    def test_two_resolve_params_from_same_parent_bind_into_path(self) -> None:
+        config: dict[str, Any] = {
+            "client": {"base_url": "https://api.example.com"},
+            "resources": [
+                {"name": "tables", "endpoint": {"path": "/tables"}},
+                {
+                    "name": "rows",
+                    "endpoint": {
+                        "path": "/docs/{doc_id}/tables/{table_id}/rows",
+                        "params": {
+                            "doc_id": {"type": "resolve", "resource": "tables", "field": "doc_id"},
+                            "table_id": {"type": "resolve", "resource": "tables", "field": "id"},
+                        },
+                    },
+                },
+            ],
+        }
+        pages = {
+            "/tables": [{"id": "t1", "doc_id": "d1"}],
+            "/docs/d1/tables/t1/rows": [{"row": 1}],
+        }
+        with patch.object(RESTClient, "paginate", _paginate_stub(pages)):
+            resources = rest_api_resources(config, team_id=1, job_id="j", db_incremental_field_last_value=None)
+            rows_resource = next(r for r in resources if r.name == "rows")
+            rows = [row for page in rows_resource for row in page]
+        assert rows == [{"row": 1}]
+
+    def test_resolve_params_from_different_parents_rejected(self) -> None:
+        with pytest.raises(ValueError, match="same\\s+parent"):
+            build_resource_dependency_graph(
+                {},
+                [
+                    {"name": "a", "endpoint": {"path": "/a"}},
+                    {"name": "b", "endpoint": {"path": "/b"}},
+                    {
+                        "name": "c",
+                        "endpoint": {
+                            "path": "/a/{x}/b/{y}",
+                            "params": {
+                                "x": {"type": "resolve", "resource": "a", "field": "id"},
+                                "y": {"type": "resolve", "resource": "b", "field": "id"},
+                            },
+                        },
+                    },
+                ],
+            )
+
+
+class TestChainedFanout:
+    def _three_level_config(self) -> dict[str, Any]:
+        return {
+            "client": {"base_url": "https://api.example.com"},
+            "resources": [
+                {"name": "orgs", "endpoint": {"path": "/orgs"}},
+                {
+                    "name": "projects",
+                    "include_from_parent": ["id"],
+                    "endpoint": {
+                        "path": "/orgs/{org_id}/projects",
+                        "params": {"org_id": {"type": "resolve", "resource": "orgs", "field": "id"}},
+                    },
+                },
+                {
+                    "name": "errors",
+                    "endpoint": {
+                        "path": "/projects/{project_id}/errors",
+                        "params": {"project_id": {"type": "resolve", "resource": "projects", "field": "id"}},
+                    },
+                },
+            ],
+        }
+
+    def test_two_level_chain_yields_grandchild_rows(self) -> None:
+        pages = {
+            "/orgs": [{"id": "o1"}],
+            "/orgs/o1/projects": [{"id": "p1"}, {"id": "p2"}],
+            "/projects/p1/errors": [{"e": "p1-a"}],
+            "/projects/p2/errors": [{"e": "p2-a"}],
+        }
+        with patch.object(RESTClient, "paginate", _paginate_stub(pages)):
+            resources = rest_api_resources(
+                self._three_level_config(), team_id=1, job_id="j", db_incremental_field_last_value=None
+            )
+            errors = next(r for r in resources if r.name == "errors")
+            rows = [row for page in errors for row in page]
+        assert rows == [{"e": "p1-a"}, {"e": "p2-a"}]
+
+    def test_chained_fanout_disables_resume_instead_of_corrupting_state(self) -> None:
+        # With 2+ dependent resources one shared resume hook would be consumed at several
+        # levels; the framework must not call it at all.
+        pages = {
+            "/orgs": [{"id": "o1"}],
+            "/orgs/o1/projects": [{"id": "p1"}],
+            "/projects/p1/errors": [{"e": 1}],
+        }
+        checkpoints: list[Any] = []
+        with patch.object(RESTClient, "paginate", _paginate_stub(pages)):
+            resources = rest_api_resources(
+                self._three_level_config(),
+                team_id=1,
+                job_id="j",
+                db_incremental_field_last_value=None,
+                resume_hook=checkpoints.append,
+            )
+            errors = next(r for r in resources if r.name == "errors")
+            list(errors)
+        assert checkpoints == []


### PR DESCRIPTION
## Problem

Batch 11 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

This batch also lands a generic framework capability — **multi-level chained dependent resources** — so fan-out sources whose child endpoints depend on a resource that is itself a dependent resource (e.g. `orgs → projects → tasks`) become expressible. An endpoint may also now declare multiple resolve params bound from the same parent row.

## Changes

Framework:
- Multi-level chained dependent resources in `common/rest_source` (a child's parent may itself be a dependent resource), plus multiple resolve params from a single parent row. With 2+ dependent resources in a chain, resume is disabled (retries re-fetch, merge dedupes).

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green and asserts the same observable behavior via the framework):
- **coda** — docs → tables → rows chained fan-out
- **aiven** — multi-resolve-param fan-out (project + invoice number from the same parent row)
- **asana** — workspaces → projects → tasks/sections, with parent filtering via `data_map`
- **clickup** — spaces → folders → lists chained fan-out
- **clockify** — workspaces → projects/users → child resources

Each reuses the shared helpers (`validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, framework `auth` for secret redaction).

Not migrated this batch (left hand-rolled, valid blockers): **circleci** (client-side dedup before hydration pinned to an exact request count, plus per-parent page caps with warning logs), **bugsnag** (interleaved multi-level resume that pins "never re-fetch a completed fan-out parent", which the chain-level no-resume tradeoff can't honor).

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 5 migrated dirs + `common/rest_source/tests/` — 376 passed.
- Smoke-run of previously-migrated fan-out/paginator consumers (adroll, bigmailer, chargebee) — 95 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-10 PR (#71605); merge in order.
