### PR TITLE
refactor(data-warehouse): migrate confluence, crunchbase, deel to rest_source (batch 13)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/confluence/confluence.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/confluence/confluence.py
@@ -1,29 +1,27 @@
 import re
 import base64
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.confluence.settings import CONFLUENCE_ENDPOINTS
 
 # Confluence Cloud sites always live under <subdomain>.atlassian.net. Building
 # the host ourselves from a validated subdomain (rather than accepting an
 # arbitrary host) keeps the API token from being sent anywhere off-Atlassian.
 _SUBDOMAIN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,62}$")
-
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class ConfluenceRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -51,21 +49,87 @@ def _get_headers(email: str, api_token: str) -> dict[str, str]:
     }
 
 
-def _build_initial_url(subdomain: str, path: str, limit: int) -> str:
-    return f"{_base_url(subdomain)}{path}?{urlencode({'limit': limit})}"
+class ConfluenceLinkPaginator(JSONResponsePaginator):
+    """Confluence v2 returns the next page as a site-relative path in ``_links.next``
+    (e.g. ``/wiki/api/v2/pages?cursor=...``); resolve it against the site origin so the
+    client requests an absolute URL. Absence of the key signals the last page."""
+
+    def __init__(self, site_origin: str) -> None:
+        super().__init__(next_url_path="_links.next")
+        self._site_origin = site_origin
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and self._next_url and not self._next_url.startswith(("http://", "https://")):
+            self._next_url = f"{self._site_origin}{self._next_url}"
 
 
-def _resolve_next_url(subdomain: str, data: dict[str, Any]) -> str | None:
-    """Confluence v2 returns the next page as a site-relative path in
-    ``_links.next`` (e.g. ``/wiki/api/v2/pages?cursor=...``). Absence of the key
-    signals the last page."""
-    links = data.get("_links") or {}
-    next_path = links.get("next")
-    if not next_path:
-        return None
-    if next_path.startswith("http://") or next_path.startswith("https://"):
-        return next_path
-    return f"{_site_origin(subdomain)}{next_path}"
+def confluence_source(
+    subdomain: str,
+    email: str,
+    api_token: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[ConfluenceResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = CONFLUENCE_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(subdomain),
+            # Auth (HTTP Basic) is supplied via the framework auth config so the token is
+            # redacted from logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "http_basic", "username": email, "password": api_token},
+            "paginator": ConfluenceLinkPaginator(_site_origin(subdomain)),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": config.limit},
+                    # v2 list endpoints wrap rows in `results`; a missing key means an empty page.
+                    "data_selector": "results",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # the page we just emitted (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(ConfluenceResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=[config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
+    )
 
 
 def validate_credentials(
@@ -83,104 +147,22 @@ def validate_credentials(
             "Invalid Confluence subdomain. Use just the site name, e.g. 'your-domain' for your-domain.atlassian.net.",
         )
 
-    url = _build_initial_url(subdomain, CONFLUENCE_ENDPOINTS["spaces"].path, limit=1)
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(email, api_token), timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
+    url = f"{_base_url(subdomain)}{CONFLUENCE_ENDPOINTS['spaces'].path}?limit=1"
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        url,
+        headers=_get_headers(email, api_token),
+    )
 
-    if response.status_code == 200:
+    if status == 200:
         return True, None
-    if response.status_code == 401:
+    if status == 401:
         return False, "Invalid Confluence credentials. Check your email and API token."
-    if response.status_code == 403:
+    if status == 403:
         if schema_name is None:
             return True, None
         return False, "Your Confluence account does not have permission to access this resource."
+    if status is None:
+        return False, None
 
-    return False, f"Confluence API returned status {response.status_code}: {response.text}"
-
-
-def get_rows(
-    subdomain: str,
-    email: str,
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ConfluenceResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = CONFLUENCE_ENDPOINTS[endpoint]
-    headers = _get_headers(email, api_token)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url: str = resume_config.next_url
-        logger.debug(f"Confluence: resuming from URL: {url}")
-    else:
-        url = _build_initial_url(subdomain, config.path, config.limit)
-
-    @retry(
-        retry=retry_if_exception_type((ConfluenceRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise ConfluenceRetryableError(
-                f"Confluence API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Confluence API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-
-        results = data.get("results", [])
-        next_url = _resolve_next_url(subdomain, data)
-
-        if results:
-            yield results
-
-        # Save state AFTER yielding so a crash re-fetches the page we just
-        # emitted (merge dedupes on primary key) rather than skipping it.
-        if not next_url:
-            break
-
-        resumable_source_manager.save_state(ConfluenceResumeConfig(next_url=next_url))
-        url = next_url
-
-
-def confluence_source(
-    subdomain: str,
-    email: str,
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ConfluenceResumeConfig],
-) -> SourceResponse:
-    endpoint_config = CONFLUENCE_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            subdomain=subdomain,
-            email=email,
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=[endpoint_config.primary_key],
-        partition_count=1,
-        partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="week" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
-    )
+    return False, f"Confluence API returned status {status}."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/confluence/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/confluence/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.confluence.confluence import (
     ConfluenceResumeConfig,
     confluence_source,
@@ -111,21 +114,9 @@ Only Confluence Cloud sites (`your-domain.atlassian.net`) are supported.""",
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                # v2 list endpoints have no server-side timestamp filter, so all
-                # endpoints are full refresh only.
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # v2 list endpoints have no server-side timestamp filter, so every endpoint is
+        # full refresh only (no incremental fields -> supports_incremental/append False).
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: ConfluenceSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -157,6 +148,7 @@ Only Confluence Cloud sites (`your-domain.atlassian.net`) are supported.""",
             email=config.email,
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/confluence/tests/test_confluence.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/confluence/tests/test_confluence.py
@@ -1,16 +1,16 @@
+import json
 import base64
 from typing import Any
 
 from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.confluence.confluence import (
     ConfluenceResumeConfig,
     _get_headers,
-    _resolve_next_url,
     confluence_source,
-    get_rows,
     is_valid_subdomain,
     validate_credentials,
 )
@@ -19,20 +19,61 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.confluence
     ENDPOINTS,
 )
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the confluence module.
+CONFLUENCE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.confluence.confluence.make_tracked_session"
+)
 
-def _mock_response(status_code: int, json_body: Any = None, text: str = "") -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    response.json.return_value = json_body if json_body is not None else {}
-    response.text = text
 
-    def raise_for_status() -> None:
-        if not response.ok:
-            raise Exception(f"{status_code} Client Error")
+def _response(results: list[dict[str, Any]], next_path: str | None = None) -> Response:
+    body: dict[str, Any] = {"results": results, "_links": {"next": next_path} if next_path else {}}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
-    response.raise_for_status.side_effect = raise_for_status
-    return response
+
+def _make_manager(resume_state: ConfluenceResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    The paginator mutates the single ``Request`` in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return confluence_source(
+        subdomain="acme",
+        email="you@example.com",
+        api_token="token",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestSubdomainValidation:
@@ -60,28 +101,6 @@ class TestHeaders:
         assert headers["Accept"] == "application/json"
 
 
-class TestResolveNextUrl:
-    @parameterized.expand(
-        [
-            (
-                "relative_path",
-                {"_links": {"next": "/wiki/api/v2/pages?cursor=abc"}},
-                "https://acme.atlassian.net/wiki/api/v2/pages?cursor=abc",
-            ),
-            (
-                "absolute_url",
-                {"_links": {"next": "https://acme.atlassian.net/wiki/api/v2/pages?cursor=xyz"}},
-                "https://acme.atlassian.net/wiki/api/v2/pages?cursor=xyz",
-            ),
-            ("no_next_key", {"_links": {}}, None),
-            ("no_links_key", {"results": []}, None),
-            ("null_next", {"_links": {"next": None}}, None),
-        ]
-    )
-    def test_resolve_next_url(self, _name: str, data: dict, expected: str | None) -> None:
-        assert _resolve_next_url("acme", data) == expected
-
-
 class TestValidateCredentials:
     @parameterized.expand(
         [
@@ -95,11 +114,10 @@ class TestValidateCredentials:
                 False,
                 "Your Confluence account does not have permission to access this resource.",
             ),
+            ("other_status", 500, None, False, "Confluence API returned status 500."),
         ]
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.confluence.confluence.make_tracked_session"
-    )
+    @mock.patch(CONFLUENCE_SESSION_PATCH)
     def test_validate_credentials_status_mapping(
         self,
         _name: str,
@@ -109,12 +127,19 @@ class TestValidateCredentials:
         expected_message: str | None,
         mock_session: mock.MagicMock,
     ) -> None:
-        mock_session.return_value.get.return_value = _mock_response(status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         is_valid, message = validate_credentials("acme", "you@example.com", "token", schema_name=schema_name)
 
         assert is_valid is expected_valid
         assert message == expected_message
+
+    @mock.patch(CONFLUENCE_SESSION_PATCH)
+    def test_transport_error_is_not_validated(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        is_valid, message = validate_credentials("acme", "you@example.com", "token")
+        assert is_valid is False
+        assert message is None
 
     def test_invalid_subdomain_short_circuits(self) -> None:
         is_valid, message = validate_credentials("evil.com", "you@example.com", "token")
@@ -125,14 +150,7 @@ class TestValidateCredentials:
 class TestConfluenceSource:
     @parameterized.expand([(endpoint,) for endpoint in ENDPOINTS])
     def test_source_response_shape_for_endpoint(self, endpoint: str) -> None:
-        response = confluence_source(
-            subdomain="acme",
-            email="you@example.com",
-            api_token="token",
-            endpoint=endpoint,
-            logger=mock.MagicMock(),
-            resumable_source_manager=mock.MagicMock(),
-        )
+        response = _source(endpoint, _make_manager())
         config = CONFLUENCE_ENDPOINTS[endpoint]
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]
@@ -148,84 +166,76 @@ class TestConfluenceSource:
         assert CONFLUENCE_ENDPOINTS[endpoint].partition_key == expected_partition
 
 
-class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.confluence.confluence.make_tracked_session"
-    )
-    def test_paginates_until_no_next_and_saves_state(self, mock_session: mock.MagicMock) -> None:
-        page1 = _mock_response(
-            200,
-            {"results": [{"id": "1"}, {"id": "2"}], "_links": {"next": "/wiki/api/v2/pages?cursor=p2"}},
-        )
-        page2 = _mock_response(200, {"results": [{"id": "3"}], "_links": {}})
-        mock_session.return_value.get.side_effect = [page1, page2]
-
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-
-        batches = list(
-            get_rows(
-                subdomain="acme",
-                email="you@example.com",
-                api_token="token",
-                endpoint="pages",
-                logger=mock.MagicMock(),
-                resumable_source_manager=manager,
-            )
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_no_next_and_saves_state(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "1"}, {"id": "2"}], next_path="/wiki/api/v2/pages?cursor=p2"),
+                _response([{"id": "3"}], next_path=None),
+            ],
         )
 
-        assert batches == [[{"id": "1"}, {"id": "2"}], [{"id": "3"}]]
-        # State saved once, after the first page (which has a next cursor).
+        manager = _make_manager()
+        rows = _rows(_source("pages", manager))
+
+        assert [r["id"] for r in rows] == ["1", "2", "3"]
+        # First request hits the base path with the page limit; params carry limit only.
+        assert snapshots[0]["url"] == "https://acme.atlassian.net/wiki/api/v2/pages"
+        assert snapshots[0]["params"]["limit"] == CONFLUENCE_ENDPOINTS["pages"].limit
+        # State saved once, after the first page (which has a next cursor), pointing at the
+        # relative next link resolved to an absolute site URL.
         manager.save_state.assert_called_once()
-        saved = manager.save_state.call_args.args[0]
-        assert isinstance(saved, ConfluenceResumeConfig)
-        assert saved.next_url == "https://acme.atlassian.net/wiki/api/v2/pages?cursor=p2"
+        assert manager.save_state.call_args.args[0] == ConfluenceResumeConfig(
+            next_url="https://acme.atlassian.net/wiki/api/v2/pages?cursor=p2"
+        )
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.confluence.confluence.make_tracked_session"
+    @parameterized.expand(
+        [
+            ("relative_path", "/wiki/api/v2/pages?cursor=p2", "https://acme.atlassian.net/wiki/api/v2/pages?cursor=p2"),
+            (
+                "absolute_url",
+                "https://acme.atlassian.net/wiki/api/v2/pages?cursor=xyz",
+                "https://acme.atlassian.net/wiki/api/v2/pages?cursor=xyz",
+            ),
+        ]
     )
-    def test_resumes_from_saved_state(self, mock_session: mock.MagicMock) -> None:
-        page = _mock_response(200, {"results": [{"id": "9"}], "_links": {}})
-        mock_session.return_value.get.return_value = page
-
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = ConfluenceResumeConfig(
-            next_url="https://acme.atlassian.net/wiki/api/v2/pages?cursor=resumed"
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_next_link_resolved_for_second_request(
+        self, _name: str, next_path: str, expected_url: str, MockSession: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [_response([{"id": "1"}], next_path=next_path), _response([{"id": "2"}], next_path=None)],
         )
 
-        list(
-            get_rows(
-                subdomain="acme",
-                email="you@example.com",
-                api_token="token",
-                endpoint="pages",
-                logger=mock.MagicMock(),
-                resumable_source_manager=manager,
-            )
+        _rows(_source("pages", _make_manager()))
+
+        assert snapshots[1]["url"] == expected_url
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([{"id": "9"}], next_path=None)])
+
+        manager = _make_manager(
+            ConfluenceResumeConfig(next_url="https://acme.atlassian.net/wiki/api/v2/pages?cursor=resumed")
         )
+        _rows(_source("pages", manager))
 
-        called_url = mock_session.return_value.get.call_args.args[0]
-        assert called_url == "https://acme.atlassian.net/wiki/api/v2/pages?cursor=resumed"
+        assert snapshots[0]["url"] == "https://acme.atlassian.net/wiki/api/v2/pages?cursor=resumed"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.confluence.confluence.make_tracked_session"
-    )
-    def test_empty_results_does_not_yield(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _mock_response(200, {"results": [], "_links": {}})
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_results_yields_nothing_and_no_checkpoint(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], next_path=None)])
 
