### PR TITLE
refactor(data-warehouse): SSRF host-pinning + migrate delighted, culture_amp, deno_deploy, e2b, firehydrant, fleetio (batch 15)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -268,6 +268,8 @@ def create_resources(
             paginator=create_paginator(client_config.get("paginator")),
             session=client_config.get("session"),
             max_retry_attempts=client_config.get("max_retries", DEFAULT_RETRY_ATTEMPTS),
+            allowed_hosts=client_config.get("allowed_hosts"),
+            allow_redirects=client_config.get("allow_redirects", True),
         )
 
         hooks = create_response_hooks(endpoint_config.get("response_actions"))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 from requests import Request, Response, Session
 from requests.auth import AuthBase
@@ -106,12 +107,28 @@ class RESTClient:
         paginator: Optional[BasePaginator] = None,
         session: Optional[Session] = None,
         max_retry_attempts: int = DEFAULT_RETRY_ATTEMPTS,
+        allowed_hosts: Optional[list[str]] = None,
+        allow_redirects: bool = True,
     ) -> None:
         self.base_url = base_url or ""
         self.headers = headers or {}
         self.auth = auth
         self.paginator = paginator
         self._max_retry_attempts = max_retry_attempts
+        self._allow_redirects = allow_redirects
+        # When set (even to an empty list), every outgoing request URL — including
+        # paginator next-page links and seeded resume URLs — must resolve to one of
+        # these hosts (the base_url host is always implicitly allowed). This pins
+        # pagination to the expected host so a tampered or spoofed ``next`` link can't
+        # exfiltrate the Authorization header to an attacker-controlled origin. Pair
+        # with ``allow_redirects=False`` to also reject cross-host redirects.
+        self._allowed_hosts: Optional[set[str]] = None
+        if allowed_hosts is not None:
+            hosts = {host.lower() for host in allowed_hosts if host}
+            base_host = urlsplit(self.base_url).hostname
+            if base_host:
+                hosts.add(base_host.lower())
+            self._allowed_hosts = hosts
         # Default to the tracked session so every source built on top of
         # `RESTClient` participates in HTTP logging, metrics, and sample
         # capture. Callers can pass a pre-built `Session` for tests or
@@ -124,6 +141,17 @@ class RESTClient:
 
     def _join_url(self, path: str) -> str:
         return resolve_request_url(self.base_url, path)
+
+    def _check_allowed_host(self, url: Optional[str]) -> None:
+        if self._allowed_hosts is None or not url:
+            return
+        host = urlsplit(url).hostname
+        if host is None or host.lower() not in self._allowed_hosts:
+            raise ValueError(
+                f"Refusing to send request to disallowed host {host!r} (url {url!r}); "
+                f"allowed hosts: {sorted(self._allowed_hosts)}. A pagination or resume URL "
+                "pointing off the expected API host is rejected to prevent credential exfiltration."
+            )
 
     def paginate(
         self,
@@ -187,12 +215,25 @@ class RESTClient:
     )
     def _send_request(self, request: Request, hooks: Hooks) -> tuple[Response, Any]:
         prepared = self.session.prepare_request(request)
+        # Fail loud on a pagination/resume URL that points off the expected host before the
+        # request (and its Authorization header) ever leaves the process. Raised outside the
+        # retryable-error type so it propagates immediately rather than being retried.
+        self._check_allowed_host(prepared.url)
         # `send` reads the body eagerly (stream=False), so a connection dropped mid-stream
         # surfaces here as ChunkedEncodingError. Reissue it like a truncated/partial body below.
         try:
-            response = self.session.send(prepared)
+            response = self.session.send(prepared, allow_redirects=self._allow_redirects)
         except ChunkedEncodingError as e:
             raise RESTClientRetryableError(f"Connection broken while reading response: {e}") from e
