### PR TITLE
feat(autoresearch): cache team group types during serialization

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -850,11 +850,18 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
 
     @tracer.start_as_current_span("team_serializer.has_group_types")
     def get_has_group_types(self, team: Team) -> bool:
-        return bool(cached_group_types_for_team(team))
+        return bool(self._get_group_types(team))
 
     @tracer.start_as_current_span("team_serializer.group_types")
     def get_group_types(self, team: Team) -> list[dict[str, Any]]:
-        return cached_group_types_for_team(team)
+        return self._get_group_types(team)
+
+    def _get_group_types(self, team: Team) -> list[dict[str, Any]]:
+        group_types = getattr(self, "_group_types_cache", None)
+        if group_types is None:
+            group_types = cached_group_types_for_team(team)
+            self._group_types_cache = group_types
+        return group_types
 
     @extend_schema_field(serializers.BooleanField())
     @tracer.start_as_current_span("team_serializer.events_retention_enforced")

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -754,6 +754,7 @@ def get_or_mint_live_events_token(team: Team, user_id: int | None) -> str:
 
 class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin, UserAccessControlSerializerMixin):
     instance: Team | None
+    _group_types_cache: list[dict[str, Any]] | None = None
 
     effective_membership_level = serializers.SerializerMethodField()
     has_group_types = serializers.SerializerMethodField()
@@ -857,7 +858,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         return self._get_group_types(team)
 
     def _get_group_types(self, team: Team) -> list[dict[str, Any]]:
-        group_types = getattr(self, "_group_types_cache", None)
+        group_types = self._group_types_cache
         if group_types is None:
             group_types = cached_group_types_for_team(team)
             self._group_types_cache = group_types


### PR DESCRIPTION
## Problem

Team API responses serialize `has_group_types` and `group_types` independently, causing the same cached lookup to run twice on a hot serializer path. This adds avoidable work to a range of authenticated API calls.

## Changes

- Cache the group types for the lifetime of a `TeamSerializer` instance and reuse them for both fields.
- Preserve the existing response shape and values.

Why: reduce repeated per-request work on a shared Python API serializer path without changing the API contract or requiring clients to combine endpoints.

Created with Autoresearch.

## How did you test this code?

- `uv run ruff check posthog/api/team.py`
- `uv run python -m compileall -q posthog/api/team.py`
- Confirmed the targeted serializer path now has one underlying group-type lookup.
- The DB-backed endpoint test could not run because the local `db` hostname/service is unavailable in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable: this is an internal performance optimization with no API or workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used repository tracing tools to identify the shared serializer span and the `/writing-tests` skill to assess whether a regression test would earn its cost. The existing endpoint coverage already verifies the response fields; adding a mock-based call-count test would have been implementation-coupled, so validation is limited to lint, compilation, and the targeted lookup reduction. Created with Autoresearch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
