### PR TITLE
refactor(data-warehouse): migrate deepgram, docuseal, drip, elevenlabs to rest_source (batch 14)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deepgram/deepgram.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deepgram/deepgram.py
@@ -1,16 +1,32 @@
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlsplit, urlunsplit
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import PreparedRequest, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import AuthConfigBase
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.config_setup import (
+    make_parent_key_name,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    EndpointResource,
+    IncrementalConfig,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.deepgram.settings import (
     DEEPGRAM_ENDPOINTS,
     DeepgramEndpointConfig,
@@ -21,81 +37,60 @@ DEEPGRAM_BASE_URL = "https://api.deepgram.com/v1"
 # The requests log caps `limit` at 1000; use the max to minimise round trips.
 REQUESTS_PAGE_SIZE = 1000
 
-REQUEST_TIMEOUT_SECONDS = 60
+# Parent (projects) list is the fan-out seed for every project-scoped endpoint.
+_PARENT_RESOURCE = "projects"
+_PARENT_ID_FIELD = "project_id"
+# The framework injects the parent id under this `_<parent>_<field>` name; the child map lifts it back
+# to the flat `project_id` column the tables have always exposed.
+_PARENT_ID_KEY = make_parent_key_name(_PARENT_RESOURCE, _PARENT_ID_FIELD)
 
 
-class DeepgramRetryableError(Exception):
-    pass
+class DeepgramTokenAuth(AuthConfigBase):
+    """Deepgram's Management API expects `Authorization: Token <key>` (not Bearer).
+
+    Supplying it through a framework auth object (rather than a hand-built header) registers the key
+    for value-based log redaction, so a failed or sampled request never persists the customer's secret.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def __call__(self, request: PreparedRequest) -> PreparedRequest:
+        request.headers["Authorization"] = f"Token {self.api_key}"
+        return request
+
+    def secret_values(self) -> tuple[str, ...]:
+        return (self.api_key,) if self.api_key else ()
+
+
+class DeepgramRequestsPaginator(PageNumberPaginator):
+    """Page/`limit` pagination over Deepgram's requests log (0-indexed `page`).
+
+    The requests log reports no total count, so — like the hand-rolled loop this replaces — a page
+    shorter than the requested `limit` (or an empty page) is the last page. Stopping on a short page
+    avoids the extra empty-page request the plain ``PageNumberPaginator`` would pay.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(base_page=0, page_param="page")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and data is not None and len(data) < REQUESTS_PAGE_SIZE:
+            self._has_next_page = False
 
 
 @dataclasses.dataclass
 class DeepgramResumeConfig:
-    # Stable project-id bookmark of the project currently being fetched. Not a positional index so a
-    # project added/removed between a crash and the retry can't resume us into the wrong project.
+    # Opaque paginator/fan-out state handed back by the rest_source framework (per-parent completed-path
+    # progress plus the in-progress project's requests-log page). Retained as a single blob so the shape
+    # can evolve without a state-format migration.
+    fanout_state: dict[str, Any] | None = None
+    # Legacy fields from the hand-rolled resume format. Kept (with defaults) so an old saved state still
+    # parses via ``dataclass(**saved)``; a run resumed from one starts fan-out fresh (a re-read the merge
+    # dedupes) rather than mis-mapping the old positional scope onto the new state.
     project_id: str | None = None
-    # Next page to fetch for the paginated requests endpoint (0-indexed). None for the unpaginated
-    # full-refresh endpoints.
     page: int | None = None
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Token {api_key}",
-        "Accept": "application/json",
-    }
-
-
-def _get_session(api_key: str) -> requests.Session:
-    # The API key travels in the Authorization header on every request; register it for value-based
-    # redaction so a failed or sampled request never persists the customer's secret in HTTP logs.
-    return make_tracked_session(redact_values=(api_key,))
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            DeepgramRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_json(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger, params: dict[str, Any]
-) -> dict:
-    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise DeepgramRetryableError(f"Deepgram API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Deepgram API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def validate_credentials(api_key: str) -> bool:
-    # Listing projects is the cheapest probe that proves the token is genuine; it is also the seed for
-    # every other (project-scoped) endpoint, so a token that can't list projects can't sync anything.
-    try:
-        response = _get_session(api_key).get(
-            f"{DEEPGRAM_BASE_URL}/projects",
-            headers=_get_headers(api_key),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _list_project_ids(session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger) -> list[str]:
-    data = _fetch_json(session, f"{DEEPGRAM_BASE_URL}/projects", headers, logger, params={})
-    return [project["project_id"] for project in data.get("projects", []) if project.get("project_id")]
 
 
 def _format_start_value(value: Any) -> str:
@@ -132,141 +127,165 @@ def _redact_url_userinfo(url: str) -> str:
     return urlunsplit(parts._replace(netloc=host))
 
 
-def _transform_row(row: dict[str, Any], project_id: str, config: DeepgramEndpointConfig) -> dict[str, Any]:
-    if config.flatten_key and isinstance(row.get(config.flatten_key), dict):
-        nested = row.pop(config.flatten_key)
-        row = {**row, **nested}
-    # Fan-out rows carry the parent project's id so the composite primary key stays unique table-wide.
-    row["project_id"] = project_id
-    # Request-log rows can echo the callback URL, which may embed Basic Auth credentials.
-    if isinstance(row.get("callback"), str):
-        row["callback"] = _redact_url_userinfo(row["callback"])
-    # A row missing a required primary-key field would let the delta merge build a partial predicate
-    # and overwrite unrelated rows in the same project, so fail loudly instead of emitting it.
-    for primary_key in config.primary_keys:
-        if row.get(primary_key) is None:
-            raise ValueError(f"Deepgram {config.name} row missing required primary key '{primary_key}'")
-    return row
+def _make_child_map(config: DeepgramEndpointConfig) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Per-row transform for a fanned-out (project-scoped) endpoint.
+
+    Reproduces the old ``_transform_row``: flatten a nested sub-object into the row root, lift the
+    framework's parent-id key back to the flat ``project_id`` column, redact any callback credentials,
+    and fail loud on a row missing a required primary key.
+    """
+
+    def _map(row: dict[str, Any]) -> dict[str, Any]:
+        if config.flatten_key and isinstance(row.get(config.flatten_key), dict):
+            nested = row.pop(config.flatten_key)
+            row = {**row, **nested}
+        # Fan-out rows carry the parent project's id so the composite primary key stays unique table-wide.
+        if _PARENT_ID_KEY in row:
+            row[_PARENT_ID_FIELD] = row.pop(_PARENT_ID_KEY)
+        # Request-log rows can echo the callback URL, which may embed Basic Auth credentials.
+        if isinstance(row.get("callback"), str):
+            row["callback"] = _redact_url_userinfo(row["callback"])
+        # A row missing a required primary-key field would let the delta merge build a partial predicate
+        # and overwrite unrelated rows in the same project, so fail loudly instead of emitting it.
+        for primary_key in config.primary_keys:
+            if row.get(primary_key) is None:
+                raise ValueError(f"Deepgram {config.name} row missing required primary key '{primary_key}'")
+        return row
+
+    return _map
 
 
-def _build_request_params(
-    config: DeepgramEndpointConfig,
-    page: int,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": REQUESTS_PAGE_SIZE, "page": page}
-    if should_use_incremental_field and db_incremental_field_last_value is not None:
-        params["start"] = _format_start_value(db_incremental_field_last_value)
-    return params
+def _incremental_config(
+    should_use_incremental_field: bool, db_incremental_field_last_value: Any
+) -> IncrementalConfig | None:
+    """Server-side `start` filter for the requests log, only when we have a cursor to filter on.
+
+    Mirrors the old behaviour: no filter on a first (full) sync, and the persisted watermark is
+    formatted (and future-clamped) the way Deepgram's `start` expects.
+    """
+    if not should_use_incremental_field or db_incremental_field_last_value is None:
+        return None
+    return {
+        "start_param": "start",
+        "cursor_path": "created",
+        "convert": _format_start_value,
+    }
 
 
-def _iter_project_endpoint(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DeepgramResumeConfig],
-    config: DeepgramEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> Iterator[list[dict[str, Any]]]:
-    project_ids = _list_project_ids(session, headers, logger)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    remaining = project_ids
-    resume_page: int | None = None
-    if resume is not None and resume.project_id is not None and resume.project_id in project_ids:
-        remaining = project_ids[project_ids.index(resume.project_id) :]
-        resume_page = resume.page
-        logger.debug(f"Deepgram: resuming {config.name} from project_id={resume.project_id}, page={resume_page}")
-
-    for index, project_id in enumerate(remaining):
-        base_url = f"{DEEPGRAM_BASE_URL}/projects/{project_id}{config.path}"
-
-        if config.paginated:
-            page = resume_page if index == 0 and resume_page is not None else 0
-            while True:
-                params = _build_request_params(
-                    config, page, should_use_incremental_field, db_incremental_field_last_value
-                )
-                data = _fetch_json(session, base_url, headers, logger, params)
-                items = data.get(config.data_key, [])
-
-                if items:
-                    yield [_transform_row(item, project_id, config) for item in items]
-
-                # A short page (fewer rows than the limit) or an empty page means we've reached the end.
-                if len(items) < REQUESTS_PAGE_SIZE:
-                    break
-
-                page += 1
-                # Save AFTER yielding so a crash re-fetches from the last saved page rather than skipping
-                # it; merge dedupes any re-pulled rows on the primary key.
-                resumable_source_manager.save_state(DeepgramResumeConfig(project_id=project_id, page=page))
-        else:
-            data = _fetch_json(session, base_url, headers, logger, params={})
-            items = data.get(config.data_key, [])
-            if items:
-                yield [_transform_row(item, project_id, config) for item in items]
-
-        resume_page = None
-        # Advance the bookmark to the next project so a crash between projects resumes correctly.
-        if index + 1 < len(remaining):
-            resumable_source_manager.save_state(DeepgramResumeConfig(project_id=remaining[index + 1], page=0))
+def _projects_resource() -> EndpointResource:
+    # The top-level /projects list synced as its own table — yielded raw (no fan-out, no per-row
+    # transform), exactly as the old is_project_list path did.
+    return {
+        "name": "projects",
+        "endpoint": {
+            "path": "/projects",
+            "data_selector": "projects",
+            "paginator": SinglePagePaginator(),
+        },
+    }
 
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DeepgramResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
+def _projects_parent_resource() -> EndpointResource:
+    # The same /projects list used as the fan-out seed. The old code skipped projects with no
+    # project_id; drop them here so the child resolve (which would otherwise raise) never sees an
+    # id-less parent row.
+    return {
+        "name": "projects",
+        "endpoint": {
+            "path": "/projects",
+            "data_selector": "projects",
+            "paginator": SinglePagePaginator(),
+        },
+        "data_map": lambda row: [row] if row.get(_PARENT_ID_FIELD) else [],
+    }
+
+
+def _child_resource(
+    endpoint: str, config: DeepgramEndpointConfig, incremental: IncrementalConfig | None
+) -> EndpointResource:
+    params: dict[str, Any] = {
+        _PARENT_ID_FIELD: {"type": "resolve", "resource": _PARENT_RESOURCE, "field": _PARENT_ID_FIELD},
+    }
+    endpoint_config: dict[str, Any] = {
+        "path": f"/projects/{{{_PARENT_ID_FIELD}}}{config.path}",
+        "params": params,
+        "data_selector": config.data_key,
+    }
+    if config.paginated:
+        params["limit"] = REQUESTS_PAGE_SIZE
+        endpoint_config["paginator"] = DeepgramRequestsPaginator()
+    else:
+        endpoint_config["paginator"] = SinglePagePaginator()
+    if incremental is not None:
+        endpoint_config["incremental"] = incremental
+    return {
+        "name": endpoint,
+        "include_from_parent": [_PARENT_ID_FIELD],
+        "endpoint": endpoint_config,
+        "data_map": _make_child_map(config),
+    }
+
+
+def _resources_for(endpoint: str, incremental: IncrementalConfig | None) -> list[EndpointResource]:
     config = DEEPGRAM_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every request so urllib3 keeps the connection alive instead of
-    # re-handshaking per project/page.
-    session = _get_session(api_key)
-
     if config.is_project_list:
-        data = _fetch_json(session, f"{DEEPGRAM_BASE_URL}/projects", headers, logger, params={})
-        items = data.get(config.data_key, [])
-        if items:
-            yield items
-        return
-
-    yield from _iter_project_endpoint(
-        session,
-        headers,
-        logger,
-        resumable_source_manager,
-        config,
-        should_use_incremental_field,
-        db_incremental_field_last_value,
-    )
+        return [_projects_resource()]
+    return [_projects_parent_resource(), _child_resource(endpoint, config, incremental)]
 
 
 def deepgram_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[DeepgramResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = DEEPGRAM_ENDPOINTS[endpoint]
+    incremental = (
+        _incremental_config(should_use_incremental_field, db_incremental_field_last_value)
+        if config.supports_incremental
+        else None
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": DEEPGRAM_BASE_URL,
+            # Auth (the Token header) is supplied via the framework auth object so its value is redacted
+            # from logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": DeepgramTokenAuth(api_key),
+        },
+        "resource_defaults": {},
+        "resources": _resources_for(endpoint, incremental),
+    }
+
+    initial_paginator_state: dict[str, Any] | None = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded so a crash re-yields the last page (merge dedupes) rather than
+        # skipping it. A ``None`` state means no page remains — nothing to persist.
+        if state is not None:
+            resumable_source_manager.save_state(DeepgramResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    resource: Resource = next(r for r in resources if r.name == endpoint)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # The requests log's default order isn't documented and can't be curl-verified without a live
         # token, so we use "desc": the pipeline finalises the incremental watermark (max `created`) only
@@ -280,3 +299,14 @@ def deepgram_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    # Listing projects is the cheapest probe that proves the token is genuine; it is also the seed for
+    # every other (project-scoped) endpoint, so a token that can't list projects can't sync anything.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{DEEPGRAM_BASE_URL}/projects",
+        headers={"Authorization": f"Token {api_key}", "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deepgram/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deepgram/source.py
@@ -128,7 +128,8 @@ You can create an API key in your [Deepgram Console](https://console.deepgram.co
         return deepgram_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deepgram/tests/test_deepgram.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deepgram/tests/test_deepgram.py
@@ -1,23 +1,77 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.deepgram import deepgram
+from products.warehouse_sources.backend.temporal.data_imports.sources.deepgram import deepgram as deepgram_mod
 from products.warehouse_sources.backend.temporal.data_imports.sources.deepgram.deepgram import (
+    DEEPGRAM_BASE_URL,
     DeepgramResumeConfig,
-    _build_request_params,
     _format_start_value,
-    _transform_row,
+    _make_child_map,
+    _redact_url_userinfo,
     deepgram_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.deepgram.settings import DEEPGRAM_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the deepgram module.
+DEEPGRAM_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.deepgram.deepgram.make_tracked_session"
+)
+
+# The framework injects the parent project id under this key before the child data_map lifts it out.
+PARENT_KEY = "_projects_project_id"
+
+
+def _response(body: Any) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: DeepgramResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session; capture each request's (url, params) AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so snapshot a copy when each request
+    is prepared instead of inspecting it after the run.
+    """
+    session.headers = {}
+    snapshots: list[tuple[str, dict[str, Any]]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append((request.url, dict(request.params or {})))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return deepgram_source(
+        api_key="token", endpoint=endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs
+    )
 
 
 class TestFormatStartValue:
@@ -41,41 +95,18 @@ class TestFormatStartValue:
         assert _format_start_value(datetime(2027, 1, 1, tzinfo=UTC)) == "2026-06-15T12:00:00.000Z"
 
 
-class TestBuildRequestParams:
-    def test_incremental_sets_start_and_page_size(self) -> None:
-        params = _build_request_params(
-            DEEPGRAM_ENDPOINTS["requests"],
-            page=3,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
-        )
-        assert params["page"] == 3
-        assert params["limit"] == deepgram.REQUESTS_PAGE_SIZE
-        assert params["start"] == "2026-03-04T02:58:14.000Z"
-
-    def test_non_incremental_omits_start(self) -> None:
-        params = _build_request_params(
-            DEEPGRAM_ENDPOINTS["requests"],
-            page=0,
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=None,
-        )
-        assert "start" not in params
-
-
-class TestTransformRow:
+class TestChildMap:
     def test_injects_project_id(self) -> None:
-        row = _transform_row({"member_id": "m1"}, "proj-1", DEEPGRAM_ENDPOINTS["members"])
+        row = _make_child_map(DEEPGRAM_ENDPOINTS["members"])({PARENT_KEY: "proj-1", "member_id": "m1"})
         assert row["project_id"] == "proj-1"
         assert row["member_id"] == "m1"
+        assert PARENT_KEY not in row
 
     def test_flattens_nested_key_to_root(self) -> None:
         # /keys nests the key under "api_key"; api_key_id must land at the row root or the composite
         # primary key can't be built and the delta merge multi-matches duplicate rows.
-        row = _transform_row(
-            {"api_key": {"api_key_id": "k1", "comment": "ci"}, "member": {"email": "a@b.co"}},
-            "proj-1",
-            DEEPGRAM_ENDPOINTS["keys"],
+        row = _make_child_map(DEEPGRAM_ENDPOINTS["keys"])(
+            {PARENT_KEY: "proj-1", "api_key": {"api_key_id": "k1", "comment": "ci"}, "member": {"email": "a@b.co"}}
         )
         assert row["api_key_id"] == "k1"
         assert row["comment"] == "ci"
@@ -92,121 +123,248 @@ class TestTransformRow:
     )
     def test_redacts_callback_userinfo(self, _name: str, callback: str, expected: str) -> None:
         # A callback URL can embed Basic Auth creds; they must not reach the warehouse.
-        row = _transform_row({"request_id": "r1", "callback": callback}, "proj-1", DEEPGRAM_ENDPOINTS["requests"])
+        row = _make_child_map(DEEPGRAM_ENDPOINTS["requests"])(
+            {PARENT_KEY: "proj-1", "request_id": "r1", "callback": callback}
+        )
         assert row["callback"] == expected
 
     def test_missing_primary_key_raises(self) -> None:
         # A row missing request_id would let the merge overwrite unrelated rows; fail instead of emit.
         with pytest.raises(ValueError, match="request_id"):
-            _transform_row({"created": "2026-01-01"}, "proj-1", DEEPGRAM_ENDPOINTS["requests"])
+            _make_child_map(DEEPGRAM_ENDPOINTS["requests"])({PARENT_KEY: "proj-1", "created": "2026-01-01"})
 
 
-class TestValidateCredentials:
-    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    def test_status_maps_to_bool(self, _name: str, status: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status)
-        with patch.object(deepgram, "make_tracked_session", return_value=session):
-            assert validate_credentials("token") is expected
-
-    def test_network_error_is_false(self) -> None:
-        with patch.object(deepgram, "make_tracked_session", side_effect=Exception("boom")):
-            assert validate_credentials("token") is False
+class TestRedactUrlUserinfo:
+    def test_malformed_url_passthrough(self) -> None:
+        assert _redact_url_userinfo("http://[") == "http://["
 
 
-def _fake_manager(resume: DeepgramResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock()
-    manager.can_resume.return_value = resume is not None
-    manager.load_state.return_value = resume
-    return manager
-
-
-class TestGetRows:
-    def _run(self, endpoint: str, fetch_side_effect: Any, manager: MagicMock, **kwargs: Any) -> list[list[dict]]:
-        with (
-            patch.object(deepgram, "make_tracked_session", return_value=MagicMock()),
-            patch.object(deepgram, "_fetch_json", side_effect=fetch_side_effect),
-        ):
-            return list(
-                get_rows(
-                    api_key="token",
-                    endpoint=endpoint,
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,
-                    **kwargs,
-                )
-            )
-
-    def test_project_list_yields_projects_without_fan_out(self) -> None:
+class TestProjectsEndpoint:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_yields_projects_without_fan_out(self, MockSession) -> None:
+        session = MockSession.return_value
         projects = [{"project_id": "p1"}, {"project_id": "p2"}]
+        snapshots = _wire(session, [_response({"projects": projects})])
 
-        def fetch(_session, url, _headers, _logger, params=None):
-            assert url.endswith("/projects")
-            return {"projects": projects}
+        rows = _rows(_source("projects", _make_manager()))
 
-        batches = self._run("projects", fetch, _fake_manager())
-        assert batches == [projects]
+        assert rows == projects
+        # projects is its own endpoint — one request, and it must NOT fan out per project.
+        assert len(snapshots) == 1
+        assert snapshots[0][0] == f"{DEEPGRAM_BASE_URL}/projects"
 
-    def test_fan_out_injects_project_id_per_row(self) -> None:
-        def fetch(_session, url, _headers, _logger, params=None):
-            if url.endswith("/projects"):
-                return {"projects": [{"project_id": "p1"}, {"project_id": "p2"}]}
-            return {"members": [{"member_id": "m1"}]}
 
-        batches = self._run("members", fetch, _fake_manager())
-        project_ids = {row["project_id"] for batch in batches for row in batch}
-        assert project_ids == {"p1", "p2"}
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_over_projects_and_injects_project_id(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [
+                _response({"projects": [{"project_id": "p1"}, {"project_id": "p2"}]}),
+                _response({"members": [{"member_id": "m1"}]}),
+                _response({"members": [{"member_id": "m2"}]}),
+            ],
+        )
 
-    def test_paginated_requests_terminate_on_short_page(self) -> None:
-        # limit is patched to 2, so a page returning fewer than 2 rows ends pagination for a project.
-        pages = {0: [{"request_id": "r1"}, {"request_id": "r2"}], 1: [{"request_id": "r3"}]}
+        rows = _rows(_source("members", _make_manager()))
 
-        def fetch(_session, url, _headers, _logger, params):
-            if url.endswith("/projects"):
-                return {"projects": [{"project_id": "p1"}]}
-            return {"requests": pages[params["page"]]}
+        assert [(r["member_id"], r["project_id"]) for r in rows] == [("m1", "p1"), ("m2", "p2")]
+        assert [url for url, _ in snapshots] == [
+            f"{DEEPGRAM_BASE_URL}/projects",
+            f"{DEEPGRAM_BASE_URL}/projects/p1/members",
+            f"{DEEPGRAM_BASE_URL}/projects/p2/members",
+        ]
 
-        with patch.object(deepgram, "REQUESTS_PAGE_SIZE", 2):
-            batches = self._run(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_flattens_keys_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"projects": [{"project_id": "p1"}]}),
+                _response({"api_keys": [{"api_key": {"api_key_id": "k1"}, "member": {"email": "a@b.co"}}]}),
+            ],
+        )
+
+        rows = _rows(_source("keys", _make_manager()))
+
+        assert rows == [{"api_key_id": "k1", "member": {"email": "a@b.co"}, "project_id": "p1"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_project_without_id_is_skipped(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A project row missing project_id can't be fanned out; the old code skipped it, so no
+        # /projects//members request is made for it.
+        snapshots = _wire(
+            session,
+            [
+                _response({"projects": [{"name": "no-id"}, {"project_id": "p2"}]}),
+                _response({"members": [{"member_id": "m2"}]}),
+            ],
+        )
+
+        rows = _rows(_source("members", _make_manager()))
+
+        assert [r["project_id"] for r in rows] == ["p2"]
+        assert [url for url, _ in snapshots] == [
+            f"{DEEPGRAM_BASE_URL}/projects",
+            f"{DEEPGRAM_BASE_URL}/projects/p2/members",
+        ]
+
+
+class TestRequestsPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_terminates_on_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        # page size patched to 2, so a page returning fewer than 2 rows ends pagination for a project
+        # without paying an extra empty-page request.
+        snapshots = _wire(
+            session,
+            [
+                _response({"projects": [{"project_id": "p1"}]}),
+                _response({"requests": [{"request_id": "r1"}, {"request_id": "r2"}]}),
+                _response({"requests": [{"request_id": "r3"}]}),
+            ],
+        )
+
+        with mock.patch.object(deepgram_mod, "REQUESTS_PAGE_SIZE", 2):
+            rows = _rows(_source("requests", _make_manager(), should_use_incremental_field=True))
+
+        assert [r["request_id"] for r in rows] == ["r1", "r2", "r3"]
+        # projects + page 0 + page 1 == 3 requests; no trailing empty page.
+        assert len(snapshots) == 3
+        assert snapshots[1][1]["page"] == 0
+        assert snapshots[2][1]["page"] == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoint_advances_page_after_yield(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"projects": [{"project_id": "p1"}]}),
+                _response({"requests": [{"request_id": "r1"}, {"request_id": "r2"}]}),
+                _response({"requests": [{"request_id": "r3"}]}),
+            ],
+        )
+        manager = _make_manager()
+
+        with mock.patch.object(deepgram_mod, "REQUESTS_PAGE_SIZE", 2):
+            _rows(_source("requests", manager, should_use_incremental_field=True))
+
+        # After yielding the first full page we persist the next page so a crash re-fetches page 1.
+        child_pages = [
+            call.args[0].fanout_state.get("child_state", {}).get("page")
+            for call in manager.save_state.call_args_list
+            if call.args[0].fanout_state and call.args[0].fanout_state.get("child_state")
+        ]
+        assert 1 in child_pages
+
+
+class TestRequestsIncremental:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_start_filter_only_on_requests(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [_response({"projects": [{"project_id": "p1"}]}), _response({"requests": []})],
+        )
+
+        _rows(
+            _source(
                 "requests",
-                fetch,
-                _fake_manager(),
+                _make_manager(),
                 should_use_incremental_field=True,
-                db_incremental_field_last_value=None,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
             )
-        request_ids = [row["request_id"] for batch in batches for row in batch]
-        assert request_ids == ["r1", "r2", "r3"]
+        )
 
-    def test_resume_starts_from_saved_project(self) -> None:
-        def fetch(_session, url, _headers, _logger, params=None):
-            if url.endswith("/projects"):
-                return {"projects": [{"project_id": "p1"}, {"project_id": "p2"}]}
-            return {"members": [{"member_id": f"m-{url.split('/projects/')[1].split('/')[0]}"}]}
+        assert snapshots[-1][1]["start"] == "2026-03-04T02:58:14.000Z"
+        assert snapshots[-1][1]["limit"] == deepgram_mod.REQUESTS_PAGE_SIZE
+        # The parent project enumeration carries no incremental filter.
+        assert "start" not in snapshots[0][1]
 
-        manager = _fake_manager(DeepgramResumeConfig(project_id="p2", page=None))
-        batches = self._run("members", fetch, manager)
-        project_ids = {row["project_id"] for batch in batches for row in batch}
-        assert project_ids == {"p2"}  # p1 skipped — already synced before the crash
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_start_filter_on_full_refresh(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(
+            session,
+            [_response({"projects": [{"project_id": "p1"}]}), _response({"requests": []})],
+        )
 
-    def test_state_saved_advances_page_after_yield(self) -> None:
-        pages = {0: [{"request_id": "r1"}, {"request_id": "r2"}], 1: [{"request_id": "r3"}]}
+        _rows(_source("requests", _make_manager(), should_use_incremental_field=False))
 
-        def fetch(_session, url, _headers, _logger, params):
-            if url.endswith("/projects"):
-                return {"projects": [{"project_id": "p1"}]}
-            return {"requests": pages[params["page"]]}
+        assert "start" not in snapshots[-1][1]
 
-        manager = _fake_manager()
-        with patch.object(deepgram, "REQUESTS_PAGE_SIZE", 2):
-            self._run(
-                "requests", fetch, manager, should_use_incremental_field=True, db_incremental_field_last_value=None
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_start_filter_when_no_cursor_yet(self, MockSession) -> None:
+        session = MockSession.return_value
+        # First incremental sync: no persisted watermark, so no server-side filter (full pull).
+        snapshots = _wire(
+            session,
+            [_response({"projects": [{"project_id": "p1"}]}), _response({"requests": []})],
+        )
+
+        _rows(
+            _source(
+                "requests", _make_manager(), should_use_incremental_field=True, db_incremental_field_last_value=None
             )
-        # After yielding page 0 we persist page 1 so a crash re-fetches page 1 rather than restarting.
-        saved_pages = [call.args[0].page for call in manager.save_state.call_args_list]
-        assert 1 in saved_pages
+        )
+
+        assert "start" not in snapshots[-1][1]
 
 
-class TestDeepgramSource:
+class TestResume:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_skips_completed_project(self, MockSession) -> None:
+        session = MockSession.return_value
+        # p1 already fully synced last run — only projects (re-enumerated) and p2 are fetched.
+        snapshots = _wire(
+            session,
+            [
+                _response({"projects": [{"project_id": "p1"}, {"project_id": "p2"}]}),
+                _response({"members": [{"member_id": "m2"}]}),
+            ],
+        )
+        resume = DeepgramResumeConfig(
+            fanout_state={"completed": ["/projects/p1/members"], "current": None, "child_state": None}
+        )
+
+        rows = _rows(_source("members", _make_manager(resume)))
+
+        assert [r["member_id"] for r in rows] == ["m2"]
+        assert [url for url, _ in snapshots] == [
+            f"{DEEPGRAM_BASE_URL}/projects",
+            f"{DEEPGRAM_BASE_URL}/projects/p2/members",
+        ]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoint_records_completed_child_path(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"projects": [{"project_id": "p1"}]}), _response({"members": [{"member_id": "m1"}]})])
+        manager = _make_manager()
+
+        _rows(_source("members", manager))
+
+        assert manager.save_state.called
+        last_saved = manager.save_state.call_args.args[0]
+        assert isinstance(last_saved, DeepgramResumeConfig)
+        assert last_saved.fanout_state is not None
+        assert last_saved.fanout_state["completed"] == ["/projects/p1/members"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_resume_state_restarts_from_beginning(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"projects": [{"project_id": "p1"}]}), _response({"members": [{"member_id": "m1"}]})])
+        # An old-format saved state (no fanout_state) parses but resumes nothing — a full re-read the
+        # merge dedupes, rather than mis-mapping the old positional scope onto the new fan-out state.
+        rows = _rows(_source("members", _make_manager(DeepgramResumeConfig(project_id="p1", page=3))))
+
+        assert [r["member_id"] for r in rows] == ["m1"]
+
+
+class TestSourceResponse:
     @parameterized.expand(
         [
             ("requests_is_incremental", "requests", "desc", ["project_id", "request_id"]),
@@ -214,18 +372,26 @@ class TestDeepgramSource:
             ("projects_top_level", "projects", "asc", ["project_id"]),
         ]
     )