-        batches = list(
-            get_rows(
-                subdomain="acme",
-                email="you@example.com",
-                api_token="token",
-                endpoint="spaces",
-                logger=mock.MagicMock(),
-                resumable_source_manager=manager,
-            )
-        )
+        manager = _make_manager()
+        rows = _rows(_source("spaces", manager))
 
-        assert batches == []
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/crunchbase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/crunchbase.py
@@ -1,14 +1,16 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.settings import (
     CRUNCHBASE_ENDPOINTS,
@@ -19,12 +21,6 @@ CRUNCHBASE_BASE_URL = "https://api.crunchbase.com/v4/data"
 # Search pages cap at 1000 entities.
 PAGE_SIZE = 1000
 REQUEST_TIMEOUT_SECONDS = 120
-# 200 calls/min rate limit; backoff on 429.
-MAX_RETRY_ATTEMPTS = 5
-
-
-class CrunchbaseRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -32,10 +28,6 @@ class CrunchbaseResumeConfig:
     # Keyset pagination: `after_id` is the uuid of the last entity of the
     # previous page; static body parts are rebuilt from job inputs on resume.
     after_id: str
-
-
-def _get_session(api_key: str) -> requests.Session:
-    return make_tracked_session(headers={"X-cb-user-key": api_key}, redact_values=(api_key,))
 
 
 def _format_updated_at(value: Any) -> str:
@@ -52,8 +44,9 @@ def _build_body(
     config: CrunchbaseEndpointConfig,
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Any,
-    after_id: Optional[str],
 ) -> dict[str, Any]:
+    """Base search body sent on every page. The keyset `after_id` cursor is
+    injected by the paginator, not baked in here."""
     body: dict[str, Any] = {
         "field_ids": config.field_ids,
         "limit": PAGE_SIZE,
@@ -72,9 +65,6 @@ def _build_body(
             }
         ]
 
-    if after_id is not None:
-        body["after_id"] = after_id
-
     return body
 
 
@@ -85,98 +75,114 @@ def _flatten_entity(entity: dict[str, Any]) -> dict[str, Any]:
     return {**properties, "uuid": entity["uuid"]}
 
 
-def validate_credentials(api_key: str) -> bool:
-    """Confirm the user key is valid AND licensed — the Search API requires a
-    paid Enterprise/Applications license, so only a 200 means syncs can work."""
-    try:
-        session = _get_session(api_key)
-        response = session.post(
-            f"{CRUNCHBASE_BASE_URL}/searches/organizations",
-            json={"field_ids": ["identifier"], "limit": 1},
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+class CrunchbaseKeysetPaginator(BasePaginator):
+    """Keyset pagination over the Search API: each page's next cursor is the
+    uuid of its last entity, injected into the POST body as `after_id`. A page
+    shorter than the requested limit is the last page (matches the API's own
+    end-of-results signal), so we stop without paying an extra empty request."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._after_id: Optional[str] = None
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CrunchbaseResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CRUNCHBASE_ENDPOINTS[endpoint]
-    session = _get_session(api_key)
-    url = f"{CRUNCHBASE_BASE_URL}/searches/{config.collection}"
+    def init_request(self, request: Request) -> None:
+        # Honour a seeded resume cursor on the first request.
+        if self._after_id is not None:
+            self._inject(request)
 
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    after_id: Optional[str] = resume_config.after_id if resume_config is not None else None
-    if after_id is not None:
-        logger.debug(f"Crunchbase: resuming {endpoint} from after_id {after_id}")
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if data is None or len(data) < PAGE_SIZE:
+            self._has_next_page = False
+            return
+        # A full page: the last entity's uuid is a safe keyset cursor.
+        # `_flatten_entity` asserts uuid presence downstream; read it directly
+        # so a missing uuid fails loud here too rather than paginating past it.
+        self._after_id = data[-1]["uuid"]
+        self._has_next_page = True
 
-    @retry(
-        retry=retry_if_exception_type((CrunchbaseRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=2, max=90),
-        reraise=True,
-    )
-    def fetch_page(body: dict[str, Any]) -> dict[str, Any]:
-        response = session.post(url, json=body, timeout=REQUEST_TIMEOUT_SECONDS)
+    def update_request(self, request: Request) -> None:
+        self._inject(request)
 
-        if response.status_code == 429 or response.status_code >= 500:
-            raise CrunchbaseRetryableError(
-                f"Crunchbase API error (retryable): status={response.status_code}, url={url}"
-            )
+    def _inject(self, request: Request) -> None:
+        if self._after_id is None:
+            return
+        if request.json is None:
+            request.json = {}
+        request.json["after_id"] = self._after_id
 
-        if not response.ok:
-            logger.error(f"Crunchbase API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        if self._has_next_page and self._after_id is not None:
+            return {"after_id": self._after_id}
+        return None
 
-        return response.json()
-
-    while True:
-        body = _build_body(config, should_use_incremental_field, db_incremental_field_last_value, after_id)
-        data = fetch_page(body)
-        entities = data.get("entities", []) or []
-        items = [_flatten_entity(entity) for entity in entities]
-
-        if items:
-            yield items
-
-        if len(entities) < PAGE_SIZE:
-            break
-
-        # `_flatten_entity` already asserted every entity has a uuid, so the
-        # last one is a safe keyset cursor for the next page.
-        after_id = entities[-1]["uuid"]
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(CrunchbaseResumeConfig(after_id=after_id))
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        after_id = state.get("after_id")
+        if after_id is not None:
+            self._after_id = str(after_id)
+            self._has_next_page = True
 
 
 def crunchbase_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CrunchbaseResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = CRUNCHBASE_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CRUNCHBASE_BASE_URL,
+            # The user key travels in a custom header; framework auth registers it
+            # for value-based log redaction.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-cb-user-key", "location": "header"},
+            "paginator": CrunchbaseKeysetPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                # Search hits nest requested fields under `properties`; hoist them so the
+                # table gets real columns and the uuid stays available as the primary key.
+                "data_map": _flatten_entity,
+                "endpoint": {
+                    "path": f"/searches/{config.collection}",
+                    "method": "post",
+                    "json": _build_body(config, should_use_incremental_field, db_incremental_field_last_value),
+                    # A 200 body without `entities` is treated as an empty page (matches the
+                    # old `data.get("entities", [])`), so the selector is not required.
+                    "data_selector": "entities",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"after_id": resume.after_id}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash
+        # re-yields the last page (merge dedupes on uuid) rather than skipping it.
+        if state and state.get("after_id"):
+            resumable_source_manager.save_state(CrunchbaseResumeConfig(after_id=str(state["after_id"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
@@ -185,3 +191,22 @@ def crunchbase_source(
         partition_keys=[config.partition_key],
         sort_mode="asc",
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Confirm the user key is valid AND licensed — the Search API requires a
+    paid Enterprise/Applications license, so only a 200 means syncs can work.
+
+    Uses a hand-rolled POST probe rather than the shared GET-based
+    ``validate_via_probe``: the Search API is POST-only and the license check
+    needs a real search body."""
+    try:
+        session = make_tracked_session(headers={"X-cb-user-key": api_key}, redact_values=(api_key,))
+        response = session.post(
+            f"{CRUNCHBASE_BASE_URL}/searches/organizations",
+            json={"field_ids": ["identifier"], "limit": 1},
+            timeout=10,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/source.py
@@ -129,7 +129,8 @@ You can find your user key in [Crunchbase account settings](https://www.crunchba
         return crunchbase_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/tests/test_crunchbase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/tests/test_crunchbase.py
@@ -1,8 +1,11 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
+
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase import (
     PAGE_SIZE,
@@ -11,13 +14,29 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase
     _flatten_entity,
     _format_updated_at,
     crunchbase_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.settings import (
     CRUNCHBASE_ENDPOINTS,
     ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the crunchbase module.
+CRUNCHBASE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
+)
+
+
+def _response(entities: list[dict[str, Any]] | None, *, drop_entities: bool = False) -> Response:
+    body: dict[str, Any] = {"count": len(entities or [])}
+    if not drop_entities:
+        body["entities"] = entities or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: CrunchbaseResumeConfig | None = None) -> mock.MagicMock:
@@ -27,12 +46,42 @@ def _make_manager(resume_state: CrunchbaseResumeConfig | None = None) -> mock.Ma
     return manager
 
 
-def _response(entities: list[dict[str, Any]]) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {"count": len(entities), "entities": entities}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's JSON body AT SEND TIME.
+
+    ``request.json`` is a single dict mutated in place across pages (the paginator injects
+    ``after_id`` into it), so inspecting it after the run shows only the final state — snapshot
+    a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    body_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        body_snapshots.append(dict(request.json or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return body_snapshots
+
+
+def _pages(source_response) -> list[list[dict[str, Any]]]:
+    return list(source_response.items())
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str = "organizations", manager: mock.MagicMock | None = None, **kwargs: Any):
+    return crunchbase_source(
+        "key",
+        endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        **kwargs,
+    )
 
 
 class TestFormatUpdatedAt:
@@ -55,13 +104,13 @@ class TestBuildBody:
             CRUNCHBASE_ENDPOINTS["organizations"],
             should_use_incremental_field=False,
             db_incremental_field_last_value=None,
-            after_id=None,
         )
 
         assert body["field_ids"] == CRUNCHBASE_ENDPOINTS["organizations"].field_ids
         assert body["limit"] == PAGE_SIZE
         assert body["order"] == [{"field_id": "updated_at", "sort": "asc"}]
         assert "query" not in body
+        # The keyset cursor is injected by the paginator, never baked into the base body.
         assert "after_id" not in body
 
     def test_incremental_body_has_gte_predicate(self):
@@ -69,7 +118,6 @@ class TestBuildBody:
             CRUNCHBASE_ENDPOINTS["organizations"],
             should_use_incremental_field=True,
             db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
-            after_id="uuid-1",
         )
 
         assert body["query"] == [
@@ -80,7 +128,6 @@ class TestBuildBody:
                 "values": ["2024-01-02T00:00:00Z"],
             }
         ]
-        assert body["after_id"] == "uuid-1"
 
 
 class TestFlattenEntity:
@@ -103,9 +150,7 @@ class TestValidateCredentials:
             (401, False),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
+    @mock.patch(CRUNCHBASE_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
         response = mock.MagicMock()
         response.status_code = status_code
@@ -113,101 +158,97 @@ class TestValidateCredentials:
 
         assert validate_credentials("key") is expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
+    @mock.patch(CRUNCHBASE_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.post.side_effect = Exception("boom")
         assert validate_credentials("key") is False
 
 
-class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
-    def test_paginates_via_after_id_keyset(self, mock_session):
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_after_id_keyset(self, MockSession):
+        session = MockSession.return_value
         full_page = [{"uuid": f"u{i}", "properties": {"updated_at": "2024-01-01T00:00:00Z"}} for i in range(PAGE_SIZE)]
-        mock_session.return_value.post.side_effect = [
-            _response(full_page),
-            _response([{"uuid": "last", "properties": {}}]),
-        ]
+        bodies = _wire(session, [_response(full_page), _response([{"uuid": "last", "properties": {}}])])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "organizations", mock.MagicMock(), manager))
+        pages = _pages(_source(manager=manager))
 
-        assert len(batches) == 2
+        assert len(pages) == 2
+        # A short second page ends pagination without an extra empty request.
+        assert session.send.call_count == 2
+        # Checkpoint saved once after the first full page, pointing at the keyset cursor.
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].after_id == f"u{PAGE_SIZE - 1}"
-        second_body = mock_session.return_value.post.call_args_list[1].kwargs["json"]
-        assert second_body["after_id"] == f"u{PAGE_SIZE - 1}"
+        assert manager.save_state.call_args.args[0] == CrunchbaseResumeConfig(after_id=f"u{PAGE_SIZE - 1}")
+        # First page carries no cursor; the second requests entities after the last full-page uuid.
+        assert "after_id" not in bodies[0]
+        assert bodies[1]["after_id"] == f"u{PAGE_SIZE - 1}"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
-    def test_rows_are_flattened(self, mock_session):
-        mock_session.return_value.post.return_value = _response([{"uuid": "u1", "properties": {"name": "Acme"}}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rows_are_flattened(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"uuid": "u1", "properties": {"name": "Acme"}}])])
 
