### PR TITLE
fix(subscriptions): only freeze report plans with zero failed steps

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -252,11 +252,22 @@ def _plan_to_freeze(
     trace_correlation_id: Optional[Union[int, str]],
 ) -> Optional[dict]:
     # Steps already carry their final HogQL by this point — see the write-back in `run_step`.
-    # Never freeze a plan the next delivery is better off re-planning: an all-failed plan would replay
-    # broken HogQL forever, and a step without any window placeholder would scan unbounded every run.
+    # Never freeze a plan the next delivery is better off re-planning: a plan where half or more of the
+    # steps failed would replay broken HogQL every run, and a step without any window placeholder would
+    # scan unbounded every run.
     if not freshly_planned:
         return None
-    if total_steps and failed_count >= total_steps:
+    # Freeze only when a strict majority of the plan's steps succeeded. If half or more failed, re-plan
+    # next run instead — a frozen mostly-broken plan replays those failures every delivery until the plan
+    # version bumps, whereas re-planning gives the planner and fix loop another shot. (An all-failed plan
+    # is just the extreme case of this.)
+    if total_steps and failed_count * 2 >= total_steps:
+        logger.warning(
+            "ai_report.plan_majority_failed_not_frozen",
+            trace_correlation_id=trace_correlation_id,
+            failed_count=failed_count,
+            total_steps=total_steps,
+        )
         return None
     if not all(any(token in step.hogql for token in WINDOW_PLACEHOLDERS) for step in plan.steps):
         logger.warning(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -252,18 +252,18 @@ def _plan_to_freeze(
     trace_correlation_id: Optional[Union[int, str]],
 ) -> Optional[dict]:
     # Steps already carry their final HogQL by this point — see the write-back in `run_step`.
-    # Never freeze a plan the next delivery is better off re-planning: a plan where half or more of the
-    # steps failed would replay broken HogQL every run, and a step without any window placeholder would
-    # scan unbounded every run.
+    # Never freeze a plan the next delivery is better off re-planning: a plan with any failed step would
+    # replay that broken HogQL every run, and a step without any window placeholder would scan unbounded
+    # every run.
     if not freshly_planned:
         return None
-    # Freeze only when a strict majority of the plan's steps succeeded. If half or more failed, re-plan
-    # next run instead — a frozen mostly-broken plan replays those failures every delivery until the plan
-    # version bumps, whereas re-planning gives the planner and fix loop another shot. (An all-failed plan
-    # is just the extreme case of this.)
-    if total_steps and failed_count * 2 >= total_steps:
+    # Freeze only when every step succeeded. If any step failed, re-plan next run instead — a frozen plan
+    # replays verbatim until the plan version bumps, so even a single broken step would re-send broken
+    # HogQL every delivery, whereas re-planning gives the planner and fix loop another shot (and lets the
+    # subscription pick up any planner/prompt improvements we've since shipped).
+    if failed_count:
         logger.warning(
-            "ai_report.plan_majority_failed_not_frozen",
+            "ai_report.plan_had_failures_not_frozen",
             trace_correlation_id=trace_correlation_id,
             failed_count=failed_count,
             total_steps=total_steps,

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -13,6 +13,7 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.report_pipe
     QueryStepDiagnostic,
     _all_queries_failed_notice,
     _arequest_hogql_fix,
+    _plan_to_freeze,
     _run_steps,
     _safe_error_message,
     generate_ai_report,
@@ -427,6 +428,40 @@ async def test_unfrozen_run_returns_plan_to_persist(
     result = await generate_ai_report(team=MagicMock(), user=MagicMock(), prompt="x", window=_test_window())
 
     assert result.plan_to_persist == {"version": AI_QUERY_PLAN_VERSION, "plan": spec.plan.model_dump()}
+
+
+@pytest.mark.parametrize(
+    "total_steps,failed_count,should_freeze",
+    [
+        (12, 0, True),  # all succeeded
+        (12, 5, True),  # minority failed — the working steps are still worth reusing
+        (12, 6, False),  # half failed — re-plan rather than replay
+        (12, 11, False),  # majority failed — don't freeze a plan that replays 11 broken queries every run
+        (1, 1, False),  # the single step failed
+    ],
+)
+def test_plan_to_freeze_requires_majority_success(total_steps: int, failed_count: int, should_freeze: bool) -> None:
+    # A frozen plan replays verbatim until AI_QUERY_PLAN_VERSION bumps, so a mostly-failed plan must NOT
+    # be frozen — otherwise a subscription whose generation was broken keeps re-sending broken queries
+    # instead of re-planning. Guards against the freeze bar regressing back to "only all-failed is skipped".
+    plan = QueryPlan(
+        overall_intent="i",
+        steps=[
+            QueryPlanStep(description=f"s{n}", hogql="SELECT count() FROM events WHERE {{date_range}}")
+            for n in range(total_steps)
+        ],
+    )
+    result = _plan_to_freeze(
+        plan,
+        freshly_planned=True,
+        failed_count=failed_count,
+        total_steps=total_steps,
+        trace_correlation_id=None,
+    )
+    if should_freeze:
+        assert result == {"version": AI_QUERY_PLAN_VERSION, "plan": plan.model_dump()}
+    else:
+        assert result is None
 
 
 @pytest.mark.parametrize(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -434,16 +434,17 @@ async def test_unfrozen_run_returns_plan_to_persist(
     "total_steps,failed_count,should_freeze",
     [
         (12, 0, True),  # all succeeded
-        (12, 5, True),  # minority failed — the working steps are still worth reusing
-        (12, 6, False),  # half failed — re-plan rather than replay
-        (12, 11, False),  # majority failed — don't freeze a plan that replays 11 broken queries every run
+        (12, 1, False),  # a single step failed — re-plan rather than replay one broken query every run
+        (12, 6, False),  # half failed
+        (12, 12, False),  # all failed
         (1, 1, False),  # the single step failed
     ],
 )
-def test_plan_to_freeze_requires_majority_success(total_steps: int, failed_count: int, should_freeze: bool) -> None:
-    # A frozen plan replays verbatim until AI_QUERY_PLAN_VERSION bumps, so a mostly-failed plan must NOT
-    # be frozen — otherwise a subscription whose generation was broken keeps re-sending broken queries
-    # instead of re-planning. Guards against the freeze bar regressing back to "only all-failed is skipped".
+def test_plan_to_freeze_requires_no_failures(total_steps: int, failed_count: int, should_freeze: bool) -> None:
+    # A frozen plan replays verbatim until AI_QUERY_PLAN_VERSION bumps, so a plan with ANY failed step must
+    # NOT be frozen — otherwise a subscription whose generation was partly broken keeps re-sending the
+    # broken queries instead of re-planning. Guards against the freeze bar loosening back to allowing
+    # partially-failed plans.
     plan = QueryPlan(
         overall_intent="i",
         steps=[


### PR DESCRIPTION
## Problem

After a fresh AI subscription report run, the generated plan is frozen and reused verbatim on every subsequent delivery (until `AI_QUERY_PLAN_VERSION` bumps). But `_plan_to_freeze` only refused to freeze when **all** steps failed. A plan where most-but-not-all steps failed (e.g. 1 of 12 queries succeeded) was frozen and then replayed those broken queries every run — so a subscription whose generation was partly broken kept re-sending a broken report instead of re-planning.

## Changes

- Freeze only when **every** step succeeded. If any step failed, return `None` so the next delivery re-plans (giving the planner and the HogQL fix loop another shot, and letting the subscription pick up any planner/prompt improvements shipped since). This is the most predictable behavior for users, and the all-failed case is subsumed.
- Log `ai_report.plan_had_failures_not_frozen` when a plan is skipped for this reason, so the signal is observable.

Third of three related PRs improving subscription-report resilience (siblings: share HogQL casing rules with the prompts; feed the project schema into the fixer).

## How did you test this code?

- Updated the parametrized unit test on the pure `_plan_to_freeze` to cover all-succeeded (frozen) vs single-step / half / all failed (re-plan) — guards against the freeze bar loosening back to allowing partially-failed plans. Existing freeze tests (all-failed, missing-placeholder, post-fix-frozen, degraded-but-shipped) still hold.
- `ruff check` passes and the freeze/frozen/degraded test subset passes locally.

## 🤖 Agent context

Human-driven (agent-assisted). Requested by the PR assignee to make AI subscription report generation more resilient, from an investigation into a subscription that delivered mostly-broken reports. The zero-failures bar was chosen over the earlier majority bar for predictability.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9A53J8RF/p1784271374393929?thread_ts=1784271374.393929&cid=C0B9A53J8RF)*