-    def test_source_response_shape(self, _name: str, endpoint: str, sort_mode: str, primary_keys: list[str]) -> None:
-        response = deepgram_source(
-            api_key="token",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    def test_shape(self, _name: str, endpoint: str, sort_mode: str, primary_keys: list[str]) -> None:
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == primary_keys
         assert response.sort_mode == sort_mode
 
     def test_partitioned_only_when_partition_key_set(self) -> None:
-        # requests has a stable `created` partition key; members has none.
-        assert deepgram_source("t", "requests", MagicMock(), MagicMock()).partition_mode == "datetime"
-        assert deepgram_source("t", "members", MagicMock(), MagicMock()).partition_mode is None
+        assert _source("requests", _make_manager()).partition_mode == "datetime"
+        assert _source("requests", _make_manager()).partition_keys == ["created"]
+        assert _source("members", _make_manager()).partition_mode is None
+
+
+class TestValidateCredentials:
+    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
+    def test_status_maps_to_bool(self, _name: str, status: int, expected: bool) -> None:
+        with mock.patch(DEEPGRAM_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+            assert validate_credentials("token") is expected
+
+    def test_network_error_is_false(self) -> None:
+        with mock.patch(DEEPGRAM_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.side_effect = Exception("boom")
+            assert validate_credentials("token") is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/docuseal.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/docuseal.py
@@ -1,20 +1,18 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.docuseal.settings import (
-    DOCUSEAL_ENDPOINTS,
-    DocusealEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.docuseal.settings import DOCUSEAL_ENDPOINTS
 
 # DocuSeal runs two hosted regions on separate base URLs. There is no programmatic way to
 # discover which region an account lives in, so the user picks it on the connection form.
@@ -26,12 +24,6 @@ DEFAULT_REGION = "us"
 
 # Max page size the API accepts (`limit`, capped server-side at 100).
 PAGE_SIZE = 100
-
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class DocusealRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -47,17 +39,146 @@ def _base_url(region: str | None) -> str:
     return DOCUSEAL_HOSTS.get(region or DEFAULT_REGION, DOCUSEAL_HOSTS[DEFAULT_REGION])
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "X-Auth-Token": api_key,
-        "Accept": "application/json",
+class DocusealCursorPaginator(BasePaginator):
+    """Walk DocuSeal's id-descending list endpoints backwards via the `after` cursor.
+
+    DocuSeal orders list responses by `id` descending (newest first) and paginates *backwards*:
+    `pagination.next` is the smallest id on the page, and passing it as `after` returns the next
+    page of older (smaller-id) records. There is no server-side time filter, so this is a full
+    walk newest -> oldest.
+
+    Two DocuSeal-specific quirks make the built-in cursor paginator unsuitable, so this local
+    subclass handles them:
+
+    * Termination is a null `next` OR a short page (< `page_size`). DocuSeal's final page still
+      carries a non-null `next` (its own smallest id), so without the short-page check we'd pay one
+      extra empty request every sync.
+    * Resume must persist the cursor of the page *currently* being streamed, not the next one, so a
+      crash re-fetches that page rather than skipping rows still buffered but not yet durably
+      written (merge dedupes the re-pulled rows on the primary key).
+    """
+
+    def __init__(self, page_size: int, cursor_param: str = "after") -> None:
+        super().__init__()
+        self.page_size = page_size
+        self.cursor_param = cursor_param
+        # Cursor used to fetch the request currently in flight (None => first page).
+        self._current_after: Optional[int] = None
+        # Cursor for the next request, discovered from `pagination.next`.
+        self._pending_after: Optional[int] = None
+        # Cursor of the page just processed — what we persist so a crash re-fetches it.
+        self._resume_after: Optional[int] = None
+
+    def _set_cursor(self, request: Request, value: Optional[int]) -> None:
+        if value is None:
+            return
+        if request.params is None:
+            request.params = {}
+        request.params[self.cursor_param] = value
+
+    def init_request(self, request: Request) -> None:
+        # Seed the first request from a resumed cursor (no-op on a fresh start).
+        self._set_cursor(request, self._current_after)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        # The page in `data` was fetched with `_current_after`; persist THAT (see class docstring).
+        self._resume_after = self._current_after
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        rows = data if data is not None else (body.get("data") or [])
+        next_cursor = (body.get("pagination") or {}).get("next")
+        # A null `next` or a short page (< page_size) both signal the end of the list.
+        if not next_cursor or len(rows) < self.page_size:
+            self._has_next_page = False
+            self._pending_after = None
+        else:
+            self._has_next_page = True
+            self._pending_after = next_cursor
+
+    def update_request(self, request: Request) -> None:
+        if self._has_next_page and self._pending_after is not None:
+            self._current_after = self._pending_after
+            self._set_cursor(request, self._current_after)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # The cursor of the page just yielded (None on the first page = restart from the top).
+        return {"after": self._resume_after}
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        self._current_after = state.get("after")
+
+
+def docuseal_source(
+    api_key: str,
+    region: str | None,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[DocusealResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = DOCUSEAL_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(region),
+            # Auth (the X-Auth-Token API key) is supplied via the framework auth config so its value
+            # is redacted from logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-Auth-Token", "location": "header"},
+            "paginator": DocusealCursorPaginator(page_size=PAGE_SIZE),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": PAGE_SIZE},
+                    # A missing `data` key is treated as an empty page (end of list), matching the
+                    # hand-rolled `data.get("data", [])`, so this selector is intentionally not
+                    # required.
+                    "data_selector": "data",
+                },
+            }
+        ],
     }
 
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"after": resume.after}
 
-def _build_url(base_url: str, path: str, params: dict[str, Any]) -> str:
-    if not params:
-        return f"{base_url}{path}"
-    return f"{base_url}{path}?{urlencode(params)}"
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded, persisting the current page's cursor so a crash re-fetches it
+        # (merge dedupes) rather than skipping buffered rows. `state` is None only on the last page.
+        if state is not None:
+            resumable_source_manager.save_state(DocusealResumeConfig(after=state.get("after")))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        # Rows arrive newest-first; declare it so the pipeline doesn't assume ascending order.
+        sort_mode="desc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime",
+        partition_format="month",
+        partition_keys=[config.partition_key],
+        column_hints=resource.column_hints,
+    )
 
 
 def validate_credentials(api_key: str, region: str | None) -> tuple[bool, str | None]:
@@ -66,117 +187,15 @@ def validate_credentials(api_key: str, region: str | None) -> tuple[bool, str | 
     DocuSeal issues a single account-wide token (no per-resource scopes), so probing any list
     endpoint is sufficient. A 401 means the token is wrong; anything else reachable counts as valid.
     """
-    url = _build_url(_base_url(region), "/templates", {"limit": 1})
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-    except Exception:
-        return False, "Could not reach DocuSeal. Check your network and try again."
-
-    if response.status_code == 200:
-        return True, None
-    if response.status_code == 401:
-        return False, "Invalid DocuSeal API key. Create a new key in your DocuSeal account settings and reconnect."
-    return False, f"DocuSeal API returned an unexpected status ({response.status_code}) while validating credentials."
-
-
-@retry(
-    retry=retry_if_exception_type((DocusealRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise DocusealRetryableError(f"DocuSeal API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"DocuSeal API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def get_rows(
-    api_key: str,
-    region: str | None,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DocusealResumeConfig],
-) -> Iterator[Any]:
-    config = DOCUSEAL_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    base_url = _base_url(region)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = make_tracked_session()
-
-    # DocuSeal orders list responses by `id` descending (newest first) and paginates *backwards*:
-    # `pagination.next` is the smallest id on the page, and passing it as `after` returns the next
-    # page of older (smaller-id) records. There is no server-side time filter, so this is a full
-    # walk newest -> oldest. Resume picks back up from the saved cursor.
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    after: int | None = resume.after if resume is not None else None
-    if resume is not None:
-        logger.debug(f"DocuSeal: resuming {endpoint} from after={after}")
-
-    while True:
-        params: dict[str, Any] = {"limit": PAGE_SIZE}
-        if after is not None:
-            params["after"] = after
-
-        data = _fetch_page(session, _build_url(base_url, config.path, params), headers, logger)
-        rows = data.get("data", [])
-        if not rows:
-            break
-
-        for row in rows:
-            batcher.batch(row)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save the cursor of the page we're on (not the next one) AFTER yielding, so a crash
-                # re-fetches this page rather than skipping rows still buffered. Merge dedupes on the
-                # primary key.
-                resumable_source_manager.save_state(DocusealResumeConfig(after=after))
-
-        next_cursor = data.get("pagination", {}).get("next")
-        # A null `next` or a short page (< limit) both signal the end of the list. Either way we
-        # stop without issuing a final empty request.
-        if not next_cursor or len(rows) < PAGE_SIZE:
-            break
-        after = next_cursor
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
-
-def docuseal_source(
-    api_key: str,
-    region: str | None,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DocusealResumeConfig],
-) -> SourceResponse:
-    endpoint_config: DocusealEndpointConfig = DOCUSEAL_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            region=region,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=endpoint_config.primary_keys,
-        # Rows arrive newest-first; declare it so the pipeline doesn't assume ascending order.
-        sort_mode="desc",
-        partition_count=1,
-        partition_size=1,
-        partition_mode="datetime",
-        partition_format="month",
-        partition_keys=[endpoint_config.partition_key],
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{_base_url(region)}/templates?limit=1",
+        headers={"X-Auth-Token": api_key, "Accept": "application/json"},
     )
+    if ok:
+        return True, None
+    if status is None:
+        return False, "Could not reach DocuSeal. Check your network and try again."
+    if status == 401:
+        return False, "Invalid DocuSeal API key. Create a new key in your DocuSeal account settings and reconnect."
+    return False, f"DocuSeal API returned an unexpected status ({status}) while validating credentials."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/source.py
@@ -152,6 +152,8 @@ Pick the region your DocuSeal account is hosted in. Self-hosted deployments are 
             api_key=config.api_key,
             region=config.region,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every DocuSeal endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/tests/test_docuseal.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/tests/test_docuseal.py
@@ -1,46 +1,69 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.docuseal import docuseal
 from products.warehouse_sources.backend.temporal.data_imports.sources.docuseal.docuseal import (
     DEFAULT_REGION,
     DOCUSEAL_HOSTS,
     PAGE_SIZE,
     DocusealResumeConfig,
     _base_url,
-    _build_url,
     docuseal_source,
-    get_rows,
     validate_credentials,
 )
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the docuseal module.
+DOCUSEAL_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.docuseal.docuseal.make_tracked_session"
+)
 
-def _ok_json_response(payload: dict | list | None = None, status_code: int = 200) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.json.return_value = payload if payload is not None else {}
-    response.raise_for_status = MagicMock()
-    return response
+
+def _response(rows: list[dict[str, Any]], next_cursor: int | None) -> Response:
+    body = {"data": rows, "pagination": {"count": len(rows), "next": next_cursor, "prev": None}}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class _FakeResumableManager:
-    def __init__(self, state: DocusealResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[DocusealResumeConfig] = []
+def _rows(start_id: int, count: int) -> list[dict[str, Any]]:
+    """`count` rows in DocuSeal's newest-first (descending id) order, starting at `start_id`."""
+    return [{"id": start_id - offset, "created_at": "2026-01-01T00:00:00Z"} for offset in range(count)]
 
-    def can_resume(self) -> bool:
-        return self._state is not None
 
-    def load_state(self) -> DocusealResumeConfig | None:
-        return self._state
+def _make_manager(resume_state: DocusealResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def save_state(self, data: DocusealResumeConfig) -> None:
-        self.saved.append(data)
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _drive(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestBaseUrl:
@@ -57,19 +80,10 @@ class TestBaseUrl:
         assert _base_url(region) == expected
 
 
-class TestBuildUrl:
-    def test_no_params(self) -> None:
-        assert _build_url("https://api.docuseal.com", "/templates", {}) == "https://api.docuseal.com/templates"
-
-    def test_with_params_is_urlencoded(self) -> None:
-        url = _build_url("https://api.docuseal.com", "/submissions", {"limit": 100, "after": 42})
-        assert url == "https://api.docuseal.com/submissions?limit=100&after=42"
-
-
 class TestValidateCredentials:
-    @patch.object(docuseal, "make_tracked_session")
-    def test_returns_true_on_200(self, mock_session: MagicMock) -> None:
-        mock_session.return_value.get.return_value = _ok_json_response({"data": []})
+    @mock.patch(DOCUSEAL_SESSION_PATCH)
+    def test_returns_true_on_200(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
         success, error = validate_credentials("key", "us")
 
@@ -78,12 +92,14 @@ class TestValidateCredentials:
         called_url = mock_session.return_value.get.call_args.args[0]
         assert called_url == f"{DOCUSEAL_HOSTS['us']}/templates?limit=1"
 
-    def test_probes_selected_region_host(self) -> None:
-        with patch.object(docuseal, "make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _ok_json_response({"data": []})
-            validate_credentials("key", "eu")
-            called_url = mock_session.return_value.get.call_args.args[0]
-            assert called_url.startswith(DOCUSEAL_HOSTS["eu"])
+    @mock.patch(DOCUSEAL_SESSION_PATCH)
+    def test_probes_selected_region_host(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+
+        validate_credentials("key", "eu")
+
+        called_url = mock_session.return_value.get.call_args.args[0]
+        assert called_url.startswith(DOCUSEAL_HOSTS["eu"])
 
     @parameterized.expand(
         [
@@ -91,11 +107,11 @@ class TestValidateCredentials:
             (500, "unexpected status"),
         ]
     )
-    @patch.object(docuseal, "make_tracked_session")
+    @mock.patch(DOCUSEAL_SESSION_PATCH)
     def test_returns_false_on_http_status(
-        self, status_code: int, expected_substring: str, mock_session: MagicMock
+        self, status_code: int, expected_substring: str, mock_session: mock.MagicMock
     ) -> None:
-        mock_session.return_value.get.return_value = _ok_json_response(status_code=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         success, error = validate_credentials("key", "us")
 
@@ -103,9 +119,9 @@ class TestValidateCredentials:
         assert error is not None
         assert expected_substring.lower() in error.lower()
 
-    @patch.object(docuseal, "make_tracked_session")
-    def test_returns_false_on_network_error(self, mock_session: MagicMock) -> None:
-        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+    @mock.patch(DOCUSEAL_SESSION_PATCH)
+    def test_returns_false_on_network_error(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
 
         success, error = validate_credentials("key", "us")
 
@@ -114,112 +130,109 @@ class TestValidateCredentials:
         assert "could not reach docuseal" in error.lower()
 
 
-def _page(rows: list[dict[str, Any]], next_cursor: int | None) -> dict[str, Any]:
-    return {"data": rows, "pagination": {"count": len(rows), "next": next_cursor, "prev": None}}
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_terminates_without_extra_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A short page carries a non-null `next` (DocuSeal's final page always does) yet is the end.
+        params = _wire(session, [_response(_rows(3, 3), next_cursor=1)])
 
-
-def _rows(start_id: int, count: int) -> list[dict[str, Any]]:
-    """`count` rows in DocuSeal's newest-first (descending id) order, starting at `start_id`."""
-    return [{"id": start_id - offset, "created_at": "2026-01-01T00:00:00Z"} for offset in range(count)]
-
-
-class TestGetRows:
-    @staticmethod
-    def _run(
-        manager: _FakeResumableManager,
-        pages: list[dict[str, Any]],
-        endpoint: str = "templates",
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-        """Drive get_rows against a queue of page responses. Returns (rows, recorded_requests)."""
-        queue = list(pages)
-        recorded: list[dict[str, Any]] = []
-
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict[str, Any]:
-            query = parse_qs(urlparse(url).query)
-            recorded.append(
-                {
-                    "url": url,
-                    "after": int(query["after"][0]) if "after" in query else None,
-                    "limit": int(query["limit"][0]) if "limit" in query else None,
-                }
-            )
-            return queue.pop(0)
-
-        with patch.object(docuseal, "_fetch_page", side_effect=fake_fetch):
-            rows: list[dict[str, Any]] = []
-            for table in get_rows(
-                api_key="tok",
-                region="us",
-                endpoint=endpoint,
-                logger=MagicMock(),
-                resumable_source_manager=manager,  # type: ignore[arg-type]
-            ):
-                rows.extend(table.to_pylist())
-        return rows, recorded
-
-    def test_single_short_page_terminates_without_extra_request(self) -> None:
-        manager = _FakeResumableManager()
-        rows, recorded = self._run(manager, [_page(_rows(3, 3), next_cursor=1)])
+        rows = _drive(
+            docuseal_source("tok", "us", "templates", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
 
         assert [r["id"] for r in rows] == [3, 2, 1]
-        # A page shorter than the page size is the last one — no follow-up request.
-        assert len(recorded) == 1
-        assert recorded[0]["after"] is None
-        assert recorded[0]["limit"] == PAGE_SIZE
+        assert session.send.call_count == 1
+        assert "after" not in params[0]
+        assert params[0]["limit"] == PAGE_SIZE
 
-    def test_walks_pages_using_after_cursor(self) -> None:
-        manager = _FakeResumableManager()
-        pages = [
-            _page(_rows(300, PAGE_SIZE), next_cursor=201),
-            _page(_rows(200, PAGE_SIZE), next_cursor=101),
-            _page(_rows(100, 50), next_cursor=51),
-        ]
-        rows, recorded = self._run(manager, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_walks_pages_using_after_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(_rows(300, PAGE_SIZE), next_cursor=201),
+                _response(_rows(200, PAGE_SIZE), next_cursor=101),
+                _response(_rows(100, 50), next_cursor=51),
+            ],
+        )
+
+        rows = _drive(
+            docuseal_source("tok", "us", "templates", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
 
         assert len(rows) == 250
-        assert [r["after"] for r in recorded] == [None, 201, 101]
+        assert [p.get("after") for p in params] == [None, 201, 101]
         # Newest-first across the whole walk.
         assert rows[0]["id"] == 300
         assert rows[-1]["id"] == 51
 
-    def test_stops_when_next_cursor_is_null(self) -> None:
-        manager = _FakeResumableManager()
-        # A full-size page whose `next` is null (empty next page) must still terminate.
-        rows, recorded = self._run(manager, [_page(_rows(100, PAGE_SIZE), next_cursor=None)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_next_cursor_is_null(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A full-size page whose `next` is null must still terminate.
+        _wire(session, [_response(_rows(100, PAGE_SIZE), next_cursor=None)])
+
+        rows = _drive(
+            docuseal_source("tok", "us", "templates", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
 
         assert len(rows) == PAGE_SIZE
-        assert len(recorded) == 1
+        assert session.send.call_count == 1
 
-    def test_empty_first_page_yields_nothing(self) -> None:
-        manager = _FakeResumableManager()
-        rows, recorded = self._run(manager, [_page([], next_cursor=None)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], next_cursor=None)])
+
+        rows = _drive(
+            docuseal_source("tok", "us", "templates", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
 
         assert rows == []
-        assert len(recorded) == 1
+        assert session.send.call_count == 1
 
-    def test_resume_uses_saved_after_cursor(self) -> None:
-        manager = _FakeResumableManager(DocusealResumeConfig(after=500))
-        rows, recorded = self._run(manager, [_page(_rows(499, 2), next_cursor=498)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_uses_saved_after_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_rows(499, 2), next_cursor=498)])
+
+        manager = _make_manager(DocusealResumeConfig(after=500))
+        rows = _drive(
+            docuseal_source("tok", "us", "templates", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
 
         # First request must continue from the saved cursor, not start over.
-        assert recorded[0]["after"] == 500
+        assert params[0]["after"] == 500
         assert [r["id"] for r in rows] == [499, 498]
 
-    def test_saves_only_already_fetched_cursors_after_yield(self) -> None:
-        # Force a mid-stream batch flush by exceeding the batcher's row threshold, then assert we never
-        # persist a cursor we haven't fetched from yet (the "save current page, not next" invariant) —
-        # otherwise a crash would skip rows still buffered.
-        manager = _FakeResumableManager()
-        pages = [
-            _page(_rows(10000 - i * PAGE_SIZE, PAGE_SIZE), next_cursor=10000 - i * PAGE_SIZE - 99) for i in range(30)
-        ]
-        pages.append(_page(_rows(10000 - 30 * PAGE_SIZE, 10), next_cursor=1))
-        rows, recorded = self._run(manager, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_only_already_fetched_cursors_after_yield(self, MockSession) -> None:
+        # Walk several full pages then a short one, and assert we never persist a cursor we haven't
+        # fetched from yet (the "save current page, not next" invariant) — otherwise a crash would
+        # skip rows still buffered.
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(_rows(1000, PAGE_SIZE), next_cursor=901),
+                _response(_rows(900, PAGE_SIZE), next_cursor=801),
+                _response(_rows(800, PAGE_SIZE), next_cursor=701),
+                _response(_rows(700, 50), next_cursor=651),
+            ],
+        )
 
-        assert len(rows) == 30 * PAGE_SIZE + 10
-        assert manager.saved, "expected at least one mid-stream save once the batch threshold was crossed"
-        fetched_afters = {r["after"] for r in recorded}
-        assert all(saved.after in fetched_afters for saved in manager.saved)
+        manager = _make_manager()
+        rows = _drive(
+            docuseal_source("tok", "us", "templates", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        assert len(rows) == 3 * PAGE_SIZE + 50
+        assert manager.save_state.called, "expected at least one checkpoint save across the walk"
+        fetched_afters = {p.get("after") for p in params}
+        saved_afters = [call.args[0].after for call in manager.save_state.call_args_list]
+        assert all(after in fetched_afters for after in saved_afters)
 
 
 class TestDocusealSourceResponse:
@@ -229,8 +242,9 @@ class TestDocusealSourceResponse:
             api_key="tok",
             region="us",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
         )
 
         assert response.name == endpoint

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/tests/test_docuseal_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/docuseal/tests/test_docuseal_source.py
@@ -141,9 +141,9 @@ class TestDocusealPipelineWiring:
 
         inputs = MagicMock()
         inputs.schema_name = "submissions"
+        inputs.team_id = 7
+        inputs.job_id = "job-123"
         manager = MagicMock()
-        logger = MagicMock()
-        inputs.logger = logger
 
         with patch.object(source_module, "docuseal_source", side_effect=fake_source) as mock_source:
             result = DocusealSource().source_for_pipeline(_config(region="eu"), manager, inputs)
@@ -153,5 +153,6 @@ class TestDocusealPipelineWiring:
         assert captured["api_key"] == "tok"
         assert captured["region"] == "eu"
         assert captured["endpoint"] == "submissions"
+        assert captured["team_id"] == 7
+        assert captured["job_id"] == "job-123"
         assert captured["resumable_source_manager"] is manager
-        assert captured["logger"] is logger

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/drip/drip.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/drip/drip.py
@@ -1,24 +1,21 @@
-import base64
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.drip.settings import DRIP_ENDPOINTS
 
 DRIP_BASE_URL = "https://api.getdrip.com/v2"
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
-
-
-class DripRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -26,28 +23,63 @@ class DripResumeConfig:
     next_page: int
 
 
-def _auth_headers(api_token: str) -> dict[str, str]:
-    # Drip uses HTTP Basic auth with the API token as the username and an empty password.
-    token = base64.b64encode(f"{api_token}:".encode("ascii")).decode("ascii")
-    return {"Authorization": f"Basic {token}", "Accept": "application/json"}
+class DripPaginator(BasePaginator):
+    """Page-number pagination matching Drip's list endpoints.
 
+    Drip returns a ``meta.total_pages`` block on its paginated endpoints; when present it is
+    authoritative (fetch while ``page < total_pages``). For a paginated endpoint that omits ``meta``
+    we fall back to "a full page implies there may be more", and a non-paginated endpoint
+    (``per_page`` is None) always returns everything in a single response. The ``page`` param is sent
+    on every request (including the single request to non-paginated endpoints), mirroring the
+    original hand-rolled source exactly.
+    """
 
-def validate_credentials(api_token: str, account_id: str) -> tuple[bool, str | None]:
-    url = f"{DRIP_BASE_URL}/{account_id}/subscribers"
-    try:
-        response = make_tracked_session().get(
-            url, headers=_auth_headers(api_token), params={"per_page": 1}, timeout=REQUEST_TIMEOUT_SECONDS
-        )
-    except Exception:
-        return False, "Could not connect to the Drip API"
+    def __init__(self, per_page: Optional[int], page: int = 1) -> None:
+        super().__init__()
+        self.per_page = per_page
+        self.page = page
 
-    if response.status_code == 200:
-        return True, None
-    if response.status_code in (401, 403):
-        return False, "Invalid Drip API token"
-    if response.status_code == 404:
-        return False, "Drip account ID not found. Please check your account ID."
-    return False, f"Drip API returned an unexpected status ({response.status_code})"
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
+        try:
+            meta = response.json().get("meta") or {}
+        except Exception:
+            meta = {}
+        total_pages = meta.get("total_pages")
+
+        if total_pages is not None:
+            has_next = self.page < total_pages
+        elif self.per_page is not None:
+            # No meta block: a full page implies there may be more; a partial/empty page ends it.
+            has_next = len(items) >= self.per_page
+        else:
+            has_next = False
+
+        if has_next:
+            self.page += 1
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page already points at the next page to fetch (update_state incremented it).
+        return {"next_page": self.page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_page = state.get("next_page")
+        if next_page is not None:
+            self.page = int(next_page)
+            self._has_next_page = True
 
 
 def _base_params(endpoint: str) -> dict[str, Any]:
@@ -62,93 +94,85 @@ def _base_params(endpoint: str) -> dict[str, Any]:
     return params
 
 
-def get_rows(
-    api_token: str,
-    account_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DripResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = DRIP_ENDPOINTS[endpoint]
-    headers = _auth_headers(api_token)
-    base_params = _base_params(endpoint)
-    url = f"{DRIP_BASE_URL}/{account_id}{config.path}"
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume else 1
-    if resume is not None:
-        logger.debug(f"Drip: resuming {endpoint} from page {page}")
-
-    @retry(
-        retry=retry_if_exception_type((DripRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_num: int) -> dict[str, Any]:
-        response = make_tracked_session().get(
-            url, headers=headers, params={**base_params, "page": page_num}, timeout=REQUEST_TIMEOUT_SECONDS
-        )
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise DripRetryableError(f"Drip API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"Drip API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(page)
-        items = data.get(config.data_key) or []
-
-        if items:
-            yield items
-
-        if not _has_next_page(data, items, config.per_page, page):
-            break
-
-        page += 1
-        # Save state AFTER yielding so a crash re-yields the last page rather than skipping it
-        # (merge on the primary key dedupes the overlap).
-        resumable_source_manager.save_state(DripResumeConfig(next_page=page))
-
-
-def _has_next_page(data: dict[str, Any], items: list[Any], per_page: int | None, page: int) -> bool:
-    meta = data.get("meta") or {}
-    total_pages = meta.get("total_pages")
-    if total_pages is not None:
-        return page < total_pages
-    # Fallback for paginated endpoints that don't return a meta block: a full page implies there may be
-    # more. Non-paginated endpoints (per_page is None) always return everything in a single response.
-    if per_page is not None:
-        return len(items) >= per_page
-    return False
-
-
 def drip_source(
     api_token: str,
     account_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[DripResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = DRIP_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": f"{DRIP_BASE_URL}/{account_id}",
+            "headers": {"Accept": "application/json"},
+            # Drip uses HTTP Basic auth with the API token as the username and an empty password;
+            # supplying it via the framework auth config keeps the token redacted from logs.
+            "auth": {"type": "http_basic", "username": api_token, "password": ""},
+            "paginator": DripPaginator(per_page=config.per_page),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": _base_params(endpoint),
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("next_page") is not None:
+            resumable_source_manager.save_state(DripResumeConfig(next_page=int(state["next_page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            account_id=account_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_token: str, account_id: str) -> tuple[bool, str | None]:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{DRIP_BASE_URL}/{account_id}/subscribers?per_page=1",
+        auth=HttpBasicAuth(username=api_token, password=""),
+    )
+
+    if ok:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid Drip API token"
+    if status == 404:
+        return False, "Drip account ID not found. Please check your account ID."
+    if status is None:
+        return False, "Could not connect to the Drip API"
+    return False, f"Drip API returned an unexpected status ({status})"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/drip/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/drip/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip import (
     DripResumeConfig,
     drip_source,
@@ -63,21 +66,10 @@ class DripSource(ResumableSource[DripSourceConfig, DripResumeConfig]):
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # Every Drip endpoint is full refresh (no reliable server-side update cursor), so no endpoint
+        # carries incremental fields and build_endpoint_schemas yields supports_incremental=False /
+        # supports_append=False for all of them.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: DripSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -97,8 +89,10 @@ class DripSource(ResumableSource[DripSourceConfig, DripResumeConfig]):
             api_token=config.api_token,
             account_id=config.account_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Drip endpoint is full refresh
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/drip/tests/test_drip.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/drip/tests/test_drip.py
@@ -1,35 +1,107 @@
+import json
 import base64
+from types import SimpleNamespace
+from typing import Any
 
 from unittest import mock
 
 from parameterized import parameterized
+from requests import PreparedRequest, Response
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip import (
     DripResumeConfig,
-    _auth_headers,
     _base_params,
-    _has_next_page,
     drip_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.drip.settings import DRIP_ENDPOINTS, ENDPOINTS
 
-
-def _make_response(status_code=200, json_data=None):
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.json.return_value = json_data if json_data is not None else {}
-    return response
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the drip module.
+DRIP_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip.make_tracked_session"
 
 
-class TestAuthHeaders:
-    def test_basic_auth_token_as_username_empty_password(self):
-        headers = _auth_headers("my_token")
-        expected = base64.b64encode(b"my_token:").decode("ascii")
-        assert headers["Authorization"] == f"Basic {expected}"
-        assert headers["Accept"] == "application/json"
+def _response(body: dict[str, Any], status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _page(data_key: str, items: list[dict[str, Any]], total_pages: int | None = None) -> Response:
+    body: dict[str, Any] = {data_key: items}
+    if total_pages is not None:
+        body["meta"] = {"total_pages": total_pages}
+    return _response(body)
+
+
+def _make_manager(resume: DripResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume is not None
+    manager.load_state.return_value = resume
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[SimpleNamespace]:
+    """Wire a mock session and capture each request AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    captured: list[SimpleNamespace] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        captured.append(SimpleNamespace(params=dict(request.params or {}), auth=request.auth))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return captured
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(session: mock.MagicMock, endpoint: str, manager: mock.MagicMock) -> list[dict[str, Any]]:
+    return _rows(
+        drip_source(
+            api_token="token",
+            account_id="9999",
+            endpoint=endpoint,
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=manager,
+        )
+    )
+
+
+class TestAuth:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_basic_auth_token_as_username_empty_password(self, MockSession) -> None:
+        session = MockSession.return_value
+        captured = _wire(session, [_page("forms", [{"id": 1}])])
+
+        _run(session, "forms", _make_manager())
+
+        auth = captured[0].auth
+        assert isinstance(auth, HttpBasicAuth)
+        prepared = PreparedRequest()
+        prepared.prepare(method="GET", url="https://api.getdrip.com/v2/9999/forms")
+        auth(prepared)
+        expected = base64.b64encode(b"token:").decode("ascii")
+        assert prepared.headers["Authorization"] == f"Basic {expected}"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_accept_header_set_on_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("forms", [{"id": 1}])])
+
+        _run(session, "forms", _make_manager())
+        assert session.headers.get("Accept") == "application/json"
 
 
 class TestBaseParams:
@@ -43,26 +115,101 @@ class TestBaseParams:
             ("goals", {}),
         ]
     )
-    def test_base_params(self, endpoint, expected):
+    def test_base_params(self, endpoint, expected) -> None:
         assert _base_params(endpoint) == expected
 
-
-class TestHasNextPage:
     @parameterized.expand(
         [
-            # meta drives pagination when present
-            ("meta_more_pages", {"meta": {"total_pages": 3}}, [1, 2], 100, 1, True),
-            ("meta_last_page", {"meta": {"total_pages": 3}}, [1, 2], 100, 3, False),
-            ("meta_single_page", {"meta": {"total_pages": 1}}, [1], 100, 1, False),
-            # fallback when there's no meta: a full page implies there may be more
-            ("no_meta_full_page", {}, list(range(100)), 100, 1, True),
-            ("no_meta_partial_page", {}, list(range(40)), 100, 1, False),
-            # non-paginated endpoints (per_page=None) always return everything at once
-            ("non_paginated", {}, [1, 2, 3], None, 1, False),
+            ("subscribers", {"per_page": 1000, "page": 1}),
+            ("campaigns", {"per_page": 100, "sort": "created_at", "direction": "asc", "page": 1}),
+            ("broadcasts", {"per_page": 100, "sort": "created_at", "direction": "asc", "page": 1}),
+            ("workflows", {"per_page": 100, "page": 1}),
+            # Non-paginated endpoints still send page=1 (mirrors the original hand-rolled source).
+            ("forms", {"page": 1}),
+            ("goals", {"page": 1}),
         ]
     )
-    def test_has_next_page(self, _name, data, items, per_page, page, expected):
-        assert _has_next_page(data, items, per_page, page) is expected
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_params_sent_on_first_request(self, endpoint, expected, MockSession) -> None:
+        session = MockSession.return_value
+        captured = _wire(session, [_page(DRIP_ENDPOINTS[endpoint].data_key, [{"id": 1}])])
+
+        _run(session, endpoint, _make_manager())
+
+        assert captured[0].params == expected
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_last_page_via_meta(self, MockSession) -> None:
+        session = MockSession.return_value
+        captured = _wire(
+            session,
+            [
+                _page("subscribers", [{"id": 1}], total_pages=2),
+                _page("subscribers", [{"id": 2}], total_pages=2),
+            ],
+        )
+
+        rows = _run(session, "subscribers", _make_manager())
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 2
+        assert captured[0].params["page"] == 1
+        assert captured[1].params["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_yielding_each_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page("subscribers", [{"id": 1}], total_pages=2),
+                _page("subscribers", [{"id": 2}], total_pages=2),
+            ],
+        )
+        manager = _make_manager()
+
+        _run(session, "subscribers", manager)
+
+        # State advances to page 2 once page 1 is yielded; the final page saves nothing further.
+        manager.save_state.assert_called_once_with(DripResumeConfig(next_page=2))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        captured = _wire(session, [_page("subscribers", [{"id": 5}], total_pages=3)])
+        manager = _make_manager(DripResumeConfig(next_page=3))
+
+        _run(session, "subscribers", manager)
+
+        # Starts at the resume point (page 3) and stops, since total_pages == 3.
+        assert captured[0].params["page"] == 3
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_then_partial_terminates_without_meta(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": i} for i in range(100)]  # workflows per_page == 100
+        partial_page = [{"id": i} for i in range(100, 140)]
+        _wire(session, [_page("workflows", full_page), _page("workflows", partial_page)])
+
+        rows = _run(session, "workflows", _make_manager())
+
+        assert [r["id"] for r in rows] == list(range(140))
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_for_non_paginated_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("forms", [{"id": 1}, {"id": 2}])])
+        manager = _make_manager()
+
+        rows = _run(session, "forms", manager)
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
 
 class TestValidateCredentials:
@@ -75,19 +222,19 @@ class TestValidateCredentials:
             ("server_error", 500, False, "Drip API returned an unexpected status (500)"),
         ]
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip.make_tracked_session")
+    @mock.patch(DRIP_SESSION_PATCH)
     def test_validate_credentials_status_mapping(
         self, _name, status_code, expected_valid, expected_message, mock_session
-    ):
-        mock_session.return_value.get.return_value = _make_response(status_code=status_code)
+    ) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         is_valid, message = validate_credentials("token", "9999")
 
         assert is_valid is expected_valid
         assert message == expected_message
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip.make_tracked_session")
-    def test_validate_credentials_connection_error(self, mock_session):
+    @mock.patch(DRIP_SESSION_PATCH)
+    def test_validate_credentials_connection_error(self, mock_session) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
 
         is_valid, message = validate_credentials("token", "9999")
@@ -96,70 +243,18 @@ class TestValidateCredentials:
         assert message == "Could not connect to the Drip API"
 
 
-class TestGetRows:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip.make_tracked_session")
-    def test_paginates_until_last_page_via_meta(self, mock_session):
-        responses = [
-            _make_response(json_data={"subscribers": [{"id": 1}], "meta": {"total_pages": 2}}),
-            _make_response(json_data={"subscribers": [{"id": 2}], "meta": {"total_pages": 2}}),
-        ]
-        mock_session.return_value.get.side_effect = responses
-
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-
-        batches = list(get_rows("token", "9999", "subscribers", mock.MagicMock(), manager))
-
-        assert batches == [[{"id": 1}], [{"id": 2}]]
-        assert mock_session.return_value.get.call_count == 2
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip.make_tracked_session")
-    def test_saves_state_after_yielding_each_page(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _make_response(json_data={"subscribers": [{"id": 1}], "meta": {"total_pages": 2}}),
-            _make_response(json_data={"subscribers": [{"id": 2}], "meta": {"total_pages": 2}}),
-        ]
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-
-        list(get_rows("token", "9999", "subscribers", mock.MagicMock(), manager))
-
-        # State advances to page 2 once page 1 has been yielded; the final page saves nothing further.
-        manager.save_state.assert_called_once_with(DripResumeConfig(next_page=2))
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip.make_tracked_session")
-    def test_resumes_from_saved_page(self, mock_session):
-        mock_session.return_value.get.return_value = _make_response(
-            json_data={"subscribers": [{"id": 5}], "meta": {"total_pages": 3}}
-        )
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = DripResumeConfig(next_page=3)
-
-        list(get_rows("token", "9999", "subscribers", mock.MagicMock(), manager))
-
-        # Should start at page 3 (the resume point) and stop, since total_pages == 3.
-        _, kwargs = mock_session.return_value.get.call_args
-        assert kwargs["params"]["page"] == 3
-        assert mock_session.return_value.get.call_count == 1
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.drip.drip.make_tracked_session")
-    def test_single_page_for_non_paginated_endpoint(self, mock_session):
-        mock_session.return_value.get.return_value = _make_response(json_data={"forms": [{"id": 1}, {"id": 2}]})
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-
-        batches = list(get_rows("token", "9999", "forms", mock.MagicMock(), manager))
-
-        assert batches == [[{"id": 1}, {"id": 2}]]
-        assert mock_session.return_value.get.call_count == 1
-        manager.save_state.assert_not_called()
-
-
 class TestDripSourceResponse:
     @parameterized.expand(list(ENDPOINTS))
-    def test_source_response_shape(self, endpoint):
-        response = drip_source("token", "9999", endpoint, mock.MagicMock(), mock.MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint, _MockSession) -> None:
+        response = drip_source(
+            api_token="token",
+            account_id="9999",
+            endpoint=endpoint,
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
+        )
 
         config = DRIP_ENDPOINTS[endpoint]
         assert response.name == endpoint
@@ -171,7 +266,15 @@ class TestDripSourceResponse:
             assert response.partition_mode is None
             assert response.partition_keys is None
 
-    def test_subscribers_partitions_on_created_at(self):
-        response = drip_source("token", "9999", "subscribers", mock.MagicMock(), mock.MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_subscribers_partitions_on_created_at(self, _MockSession) -> None:
+        response = drip_source(
+            api_token="token",
+            account_id="9999",
+            endpoint="subscribers",
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
+        )
         assert response.partition_keys == ["created_at"]
         assert response.partition_format == "month"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/drip/tests/test_drip_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/drip/tests/test_drip_source.py
@@ -121,8 +121,10 @@ class TestDripSource:
             api_token="test_token",
             account_id="9999999",
             endpoint="subscribers",
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=manager,
+            db_incremental_field_last_value=None,
         )
 
     @parameterized.expand(ENDPOINTS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/elevenlabs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/elevenlabs.py
@@ -1,29 +1,24 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.elevenlabs.settings import (
     ELEVENLABS_ENDPOINTS,
     ElevenLabsEndpointConfig,
 )
 
 ELEVENLABS_BASE_URL = "https://api.elevenlabs.io"
-
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class ElevenLabsRetryableError(Exception):
-    """Raised for 429 / 5xx responses so tenacity retries them; credential/4xx errors are not wrapped."""
-
-    pass
 
 
 @dataclasses.dataclass
@@ -65,7 +60,7 @@ def _build_params(
 ) -> dict[str, Any]:
     """Build the constant per-request query params (page size, sort, server-side incremental filter).
 
-    The cursor is added per page by the caller. The incremental filter is applied on every page (the
+    The cursor is added per page by the paginator. The incremental filter is applied on every page (the
     API keeps the time-window filter alongside the cursor), so pagination terminates at `has_more`
     rather than re-walking full history each incremental run.
     """
@@ -85,6 +80,56 @@ def _build_params(
     return params
 
 
+class ElevenLabsCursorPaginator(BasePaginator):
+    """Cursor pagination where the request param and response cursor key differ per endpoint.
+
+    Termination requires BOTH a truthy ``has_more`` flag AND a next cursor: some endpoints echo a
+    stale cursor (the last item id on the final page) alongside ``has_more=False``, so keying off the
+    cursor alone would issue one needless extra request.
+    """
+
+    def __init__(self, cursor_param: str, cursor_response_key: str) -> None:
+        super().__init__()
+        self.cursor_param = cursor_param
+        self.cursor_response_key = cursor_response_key
+        self._cursor_value: Optional[str] = None
+
+    def _apply_cursor(self, request: Request) -> None:
+        if self._cursor_value is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._cursor_value
+
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume cursor to the first request.
+        self._apply_cursor(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        next_cursor = body.get(self.cursor_response_key) if isinstance(body, dict) else None
+        has_more = bool(body.get("has_more")) if isinstance(body, dict) else False
+        if has_more and next_cursor:
+            self._cursor_value = next_cursor
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        self._apply_cursor(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor_value} if self._has_next_page and self._cursor_value is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor_value = cursor
+            self._has_next_page = True
+
+
 def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tuple[bool, str | None]:
     """Probe the API key. 200 => valid. 401 => invalid key. 403 => valid key missing a scope.
 
@@ -98,116 +143,37 @@ def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tup
     """
     config = ELEVENLABS_ENDPOINTS.get(schema_name) if schema_name else None
     probe_path = config.path if config else "/v1/user"
-    url = f"{ELEVENLABS_BASE_URL}{probe_path}"
-    params: dict[str, Any] = {"page_size": 1} if config else {}
+    # Bake the probe's page_size into the URL: validate_via_probe issues a bare GET with no params.
+    url = f"{ELEVENLABS_BASE_URL}{probe_path}{'?page_size=1' if config else ''}"
 
-    try:
-        response = make_tracked_session(redact_values=(api_key,), allow_redirects=False).get(
-            url, headers=_get_headers(api_key), params=params, timeout=10
-        )
-    except Exception:
+    # Don't follow redirects: requests preserves the custom `xi-api-key` header across a cross-origin
+    # 3xx, so a redirect off the fixed API host could replay the key to another origin.
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,), allow_redirects=False),
+        url,
+        headers=_get_headers(api_key),
+    )
+
+    if status is None:
         return False, "Could not reach the ElevenLabs API. Please try again."
-
-    if response.status_code == 200:
+    if status == 200:
         return True, None
-    if response.status_code == 401:
+    if status == 401:
         return False, "Invalid ElevenLabs API key"
-    if response.status_code == 403:
+    if status == 403:
         if schema_name is None:
             return True, None
         return False, f"Your ElevenLabs API key is missing the permission required to sync `{schema_name}`."
     # A 429/5xx/unexpected status leaves the key unverified. Don't accept it — surface it so the user
     # can retry, rather than saving a source that only fails on its first sync.
-    return False, f"Could not verify the ElevenLabs API key (status {response.status_code}). Please try again."
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            ElevenLabsRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    params: dict[str, Any],
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-) -> dict:
-    response = session.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # ElevenLabs rate limiting is concurrency-based per plan; a 429 clears once in-flight requests
-    # drain, so back off and retry. 5xx are transient server faults.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ElevenLabsRetryableError(f"ElevenLabs API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"ElevenLabs API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ElevenLabsResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = ELEVENLABS_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across pages so urllib3 keeps the connection alive instead of re-handshaking.
-    # Redact the key so it can't leak into captured HTTP samples or logged URLs. Don't follow redirects:
-    # requests preserves the custom `xi-api-key` header across a cross-origin 3xx, so a redirect off the
-    # fixed API host could replay the key to another origin — fail the request instead.
-    session = make_tracked_session(redact_values=(api_key,), allow_redirects=False)
-    url = f"{ELEVENLABS_BASE_URL}{config.path}"
-
-    params = _build_params(config, should_use_incremental_field, db_incremental_field_last_value, incremental_field)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    cursor = resume.cursor if resume is not None else None
-    if cursor:
-        logger.debug(f"ElevenLabs: resuming {endpoint} from cursor")
-
-    while True:
-        page_params = dict(params)
-        if cursor:
-            page_params[config.cursor_param] = cursor
-
-        data = _fetch_page(session, url, page_params, headers, logger)
-
-        items = data.get(config.items_key) or []
-        if items:
-            # Yield the rows in the shape the API returns them; the pipeline batches and merges on the
-            # endpoint's primary key.
-            yield items
-
-        next_cursor = data.get(config.cursor_response_key)
-        has_more = bool(data.get("has_more"))
-        if not has_more or not next_cursor:
-            break
-
-        # Save state AFTER yielding so a crash re-yields the last page rather than skipping it; merge
-        # dedupes the re-pulled rows on the primary key.
-        resumable_source_manager.save_state(ElevenLabsResumeConfig(cursor=next_cursor))
-        cursor = next_cursor
+    return False, f"Could not verify the ElevenLabs API key (status {status}). Please try again."
 
 
 def elevenlabs_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ElevenLabsResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -215,17 +181,58 @@ def elevenlabs_source(
 ) -> SourceResponse:
     config = ELEVENLABS_ENDPOINTS[endpoint]
 
+    params = _build_params(config, should_use_incremental_field, db_incremental_field_last_value, incremental_field)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ELEVENLABS_BASE_URL,
+            # Only the non-secret Accept header is set here; the key is injected via `auth` so it's
+            # redacted from logs and captured HTTP samples.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "xi-api-key", "location": "header"},
+            "paginator": ElevenLabsCursorPaginator(config.cursor_param, config.cursor_response_key),
+            # Redact the key and refuse redirects: requests preserves the custom `xi-api-key` header
+            # across a cross-origin 3xx, so following one could replay the key to another origin.
+            "session": make_tracked_session(redact_values=(api_key,), allow_redirects=False),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Top-level array key; a 200 body missing it is a legit zero-row page (the old
+                    # code yielded nothing rather than raising), so the selector is not required.
+                    "data_selector": config.items_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.cursor:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes) rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(ElevenLabsResumeConfig(cursor=str(state["cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         sort_mode=config.sort_mode,  # type: ignore[arg-type]
         partition_count=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/source.py
@@ -134,7 +134,8 @@ Grant the following read permissions when creating the key:
         return elevenlabs_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/tests/test_elevenlabs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/tests/test_elevenlabs.py
@@ -1,39 +1,72 @@
 import os
+import json
 import time
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.elevenlabs import elevenlabs
 from products.warehouse_sources.backend.temporal.data_imports.sources.elevenlabs.elevenlabs import (
     ElevenLabsResumeConfig,
     _build_params,
     _to_unix_seconds,
     elevenlabs_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.elevenlabs.settings import ELEVENLABS_ENDPOINTS
 
+# The RESTClient uses the session built by make_tracked_session in the elevenlabs module (passed via
+# the client config's `session` slot), and validate_credentials builds its probe session there too.
+SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.elevenlabs.elevenlabs.make_tracked_session"
+)
 
-class _FakeResumableManager:
-    def __init__(self, state: ElevenLabsResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[ElevenLabsResumeConfig] = []
 
-    def can_resume(self) -> bool:
-        return self._state is not None
+def _response(body: dict[str, Any], status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://api.elevenlabs.io/v1/history"
+    return resp
 
-    def load_state(self) -> ElevenLabsResumeConfig | None:
-        return self._state
 
-    def save_state(self, data: ElevenLabsResumeConfig) -> None:
-        self.saved.append(data)
+def _make_manager(resume_state: ElevenLabsResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages (the paginator injects the next
+    cursor into it), so inspecting it after the run shows only the final state — snapshot a copy when
+    each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **incremental: Any):
+    return elevenlabs_source("k", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **incremental)
 
 
 class TestToUnixSeconds:
@@ -95,102 +128,108 @@ class TestBuildParams:
         assert "date_after_unix" not in params
 
 
-class TestFetchPageRetries:
-    @parameterized.expand(
-        [
-            ("rate_limited", 429),
-            ("server_error", 500),
-            ("bad_gateway", 502),
-        ]
-    )
-    def test_retryable_status_codes_are_retried(self, _name: str, status_code: int) -> None:
-        retryable = MagicMock(status_code=status_code, ok=False)
-        good = MagicMock(status_code=200, ok=True)
-        good.json.return_value = {"history": []}
-        session = MagicMock()
-        session.get.side_effect = [retryable, good]
-
-        with patch.object(elevenlabs._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = elevenlabs._fetch_page(session, "https://api.elevenlabs.io/v1/history", {}, {}, MagicMock())
-
-        assert result == {"history": []}
-        assert session.get.call_count == 2
-
-    @parameterized.expand(
-        [
-            ("read_timeout", requests.ReadTimeout("Read timed out.")),
-            ("connection_error", requests.ConnectionError("Connection reset by peer")),
-            ("chunked", requests.exceptions.ChunkedEncodingError("Connection broken")),
-        ]
-    )
-    def test_transient_network_errors_are_retried(self, _name: str, transient: Exception) -> None:
-        good = MagicMock(status_code=200, ok=True)
-        good.json.return_value = {"history": []}
-        session = MagicMock()
-        session.get.side_effect = [transient, good]
-
-        with patch.object(elevenlabs._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = elevenlabs._fetch_page(session, "https://api.elevenlabs.io/v1/history", {}, {}, MagicMock())
-
-        assert result == {"history": []}
-        assert session.get.call_count == 2
-
-    def test_credential_error_raises_without_retry(self) -> None:
-        # 401 is a credential problem; retrying wastes the whole retry budget on a doomed request.
-        resp = MagicMock(status_code=401, ok=False, text="unauthorized")
-        resp.raise_for_status.side_effect = requests.HTTPError(
-            "401 Client Error: Unauthorized for url: https://api.elevenlabs.io/v1/history", response=resp
+class TestPagination:
+    @mock.patch(SESSION_PATCH)
+    def test_walks_cursor_pages_and_saves_state_after_each_yield(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"history": [{"history_item_id": "a"}], "has_more": True, "last_history_item_id": "a"}),
+                _response({"history": [{"history_item_id": "b"}], "has_more": False, "last_history_item_id": "b"}),
+            ],
         )
-        session = MagicMock()
-        session.get.return_value = resp
-
-        with pytest.raises(requests.HTTPError):
-            elevenlabs._fetch_page(session, "https://api.elevenlabs.io/v1/history", {}, {}, MagicMock())
-
-        assert session.get.call_count == 1
-
-
-class TestGetRowsPagination:
-    @staticmethod
-    def _run(manager: _FakeResumableManager, pages: dict[Any, dict], **incremental: Any) -> list[dict]:
-        def fake_fetch(session: Any, url: str, params: dict, headers: dict, logger: Any) -> dict:
-            return pages[params.get("start_after_history_item_id")]
-
-        with patch.object(elevenlabs, "_fetch_page", fake_fetch):
-            return [
-                row
-                for batch in get_rows("k", "history", MagicMock(), manager, **incremental)  # type: ignore[arg-type]
-                for row in batch
-            ]
-
-    def test_walks_cursor_pages_and_saves_state_after_each_yield(self) -> None:
-        pages = {
-            None: {"history": [{"history_item_id": "a"}], "has_more": True, "last_history_item_id": "a"},
-            "a": {"history": [{"history_item_id": "b"}], "has_more": False, "last_history_item_id": "b"},
-        }
-        manager = _FakeResumableManager()
-        rows = self._run(manager, pages)
+        manager = _make_manager()
+        rows = _rows(_source("history", manager))
 
         assert rows == [{"history_item_id": "a"}, {"history_item_id": "b"}]
+        # Page 1 sends no cursor; page 2 sends the cursor from page 1 under the endpoint's cursor param.
+        assert "start_after_history_item_id" not in params[0]
+        assert params[0]["page_size"] == 1000
+        assert params[1]["start_after_history_item_id"] == "a"
         # Saved only once (after page 1, since page 2 is terminal) so a crash re-yields the last page.
-        assert [s.cursor for s in manager.saved] == ["a"]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == ElevenLabsResumeConfig(cursor="a")
 
-    def test_terminates_when_has_more_false_even_with_a_cursor(self) -> None:
-        # A stale next cursor with has_more=False must not loop forever.
-        pages = {None: {"history": [{"history_item_id": "a"}], "has_more": False, "last_history_item_id": "a"}}
-        rows = self._run(_FakeResumableManager(), pages)
+    @mock.patch(SESSION_PATCH)
+    def test_terminates_when_has_more_false_even_with_a_cursor(self, MockSession) -> None:
+        # A stale next cursor with has_more=False must not trigger another request.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response({"history": [{"history_item_id": "a"}], "has_more": False, "last_history_item_id": "a"})],
+        )
+        manager = _make_manager()
+        rows = _rows(_source("history", manager))
+
         assert rows == [{"history_item_id": "a"}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resumes_from_saved_cursor(self) -> None:
-        def fake_fetch(session: Any, url: str, params: dict, headers: dict, logger: Any) -> dict:
-            assert params["cursor"] == "C1"
-            return {"conversations": [{"conversation_id": "x"}], "has_more": False, "next_cursor": None}
-
-        manager = _FakeResumableManager(ElevenLabsResumeConfig(cursor="C1"))
-        with patch.object(elevenlabs, "_fetch_page", fake_fetch):
-            rows = [row for batch in get_rows("k", "conversations", MagicMock(), manager) for row in batch]  # type: ignore[arg-type]
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [_response({"conversations": [{"conversation_id": "x"}], "has_more": False, "next_cursor": None})],
+        )
+        manager = _make_manager(ElevenLabsResumeConfig(cursor="C1"))
+        rows = _rows(_source("conversations", manager))
 
         assert rows == [{"conversation_id": "x"}]
+        # The resumed run starts at the saved cursor, sent under the conversations cursor param.
+        assert params[0]["cursor"] == "C1"
+
+    @mock.patch(SESSION_PATCH)
+    def test_incremental_filter_reaches_the_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [_response({"history": [{"history_item_id": "a"}], "has_more": False, "last_history_item_id": "a"})],
+        )
+        _rows(
+            _source(
+                "history",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=1700000000,
+                incremental_field="date_unix",
+            )
+        )
+        assert params[0]["date_after_unix"] == 1700000000
+
+    @mock.patch(SESSION_PATCH)
+    def test_missing_items_key_yields_no_rows_without_raising(self, MockSession) -> None:
+        # A 200 body without the endpoint's array key is a legit zero-row page, not a hard error.
+        session = MockSession.return_value
+        _wire(session, [_response({"has_more": False})])
+        rows = _rows(_source("history", _make_manager()))
+        assert rows == []
+
+    @mock.patch("time.sleep", lambda *_a, **_k: None)
+    @mock.patch(SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(self, MockSession) -> None:
+        # 429/5xx are transient; the shared transport retries them and the page eventually lands.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status=503),
+                _response({"history": [{"history_item_id": "a"}], "has_more": False, "last_history_item_id": "a"}),
+            ],
+        )
+        rows = _rows(_source("history", _make_manager()))
+        assert rows == [{"history_item_id": "a"}]
+        assert session.send.call_count == 2
+
+    @mock.patch(SESSION_PATCH)
+    def test_credential_error_fails_loud(self, MockSession) -> None:
+        # A 401 is a doomed credential problem; it must raise (feeding get_non_retryable_errors), not retry.
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=401)])
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("history", _make_manager()))
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
@@ -205,39 +244,36 @@ class TestValidateCredentials:
             ("server_error_at_create", 500, None, False),
         ]
     )
-    def test_status_mapping(self, _name: str, status: int, schema_name: str | None, expected_ok: bool) -> None:
-        resp = MagicMock(status_code=status)
-        with patch.object(elevenlabs, "make_tracked_session") as mts:
-            mts.return_value.get.return_value = resp
-            ok, _msg = validate_credentials("k", schema_name)
+    @mock.patch(SESSION_PATCH)
+    def test_status_mapping(self, _name: str, status: int, schema_name: str | None, expected_ok: bool, mts) -> None:
+        mts.return_value.get.return_value = mock.MagicMock(status_code=status)
+        ok, _msg = validate_credentials("k", schema_name)
         assert ok is expected_ok
 
-    def test_network_error_is_not_valid(self) -> None:
-        with patch.object(elevenlabs, "make_tracked_session") as mts:
-            mts.return_value.get.side_effect = requests.ConnectionError("boom")
-            ok, msg = validate_credentials("k")
+    @mock.patch(SESSION_PATCH)
+    def test_network_error_is_not_valid(self, mts) -> None:
+        mts.return_value.get.side_effect = requests.ConnectionError("boom")
+        ok, msg = validate_credentials("k")
         assert ok is False
         assert msg is not None
 
-    def test_session_does_not_follow_redirects(self) -> None:
+    @mock.patch(SESSION_PATCH)
+    def test_session_does_not_follow_redirects(self, mts) -> None:
         # requests keeps the custom xi-api-key header across a cross-origin 3xx; following one would
         # replay the key to the redirect target, so the credentialed session must refuse redirects.
-        with patch.object(elevenlabs, "make_tracked_session") as mts:
-            mts.return_value.get.return_value = MagicMock(status_code=200)
-            validate_credentials("k")
+        mts.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("k")
         assert mts.call_args.kwargs["allow_redirects"] is False
 
 
-class TestGetRowsSecurity:
-    def test_session_does_not_follow_redirects(self) -> None:
+class TestSyncSecurity:
+    @mock.patch(SESSION_PATCH)
+    def test_sync_session_does_not_follow_redirects(self, MockSession) -> None:
         # Same key-leak boundary as validation: the sync session must not forward xi-api-key on a 3xx.
-        page = {"history": [], "has_more": False, "last_history_item_id": None}
-        with (
-            patch.object(elevenlabs, "make_tracked_session") as mts,
-            patch.object(elevenlabs, "_fetch_page", lambda *_a, **_k: page),
-        ):
-            list(get_rows("k", "history", MagicMock(), _FakeResumableManager()))  # type: ignore[arg-type]
-        assert mts.call_args.kwargs["allow_redirects"] is False
+        session = MockSession.return_value
+        _wire(session, [_response({"history": [], "has_more": False, "last_history_item_id": None})])
+        _rows(_source("history", _make_manager()))
+        assert any(call.kwargs.get("allow_redirects") is False for call in MockSession.call_args_list)
 
 
 class TestSourceResponse:
@@ -249,11 +285,12 @@ class TestSourceResponse:
             ("voices", ["voice_id"], "asc", "created_at_unix"),
         ]
     )
+    @mock.patch(SESSION_PATCH)
     def test_response_shape_per_endpoint(
-        self, endpoint: str, primary_keys: list[str], sort_mode: str, partition_key: str
+        self, endpoint: str, primary_keys: list[str], sort_mode: str, partition_key: str, _mts
     ) -> None:
         # sort_mode="asc" on a newest-first endpoint corrupts the watermark; the pk must be table-unique.
-        response = elevenlabs_source("k", endpoint, MagicMock(), MagicMock())
+        response = _source(endpoint, _make_manager())
         assert response.primary_keys == primary_keys
         assert response.sort_mode == sort_mode
         assert response.partition_keys == [partition_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/tests/test_elevenlabs_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/tests/test_elevenlabs_source.py
@@ -92,6 +92,8 @@ class TestElevenLabsPipelinePlumbing:
         manager = MagicMock()
         inputs = MagicMock(
             schema_name="history",
+            team_id=7,
+            job_id="job-1",
             should_use_incremental_field=True,
             db_incremental_field_last_value=1700000000,
             incremental_field="date_unix",
@@ -102,6 +104,8 @@ class TestElevenLabsPipelinePlumbing:
         _args, kwargs = mocked.call_args
         assert kwargs["endpoint"] == "history"
         assert kwargs["api_key"] == "sk_test"
+        assert kwargs["team_id"] == 7
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == 1700000000
         assert kwargs["incremental_field"] == "date_unix"


### PR DESCRIPTION
## Problem

Batch 14 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green and asserts the same observable behavior via the framework, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **deepgram**
- **docuseal**
- **drip**
- **elevenlabs**

Not migrated this batch (left hand-rolled, valid blockers — all documented framework gaps):
- **datadog** — retries HTTP 408 (framework retries 429/5xx only), two-secret-header auth, and SSRF host-pinning of cursor next/resume URLs.
- **dockerhub** — custom JWT login-exchange auth with mid-sync 401 re-auth, next-link host-pinning, and 200-body-shape retryable classification.
- **emailoctopus** — 2D per-list × per-status(query-param) fan-out with per-pair interleaved resume; resolve binds only to path.
- **everhour** — client-side dedup + ignored-offset early termination, plus an always-on computed from/to date window (including full refresh).

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 4 migrated dirs + `common/rest_source/tests/` — 326 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-13 PR (#71830); merge in order.