+
+        # With redirects disabled, a 3xx is not an error to `raise_for_status` and would fall
+        # through to JSON parsing; reject it explicitly so a redirect can't smuggle the request
+        # (and credentials) to another origin.
+        if not self._allow_redirects and response.is_redirect:
+            raise ValueError(
+                f"Unexpected redirect ({response.status_code}) to "
+                f"{response.headers.get('Location')!r} from {prepared.url}; refusing to follow."
+            )
 
         if response.status_code == 429 or response.status_code >= 500:
             raise RESTClientRetryableError(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_ssrf_host_pinning.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_ssrf_host_pinning.py
@@ -1,0 +1,103 @@
+import json
+from typing import Any, Optional
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client"
+
+
+def _make_response(json_body: Any, status_code: int = 200, headers: Optional[dict[str, str]] = None) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(json_body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    for key, value in (headers or {}).items():
+        resp.headers[key] = value
+    return resp
+
+
+def _session_echoing_url(MockSession) -> MagicMock:
+    # Emulate Session.prepare_request: the prepared URL is the request's final URL, which is
+    # what the host check inspects. Absolute next-page URLs set by the paginator flow straight
+    # through here.
+    mock_session = MockSession.return_value
+    mock_session.headers = {}
+
+    def _prep(request: Any) -> MagicMock:
+        prepared = MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    mock_session.prepare_request.side_effect = _prep
+    return mock_session
+
+
+class TestSSRFHostPinning:
+    @parameterized.expand(
+        [
+            # (allowed_hosts, next_page_host, expect_reject)
+            ("same_host_pins_rejects_offhost", [], "evil.com", True),
+            ("same_host_allows_base_host", [], "api.example.com", False),
+            ("extra_host_in_allowlist_permitted", ["cdn.example.com"], "cdn.example.com", False),
+            ("host_not_in_allowlist_rejected", ["cdn.example.com"], "evil.com", True),
+            ("no_allowlist_disables_enforcement", None, "evil.com", False),
+        ]
+    )
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_offhost_next_url_enforcement(
+        self, _name: str, allowed_hosts: Optional[list[str]], next_host: str, expect_reject: bool, MockSession
+    ) -> None:
+        mock_session = _session_echoing_url(MockSession)
+        mock_session.send.side_effect = [
+            _make_response({"results": [{"id": 1}], "next": f"https://{next_host}/page2"}),
+            _make_response({"results": [{"id": 2}], "next": None}),
+        ]
+
+        client = RESTClient(base_url="https://api.example.com", allowed_hosts=allowed_hosts)
+        pager = client.paginate(
+            path="/items", data_selector="results", paginator=JSONResponsePaginator(next_url_path="next")
+        )
+
+        if expect_reject:
+            with pytest.raises(ValueError, match="disallowed host"):
+                list(pager)
+            # The first page was yielded, but the off-host second request never went out.
+            assert mock_session.send.call_count == 1
+        else:
+            pages = list(pager)
+            assert [row["id"] for page in pages for row in page] == [1, 2]
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_redirect_rejected_when_disabled(self, MockSession) -> None:
+        mock_session = _session_echoing_url(MockSession)
+        mock_session.send.return_value = _make_response(
+            {}, status_code=302, headers={"Location": "https://evil.com/steal"}
+        )
+
+        client = RESTClient(base_url="https://api.example.com", allow_redirects=False)
+        with pytest.raises(ValueError, match="Unexpected redirect"):
+            list(client.paginate(path="/items", data_selector="results"))
+
+        # The redirect target was never followed: send ran once and got no allow_redirects.
+        _, kwargs = mock_session.send.call_args
+        assert kwargs.get("allow_redirects") is False
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_redirects_followed_by_default(self, MockSession) -> None:
+        mock_session = _session_echoing_url(MockSession)
+        mock_session.send.return_value = _make_response({"results": [{"id": 1}]})
+
+        client = RESTClient(base_url="https://api.example.com")
+        list(client.paginate(path="/items", data_selector="results"))
+
+        _, kwargs = mock_session.send.call_args
+        assert kwargs.get("allow_redirects") is True

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -170,6 +170,14 @@ class ClientConfig(TypedDict, total=False):
     # Cap on retry attempts per request. Left unset, RESTClient uses its default;
     # the inline preview sets 1 so a rate-limited endpoint errors instead of sleeping.
     max_retries: int
+    # SSRF host-pinning. When set (even to an empty list), every outgoing request URL —
+    # including paginator next-page links and seeded resume URLs — must resolve to one of
+    # these hosts; the base_url host is always implicitly allowed. Off-host URLs are rejected
+    # so a spoofed ``next`` link can't exfiltrate credentials. Pair with allow_redirects=False.
+    allowed_hosts: Optional[list[str]]
+    # When False, redirects are not followed and any 3xx is rejected — closes the redirect-based
+    # off-host escape that host-pinning alone would miss. Defaults to True (follow redirects).
+    allow_redirects: bool
 
 
 class IncrementalArgs(TypedDict, total=False):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/culture_amp/culture_amp.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/culture_amp/culture_amp.py
@@ -1,58 +1,70 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import quote, urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import OAuth2Auth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.culture_amp.settings import (
     CULTURE_AMP_BASE_URL,
     CULTURE_AMP_ENDPOINTS,
     CULTURE_AMP_TOKEN_URL,
 )
 
-REQUEST_TIMEOUT_SECONDS = 60
-# Rate limits are undisclosed ("generous"); back off on 429/503.
-MAX_RETRY_ATTEMPTS = 5
+# Fan-out parent resource name. With include_from_parent=["id"] the framework injects the parent
+# employee id into demographic rows as `_employees_id`; a data_map renames it to the `_employee_id`
+# key the rows carried before the rest_source migration.
+_EMPLOYEES_PARENT = "employees"
+_PARENT_EMPLOYEE_ID_KEY = f"_{_EMPLOYEES_PARENT}_id"
+_EMPLOYEE_ID_KEY = "_employee_id"
+_DEMOGRAPHICS_CHILD_PATH = "employees/{employee_id}/demographics"
 
-
-class CultureAmpRetryableError(Exception):
-    pass
+# Scope minted for the create-time credential probe: enough to list employees.
+_VALIDATE_SCOPES = "employees-read"
 
 
 @dataclasses.dataclass
 class CultureAmpResumeConfig:
-    # Cursor endpoints: the afterKey of the next unfetched page. Fan-out: the id
-    # of the last fully-processed employee, re-located in a freshly-fetched list
-    # on resume so an employee added/removed mid-sync can't shift the position.
+    # Pre-framework fields, kept so previously saved state still parses (dataclass(**saved)).
+    # Cursor endpoints: the afterKey of the next unfetched page.
     cursor: Optional[str] = None
+    # Fan-out: id of the last fully-processed employee (pre-framework shape).
     last_processed_employee_id: Optional[str] = None
+    # Framework fan-out checkpoint for employee_demographics
+    # ({"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}).
+    fanout_state: Optional[dict[str, Any]] = None
 
 
-def _get_session(client_secret: str) -> requests.Session:
-    return make_tracked_session(redact_values=(client_secret,))
+def _scoped(account_id: str, scopes: str) -> str:
+    """Build the Culture Amp scope string (`target-entity:{account_id}:{scopes}`)."""
+    return f"target-entity:{account_id}:{scopes}"
 
 
-def _mint_token(session: requests.Session, client_id: str, client_secret: str, account_id: str, scopes: str) -> str:
-    """Exchange client credentials for a bearer JWT (~1h lifetime)."""
-    response = session.post(
-        CULTURE_AMP_TOKEN_URL,
-        data={
-            "grant_type": "client_credentials",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "scope": f"target-entity:{account_id}:{scopes}",
-        },
-        timeout=REQUEST_TIMEOUT_SECONDS,
+def _make_auth(client_id: str, client_secret: str, account_id: str, scopes: str) -> OAuth2Auth:
+    # Culture Amp uses OAuth2 client-credentials; tokens last ~1h and the framework re-mints on
+    # expiry mid-run. Scopes are minted per endpoint so credentials granted a subset of permissions
+    # can still sync the streams they cover.
+    return OAuth2Auth(
+        token_url=CULTURE_AMP_TOKEN_URL,
+        client_id=client_id,
+        client_secret=client_secret,
+        grant_type="client_credentials",
+        scopes=_scoped(account_id, scopes),
     )
-    response.raise_for_status()
-    return response.json()["access_token"]
 
 
 def _format_timestamp(value: Any) -> str:
@@ -65,120 +77,38 @@ def _format_timestamp(value: Any) -> str:
     return str(value)
 
 
-def validate_credentials(client_id: str, client_secret: str, account_id: str) -> bool:
-    """Confirm the credentials are valid by minting an employees-read token."""
-    try:
-        _mint_token(_get_session(client_secret), client_id, client_secret, account_id, "employees-read")
-        return True
-    except Exception:
-        return False
+def _paginator() -> JSONResponseCursorPaginator:
+    # Every Culture Amp list paginates with a `cursor` query param and an `afterKey` under
+    # `pagination` in the response body.
+    return JSONResponseCursorPaginator(cursor_path="pagination.afterKey", cursor_param="cursor")
 
 
-def get_rows(
-    client_id: str,
-    client_secret: str,
-    account_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CultureAmpResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CULTURE_AMP_ENDPOINTS[endpoint]
-    session = _get_session(client_secret)
-    token = _mint_token(session, client_id, client_secret, account_id, config.scopes)
+def _client_config(auth: OAuth2Auth) -> ClientConfig:
+    return {
+        "base_url": CULTURE_AMP_BASE_URL,
+        "auth": auth,
+        "paginator": _paginator(),
+    }
 
-    @retry(
-        retry=retry_if_exception_type((CultureAmpRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=2, max=90),
-        reraise=True,
-    )
-    def fetch(url: str) -> dict[str, Any]:
-        nonlocal token
-        response = session.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=REQUEST_TIMEOUT_SECONDS)
 
-        # Tokens expire after ~1h; re-mint once if one expires mid-sync.
-        if response.status_code == 401:
-            token = _mint_token(session, client_id, client_secret, account_id, config.scopes)
-            response = session.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=REQUEST_TIMEOUT_SECONDS)
+def _rename_employee_id(row: dict[str, Any]) -> dict[str, Any]:
+    row[_EMPLOYEE_ID_KEY] = row.pop(_PARENT_EMPLOYEE_ID_KEY)
+    return row
 
-        if response.status_code in (429, 503) or response.status_code >= 500:
-            raise CultureAmpRetryableError(
-                f"Culture Amp API error (retryable): status={response.status_code}, url={url}"
-            )
 
-        if not response.ok:
-            logger.error(f"Culture Amp API error: status={response.status_code}, body={response.text[:500]}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    def paginate(path: str, params: dict[str, Any], on_page_done: Any = None) -> Iterator[list[dict[str, Any]]]:
-        cursor = params.pop("cursor", None)
-        while True:
-            query = dict(params)
-            if cursor:
-                query["cursor"] = cursor
-            url = f"{CULTURE_AMP_BASE_URL}{path}"
-            if query:
-                url = f"{url}?{urlencode(query)}"
-
-            body = fetch(url)
-            items = body.get("data") or []
-            if isinstance(items, dict):
-                items = [items]
-            items = [row for row in items if isinstance(row, dict)]
-
-            if items:
-                yield items
-
-            cursor = (body.get("pagination") or {}).get("afterKey")
-            if not cursor:
-                return
-            if on_page_done is not None:
-                on_page_done(cursor)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if config.per_employee:
-        employee_ids: list[str] = []
-        for page in paginate("/employees", {}):
-            employee_ids.extend(str(row["id"]) for row in page)
-
-        start_index = 0
-        if resume_config is not None and resume_config.last_processed_employee_id is not None:
-            start_id = resume_config.last_processed_employee_id
-            logger.debug(f"Culture Amp: resuming {endpoint} from after employee id {start_id}")
-            try:
-                start_index = employee_ids.index(start_id) + 1
-            except ValueError:
-                # The saved employee no longer exists; restart from the beginning
-                # (merge dedupes on primary key, so re-yielding is safe).
-                start_index = 0
-
-        for index in range(start_index, len(employee_ids)):
-            employee_id = employee_ids[index]
-            path = config.path.format(employee_id=quote(employee_id, safe=""))
-            for page in paginate(path, {}):
-                yield [{**row, "_employee_id": employee_id} for row in page]
-            # Save state AFTER yielding so a crash re-yields the in-flight
-            # employee (merge dedupes on primary key).
-            resumable_source_manager.save_state(CultureAmpResumeConfig(last_processed_employee_id=employee_id))
-        return
-
-    params: dict[str, Any] = {}
-    if config.incremental_fields and should_use_incremental_field and db_incremental_field_last_value is not None:
-        params["after_date"] = _format_timestamp(db_incremental_field_last_value)
-    if resume_config is not None and resume_config.cursor:
-        params["cursor"] = resume_config.cursor
-        logger.debug(f"Culture Amp: resuming {endpoint} from saved cursor")
-
-    def save_cursor(after_key: str) -> None:
-        # Save state AFTER the previous page yielded so a crash re-yields it.
-        resumable_source_manager.save_state(CultureAmpResumeConfig(cursor=after_key))
-
-    yield from paginate(config.path, params, on_page_done=save_cursor)
+def _fanout_initial_state(resume: CultureAmpResumeConfig) -> Optional[dict[str, Any]]:
+    if resume.fanout_state is not None:
+        return resume.fanout_state
+    # Pre-framework state saved only the last fully-processed employee id. Translate it into a
+    # single completed child path so that employee is skipped on resume; any earlier employees
+    # are re-fetched, which is safe (merge dedupes on the [_employee_id, name] primary key).
+    if resume.last_processed_employee_id is None:
+        return None
+    return {
+        "completed": [_DEMOGRAPHICS_CHILD_PATH.format(employee_id=resume.last_processed_employee_id)],
+        "current": None,
+        "child_state": None,
+    }
 
 
 def culture_amp_source(
@@ -186,29 +116,124 @@ def culture_amp_source(
     client_secret: str,
     account_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CultureAmpResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = CULTURE_AMP_ENDPOINTS[endpoint]
+    auth = _make_auth(client_id, client_secret, account_id, config.scopes)
+
+    resume: Optional[CultureAmpResumeConfig] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+
+    if config.per_employee:
+        initial_state = _fanout_initial_state(resume) if resume is not None else None
+
+        def save_fanout_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            if state is not None:
+                resumable_source_manager.save_state(CultureAmpResumeConfig(fanout_state=state))
+
+        rest_config: RESTAPIConfig = {
+            "client": _client_config(auth),
+            "resources": [
+                {
+                    "name": _EMPLOYEES_PARENT,
+                    "endpoint": {
+                        "path": "employees",
+                        "data_selector": "data",
+                    },
+                },
+                {
+                    "name": endpoint,
+                    "endpoint": {
+                        "path": _DEMOGRAPHICS_CHILD_PATH,
+                        "params": {
+                            "employee_id": {
+                                "type": "resolve",
+                                "resource": _EMPLOYEES_PARENT,
+                                "field": "id",
+                            },
+                        },
+                        "data_selector": "data",
+                        # Each employee's demographics list is cursor-paged like every other list.
+                        "paginator": _paginator(),
+                    },
+                    "include_from_parent": ["id"],
+                    "data_map": _rename_employee_id,
+                },
+            ],
+        }
+        resources = {
+            res.name: res
+            for res in rest_api_resources(
+                rest_config,
+                team_id,
+                job_id,
+                None,
+                resume_hook=save_fanout_checkpoint,
+                initial_paginator_state=initial_state,
+            )
+        }
+        resource = resources[endpoint]
+    else:
+        params: dict[str, Any] = {}
+        if config.incremental_fields and should_use_incremental_field and db_incremental_field_last_value is not None:
+            params["after_date"] = _format_timestamp(db_incremental_field_last_value)
+
+        initial_paginator_state: Optional[dict[str, Any]] = None
+        if resume is not None and resume.cursor is not None:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only while a next page remains; the framework calls the hook AFTER a page is
+            # yielded, so a crash re-yields the last batch (merge dedupes on primary key) rather
+            # than skipping it.
+            if state is not None and state.get("cursor") is not None:
+                resumable_source_manager.save_state(CultureAmpResumeConfig(cursor=state["cursor"]))
+
+        endpoint_config: Endpoint = {
+            "path": config.path,
+            "params": params,
+            "data_selector": "data",
+        }
+        rest_config = {
+            "client": _client_config(auth),
+            "resources": [{"name": endpoint, "endpoint": endpoint_config}],
+        }
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            None,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            client_id=client_id,
-            client_secret=client_secret,
-            account_id=account_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=list(config.primary_keys) if config.primary_keys else None,
         partition_count=1,
         partition_size=1,
-        # Result ordering within an after_date window is undocumented, so the
-        # pipeline defers incremental watermark commits until a run completes.
+        # Result ordering within an after_date window is undocumented, so the pipeline defers
+        # incremental watermark commits until a run completes.
         sort_mode="desc" if config.incremental_fields else "asc",
     )
+
+
+def validate_credentials(client_id: str, client_secret: str, account_id: str) -> bool:
+    """Confirm the credentials are valid by minting an employees-read token and probing /employees."""
+    auth = _make_auth(client_id, client_secret, account_id, _VALIDATE_SCOPES)
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(client_secret,)),
+        f"{CULTURE_AMP_BASE_URL}/employees",
+        auth=auth,
+        # 200 means the token minted and /employees is readable. 403 means the token minted (the
+        # credentials are valid) but lacks the employees scope — accept at create time, matching
+        # the old mint-only check; the sync-time non-retryable copy guides the permission fix.
+        ok_statuses=(200, 403),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/culture_amp/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/culture_amp/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.culture_amp.culture_amp import (
     CultureAmpResumeConfig,
     culture_amp_source,
@@ -110,21 +113,7 @@ An account admin can generate API credentials in Culture Amp under Settings > In
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CultureAmpSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -151,7 +140,8 @@ An account admin can generate API credentials in Culture Amp under Settings > In
             client_secret=config.client_secret,
             account_id=config.account_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/culture_amp/tests/test_culture_amp.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/culture_amp/tests/test_culture_amp.py
@@ -1,14 +1,18 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
 
+import requests
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.culture_amp.culture_amp import (
     CultureAmpResumeConfig,
     _format_timestamp,
+    _make_auth,
     culture_amp_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.culture_amp.settings import (
@@ -16,7 +20,43 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.culture_am
     ENDPOINTS,
 )
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.culture_amp.culture_amp"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# OAuth2Auth mints tokens through its own tracked session in the auth module.
+AUTH_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth.make_tracked_session"
+)
+# validate_credentials probes through a tracked session built in the culture_amp module.
+PROBE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.culture_amp.culture_amp.make_tracked_session"
+)
+
+DEMOGRAPHICS_PATH = "employees/{employee_id}/demographics"
+
+
+def _response(payload: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(payload).encode()
+    resp.url = "https://api.cultureamp.com/v1/test"
+    return resp
+
+
+def _page(rows: list[dict[str, Any]], after_key: str | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {"data": rows}
+    if after_key:
+        body["pagination"] = {"afterKey": after_key, "nextPath": f"/v1/x?cursor={after_key}"}
+    return body
+
+
+def _token_response(expires_in: int = 3599) -> mock.MagicMock:
+    # OAuth2Auth reads the token exchange body via response.raw.read (stream=True).
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.raw.read.return_value = json.dumps(
+        {"access_token": "tok-1", "expires_in": expires_in, "token_type": "Bearer"}
+    ).encode()
+    return resp
 
 
 def _make_manager(resume_state: CultureAmpResumeConfig | None = None) -> mock.MagicMock:
@@ -26,23 +66,50 @@ def _make_manager(resume_state: CultureAmpResumeConfig | None = None) -> mock.Ma
     return manager
 
 
-def _response(body: Any, status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = body
-    resp.status_code = status_code
-    resp.ok = status_code < 400
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock RESTClient session and snapshot each request AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead. A real
+    ``requests.Session`` does the preparing so the OAuth2 auth (token mint + Bearer header) is
+    actually applied, letting tests assert on the minted Authorization header and the request URLs.
+    """
+    session.headers = {}
+    real_session = requests.Session()
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> requests.PreparedRequest:
+        prepared = real_session.prepare_request(request)
+        snapshots.append({"params": dict(request.params or {}), "url": prepared.url, "headers": dict(prepared.headers)})
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _token_response() -> mock.MagicMock:
-    return _response({"access_token": "tok-1", "expires_in": 3599, "token_type": "Bearer"})
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
-def _page(rows: list[dict[str, Any]], after_key: str | None = None) -> dict[str, Any]:
-    body: dict[str, Any] = {"data": rows}
-    if after_key:
-        body["pagination"] = {"afterKey": after_key, "nextPath": f"/v1/x?cursor={after_key}"}
-    return body
+def _source(
+    endpoint: str,
+    manager: mock.MagicMock,
+    *,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+):
+    return culture_amp_source(
+        client_id="cid",
+        client_secret="sec",
+        account_id="entity-1",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
 
 
 class TestFormatTimestamp:
@@ -59,155 +126,364 @@ class TestFormatTimestamp:
         assert _format_timestamp(value) == expected
 
 
+class TestScopedAuth:
+    @pytest.mark.parametrize(
+        "endpoint, expected_scope",
+        [
+            ("employees", "target-entity:entity-1:employees-read"),
+            ("employee_demographics", "target-entity:entity-1:employees-read,employee-demographics-read"),
+            ("performance_cycles", "target-entity:entity-1:performance-evaluations-read"),
+            ("manager_reviews", "target-entity:entity-1:performance-evaluations-read"),
+        ],
+    )
+    def test_scope_is_built_per_endpoint(self, endpoint, expected_scope):
+        config = CULTURE_AMP_ENDPOINTS[endpoint]
+        auth = _make_auth("cid", "sec", "entity-1", config.scopes)
+        assert auth.scopes == expected_scope
+        assert auth.grant_type == "client_credentials"
+
+
 class TestValidateCredentials:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_valid_credentials_mint_scoped_token(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
+    @pytest.mark.parametrize(
+        "status, expected",
+        [
+            (200, True),
+            # 403 = token minted (credentials valid) but missing the employees scope — accepted at create.
+            (403, True),
+            (401, False),
+            (500, False),
+        ],
+    )
+    @mock.patch(PROBE_SESSION_PATCH)
+    def test_maps_probe_status(self, mock_session, status, expected):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("cid", "sec", "entity-1") is expected
 
-        assert validate_credentials("cid", "sec", "entity-1") is True
-        body = mock_session.return_value.post.call_args.kwargs["data"]
-        assert body["grant_type"] == "client_credentials"
-        assert body["scope"] == "target-entity:entity-1:employees-read"
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_invalid_credentials(self, mock_session):
-        response = _response({}, status_code=401)
-        response.raise_for_status.side_effect = Exception("401")
-        mock_session.return_value.post.return_value = response
-
+    @mock.patch(PROBE_SESSION_PATCH)
+    def test_invalid_on_exception(self, mock_session):
+        # A failed token mint (bad credentials) raises out of the auth callable during the probe.
+        mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("cid", "bad", "entity-1") is False
+
+    @mock.patch(PROBE_SESSION_PATCH)
+    def test_probes_employees_with_employees_read_scope(self, mock_session):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+
+        validate_credentials("cid", "sec", "entity-1")
+
+        call = mock_session.return_value.get.call_args
+        assert call.args[0] == "https://api.cultureamp.com/v1/employees"
+        assert call.kwargs["auth"].scopes == "target-entity:entity-1:employees-read"
 
 
 class TestCursorEndpoints:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_employees_follow_after_key_until_absent(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "e1"}], after_key="k1")),
-            _response(_page([{"id": "e2"}])),
-        ]
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follow_after_key_until_absent(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}], after_key="k1")),
+                _response(_page([{"id": "e2"}])),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("cid", "sec", "entity-1", "employees", mock.MagicMock(), manager))
+        rows = _rows(_source("employees", manager))
 
-        assert [row["id"] for batch in batches for row in batch] == ["e1", "e2"]
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert "cursor=k1" in second_url
+        assert [row["id"] for row in rows] == ["e1", "e2"]
+        assert "cursor" not in snapshots[0]["params"]
+        assert snapshots[1]["params"]["cursor"] == "k1"
+        # State saved only while a next page remains, after the batch is yielded.
         assert [call.args[0].cursor for call in manager.save_state.call_args_list] == ["k1"]
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_incremental_passes_after_date(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _response(_page([]))
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_stops_without_saving(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(session, [_response(_page([]))])
 
-        list(
-            get_rows(
-                "cid",
-                "sec",
-                "entity-1",
+        manager = _make_manager()
+        rows = _rows(_source("performance_cycles", manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_passes_after_date(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_response(_page([]))])
+
+        _rows(
+            _source(
                 "performance_cycles",
-                mock.MagicMock(),
                 _make_manager(),
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC),
             )
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert "after_date=2024-01-02T03%3A04%3A05Z" in url
+        assert snapshots[0]["params"]["after_date"] == "2024-01-02T03:04:05Z"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resumes_from_saved_cursor(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _response(_page([{"managerReviewId": "r9"}]))
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_after_date_without_watermark(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_response(_page([]))])
+
+        _rows(_source("performance_cycles", _make_manager(), should_use_incremental_field=True))
+
+        assert "after_date" not in snapshots[0]["params"]
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_ignores_after_date(self, MockSession, MockAuth):
+        # employees has no server-side filter — an incremental value must not inject after_date.
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_response(_page([{"id": "e1"}]))])
+
+        _rows(
+            _source(
+                "employees",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
+            )
+        )
+
+        assert "after_date" not in snapshots[0]["params"]
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_response(_page([{"managerReviewId": "r9"}]))])
 
         manager = _make_manager(CultureAmpResumeConfig(cursor="k9"))
-        list(get_rows("cid", "sec", "entity-1", "manager_reviews", mock.MagicMock(), manager))
+        _rows(_source("manager_reviews", manager))
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert "cursor=k9" in url
+        assert snapshots[0]["params"]["cursor"] == "k9"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_mid_sync_401_re_mints_token(self, mock_session):
-        mock_session.return_value.post.side_effect = [_token_response(), _token_response()]
-        mock_session.return_value.get.side_effect = [
-            _response({}, status_code=401),
-            _response(_page([{"id": "e1"}])),
-        ]
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_endpoint_scope_is_minted_per_stream(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(session, [_response(_page([]))])
 
-        batches = list(get_rows("cid", "sec", "entity-1", "employees", mock.MagicMock(), _make_manager()))
+        _rows(_source("performance_cycles", _make_manager()))
 
-        assert batches == [[{"id": "e1"}]]
-        assert mock_session.return_value.post.call_count == 2
+        data = MockAuth.return_value.post.call_args.kwargs["data"]
+        assert data["scope"] == "target-entity:entity-1:performance-evaluations-read"
+        assert data["grant_type"] == "client_credentials"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_endpoint_scopes_are_minted_per_stream(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _response(_page([]))
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_mints_token_once_and_sends_bearer(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}], after_key="k1")),
+                _response(_page([{"id": "e2"}])),
+            ],
+        )
 
-        list(get_rows("cid", "sec", "entity-1", "performance_cycles", mock.MagicMock(), _make_manager()))
+        _rows(_source("employees", _make_manager()))
 
-        scope = mock_session.return_value.post.call_args.kwargs["data"]["scope"]
-        assert scope == "target-entity:entity-1:performance-evaluations-read"
+        # One mint covers the whole run while the token is unexpired.
+        assert MockAuth.return_value.post.call_count == 1
+        assert MockAuth.return_value.post.call_args.args[0] == "https://api.cultureamp.com/v1/oauth2/token"
+        assert all(s["headers"]["Authorization"] == "Bearer tok-1" for s in snapshots)
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_remints_token_when_expired_mid_run(self, MockSession, MockAuth):
+        # expires_in=0 forces a re-mint per request — the deterministic stand-in for a sync
+        # outliving the ~1h token lifetime. Replaces the pre-framework reactive-401 re-mint.
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response(expires_in=0)
+        _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}], after_key="k1")),
+                _response(_page([{"id": "e2"}])),
+            ],
+        )
+
+        rows = _rows(_source("employees", _make_manager()))
+
+        assert [row["id"] for row in rows] == ["e1", "e2"]
+        assert MockAuth.return_value.post.call_count == 2
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_4xx_raises_immediately(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(session, [_response({}, status_code=400)])
+
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("employees", _make_manager()))
+
+        assert session.send.call_count == 1
 
 
 class TestEmployeeDemographicsFanOut:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_fans_out_per_employee_and_injects_employee_id(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "e1"}, {"id": "e2"}])),
-            _response(_page([{"name": "department", "value": "eng"}])),
-            _response(_page([{"name": "department", "value": "sales"}])),
-        ]
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_per_employee_and_injects_employee_id(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}, {"id": "e2"}])),
+                _response(_page([{"name": "department", "value": "eng"}])),
+                _response(_page([{"name": "department", "value": "sales"}])),
+            ],
+        )
+
+        rows = _rows(_source("employee_demographics", _make_manager()))
+
+        assert [(r["_employee_id"], r["value"]) for r in rows] == [("e1", "eng"), ("e2", "sales")]
+        # The framework's include_from_parent key is renamed away — rows keep their old shape.
+        assert all("_employees_id" not in r for r in rows)
+        urls = [s["url"] for s in snapshots]
+        assert urls[0] == "https://api.cultureamp.com/v1/employees"
+        assert urls[1] == "https://api.cultureamp.com/v1/employees/e1/demographics"
+        assert urls[2] == "https://api.cultureamp.com/v1/employees/e2/demographics"
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_fanout_checkpoints_between_employees(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}, {"id": "e2"}])),
+                _response(_page([{"name": "department", "value": "eng"}])),
+                _response(_page([{"name": "department", "value": "sales"}])),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("cid", "sec", "entity-1", "employee_demographics", mock.MagicMock(), manager))
+        _rows(_source("employee_demographics", manager))
 
-        flat = [row for batch in batches for row in batch]
-        assert [(r["_employee_id"], r["value"]) for r in flat] == [("e1", "eng"), ("e2", "sales")]
-        assert [call.args[0].last_processed_employee_id for call in manager.save_state.call_args_list] == ["e1", "e2"]
+        saved = [call.args[0].fanout_state for call in manager.save_state.call_args_list]
+        e1_path = DEMOGRAPHICS_PATH.format(employee_id="e1")
+        e2_path = DEMOGRAPHICS_PATH.format(employee_id="e2")
+        # Completing each employee moves its child path into the completed list.
+        assert saved[-1]["completed"] == [e1_path, e2_path]
+        assert saved[-1]["current"] is None
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resumes_from_saved_employee_id(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "e1"}, {"id": "e2"}])),
-            _response(_page([{"name": "department", "value": "sales"}])),
-        ]
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_fanout_state(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}, {"id": "e2"}])),
+                _response(_page([{"name": "department", "value": "sales"}])),
+            ],
+        )
+
+        manager = _make_manager(
+            CultureAmpResumeConfig(fanout_state={"completed": [DEMOGRAPHICS_PATH.format(employee_id="e1")]})
+        )
+        rows = _rows(_source("employee_demographics", manager))
+
+        assert [r["_employee_id"] for r in rows] == ["e2"]
+        assert len(snapshots) == 2
+        assert snapshots[1]["url"].endswith("/employees/e2/demographics")
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_pre_framework_employee_id(self, MockSession, MockAuth):
+        # Old saved state carried only the last processed employee id; it still resumes correctly.
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}, {"id": "e2"}])),
+                _response(_page([{"name": "department", "value": "sales"}])),
+            ],
+        )
 
         manager = _make_manager(CultureAmpResumeConfig(last_processed_employee_id="e1"))
-        batches = list(get_rows("cid", "sec", "entity-1", "employee_demographics", mock.MagicMock(), manager))
+        rows = _rows(_source("employee_demographics", manager))
 
-        flat = [row for batch in batches for row in batch]
-        assert [r["_employee_id"] for r in flat] == ["e2"]
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert len(urls) == 2
-        assert "/employees/e2/demographics" in urls[1]
+        assert [r["_employee_id"] for r in rows] == ["e2"]
+        assert len(snapshots) == 2
+        assert snapshots[1]["url"].endswith("/employees/e2/demographics")
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resumes_from_beginning_when_saved_employee_removed(self, mock_session):
-        # The employee whose id was saved (e9) is gone from the refetched list,
-        # so the sync restarts from the top rather than skipping anyone.
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [
-            _response(_page([{"id": "e1"}, {"id": "e2"}])),
-            _response(_page([{"name": "department", "value": "eng"}])),
-            _response(_page([{"name": "department", "value": "sales"}])),
-        ]
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_beginning_when_saved_employee_removed(self, MockSession, MockAuth):
+        # The employee whose id was saved (e9) is gone from the refetched list, so no one is
+        # skipped and the sync processes everyone rather than dropping rows.
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}, {"id": "e2"}])),
+                _response(_page([{"name": "department", "value": "eng"}])),
+                _response(_page([{"name": "department", "value": "sales"}])),
+            ],
+        )
 
         manager = _make_manager(CultureAmpResumeConfig(last_processed_employee_id="e9"))
-        batches = list(get_rows("cid", "sec", "entity-1", "employee_demographics", mock.MagicMock(), manager))
+        rows = _rows(_source("employee_demographics", manager))
 
-        flat = [row for batch in batches for row in batch]
-        assert [r["_employee_id"] for r in flat] == ["e1", "e2"]
+        assert [r["_employee_id"] for r in rows] == ["e1", "e2"]
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_employee_listing(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "e1"}], after_key="emp-2")),
+                _response(_page([{"name": "department", "value": "eng"}])),
+                _response(_page([{"id": "e2"}])),
+                _response(_page([{"name": "department", "value": "sales"}])),
+            ],
+        )
+
+        rows = _rows(_source("employee_demographics", _make_manager()))
+
+        assert [(r["_employee_id"], r["value"]) for r in rows] == [("e1", "eng"), ("e2", "sales")]
+        # Parent pages are consumed lazily: employees page 1, its demographics, employees page 2, ...
+        assert snapshots[0]["url"].endswith("/employees")
+        assert snapshots[1]["url"].endswith("/employees/e1/demographics")
+        assert snapshots[2]["params"]["cursor"] == "emp-2"
+        assert snapshots[3]["url"].endswith("/employees/e2/demographics")
 
 
 class TestCultureAmpSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata_per_endpoint(self, MockSession, MockAuth, endpoint):
         config = CULTURE_AMP_ENDPOINTS[endpoint]
-        response = culture_amp_source("cid", "sec", "entity-1", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/delighted/delighted.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/delighted/delighted.py
@@ -1,17 +1,23 @@
-import base64
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import parse_qs, urlencode, urlparse, urlsplit, urlunsplit
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.delighted.settings import (
     DELIGHTED_ENDPOINTS,
     DelightedEndpointConfig,
@@ -21,34 +27,11 @@ DELIGHTED_HOST = "api.delighted.com"
 DELIGHTED_BASE_URL = f"https://{DELIGHTED_HOST}/v1"
 # Delighted caps list pages at 100 items.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-# Upper bound on how long we honor a server-provided Retry-After header.
-MAX_RETRY_AFTER_SECONDS = 120
-
-
-class DelightedRetryableError(Exception):
-    def __init__(self, message: str, retry_after: Optional[float] = None):
-        super().__init__(message)
-        self.retry_after = retry_after
-
-
-class DelightedUnexpectedRedirectError(Exception):
-    """Raised when the API host returns a redirect we refuse to follow (SSRF guard)."""
 
 
 @dataclasses.dataclass
 class DelightedResumeConfig:
     next_url: str
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    # Delighted uses Basic auth with the API key as the username and a blank password.
-    token = base64.b64encode(f"{api_key}:".encode("ascii")).decode("ascii")
-    return {
-        "Authorization": f"Basic {token}",
-        "Accept": "application/json",
-    }
 
 
 def _to_epoch(value: Any) -> Optional[int]:
@@ -74,26 +57,6 @@ def _to_epoch(value: Any) -> Optional[int]:
         return int(value)
     except (TypeError, ValueError):
         return None
-
-
-def _is_delighted_url(url: str) -> bool:
-    """Whether ``url`` points at the Delighted API host over HTTPS.
-
-    Pagination/resume URLs are server-controlled (Link header / state store), so we pin them to
-    the API host to avoid forwarding the Authorization header to an arbitrary address (SSRF).
-    """
-    try:
-        parsed = urlparse(url)
-        return parsed.scheme == "https" and (parsed.hostname or "").lower() == DELIGHTED_HOST
-    except Exception:
-        return False
-
-
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    clean_params = {key: value for key, value in params.items() if value is not None}
-    if not clean_params:
-        return f"{DELIGHTED_BASE_URL}{path}"
-    return f"{DELIGHTED_BASE_URL}{path}?{urlencode(clean_params)}"
 
 
 def _build_params(
@@ -132,136 +95,69 @@ def _next_page_url(url: str) -> str:
     return urlunsplit((scheme, netloc, path, urlencode(query_params), fragment))
 
 
-def _next_url(
-    response: requests.Response, current_url: str, items_count: int, config: DelightedEndpointConfig
-) -> Optional[str]:
-    # Prefer an explicit Link header cursor (people uses RFC 5988 `rel="next"`); fall back to
-    # page-number increments for page/per_page endpoints. The page-based endpoints signal the
-    # end of results only by returning a short page, so a final empty page may be fetched when
-    # the row count is an exact multiple of the page size.
-    link_next = response.links.get("next", {}).get("url")
-    if link_next and _is_delighted_url(link_next):
-        return link_next
+class DelightedPaginator(BasePaginator):
+    """Reproduces Delighted's mixed list pagination.
 
-    if config.pagination == "page" and items_count == PAGE_SIZE:
-        return _next_page_url(current_url)
+    A server-provided RFC 5988 ``Link`` header ``rel="next"`` cursor takes priority (the
+    ``people`` endpoint paginates this way). Otherwise page/per_page list endpoints advance by
+    incrementing the ``page`` query param while a full page comes back; a short page ends the run.
 
-    return None
+    Off-host ``next`` links are not filtered here — the client's ``allowed_hosts`` pin rejects any
+    request to a host other than the API host before it leaves the process, so a tampered link
+    raises rather than forwarding the Authorization header off-host (SSRF).
+    """
 
+    def __init__(self, page_mode: bool, page_size: int) -> None:
+        super().__init__()
+        self.page_mode = page_mode
+        self.page_size = page_size
+        self._next_url: Optional[str] = None
 
-def _parse_retry_after(response: requests.Response) -> Optional[float]:
-    header = response.headers.get("Retry-After")
-    if header is None:
-        return None
-    try:
-        return max(float(header), 0.0)
-    except (TypeError, ValueError):
-        return None
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume URL to the first request so a resumed run starts at the saved
+        # next-page link rather than the base path.
+        if self._next_url is not None:
+            request.url = self._next_url
+            request.params = {}
 
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        link_next = response.links.get("next", {}).get("url") if response.links else None
+        if link_next:
+            self._next_url = link_next
+            self._has_next_page = True
+            return
 
-def _retry_wait(retry_state: RetryCallState) -> float:
-    exception = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exception, DelightedRetryableError) and exception.retry_after is not None:
-        return min(exception.retry_after, MAX_RETRY_AFTER_SECONDS)
-    return wait_exponential_jitter(initial=1, max=60)(retry_state)
+        # Page-number endpoints signal the end of results only by returning a short page, so a
+        # final empty page may be fetched when the row count is an exact multiple of the page size.
+        self._next_url = None
+        if self.page_mode and data is not None and len(data) == self.page_size:
+            self._next_url = _next_page_url(response.url)
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
 
+    def update_request(self, request: Request) -> None:
+        if self._next_url is not None:
+            request.url = self._next_url
+            # The next-page URL is self-contained; drop the original params so prepare_request
+            # doesn't re-append them each page.
+            request.params = {}
 
-def validate_credentials(api_key: str) -> bool:
-    """Confirm the API key is valid. /v1/metrics.json is a cheap authenticated probe."""
-    try:
-        response = make_tracked_session().get(
-            f"{DELIGHTED_BASE_URL}/metrics.json",
-            headers=_get_headers(api_key),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"next_url": self._next_url} if self._has_next_page and self._next_url is not None else None
 
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DelightedResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = DELIGHTED_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-
-    since_value = _to_epoch(db_incremental_field_last_value) if should_use_incremental_field else None
-    cursor_field = incremental_field if should_use_incremental_field else None
-
-    @retry(
-        retry=retry_if_exception_type((DelightedRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_retry_wait,
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> requests.Response:
-        # Don't follow redirects: a 3xx from the API host could point at an internal address,
-        # bypassing the host validation done before the request and leaking the API key (SSRF).
-        response = make_tracked_session().get(
-            page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False
-        )
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise DelightedRetryableError(
-                f"Delighted API error (retryable): status={response.status_code}, url={page_url}",
-                retry_after=_parse_retry_after(response),
-            )
-
-        # A 3xx isn't an error status (`response.ok` is True), so reject it explicitly rather than
-        # silently parsing the redirect body as data.
-        if response.is_redirect or response.is_permanent_redirect:
-            raise DelightedUnexpectedRedirectError(
-                f"Delighted API returned an unexpected redirect (status={response.status_code}); refusing to follow it"
-            )
-
-        if not response.ok:
-            logger.error(f"Delighted API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response
-
-    if config.pagination == "none":
-        data = fetch_page(_build_url(config.path, {})).json()
-        rows = data if isinstance(data, list) else [data]
-        if rows:
-            yield rows
-        return
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None and _is_delighted_url(resume_config.next_url):
-        url: str = resume_config.next_url
-        logger.debug(f"Delighted: resuming from URL: {url}")
-    else:
-        if resume_config is not None:
-            logger.warning("Delighted: ignoring resume URL whose host does not match the Delighted API host")
-        url = _build_url(config.path, _build_params(config, cursor_field, since_value))
-
-    while True:
-        response = fetch_page(url)
-        data = response.json()
-        items = data if isinstance(data, list) else []
-
-        if items:
-            yield items
-
-        next_url = _next_url(response, url, len(items), config)
-        if not next_url:
-            break
-
-        resumable_source_manager.save_state(DelightedResumeConfig(next_url=next_url))
-        url = next_url
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_url = state.get("next_url")
+        if next_url is not None:
+            self._next_url = next_url
+            self._has_next_page = True
 
 
 def delighted_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[DelightedResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -269,17 +165,66 @@ def delighted_source(
 ) -> SourceResponse:
     config = DELIGHTED_ENDPOINTS[endpoint]
 
+    since_value = _to_epoch(db_incremental_field_last_value) if should_use_incremental_field else None
+    cursor_field = incremental_field if should_use_incremental_field else None
+    params = _build_params(config, cursor_field, since_value)
+
+    paginator: BasePaginator = (
+        SinglePagePaginator()
+        if config.pagination == "none"
+        else DelightedPaginator(page_mode=config.pagination == "page", page_size=PAGE_SIZE)
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": DELIGHTED_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Basic auth: the API key is the username, password is blank. Supplied via the framework
+            # auth config so the credential participates in log redaction.
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            # Pin every request (paginator next links and seeded resume URLs included) to the API
+            # host, and refuse to follow redirects: a server-controlled next/redirect must never
+            # carry the Authorization header to another origin (SSRF). Base host is implicitly
+            # allowed, so an empty list means "the Delighted API host only".
+            "allowed_hosts": [],
+            "allow_redirects": False,
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.pagination != "none" and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(DelightedResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key] if config.primary_key else None,
         sort_mode="asc",
         partition_count=1,
@@ -287,4 +232,15 @@ def delighted_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Confirm the API key is valid. /v1/metrics.json is a cheap authenticated probe."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{DELIGHTED_BASE_URL}/metrics.json",
+        auth=HttpBasicAuth(username=api_key, password=""),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/delighted/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/delighted/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted import (
     DelightedResumeConfig,
     delighted_source,
@@ -97,21 +100,7 @@ You can find your API key in your Delighted account under **Settings → API**. 
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=(incremental_fields := INCREMENTAL_FIELDS.get(endpoint)) is not None,
-                supports_append=incremental_fields is not None,
-                incremental_fields=incremental_fields or [],
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: DelightedSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -133,7 +122,8 @@ You can find your API key in your Delighted account under **Settings → API**. 
         return delighted_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/delighted/tests/test_delighted.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/delighted/tests/test_delighted.py
@@ -1,30 +1,54 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, urlencode, urlsplit
 
 import pytest
 from unittest import mock
 
+from requests import HTTPError, Response
+from requests.structures import CaseInsensitiveDict
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted import (
     PAGE_SIZE,
     DelightedResumeConfig,
-    DelightedRetryableError,
-    DelightedUnexpectedRedirectError,
     _build_params,
-    _build_url,
-    _is_delighted_url,
     _next_page_url,
-    _parse_retry_after,
-    _retry_wait,
     _to_epoch,
     delighted_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.delighted.settings import (
     DELIGHTED_ENDPOINTS,
     ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the delighted module.
+DELIGHTED_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
+)
+
+
+def _response(
+    body: Any,
+    *,
+    status_code: int = 200,
+    url: str = "https://api.delighted.com/v1/survey_responses.json",
+    links_next: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.url = url
+    resp.reason = "Unauthorized" if status_code == 401 else ""
+    resp._content = json.dumps(body).encode()
+    hdrs = dict(headers or {})
+    if links_next is not None:
+        hdrs["Link"] = f'<{links_next}>; rel="next"'
+    resp.headers = CaseInsensitiveDict(hdrs)
+    return resp
 
 
 def _make_manager(resume_state: DelightedResumeConfig | None = None) -> mock.MagicMock:
@@ -34,25 +58,43 @@ def _make_manager(resume_state: DelightedResumeConfig | None = None) -> mock.Mag
     return manager
 
 
-def _response(
-    body: Any,
-    status_code: int = 200,
-    links: dict[str, dict[str, str]] | None = None,
-    headers: dict[str, str] | None = None,
-) -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.json.return_value = body
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.is_redirect = status_code in (301, 302, 303, 307, 308)
-    response.is_permanent_redirect = status_code in (301, 308)
-    response.links = links or {}
-    response.headers = headers or {}
-    return response
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[str], list[dict[str, Any]]]:
+    """Wire a mock session; return per-request (sent URL, params snapshot) captured at prepare time.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy each time
+    the request is prepared. ``prepared.url`` is what the allowed-host check and the paginator see,
+    so mirror how ``requests`` merges query params into the URL.
+    """
+    session.headers = {}
+    url_snapshots: list[str] = []
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        url = request.url
+        if request.params:
+            sep = "&" if urlsplit(url).query else "?"
+            url = f"{url}{sep}{urlencode(request.params)}"
+        url_snapshots.append(url)
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return url_snapshots, param_snapshots
 
 
 def _query_params(url: str) -> dict[str, str]:
     return {key: values[-1] for key, values in parse_qs(urlsplit(url).query).items()}
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return delighted_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
 
 
 class TestToEpoch:
@@ -125,32 +167,6 @@ class TestBuildParams:
         assert _build_params(DELIGHTED_ENDPOINTS["metrics"], incremental_field=None, since_value=None) == {}
 
 
-class TestBuildUrl:
-    def test_no_params(self):
-        assert _build_url("/metrics.json", {}) == "https://api.delighted.com/v1/metrics.json"
-
-    def test_drops_none_values_and_encodes(self):
-        url = _build_url("/people.json", {"per_page": 100, "since": None})
-        assert url == "https://api.delighted.com/v1/people.json?per_page=100"
-
-
-class TestIsDelightedUrl:
-    @pytest.mark.parametrize(
-        "url, expected",
-        [
-            ("https://api.delighted.com/v1/people.json?page=2", True),
-            ("https://API.DELIGHTED.COM/v1/people.json", True),
-            ("http://api.delighted.com/v1/people.json", False),
-            ("https://evil.example.com/steal", False),
-            ("https://api.delighted.com.evil.example.com/steal", False),
-            ("not a url", False),
-            ("", False),
-        ],
-    )
-    def test_only_https_api_host_is_allowed(self, url, expected):
-        assert _is_delighted_url(url) is expected
-
-
 class TestNextPageUrl:
     @pytest.mark.parametrize(
         "url, expected_page",
@@ -174,50 +190,6 @@ class TestNextPageUrl:
         assert params["since"] == "1700000000"
 
 
-class TestParseRetryAfter:
-    @pytest.mark.parametrize(
-        "header, expected",
-        [
-            (None, None),
-            ("5", 5.0),
-            ("0", 0.0),
-            ("2.5", 2.5),
-            ("-3", 0.0),
-            ("soon", None),
-        ],
-    )
-    def test_parse_retry_after_values(self, header, expected):
-        headers = {} if header is None else {"Retry-After": header}
-        assert _parse_retry_after(_response([], headers=headers)) == expected
-
-
-class TestRetryWait:
-    def _retry_state(self, exception: Exception | None) -> mock.MagicMock:
-        state = mock.MagicMock()
-        state.attempt_number = 1
-        state.outcome.exception.return_value = exception
-        return state
-
-    def test_uses_server_retry_after_when_present(self):
-        state = self._retry_state(DelightedRetryableError("rate limited", retry_after=7.0))
-        assert _retry_wait(state) == 7.0
-
-    def test_caps_server_retry_after(self):
-        state = self._retry_state(DelightedRetryableError("rate limited", retry_after=9999.0))
-        assert _retry_wait(state) == 120.0
-
-    @pytest.mark.parametrize(
-        "exception",
-        [
-            DelightedRetryableError("server error", retry_after=None),
-            ValueError("boom"),
-        ],
-    )
-    def test_falls_back_to_exponential_backoff(self, exception):
-        state = self._retry_state(exception)
-        assert 0 <= _retry_wait(state) <= 60
-
-
 class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected",
@@ -228,255 +200,236 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
+    @mock.patch(DELIGHTED_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
-        mock_session.return_value.get.return_value = _response({}, status_code=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         assert validate_credentials("key") is expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
+    @mock.patch(DELIGHTED_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("key") is False
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
+    @mock.patch(DELIGHTED_SESSION_PATCH)
     def test_validate_credentials_uses_basic_auth_with_blank_password(self, mock_session):
-        mock_session.return_value.get.return_value = _response({}, status_code=200)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
         validate_credentials("my-key")
 
-        headers = mock_session.return_value.get.call_args.kwargs["headers"]
+        auth = mock_session.return_value.get.call_args.kwargs["auth"]
+        prepared = mock.MagicMock()
+        prepared.headers = {}
+        auth(prepared)
         # base64("my-key:")
-        assert headers["Authorization"] == "Basic bXkta2V5Og=="
+        assert prepared.headers["Authorization"] == "Basic bXkta2V5Og=="
 
 
-class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_page_pagination_advances_until_short_page(self, mock_session):
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_page_pagination_advances_until_short_page(self, MockSession):
+        session = MockSession.return_value
         full_page = [{"person_id": str(i), "bounced_at": i} for i in range(PAGE_SIZE)]
         short_page = [{"person_id": "x", "bounced_at": 999}]
-        mock_session.return_value.get.side_effect = [_response(full_page), _response(short_page)]
+        urls, _ = _wire(
+            session,
+            [
+                _response(full_page, url="https://api.delighted.com/v1/bounces.json?per_page=100"),
+                _response(short_page, url="https://api.delighted.com/v1/bounces.json?per_page=100&page=2"),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("key", "bounces", mock.MagicMock(), manager))
+        rows = _rows(_source("bounces", manager))
 
-        assert len(batches) == 2
-        assert len(batches[0]) == PAGE_SIZE
-        assert batches[1] == short_page
-
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert _query_params(second_url)["page"] == "2"
+        assert len(rows) == PAGE_SIZE + 1
+        assert rows[-1] == short_page[0]
+        assert _query_params(urls[1])["page"] == "2"
 
         # State is saved only while a next page exists.
         manager.save_state.assert_called_once()
         assert _query_params(manager.save_state.call_args.args[0].next_url)["page"] == "2"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_link_header_pagination_follows_next_url(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_link_header_pagination_follows_next_url(self, MockSession):
+        session = MockSession.return_value
         next_url = "https://api.delighted.com/v1/people.json?page_info=abc123&per_page=100"
-        first = _response([{"id": "1"}], links={"next": {"url": next_url}})
-        second = _response([{"id": "2"}])
-        mock_session.return_value.get.side_effect = [first, second]
+        urls, _ = _wire(
+            session,
+            [_response([{"id": "1"}], links_next=next_url), _response([{"id": "2"}])],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("key", "people", mock.MagicMock(), manager))
+        rows = _rows(_source("people", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["1", "2"]
-        assert mock_session.return_value.get.call_args_list[1].args[0] == next_url
+        assert [r["id"] for r in rows] == ["1", "2"]
+        assert urls[1] == next_url
         manager.save_state.assert_called_once()
         assert manager.save_state.call_args.args[0].next_url == next_url
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_link_header_takes_priority_over_page_counting(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_link_header_takes_priority_over_page_counting(self, MockSession):
+        session = MockSession.return_value
         next_url = "https://api.delighted.com/v1/survey_responses.json?page_info=zzz"
         full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
-        first = _response(full_page, links={"next": {"url": next_url}})
-        second = _response([])
-        mock_session.return_value.get.side_effect = [first, second]
+        urls, _ = _wire(
+            session,
+            [_response(full_page, links_next=next_url), _response([])],
+        )
 
         manager = _make_manager()
-        list(get_rows("key", "survey_responses", mock.MagicMock(), manager))
+        _rows(_source("survey_responses", manager))
 
-        assert mock_session.return_value.get.call_args_list[1].args[0] == next_url
+        assert urls[1] == next_url
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_resumes_from_saved_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "9"}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession):
+        session = MockSession.return_value
+        urls, _ = _wire(session, [_response([{"id": "9"}])])
 
         resume_url = "https://api.delighted.com/v1/survey_responses.json?page=5&per_page=100"
         manager = _make_manager(DelightedResumeConfig(next_url=resume_url))
 
-        list(get_rows("key", "survey_responses", mock.MagicMock(), manager))
+        _rows(_source("survey_responses", manager))
 
-        assert mock_session.return_value.get.call_args_list[0].args[0] == resume_url
+        assert urls[0] == resume_url
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_fetch_page_disables_redirects(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fetch_disables_redirects(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
-        list(get_rows("key", "survey_responses", mock.MagicMock(), _make_manager()))
+        _rows(_source("survey_responses", _make_manager()))
 
-        assert mock_session.return_value.get.call_args.kwargs["allow_redirects"] is False
+        assert session.send.call_args.kwargs["allow_redirects"] is False
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_unexpected_redirect_is_rejected(self, mock_session):
-        mock_session.return_value.get.return_value = _response([], status_code=302)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unexpected_redirect_is_rejected(self, MockSession):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response([], status_code=302, headers={"Location": "https://internal.example.com/"})],
+        )
 
-        with pytest.raises(DelightedUnexpectedRedirectError):
-            list(get_rows("key", "survey_responses", mock.MagicMock(), _make_manager()))
+        with pytest.raises(ValueError, match="[Rr]edirect"):
+            _rows(_source("survey_responses", _make_manager()))
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_offhost_link_header_is_not_followed(self, mock_session):
-        # A server-controlled Link header pointing off-host must not receive the API credentials.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_offhost_link_header_is_rejected(self, MockSession):
+        # A server-controlled Link header pointing off-host must not receive the API credentials:
+        # the host pin rejects it before the request leaves the process.
+        session = MockSession.return_value
         full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
-        first = _response(full_page, links={"next": {"url": "https://evil.example.com/steal"}})
-        second = _response([])
-        mock_session.return_value.get.side_effect = [first, second]
+        _wire(session, [_response(full_page, links_next="https://evil.example.com/steal"), _response([])])
 
-        list(get_rows("key", "survey_responses", mock.MagicMock(), _make_manager()))
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("survey_responses", _make_manager()))
 
-        # Falls back to page-number increment on the API host rather than the off-host URL.
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert second_url.startswith("https://api.delighted.com/")
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_offhost_resume_url_is_ignored(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_offhost_resume_url_is_rejected(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
         manager = _make_manager(DelightedResumeConfig(next_url="https://evil.example.com/steal"))
-        list(get_rows("key", "survey_responses", mock.MagicMock(), manager))
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert first_url.startswith("https://api.delighted.com/")
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("survey_responses", manager))
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_incremental_request_params_for_updated_at_cursor(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_params_for_updated_at_cursor(self, MockSession):
+        session = MockSession.return_value
+        _, params = _wire(session, [_response([])])
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
+        _rows(
+            _source(
                 "survey_responses",
-                mock.MagicMock(),
-                manager,
+                _make_manager(),
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=1700000000,
                 incremental_field="updated_at",
             )
         )
 
-        params = _query_params(mock_session.return_value.get.call_args.args[0])
-        assert params["updated_since"] == "1700000000"
-        assert params["order"] == "asc:updated_at"
+        assert params[0]["updated_since"] == 1700000000
+        assert params[0]["order"] == "asc:updated_at"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_full_refresh_ignores_incremental_field(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_ignores_incremental_field(self, MockSession):
+        session = MockSession.return_value
+        _, params = _wire(session, [_response([])])
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
+        _rows(
+            _source(
                 "survey_responses",
-                mock.MagicMock(),
-                manager,
+                _make_manager(),
                 should_use_incremental_field=False,
                 db_incremental_field_last_value=1700000000,
                 incremental_field="updated_at",
             )
         )
 
-        params = _query_params(mock_session.return_value.get.call_args.args[0])
-        assert "updated_since" not in params
-        assert params["order"] == "asc"
+        assert "updated_since" not in params[0]
+        assert params[0]["order"] == "asc"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_empty_response_stops(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "unsubscribes", mock.MagicMock(), manager))
+        rows = _rows(_source("unsubscribes", manager))
 
-        assert batches == []
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_metrics_yields_single_row_without_pagination(self, mock_session):
-        mock_session.return_value.get.return_value = _response({"nps": 42, "response_count": 10})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_metrics_yields_single_row_without_pagination(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"nps": 42, "response_count": 10}, url="https://api.delighted.com/v1/metrics.json")])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "metrics", mock.MagicMock(), manager))
+        rows = _rows(_source("metrics", manager))
 
-        assert batches == [[{"nps": 42, "response_count": 10}]]
-        assert mock_session.return_value.get.call_count == 1
+        assert rows == [{"nps": 42, "response_count": 10}]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
         manager.can_resume.assert_not_called()
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_retries_429_honoring_retry_after_then_succeeds(self, mock_session):
-        rate_limited = _response({}, status_code=429, headers={"Retry-After": "0"})
-        ok = _response([{"id": "1"}])
-        mock_session.return_value.get.side_effect = [rate_limited, ok]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_429_honoring_retry_after_then_succeeds(self, MockSession):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status_code=429, headers={"Retry-After": "0"}),
+                _response([{"id": "1"}]),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("key", "people", mock.MagicMock(), manager))
+        rows = _rows(_source("people", manager))
 
-        assert batches == [[{"id": "1"}]]
-        assert mock_session.return_value.get.call_count == 2
+        assert rows == [{"id": "1"}]
+        assert session.send.call_count == 2
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.delighted.delighted.make_tracked_session"
-    )
-    def test_non_retryable_status_raises_immediately(self, mock_session):
-        unauthorized = _response({}, status_code=401)
-        unauthorized.raise_for_status.side_effect = Exception("401 Client Error")
-        mock_session.return_value.get.return_value = unauthorized
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_retryable_status_raises_immediately(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=401, url="https://api.delighted.com/v1/people.json")])
 
         manager = _make_manager()
-        with pytest.raises(Exception, match="401 Client Error"):
-            list(get_rows("key", "people", mock.MagicMock(), manager))
+        with pytest.raises(HTTPError, match="401"):
+            _rows(_source("people", manager))
 
-        assert mock_session.return_value.get.call_count == 1
+        assert session.send.call_count == 1
 
 
 class TestDelightedSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = DELIGHTED_ENDPOINTS[endpoint]
-        response = delighted_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.sort_mode == "asc"
@@ -501,7 +454,7 @@ class TestDelightedSourceResponse:
         ],
     )
     def test_primary_key_per_endpoint(self, endpoint, expected_primary_key):
-        response = delighted_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
         assert response.primary_keys == [expected_primary_key]
 
     @pytest.mark.parametrize("config", list(DELIGHTED_ENDPOINTS.values()))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deno_deploy/deno_deploy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deno_deploy/deno_deploy.py
@@ -1,18 +1,22 @@
-import re
 import hashlib
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Optional
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+    JSONResponseCursorPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.deno_deploy.settings import (
     DENO_DEPLOY_ENDPOINTS,
     DenoDeployEndpointConfig,
@@ -24,47 +28,31 @@ DENO_DEPLOY_BASE_URL = f"https://{DENO_DEPLOY_HOST}"
 # Default page size for the cursor-paginated list endpoints (API default is 30, max 100).
 DEFAULT_LIST_PAGE_SIZE = 100
 
-
-class DenoDeployRetryableError(Exception):
-    pass
-
-
-def _require_deno_deploy_url(url: str) -> str:
-    """SSRF guard for every authenticated request. The bearer token is attached to whatever URL we
-    fetch, and both pagination `Link` headers and persisted resume URLs are attacker-influenceable, so
-    only accept HTTPS URLs whose host is exactly `api.deno.com` before the token can be forwarded."""
-    try:
-        parts = urlsplit(url)
-    except ValueError as e:
-        raise ValueError(f"Refusing to fetch malformed Deno Deploy URL: {e}")
-    if parts.scheme != "https" or parts.hostname != DENO_DEPLOY_HOST:
-        raise ValueError(f"Refusing to fetch off-host Deno Deploy URL (host={parts.hostname!r})")
-    return url
-
-
-def _make_session(access_token: str) -> requests.Session:
-    """A tracked session that (1) masks the bearer token in logged URLs and captured samples and
-    (2) never follows redirects, so a tampered response can't bounce the `Authorization` header to an
-    attacker-controlled host."""
-    return make_tracked_session(redact_values=(access_token,), allow_redirects=False)
+# Name of the parent resource every fan-out endpoint hangs off. Its id/slug are carried into each
+# child row via include_from_parent, which the framework surfaces as `_apps_id` / `_apps_slug`.
+_APPS_RESOURCE = "apps"
+_PARENT_ID_KEY = f"_{_APPS_RESOURCE}_id"
+_PARENT_SLUG_KEY = f"_{_APPS_RESOURCE}_slug"
 
 
 @dataclasses.dataclass
 class DenoDeployResumeConfig:
-    # Full URL of the next page to fetch. None means "start this app's endpoint at its first page" —
-    # used when the bookmark advances to a fan-out app whose first-page URL isn't known until built.
+    # Full URL of the next page to fetch, for the top-level (non-fan-out) list endpoints. This is the
+    # legacy field name; a saved state written before the rest_source migration still parses here.
     next_url: str | None = None
-    # The fan-out app currently being processed, as a stable app id (not a positional index) so apps
-    # added/removed between a crash and the retry can't resume into the wrong app. None for the
-    # top-level (non-fan-out) endpoints.
+    # Legacy fan-out bookmark (stable app id). Retained so old saved state parses; the rest_source
+    # fan-out now checkpoints under `fanout_state` instead, and a state carrying only this restarts
+    # the fan-out from scratch (the merge dedupes the re-pulled rows).
     app_id: str | None = None
+    # rest_source fan-out resume snapshot: {"completed": [child_path, ...], "current": child_path |
+    # None, "child_state": {...} | None}. Skips fully-synced apps and resumes the in-progress one.
+    fanout_state: dict[str, Any] | None = None
 
 
-def _get_headers(access_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json",
-    }
+def _headers() -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs; only
+    # the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def _format_rfc3339(dt: datetime) -> str:
@@ -80,131 +68,6 @@ def _as_utc_datetime(value: Any) -> datetime | None:
     if isinstance(value, date):
         return datetime.combine(value, datetime.min.time(), tzinfo=UTC)
     return None
-
-
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    if not params:
-        return f"{DENO_DEPLOY_BASE_URL}{path}"
-    return f"{DENO_DEPLOY_BASE_URL}{path}?{urlencode(params)}"
-
-
-def _parse_next_link(link_header: str) -> str | None:
-    """Return the URL with rel="next" from Deno Deploy's Link header, if any.
-
-    The header looks like: `Link: </v2/apps?cursor=eyJ...&limit=30>; rel="next"`. The URL may be
-    relative to the API host, so resolve it against the base URL."""
-    if not link_header:
-        return None
-    for part in link_header.split(","):
-        match = re.search(r'<([^>]+)>;\s*rel="next"', part.strip())
-        if match:
-            url = match.group(1)
-            if url.startswith("/"):
-                return f"{DENO_DEPLOY_BASE_URL}{url}"
-            return url
-    return None
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            DenoDeployRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> requests.Response:
-    # Validate every URL at the single choke point where the token is attached: this covers freshly
-    # built URLs, `Link`-header continuations, logs cursors, and persisted resume URLs alike.
-    _require_deno_deploy_url(url)
-    response = session.get(url, headers=headers, timeout=60)
-
-    # Rate limits aren't documented in the spec; treat 429 and 5xx as transient and retry.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise DenoDeployRetryableError(f"Deno Deploy API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Deno Deploy API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response
-
-
-def validate_credentials(access_token: str) -> tuple[bool, str | None]:
-    """Confirm the org access token is genuine with one cheap probe against the apps list."""
-    url = _require_deno_deploy_url(_build_url("/v2/apps", {"limit": 1}))
-    try:
-        response = _make_session(access_token).get(url, headers=_get_headers(access_token), timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
-
-    if response.status_code == 200:
-        return True, None
-    if response.status_code == 401:
-        return False, "Invalid Deno Deploy access token. Create a new organization access token and reconnect."
-    if response.status_code == 403:
-        return False, "Your Deno Deploy access token does not have permission to read this organization's data."
-
-    try:
-        message = response.json().get("message", response.text)
-    except ValueError:
-        message = response.text
-    return False, message
-
-
-def _iter_app_refs(
-    session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger
-) -> Iterator[tuple[str, str]]:
-    """Page through /v2/apps and yield each app's (id, slug), following the Link header cursor."""
-    url: str | None = _build_url("/v2/apps", {"limit": DEFAULT_LIST_PAGE_SIZE})
-    while url:
-        response = _fetch(session, url, headers, logger)
-        data = response.json()
-        for app in data if isinstance(data, list) else []:
-            yield app["id"], app.get("slug", "")
-        url = _parse_next_link(response.headers.get("Link", ""))
-
-
-def _log_row_id(app_id: str, log: dict[str, Any]) -> str:
-    """Runtime log lines carry no natural id, so synthesize a stable content hash. Merging on it makes
-    re-pulling the overlapping boundary window idempotent (identical lines collapse to one row). Two
-    genuinely distinct lines identical across every field would also collapse — an accepted, rare loss
-    for a source without log ids."""
-    parts = [
-        app_id,
-        str(log.get("timestamp", "")),
-        str(log.get("level", "")),
-        str(log.get("message", "")),
-        str(log.get("revision_id", "")),
-        str(log.get("region", "")),
-        str(log.get("trace_id", "")),
-        str(log.get("span_id", "")),
-    ]
-    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
-
-
-def _shape_log(log: dict[str, Any], app_id: str, app_slug: str) -> dict[str, Any]:
-    return {**log, "app_id": app_id, "app_slug": app_slug, "id": _log_row_id(app_id, log)}
-
-
-def _reshape_analytics(body: dict[str, Any], app_id: str, app_slug: str) -> list[dict[str, Any]]:
-    """Deno returns analytics as a columnar {fields: [{name}], values: [[...], ...]} payload. Reshape
-    it into one dict per time bucket keyed by field name (the docs say to map by name, not position)."""
-    field_names = [f["name"] for f in body.get("fields", [])]
-    rows: list[dict[str, Any]] = []
-    for value_row in body.get("values", []):
-        row: dict[str, Any] = dict(zip(field_names, value_row))
-        row["app_id"] = app_id
-        row["app_slug"] = app_slug
-        rows.append(row)
-    return rows
 
 
 def _time_window_params(
@@ -229,176 +92,213 @@ def _time_window_params(
     return _format_rfc3339(start), _format_rfc3339(now)
 
 
-def _initial_child_url(
-    config: DenoDeployEndpointConfig,
-    app_id: str,
+def _log_row_id(app_id: str, log: dict[str, Any]) -> str:
+    """Runtime log lines carry no natural id, so synthesize a stable content hash. Merging on it makes
+    re-pulling the overlapping boundary window idempotent (identical lines collapse to one row). Two
+    genuinely distinct lines identical across every field would also collapse — an accepted, rare loss
+    for a source without log ids."""
+    parts = [
+        app_id,
+        str(log.get("timestamp", "")),
+        str(log.get("level", "")),
+        str(log.get("message", "")),
+        str(log.get("revision_id", "")),
+        str(log.get("region", "")),
+        str(log.get("trace_id", "")),
+        str(log.get("span_id", "")),
+    ]
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+def _reshape_analytics(body: dict[str, Any], app_id: str, app_slug: str) -> list[dict[str, Any]]:
+    """Deno returns analytics as a columnar {fields: [{name}], values: [[...], ...]} payload. Reshape
+    it into one dict per time bucket keyed by field name (the docs say to map by name, not position)."""
+    field_names = [f["name"] for f in body.get("fields", [])]
+    rows: list[dict[str, Any]] = []
+    for value_row in body.get("values", []):
+        row: dict[str, Any] = dict(zip(field_names, value_row))
+        row["app_id"] = app_id
+        row["app_slug"] = app_slug
+        rows.append(row)
+    return rows
+
+
+def _ensure_parent_slug(app: dict[str, Any]) -> dict[str, Any]:
+    # The fan-out carries the parent slug into every child row; default it so an app without a slug
+    # doesn't fail the include_from_parent lookup (the hand-rolled source used app.get("slug", "")).
+    app.setdefault("slug", "")
+    return app
+
+
+def _list_child_map(row: dict[str, Any]) -> dict[str, Any]:
+    # Rename the framework's include_from_parent keys back to the flat app_id / app_slug the child
+    # rows carried before the migration.
+    row["app_id"] = row.pop(_PARENT_ID_KEY)
+    row["app_slug"] = row.pop(_PARENT_SLUG_KEY)
+    return row
+
+
+def _logs_child_map(row: dict[str, Any]) -> dict[str, Any]:
+    app_id = row.pop(_PARENT_ID_KEY)
+    app_slug = row.pop(_PARENT_SLUG_KEY)
+    # `row` still holds only the raw log fields, so the content hash matches the pre-migration id.
+    row_id = _log_row_id(app_id, row)
+    row["app_id"] = app_id
+    row["app_slug"] = app_slug
+    row["id"] = row_id
+    return row
+
+
+def _analytics_child_map(body: dict[str, Any]) -> list[dict[str, Any]]:
+    app_id = body.pop(_PARENT_ID_KEY)
+    app_slug = body.pop(_PARENT_SLUG_KEY)
+    return _reshape_analytics(body, app_id, app_slug)
+
+
+def _apps_parent_resource() -> EndpointResource:
+    # Parent list driving the fan-out. A separate dict per call — config setup mutates it.
+    return {
+        "name": _APPS_RESOURCE,
+        "endpoint": {
+            "path": "/v2/apps",
+            "params": {"limit": DEFAULT_LIST_PAGE_SIZE},
+            "paginator": HeaderLinkPaginator(),
+        },
+        "data_map": _ensure_parent_slug,
+    }
+
+
+def _resource_chain(
+    endpoint: str,
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Any,
-) -> str:
-    path = config.path.format(app=app_id)
+) -> list[EndpointResource]:
+    config = DENO_DEPLOY_ENDPOINTS[endpoint]
+
+    if not config.fan_out_over_apps:
+        # Top-level cursor-paginated list (apps, domains): a plain Link-header list, rows used as-is.
+        return [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": config.page_size or DEFAULT_LIST_PAGE_SIZE},
+                    "paginator": HeaderLinkPaginator(),
+                },
+            }
+        ]
+
+    resolve_app = {"type": "resolve", "resource": _APPS_RESOURCE, "field": "id"}
+
     if config.kind == "logs":
         start, end = _time_window_params(config, should_use_incremental_field, db_incremental_field_last_value)
-        return _build_url(path, {"start": start, "end": end, "limit": config.page_size or 1000})
-    if config.kind == "analytics":
+        child: EndpointResource = {
+            "name": endpoint,
+            "endpoint": {
+                "path": config.path,
+                "params": {
+                    "app": resolve_app,
+                    "start": start,
+                    "end": end,
+                    "limit": config.page_size or 1000,
+                },
+                "data_selector": "logs",
+                # Cursor lives in the body (`next_cursor`); echo it as `cursor`, preserving start/end/limit.
+                "paginator": JSONResponseCursorPaginator(cursor_path="next_cursor", cursor_param="cursor"),
+            },
+            "include_from_parent": ["id", "slug"],
+            "data_map": _logs_child_map,
+        }
+    elif config.kind == "analytics":
         since, until = _time_window_params(config, should_use_incremental_field, db_incremental_field_last_value)
-        return _build_url(path, {"since": since, "until": until})
-    # Plain list child (revisions).
-    return _build_url(path, {"limit": config.page_size or DEFAULT_LIST_PAGE_SIZE})
-
-
-def _logs_next_url(current_url: str, next_cursor: str) -> str:
-    """The logs endpoint returns its cursor in the body (`next_cursor`), not a Link header. Rebuild the
-    next-page URL by swapping the `cursor` query param on the current URL, preserving start/end/limit.
-
-    `parse_qsl` decodes the existing (already percent-encoded) query values so `urlencode` re-encodes
-    them exactly once — splitting the raw query string by hand would double-encode `start`/`end`."""
-    parts = urlsplit(current_url)
-    params = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != "cursor"]
-    params.append(("cursor", next_cursor))
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(params), ""))
-
-
-def _parse_page(
-    config: DenoDeployEndpointConfig, response: requests.Response, app_id: str, app_slug: str
-) -> tuple[list[dict[str, Any]], str | None]:
-    """Return (rows, next_url) for one fetched page, shaped per endpoint kind."""
-    if config.kind == "logs":
-        body = response.json()
-        rows = [_shape_log(log, app_id, app_slug) for log in body.get("logs", [])]
-        next_cursor = body.get("next_cursor")
-        next_url = _logs_next_url(response.url, next_cursor) if next_cursor else None
-        return rows, next_url
-    if config.kind == "analytics":
-        return _reshape_analytics(response.json(), app_id, app_slug), None
-    # Plain list child (revisions): inject the parent app context the child response omits.
-    data = response.json()
-    rows = [{**item, "app_id": app_id, "app_slug": app_slug} for item in (data if isinstance(data, list) else [])]
-    return rows, _parse_next_link(response.headers.get("Link", ""))
-
-
-def _list_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    config: DenoDeployEndpointConfig,
-    resumable_source_manager: ResumableSourceManager[DenoDeployResumeConfig],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    """Top-level cursor-paginated list (apps, domains), following the Link header."""
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None and resume.next_url:
-        url: str | None = resume.next_url
-        logger.debug(f"Deno Deploy: resuming {config.name} from URL: {url}")
+        child = {
+            "name": endpoint,
+            "endpoint": {
+                "path": config.path,
+                "params": {"app": resolve_app, "since": since, "until": until},
+                # No data_selector: the columnar {fields, values} body is one item the data_map explodes.
+                "paginator": SinglePagePaginator(),
+            },
+            "include_from_parent": ["id", "slug"],
+            "data_map": _analytics_child_map,
+        }
     else:
-        url = _build_url(config.path, {"limit": config.page_size or DEFAULT_LIST_PAGE_SIZE})
+        # Plain fan-out list child (revisions): inject the parent app context the child response omits.
+        child = {
+            "name": endpoint,
+            "endpoint": {
+                "path": config.path,
+                "params": {"app": resolve_app, "limit": config.page_size or DEFAULT_LIST_PAGE_SIZE},
+                "paginator": HeaderLinkPaginator(),
+            },
+            "include_from_parent": ["id", "slug"],
+            "data_map": _list_child_map,
+        }
 
-    while url:
-        response = _fetch(session, url, headers, logger)
-        data = response.json()
-        rows = data if isinstance(data, list) else []
-        next_url = _parse_next_link(response.headers.get("Link", ""))
-        if rows:
-            yield rows
-        if not next_url:
-            break
-        # Save AFTER yielding so a crash mid-yield re-fetches this page rather than skipping it; merge
-        # dedupes the re-pulled rows on the primary key.
-        resumable_source_manager.save_state(DenoDeployResumeConfig(next_url=next_url))
-        url = next_url
-
-
-def _fan_out_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    config: DenoDeployEndpointConfig,
-    resumable_source_manager: ResumableSourceManager[DenoDeployResumeConfig],
-    logger: FilteringBoundLogger,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> Iterator[list[dict[str, Any]]]:
-    """Fan out over every app in the org, walking the child endpoint (revisions, analytics, logs) per
-    app. A stable app-id bookmark lets a retry resume mid-fan-out without re-walking finished apps."""
-    app_refs = list(_iter_app_refs(session, headers, logger))
-    app_ids = [ref[0] for ref in app_refs]
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_index = 0
-    resume_url: str | None = None
-    if resume is not None and resume.app_id is not None and resume.app_id in app_ids:
-        start_index = app_ids.index(resume.app_id)
-        resume_url = resume.next_url
-        logger.debug(f"Deno Deploy: resuming {config.name} fan-out from app_id={resume.app_id}, url={resume_url}")
-
-    for index in range(start_index, len(app_refs)):
-        app_id, app_slug = app_refs[index]
-        url: str | None = resume_url or _initial_child_url(
-            config, app_id, should_use_incremental_field, db_incremental_field_last_value
-        )
-        resume_url = None  # only the resumed-into app uses the saved URL; the rest start fresh
-
-        while url:
-            response = _fetch(session, url, headers, logger)
-            rows, next_url = _parse_page(config, response, app_id, app_slug)
-            if rows:
-                yield rows
-            if not next_url:
-                break
-            resumable_source_manager.save_state(DenoDeployResumeConfig(next_url=next_url, app_id=app_id))
-            url = next_url
-
-        # Advance the bookmark to the next app so a crash between apps resumes there; its first-page
-        # URL is rebuilt fresh when the loop reaches it.
-        if index + 1 < len(app_refs):
-            resumable_source_manager.save_state(DenoDeployResumeConfig(next_url=None, app_id=app_refs[index + 1][0]))
-
-
-def get_rows(
-    access_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DenoDeployResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = DENO_DEPLOY_ENDPOINTS[endpoint]
-    headers = _get_headers(access_token)
-    session = _make_session(access_token)
-
-    if config.fan_out_over_apps:
-        yield from _fan_out_rows(
-            session,
-            headers,
-            config,
-            resumable_source_manager,
-            logger,
-            should_use_incremental_field,
-            db_incremental_field_last_value,
-        )
-        return
-
-    yield from _list_rows(session, headers, config, resumable_source_manager, logger)
+    return [_apps_parent_resource(), child]
 
 
 def deno_deploy_source(
     access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[DenoDeployResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
-    endpoint_config = DENO_DEPLOY_ENDPOINTS[endpoint]
+    config = DENO_DEPLOY_ENDPOINTS[endpoint]
+    is_fan_out = config.fan_out_over_apps
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": DENO_DEPLOY_BASE_URL,
+            "headers": _headers(),
+            "auth": {"type": "bearer", "token": access_token},
+            # SSRF host-pinning: every request URL — including Link-header continuations and seeded
+            # resume URLs — must resolve to api.deno.com before the bearer token leaves the process,
+            # and redirects are rejected so a 3xx can't bounce the token to another origin.
+            "allowed_hosts": [DENO_DEPLOY_HOST],
+            "allow_redirects": False,
+        },
+        "resources": _resource_chain(endpoint, should_use_incremental_field, db_incremental_field_last_value),
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            if is_fan_out:
+                initial_paginator_state = resume.fanout_state
+            elif resume.next_url:
+                initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes) rather than skipping it.
+        if state is None:
+            return
+        if is_fan_out:
+            resumable_source_manager.save_state(DenoDeployResumeConfig(fanout_state=state))
+        elif state.get("next_url"):
+            resumable_source_manager.save_state(DenoDeployResumeConfig(next_url=state["next_url"]))
+
+    # The time window is baked into the endpoint params above, so the framework's incremental param
+    # injection is unused — pass a None watermark to keep it out of the request.
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    resource = next(r for r in resources if r.name == endpoint)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            access_token=access_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
-        primary_keys=endpoint_config.primary_keys,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
         # Every endpoint emits ascending by its partition/incremental field: the list endpoints are
         # full-refresh (order only needs to be stable), and the time-windowed endpoints (logs,
         # analytics) return oldest-first within the [start, end] window, matching the watermark's
@@ -406,7 +306,25 @@ def deno_deploy_source(
         sort_mode="asc",
         partition_count=1,
         partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="week" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(access_token: str) -> tuple[bool, str | None]:
+    """Confirm the org access token is genuine with one cheap probe against the apps list."""
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_token,), allow_redirects=False),
+        f"{DENO_DEPLOY_BASE_URL}/v2/apps?limit=1",
+        headers={"Authorization": f"Bearer {access_token}", **_headers()},
+    )
+    if ok:
+        return True, None
+    if status == 401:
+        return False, "Invalid Deno Deploy access token. Create a new organization access token and reconnect."
+    if status == 403:
+        return False, "Your Deno Deploy access token does not have permission to read this organization's data."
+    if status is None:
+        return False, "Could not reach the Deno Deploy API. Check your connection and try again."
+    return False, f"Deno Deploy API returned an unexpected status ({status})."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deno_deploy/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deno_deploy/source.py
@@ -128,7 +128,8 @@ Create an organization access token in your [Deno Deploy dashboard](https://app.
         return deno_deploy_source(
             access_token=config.access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/deno_deploy/tests/test_deno_deploy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/deno_deploy/tests/test_deno_deploy.py
@@ -1,349 +1,323 @@
+import json
 from datetime import UTC, date, datetime
-from typing import Any, cast
-from urllib.parse import parse_qsl, urlsplit
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.deno_deploy import deno_deploy
 from products.warehouse_sources.backend.temporal.data_imports.sources.deno_deploy.deno_deploy import (
     DENO_DEPLOY_ENDPOINTS,
     DenoDeployResumeConfig,
+    _as_utc_datetime,
     _format_rfc3339,
-    _initial_child_url,
     _log_row_id,
-    _logs_next_url,
-    _parse_next_link,
-    _require_deno_deploy_url,
     _reshape_analytics,
-    _shape_log,
     _time_window_params,
     deno_deploy_source,
-    get_rows,
     validate_credentials,
 )
 
-
-class FakeResponse:
-    def __init__(
-        self,
-        json_data: Any,
-        headers: dict[str, str] | None = None,
-        status_code: int = 200,
-        url: str = "https://api.deno.com/v2/apps",
-    ) -> None:
-        self._json = json_data
-        self.headers = headers or {}
-        self.status_code = status_code
-        self.ok = status_code < 400
-        self.url = url
-        self.text = "" if json_data is None else str(json_data)
-
-    def json(self) -> Any:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            raise requests.HTTPError(f"{self.status_code} Client Error", response=cast(requests.Response, self))
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the deno_deploy module.
+DENO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.deno_deploy.deno_deploy.make_tracked_session"
+)
 
 
-class FakeSession:
-    def __init__(self, responses: list[FakeResponse]) -> None:
-        self._responses = list(responses)
-        self.urls: list[str] = []
-
-    def get(self, url: str, headers: dict[str, str] | None = None, timeout: int | None = None) -> FakeResponse:
-        self.urls.append(url)
-        return self._responses.pop(0)
-
-
-class FakeManager:
-    """Stand-in for ResumableSourceManager that records saved state and can seed a resume state."""
-
-    def __init__(self, state: DenoDeployResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[DenoDeployResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> DenoDeployResumeConfig | None:
-        return self._state
-
-    def save_state(self, state: DenoDeployResumeConfig) -> None:
-        self.saved.append(state)
+def _response(
+    body: Any,
+    *,
+    status: int = 200,
+    link: str | None = None,
+    location: str | None = None,
+) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    if link:
+        resp.headers["Link"] = link
+    if location:
+        resp.headers["Location"] = location
+    return resp
 
 
-def _run(endpoint: str, session: FakeSession, manager: FakeManager, **kwargs: Any) -> list[dict[str, Any]]:
-    with patch.object(deno_deploy, "make_tracked_session", return_value=session):
-        rows: list[dict[str, Any]] = []
-        for batch in get_rows(
-            access_token="ddo_test",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(batch)
-        return rows
+def _make_manager(resume_state: DenoDeployResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class TestParseNextLink:
-    @parameterized.expand(
-        [
-            (
-                "absolute",
-                '<https://api.deno.com/v2/apps?cursor=abc&limit=30>; rel="next"',
-                "https://api.deno.com/v2/apps?cursor=abc&limit=30",
-            ),
-            ("relative", '</v2/apps?cursor=abc>; rel="next"', "https://api.deno.com/v2/apps?cursor=abc"),
-            ("empty", "", None),
-            ("no_next_rel", '<https://api.deno.com/v2/apps?cursor=abc>; rel="prev"', None),
-        ]
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session; return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so a copy is snapshotted when
+    each request is prepared. The prepared stand-in carries the request URL so the SSRF host check
+    (which reads ``prepared.url``) sees the real target host.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> SimpleNamespace:
+        param_snapshots.append(dict(request.params or {}))
+        return SimpleNamespace(url=request.url)
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any) -> Any:
+    return deno_deploy_source(
+        access_token="ddo_test",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job",
+        resumable_source_manager=manager,
+        **kwargs,
     )
-    def test_parse_next_link(self, _name: str, header: str, expected: str | None) -> None:
-        assert _parse_next_link(header) == expected
 
 
-class TestFormatRfc3339:
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPureHelpers:
     @parameterized.expand(
         [
             ("utc", datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC), "2026-03-04T02:58:14Z"),
             ("naive_treated_as_utc", datetime(2026, 3, 4, 2, 58, 14), "2026-03-04T02:58:14Z"),
         ]
     )
-    def test_format(self, _name: str, value: datetime, expected: str) -> None:
+    def test_format_rfc3339(self, _name: str, value: datetime, expected: str) -> None:
         result = _format_rfc3339(value)
         assert result == expected
         assert "+00:00" not in result
 
-
-class TestLogRowId:
-    def test_stable_and_content_addressed(self) -> None:
+    def test_log_row_id_stable_and_content_addressed(self) -> None:
         log = {"timestamp": "2026-01-01T00:00:00Z", "level": "info", "message": "hi", "trace_id": "t1"}
         first = _log_row_id("app-1", log)
-        # Same content -> same id (idempotent merge on re-pull of the boundary window).
-        assert first == _log_row_id("app-1", dict(log))
-        # Different app or content -> different id.
-        assert first != _log_row_id("app-2", log)
-        assert first != _log_row_id("app-1", {**log, "message": "bye"})
+        assert first == _log_row_id("app-1", dict(log))  # same content -> same id
+        assert first != _log_row_id("app-2", log)  # different app -> different id
+        assert first != _log_row_id("app-1", {**log, "message": "bye"})  # different content -> different id
 
-
-class TestReshapeAnalytics:
-    def test_columnar_to_rows(self) -> None:
+    def test_reshape_analytics_columnar_to_rows(self) -> None:
         body = {
             "fields": [{"name": "time", "type": "time"}, {"name": "request_count", "type": "number"}],
             "values": [["2026-01-01T00:00:00Z", 5], ["2026-01-01T00:15:00Z", 9]],
         }
-        rows = _reshape_analytics(body, "app-1", "my-app")
-        assert rows == [
+        assert _reshape_analytics(body, "app-1", "my-app") == [
             {"time": "2026-01-01T00:00:00Z", "request_count": 5, "app_id": "app-1", "app_slug": "my-app"},
             {"time": "2026-01-01T00:15:00Z", "request_count": 9, "app_id": "app-1", "app_slug": "my-app"},
         ]
 
-    def test_empty_values(self) -> None:
-        assert _reshape_analytics({"fields": [{"name": "time", "type": "time"}], "values": []}, "a", "s") == []
-
-
-class TestShapeLog:
-    def test_injects_context_and_id(self) -> None:
-        row = _shape_log({"timestamp": "2026-01-01T00:00:00Z", "message": "hi"}, "app-1", "my-app")
-        assert row["app_id"] == "app-1"
-        assert row["app_slug"] == "my-app"
-        assert row["message"] == "hi"
-        assert isinstance(row["id"], str) and len(row["id"]) == 64  # sha256 hexdigest
-
-
-class TestTimeWindowParams:
-    @freeze_time("2026-06-01T12:00:00Z")
-    def test_first_sync_uses_lookback(self) -> None:
-        # No watermark -> start = now - default_lookback_days (7 for logs).
-        start, end = _time_window_params(
-            DENO_DEPLOY_ENDPOINTS["logs"], should_use_incremental_field=True, db_incremental_field_last_value=None
-        )
-        assert end == "2026-06-01T12:00:00Z"
-        assert start == "2026-05-25T12:00:00Z"
+    def test_reshape_analytics_empty_values(self) -> None:
+        assert _reshape_analytics({"fields": [{"name": "time"}], "values": []}, "a", "s") == []
 
     @freeze_time("2026-06-01T12:00:00Z")
-    def test_incremental_subtracts_lookback(self) -> None:
-        # Watermark present -> start = watermark - incremental_lookback (5 min for logs).
-        start, _ = _time_window_params(
-            DENO_DEPLOY_ENDPOINTS["logs"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC),
-        )
-        assert start == "2026-06-01T09:55:00Z"
-
-    @freeze_time("2026-06-01T12:00:00Z")
-    def test_future_watermark_clamped_to_now(self) -> None:
-        # A future-dated watermark can't push start past now.
-        start, end = _time_window_params(
-            DENO_DEPLOY_ENDPOINTS["analytics"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2027, 1, 1, tzinfo=UTC),
-        )
-        # start = min(future, now) - 30min lookback = now - 30min
-        assert start == "2026-06-01T11:30:00Z"
+    def test_time_window_first_sync_uses_lookback(self) -> None:
+        start, end = _time_window_params(DENO_DEPLOY_ENDPOINTS["logs"], True, None)
+        assert start == "2026-05-25T12:00:00Z"  # now - 7d default lookback
         assert end == "2026-06-01T12:00:00Z"
 
-
-class TestInitialChildUrl:
     @freeze_time("2026-06-01T12:00:00Z")
-    def test_logs_url_has_bounded_window(self) -> None:
-        url = _initial_child_url(DENO_DEPLOY_ENDPOINTS["logs"], "app-1", True, None)
-        assert url.startswith("https://api.deno.com/v2/apps/app-1/logs?")
-        # end must always be present (omitting it switches the endpoint to real-time streaming).
-        assert "start=" in url and "end=" in url and "limit=1000" in url
+    def test_time_window_incremental_subtracts_lookback(self) -> None:
+        start, _ = _time_window_params(DENO_DEPLOY_ENDPOINTS["logs"], True, datetime(2026, 6, 1, 10, 0, 0, tzinfo=UTC))
+        assert start == "2026-06-01T09:55:00Z"  # watermark - 5min lookback
 
     @freeze_time("2026-06-01T12:00:00Z")
-    def test_analytics_url_uses_since_until(self) -> None:
-        url = _initial_child_url(DENO_DEPLOY_ENDPOINTS["analytics"], "app-1", True, None)
-        assert "since=" in url and "until=" in url
+    def test_time_window_future_watermark_clamped(self) -> None:
+        start, end = _time_window_params(DENO_DEPLOY_ENDPOINTS["analytics"], True, datetime(2027, 1, 1, tzinfo=UTC))
+        assert start == "2026-06-01T11:30:00Z"  # min(future, now) - 30min lookback
+        assert end == "2026-06-01T12:00:00Z"
 
-    def test_revisions_url_uses_limit(self) -> None:
-        url = _initial_child_url(DENO_DEPLOY_ENDPOINTS["revisions"], "app-1", False, None)
-        assert url == "https://api.deno.com/v2/apps/app-1/revisions?limit=100"
-
-
-class TestLogsNextUrl:
-    def test_swaps_cursor_preserving_window(self) -> None:
-        current = "https://api.deno.com/v2/apps/app-1/logs?start=2026-01-01T00%3A00%3A00Z&end=2026-01-02T00%3A00%3A00Z&limit=1000&cursor=old"
-        nxt = _logs_next_url(current, "new")
-        assert "cursor=new" in nxt
-        assert "cursor=old" not in nxt
-        assert "start=" in nxt and "end=" in nxt and "limit=1000" in nxt
-        # The already-encoded start/end must be encoded exactly once, not doubled (`%253A`); parsing the
-        # rebuilt URL must recover the original timestamps.
-        assert "%253A" not in nxt
-        params = dict(parse_qsl(urlsplit(nxt).query))
-        assert params["start"] == "2026-01-01T00:00:00Z"
-        assert params["end"] == "2026-01-02T00:00:00Z"
-
-
-class TestRequireDenoDeployUrl:
-    @parameterized.expand(
-        [
-            ("https_apex", "https://api.deno.com/v2/apps?limit=1", True),
-            ("http_scheme_rejected", "http://api.deno.com/v2/apps", False),
-            ("other_host_rejected", "https://evil.example.com/v2/apps", False),
-            ("subdomain_rejected", "https://api.deno.com.evil.com/v2/apps", False),
-            ("host_as_userinfo_rejected", "https://api.deno.com@evil.com/v2/apps", False),
-        ]
-    )
-    def test_only_https_deno_host_allowed(self, _name: str, url: str, allowed: bool) -> None:
-        if allowed:
-            assert _require_deno_deploy_url(url) == url
+    @parameterized.expand([("date", date(2026, 1, 1), True), ("string", "cursor", False)])
+    def test_as_utc_datetime(self, _name: str, value: Any, coerces: bool) -> None:
+        result = _as_utc_datetime(value)
+        if coerces:
+            assert result is not None and result.tzinfo is UTC
         else:
-            with pytest.raises(ValueError):
-                _require_deno_deploy_url(url)
+            assert result is None
 
 
-class TestValidateCredentials:
-    @parameterized.expand(
-        [
-            ("ok", 200, True),
-            ("unauthorized", 401, False),
-            ("forbidden", 403, False),
-        ]
-    )
-    def test_status_mapping(self, _name: str, status: int, expected_ok: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = FakeResponse({"message": "x"}, status_code=status)
-        with patch.object(deno_deploy, "make_tracked_session", return_value=session):
-            ok, error = validate_credentials("ddo_test")
-        assert ok is expected_ok
-        assert (error is None) is expected_ok
-
-    def test_network_error(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(deno_deploy, "make_tracked_session", return_value=session):
-            ok, error = validate_credentials("ddo_test")
-        assert ok is False
-        assert error is not None
-
-
-class TestListEndpointPagination:
-    def test_apps_follows_link_header_and_checkpoints(self) -> None:
-        session = FakeSession(
+class TestListEndpoint:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_apps_follows_link_header_and_checkpoints(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
             [
-                FakeResponse(
+                _response(
                     [{"id": "a1", "slug": "one"}],
-                    headers={"Link": '<https://api.deno.com/v2/apps?cursor=p2&limit=100>; rel="next"'},
+                    link='<https://api.deno.com/v2/apps?cursor=p2&limit=100>; rel="next"',
                 ),
-                FakeResponse([{"id": "a2", "slug": "two"}], headers={}),
-            ]
+                _response([{"id": "a2", "slug": "two"}]),
+            ],
         )
-        manager = FakeManager()
-        rows = _run("apps", session, manager)
-        assert [r["id"] for r in rows] == ["a1", "a2"]
-        # Saved state points at the not-yet-yielded next page (checkpoint after yielding page one).
-        assert manager.saved == [DenoDeployResumeConfig(next_url="https://api.deno.com/v2/apps?cursor=p2&limit=100")]
+        manager = _make_manager()
+        rows = _rows(_source("apps", manager))
 
-    def test_apps_resumes_from_saved_url(self) -> None:
-        session = FakeSession([FakeResponse([{"id": "a2", "slug": "two"}], headers={})])
-        manager = FakeManager(state=DenoDeployResumeConfig(next_url="https://api.deno.com/v2/apps?cursor=p2"))
-        rows = _run("apps", session, manager)
+        assert [r["id"] for r in rows] == ["a1", "a2"]  # rows used as-is, both pages
+        # Checkpoint saved after the first page points at the not-yet-fetched next URL.
+        manager.save_state.assert_called_once_with(
+            DenoDeployResumeConfig(next_url="https://api.deno.com/v2/apps?cursor=p2&limit=100")
+        )
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_apps_resumes_from_saved_url(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "a2", "slug": "two"}])])
+        manager = _make_manager(DenoDeployResumeConfig(next_url="https://api.deno.com/v2/apps?cursor=p2"))
+
+        rows = _rows(_source("apps", manager))
         assert [r["id"] for r in rows] == ["a2"]
-        # It resumed from the saved URL rather than the default first page.
-        assert session.urls[0] == "https://api.deno.com/v2/apps?cursor=p2"
+        assert params[0] == {}  # resumed via the seeded next URL, not the default first page params
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_apps_single_short_page_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "a1", "slug": "one"}])])
+        manager = _make_manager()
+
+        _rows(_source("apps", manager))
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
 
 class TestFanOut:
-    def test_revisions_inject_parent_app_context(self) -> None:
-        session = FakeSession(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_revisions_inject_parent_app_context(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
             [
-                FakeResponse([{"id": "a1", "slug": "one"}, {"id": "a2", "slug": "two"}], headers={}),  # /v2/apps
-                FakeResponse([{"id": "r1", "status": "success"}], headers={}),  # a1 revisions
-                FakeResponse([{"id": "r2", "status": "failed"}], headers={}),  # a2 revisions
-            ]
+                _response([{"id": "a1", "slug": "one"}, {"id": "a2", "slug": "two"}]),  # /v2/apps
+                _response([{"id": "r1", "status": "success"}]),  # a1 revisions
+                _response([{"id": "r2", "status": "failed"}]),  # a2 revisions
+            ],
         )
-        rows = _run("revisions", session, FakeManager())
+        rows = _rows(_source("revisions", _make_manager()))
+
         assert rows == [
             {"id": "r1", "status": "success", "app_id": "a1", "app_slug": "one"},
             {"id": "r2", "status": "failed", "app_id": "a2", "app_slug": "two"},
         ]
+        assert params[1]["limit"] == 100  # child list uses the default page size
 
     @freeze_time("2026-06-01T12:00:00Z")
-    def test_logs_paginate_via_next_cursor(self) -> None:
-        session = FakeSession(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_logs_paginate_via_next_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
             [
-                FakeResponse([{"id": "a1", "slug": "one"}], headers={}),  # /v2/apps
-                FakeResponse(
-                    {"logs": [{"timestamp": "2026-06-01T10:00:00Z", "message": "m1"}], "next_cursor": "c2"},
-                    url="https://api.deno.com/v2/apps/a1/logs?start=x&end=y&limit=1000",
-                ),
-                FakeResponse(
-                    {"logs": [{"timestamp": "2026-06-01T11:00:00Z", "message": "m2"}], "next_cursor": None},
-                    url="https://api.deno.com/v2/apps/a1/logs?start=x&end=y&limit=1000&cursor=c2",
-                ),
-            ]
+                _response([{"id": "a1", "slug": "one"}]),  # /v2/apps
+                _response({"logs": [{"timestamp": "2026-06-01T10:00:00Z", "message": "m1"}], "next_cursor": "c2"}),
+                _response({"logs": [{"timestamp": "2026-06-01T11:00:00Z", "message": "m2"}], "next_cursor": None}),
+            ],
         )
-        manager = FakeManager()
-        rows = _run("logs", session, manager, should_use_incremental_field=True, db_incremental_field_last_value=None)
-        assert [r["message"] for r in rows] == ["m1", "m2"]
-        assert all("id" in r and r["app_id"] == "a1" for r in rows)
-        # Second logs fetch followed the body cursor.
-        assert "cursor=c2" in session.urls[-1]
-        # Checkpoint carried the app id for mid-fan-out resume.
-        assert manager.saved[0].app_id == "a1"
+        manager = _make_manager()
+        rows = _rows(_source("logs", manager, should_use_incremental_field=True, db_incremental_field_last_value=None))
 
-    def test_fanout_resumes_from_saved_app(self) -> None:
-        session = FakeSession(
+        assert [r["message"] for r in rows] == ["m1", "m2"]
+        assert all(len(r["id"]) == 64 and r["app_id"] == "a1" and r["app_slug"] == "one" for r in rows)
+        # First logs page carries the bounded window; the second follows the body cursor.
+        assert params[1]["start"] and params[1]["end"] and params[1]["limit"] == 1000 and "cursor" not in params[1]
+        assert params[2]["cursor"] == "c2"
+        # Checkpoint persists the fan-out resume snapshot carrying the cursor.
+        saved = [c.args[0] for c in manager.save_state.call_args_list]
+        assert any(s.fanout_state and s.fanout_state.get("child_state") == {"cursor": "c2"} for s in saved)
+
+    @freeze_time("2026-06-01T12:00:00Z")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_analytics_columnar_explode_with_window(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
             [
-                FakeResponse([{"id": "a1", "slug": "one"}, {"id": "a2", "slug": "two"}], headers={}),  # /v2/apps
-                FakeResponse([{"id": "r2", "status": "success"}], headers={}),  # a2 revisions only
-            ]
+                _response([{"id": "a1", "slug": "one"}]),  # /v2/apps
+                _response(
+                    {
+                        "fields": [{"name": "time"}, {"name": "request_count"}],
+                        "values": [["2026-06-01T00:00:00Z", 5], ["2026-06-01T00:15:00Z", 9]],
+                    }
+                ),
+            ],
         )
-        manager = FakeManager(state=DenoDeployResumeConfig(next_url=None, app_id="a2"))
-        rows = _run("revisions", session, manager)
-        # a1 skipped: resume started at a2.
-        assert [r["id"] for r in rows] == ["r2"]
+        rows = _rows(_source("analytics", _make_manager(), should_use_incremental_field=True))
+
+        assert rows == [
+            {"time": "2026-06-01T00:00:00Z", "request_count": 5, "app_id": "a1", "app_slug": "one"},
+            {"time": "2026-06-01T00:15:00Z", "request_count": 9, "app_id": "a1", "app_slug": "one"},
+        ]
+        assert params[1]["since"] and params[1]["until"]  # server-side time filters present
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fanout_resumes_and_skips_completed_app(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "a1", "slug": "one"}, {"id": "a2", "slug": "two"}]),  # /v2/apps
+                _response([{"id": "r2", "status": "success"}]),  # a2 revisions only
+            ],
+        )
+        manager = _make_manager(
+            DenoDeployResumeConfig(
+                fanout_state={"completed": ["/v2/apps/a1/revisions"], "current": None, "child_state": None}
+            )
+        )
+        rows = _rows(_source("revisions", manager))
+
+        assert [r["id"] for r in rows] == ["r2"]  # a1 skipped, resumed at a2
         assert rows[0]["app_id"] == "a2"
