### PR TITLE
fix(mysql): map SSH tunnel errors to friendly guidance during validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -312,10 +312,17 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
         try:
             self.get_schemas(config, team_id)
         except BaseSSHTunnelForwarderError as e:
+            # sshtunnel surfaces raw library strings (e.g. "Could not establish session to SSH
+            # gateway"); map them to the friendly guidance in `get_non_retryable_errors` — which the
+            # generic `except Exception` branch below already applies — instead of leaking the
+            # internal wording to the wizard.
+            ssh_error = e.value or ""
+            for pattern, friendly_error in self.get_non_retryable_errors().items():
+                if friendly_error and pattern in ssh_error:
+                    return False, friendly_error
             return (
                 False,
-                e.value
-                or f"Could not connect to {self.get_source_config.name} via the SSH tunnel. Please check all connection details are valid.",
+                f"Could not connect to {self.get_source_config.name} via the SSH tunnel. Please check all connection details are valid.",
             )
         except Exception as e:
             # Connection/credential failures we already classify as non-retryable during sync

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import MagicMock
 
 import pymysql
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.schema import SourceFieldInputConfig
 
@@ -1842,6 +1843,18 @@ class TestMySQLSourceValidateCredentials:
         assert valid is False
         assert error is not None
         capture.assert_called_once()
+
+    def test_ssh_tunnel_error_is_mapped_not_leaked(self, source, mocker):
+        # sshtunnel's raw "Could not establish session to SSH gateway" must be replaced with the
+        # friendly guidance, not surfaced verbatim to the wizard.
+        raw = "Could not establish session to SSH gateway"
+        mocker.patch.object(source, "get_schemas", side_effect=BaseSSHTunnelForwarderError(raw))
+
+        valid, error = source.validate_credentials(_make_config(), team_id=1)
+
+        assert valid is False
+        assert error != raw
+        assert error == source.get_non_retryable_errors()[raw]
 
 
 class _RaisingTunnel:


### PR DESCRIPTION
## Problem

When you set up a MySQL source through an SSH tunnel and the tunnel can't be established, the new-source wizard showed a raw sshtunnel library string. It reads like an internal error and tells the user nothing about what to fix (bad SSH host/port, bastion down, our IPs not allowlisted).

The friendly guidance for exactly this failure already exists in `get_non_retryable_errors` and is used on the sync path — the create-time `validate_credentials` path just wasn't using it.

## Changes

In `validate_credentials`, the `BaseSSHTunnelForwarderError` handler now runs the tunnel error through the same `get_non_retryable_errors` mapping the generic exception branch already applies, falling back to a generic "could not connect via the SSH tunnel, check your connection details" message.

Net effect: the wizard shows the actionable SSH-tunnel guidance, and no raw library string is surfaced on any path.

## How did you test this code?

Added one case to `TestMySQLSourceValidateCredentials`: a `BaseSSHTunnelForwarderError` carrying the raw gateway string now returns the mapped friendly message, not the raw value. Existing validate cases only exercised the generic `Exception` branch, so this branch was previously untested.

Ran the validate-credentials tests locally; all pass. No manual wizard testing was done.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a day's worth of data-warehouse source-creation failures. For MySQL, the raw "session to SSH gateway" string was reaching users even though a friendly mapping already existed for it. The fix reuses that existing mapping in the create-time path rather than adding new copy. Postgres and MSSQL share the same `except BaseSSHTunnelForwarderError` shape, but neither had this failure in the data, so I kept this PR to MySQL only.

Invoked `/writing-tests` before adding the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