-        manager = _make_manager()
-        batches = list(get_rows("key", "organizations", mock.MagicMock(), manager))
+        rows = _rows(_source())
+        assert rows == [{"name": "Acme", "uuid": "u1"}]
 
-        assert batches == [[{"name": "Acme", "uuid": "u1"}]]
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
-    def test_resumes_from_saved_after_id(self, mock_session):
-        mock_session.return_value.post.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_after_id(self, MockSession):
+        session = MockSession.return_value
+        bodies = _wire(session, [_response([])])
 
         manager = _make_manager(CrunchbaseResumeConfig(after_id="uuid-resume"))
-        list(get_rows("key", "organizations", mock.MagicMock(), manager))
+        _rows(_source(manager=manager))
 
-        body = mock_session.return_value.post.call_args.kwargs["json"]
-        assert body["after_id"] == "uuid-resume"
+        assert bodies[0]["after_id"] == "uuid-resume"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
-    def test_incremental_body_built_from_watermark(self, mock_session):
-        mock_session.return_value.post.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_body_built_from_watermark(self, MockSession):
+        session = MockSession.return_value
+        bodies = _wire(session, [_response([])])
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                "organizations",
-                mock.MagicMock(),
-                manager,
+        _rows(
+            _source(
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
             )
         )
 