+        assert session.send.call_count == 2  # apps list + a2 only
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_resume_state_restarts_fanout(self, MockSession) -> None:
+        # A pre-migration state carrying only the legacy app_id bookmark must still parse and simply
+        # restart the fan-out (merge dedupes the re-pulled rows).
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "a1", "slug": "one"}]),  # /v2/apps
+                _response([{"id": "r1", "status": "success"}]),  # a1 revisions
+            ],
+        )
+        manager = _make_manager(DenoDeployResumeConfig(next_url=None, app_id="a2"))
+        rows = _rows(_source("revisions", manager))
+        assert [r["id"] for r in rows] == ["r1"]  # fresh full walk, a1 not skipped
+
+
+class TestSsrfGuards:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_off_host_link_is_rejected(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(
+                    [{"id": "a1", "slug": "one"}], link='<https://evil.example.com/v2/apps?cursor=p2>; rel="next"'
+                ),
+                _response([{"id": "a2", "slug": "two"}]),
+            ],
+        )
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("apps", _make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_redirect_is_rejected(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=302, location="https://evil.example.com")])
+        with pytest.raises(ValueError, match="[Rr]edirect"):
+            _rows(_source("apps", _make_manager()))
 
 
 class TestSourceResponse:
@@ -357,30 +331,27 @@ class TestSourceResponse:
         ]
     )
     def test_response_shape(self, endpoint: str, pk: list[str], partition: str, incremental: bool) -> None:
-        response = deno_deploy_source(
-            access_token="ddo_test",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-            should_use_incremental_field=incremental,
-            db_incremental_field_last_value=None,
-        )
+        response = _source(endpoint, _make_manager(), should_use_incremental_field=incremental)
         assert response.name == endpoint
         assert response.primary_keys == pk
         assert response.partition_keys == [partition]
         assert response.partition_mode == "datetime"
+        assert response.partition_format == "week"
         assert response.sort_mode == "asc"
 
-    @parameterized.expand([("date", date(2026, 1, 1)), ("string", "cursor")])
-    def test_format_rfc3339_non_datetime_paths(self, _name: str, value: Any) -> None:
-        # _time_window_params only calls _format_rfc3339 on datetimes it resolves, so exercise the
-        # _as_utc_datetime coercion directly to lock in date handling.
-        from products.warehouse_sources.backend.temporal.data_imports.sources.deno_deploy.deno_deploy import (
-            _as_utc_datetime,
-        )
 
-        result = _as_utc_datetime(value)
-        if isinstance(value, date):
-            assert result is not None and result.tzinfo is UTC
-        else:
-            assert result is None
+class TestValidateCredentials:
+    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
+    @mock.patch(DENO_SESSION_PATCH)
+    def test_status_mapping(self, _name: str, status: int, expected_ok: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        ok, error = validate_credentials("ddo_test")
+        assert ok is expected_ok
+        assert (error is None) is expected_ok
+
+    @mock.patch(DENO_SESSION_PATCH)
+    def test_network_error_is_swallowed(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        ok, error = validate_credentials("ddo_test")
+        assert ok is False
+        assert error is not None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/e2b/e2b.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/e2b/e2b.py
@@ -1,15 +1,17 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.e2b.settings import E2B_ENDPOINTS
 
 # E2B exposes a single global base URL; there are no regional hosts.
@@ -18,6 +20,7 @@ E2B_BASE_URL = "https://api.e2b.app"
 # Cursor pagination: `limit` maxes out at 100, and the next cursor is returned in this response header.
 E2B_PAGE_LIMIT = 100
 NEXT_TOKEN_HEADER = "X-Next-Token"
+NEXT_TOKEN_PARAM = "nextToken"
 
 # E2B lets users stash arbitrary key/value data on a sandbox, and its own docs suggest keeping secrets
 # (API keys, tokens) there. Writing it to the warehouse table would let anyone with table read access
@@ -25,9 +28,7 @@ NEXT_TOKEN_HEADER = "X-Next-Token"
 SENSITIVE_FIELDS = ("metadata",)
 
 
-def _scrub(item: Any) -> Any:
-    if not isinstance(item, dict):
-        return item
+def _scrub(item: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in item.items() if key not in SENSITIVE_FIELDS}
 
 
@@ -42,11 +43,129 @@ class E2BResumeConfig:
     next_token: str | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "X-API-Key": api_key,
-        "Accept": "application/json",
+class HeaderCursorPaginator(BasePaginator):
+    """E2B returns the next-page cursor in a response header (not the body), and expects it echoed
+    back as a query param. No built-in paginator reads a cursor from a header, so this small subclass
+    does — resumably. Terminates when the header is absent, or repeats the cursor just sent (a
+    defensive guard against an endpoint that echoes the token instead of dropping it)."""
+
+    def __init__(self, header_name: str = NEXT_TOKEN_HEADER, cursor_param: str = NEXT_TOKEN_PARAM) -> None:
+        super().__init__()
+        self.header_name = header_name
+        self.cursor_param = cursor_param
+        self._cursor_value: Optional[str] = None
+
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume cursor to the first request so a resumed run starts mid-list.
+        if self._cursor_value is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._cursor_value
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        sent = self._cursor_value
+        next_token = response.headers.get(self.header_name) or None
+        if not next_token or next_token == sent:
+            self._has_next_page = False
+        else:
+            self._cursor_value = next_token
+            self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        if self._cursor_value is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._cursor_value
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"next_token": self._cursor_value} if self._has_next_page and self._cursor_value is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_token = state.get("next_token")
+        if next_token is not None:
+            self._cursor_value = next_token
+            self._has_next_page = True
+
+
+def e2b_source(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[E2BResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = E2B_ENDPOINTS[endpoint]
+
+    # One tracked session reused across every page so urllib3 keeps the connection alive.
+    # `redact_values` masks the key from tracked HTTP samples (the `X-API-Key` header isn't on the
+    # generic scrubber's denylist); `allow_redirects=False` keeps it from replaying to another host;
+    # `capture=False` keeps raw response bodies (which can hold secret-bearing sandbox metadata the
+    # name-based scrubbers miss) out of sample storage, since `_scrub` only runs after capture.
+    session = make_tracked_session(redact_values=(api_key,), allow_redirects=False, capture=False)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": E2B_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Auth via the framework so the key is injected per-request and redacted from logs.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-API-Key", "location": "header"},
+            "paginator": HeaderCursorPaginator(),
+            "session": session,
+            # Same-host-only (base_url host is implicitly allowed) + no redirects: an off-host
+            # pagination/resume URL or a 3xx can't replay the API key to another origin.
+            "allowed_hosts": [],
+            "allow_redirects": False,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": E2B_PAGE_LIMIT},
+                    # E2B list endpoints return a bare JSON array. Require a list so a wrapped/error
+                    # body (a response-shape change) fails loud instead of syncing the object as a row.
+                    "data_selector_required": True,
+                },
+                # Drop secret-bearing sandbox metadata before ingesting.
+                "data_map": _scrub,
+            }
+        ],
     }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_token is not None:
+            initial_paginator_state = {"next_token": resume.next_token}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("next_token") is not None:
+            resumable_source_manager.save_state(E2BResumeConfig(next_token=state["next_token"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        sort_mode="asc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
+    )
 
 
 def validate_credentials(api_key: str) -> bool:
@@ -58,127 +177,13 @@ def validate_credentials(api_key: str) -> bool:
     # generic scrubber's denylist); `allow_redirects=False` keeps the key from replaying to another host;
     # `capture=False` keeps the raw response body out of sample storage, since a sandbox's user-set
     # metadata can carry secrets the name-based scrubbers can't recognise (see `SENSITIVE_FIELDS`).
-    session = make_tracked_session(redact_values=(api_key,), allow_redirects=False, capture=False)
-    response = session.get(
-        f"{E2B_BASE_URL}/v2/sandboxes",
-        headers=_get_headers(api_key),
-        params={"limit": 1},
-        timeout=10,
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,), allow_redirects=False, capture=False),
+        f"{E2B_BASE_URL}/v2/sandboxes?limit=1",
+        headers={"X-API-Key": api_key, "Accept": "application/json"},
     )
-    if response.status_code == 200:
+    if ok:
         return True
-    if response.status_code in (401, 403):
+    if status in (401, 403):
         return False
-    raise E2BRetryableError(f"E2B credential probe failed (retryable): status={response.status_code}")
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            E2BRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> requests.Response:
-    response = session.get(url, headers=headers, params=params, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise E2BRetryableError(f"E2B API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"E2B API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[E2BResumeConfig],
-) -> Iterator[Any]:
-    config = E2B_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # One session reused across every page so urllib3 keeps the connection alive. `redact_values` masks
-    # the key from tracked HTTP samples; `allow_redirects=False` keeps it from replaying to another host;
-    # `capture=False` keeps raw response bodies (which can hold secret-bearing sandbox metadata that the
-    # name-based scrubbers miss) out of sample storage, since `_scrub` only runs after capture.
-    session = make_tracked_session(redact_values=(api_key,), allow_redirects=False, capture=False)
-    url = f"{E2B_BASE_URL}{config.path}"
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    next_token = resume.next_token if resume else None
-    if next_token:
-        logger.debug(f"E2B: resuming {endpoint} from cursor")
-
-    while True:
-        params: dict[str, Any] = {"limit": E2B_PAGE_LIMIT}
-        if next_token:
-            params["nextToken"] = next_token
-
-        response = _fetch_page(session, url, headers, params, logger)
-        items = response.json()
-        # E2B list endpoints return a bare JSON array, not a wrapped `{data: [...]}` envelope.
-        if not isinstance(items, list):
-            logger.warning(f"E2B: unexpected non-list response for {endpoint}, stopping")
-            break
-
-        page_token = response.headers.get(NEXT_TOKEN_HEADER) or None
-
-        for item in items:
-            batcher.batch(_scrub(item))
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save AFTER yielding so a crash re-yields the last page rather than skipping it;
-                # merge dedupes on the primary key. Only persist while there's another page to fetch.
-                if page_token:
-                    resumable_source_manager.save_state(E2BResumeConfig(next_token=page_token))
-
-        # Terminate when the API stops handing back a cursor, or hands back the same one (defensive
-        # guard against an endpoint that echoes the token instead of dropping it).
-        if not page_token or page_token == next_token:
-            break
-        next_token = page_token
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
-
-def e2b_source(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[E2BResumeConfig],
-) -> SourceResponse:
-    config = E2B_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=config.primary_keys,
-        sort_mode="asc",
-        partition_count=1,
-        partition_size=1,
-        partition_mode="datetime" if config.partition_key else None,
-        partition_format="week" if config.partition_key else None,
-        partition_keys=[config.partition_key] if config.partition_key else None,
-    )
+    raise E2BRetryableError(f"E2B credential probe failed (retryable): status={status}")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/e2b/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/e2b/source.py
@@ -132,6 +132,7 @@ You can create a team-scoped API key (prefixed `e2b_`) in your [E2B dashboard](h
         return e2b_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/e2b/tests/test_e2b.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/e2b/tests/test_e2b.py
@@ -1,197 +1,222 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.e2b import e2b
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
 from products.warehouse_sources.backend.temporal.data_imports.sources.e2b.e2b import (
     E2BResumeConfig,
+    E2BRetryableError,
     e2b_source,
-    get_rows,
     validate_credentials,
 )
 
-
-class _FakeResumableManager:
-    def __init__(self, state: E2BResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[E2BResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> E2BResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: E2BResumeConfig) -> None:
-        self.saved.append(data)
+# e2b builds its own tracked session and hands it to the RESTClient, so patch it in the e2b module.
+E2B_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.e2b.e2b.make_tracked_session"
 
 
-def _response(items: Any, next_token: str | None = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = 200
-    response.ok = True
-    response.json.return_value = items
-    response.headers = {"X-Next-Token": next_token} if next_token else {}
-    return response
+def _response(body: Any, *, next_token: str | None = None, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    if next_token is not None:
+        resp.headers["X-Next-Token"] = next_token
+    return resp
 
 
-def _collect(manager: _FakeResumableManager, monkeypatch: Any, pages: list[MagicMock], endpoint: str = "sandboxes"):
-    """Drive get_rows with a scripted sequence of pages, recording the nextToken each fetch sent."""
-    sent_tokens: list[str | None] = []
-    pages_iter = iter(pages)
+def _make_manager(resume_state: E2BResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], params: dict[str, Any], logger: Any) -> MagicMock:
-        sent_tokens.append(params.get("nextToken"))
-        return next(pages_iter)
 
-    monkeypatch.setattr(e2b, "_fetch_page", fake_fetch)
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
 
-    rows: list[dict] = []
-    for table in get_rows(api_key="e2b_test", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=manager):  # type: ignore[arg-type]
-        rows.extend(table.to_pylist())
-    return rows, sent_tokens
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        # allowed_hosts pins requests to the base host, so the prepared URL must resolve there.
+        prepared.url = "https://api.e2b.app/v2/sandboxes"
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(manager: mock.MagicMock, endpoint: str = "sandboxes", api_key: str = "e2b_test"):
+    return e2b_source(api_key=api_key, endpoint=endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestPagination:
-    def test_follows_next_token_header_across_pages(self, monkeypatch: Any) -> None:
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_follows_next_token_header_across_pages(self, MockSession) -> None:
         # The paginator must chase the X-Next-Token header; stopping after page one silently drops data.
-        pages = [_response([{"sandboxID": "a"}, {"sandboxID": "b"}], next_token="t1"), _response([{"sandboxID": "c"}])]
-        rows, sent_tokens = _collect(_FakeResumableManager(), monkeypatch, pages)
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [_response([{"sandboxID": "a"}, {"sandboxID": "b"}], next_token="t1"), _response([{"sandboxID": "c"}])],
+        )
+
+        rows = _rows(_source(_make_manager()))
+
         assert rows == [{"sandboxID": "a"}, {"sandboxID": "b"}, {"sandboxID": "c"}]
-        # First page requested with no cursor, second page with the header token.
-        assert sent_tokens == [None, "t1"]
+        # First page requested with no cursor, second page with the header token; limit ridden every page.
+        assert params[0].get("nextToken") is None
+        assert params[0]["limit"] == 100
+        assert params[1]["nextToken"] == "t1"
 
-    def test_terminates_when_token_repeats(self, monkeypatch: Any) -> None:
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_terminates_when_token_repeats(self, MockSession) -> None:
         # An endpoint that echoes the same cursor instead of dropping it must not loop forever.
-        pages = [_response([{"sandboxID": "a"}], next_token="same"), _response([{"sandboxID": "b"}], next_token="same")]
-        rows, sent_tokens = _collect(_FakeResumableManager(), monkeypatch, pages)
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [_response([{"sandboxID": "a"}], next_token="same"), _response([{"sandboxID": "b"}], next_token="same")],
+        )
+
+        rows = _rows(_source(_make_manager()))
+
         assert rows == [{"sandboxID": "a"}, {"sandboxID": "b"}]
-        assert sent_tokens == [None, "same"]
+        assert params[0].get("nextToken") is None
+        assert params[1]["nextToken"] == "same"
+        assert session.send.call_count == 2
 
-    def test_resumes_from_saved_cursor(self, monkeypatch: Any) -> None:
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
         # A resumed run must start from the persisted cursor, not re-page from the beginning.
-        manager = _FakeResumableManager(E2BResumeConfig(next_token="resume_tok"))
-        pages = [_response([{"sandboxID": "x"}])]
-        rows, sent_tokens = _collect(manager, monkeypatch, pages)
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"sandboxID": "x"}])])
+
+        rows = _rows(_source(_make_manager(E2BResumeConfig(next_token="resume_tok"))))
+
         assert rows == [{"sandboxID": "x"}]
