### PR TITLE
fix(github): surface a clean error when credential check gets a non-JSON body

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -286,13 +286,21 @@ def validate_credentials(personal_access_token: str, repository: str) -> tuple[b
             return False, f"Repository '{repository}' not found or not accessible"
 
         try:
-            error_data = response.json()
-            message = error_data.get("message", response.text)
+            body = response.json()
+            message = body.get("message") if isinstance(body, dict) else None
+        except ValueError:
+            message = None
+        if message:
             return False, message
-        except Exception:
-            pass
 
-        return False, response.text
+        # A non-JSON body means GitHub returned an HTML error page (e.g. its 5xx "Unicorn!" page) —
+        # never surface that raw markup to the user.
+        if response.status_code >= 500:
+            return False, "GitHub is temporarily unavailable. Please try again in a few minutes."
+        return (
+            False,
+            f"GitHub rejected the request (status {response.status_code}). Please check your token and repository access.",
+        )
     except requests.exceptions.RequestException as e:
         return False, str(e)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_validate_credentials.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_validate_credentials.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest import mock
+
+import requests
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.github import github
+
+
+def _response(status_code: int, *, json_body: object | None = None, text: str = "") -> mock.Mock:
+    response = mock.Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.text = text
+    if json_body is None:
+        response.json.side_effect = requests.exceptions.JSONDecodeError("no json", "", 0)
+    else:
+        response.json.return_value = json_body
+    return response
+
+
+def _validate_with(response: mock.Mock) -> tuple[bool, str | None]:
+    session = mock.Mock()
+    session.get.return_value = response
+    with mock.patch.object(github, "make_tracked_session", return_value=session):
+        return github.validate_credentials("token", "owner/repo")
+
+
+@pytest.mark.parametrize(
+    "status_code,expected_substring",
+    [
+        # GitHub's 5xx "Unicorn!" page is HTML, so response.json() raises — we must never echo the markup.
+        (503, "temporarily unavailable"),
+        (418, "status 418"),
+    ],
+)
+def test_non_json_body_is_not_leaked(status_code, expected_substring):
+    is_valid, message = _validate_with(_response(status_code, text="<!DOCTYPE html><html>...</html>"))
+    assert is_valid is False
+    assert message is not None
+    assert "<" not in message
+    assert expected_substring in message
+
+
+def test_json_error_message_is_surfaced():
+    is_valid, message = _validate_with(_response(422, json_body={"message": "Validation failed"}))
+    assert is_valid is False
+    assert message == "Validation failed"


### PR DESCRIPTION
## Problem

When you validate a GitHub source in the new-source wizard, we probe `GET /repos/{owner}/{repo}`. If GitHub returns a server error, it responds with an HTML error page (its 5xx "Unicorn!" page), not JSON. The validator tried to parse the body as JSON, fell through when that failed, and returned the raw `response.text` — so the entire HTML page landed in the wizard's error banner. It gives the user nothing to act on and looks broken.

This was the single largest GitHub source-creation failure yesterday.

## Changes

In `validate_credentials`, when the response body is not JSON (or carries no `message`), return a clean message instead of the raw body:

- 5xx: "GitHub is temporarily unavailable. Please try again in a few minutes."
- other non-JSON: a short "GitHub rejected the request (status N)" with a check-your-token nudge.

Genuine GitHub JSON error messages (e.g. validation failures) are still surfaced verbatim as before. The raw `response.text` is no longer returned on any path.

## How did you test this code?

Added `test_github_validate_credentials.py`:

- a non-JSON 5xx body (HTML) and a non-JSON non-5xx body both produce a clean message with no markup — this is the regression the PR fixes; no existing test exercised `validate_credentials`.
- a JSON `{"message": ...}` error is still surfaced verbatim, guarding the happy path.

Ran the new file plus the existing github source tests locally; all pass. No manual wizard testing was done.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a day's worth of data-warehouse source-creation failures and fixed the ones where an internal error leaked to users. For GitHub, the raw HTML error page was reaching the wizard. Found the leak in `github.validate_credentials` (the `response.json()` → fall through to `response.text` path). Most other GitHub failures already have clear messages via `get_non_retryable_errors`, so no other change was warranted here.

Invoked `/writing-tests` before adding the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