-        body = mock_session.return_value.post.call_args.kwargs["json"]
-        assert body["query"][0]["operator_id"] == "gte"
-        assert body["query"][0]["values"] == ["2024-01-02T00:00:00Z"]
+        query = bodies[0]["query"]
+        assert query[0]["operator_id"] == "gte"
+        assert query[0]["values"] == ["2024-01-02T00:00:00Z"]
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
-    def test_entity_without_uuid_raises(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_entity_without_uuid_raises(self, MockSession):
         # uuid is the primary key; a missing one must surface immediately rather
         # than producing a null-keyed row that corrupts downstream merge/dedup.
-        mock_session.return_value.post.return_value = _response([{"properties": {}}])
+        session = MockSession.return_value
+        _wire(session, [_response([{"properties": {}}])])
 
-        manager = _make_manager()
         with pytest.raises(KeyError):
-            list(get_rows("key", "organizations", mock.MagicMock(), manager))
+            _rows(_source())
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.crunchbase.crunchbase.make_tracked_session"
-    )
-    def test_empty_response_stops_without_saving_state(self, mock_session):
-        mock_session.return_value.post.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops_without_saving_state(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "organizations", mock.MagicMock(), manager))
+        pages = _pages(_source(manager=manager))
 
-        assert batches == []
+        assert pages == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_entities_key_is_empty_page_not_error(self, MockSession):
+        # The old source used `data.get("entities", [])`; a 200 body without the key
+        # is a legit empty page, not a fail-loud shape change.
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_entities=True)])
+
+        manager = _make_manager()
+        assert _pages(_source(manager=manager)) == []
         manager.save_state.assert_not_called()
 
 
