### PR TITLE
fix(insights): keep interval-only dashboard override when opening insight

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
@@ -34,6 +34,7 @@ describe('isDashboardFilterEmpty', () => {
             },
         ],
         ['breakdown_filter set', { breakdown_filter: { breakdown: 'browser' } }],
+        ['interval set', { interval: 'week' }],
     ]
 
     test.each(nonEmptyCases)('returns false for %s', (_, filter) => {

--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
@@ -7,6 +7,7 @@ export function isDashboardFilterEmpty(filter: DashboardFilter | TileFilters | n
         (filter.date_from == null &&
             filter.date_to == null &&
             (filter.properties == null || (Array.isArray(filter.properties) && filter.properties.length === 0)) &&
-            filter.breakdown_filter == null)
+            filter.breakdown_filter == null &&
+            filter.interval == null)
     )
 }


### PR DESCRIPTION
## TL;DR

If a dashboard forces a specific time granularity (say weekly) but doesn't touch dates, properties, or breakdowns, opening one of its insights on its own used to throw that weekly setting away and render at the insight's own interval. Now it keeps it.

## Problem

`isDashboardFilterEmpty()` decides whether a dashboard/tile filter override carries any real constraint. When it reports "empty", `insightSceneLogic` and `insightLogic` null out the override before handing it to the query. The check only looked at `date_from`, `date_to`, `properties`, and `breakdown_filter` — so an override whose only set field is `interval` read as empty and got discarded. Opening an individual insight that carried an interval-only dashboard override (via the `filters_override` / tile-override path) rendered at the insight's own interval instead of the forced one.

`interval` was added to `DashboardFilter` / `TileFilters` in the interval-override work but never added here.

The main dashboard-tile render path is unaffected — it builds effective filters through `combineDashboardFilters` (key-generic) and never calls `isDashboardFilterEmpty`.

## Changes

- `frontend/src/scenes/dashboard/dashboardFilterEmpty.ts`: include `filter.interval == null` in the emptiness check.
- `frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts`: add `['interval set', { interval: 'week' }]` to the `nonEmptyCases` table.

Pure-function change plus one parameterized test case. No behavior change to any filter type other than interval-only overrides on the single-insight override path.

## How did you test this code?

Added a parameterized non-empty case that fails if `interval` is dropped from `isDashboardFilterEmpty`. I (Claude) could not run the Jest suite locally — this environment has no installed frontend `node_modules`, so `jest` isn't available. CI runs the suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) made a one-line fix to `isDashboardFilterEmpty` plus a matching test case, following a precise diagnosis of the interval-only override being dropped on the single-insight path. The added case catches a regression (interval override silently discarded) that no existing case covered. Confirmed `interval?: IntervalType` exists on both `DashboardFilter` and `TileFilters` in `schema-general.ts` and that `'week'` is a valid `IntervalType`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