-        assert sent_tokens == ["resume_tok"]
+        assert params[0]["nextToken"] == "resume_tok"
 
-    def test_non_list_response_stops_without_crashing(self, monkeypatch: Any) -> None:
-        # A wrapped/error body must be tolerated rather than raising while iterating a dict.
-        pages = [_response({"code": 500, "message": "boom"})]
-        rows, _ = _collect(_FakeResumableManager(), monkeypatch, pages)
-        assert rows == []
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"sandboxID": "a"}, {"sandboxID": "b"}])])
 
-    def test_builds_a_redacted_redirect_pinned_uncaptured_session(self, monkeypatch: Any) -> None:
-        # The sync session carries the same X-API-Key header the scrubber can't see, so it must redact the
-        # key and refuse redirects; `capture=False` keeps secret-bearing sandbox metadata out of sample
-        # storage, which the row-level `_scrub` can't do (it only runs after capture).
-        session = MagicMock()
-        monkeypatch.setattr(e2b, "_fetch_page", lambda *a, **k: _response([]))
-        with patch.object(e2b, "make_tracked_session", return_value=session) as make_session:
-            list(
-                get_rows(
-                    api_key="e2b_secret",
-                    endpoint="sandboxes",
-                    logger=MagicMock(),
-                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-                )
-            )
-        assert make_session.call_args.kwargs == {
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == [{"sandboxID": "a"}, {"sandboxID": "b"}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_non_list_response_fails_loudly(self, MockSession) -> None:
+        # E2B list endpoints return a bare JSON array; a wrapped/error object on a 200 is a response-shape
+        # change. data_selector_required makes it fail loud rather than syncing the object as a row.
+        session = MockSession.return_value
+        _wire(session, [_response({"code": 500, "message": "boom"})])
+
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source(_make_manager()))
+
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_drops_sensitive_metadata_before_ingesting(self, MockSession) -> None:
+        # E2B lets users stash secrets in sandbox metadata; writing it to the table would leak them to
+        # anyone with table read access, so it must be stripped before ingesting. Other fields survive.
+        session = MockSession.return_value
+        _wire(session, [_response([{"sandboxID": "a", "metadata": {"API_KEY": "sk-secret"}, "state": "running"}])])
+
+        rows = _rows(_source(_make_manager()))
+
+        assert rows == [{"sandboxID": "a", "state": "running"}]
+
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_saves_next_page_cursor_after_yielding_a_page(self, MockSession) -> None:
+        # Save-after-yield with the NEXT page's token is what makes resume re-yield (not skip) the last
+        # page on a crash, and only while a page remains (the final short page saves nothing).
+        session = MockSession.return_value
+        _wire(session, [_response([{"sandboxID": "a"}], next_token="t1"), _response([{"sandboxID": "last"}])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == [{"sandboxID": "a"}, {"sandboxID": "last"}]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == E2BResumeConfig(next_token="t1")
+
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_builds_a_redacted_redirect_pinned_uncaptured_session(self, MockSession) -> None:
+        # The sync session carries the X-API-Key header the scrubber can't see, so it must redact the
+        # key and refuse redirects; capture=False keeps secret-bearing sandbox metadata out of sample
+        # storage, which the row-level scrub can't do (it only runs after capture).
+        _wire(MockSession.return_value, [_response([])])
+
+        _rows(_source(_make_manager(), api_key="e2b_secret"))
+
+        assert MockSession.call_args.kwargs == {
             "redact_values": ("e2b_secret",),
             "allow_redirects": False,
             "capture": False,
         }
 
-    def test_drops_sensitive_metadata_before_ingesting(self, monkeypatch: Any) -> None:
-        # E2B lets users stash secrets in sandbox metadata; writing it to the table would leak them to
-        # anyone with table read access, so it must be stripped before batching. Other fields survive.
-        pages = [_response([{"sandboxID": "a", "metadata": {"API_KEY": "sk-secret"}, "state": "running"}])]
-        rows, _ = _collect(_FakeResumableManager(), monkeypatch, pages)
-        assert rows == [{"sandboxID": "a", "state": "running"}]
-
-    def test_saves_next_page_cursor_after_yielding_a_batch(self, monkeypatch: Any) -> None:
-        # Save-after-yield with the NEXT page's token is what makes resume re-yield (not skip) the last
-        # batch on a crash. A full 2000-row page forces the batcher to flush mid-loop.
-        manager = _FakeResumableManager()
-        pages = [
-            _response([{"sandboxID": str(i)} for i in range(2000)], next_token="t1"),
-            _response([{"sandboxID": "last"}]),
-        ]
-        rows, _ = _collect(manager, monkeypatch, pages)
-        assert len(rows) == 2001
-        assert manager.saved == [E2BResumeConfig(next_token="t1")]
-
-
-class TestFetchPageRetries:
-    @parameterized.expand(
-        [
-            ("read_timeout", requests.ReadTimeout("Read timed out.")),
-            ("connection_error", requests.ConnectionError("Connection reset by peer")),
-            ("chunked_encoding", requests.exceptions.ChunkedEncodingError("Connection broken")),
-        ]
-    )
-    def test_transient_errors_are_retried(self, _name: str, transient_error: Exception) -> None:
-        good = _response([])
-        session = MagicMock()
-        session.get.side_effect = [transient_error, good]
-
-        with patch.object(e2b._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = e2b._fetch_page(session, "https://api.e2b.app/v2/sandboxes", {}, {}, MagicMock())
-
-        assert result is good
-        assert session.get.call_count == 2
-
     @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_retryable_status_codes_retry_then_succeed(self, _name: str, status: int) -> None:
-        bad = MagicMock(status_code=status, ok=False, text="err")
-        good = _response([])
-        session = MagicMock()
-        session.get.side_effect = [bad, good]
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_retryable_status_codes_retry_then_succeed(self, _name: str, status: int, MockSession) -> None:
+        # A rate limit or 5xx is transient — the framework transport must retry rather than fail the sync.
+        session = MockSession.return_value
+        _wire(session, [_response(None, status=status), _response([{"sandboxID": "a"}])])
 
-        with patch.object(e2b._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = e2b._fetch_page(session, "https://api.e2b.app/v2/sandboxes", {}, {}, MagicMock())
+        with mock.patch.object(RESTClient._send_request.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
+            rows = _rows(_source(_make_manager()))
 
-        assert result is good
-        assert session.get.call_count == 2
+        assert rows == [{"sandboxID": "a"}]
+        assert session.send.call_count == 2
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    def test_status_code_maps_to_validity(self, _name: str, status: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status)
-        with patch.object(e2b, "make_tracked_session", return_value=session) as make_session:
-            assert validate_credentials("e2b_test") is expected
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_status_code_maps_to_validity(self, _name: str, status: int, expected: bool, MockSession) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=status)
+
+        assert validate_credentials("e2b_test") is expected
         # The key rides in the X-API-Key header, which the generic scrubber's denylist doesn't cover, so
-        # the probe must redact it from tracked samples, pin redirects off to stop it replaying elsewhere,
-        # and disable capture so the sandbox response body never reaches sample storage.
-        assert make_session.call_args.kwargs == {
+        # the probe must redact it, pin redirects off to stop it replaying elsewhere, and disable capture
+        # so the sandbox response body never reaches sample storage.
+        assert MockSession.call_args.kwargs == {
             "redact_values": ("e2b_test",),
             "allow_redirects": False,
             "capture": False,
         }
 
     @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_transient_status_raises_rather_than_reporting_invalid(self, _name: str, status: int) -> None:
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_transient_status_raises_rather_than_reporting_invalid(self, _name: str, status: int, MockSession) -> None:
         # A rate limit or 5xx says nothing about the key; mapping it to "invalid" sends the user the wrong way.
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status)
-        with patch.object(e2b, "make_tracked_session", return_value=session):
-            with pytest.raises(e2b.E2BRetryableError):
-                validate_credentials("e2b_test")
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=status)
 
-    def test_network_error_propagates(self) -> None:
-        # A connection failure is transient — it must bubble up, not be swallowed into a False "invalid key".
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError()
-        with patch.object(e2b, "make_tracked_session", return_value=session):
-            with pytest.raises(requests.ConnectionError):
-                validate_credentials("e2b_test")
+        with pytest.raises(E2BRetryableError):
+            validate_credentials("e2b_test")
+
+    @mock.patch(E2B_SESSION_PATCH)
+    def test_network_error_is_treated_as_transient(self, MockSession) -> None:
+        # A connection failure is transient — it must surface as a retryable error, not a False "invalid key".
+        MockSession.return_value.get.side_effect = Exception("connection reset")
+
+        with pytest.raises(E2BRetryableError):
+            validate_credentials("e2b_test")
 
 
 class TestSourceResponsePartitioning:
@@ -206,9 +231,7 @@ class TestSourceResponsePartitioning:
     def test_primary_keys_and_partitioning_per_endpoint(
         self, endpoint: str, expected_pks: list[str], expected_partition: str | None
     ) -> None:
-        response = e2b_source(
-            api_key="e2b_test", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.primary_keys == expected_pks
         assert response.sort_mode == "asc"
         if expected_partition is None:
@@ -217,12 +240,11 @@ class TestSourceResponsePartitioning:
         else:
             assert response.partition_keys == [expected_partition]
             assert response.partition_mode == "datetime"
+            assert response.partition_format == "week"
 
 
 @pytest.mark.parametrize("endpoint", ["sandboxes", "templates", "snapshots"])
 def test_every_endpoint_builds_a_source_response(endpoint: str) -> None:
-    response = e2b_source(
-        api_key="e2b_test", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=MagicMock()
-    )
+    response = _source(_make_manager(), endpoint=endpoint)
     assert response.name == endpoint
     assert callable(response.items)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firehydrant/firehydrant.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firehydrant/firehydrant.py
@@ -1,17 +1,17 @@
-import time
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-from urllib3.util.retry import Retry
+from typing import Any, Optional
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.firehydrant.settings import FIREHYDRANT_ENDPOINTS
 
 # FireHydrant accounts are region-pinned: US accounts live on api.firehydrant.io, EU accounts on the
@@ -24,12 +24,6 @@ DEFAULT_REGION = "us"
 # FireHydrant caps per_page at 200. 100 keeps each response comfortably small while halving the
 # request count versus the default page size.
 PAGE_SIZE = 100
-# Cap how long we'll honor a Retry-After before falling back to tenacity's own backoff.
-MAX_RETRY_AFTER_SECONDS = 60
-
-
-class FireHydrantRetryableError(Exception):
-    """Raised for transient FireHydrant API failures (429 / 5xx) that should be retried."""
 
 
 @dataclasses.dataclass
@@ -50,51 +44,6 @@ def base_url_for_region(region: str | None) -> str:
     return BASE_URLS.get((region or DEFAULT_REGION).lower(), BASE_URLS[DEFAULT_REGION])
 
 
-def _build_url(base_url: str, path: str, page: int) -> str:
-    query = urlencode({"page": page, "per_page": PAGE_SIZE})
-    return f"{base_url}{path}?{query}"
-
-
-def _fetch_page_once(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any] | list[Any]:
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429:
-        # FireHydrant returns a Retry-After header when the 50-req/10s account limit is exceeded.
-        # Honor it (bounded), then raise so tenacity retries.
-        retry_after = response.headers.get("Retry-After")
-        delay = min(int(retry_after), MAX_RETRY_AFTER_SECONDS) if retry_after and retry_after.isdigit() else 1
-        logger.warning(f"FireHydrant rate limited (429): sleeping {delay}s before retry, url={url}")
-        time.sleep(delay)
-        raise FireHydrantRetryableError(f"FireHydrant rate limited: url={url}")
-
-    if response.status_code >= 500:
-        raise FireHydrantRetryableError(f"FireHydrant API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Don't log the raw body on auth failures — keep it out of job logs in case the API echoes
-        # anything sensitive. Other 4xx bodies carry no credentials and are useful for debugging. The
-        # url holds only the path and pagination params (the token lives in the Authorization header).
-        if response.status_code in (401, 403):
-            logger.error(f"FireHydrant auth error: status={response.status_code}, url={url}")
-        else:
-            logger.error(f"FireHydrant API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-# Retry transport failures and retryable statuses (429 / 5xx) with bounded exponential backoff. The
-# core request logic lives in `_fetch_page_once` so it can be unit-tested without tenacity's waits.
-_fetch_page = retry(
-    retry=retry_if_exception_type((FireHydrantRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)(_fetch_page_once)
-
-
 def validate_credentials(api_key: str, region: str | None = None) -> tuple[bool, str | None]:
     """Probe the authenticated ping endpoint to confirm the token is genuine.
 
@@ -102,98 +51,93 @@ def validate_credentials(api_key: str, region: str | None = None) -> tuple[bool,
     token lacks the required permissions — we surface that as a permissions failure rather than
     silently accepting an unverified key (which would let a broken source register as authenticated).
     """
-    url = f"{base_url_for_region(region)}/v1/ping"
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(url, headers=_get_headers(api_key), timeout=10)
-    except Exception:
-        return False, "Could not reach the FireHydrant API. Please try again."
-
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{base_url_for_region(region)}/v1/ping",
+        headers=_get_headers(api_key),
+    )
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status is None:
+        return False, "Could not reach the FireHydrant API. Please try again."
+    if status == 401:
         return False, "Invalid FireHydrant API key"
-    if response.status_code == 403:
+    if status == 403:
         return (
             False,
             "Your FireHydrant API key is missing the permissions needed to access this data. "
             "Grant the required permissions in your FireHydrant settings, then reconnect.",
         )
-    return False, f"FireHydrant API returned an unexpected status: {response.status_code}"
-
-
-def _extract_items(payload: dict[str, Any] | list[Any]) -> list[dict[str, Any]]:
-    """Pull the row list out of a FireHydrant response.
-
-    Paginated endpoints wrap rows in a top-level `data` array; a few endpoints return a bare list or an
-    object with no `data` key, so we degrade gracefully rather than assume a single shape.
-    """
-    if isinstance(payload, list):
-        return payload
-    data = payload.get("data")
-    if isinstance(data, list):
-        return data
-    return []
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FireHydrantResumeConfig],
-    region: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = FIREHYDRANT_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    base_url = base_url_for_region(region)
-    # One session reused across every page so urllib3 keeps the connection alive instead of
-    # re-handshaking per request. Redact the token so it never lands in logged URLs or HTTP samples.
-    # `retry=Retry(total=0)` disables the adapter's own retries so tenacity is the single retry
-    # authority — otherwise adapter and tenacity backoffs would stack and could bypass the
-    # `MAX_RETRY_AFTER_SECONDS` cap on `Retry-After`.
-    session = make_tracked_session(retry=Retry(total=0), redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume else 1
-
-    while True:
-        payload = _fetch_page(session, _build_url(base_url, config.path, page), headers, logger)
-        items = _extract_items(payload)
-        if items:
-            yield items
-
-        pagination = payload.get("pagination", {}) if isinstance(payload, dict) else {}
-        next_page = pagination.get("next")
-        if not next_page:
-            break
-
-        # Save AFTER yielding so a crash re-yields the last page rather than skipping it — merge
-        # dedupes the re-pulled rows on the primary key.
-        resumable_source_manager.save_state(FireHydrantResumeConfig(next_page=next_page))
-        page = next_page
+    return False, f"FireHydrant API returned an unexpected status: {status}"
 
 
 def firehydrant_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FireHydrantResumeConfig],
     region: str | None = None,
 ) -> SourceResponse:
     config = FIREHYDRANT_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url_for_region(region),
+            # Auth (Bearer) is supplied via the framework auth config so the token is redacted from
+            # logs; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            # FireHydrant returns the next page number in `pagination.next` (null on the last page);
+            # inject it as the `page` query param. Termination is `pagination.next` being falsy —
+            # endpoints returning a single unpaginated response carry no `pagination`, so they stop
+            # after one page.
+            "paginator": JSONResponseCursorPaginator(cursor_path="pagination.next", cursor_param="page"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"per_page": PAGE_SIZE},
+                    # Paginated endpoints wrap rows in a top-level `data` array. A missing/empty `data`
+                    # key degrades to zero rows (not required) so an endpoint with nothing to return
+                    # ends cleanly rather than raising.
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"cursor": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("cursor") is not None:
+            resumable_source_manager.save_state(FireHydrantResumeConfig(next_page=int(state["cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            region=region,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firehydrant/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firehydrant/source.py
@@ -156,7 +156,8 @@ You can create a bot token or personal API key in your [FireHydrant API keys set
         return firehydrant_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             region=config.region,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firehydrant/tests/test_firehydrant.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firehydrant/tests/test_firehydrant.py
@@ -1,177 +1,194 @@
+import json
 from typing import Any
 
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.firehydrant import firehydrant
 from products.warehouse_sources.backend.temporal.data_imports.sources.firehydrant.firehydrant import (
     PAGE_SIZE,
     FireHydrantResumeConfig,
-    _build_url,
-    _extract_items,
     base_url_for_region,
     firehydrant_source,
-    get_rows,
+    validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.firehydrant.settings import (
     ENDPOINTS,
     FIREHYDRANT_ENDPOINTS,
 )
 
-
-class _FakeResumableManager:
-    def __init__(self, state: FireHydrantResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[FireHydrantResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> FireHydrantResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: FireHydrantResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
 
 
-def _collect(
-    manager: _FakeResumableManager,
-    monkeypatch: Any,
-    pages: dict[str, Any],
-    endpoint: str,
-    region: str | None = None,
-) -> list[dict]:
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-        result = pages[url]
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    monkeypatch.setattr(firehydrant, "_fetch_page", fake_fetch)
-
-    rows: list[dict] = []
-    for batch in get_rows(
-        api_key="fhb_test",
-        endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-        region=region,
-    ):
-        rows.extend(batch)
-    return rows
+def _response(
+    items: list[dict[str, Any]] | None, *, next_page: int | None = None, drop_pagination: bool = False
+) -> Response:
+    body: dict[str, Any] = {"data": items or []}
+    if not drop_pagination:
+        body["pagination"] = {"next": next_page}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class TestBuildUrl:
-    @parameterized.expand(
-        [
-            # region -> host: EU accounts are pinned to the data-residency host, so an unknown or
-            # missing region must fall back to the US default rather than a wrong host.
-            ("default_us", None, "https://api.firehydrant.io"),
-            ("us", "us", "https://api.firehydrant.io"),
-            ("eu", "eu", "https://api.eu.firehydrant.io"),
-            ("unknown_falls_back", "apac", "https://api.firehydrant.io"),
-        ]
-    )
-    def test_includes_page_and_per_page(self, _name: str, region: str | None, base_host: str) -> None:
-        url = _build_url(base_url_for_region(region), "/v1/incidents", 3)
-        assert url == f"{base_host}/v1/incidents?page=3&per_page={PAGE_SIZE}"
+def _make_manager(resume_state: FireHydrantResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class TestExtractItems:
-    @parameterized.expand(
-        [
-            ("wrapped_data", {"data": [{"id": "1"}], "pagination": {}}, [{"id": "1"}]),
-            ("bare_list", [{"id": "1"}, {"id": "2"}], [{"id": "1"}, {"id": "2"}]),
-            ("missing_data_key", {"pagination": {}}, []),
-            ("data_not_a_list", {"data": {"id": "1"}}, []),
-        ]
-    )
-    def test_extract_items(self, _name: str, payload: Any, expected: list[dict]) -> None:
-        assert _extract_items(payload) == expected
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Wire a mock session; capture each request's params AND url AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, url_snapshots
 
 
-class TestGetRows:
-    def test_follows_page_pagination(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.firehydrant.io/v1/incidents?page=1&per_page=100": {
-                "data": [{"id": "i1"}, {"id": "i2"}],
-                "pagination": {"page": 1, "next": 2, "last": 2},
-            },
-            "https://api.firehydrant.io/v1/incidents?page=2&per_page=100": {
-                "data": [{"id": "i3"}],
-                "pagination": {"page": 2, "next": None, "last": 2},
-            },
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, "incidents")
-        assert rows == [{"id": "i1"}, {"id": "i2"}, {"id": "i3"}]
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
-    def test_single_unpaginated_response_terminates(self, monkeypatch: Any) -> None:
-        # signals_on_call and similar endpoints may return a single page with no `next`.
-        pages = {
-            "https://api.firehydrant.io/v1/signals_on_call?page=1&per_page=100": {
-                "data": [{"id": "s1"}],
-            },
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, "signals_on_call")
-        assert rows == [{"id": "s1"}]
 
-    def test_state_saved_after_each_page_with_next(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            "https://api.firehydrant.io/v1/services?page=1&per_page=100": {
-                "data": [{"id": "a"}],
-                "pagination": {"next": 2},
-            },
-            "https://api.firehydrant.io/v1/services?page=2&per_page=100": {
-                "data": [{"id": "b"}],
-                "pagination": {"next": 3},
-            },
-            "https://api.firehydrant.io/v1/services?page=3&per_page=100": {
-                "data": [{"id": "c"}],
-                "pagination": {"next": None},
-            },
-        }
-        _collect(manager, monkeypatch, pages, "services")
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_page_pagination(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(
+            session,
+            [
+                _response([{"id": "i1"}, {"id": "i2"}], next_page=2),
+                _response([{"id": "i3"}], next_page=None),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(
+            firehydrant_source("fhb_test", "incidents", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        assert [r["id"] for r in rows] == ["i1", "i2", "i3"]
+        # First request carries per_page but no explicit page (FireHydrant defaults to page 1);
+        # the second request injects the `page` cursor from `pagination.next`.
+        assert params[0]["per_page"] == PAGE_SIZE
+        assert "page" not in params[0]
+        assert params[1]["page"] == 2
+        assert params[1]["per_page"] == PAGE_SIZE
+        # Checkpoint saved once, pointing at the next page; the final (next=None) page saves nothing.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == FireHydrantResumeConfig(next_page=2)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_unpaginated_response_terminates(self, MockSession) -> None:
+        # signals_on_call and similar endpoints may return a single page with no `pagination` object.
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "s1"}], drop_pagination=True)])
+
+        manager = _make_manager()
+        rows = _rows(
+            firehydrant_source("fhb_test", "signals_on_call", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        assert [r["id"] for r in rows] == ["s1"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_state_saved_after_each_page_with_next(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "a"}], next_page=2),
+                _response([{"id": "b"}], next_page=3),
+                _response([{"id": "c"}], next_page=None),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(firehydrant_source("fhb_test", "services", team_id=1, job_id="j", resumable_source_manager=manager))
+
         # State saved only when a next page exists — not after the final page.
-        assert [s.next_page for s in manager.saved] == [2, 3]
+        assert [c.args[0].next_page for c in manager.save_state.call_args_list] == [2, 3]
 
-    def test_region_routes_requests_to_eu_host(self, monkeypatch: Any) -> None:
-        # EU accounts only answer on the data-residency host; if get_rows ignored region it would hit
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_region_routes_requests_to_eu_host(self, MockSession) -> None:
+        # EU accounts only answer on the data-residency host; if the source ignored region it would hit
         # the US host and every EU sync would fail.
-        pages = {
-            "https://api.eu.firehydrant.io/v1/incidents?page=1&per_page=100": {
-                "data": [{"id": "eu1"}],
-                "pagination": {"next": None},
-            },
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, "incidents", region="eu")
-        assert rows == [{"id": "eu1"}]
+        session = MockSession.return_value
+        _params, urls = _wire(session, [_response([{"id": "eu1"}], next_page=None)])
 
-    def test_resume_from_saved_state(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(FireHydrantResumeConfig(next_page=2))
-        pages = {
-            "https://api.firehydrant.io/v1/services?page=2&per_page=100": {
-                "data": [{"id": "b"}],
-                "pagination": {"next": None},
-            },
-        }
-        rows = _collect(manager, monkeypatch, pages, "services")
+        manager = _make_manager()
+        rows = _rows(
+            firehydrant_source(
+                "fhb_test", "incidents", team_id=1, job_id="j", resumable_source_manager=manager, region="eu"
+            )
+        )
+
+        assert [r["id"] for r in rows] == ["eu1"]
+        assert urls[0].startswith("https://api.eu.firehydrant.io/v1/incidents")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_from_saved_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response([{"id": "b"}], next_page=None)])
+
+        manager = _make_manager(FireHydrantResumeConfig(next_page=2))
+        rows = _rows(
+            firehydrant_source("fhb_test", "services", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
         # Resumes at page 2 (page 1 is never requested), proving the saved cursor is honored.
-        assert rows == [{"id": "b"}]
+        assert [r["id"] for r in rows] == ["b"]
+        assert params[0]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rate_limit_then_success_is_retried(self, MockSession, monkeypatch: Any) -> None:
+        # 429 must be classified retryable (not fatal): a 429 followed by a 200 recovers and yields rows.
+        import tenacity.nap
+
+        monkeypatch.setattr(tenacity.nap.time, "sleep", lambda _s: None)
+
+        session = MockSession.return_value
+        throttled = Response()
+        throttled.status_code = 429
+        throttled.headers["Retry-After"] = "1"
+        _wire(session, [throttled, _response([{"id": "ok"}], next_page=None)])
+
+        manager = _make_manager()
+        rows = _rows(
+            firehydrant_source("fhb_test", "incidents", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+        assert [r["id"] for r in rows] == ["ok"]
 
 
-class TestFireHydrantSource:
+class TestSourceResponse:
     @parameterized.expand(list(ENDPOINTS))
     def test_source_response_matches_endpoint_config(self, endpoint: str) -> None:
         config = FIREHYDRANT_ENDPOINTS[endpoint]
         response = firehydrant_source(
             api_key="fhb_test",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
         )
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -215,19 +232,19 @@ class TestValidateCredentials:
     def test_status_mapping(self, _name: str, status_code: int, expected_valid: bool) -> None:
         response = requests.Response()
         response.status_code = status_code
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.return_value = response
 
-        with patch.object(firehydrant, "make_tracked_session", lambda *a, **k: session):
-            valid, _error = firehydrant.validate_credentials("fhb_test")
+        with mock.patch.object(firehydrant, "make_tracked_session", lambda *a, **k: session):
+            valid, _error = validate_credentials("fhb_test")
         assert valid is expected_valid
 
     def test_network_error_is_invalid(self, monkeypatch: Any) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = requests.ConnectionError("boom")
         monkeypatch.setattr(firehydrant, "make_tracked_session", lambda *a, **k: session)
 
-        valid, error = firehydrant.validate_credentials("fhb_test")
+        valid, error = validate_credentials("fhb_test")
         assert valid is False
         assert error is not None
 
@@ -241,12 +258,25 @@ class TestValidateCredentials:
         # The key is only valid against its own region's host, so validation must probe there.
         response = requests.Response()
         response.status_code = 200
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.return_value = response
 
-        with patch.object(firehydrant, "make_tracked_session", lambda *a, **k: session):
-            firehydrant.validate_credentials("fhb_test", region=region)
+        with mock.patch.object(firehydrant, "make_tracked_session", lambda *a, **k: session):
+            validate_credentials("fhb_test", region=region)
         assert session.get.call_args.args[0] == expected_url
+
+    @parameterized.expand(
+        [
+            ("default_us", None, "https://api.firehydrant.io"),
+            ("us", "us", "https://api.firehydrant.io"),
+            ("eu", "eu", "https://api.eu.firehydrant.io"),
+            ("unknown_falls_back", "apac", "https://api.firehydrant.io"),
+        ]
+    )
+    def test_base_url_for_region(self, _name: str, region: str | None, expected_host: str) -> None:
+        # EU accounts are pinned to the data-residency host; an unknown or missing region must fall
+        # back to the US default rather than a wrong host.
+        assert base_url_for_region(region) == expected_host
 
 
 class TestCredentialRedaction:
@@ -255,62 +285,27 @@ class TestCredentialRedaction:
     def test_validate_credentials_redacts_api_key(self, monkeypatch: Any) -> None:
         captured: dict[str, Any] = {}
 
-        def fake_session(*args: Any, **kwargs: Any) -> MagicMock:
+        def fake_session(*args: Any, **kwargs: Any) -> mock.MagicMock:
             captured.update(kwargs)
             response = requests.Response()
             response.status_code = 200
-            session = MagicMock()
+            session = mock.MagicMock()
             session.get.return_value = response
             return session
 
         monkeypatch.setattr(firehydrant, "make_tracked_session", fake_session)
-        firehydrant.validate_credentials("fhb_secret")
+        validate_credentials("fhb_secret")
         assert captured.get("redact_values") == ("fhb_secret",)
 
-    def test_get_rows_redacts_api_key(self, monkeypatch: Any) -> None:
-        captured: dict[str, Any] = {}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_transport_redacts_api_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], next_page=None)])
 
-        def fake_session(*args: Any, **kwargs: Any) -> MagicMock:
-            captured.update(kwargs)
-            return MagicMock()
-
-        monkeypatch.setattr(firehydrant, "make_tracked_session", fake_session)
-        monkeypatch.setattr(firehydrant, "_fetch_page", lambda *a, **k: {"data": [], "pagination": {}})
-
-        list(
-            get_rows(
-                api_key="fhb_secret",
-                endpoint="incidents",
-                logger=MagicMock(),
-                resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+        _rows(
+            firehydrant_source(
+                "fhb_secret", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager()
             )
         )
-        assert captured.get("redact_values") == ("fhb_secret",)
-
-
-class TestFetchPageRetries:
-    def _session_returning(self, status_code: int, headers: dict[str, str] | None = None) -> MagicMock:
-        response = requests.Response()
-        response.status_code = status_code
-        response.headers.update(headers or {})
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
-    # Tested through `_fetch_page_once` (the undecorated core) so tenacity's waits don't run.
-    _URL = "https://api.firehydrant.io/v1/incidents?page=1&per_page=100"
-
-    def test_rate_limit_honors_retry_after_then_raises_retryable(self, monkeypatch: Any) -> None:
-        slept: list[int] = []
-        monkeypatch.setattr(firehydrant.time, "sleep", lambda s: slept.append(s))
-        session = self._session_returning(429, {"Retry-After": "7"})
-
-        with pytest.raises(firehydrant.FireHydrantRetryableError):
-            firehydrant._fetch_page_once(session, self._URL, {}, MagicMock())
-
-        assert slept == [7]
-
-    def test_server_error_is_retryable(self) -> None:
-        session = self._session_returning(503)
-        with pytest.raises(firehydrant.FireHydrantRetryableError):
-            firehydrant._fetch_page_once(session, self._URL, {}, MagicMock())
+        # The bearer token is registered for value-based redaction when the tracked session is built.
+        assert "fhb_secret" in MockSession.call_args.kwargs.get("redact_values", ())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fleetio/fleetio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fleetio/fleetio.py
@@ -1,17 +1,21 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import PreparedRequest
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import AuthConfigBase
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.fleetio.settings import (
     FLEETIO_ENDPOINTS,
     FleetioEndpointConfig,
@@ -27,28 +31,35 @@ FLEETIO_API_VERSION = "2024-06-30"
 PER_PAGE = 100
 DEFAULT_INCREMENTAL_FIELD = "updated_at"
 
-MAX_RETRIES = 5
+
+class FleetioAuth(AuthConfigBase):
+    """Fleetio authenticates with two separate headers, not one.
+
+    `Authorization: Token <api_key>` carries the API key and `Account-Token: <account_token>` selects
+    the account. The generic auth types each carry a single credential header, so both are set here and
+    both reported as secret so the tracked session masks them wherever they surface in logs or captured
+    samples — the `Account-Token` header name is connector-specific and not one the generic auth
+    scrubbers recognise.
+    """
+
+    def __init__(self, api_key: str, account_token: str) -> None:
+        self.api_key = api_key
+        self.account_token = account_token
+
+    def __call__(self, request: PreparedRequest) -> PreparedRequest:
+        request.headers["Authorization"] = f"Token {self.api_key}"
+        request.headers["Account-Token"] = self.account_token
+        return request
+
+    def secret_values(self) -> tuple[str, ...]:
+        return tuple(value for value in (self.api_key, self.account_token) if value)
 
 
-class FleetioRetryableError(Exception):
-    """Transient 5xx — safe to retry with backoff."""
-
-
-class FleetioRateLimitError(Exception):
-    """429 Too Many Requests. Carries the server's Retry-After (seconds) so we can honor it."""
-
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
-
-
-def _get_headers(api_key: str, account_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Token {api_key}",
-        "Account-Token": account_token,
-        "X-Api-Version": FLEETIO_API_VERSION,
-        "Accept": "application/json",
-    }
+def _non_secret_headers() -> dict[str, str]:
+    # Only the non-secret version/accept headers live here; the credentials go through FleetioAuth so
+    # their values are registered for redaction. Pinning the version is what guarantees the
+    # cursor-pagination + filter/sort contract.
+    return {"X-Api-Version": FLEETIO_API_VERSION, "Accept": "application/json"}
 
 
 def _format_incremental_value(value: Any) -> str:
@@ -65,25 +76,13 @@ def _format_incremental_value(value: Any) -> str:
     return str(value)
 
 
-def _build_url(base_url: str, params: dict[str, Any]) -> str:
-    """Build a URL with an encoded query string.
-
-    The `filter[updated_at][gt]` / `sort[updated_at]` keys contain literal brackets; `urlencode`
-    percent-encodes them (and the timestamp's `+`/`:`), which Rack decodes back to brackets on the
-    server, so the encoded form is equivalent to the documented literal form.
-    """
-    if not params:
-        return base_url
-    return f"{base_url}?{urlencode(params)}"
-
-
 def _build_base_params(
     config: FleetioEndpointConfig,
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Any,
     incremental_field: str | None,
 ) -> dict[str, Any]:
-    """Build the query params reused on every page (the cursor is added per request).
+    """Build the query params reused on every page (the cursor is added per request by the paginator).
 
     Sort ascending on the field we checkpoint against so `SourceResponse.sort_mode="asc"` holds and
     the watermark advances correctly: the chosen incremental field when syncing incrementally, else a
@@ -99,8 +98,7 @@ def _build_base_params(
         # `filter[<field>][gt]` is the documented server-side timestamp filter for API versions
         # 2024-01-01+ (the `gt` operator mirrors the legacy `q[<field>_gt]` ransack predicate). The
         # cursor envelope carries the active filter forward, so it stays applied on every page rather
-        # than only the first — no unbounded history re-walk on incremental syncs. Not yet verified
-        # against a live account (no test credentials); see PR notes.
+        # than only the first — no unbounded history re-walk on incremental syncs.
         filter_field = incremental_field or DEFAULT_INCREMENTAL_FIELD
         params[f"filter[{filter_field}][gt]"] = _format_incremental_value(db_incremental_field_last_value)
 
@@ -113,162 +111,97 @@ class FleetioResumeConfig:
     start_cursor: str | None = None
 
 
-def _parse_retry_after(value: str | None) -> float | None:
-    if not value:
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
-
-
-def _retry_wait(retry_state: Any) -> float:
-    """Honor a 429's Retry-After header when present, else fall back to exponential backoff."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, FleetioRateLimitError) and exc.retry_after is not None:
-        return exc.retry_after
-    return wait_exponential_jitter(initial=1, max=30)(retry_state)
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (FleetioRetryableError, FleetioRateLimitError, requests.ReadTimeout, requests.ConnectionError)
-    ),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=_retry_wait,
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429:
-        raise FleetioRateLimitError(
-            f"Fleetio API rate limited: url={url}",
-            retry_after=_parse_retry_after(response.headers.get("Retry-After")),
-        )
-
-    if response.status_code >= 500:
-        raise FleetioRetryableError(f"Fleetio API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Fleetio API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    if not isinstance(data, dict):
-        # With X-Api-Version pinned, every index endpoint returns the cursor envelope
-        # ({"records": [...], "next_cursor": ...}). A bare list would mean the version pin was
-        # ignored (legacy page-based response); fail loudly rather than silently syncing one page.
-        raise FleetioRetryableError(f"Unexpected Fleetio response shape (expected cursor envelope): url={url}")
-    return data
-
-
 def validate_credentials(api_key: str, account_token: str) -> bool:
     # Probe a cheap index endpoint; Fleetio API keys are account-scoped (no per-endpoint scopes), so
-    # one 200 confirms both headers are genuine.
-    url = _build_url(f"{FLEETIO_BASE_URL}/vehicles", {"per_page": 1})
-    try:
-        # Redact both credentials in logged URLs and captured samples. `Account-Token` is a
-        # connector-specific header name the generic auth scrubbers don't recognise, so value-based
-        # redaction is required to keep it out of HTTP telemetry.
-        session = make_tracked_session(redact_values=(api_key, account_token))
-        response = session.get(url, headers=_get_headers(api_key, account_token), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    account_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FleetioResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = FLEETIO_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key, account_token)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # One session reused across every page so urllib3 keeps the connection alive. Redact both
-    # credentials in logged URLs and captured samples — `Account-Token` is a connector-specific
-    # header name the generic auth scrubbers don't recognise.
-    session = make_tracked_session(redact_values=(api_key, account_token))
-
-    base_params = _build_base_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    # one 200 confirms both headers are genuine. Both credentials are redacted from logged URLs and
+    # captured samples — `Account-Token` is a connector-specific header name the generic auth scrubbers
+    # don't recognise, so value-based redaction is required to keep it out of HTTP telemetry.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key, account_token)),
+        f"{FLEETIO_BASE_URL}/vehicles?per_page=1",
+        headers=_non_secret_headers(),
+        auth=FleetioAuth(api_key, account_token),
     )
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_cursor = resume.start_cursor if resume else None
-    if start_cursor:
-        logger.debug(f"Fleetio: resuming {endpoint} from cursor={start_cursor}")
-
-    while True:
-        params = dict(base_params)
-        if start_cursor:
-            params["start_cursor"] = start_cursor
-        url = _build_url(f"{FLEETIO_BASE_URL}{config.path}", params)
-
-        data = _fetch_page(session, url, headers, logger)
-        records = data.get("records", [])
-        next_cursor = data.get("next_cursor")
-
-        yielded_this_page = False
-        for item in records:
-            batcher.batch(item)
-
-            if batcher.should_yield():
-                yield batcher.get_table()
-                yielded_this_page = True
-
-        # Save state once, AFTER every record on this page has been batched, so a mid-page yield (the
-        # 100 MB byte-size limit) can't advance the cursor past records we haven't seen yet. A crash
-        # then re-fetches the whole page rather than skipping its tail — merge dedupes on the primary
-        # key. Only save when we yielded data and more pages remain.
-        if yielded_this_page and next_cursor:
-            resumable_source_manager.save_state(FleetioResumeConfig(start_cursor=next_cursor))
-
-        if not next_cursor:
-            break
-        start_cursor = next_cursor
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    return ok
 
 
 def fleetio_source(
     api_key: str,
     account_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FleetioResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
 ) -> SourceResponse:
-    endpoint_config = FLEETIO_ENDPOINTS[endpoint]
+    config = FLEETIO_ENDPOINTS[endpoint]
+
+    params = _build_base_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": FLEETIO_BASE_URL,
+            "headers": _non_secret_headers(),
+            "auth": FleetioAuth(api_key, account_token),
+            # Every index endpoint returns the cursor envelope ({"records": [...], "next_cursor": ...});
+            # the cursor is carried forward as the `start_cursor` query param.
+            "paginator": JSONResponseCursorPaginator(cursor_path="next_cursor", cursor_param="start_cursor"),
+            # Pin every request — including the paginator's next-page cursor requests — to the Fleetio
+            # host and refuse redirects, so a tampered/spoofed response can't exfiltrate the two
+            # credential headers to another origin.
+            "allowed_hosts": [],
+            "allow_redirects": False,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    "data_selector": "records",
+                    # A 200 body without `records` (e.g. a bare list because the version pin was
+                    # ignored and a legacy page-based response came back) means the response shape
+                    # changed — fail loud instead of silently syncing 0 rows or one page.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.start_cursor:
+            initial_paginator_state = {"cursor": resume.start_cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(FleetioResumeConfig(start_cursor=state["cursor"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            account_token=account_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
-        primary_keys=endpoint_config.primary_keys,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="month" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fleetio/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fleetio/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.fleetio.fleetio import (
     FleetioResumeConfig,
     fleetio_source,
@@ -27,7 +30,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.fleetio.fl
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.fleetio.settings import (
     ENDPOINTS,
-    FLEETIO_ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import FleetioSourceConfig
@@ -113,22 +115,7 @@ Create an API key under **Account Menu → Account Settings → API Keys** in Fl
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = FLEETIO_ENDPOINTS[endpoint]
-            has_incremental = len(endpoint_config.incremental_fields) > 0
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=has_incremental,
-                supports_append=has_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: FleetioSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -151,7 +138,8 @@ Create an API key under **Account Menu → Account Settings → API Keys** in Fl
             api_key=config.api_key,
             account_token=config.account_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fleetio/tests/test_fleetio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fleetio/tests/test_fleetio.py
@@ -1,25 +1,83 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
 from parameterized import parameterized
+from requests import PreparedRequest, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.fleetio import fleetio
 from products.warehouse_sources.backend.temporal.data_imports.sources.fleetio.fleetio import (
     FLEETIO_API_VERSION,
-    FleetioRateLimitError,
+    FleetioAuth,
     FleetioResumeConfig,
     _build_base_params,
-    _build_url,
     _format_incremental_value,
-    _get_headers,
-    _parse_retry_after,
-    get_rows,
+    fleetio_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.fleetio.settings import FLEETIO_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the fleetio module.
+FLEETIO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.fleetio.fleetio.make_tracked_session"
+)
+
+
+def _response(records: list[dict[str, Any]] | None, next_cursor: str | None, *, body: Any = None) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    envelope: Any = body if body is not None else {"records": records or [], "next_cursor": next_cursor}
+    resp._content = json.dumps(envelope).encode()
+    return resp
+
+
+def _make_manager(resume_state: FleetioResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages (the paginator injects the cursor
+    into it), so inspecting it after the run shows only the final state — snapshot a copy when each
+    request is prepared. The prepared request carries a real on-host URL so the client's SSRF
+    allowed-hosts check passes.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = "https://secure.fleetio.com/api/v1/vehicles"
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(manager: mock.MagicMock, **kwargs: Any):
+    return fleetio_source(
+        api_key="k",
+        account_token="a",
+        endpoint="vehicles",
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
 
 
 class TestFormatIncrementalValue:
@@ -35,28 +93,18 @@ class TestFormatIncrementalValue:
         assert _format_incremental_value(value) == expected
 
 
-class TestHeaders:
-    def test_includes_both_auth_headers_and_pinned_version(self) -> None:
-        headers = _get_headers("key123", "acct456")
-        assert headers["Authorization"] == "Token key123"
-        assert headers["Account-Token"] == "acct456"
-        # The version pin is what guarantees the cursor-pagination + filter/sort contract.
-        assert headers["X-Api-Version"] == FLEETIO_API_VERSION
+class TestFleetioAuth:
+    def test_sets_both_credential_headers(self) -> None:
+        request = PreparedRequest()
+        request.headers = {}
+        FleetioAuth("key123", "acct456")(request)
+        assert request.headers["Authorization"] == "Token key123"
+        assert request.headers["Account-Token"] == "acct456"
 
-
-class TestBuildUrl:
-    def test_no_params_returns_base(self) -> None:
-        assert _build_url("https://x/api", {}) == "https://x/api"
-
-    def test_brackets_and_timestamp_are_encoded(self) -> None:
-        url = _build_url(
-            "https://x/api/vehicles",
-            {"filter[updated_at][gt]": "2026-03-04T02:58:14+00:00", "per_page": 100},
-        )
-        # urlencode percent-encodes the brackets and the `+`/`:` in the timestamp; Rack decodes
-        # them back server-side, so the encoded form is equivalent to the literal documented form.
-        assert "filter%5Bupdated_at%5D%5Bgt%5D=2026-03-04T02%3A58%3A14%2B00%3A00" in url
-        assert "per_page=100" in url
+    def test_reports_both_credentials_as_secret_for_redaction(self) -> None:
+        # Both the API key and the account token must be masked in HTTP telemetry; the account-token
+        # header name isn't one the generic scrubbers recognise, so value-based redaction is required.
+        assert set(FleetioAuth("key123", "acct456").secret_values()) == {"key123", "acct456"}
 
 
 class TestBuildBaseParams:
@@ -100,162 +148,92 @@ class TestBuildBaseParams:
         assert params["filter[created_at][gt]"] == "2026-01-01T00:00:00+00:00"
 
 
-class TestParseRetryAfter:
-    @parameterized.expand(
-        [("seconds", "30", 30.0), ("float", "1.5", 1.5), ("blank", None, None), ("garbage", "soon", None)]
-    )
-    def test_parse(self, _name: str, value: str | None, expected: float | None) -> None:
-        assert _parse_retry_after(value) == expected
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_next_cursor_is_null(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 1}, {"id": 2}], "CUR2"), _response([{"id": 3}], None)])
 
+        manager = _make_manager()
+        rows = _rows(_source(manager))
 
-class _FakeResumableManager:
-    def __init__(self, state: FleetioResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[FleetioResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> FleetioResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: FleetioResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        pages: dict[str, Any],
-        **kwargs: Any,
-    ) -> tuple[list[dict], list[str]]:
-        fetched: list[str] = []
-
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            fetched.append(url)
-            result = pages[url]
-            if isinstance(result, Exception):
-                raise result
-            return result
-
-        monkeypatch.setattr(fleetio, "_fetch_page", fake_fetch)
-
-        rows: list[dict] = []
-        for table in get_rows(
-            api_key="k",
-            account_token="a",
-            endpoint="vehicles",
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(table.to_pylist())
-        return rows, fetched
-
-    def test_paginates_until_next_cursor_is_null(self, monkeypatch: Any) -> None:
-        base = "https://secure.fleetio.com/api/v1/vehicles?per_page=100&sort%5Bcreated_at%5D=asc"
-        page2 = base + "&start_cursor=CUR2"
-        pages = {
-            base: {"records": [{"id": 1}, {"id": 2}], "next_cursor": "CUR2"},
-            page2: {"records": [{"id": 3}], "next_cursor": None},
-        }
-        rows, fetched = self._collect(_FakeResumableManager(), monkeypatch, pages)
         assert rows == [{"id": 1}, {"id": 2}, {"id": 3}]
-        assert fetched == [base, page2]
+        # First page carries no cursor; the second is fetched with the cursor from page one.
+        assert "start_cursor" not in params[0]
+        assert params[0]["per_page"] == 100
+        assert params[0]["sort[created_at]"] == "asc"
+        assert params[1]["start_cursor"] == "CUR2"
+        # Checkpoint saved once (pointing at the next page); the terminal page saves nothing.
+        manager.save_state.assert_called_once_with(FleetioResumeConfig(start_cursor="CUR2"))
 
-    def test_resume_starts_from_saved_cursor(self, monkeypatch: Any) -> None:
-        resumed = "https://secure.fleetio.com/api/v1/vehicles?per_page=100&sort%5Bcreated_at%5D=asc&start_cursor=SAVED"
-        pages = {resumed: {"records": [{"id": 9}], "next_cursor": None}}
-        manager = _FakeResumableManager(FleetioResumeConfig(start_cursor="SAVED"))
-        rows, fetched = self._collect(manager, monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_terminal_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}, {"id": 2}], None)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_starts_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 9}], None)])
+
+        manager = _make_manager(FleetioResumeConfig(start_cursor="SAVED"))
+        rows = _rows(_source(manager))
+
         assert rows == [{"id": 9}]
-        assert fetched == [resumed]
+        assert params[0]["start_cursor"] == "SAVED"
 
-    def test_saves_state_after_yielding_a_batch_with_more_pages(self, monkeypatch: Any) -> None:
-        # Force a yield after every row by capping the batch at one row.
-        real_batcher = fleetio.Batcher
-        monkeypatch.setattr(
-            fleetio,
-            "Batcher",
-            lambda **kwargs: real_batcher(
-                logger=kwargs["logger"], chunk_size=1, chunk_size_bytes=kwargs["chunk_size_bytes"]
-            ),
-        )
-        base = "https://secure.fleetio.com/api/v1/vehicles?per_page=100&sort%5Bcreated_at%5D=asc"
-        page2 = base + "&start_cursor=CUR2"
-        pages = {
-            base: {"records": [{"id": 1}], "next_cursor": "CUR2"},
-            page2: {"records": [{"id": 2}], "next_cursor": None},
-        }
-        manager = _FakeResumableManager()
-        self._collect(manager, monkeypatch, pages)
-        # State saved with the NEXT page's cursor (so a crash re-yields, never skips), and only while
-        # more pages remain — the final page (next_cursor=None) saves nothing.
-        assert manager.saved == [FleetioResumeConfig(start_cursor="CUR2")]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_reaches_the_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 1}], None)])
 
-    def test_saves_state_once_per_page_even_when_yielding_mid_page(self, monkeypatch: Any) -> None:
-        # Multiple yields within a single page (chunk_size=1, two records) must save the cursor only
-        # once, AFTER the whole page is batched — saving on the first mid-page yield would advance the
-        # cursor past the page's remaining records and skip them on resume.
-        real_batcher = fleetio.Batcher
-        monkeypatch.setattr(
-            fleetio,
-            "Batcher",
-            lambda **kwargs: real_batcher(
-                logger=kwargs["logger"], chunk_size=1, chunk_size_bytes=kwargs["chunk_size_bytes"]
-            ),
+        rows = _rows(
+            _source(
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+                incremental_field="updated_at",
+            )
         )
-        base = "https://secure.fleetio.com/api/v1/vehicles?per_page=100&sort%5Bcreated_at%5D=asc"
-        page2 = base + "&start_cursor=CUR2"
-        pages = {
-            base: {"records": [{"id": 1}, {"id": 2}], "next_cursor": "CUR2"},
-            page2: {"records": [{"id": 3}], "next_cursor": None},
-        }
-        manager = _FakeResumableManager()
-        rows, _ = self._collect(manager, monkeypatch, pages)
-        assert rows == [{"id": 1}, {"id": 2}, {"id": 3}]
-        assert manager.saved == [FleetioResumeConfig(start_cursor="CUR2")]
+
+        assert rows == [{"id": 1}]
+        assert params[0]["sort[updated_at]"] == "asc"
+        assert params[0]["filter[updated_at][gt]"] == "2026-03-04T02:58:14+00:00"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_version_header_is_set_on_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}], None)])
+
+        _rows(_source(_make_manager()))
+        assert session.headers.get("X-Api-Version") == FLEETIO_API_VERSION
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_bare_list_body_fails_loudly(self, MockSession) -> None:
+        # A bare list means the version pin was ignored (legacy page-based response) — fail loud
+        # instead of silently truncating to one page.
+        session = MockSession.return_value
+        _wire(session, [_response(None, None, body=[{"id": 1}])])
+
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(_make_manager()))
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code,expected", [(200, True), (401, False), (403, False)])
-    def test_status_maps_to_bool(self, status_code: int, expected: bool, monkeypatch: Any) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-        monkeypatch.setattr(fleetio, "make_tracked_session", lambda *a, **k: session)
+    @mock.patch(FLEETIO_SESSION_PATCH)
+    def test_status_maps_to_bool(self, mock_session, status_code: int, expected: bool) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("k", "a") is expected
 
-    def test_network_error_is_not_valid(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        monkeypatch.setattr(fleetio, "make_tracked_session", lambda *a, **k: session)
+    @mock.patch(FLEETIO_SESSION_PATCH)
+    def test_network_error_is_not_valid(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("k", "a") is False
-
-
-class TestFetchPage:
-    def _session_returning(self, status_code: int, headers: dict[str, str] | None = None, json_body: Any = None):
-        response = MagicMock()
-        response.status_code = status_code
-        response.headers = headers or {}
-        response.ok = status_code < 400
-        response.json.return_value = json_body if json_body is not None else {"records": [], "next_cursor": None}
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
-    def test_429_raises_rate_limit_with_retry_after(self) -> None:
-        # Call the undecorated body (bypassing tenacity) to assert the error carries Retry-After.
-        session = self._session_returning(429, headers={"Retry-After": "12"})
-        with pytest.raises(FleetioRateLimitError) as exc:
-            fleetio._fetch_page.__wrapped__(session, "https://x", {}, MagicMock())  # type: ignore[attr-defined]
-        assert exc.value.retry_after == 12.0
-
-    def test_non_dict_response_is_treated_as_retryable(self) -> None:
-        # A bare list means the version pin was ignored (legacy response) — fail loudly, don't truncate.
-        session = self._session_returning(200, json_body=[{"id": 1}])
-        with pytest.raises(fleetio.FleetioRetryableError):
-            fleetio._fetch_page.__wrapped__(session, "https://x", {}, MagicMock())  # type: ignore[attr-defined]


### PR DESCRIPTION
## Problem

Batch 15 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

This batch also lands a generic framework capability — **SSRF host-pinning + redirect control** — so sources that pin pagination/resume URLs to the expected host no longer need bespoke transport code.

## Changes

Framework:
- `client={"allowed_hosts": [...], "allow_redirects": False}` in `common/rest_source`. When `allowed_hosts` is set (even to `[]`, meaning base-host-only), every outgoing request URL — including paginator next-page links and seeded resume URLs — must resolve to an allowed host (the base_url host is always implicitly allowed); an off-host URL raises before the request (and its Authorization header) leaves the process. `allow_redirects=False` stops the session following redirects and rejects any 3xx. This closes the credential-exfiltration path a spoofed `next` link would otherwise open.

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **delighted** — now expressible via the new SSRF host-pinning (off-host link/resume URL rejection + disabled redirects)
- **culture_amp** — OAuth2 client-credentials with per-endpoint scopes + per-employee demographics fan-out
- **deno_deploy**
- **e2b**
- **firehydrant**
- **fleetio**

Not migrated this batch (left hand-rolled, valid blockers):
- **concord** — five transport modes in one source (single, recursive folders-tree, page, offset, and a date-windowed audit-log download).
- **easypost** — client-side incremental watermark filtering with early termination (stops paginating despite `has_more=true`).

## How did you test this code?

- New framework capability: 7 parameterized cases in `test_ssrf_host_pinning.py` covering same-host pinning, explicit allowlists, off-host rejection, disabled enforcement, and redirect rejection/allow.
- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 6 migrated dirs + `common/rest_source/tests/` — 462 passed. Additive framework change: all existing `rest_source` tests plus fan-out/paginator consumer smoke (adroll, bigmailer, chargebee, airtable, clickup) stay green.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-14 PR (#71840); merge in order.