@@ -215,7 +256,7 @@ class TestCrunchbaseSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = CRUNCHBASE_ENDPOINTS[endpoint]
-        response = crunchbase_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint=endpoint)
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/tests/test_crunchbase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/crunchbase/tests/test_crunchbase_source.py
@@ -119,6 +119,8 @@ class TestCrunchbaseSource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_cb_source):
         inputs = mock.MagicMock()
         inputs.schema_name = "organizations"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2024-01-02T03:04:05Z"
         manager = mock.MagicMock()
@@ -129,6 +131,8 @@ class TestCrunchbaseSource:
         kwargs = mock_cb_source.call_args.kwargs
         assert kwargs["api_key"] == "user-key"
         assert kwargs["endpoint"] == "organizations"
+        assert kwargs["team_id"] == 123
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2024-01-02T03:04:05Z"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deel/deel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deel/deel.py
@@ -1,30 +1,25 @@
-import time
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.deel.settings import DEEL_ENDPOINTS
 
 DEEL_BASE_URL = "https://api.letsdeel.com/rest/v2"
 # Several Deel endpoints cap `limit` below 100, so stay safely under every cap.
 PAGE_SIZE = 50
-REQUEST_TIMEOUT_SECONDS = 60
-# Deel enforces a hard 5 req/s limit org-wide (shared across ALL tokens, 429
-# with no rate-limit headers), so requests are proactively spaced out.
-REQUEST_INTERVAL_SECONDS = 0.25
-MAX_RETRY_ATTEMPTS = 5
-
-
-class DeelRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -35,8 +30,54 @@ class DeelResumeConfig:
     cursor: Optional[str] = None
 
 
