### PR TITLE
fix(review_hog): space one-shot LLM retries across overload spells

### DIFF
--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -265,6 +265,22 @@ read `FINAL_REPORT.md` there first (config glossary + coverage matrix + ranking)
    rate drops materially (toward ≤50%) on frozen-PR evals with the valid-finding set intact (item 5's
    coverage matrix as the guard); kill if valid findings drop with the noise.
 
+### ✅ BUILT 2026-07-17 — one-shot LLM stages retry across provider overload spells
+
+First cross-repo dogfood run (a `PostHog/billing` PR via the Stage 5c UI trigger) died in dedup on
+Anthropic 529s — nothing repo-specific: the review wave completed 9/9, then all four dedup attempts
+(2 activity attempts × 2 parent-workflow retries, ~40s apart) landed inside the same overload spell
+and the run failed within 2 minutes flat. The same spell had hit chunking ~17 minutes earlier and
+recovered on its immediate retry, so overload is intermittent-but-minutes-long — the failure mode is
+retry _spacing_, not retry _count_. Fix: the fatal one-shot LLM stages (chunking, selection, dedup)
+now run under `_ONESHOT_RETRY` (5 attempts, 30s initial, ×2 backoff capped at 4m — ~7.5m of waits
+per run, ~2× with the parent retry) instead of `_RETRY`'s two back-to-back attempts. Failed 529
+attempts are free (the call aborts before persistence) and the non-retryable classes (4xx,
+max_tokens truncation) still fail fast. The gateway's Bedrock fallback was NOT the lever: it's
+deliberately off for one-shot calls, whose `output_config` (effort pin + schema constraint) the
+Bedrock path would silently strip. Sandbox-stage units keep `_RETRY` — their overload exposure is
+absorbed by the best-effort fan-out + failure floor, not by a single fatal call.
+
 ### ✅ BUILT 2026-07-16 — inline finding comments: colored severity badges replace the text meta
 
 The inline comment `_format_issue_comment` builds (`publish_review.py`) had its meta line recolored after comparing it against Greptile's PR comments — a deliberately minimal change that leaves the four collapsed sections (`Issue description`, `Suggested fix`, `Why we think it's a valid issue`, `Prompt to fix with AI`) exactly as they were.

--- a/products/review_hog/backend/temporal/workflow.py
+++ b/products/review_hog/backend/temporal/workflow.py
@@ -88,6 +88,17 @@ _FETCH_TIMEOUT = timedelta(minutes=5)
 _RETRY = RetryPolicy(maximum_attempts=2)
 # The validate activity's final-attempt fallback keys off the same constant — don't let them drift.
 _VALIDATE_RETRY = RetryPolicy(maximum_attempts=VALIDATION_MAX_ATTEMPTS)
+# The one-shot LLM stages (chunking, selection, dedup): provider overload (529) spells last
+# minutes, so back-to-back attempts all land inside the same spell and the run dies in ~2 minutes
+# flat (observed). Spaced escalating attempts ride the spell out — waits total ~7.5m per run, ~2×
+# that with the parent retry. Failed attempts are cheap (the call aborts before any persistence)
+# and non-retryable failures (4xx, max_tokens truncation) still fail fast regardless of attempts.
+_ONESHOT_RETRY = RetryPolicy(
+    maximum_attempts=5,
+    initial_interval=timedelta(seconds=30),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(minutes=4),
+)
 
 
 def _enforce_failure_floor(stage: str, failed: int, total: int) -> None:
@@ -162,7 +173,7 @@ class ReviewPerspectivesWorkflow:
                     ),
                     start_to_close_timeout=_SANDBOX_TIMEOUT,
                     heartbeat_timeout=_SANDBOX_HEARTBEAT,
-                    retry_policy=_RETRY,
+                    retry_policy=_ONESHOT_RETRY,
                 )
             except ActivityError:
                 # Selection is an optimization; failing it must never cost the review.
@@ -471,7 +482,7 @@ class ReviewPRWorkflow:
                 stage,
                 start_to_close_timeout=_SANDBOX_TIMEOUT,
                 heartbeat_timeout=_SANDBOX_HEARTBEAT,
-                retry_policy=_RETRY,
+                retry_policy=_ONESHOT_RETRY,
             )
 
             parent_id = workflow.info().workflow_id
@@ -502,7 +513,7 @@ class ReviewPRWorkflow:
                 stage,
                 start_to_close_timeout=_SANDBOX_TIMEOUT,
                 heartbeat_timeout=_SANDBOX_HEARTBEAT,
-                retry_policy=_RETRY,
+                retry_policy=_ONESHOT_RETRY,
             )
             workflow.logger.info(f"Persisted {len(dedup.issue_ids)} finding(s) to the review report")
 

--- a/products/review_hog/backend/temporal/workflow.py
+++ b/products/review_hog/backend/temporal/workflow.py
@@ -91,8 +91,9 @@ _VALIDATE_RETRY = RetryPolicy(maximum_attempts=VALIDATION_MAX_ATTEMPTS)
 # The one-shot LLM stages (chunking, selection, dedup): provider overload (529) spells last
 # minutes, so back-to-back attempts all land inside the same spell and the run dies in ~2 minutes
 # flat (observed). Spaced escalating attempts ride the spell out — waits total ~7.5m per run, ~2×
-# that with the parent retry. Failed attempts are cheap (the call aborts before any persistence)
-# and non-retryable failures (4xx, max_tokens truncation) still fail fast regardless of attempts.
+# that with the parent retry. Overload-failed attempts are cheap (the provider call dies before
+# anything persists; a rare failure after persistence redoes the LLM call, superseded latest-wins
+# per issue_key). Non-retryable failures (4xx, max_tokens truncation) still fail fast.
 _ONESHOT_RETRY = RetryPolicy(
     maximum_attempts=5,
     initial_interval=timedelta(seconds=30),


### PR DESCRIPTION
## Problem

The first cross-repo run of the Code review UI trigger (a `PostHog/billing` PR) failed partway: the review wave completed 9/9, then the dedup stage died. Error tracking shows all four dedup attempts (2 activity attempts × 2 parent-workflow retries, ~40s apart) failed with `InternalServerError (status=529)` from the LLM provider — every retry landed inside the same overload spell, and the run was dead ~2 minutes after the first failure. The same spell had hit the chunking call minutes earlier and recovered on its immediate retry, so overload is intermittent but lasts minutes: the failure mode is retry *spacing*, not retry *count*. Nothing about the failure was specific to the target repo.

## Changes

- The fatal one-shot LLM stages (chunking, perspective selection, dedup) now run under a dedicated `_ONESHOT_RETRY` policy — 5 attempts, 30s initial interval, ×2 backoff capped at 4m (~7.5m of waits per run, roughly doubled by the existing parent-workflow retry) — instead of `_RETRY`'s two back-to-back attempts.
- Failed 529 attempts are cheap: the call aborts before any persistence, and the resume-aware artefact cache makes re-entry idempotent. Non-retryable classes (4xx, `max_tokens` truncation) are already marked `non_retryable` and still fail fast.
- Sandbox-stage units keep `_RETRY`: their overload exposure is absorbed by the best-effort fan-out + failure floor, not by a single fatal call.
- Only retry-policy *values* change — no workflow command added/removed/reordered, so in-flight executions replay deterministically across deploy.
- ARCHITECTURE.md documents the incident and the reasoning (including why the gateway's Bedrock fallback was not the lever: it is deliberately off for one-shot calls because it would strip the schema constraint).

## How did you test this code?

- `ruff check` + `ruff format --check` on the touched module; `oxfmt` on the doc.
- No new tests: the change is retry-policy configuration passed to Temporal; asserting the constant's values would pin implementation details without catching a realistic regression. Existing `test_temporal_workflow.py` coverage runs in CI (the sandbox environment here cannot execute pytest).
- Not manually tested against a live overload window (not reproducible on demand).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Covered in-PR: `products/review_hog/ARCHITECTURE.md`.

## 🤖 Agent context

Human-driven (agent-assisted) — diagnosed from error tracking and the failed run's status-comment timeline, fix scoped to the retry policy of the one-shot LLM stages.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
