### PR TITLE
fix(error-tracking): run symbol cleanup every 30 minutes

### DIFF
--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/schedule.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/schedule.py
@@ -18,7 +18,7 @@ from products.error_tracking.backend.temporal.symbol_set_cleanup.types import Sy
 from products.error_tracking.backend.temporal.symbol_set_cleanup.workflow import WORKFLOW_NAME
 
 SCHEDULE_ID = "error-tracking-symbol-set-cleanup-schedule"
-SCHEDULE_INTERVAL = timedelta(hours=1)
+SCHEDULE_INTERVAL = timedelta(minutes=30)
 
 
 async def create_error_tracking_symbol_set_cleanup_schedule(client: Client) -> None:

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup_schedule.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup_schedule.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pytest
 from unittest.mock import AsyncMock, patch
 
@@ -52,7 +54,8 @@ def assert_symbol_set_cleanup_schedule(schedule) -> None:
 
 class TestCreateErrorTrackingSymbolSetCleanupSchedule:
     @pytest.mark.asyncio
-    async def test_creates_hourly_schedule_when_missing(self, mock_client, schedule_helpers) -> None:
+    async def test_creates_30_minute_schedule_when_missing(self, mock_client, schedule_helpers) -> None:
+        assert SCHEDULE_INTERVAL == timedelta(minutes=30)
         schedule_helpers["exists"].return_value = False
 
         await create_error_tracking_symbol_set_cleanup_schedule(mock_client)


### PR DESCRIPTION
## Problem

Error tracking symbol set cleanup currently runs hourly. Running it every 30 minutes reduces the delay before eligible symbol sets are removed.

## Changes

- Change the Temporal schedule interval from one hour to 30 minutes.
- Keep the existing overlap policy so a cleanup run is skipped if the previous run is still active.
- Lock the new cadence into the schedule test.

After deployment, run the schedule reconciliation command:

```sh
python manage.py schedule_temporal_workflows
```

## How did you test this code?

- `hogli test products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup_schedule.py` (2 passed). The updated assertion catches a regression back to the hourly cadence.
- `ruff format --check` and `ruff check` on the changed files.
- `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this changes an internal cleanup cadence only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the Pi coding agent in a local session with no shareable session link. I invoked the `/error-tracking`, `/writing-tests`, `/running-ci-preflight`, and `/pr` skills.

The schedule keeps `SKIP` overlap behavior, so increasing the cadence does not allow concurrent cleanup runs. The existing schedule registration updates the Temporal schedule on deployment.