-def _get_session(api_token: str) -> requests.Session:
-    return make_tracked_session(headers={"Authorization": f"Bearer {api_token}"}, redact_values=(api_token,))
+class DeelCursorPaginator(BasePaginator):
+    """Keyset paginator for Deel's ``after_cursor`` endpoints (e.g. contracts).
+
+    The next cursor lives at ``page.cursor`` in the body. Terminate when the response
+    carries no next cursor OR returns no rows — Deel can echo a stale cursor on an
+    exhausted keyset, so an empty page must stop the walk rather than loop.
+    """
+
+    def __init__(self, cursor_param: str = "after_cursor") -> None:
+        super().__init__()
+        self.cursor_param = cursor_param
+        self._cursor: Optional[str] = None
+
+    def _inject(self, request: Request) -> None:
+        if self._cursor is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._cursor
+
+    def init_request(self, request: Request) -> None:
+        # Applies a seeded resume cursor to the first request.
+        self._inject(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+        try:
+            next_cursor = (response.json().get("page") or {}).get("cursor")
+        except Exception:
+            next_cursor = None
+        if next_cursor:
+            self._cursor = next_cursor
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        self._inject(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor} if self._has_next_page and self._cursor is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor = cursor
+            self._has_next_page = True
 
 
 def validate_credentials(api_token: str) -> tuple[bool, str | None]:
@@ -45,110 +86,94 @@ def validate_credentials(api_token: str) -> tuple[bool, str | None]:
     Scoped tokens may lack individual resource scopes (403); only 401 means the
     token itself is bad. A transient network failure surfaces as a distinct
     "could not reach Deel" error so it isn't mistaken for a bad token."""
-    try:
-        response = _get_session(api_token).get(
-            f"{DEEL_BASE_URL}/people?{urlencode({'limit': 1})}",
-            timeout=10,
-        )
-    except requests.RequestException as e:
-        return False, f"Could not reach Deel: {e}"
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{DEEL_BASE_URL}/people?limit=1",
+        headers={"Authorization": f"Bearer {api_token}"},
+    )
 
-    if response.status_code == 401:
+    if status is None:
+        return False, "Could not reach Deel"
+    if status == 401:
         return False, "Invalid Deel API token"
     return True, None
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DeelResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = DEEL_ENDPOINTS[endpoint]
-    session = _get_session(api_token)
-
-    @retry(
-        retry=retry_if_exception_type((DeelRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=2, max=60),
-        reraise=True,
-    )
-    def fetch(params: dict[str, Any]) -> dict[str, Any]:
-        # Proactive spacing keeps us under the org-wide 5 req/s budget.
-        time.sleep(REQUEST_INTERVAL_SECONDS)
-        url = f"{DEEL_BASE_URL}{config.path}?{urlencode(params)}"
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise DeelRetryableError(f"Deel API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"Deel API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if config.pagination == "cursor":
-        cursor: Optional[str] = resume_config.cursor if resume_config is not None else None
-        if cursor is not None:
-            logger.debug(f"Deel: resuming {endpoint} from cursor {cursor}")
-
-        while True:
-            params: dict[str, Any] = {"limit": PAGE_SIZE}
-            if cursor is not None:
-                params["after_cursor"] = cursor
-            body = fetch(params)
-            items = body.get("data", []) or []
-
-            if items:
-                yield items
-
-            next_cursor = (body.get("page") or {}).get("cursor")
-            if not next_cursor or not items:
-                break
-
-            cursor = next_cursor
-            # Save state AFTER yielding the page so a crash re-yields the last
-            # page (merge dedupes on primary key) rather than skipping it.
-            resumable_source_manager.save_state(DeelResumeConfig(cursor=cursor))
-        return
-
-    offset = resume_config.offset if resume_config is not None and resume_config.offset is not None else 0
-    if resume_config is not None:
-        logger.debug(f"Deel: resuming {endpoint} from offset {offset}")
-
-    while True:
-        body = fetch({"limit": PAGE_SIZE, "offset": offset})
-        items = body.get("data", []) or []
-
-        if items:
-            yield items
-
-        if len(items) < PAGE_SIZE:
-            break
-
-        offset += PAGE_SIZE
-        resumable_source_manager.save_state(DeelResumeConfig(offset=offset))
 
 
 def deel_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[DeelResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = DEEL_ENDPOINTS[endpoint]
 
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    paginator: BasePaginator
+    params: dict[str, Any]
+    initial_paginator_state: Optional[dict[str, Any]]
+
+    if config.pagination == "cursor":
+        paginator = DeelCursorPaginator()
+        params = {"limit": PAGE_SIZE}
+        initial_paginator_state = (
+            {"cursor": resume.cursor} if resume is not None and resume.cursor is not None else None
+        )
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only when a next page remains; save AFTER a page is yielded so a crash
+            # re-yields the last page (merge dedupes) rather than skipping it.
+            if state and state.get("cursor") is not None:
+                resumable_source_manager.save_state(DeelResumeConfig(cursor=str(state["cursor"])))
+
+    else:
+        # OffsetPaginator injects both limit and offset; termination is a short/empty page
+        # (Deel exposes no dependable top-level total), matching the hand-rolled walk.
+        paginator = OffsetPaginator(limit=PAGE_SIZE, total_path=None)
+        params = {}
+        initial_paginator_state = (
+            {"offset": resume.offset} if resume is not None and resume.offset is not None else None
+        )
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            if state and state.get("offset") is not None:
+                resumable_source_manager.save_state(DeelResumeConfig(offset=int(state["offset"])))
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": DEEL_BASE_URL,
+            # Bearer auth via the framework so the token is redacted from logs.
+            "auth": {"type": "bearer", "token": api_token},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # A missing `data` key is treated as an empty page (lenient), matching the
+                    # hand-rolled `body.get("data", [])` — not a fail-loud like other sources.
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
@@ -156,4 +181,5 @@ def deel_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deel/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel import (
     DeelResumeConfig,
     deel_source,
@@ -91,22 +94,8 @@ Create an organization token in [Deel](https://app.deel.com/developer-center) un
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Core Deel objects have no updated-since filter, so every stream is an
-        # honest full refresh.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # honest full refresh (no incremental fields).
+        return build_endpoint_schemas(ENDPOINTS, {}, names)
 
     def validate_credentials(
         self, config: DeelSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -125,6 +114,8 @@ Create an organization token in [Deel](https://app.deel.com/developer-center) un
         return deel_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Deel endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deel/tests/test_deel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deel/tests/test_deel.py
@@ -1,19 +1,37 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel import (
     PAGE_SIZE,
     DeelResumeConfig,
     deel_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.deel.settings import DEEL_ENDPOINTS, ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the deel module.
+DEEL_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session"
+
+
+def _response(items: list[dict[str, Any]] | None, *, cursor: str | None = None, drop_data: bool = False) -> Response:
+    page: dict[str, Any] = {"total_rows": len(items or [])}
+    if cursor is not None:
+        page["cursor"] = cursor
+    body: dict[str, Any] = {"page": page}
+    if not drop_data:
+        body["data"] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: DeelResumeConfig | None = None) -> mock.MagicMock:
@@ -23,21 +41,30 @@ def _make_manager(resume_state: DeelResumeConfig | None = None) -> mock.MagicMoc
     return manager
 
 
-def _response(items: list[dict[str, Any]], cursor: str | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    page: dict[str, Any] = {"total_rows": len(items)}
-    if cursor is not None:
-        page["cursor"] = cursor
-    resp.json.return_value = {"data": items, "page": page}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy
+    when each request is prepared instead of inspecting the final state.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-@pytest.fixture(autouse=True)
-def _no_sleep():
-    with mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.time.sleep"):
-        yield
+def _source(endpoint: str, manager: mock.MagicMock):
+    return deel_source("token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestValidateCredentials:
@@ -45,13 +72,12 @@ class TestValidateCredentials:
         "status_code, expected",
         [
             (200, (True, None)),
-            # A valid token without people:read still 403s; only 401 means the
-            # token itself is bad.
+            # A valid token without people:read still 403s; only 401 means the token is bad.
             (403, (True, None)),
             (401, (False, "Invalid Deel API token")),
         ],
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    @mock.patch(DEEL_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
         response = mock.MagicMock()
         response.status_code = status_code
@@ -59,7 +85,7 @@ class TestValidateCredentials:
 
         assert validate_credentials("token") == expected
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    @mock.patch(DEEL_SESSION_PATCH)
     def test_validate_credentials_reports_network_error_distinctly(self, mock_session):
         # A transient network failure must not masquerade as a bad token.
         mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
@@ -68,97 +94,114 @@ class TestValidateCredentials:
         assert error is not None and error.startswith("Could not reach Deel")
 
 
-class TestGetRowsOffsetPagination:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_paginates_until_short_page(self, mock_session):
+class TestOffsetPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession):
+        session = MockSession.return_value
         full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
-        mock_session.return_value.get.side_effect = [
-            _response(full_page),
-            _response([{"id": "last"}]),
-        ]
+        params = _wire(session, [_response(full_page), _response([{"id": "last"}])])
 
         manager = _make_manager()
-        batches = list(get_rows("token", "people", mock.MagicMock(), manager))
+        rows = _rows(_source("people", manager))
 
-        assert len(batches) == 2
+        assert [r["id"] for r in rows] == [*(str(i) for i in range(PAGE_SIZE)), "last"]
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == PAGE_SIZE
+        assert params[1]["offset"] == PAGE_SIZE
+        # Checkpoint saved once after the first full page; the short page ends the walk.
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].offset == PAGE_SIZE
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert parse_qs(urlparse(second_url).query)["offset"] == [str(PAGE_SIZE)]
+        assert manager.save_state.call_args.args[0] == DeelResumeConfig(offset=PAGE_SIZE)
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_resumes_from_saved_offset(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_response([])])
 
         manager = _make_manager(DeelResumeConfig(offset=150))
-        list(get_rows("token", "people", mock.MagicMock(), manager))
+        _rows(_source("people", manager))
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["offset"] == ["150"]
+        assert params[0]["offset"] == 150
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_empty_response_stops_without_saving_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops_without_saving_state(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
         manager = _make_manager()
-        batches = list(get_rows("token", "people", mock.MagicMock(), manager))
+        rows = _rows(_source("people", manager))
 
-        assert batches == []
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_is_lenient_empty_page(self, MockSession):
+        # Deel's hand-rolled walk used `body.get("data", [])`, so a body without `data`
+        # is a zero-row page, not a hard failure.
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_data=True)])
+
+        manager = _make_manager()
+        rows = _rows(_source("people", manager))
+
+        assert rows == []
         manager.save_state.assert_not_called()
 
 
-class TestGetRowsCursorPagination:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_paginates_via_after_cursor(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "1"}], cursor="cur_abc"),
-            _response([{"id": "2"}]),
-        ]
+class TestCursorPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_after_cursor(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "1"}], cursor="cur_abc"), _response([{"id": "2"}])])
 
         manager = _make_manager()
-        batches = list(get_rows("token", "contracts", mock.MagicMock(), manager))
+        rows = _rows(_source("contracts", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["1", "2"]
+        assert [r["id"] for r in rows] == ["1", "2"]
+        assert params[0]["limit"] == PAGE_SIZE
+        assert "after_cursor" not in params[0]
+        assert params[1]["after_cursor"] == "cur_abc"
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].cursor == "cur_abc"
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert parse_qs(urlparse(second_url).query)["after_cursor"] == ["cur_abc"]
+        assert manager.save_state.call_args.args[0] == DeelResumeConfig(cursor="cur_abc")
 
     @pytest.mark.parametrize("num_pages", [2, 3])
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_saves_state_after_each_non_terminal_page(self, mock_session, num_pages):
-        # Pages 1..n-1 carry a cursor; the terminal page has none, so state is
-        # saved exactly n - 1 times — once after every page that advances.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_each_non_terminal_page(self, MockSession, num_pages):
+        # Pages 1..n-1 carry a cursor; the terminal page has none, so state is saved
+        # exactly n - 1 times — once after every page that advances the walk.
+        session = MockSession.return_value
         responses = [_response([{"id": str(i)}], cursor=f"cur_{i}") for i in range(1, num_pages)]
         responses.append(_response([{"id": str(num_pages)}]))
-        mock_session.return_value.get.side_effect = responses
+        _wire(session, responses)
 
         manager = _make_manager()
-        list(get_rows("token", "contracts", mock.MagicMock(), manager))
+        _rows(_source("contracts", manager))
 
         assert manager.save_state.call_count == num_pages - 1
         saved_cursors = [call.args[0].cursor for call in manager.save_state.call_args_list]
         assert saved_cursors == [f"cur_{i}" for i in range(1, num_pages)]
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_resumes_from_saved_cursor(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_response([])])
 
         manager = _make_manager(DeelResumeConfig(cursor="cur_resume"))
-        list(get_rows("token", "contracts", mock.MagicMock(), manager))
+        _rows(_source("contracts", manager))
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["after_cursor"] == ["cur_resume"]
+        assert params[0]["after_cursor"] == "cur_resume"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_empty_page_with_cursor_stops(self, mock_session):
-        mock_session.return_value.get.return_value = _response([], cursor="cur_loop")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_with_cursor_stops(self, MockSession):
+        # A cursor echoed alongside an empty page must terminate rather than loop.
+        session = MockSession.return_value
+        _wire(session, [_response([], cursor="cur_loop")])
 
         manager = _make_manager()
-        batches = list(get_rows("token", "contracts", mock.MagicMock(), manager))
+        rows = _rows(_source("contracts", manager))
 
-        assert batches == []
-        assert mock_session.return_value.get.call_count == 1
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
 
@@ -166,7 +209,7 @@ class TestDeelSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = DEEL_ENDPOINTS[endpoint]
-        response = deel_source("token", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]


### PR DESCRIPTION
## Problem

Batch 13 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green and asserts the same observable behavior via the framework, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **confluence**
- **crunchbase** — POST-body (`param_location="json"`) search pagination
- **deel**

Not migrated this batch (left hand-rolled, valid blockers — all documented framework gaps):
- **convex** — a 400 body-error envelope must raise a specific non-retryable "resync" error, plus two incompatible cursor transport modes (snapshot string-cursor vs deltas int-cursor).
- **coupa** — bespoke OAuth2: scope-fallback token minting (400 `invalid_scope` body classification) and mid-sync 401 inline token re-mint.
- **cursor** — multiple transport modes with client-side date-window chunking and response-envelope field injection.
- **dixa** — dual transport: date-windowed conversation export with client-side window-walking and rate-limit sleeps, plus cursor-paginated lists.
- **delighted** — SSRF guards (disabled redirects, off-host link/resume URL rejection) pinned by tests.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 3 migrated dirs + `common/rest_source/tests/` — 276 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-12 PR (#71829); merge in order.
