### PR TITLE
refactor(data-warehouse): migrate devin_ai, eventbrite, firecrawl to rest_source (batch 16)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/devin_ai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/devin_ai.py
@@ -1,24 +1,22 @@
 import re
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.devin_ai.settings import DEVIN_AI_ENDPOINTS
 
 DEVIN_AI_BASE_URL = "https://api.devin.ai"
 # v3 cursor pagination caps `first` at 200.
 PAGE_SIZE = 200
-
-
-class DevinAIRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -50,113 +48,138 @@ def _endpoint_path(endpoint: str, org_id: str) -> str:
     return DEVIN_AI_ENDPOINTS[endpoint].path.format(org_id=_validate_org_id(org_id))
 
 
-@retry(
-    retry=retry_if_exception_type(
-        (
-            DevinAIRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    params: dict[str, Any],
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-) -> dict:
-    response = session.get(url, params=params, headers=headers, timeout=60)
+class DevinCursorPaginator(BasePaginator):
+    """Cursor paginator for Devin's v3 list envelope.
 
-    # 429 (rate limit) and 5xx are transient — retry with backoff.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise DevinAIRetryableError(f"Devin API error (retryable): status={response.status_code}, url={url}")
+    The response body carries ``{"items", "end_cursor", "has_next_page"}``. Each page after the first
+    is fetched with ``after=<previous end_cursor>``. Pagination stops as soon as the API reports no
+    next page OR omits the cursor — the ``has_next_page`` guard defends against a stale cursor lingering
+    on the final page (which would otherwise loop forever). Resumable: a saved ``after`` cursor is
+    replayed onto the first request so a restart continues from the last completed page.
+    """
 
-    if not response.ok:
-        logger.error(f"Devin API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
+    def __init__(self) -> None:
+        super().__init__()
+        self._after: Optional[str] = None
 
-    return response.json()
+    def _apply_cursor(self, request: Request) -> None:
+        if self._after is None:
+            return
+        if request.params is None:
+            request.params = {}
+        request.params["after"] = self._after
 
+    def init_request(self, request: Request) -> None:
+        # Seed a resumed cursor onto the first request.
+        self._apply_cursor(request)
 
-def get_status_code(api_key: str, org_id: str, endpoint: str) -> int:
-    """Cheap single-page probe used by credential validation. Returns the HTTP status code."""
-    url = f"{DEVIN_AI_BASE_URL}{_endpoint_path(endpoint, org_id)}"
-    response = make_tracked_session().get(url, params={"first": 1}, headers=_get_headers(api_key), timeout=10)
-    return response.status_code
+    def update_request(self, request: Request) -> None:
+        self._apply_cursor(request)
 
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        if not isinstance(body, dict):
+            self._has_next_page = False
+            return
 
-def get_rows(
-    api_key: str,
-    org_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DevinAIResumeConfig],
-) -> Iterator[Any]:
-    headers = _get_headers(api_key)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = make_tracked_session()
+        next_cursor = body.get("end_cursor")
+        if body.get("has_next_page") and next_cursor:
+            self._after = next_cursor
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
 
-    url = f"{DEVIN_AI_BASE_URL}{_endpoint_path(endpoint, org_id)}"
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # ``_after`` already points at the next page's cursor; only meaningful while more pages remain.
+        return {"after": self._after} if self._has_next_page and self._after is not None else None
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    after = resume.after if resume else None
-    if after:
-        logger.debug(f"Devin: resuming {endpoint} from cursor: {after}")
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        after = state.get("after")
+        if after is not None:
+            self._after = after
+            self._has_next_page = True
 
-    # Yield one full page at a time and only save state at the page boundary, after the page has been
-    # yielded. The pipeline batches internally, so a source-level batcher would only double-buffer and,
-    # because it spans pages, would force a mid-page save that drops the un-yielded tail on crash-resume.
-    while True:
-        params: dict[str, Any] = {"first": PAGE_SIZE}
-        if after:
-            params["after"] = after
-
-        data = _fetch_page(session, url, params, headers, logger)
-
-        items = data.get("items", [])
-        if items:
-            yield items
-
-        next_cursor = data.get("end_cursor")
-        if not data.get("has_next_page") or not next_cursor:
-            break
-
-        after = next_cursor
-        # Save state AFTER yielding the page so a crash re-fetches this page (merge dedupes on the
-        # primary key) rather than skipping it.
-        resumable_source_manager.save_state(DevinAIResumeConfig(after=next_cursor))
+    def __str__(self) -> str:
+        return "DevinCursorPaginator()"
 
 
 def devin_ai_source(
     api_key: str,
     org_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[DevinAIResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     endpoint_config = DEVIN_AI_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": DEVIN_AI_BASE_URL,
+            # Only the non-secret Accept header goes here; the Bearer token is supplied via the
+            # framework `auth` config so its value is redacted from logs.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    # `_endpoint_path` validates org_id so a malformed value can't inject `/` or `?`
+                    # and retarget the stored key at a different Devin API path.
+                    "path": _endpoint_path(endpoint, org_id),
+                    "params": {"first": PAGE_SIZE},
+                    "data_selector": "items",
+                    "paginator": DevinCursorPaginator(),
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.after is not None:
+            initial_paginator_state = {"after": resume.after}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("after") is not None:
+            resumable_source_manager.save_state(DevinAIResumeConfig(after=str(state["after"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            org_id=org_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=endpoint_config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if endpoint_config.partition_key else None,
         partition_format="week" if endpoint_config.partition_key else None,
         partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def get_status_code(api_key: str, org_id: str, endpoint: str) -> int:
+    """Cheap single-page probe used by credential validation. Returns the HTTP status code."""
+    url = f"{DEVIN_AI_BASE_URL}{_endpoint_path(endpoint, org_id)}"
+    session = make_tracked_session(redact_values=(api_key,))
+    response = session.get(url, params={"first": 1}, headers=_get_headers(api_key), timeout=10)
+    return response.status_code
 
 
 def validate_credentials(api_key: str, org_id: str, endpoint: str = "sessions") -> int:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/source.py
@@ -175,6 +175,7 @@ Your organization ID is the `org-...` identifier shown in your Devin organizatio
             api_key=config.api_key,
             org_id=config.org_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/tests/test_devin_ai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/tests/test_devin_ai.py
@@ -1,61 +1,79 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.devin_ai import devin_ai
 from products.warehouse_sources.backend.temporal.data_imports.sources.devin_ai.devin_ai import (
-    DEVIN_AI_BASE_URL,
     PAGE_SIZE,
     DevinAIResumeConfig,
     _endpoint_path,
     devin_ai_source,
-    get_rows,
     get_status_code,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.devin_ai.settings import DEVIN_AI_ENDPOINTS
 
-
-class _FakeResumableManager:
-    def __init__(self, state: DevinAIResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[DevinAIResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> DevinAIResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: DevinAIResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# get_status_code builds its own tracked session in the devin_ai module.
+DEVIN_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.devin_ai.devin_ai.make_tracked_session"
+)
 
 
-def _collect(manager: _FakeResumableManager, monkeypatch: Any, endpoint: str, pages: list[dict]) -> list[dict]:
-    """Feed successive `pages` from _fetch_page and return the flattened rows."""
-    calls: list[dict[str, Any]] = []
+def _response(
+    items: list[dict[str, Any]] | None, *, has_next_page: bool = False, end_cursor: str | None = None
+) -> Response:
+    body: dict[str, Any] = {"has_next_page": has_next_page, "end_cursor": end_cursor}
+    if items is not None:
+        body["items"] = items
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
-    def fake_fetch(session: Any, url: str, params: dict[str, Any], headers: dict[str, str], logger: Any) -> dict:
-        calls.append({"url": url, "params": params})
-        return pages[len(calls) - 1]
 
-    monkeypatch.setattr(devin_ai, "_fetch_page", fake_fetch)
+def _make_manager(resume_state: DevinAIResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    rows: list[dict] = []
-    for page in get_rows(
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so snapshot a copy when each request
+    is prepared rather than inspecting the final state after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return devin_ai_source(
         api_key="cog_test",
         org_id="org-abc",
         endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        # get_rows yields one page's items as a list[dict]; the pipeline batches internally.
-        rows.extend(page)
-    manager.calls = calls  # type: ignore[attr-defined]
-    return rows
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
 
 
 class TestEndpointPath:
@@ -85,131 +103,105 @@ class TestEndpointPath:
             _endpoint_path("sessions", org_id)
 
 
-class TestGetRows:
-    def test_yields_items_as_dicts(self, monkeypatch: Any) -> None:
-        pages = [{"items": [{"session_id": "s1"}, {"session_id": "s2"}], "has_next_page": False, "end_cursor": None}]
-        rows = _collect(_FakeResumableManager(), monkeypatch, "sessions", pages)
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_yields_items_as_dicts(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"session_id": "s1"}, {"session_id": "s2"}])])
+
+        rows = _rows(_source("sessions", _make_manager()))
         assert rows == [{"session_id": "s1"}, {"session_id": "s2"}]
 
-    def test_first_page_has_no_after_and_uses_page_size(self, monkeypatch: Any) -> None:
-        pages = [{"items": [{"session_id": "s1"}], "has_next_page": False, "end_cursor": None}]
-        manager = _FakeResumableManager()
-        _collect(manager, monkeypatch, "sessions", pages)
-        first_call = manager.calls[0]  # type: ignore[attr-defined]
-        assert first_call["params"] == {"first": PAGE_SIZE}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_first_page_has_no_after_and_uses_page_size(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"session_id": "s1"}])])
 
-    def test_follows_cursor_pagination(self, monkeypatch: Any) -> None:
-        pages = [
-            {"items": [{"session_id": "s1"}], "has_next_page": True, "end_cursor": "cur1"},
-            {"items": [{"session_id": "s2"}], "has_next_page": False, "end_cursor": None},
-        ]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, "sessions", pages)
+        _rows(_source("sessions", _make_manager()))
+        assert params[0] == {"first": PAGE_SIZE}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_cursor_pagination(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response([{"session_id": "s1"}], has_next_page=True, end_cursor="cur1"),
+                _response([{"session_id": "s2"}], has_next_page=False, end_cursor=None),
+            ],
+        )
+
+        rows = _rows(_source("sessions", _make_manager()))
         assert rows == [{"session_id": "s1"}, {"session_id": "s2"}]
-        # Second request must carry the cursor from the first page's end_cursor.
-        assert manager.calls[1]["params"] == {"first": PAGE_SIZE, "after": "cur1"}  # type: ignore[attr-defined]
+        # The second request must carry the cursor from the first page's end_cursor.
+        assert params[1] == {"first": PAGE_SIZE, "after": "cur1"}
 
-    def test_stops_when_has_next_page_false_even_if_cursor_present(self, monkeypatch: Any) -> None:
-        # A defensive guard: if the API returns a cursor but has_next_page is false, we must not loop.
-        pages = [{"items": [{"session_id": "s1"}], "has_next_page": False, "end_cursor": "cur1"}]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, "sessions", pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_has_next_page_false_even_if_cursor_present(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A defensive guard: a cursor with has_next_page false must not loop.
+        _wire(session, [_response([{"session_id": "s1"}], has_next_page=False, end_cursor="cur1")])
+
+        rows = _rows(_source("sessions", _make_manager()))
         assert rows == [{"session_id": "s1"}]
-        assert len(manager.calls) == 1  # type: ignore[attr-defined]
+        assert session.send.call_count == 1
 
-    def test_resumes_from_saved_cursor(self, monkeypatch: Any) -> None:
-        pages = [{"items": [{"session_id": "s3"}], "has_next_page": False, "end_cursor": None}]
-        manager = _FakeResumableManager(DevinAIResumeConfig(after="saved_cursor"))
-        rows = _collect(manager, monkeypatch, "sessions", pages)
-        assert rows == [{"session_id": "s3"}]
-        assert manager.calls[0]["params"] == {"first": PAGE_SIZE, "after": "saved_cursor"}  # type: ignore[attr-defined]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"session_id": "s3"}])])
 
-    def test_saves_next_cursor_at_page_boundary_only(self, monkeypatch: Any) -> None:
+        _rows(_source("sessions", _make_manager(DevinAIResumeConfig(after="saved_cursor"))))
+        assert params[0] == {"first": PAGE_SIZE, "after": "saved_cursor"}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_cursor_at_page_boundary_only(self, MockSession) -> None:
+        session = MockSession.return_value
         # State is saved once per completed page that has a successor, after the page is yielded — so a
-        # crash re-fetches the last page (merge dedupes) rather than skipping its tail.
-        pages = [
-            {"items": [{"session_id": "s1"}], "has_next_page": True, "end_cursor": "cur1"},
-            {"items": [{"session_id": "s2"}], "has_next_page": True, "end_cursor": "cur2"},
-            {"items": [{"session_id": "s3"}], "has_next_page": False, "end_cursor": None},
-        ]
-        manager = _FakeResumableManager()
-        _collect(manager, monkeypatch, "sessions", pages)
-        # No save after the final page (nothing left to resume into).
-        assert manager.saved == [DevinAIResumeConfig(after="cur1"), DevinAIResumeConfig(after="cur2")]
+        # crash re-fetches the last page (merge dedupes) rather than skipping its tail. No save after the
+        # final page (nothing left to resume into).
+        _wire(
+            session,
+            [
+                _response([{"session_id": "s1"}], has_next_page=True, end_cursor="cur1"),
+                _response([{"session_id": "s2"}], has_next_page=True, end_cursor="cur2"),
+                _response([{"session_id": "s3"}], has_next_page=False, end_cursor=None),
+            ],
+        )
 
+        manager = _make_manager()
+        _rows(_source("sessions", manager))
+        saved = [c.args[0] for c in manager.save_state.call_args_list]
+        assert saved == [DevinAIResumeConfig(after="cur1"), DevinAIResumeConfig(after="cur2")]
 
-class TestFetchPageRetries:
-    @parameterized.expand(
-        [
-            ("rate_limited", 429),
-            ("server_error", 500),
-            ("bad_gateway", 502),
-        ]
-    )
-    def test_retryable_status_codes_are_retried(self, _name: str, status_code: int) -> None:
-        retryable = MagicMock()
-        retryable.status_code = status_code
-        retryable.ok = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_items_key_yields_no_rows_without_raising(self, MockSession) -> None:
+        session = MockSession.return_value
+        # The Devin envelope tolerates a page with no `items` key (defaults to empty) rather than failing.
+        _wire(session, [_response(None, has_next_page=False, end_cursor=None)])
 
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = {"items": []}
+        rows = _rows(_source("sessions", _make_manager()))
+        assert rows == []
 
-        session = MagicMock()
-        session.get.side_effect = [retryable, good]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_bearer_token_is_set_on_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"session_id": "s1"}])])
 
-        with patch.object(devin_ai._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = devin_ai._fetch_page(session, f"{DEVIN_AI_BASE_URL}/x", {}, {}, MagicMock())
-
-        assert result == {"items": []}
-        assert session.get.call_count == 2
-
-    @parameterized.expand(
-        [
-            ("chunked_encoding", requests.exceptions.ChunkedEncodingError("Connection broken")),
-            ("read_timeout", requests.ReadTimeout("Read timed out.")),
-            ("connection_error", requests.ConnectionError("Connection reset by peer")),
-        ]
-    )
-    def test_transient_transport_errors_are_retried(self, _name: str, transient_error: Exception) -> None:
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = {"items": []}
-
-        session = MagicMock()
-        session.get.side_effect = [transient_error, good]
-
-        with patch.object(devin_ai._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = devin_ai._fetch_page(session, f"{DEVIN_AI_BASE_URL}/x", {}, {}, MagicMock())
-
-        assert result == {"items": []}
-        assert session.get.call_count == 2
-
-    def test_client_error_raises_immediately(self) -> None:
-        forbidden = MagicMock()
-        forbidden.status_code = 403
-        forbidden.ok = False
-        forbidden.raise_for_status.side_effect = requests.HTTPError("403 Client Error", response=forbidden)
-
-        session = MagicMock()
-        session.get.return_value = forbidden
-
-        with pytest.raises(requests.HTTPError):
-            devin_ai._fetch_page(session, f"{DEVIN_AI_BASE_URL}/x", {}, {}, MagicMock())
-
-        assert session.get.call_count == 1
+        _rows(_source("sessions", _make_manager()))
+        # The token is applied via the framework auth (redacted), not a hand-built header on the session.
+        assert session.headers.get("Authorization") is None
+        assert session.auth is not None
 
 
 class TestGetStatusCode:
     def test_returns_status_and_probes_with_first_one(self) -> None:
-        response = MagicMock()
+        response = mock.MagicMock()
         response.status_code = 200
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.return_value = response
 
-        with patch.object(devin_ai, "make_tracked_session", return_value=session):
+        with mock.patch(DEVIN_SESSION_PATCH, return_value=session):
             status = get_status_code("cog_test", "org-abc", "sessions")
 
         assert status == 200
@@ -220,14 +212,9 @@ class TestGetStatusCode:
 
 class TestDevinAISource:
     @parameterized.expand(list(DEVIN_AI_ENDPOINTS.keys()))
-    def test_source_response_uses_endpoint_primary_keys_and_stable_partition(self, endpoint: str) -> None:
-        response = devin_ai_source(
-            api_key="cog_test",
-            org_id="org-abc",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_uses_endpoint_primary_keys_and_stable_partition(self, endpoint: str, MockSession) -> None:
+        response = _source(endpoint, _make_manager())
         cfg = DEVIN_AI_ENDPOINTS[endpoint]
         assert response.name == endpoint
         assert response.primary_keys == cfg.primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/eventbrite.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/eventbrite.py
@@ -1,16 +1,26 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+    EndpointResource,
+    IncrementalConfig,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.eventbrite.settings import (
     EVENTBRITE_ENDPOINTS,
     ORG_EVENTS_PATH,
@@ -22,16 +32,15 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.eventbrite
 EVENTBRITE_BASE_URL = "https://www.eventbriteapi.com/v3"
 
 
-class EventbriteRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class EventbriteResumeConfig:
-    # Continuation token for the next page. Only persisted for top-level endpoints — fan-out
-    # endpoints restart from the first parent on resume and rely on merge dedupe (same as Stripe's
-    # nested-resource handling), since parent ordering is not guaranteed stable.
-    continuation: str
+    # Continuation token for the next page of a top-level list endpoint (organizations/categories/
+    # formats). Fan-out endpoints (org/event scoped) instead persist the framework's dependent-resource
+    # checkpoint under `fanout_state`; a two-level fan-out (attendees/ticket_classes) has no resume at
+    # all and relies on merge dedupe. Both fields default so an old `{"continuation": ...}` state still
+    # parses after this change.
+    continuation: str = ""
+    fanout_state: Optional[dict[str, Any]] = None
 
 
 def _get_headers(api_token: str) -> dict[str, str]:
@@ -51,172 +60,122 @@ def _format_changed_since(value: Any) -> str:
     return str(value)
 
 
-def validate_credentials(api_token: str) -> bool:
-    url = f"{EVENTBRITE_BASE_URL}/users/me/"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_token), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+class EventbriteContinuationPaginator(BasePaginator):
+    """Eventbrite v3 continuation-token pagination.
 
-
-@retry(
-    retry=retry_if_exception_type((EventbriteRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=2, max=60),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.get(url, params=params, timeout=60)
-
-    # Eventbrite enforces a strict per-token rate limit; honor it via retry/backoff.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise EventbriteRetryableError(f"Eventbrite API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Eventbrite API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _iter_pages(
-    session: requests.Session,
-    url: str,
-    base_params: dict[str, Any],
-    data_key: str,
-    logger: FilteringBoundLogger,
-    start_continuation: Optional[str] = None,
-) -> Iterator[tuple[dict[str, Any], Optional[str]]]:
-    """Yield (record, resume_continuation) across continuation-token pages of a single list endpoint.
-
-    `resume_continuation` is the token a caller should persist right after yielding the record so a
-    crash resumes without skipping any records. For every item except the last on its page it is the
-    *current* page's token, so resume re-fetches the current page and replays its remaining items
-    (merge dedupes already-persisted ones). Only for the final item of a page — once the whole page is
-    accounted for — is it the *next* page's token (or None on the last page). Saving the next-page
-    token mid-page would skip the current page's remaining records on resume.
+    Stops on ``pagination.has_more_items == false`` rather than merely the absence of a continuation
+    token: Eventbrite can still return a token on the final page, so gating strictly on
+    ``has_more_items`` preserves the hand-rolled behavior exactly.
     """
-    continuation = start_continuation
-    while True:
-        current_continuation = continuation
-        params = dict(base_params)
-        if current_continuation:
-            params["continuation"] = current_continuation
 
-        data = _fetch_page(session, url, params, logger)
-        items = data.get(data_key, []) or []
-        pagination = data.get("pagination") or {}
-        next_continuation = pagination.get("continuation") if pagination.get("has_more_items") else None
+    def __init__(self, cursor_param: str = "continuation") -> None:
+        super().__init__()
+        self.cursor_param = cursor_param
+        self._continuation: Optional[str] = None
 
-        last_index = len(items) - 1
-        for index, item in enumerate(items):
-            resume_continuation = next_continuation if index == last_index else current_continuation
-            yield item, resume_continuation
+    def _apply(self, request: Request) -> None:
+        if self._continuation is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._continuation
 
-        if not next_continuation:
-            break
-        continuation = next_continuation
+    def init_request(self, request: Request) -> None:
+        # Seed a resumed run's first request with the saved continuation token.
+        self._apply(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            pagination = response.json().get("pagination") or {}
+        except Exception:
+            pagination = {}
+        continuation = pagination.get("continuation")
+        if pagination.get("has_more_items") and continuation:
+            self._continuation = continuation
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        if self._has_next_page:
+            self._apply(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        if self._has_next_page and self._continuation is not None:
+            return {"continuation": self._continuation}
+        return None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        continuation = state.get("continuation")
+        if continuation is not None:
+            self._continuation = continuation
+            self._has_next_page = True
 
 
-def _iter_organization_ids(session: requests.Session, logger: FilteringBoundLogger) -> Iterator[str]:
-    url = f"{EVENTBRITE_BASE_URL}{ORGANIZATIONS_PATH}"
-    for org, _ in _iter_pages(session, url, {}, "organizations", logger):
-        # Fail fast on a malformed response rather than silently dropping all of an org's children.
-        yield str(org["id"])
+def _client_config(api_token: str) -> ClientConfig:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs;
+    # only the non-secret Accept header is set on the client.
+    return {
+        "base_url": EVENTBRITE_BASE_URL,
+        "auth": {"type": "bearer", "token": api_token},
+        "headers": {"Accept": "application/json"},
+        "paginator": EventbriteContinuationPaginator(),
+    }
 
 
-def _iter_event_ids(session: requests.Session, logger: FilteringBoundLogger) -> Iterator[str]:
-    for org_id in _iter_organization_ids(session, logger):
-        url = f"{EVENTBRITE_BASE_URL}{ORG_EVENTS_PATH.format(organization_id=org_id)}"
-        for event, _ in _iter_pages(session, url, {}, "events", logger):
-            yield str(event["id"])
+def _changed_since_incremental(config: EventbriteEndpointConfig) -> IncrementalConfig:
+    return {
+        "cursor_path": config.changed_since_field or "changed",
+        "start_param": "changed_since",
+        "convert": _format_changed_since,
+    }
 
 
-def _iter_records(
-    session: requests.Session,
+def _leaf_endpoint(
     config: EventbriteEndpointConfig,
-    logger: FilteringBoundLogger,
-    changed_since: Optional[str],
-    resume: Optional[EventbriteResumeConfig],
-) -> Iterator[tuple[dict[str, Any], Optional[str]]]:
-    base_params: dict[str, Any] = {}
-    if changed_since:
-        base_params["changed_since"] = changed_since
-
-    if config.scope == EndpointScope.TOP_LEVEL:
-        url = f"{EVENTBRITE_BASE_URL}{config.path}"
-        start = resume.continuation if resume else None
-        yield from _iter_pages(session, url, base_params, config.data_key, logger, start_continuation=start)
-        return
-
-    if config.scope == EndpointScope.ORG:
-        parent_ids = _iter_organization_ids(session, logger)
-        placeholder = "organization_id"
-    else:
-        parent_ids = _iter_event_ids(session, logger)
-        placeholder = "event_id"
-
-    # Fan-out: paginate the child endpoint per parent. We never persist a resume token here, so
-    # downstream always sees next_continuation=None for these records.
-    for parent_id in parent_ids:
-        url = f"{EVENTBRITE_BASE_URL}{config.path.format(**{placeholder: parent_id})}"
-        for record, _ in _iter_pages(session, url, base_params, config.data_key, logger):
-            yield record, None
+    *,
+    resolve: Optional[tuple[str, str, str]] = None,
+    incremental: Optional[IncrementalConfig] = None,
+) -> Endpoint:
+    endpoint: Endpoint = {"path": config.path, "data_selector": config.data_key}
+    if resolve is not None:
+        param_name, parent, field = resolve
+        endpoint["params"] = {param_name: {"type": "resolve", "resource": parent, "field": field}}
+    if incremental is not None:
+        endpoint["incremental"] = incremental
+    return endpoint
 
 
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[EventbriteResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = EVENTBRITE_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_get_headers(api_token))
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
+def _parent_resource(
+    name: str, path: str, data_selector: str, resolve: Optional[tuple[str, str, str]]
+) -> EndpointResource:
+    endpoint: Endpoint = {"path": path, "data_selector": data_selector}
+    if resolve is not None:
+        param_name, parent, field = resolve
+        endpoint["params"] = {param_name: {"type": "resolve", "resource": parent, "field": field}}
+    return {"name": name, "endpoint": endpoint}
 
-    # Only narrow with the server-side `changed_since` filter when the endpoint supports it and the
-    # user's chosen cursor is the field that filter targets (`changed`). Honors inputs.incremental_field
-    # rather than assuming it.
-    changed_since: Optional[str] = None
-    if (
+
+def _should_apply_incremental(
+    config: EventbriteEndpointConfig,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+    incremental_field: Optional[str],
+) -> bool:
+    # Mirror the hand-rolled gate: only narrow with the server-side `changed_since` filter when the
+    # endpoint supports it and the user's chosen cursor is the field that filter targets (`changed`).
+    return (
         should_use_incremental_field
-        and config.changed_since_field
-        and db_incremental_field_last_value
+        and config.changed_since_field is not None
+        and db_incremental_field_last_value is not None
         and incremental_field in (None, config.changed_since_field)
-    ):
-        changed_since = _format_changed_since(db_incremental_field_last_value)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None:
-        logger.debug(f"Eventbrite: resuming {endpoint} from continuation token")
-
-    for record, resume_continuation in _iter_records(session, config, logger, changed_since, resume):
-        batcher.batch(record)
-
-        if batcher.should_yield():
-            yield batcher.get_table()
-
-            # Save state after yielding so a crash re-yields the last batch (merge dedupes on PK).
-            if resume_continuation:
-                resumable_source_manager.save_state(EventbriteResumeConfig(continuation=resume_continuation))
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    )
 
 
 def eventbrite_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[EventbriteResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -224,21 +183,87 @@ def eventbrite_source(
 ) -> SourceResponse:
     config = EVENTBRITE_ENDPOINTS[endpoint]
 
+    incremental: Optional[IncrementalConfig] = None
+    if _should_apply_incremental(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    ):
+        incremental = _changed_since_incremental(config)
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resume is not None:
+        if resume.fanout_state:
+            initial_paginator_state = resume.fanout_state
+        elif resume.continuation:
+            initial_paginator_state = {"continuation": resume.continuation}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded so a crash re-yields the last page (merge dedupes on PK).
+        if not state:
+            return
+        if "continuation" in state:
+            if state.get("continuation"):
+                resumable_source_manager.save_state(EventbriteResumeConfig(continuation=state["continuation"]))
+        else:
+            resumable_source_manager.save_state(EventbriteResumeConfig(fanout_state=state))
+
+    client = _client_config(api_token)
+
+    resource: Resource
+    if config.scope == EndpointScope.TOP_LEVEL:
+        rest_config: RESTAPIConfig = {
+            "client": client,
+            "resources": [{"name": endpoint, "endpoint": _leaf_endpoint(config)}],
+        }
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+    else:
+        resources: list[str | EndpointResource] = [
+            _parent_resource("organizations", ORGANIZATIONS_PATH, "organizations", None)
+        ]
+        if config.scope == EndpointScope.ORG:
+            leaf = _leaf_endpoint(config, resolve=("organization_id", "organizations", "id"), incremental=incremental)
+        else:  # EndpointScope.EVENT — two-level fan-out: organizations -> events -> leaf
+            resources.append(
+                _parent_resource("events", ORG_EVENTS_PATH, "events", ("organization_id", "organizations", "id"))
+            )
+            leaf = _leaf_endpoint(config, resolve=("event_id", "events", "id"), incremental=incremental)
+        resources.append({"name": endpoint, "endpoint": leaf})
+
+        rest_config = {"client": client, "resources": resources}
+        built = rest_api_resources(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+        resource = next(r for r in built if r.name == endpoint)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_token: str) -> bool:
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{EVENTBRITE_BASE_URL}/users/me/",
+        headers=_get_headers(api_token),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/source.py
@@ -133,7 +133,8 @@ The token needs read access to your organizations, events, orders, and attendees
         return eventbrite_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/tests/test_eventbrite.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/tests/test_eventbrite.py
@@ -1,29 +1,84 @@
+import json
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.eventbrite import eventbrite as eb
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.eventbrite.eventbrite import (
     EventbriteResumeConfig,
     _format_changed_since,
-    _iter_pages,
-    _iter_records,
     eventbrite_source,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.eventbrite.settings import EVENTBRITE_ENDPOINTS
 
-LOGGER = mock.MagicMock()
-SESSION = mock.MagicMock()
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the eventbrite module.
+EB_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.eventbrite.eventbrite.make_tracked_session"
+)
 
 
-def _page(data_key: str, items: list[dict[str, Any]], continuation: str | None) -> dict[str, Any]:
-    return {
+def _response(
+    data_key: str, items: list[dict[str, Any]], *, has_more: bool = False, continuation: str | None = None
+) -> Response:
+    body: dict[str, Any] = {
         data_key: items,
-        "pagination": {"has_more_items": continuation is not None, "continuation": continuation},
+        "pagination": {"has_more_items": has_more, "continuation": continuation},
     }
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: EventbriteResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(
+    session: mock.MagicMock, responses: list[Response] | Callable[[str], Response]
+) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session; return per-request (url, params) snapshots captured AT SEND TIME.
+
+    ``responses`` is either a flat list (consumed in request order) or a router callable keyed on the
+    resolved request URL — the latter is needed for fan-out, whose request order interleaves parents
+    and children. ``request.params`` is one dict mutated in place across pages, so snapshot a copy.
+    """
+    session.headers = {}
+    snapshots: list[tuple[str, dict[str, Any]]] = []
+    iterator = iter(responses) if isinstance(responses, list) else None
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        snapshots.append((request.url, dict(request.params or {})))
+        return prepared
+
+    def _send(prepared: Any, **_kwargs: Any) -> Response:
+        if iterator is not None:
+            return next(iterator)
+        assert callable(responses)
+        return responses(prepared.url)
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = _send
+    return snapshots
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(endpoint: str, manager: mock.MagicMock, **kwargs: Any) -> Any:
+    return eventbrite_source("token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
 
 
 class TestFormatChangedSince:
@@ -45,127 +100,207 @@ class TestFormatChangedSince:
         assert result.endswith("Z")
 
 
-class TestIterPages:
-    @mock.patch.object(eb, "_fetch_page")
-    def test_follows_continuation_until_exhausted(self, mock_fetch: mock.MagicMock) -> None:
-        mock_fetch.side_effect = [
-            _page("events", [{"id": "1"}, {"id": "2"}], "tok2"),
-            _page("events", [{"id": "3"}], None),
-        ]
+class TestTopLevelPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_continuation_until_has_more_false(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snaps = _wire(
+            session,
+            [
+                _response("organizations", [{"id": "1"}, {"id": "2"}], has_more=True, continuation="tok2"),
+                _response("organizations", [{"id": "3"}], has_more=False, continuation=None),
+            ],
+        )
 
-        results = list(_iter_pages(SESSION, "https://x/events/", {}, "events", LOGGER))
+        manager = _make_manager()
+        rows = _rows(_run("organizations", manager))
 
-        assert [record["id"] for record, _ in results] == ["1", "2", "3"]
-        # Resume token: mid-page items carry the current page's token (None for the first page, which
-        # restarts from the start); only the last item of a page advances to the next page's token.
-        assert [token for _, token in results] == [None, "tok2", None]
-        assert mock_fetch.call_count == 2
+        assert [r["id"] for r in rows] == ["1", "2", "3"]
+        assert "continuation" not in snaps[0][1]
+        assert snaps[1][1]["continuation"] == "tok2"
+        assert session.send.call_count == 2
+        # Checkpoint saved after the first page (points at the next page's token); the last page ends it.
+        manager.save_state.assert_called_once_with(EventbriteResumeConfig(continuation="tok2"))
 
-    @mock.patch.object(eb, "_fetch_page")
-    def test_starts_from_resume_continuation(self, mock_fetch: mock.MagicMock) -> None:
-        mock_fetch.side_effect = [_page("events", [{"id": "9"}], None)]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_has_more_false_even_with_continuation_token(self, MockSession: mock.MagicMock) -> None:
+        # Eventbrite can still return a continuation token on the final page; gate strictly on
+        # has_more_items so a stale token does not trigger an extra (infinite) request.
+        session = MockSession.return_value
+        _wire(session, [_response("categories", [{"id": "1"}], has_more=False, continuation="stale-tok")])
 
-        list(_iter_pages(SESSION, "https://x/events/", {}, "events", LOGGER, start_continuation="resume-tok"))
+        rows = _rows(_run("categories", _make_manager()))
 
-        _, _, params, _ = mock_fetch.call_args[0]
-        assert params["continuation"] == "resume-tok"
+        assert [r["id"] for r in rows] == ["1"]
+        assert session.send.call_count == 1
 
-    @mock.patch.object(eb, "_fetch_page")
-    def test_mid_page_records_carry_current_page_token(self, mock_fetch: mock.MagicMock) -> None:
-        # Resuming from a mid-page record must re-fetch the page it came from, not the next one,
-        # otherwise the rest of that page is skipped. Non-final items therefore carry the token that
-        # fetched their own (here second) page rather than the next page's token.
-        mock_fetch.side_effect = [
-            _page("events", [{"id": "1"}], "tok2"),
-            _page("events", [{"id": "2"}, {"id": "3"}], "tok3"),
-            _page("events", [{"id": "4"}], None),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_seeds_continuation(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("organizations", [{"id": "9"}], has_more=False, continuation=None)])
 
-        results = list(_iter_pages(SESSION, "https://x/events/", {}, "events", LOGGER))
+        manager = _make_manager(EventbriteResumeConfig(continuation="resume-tok"))
+        _rows(_run("organizations", manager))
 
-        assert [record["id"] for record, _ in results] == ["1", "2", "3", "4"]
-        assert [token for _, token in results] == ["tok2", "tok2", "tok3", None]
+        assert snaps[0][1]["continuation"] == "resume-tok"
 
-    @mock.patch.object(eb, "_fetch_page")
-    def test_handles_empty_page(self, mock_fetch: mock.MagicMock) -> None:
-        mock_fetch.side_effect = [_page("events", [], None)]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_yields_no_rows(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response("formats", [], has_more=False, continuation=None)])
 
-        assert list(_iter_pages(SESSION, "https://x/events/", {}, "events", LOGGER)) == []
+        rows = _rows(_run("formats", _make_manager()))
+
+        assert rows == []
+        assert session.send.call_count == 1
 
 
-class TestIterRecords:
-    @mock.patch.object(eb, "_fetch_page")
-    def test_top_level_uses_resume_continuation(self, mock_fetch: mock.MagicMock) -> None:
-        mock_fetch.side_effect = [_page("organizations", [{"id": "o1"}], None)]
-        config = EVENTBRITE_ENDPOINTS["organizations"]
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_org_fan_out_builds_child_urls_per_org(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
 
-        list(_iter_records(SESSION, config, LOGGER, None, EventbriteResumeConfig(continuation="resume-tok")))
-
-        _, url, params, _ = mock_fetch.call_args[0]
-        assert url.endswith("/users/me/organizations/")
-        assert params["continuation"] == "resume-tok"
-
-    @mock.patch.object(eb, "_fetch_page")
-    def test_org_fan_out_builds_child_urls_and_no_resume_token(self, mock_fetch: mock.MagicMock) -> None:
-        def router(_session: Any, url: str, _params: dict[str, Any], _logger: Any) -> dict[str, Any]:
+        def router(url: str) -> Response:
             if url.endswith("/users/me/organizations/"):
-                return _page("organizations", [{"id": "org1"}, {"id": "org2"}], None)
+                return _response("organizations", [{"id": "org1"}, {"id": "org2"}])
             if url.endswith("/organizations/org1/events/"):
-                return _page("events", [{"id": "e1"}], None)
+                return _response("events", [{"id": "e1"}])
             if url.endswith("/organizations/org2/events/"):
-                return _page("events", [{"id": "e2"}], None)
+                return _response("events", [{"id": "e2"}])
             raise AssertionError(f"unexpected url {url}")
 
-        mock_fetch.side_effect = router
-        config = EVENTBRITE_ENDPOINTS["events"]
+        _wire(session, router)
 
-        results = list(_iter_records(SESSION, config, LOGGER, None, None))
+        rows = _rows(_run("events", _make_manager()))
 
-        assert [record["id"] for record, _ in results] == ["e1", "e2"]
-        assert all(token is None for _, token in results)
+        # Child rows are yielded with their raw shape (no parent ids injected).
+        assert rows == [{"id": "e1"}, {"id": "e2"}]
 
-    @mock.patch.object(eb, "_fetch_page")
-    def test_event_fan_out_is_two_levels(self, mock_fetch: mock.MagicMock) -> None:
-        def router(_session: Any, url: str, _params: dict[str, Any], _logger: Any) -> dict[str, Any]:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_event_fan_out_is_two_levels(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+
+        def router(url: str) -> Response:
             if url.endswith("/users/me/organizations/"):
-                return _page("organizations", [{"id": "org1"}], None)
+                return _response("organizations", [{"id": "org1"}])
             if url.endswith("/organizations/org1/events/"):
-                return _page("events", [{"id": "e1"}, {"id": "e2"}], None)
+                return _response("events", [{"id": "e1"}, {"id": "e2"}])
             if url.endswith("/events/e1/attendees/"):
-                return _page("attendees", [{"id": "a1"}], None)
+                return _response("attendees", [{"id": "a1"}])
             if url.endswith("/events/e2/attendees/"):
-                return _page("attendees", [{"id": "a2"}], None)
+                return _response("attendees", [{"id": "a2"}])
             raise AssertionError(f"unexpected url {url}")
 
-        mock_fetch.side_effect = router
-        config = EVENTBRITE_ENDPOINTS["attendees"]
+        _wire(session, router)
 
-        results = list(_iter_records(SESSION, config, LOGGER, None, None))
+        rows = _rows(_run("attendees", _make_manager()))
 
-        assert [record["id"] for record, _ in results] == ["a1", "a2"]
+        assert [r["id"] for r in rows] == ["a1", "a2"]
 
-    @mock.patch.object(eb, "_fetch_page")
-    def test_changed_since_applied_only_to_child_endpoint(self, mock_fetch: mock.MagicMock) -> None:
-        seen_params: dict[str, dict[str, Any]] = {}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_child_endpoint_paginates_with_continuation(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        events_pages = iter(
+            [
+                _response("events", [{"id": "e1"}], has_more=True, continuation="p2"),
+                _response("events", [{"id": "e2"}], has_more=False, continuation=None),
+            ]
+        )
 
-        def router(_session: Any, url: str, params: dict[str, Any], _logger: Any) -> dict[str, Any]:
-            seen_params[url] = params
+        def router(url: str) -> Response:
             if url.endswith("/users/me/organizations/"):
-                return _page("organizations", [{"id": "org1"}], None)
-            if url.endswith("/organizations/org1/orders/"):
-                return _page("orders", [{"id": "ord1"}], None)
+                return _response("organizations", [{"id": "org1"}])
+            if url.endswith("/organizations/org1/events/"):
+                return next(events_pages)
             raise AssertionError(f"unexpected url {url}")
 
-        mock_fetch.side_effect = router
-        config = EVENTBRITE_ENDPOINTS["orders"]
+        _wire(session, router)
 
-        list(_iter_records(SESSION, config, LOGGER, "2026-01-01T00:00:00Z", None))
+        rows = _rows(_run("events", _make_manager()))
 
-        # The parent organizations listing must not be narrowed by the child's incremental filter.
-        org_url = next(u for u in seen_params if u.endswith("/users/me/organizations/"))
-        order_url = next(u for u in seen_params if u.endswith("/organizations/org1/orders/"))
-        assert "changed_since" not in seen_params[org_url]
-        assert seen_params[order_url]["changed_since"] == "2026-01-01T00:00:00Z"
+        assert [r["id"] for r in rows] == ["e1", "e2"]
+
+
+class TestIncrementalFilter:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_changed_since_applied_only_to_child_endpoint(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+
+        def router(url: str) -> Response:
+            if url.endswith("/users/me/organizations/"):
+                return _response("organizations", [{"id": "org1"}])
+            if url.endswith("/organizations/org1/orders/"):
+                return _response("orders", [{"id": "ord1"}])
+            raise AssertionError(f"unexpected url {url}")
+
+        snaps = _wire(session, router)
+
+        _rows(
+            _run(
+                "orders",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value="2026-01-01T00:00:00Z",
+                incremental_field="changed",
+            )
+        )
+
+        org_params = next(p for u, p in snaps if u.endswith("/users/me/organizations/"))
+        order_params = next(p for u, p in snaps if u.endswith("/organizations/org1/orders/"))
+        assert "changed_since" not in org_params
+        assert order_params["changed_since"] == "2026-01-01T00:00:00Z"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_changed_since_omitted_when_not_incremental(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+
+        def router(url: str) -> Response:
+            if url.endswith("/users/me/organizations/"):
+                return _response("organizations", [{"id": "org1"}])
+            if url.endswith("/organizations/org1/orders/"):
+                return _response("orders", [{"id": "ord1"}])
+            raise AssertionError(f"unexpected url {url}")
+
+        snaps = _wire(session, router)
+
+        _rows(
+            _run(
+                "orders",
+                _make_manager(),
+                should_use_incremental_field=False,
+                db_incremental_field_last_value="2026-01-01T00:00:00Z",
+                incremental_field="changed",
+            )
+        )
+
+        order_params = next(p for u, p in snaps if u.endswith("/organizations/org1/orders/"))
+        assert "changed_since" not in order_params
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_changed_since_omitted_for_unrelated_incremental_field(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+
+        def router(url: str) -> Response:
+            if url.endswith("/users/me/organizations/"):
+                return _response("organizations", [{"id": "org1"}])
+            if url.endswith("/organizations/org1/orders/"):
+                return _response("orders", [{"id": "ord1"}])
+            raise AssertionError(f"unexpected url {url}")
+
+        snaps = _wire(session, router)
+
+        _rows(
+            _run(
+                "orders",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value="2026-01-01T00:00:00Z",
+                incremental_field="some_other_field",
+            )
+        )
+
+        order_params = next(p for u, p in snaps if u.endswith("/organizations/org1/orders/"))
+        assert "changed_since" not in order_params
 
 
 class TestValidateCredentials:
@@ -173,7 +308,7 @@ class TestValidateCredentials:
         "status_code, expected",
         [(200, True), (401, False), (403, False), (500, False)],
     )
-    @mock.patch.object(eb, "make_tracked_session")
+    @mock.patch(EB_SESSION_PATCH)
     def test_validate_credentials_status_mapping(
         self, mock_session_factory: mock.MagicMock, status_code: int, expected: bool
     ) -> None:
@@ -183,7 +318,7 @@ class TestValidateCredentials:
 
         assert validate_credentials("token") is expected
 
-    @mock.patch.object(eb, "make_tracked_session")
+    @mock.patch(EB_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session_factory: mock.MagicMock) -> None:
         session = mock.MagicMock()
         session.get.side_effect = Exception("network down")
@@ -194,10 +329,10 @@ class TestValidateCredentials:
 
 class TestEventbriteSourceResponse:
     @pytest.mark.parametrize("endpoint", ["organizations", "events", "orders", "attendees"])
-    def test_partitioned_endpoints(self, endpoint: str) -> None:
-        response = eventbrite_source(
-            api_token="token", endpoint=endpoint, logger=LOGGER, resumable_source_manager=mock.MagicMock()
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_partitioned_endpoints(self, MockSession: mock.MagicMock, endpoint: str) -> None:
+        MockSession.return_value.headers = {}
+        response = _run(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
@@ -206,10 +341,10 @@ class TestEventbriteSourceResponse:
         assert response.partition_keys == ["created"]
 
     @pytest.mark.parametrize("endpoint", ["categories", "formats", "venues", "ticket_classes"])
-    def test_non_partitioned_endpoints(self, endpoint: str) -> None:
-        response = eventbrite_source(
-            api_token="token", endpoint=endpoint, logger=LOGGER, resumable_source_manager=mock.MagicMock()
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_partitioned_endpoints(self, MockSession: mock.MagicMock, endpoint: str) -> None:
+        MockSession.return_value.headers = {}
+        response = _run(endpoint, _make_manager())
 
         assert response.partition_mode is None
         assert response.partition_keys is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/tests/test_eventbrite_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/eventbrite/tests/test_eventbrite_source.py
@@ -131,7 +131,8 @@ class TestEventbriteSource:
         manager = mock.MagicMock()
         inputs = mock.MagicMock()
         inputs.schema_name = "orders"
-        inputs.logger = mock.MagicMock()
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2026-01-01T00:00:00Z"
         inputs.incremental_field = "changed"
@@ -141,7 +142,8 @@ class TestEventbriteSource:
         mock_eventbrite_source.assert_called_once_with(
             api_token=self.config.api_token,
             endpoint="orders",
-            logger=inputs.logger,
+            team_id=123,
+            job_id="job-1",
             resumable_source_manager=manager,
             should_use_incremental_field=True,
             db_incremental_field_last_value="2026-01-01T00:00:00Z",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firecrawl/firecrawl.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firecrawl/firecrawl.py
@@ -1,31 +1,34 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from typing import Any, Optional
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+    OffsetPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.firecrawl.settings import (
     FIRECRAWL_BASE_URL,
     FIRECRAWL_ENDPOINTS,
-    FirecrawlEndpointConfig,
 )
 
 # Both the cursor endpoint (activity) and the offset endpoints (monitors, monitor checks) cap page
 # size at 100. Ask for the maximum to minimize round trips.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-# Hard stop so a misbehaving offset endpoint (one that never shrinks a page below PAGE_SIZE) can't
-# spin forever. 100 * 100_000 = 10M rows per resource, far above any realistic account.
-MAX_PAGE_ITERATIONS = 100_000
-
-
-class FirecrawlRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -34,227 +37,57 @@ class FirecrawlResumeConfig:
     cursor: str | None = None
     # Offset for the offset-paginated endpoints (monitors, monitor_checks).
     offset: int | None = None
-    # monitor_checks fan-out: the monitor whose checks we're currently paging. A stable ID bookmark
-    # (not a positional index) so monitors added/removed between a crash and the retry can't resume
-    # us into the wrong monitor. None for the non-fan-out endpoints.
+    # Legacy monitor_checks fan-out bookmark. Retained (with a default) so state saved by the old
+    # transport still deserializes; the framework fan-out now checkpoints into `fanout_state`.
     monitor_id: str | None = None
+    # monitor_checks fan-out resume state, as emitted by the shared dependent-resource paginator:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: dict | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
+def _auth_headers(api_key: str) -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs;
+    # this header form is used only for the credential probe, which bypasses the framework auth.
+    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+
+
+def _client_config(api_key: str) -> ClientConfig:
     return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
+        "base_url": FIRECRAWL_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_key},
     }
-
-
-@retry(
-    # ChunkedEncodingError is a mid-stream connection break (server truncated a chunked body); it's
-    # transient like ConnectionError/ReadTimeout but not a ConnectionError subclass, so list it.
-    retry=retry_if_exception_type(
-        (
-            FirecrawlRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    params: dict[str, Any] | None,
-    logger: FilteringBoundLogger,
-) -> dict:
-    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Plan-based rate/concurrency limits surface as 429; 5xx are transient. Back off and retry both.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise FirecrawlRetryableError(f"Firecrawl API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Firecrawl API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
 
 
 def validate_credentials(api_key: str) -> bool:
     # credit-usage is a cheap, always-present team endpoint: a genuine key returns 200, an invalid or
     # revoked one 401. We only confirm the token itself here (see FirecrawlSource.validate_credentials).
-    url = f"{FIRECRAWL_BASE_URL}/v2/team/credit-usage"
-    try:
-        # Redact the bearer token from tracked logs/samples in case Firecrawl reflects it back
-        # (redirect URL, error body, or a non-denylisted field).
-        response = make_tracked_session(redact_values=(api_key,)).get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _fetch_single(
-    session: requests.Session, headers: dict[str, str], cfg: FirecrawlEndpointConfig, logger: FilteringBoundLogger
-) -> list[dict]:
-    """Unpaginated endpoints: one request, return the whole row array."""
-    data = _fetch(session, f"{FIRECRAWL_BASE_URL}{cfg.path}", headers, None, logger)
-    # Index (not .get) so a renamed/missing selector fails the sync loudly instead of silently
-    # replacing warehouse data with zero rows on a full refresh.
-    return data[cfg.data_selector] or []
-
-
-def _iter_cursor_pages(
-    session: requests.Session,
-    headers: dict[str, str],
-    cfg: FirecrawlEndpointConfig,
-    manager: ResumableSourceManager[FirecrawlResumeConfig],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict]]:
-    """Cursor-paginated endpoints (team activity). Yields one page of rows at a time."""
-    resume = manager.load_state() if manager.can_resume() else None
-    cursor = resume.cursor if resume else None
-    if cursor:
-        logger.debug(f"Firecrawl: resuming {cfg.name} from cursor")
-
-    url = f"{FIRECRAWL_BASE_URL}{cfg.path}"
-    for _ in range(MAX_PAGE_ITERATIONS):
-        params: dict[str, Any] = {"limit": PAGE_SIZE}
-        if cursor:
-            params["cursor"] = cursor
-        data = _fetch(session, url, headers, params, logger)
-
-        # Index (not .get) so a renamed/missing selector fails loudly rather than truncating the sync.
-        yield data[cfg.data_selector] or []
-
-        next_cursor = data.get("cursor")
-        if not data.get("has_more") or not next_cursor:
-            break
-        cursor = next_cursor
-        # Save AFTER yielding the page so a crash resumes at the next page rather than replaying the
-        # whole log; full-refresh keeps already-written rows on resume, and the primary key dedupes.
-        manager.save_state(FirecrawlResumeConfig(cursor=cursor))
-
-
-def _iter_offset_pages(
-    session: requests.Session,
-    headers: dict[str, str],
-    path: str,
-    data_selector: str,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[FirecrawlResumeConfig] | None = None,
-    monitor_id: str | None = None,
-    start_offset: int = 0,
-) -> Iterator[list[dict]]:
-    """Offset-paginated endpoints (monitors, monitor checks). Yields one page of rows at a time.
-
-    Termination is a short page (< PAGE_SIZE): these endpoints return no total or has_more flag, so
-    a full page means "there may be more". When a manager is supplied, saves the next offset (and the
-    fan-out monitor_id) after each page so a resume picks up mid-resource.
-    """
-    offset = start_offset
-    url = f"{FIRECRAWL_BASE_URL}{path}"
-    for _ in range(MAX_PAGE_ITERATIONS):
-        data = _fetch(session, url, headers, {"limit": PAGE_SIZE, "offset": offset}, logger)
-        # Index (not .get) so a renamed/missing selector fails loudly rather than truncating the sync.
-        items = data[data_selector] or []
-
-        yield items
-
-        if len(items) < PAGE_SIZE:
-            break
-        offset += PAGE_SIZE
-        if manager is not None:
-            manager.save_state(FirecrawlResumeConfig(offset=offset, monitor_id=monitor_id))
-
-
-def _iter_monitor_ids(session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger) -> list[str]:
-    monitor_ids: list[str] = []
-    for page in _iter_offset_pages(session, headers, FIRECRAWL_ENDPOINTS["monitors"].path, "data", logger):
-        # Index (not a guarded skip) so a monitor row missing its id fails loudly rather than
-        # silently dropping every check for that monitor.
-        monitor_ids.extend(item["id"] for item in page)
-    return monitor_ids
-
-
-def _iter_monitor_checks(
-    session: requests.Session,
-    headers: dict[str, str],
-    cfg: FirecrawlEndpointConfig,
-    manager: ResumableSourceManager[FirecrawlResumeConfig],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict]]:
-    """Fan out over every monitor, paging each monitor's checks. Each check id is a globally-unique
-    uuid, and every row also carries its `monitorId`, so the primary key stays unique table-wide."""
-    monitor_ids = _iter_monitor_ids(session, headers, logger)
-
-    resume = manager.load_state() if manager.can_resume() else None
-    remaining = monitor_ids
-    resume_offset = 0
-    if resume is not None and resume.monitor_id is not None and resume.monitor_id in monitor_ids:
-        remaining = monitor_ids[monitor_ids.index(resume.monitor_id) :]
-        resume_offset = resume.offset or 0
-        logger.debug(f"Firecrawl: resuming monitor_checks from monitor {resume.monitor_id}, offset {resume_offset}")
-
-    for index, monitor_id in enumerate(remaining):
-        path = cfg.path.replace("{monitor_id}", monitor_id)
-        start_offset = resume_offset if index == 0 else 0
-        yield from _iter_offset_pages(
-            session,
-            headers,
-            path,
-            cfg.data_selector,
-            logger,
-            manager=manager,
-            monitor_id=monitor_id,
-            start_offset=start_offset,
-        )
-        # Advance the bookmark to the next monitor so a crash between monitors resumes correctly.
-        if index + 1 < len(remaining):
-            manager.save_state(FirecrawlResumeConfig(offset=0, monitor_id=remaining[index + 1]))
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FirecrawlResumeConfig],
-) -> Iterator[list[dict]]:
-    cfg = FIRECRAWL_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every page so urllib3 keeps the connection alive. Redact the bearer
-    # token from tracked logs/samples in case Firecrawl reflects it back in a URL or response body.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    if cfg.fan_out_over_monitors:
-        yield from _iter_monitor_checks(session, headers, cfg, resumable_source_manager, logger)
-    elif cfg.pagination == "cursor":
-        yield from _iter_cursor_pages(session, headers, cfg, resumable_source_manager, logger)
-    elif cfg.pagination == "offset":
-        yield from _iter_offset_pages(
-            session, headers, cfg.path, cfg.data_selector, logger, manager=resumable_source_manager
-        )
-    else:
-        yield _fetch_single(session, headers, cfg, logger)
+    # Redact the bearer token from tracked logs/samples in case Firecrawl reflects it back.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{FIRECRAWL_BASE_URL}/v2/team/credit-usage",
+        headers=_auth_headers(api_key),
+    )
+    return ok
 
 
 def firecrawl_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FirecrawlResumeConfig],
 ) -> SourceResponse:
     cfg = FIRECRAWL_ENDPOINTS[endpoint]
 
+    if cfg.fan_out_over_monitors:
+        resource = _fan_out_resource(api_key, endpoint, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _paginated_resource(api_key, endpoint, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=cfg.primary_keys,
         sort_mode="asc",
         partition_count=1,
@@ -263,3 +96,137 @@ def firecrawl_source(
         partition_format=cfg.partition_format if cfg.partition_key else None,
         partition_keys=[cfg.partition_key] if cfg.partition_key else None,
     )
+
+
+def _paginated_resource(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[FirecrawlResumeConfig],
+) -> Resource:
+    cfg = FIRECRAWL_ENDPOINTS[endpoint]
+
+    params: dict[str, Any] = {}
+    if cfg.pagination == "cursor":
+        paginator: Any = JSONResponseCursorPaginator(cursor_path="cursor", cursor_param="cursor")
+        params["limit"] = PAGE_SIZE
+    elif cfg.pagination == "offset":
+        # No top-level total; termination is a short/empty page (OffsetPaginator default).
+        paginator = OffsetPaginator(limit=PAGE_SIZE, total_path=None)
+    else:
+        paginator = SinglePagePaginator()
+
+    endpoint_config: Endpoint = {
+        "path": cfg.path,
+        "params": params,
+        "paginator": paginator,
+        "data_selector": cfg.data_selector,
+        # Index (not .get) semantics: a 200 body missing the selector means the response shape changed
+        # - fail the sync loudly instead of silently replacing warehouse data with zero rows.
+        "data_selector_required": True,
+    }
+    config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": endpoint,
+                "table_name": endpoint,
+                "write_disposition": "replace",
+                "endpoint": endpoint_config,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None:
+            if cfg.pagination == "cursor" and resume.cursor is not None:
+                initial_paginator_state = {"cursor": resume.cursor}
+            elif cfg.pagination == "offset" and resume.offset is not None:
+                initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER the page is yielded so a crash re-yields
+        # the last page (the primary key dedupes) rather than skipping it.
+        if not state:
+            return
+        if cfg.pagination == "cursor" and state.get("cursor") is not None:
+            manager.save_state(FirecrawlResumeConfig(cursor=state["cursor"]))
+        elif cfg.pagination == "offset" and state.get("offset") is not None:
+            manager.save_state(FirecrawlResumeConfig(offset=int(state["offset"])))
+
+    return rest_api_resource(
+        config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _fan_out_resource(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[FirecrawlResumeConfig],
+) -> Resource:
+    """Fan out over every monitor, paging each monitor's checks. The monitor list is fetched purely
+    to drive the fan-out (the monitors table is synced by its own endpoint); each check row already
+    carries its `monitorId`, so no parent field is injected. Single-hop fan-out is resumable: the
+    shared paginator checkpoints per-monitor progress so a restart skips monitors already fully synced.
+    """
+    cfg = FIRECRAWL_ENDPOINTS[endpoint]
+    monitors_cfg = FIRECRAWL_ENDPOINTS["monitors"]
+
+    parent_resource: EndpointResource = {
+        "name": "monitors",
+        "table_name": "monitors",
+        "write_disposition": "replace",
+        "endpoint": {
+            "path": monitors_cfg.path,
+            "paginator": OffsetPaginator(limit=PAGE_SIZE, total_path=None),
+            "data_selector": monitors_cfg.data_selector,
+            "data_selector_required": True,
+        },
+    }
+    child_resource: EndpointResource = {
+        "name": endpoint,
+        "table_name": endpoint,
+        "write_disposition": "replace",
+        "include_from_parent": [],
+        "endpoint": {
+            "path": cfg.path,
+            "params": {"monitor_id": {"type": "resolve", "resource": "monitors", "field": "id"}},
+            "paginator": OffsetPaginator(limit=PAGE_SIZE, total_path=None),
+            "data_selector": cfg.data_selector,
+            "data_selector_required": True,
+        },
+    }
+    config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [parent_resource, child_resource],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state is not None:
+            manager.save_state(FirecrawlResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(r for r in resources if getattr(r, "name", None) == endpoint)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firecrawl/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firecrawl/source.py
@@ -139,6 +139,7 @@ You can create an API key in your [Firecrawl dashboard](https://www.firecrawl.de
         return firecrawl_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firecrawl/tests/test_firecrawl.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firecrawl/tests/test_firecrawl.py
@@ -1,227 +1,230 @@
-from typing import Any, cast
+import json
+from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.firecrawl import firecrawl
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
 from products.warehouse_sources.backend.temporal.data_imports.sources.firecrawl.firecrawl import (
     FirecrawlResumeConfig,
     firecrawl_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.firecrawl.settings import FIRECRAWL_ENDPOINTS
 
-
-class _FakeResumableManager:
-    def __init__(self, state: FirecrawlResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[FirecrawlResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> FirecrawlResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: FirecrawlResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the firecrawl module.
+FIRECRAWL_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.firecrawl.firecrawl.make_tracked_session"
+)
 
 
-def _collect(manager: _FakeResumableManager, endpoint: str) -> list[dict]:
-    rows: list[dict] = []
-    for page in get_rows(
+def _response(selector: str, items: list[dict[str, Any]] | None, *, extra: dict[str, Any] | None = None) -> Response:
+    body: dict[str, Any] = {selector: items if items is not None else []}
+    if extra:
+        body.update(extra)
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _status_response(status_code: int, *, reason: str = "", body: Any = None) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.reason = reason
+    resp.url = "https://api.firecrawl.dev/v2/team/activity"
+    resp._content = json.dumps(body if body is not None else {}).encode()
+    return resp
+
+
+def _make_manager(resume_state: FirecrawlResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire_sequence(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Drive the session with an ordered list of responses; capture each request's params at send time.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared instead of inspecting it after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        param_snapshots.append(dict(request.params or {}))
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _wire_by_url(session: mock.MagicMock, handler: Any) -> list[str]:
+    """Drive the session by dispatching each prepared request's URL through ``handler`` (url -> Response)."""
+    session.headers = {}
+    requested: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        requested.append(request.url)
+        return prepared
+
+    def _send(prepared: Any, **_: Any) -> Response:
+        return handler(prepared.url)
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = _send
+    return requested
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return firecrawl_source(
         api_key="fc-test",
         endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        rows.extend(page)
-    return rows
-
-
-def _make_response(status_code: int, *, ok: bool | None = None, body: Any = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = ok if ok is not None else status_code < 400
-    response.json.return_value = body if body is not None else {}
-    response.text = ""
-    return response
-
-
-class TestFetchRetryClassification:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 502)])
-    def test_retryable_statuses_raise_and_retry(self, _name: str, status_code: int) -> None:
-        # 429 (plan rate/concurrency limit) and 5xx must retry rather than fail the sync outright.
-        session = MagicMock()
-        session.get.side_effect = [_make_response(status_code), _make_response(200, body={"data": []})]
-
-        with patch.object(firecrawl._fetch.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = firecrawl._fetch(session, "https://api.firecrawl.dev/v2/team/activity", {}, None, MagicMock())
-
-        assert result == {"data": []}
-        assert session.get.call_count == 2
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_immediately(self, _name: str, status_code: int) -> None:
-        # A 4xx credential/permission error can never be fixed by retrying, so it must surface at once.
-        response = _make_response(status_code)
-        response.raise_for_status.side_effect = requests.HTTPError(
-            f"{status_code} Client Error", response=cast(requests.Response, response)
-        )
-        session = MagicMock()
-        session.get.return_value = response
-
-        with pytest.raises(requests.HTTPError):
-            firecrawl._fetch(session, "https://api.firecrawl.dev/v2/team/activity", {}, None, MagicMock())
-        assert session.get.call_count == 1
-
-    @parameterized.expand(
-        [
-            ("chunked", requests.exceptions.ChunkedEncodingError("Connection broken")),
-            ("read_timeout", requests.ReadTimeout("Read timed out.")),
-            ("connection", requests.ConnectionError("Connection reset by peer")),
-        ]
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager,
     )
-    def test_transient_network_errors_are_retried(self, _name: str, transient: Exception) -> None:
-        session = MagicMock()
-        session.get.side_effect = [transient, _make_response(200, body={"data": []})]
-
-        with patch.object(firecrawl._fetch.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = firecrawl._fetch(session, "https://api.firecrawl.dev/v2/team/activity", {}, None, MagicMock())
-
-        assert result == {"data": []}
-        assert session.get.call_count == 2
-
-    def test_transient_error_reraised_after_five_attempts(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ReadTimeout("Read timed out.")
-
-        with patch.object(firecrawl._fetch.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(requests.ReadTimeout):
-                firecrawl._fetch(session, "https://api.firecrawl.dev/v2/team/activity", {}, None, MagicMock())
-        assert session.get.call_count == 5
 
 
-class TestValidateCredentials:
-    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("server_error", 500, False)])
-    def test_status_maps_to_bool(self, _name: str, status_code: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = _make_response(status_code)
-        with patch.object(firecrawl, "make_tracked_session", return_value=session):
-            assert validate_credentials("fc-test") is expected
-
-    def test_network_failure_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(firecrawl, "make_tracked_session", return_value=session):
-            assert validate_credentials("fc-test") is False
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestCursorPagination:
-    def _patch_fetch(self, monkeypatch: Any, pages_by_cursor: dict[Any, Any]) -> list[Any]:
-        seen_cursors: list[Any] = []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_cursor_until_cursor_empty(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire_sequence(
+            session,
+            [
+                _response("data", [{"id": "a"}], extra={"cursor": "c1", "has_more": True}),
+                _response("data", [{"id": "b"}], extra={"cursor": "c2", "has_more": True}),
+                _response("data", [{"id": "c"}], extra={"cursor": None, "has_more": False}),
+            ],
+        )
+        manager = _make_manager()
 
-        def fake_fetch(session: Any, url: str, headers: Any, params: Any, logger: Any) -> dict:
-            cursor = params.get("cursor") if params else None
-            seen_cursors.append(cursor)
-            return pages_by_cursor[cursor]
-
-        monkeypatch.setattr(firecrawl, "_fetch", fake_fetch)
-        return seen_cursors
-
-    def test_follows_cursor_until_has_more_false(self, monkeypatch: Any) -> None:
-        pages = {
-            None: {"data": [{"id": "a"}], "cursor": "c1", "has_more": True},
-            "c1": {"data": [{"id": "b"}], "cursor": "c2", "has_more": True},
-            "c2": {"data": [{"id": "c"}], "cursor": None, "has_more": False},
-        }
-        seen = self._patch_fetch(monkeypatch, pages)
-        manager = _FakeResumableManager()
-
-        rows = _collect(manager, "team_activity")
+        rows = _rows(_source("team_activity", manager))
 
         assert [r["id"] for r in rows] == ["a", "b", "c"]
-        assert seen == [None, "c1", "c2"]
-        # State is saved only for the pages that had a next cursor, and points at the NEXT page.
-        assert [s.cursor for s in manager.saved] == ["c1", "c2"]
+        # limit is sent on every page; the cursor is injected only from the second page on.
+        assert params[0] == {"limit": 100}
+        assert params[1]["cursor"] == "c1"
+        assert params[2]["cursor"] == "c2"
+        # Checkpoint is saved only while a next cursor remains, and it points at the NEXT page.
+        saved = [c.args[0] for c in manager.save_state.call_args_list]
+        assert [s.cursor for s in saved] == ["c1", "c2"]
 
-    def test_resumes_from_saved_cursor(self, monkeypatch: Any) -> None:
-        pages = {
-            "c1": {"data": [{"id": "b"}], "cursor": None, "has_more": False},
-        }
-        seen = self._patch_fetch(monkeypatch, pages)
-        manager = _FakeResumableManager(FirecrawlResumeConfig(cursor="c1"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire_sequence(session, [_response("data", [{"id": "b"}], extra={"cursor": None, "has_more": False})])
+        manager = _make_manager(FirecrawlResumeConfig(cursor="c1"))
 
-        rows = _collect(manager, "team_activity")
+        rows = _rows(_source("team_activity", manager))
 
         assert [r["id"] for r in rows] == ["b"]
-        assert seen == ["c1"]  # never re-fetched the already-processed first page
+        # The resumed cursor is applied to the very first request; the earlier page is never re-fetched.
+        assert params[0]["cursor"] == "c1"
+        assert session.send.call_count == 1
 
-    def test_stops_when_cursor_missing_even_if_has_more_true(self, monkeypatch: Any) -> None:
-        # Guard against an infinite loop if the API ever returns has_more=true with a null cursor.
-        pages = {None: {"data": [{"id": "a"}], "cursor": None, "has_more": True}}
-        self._patch_fetch(monkeypatch, pages)
-        rows = _collect(_FakeResumableManager(), "team_activity")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_cursor_missing(self, MockSession) -> None:
+        # No next cursor terminates the walk even though the body claims has_more=true.
+        session = MockSession.return_value
+        _wire_sequence(session, [_response("data", [{"id": "a"}], extra={"cursor": None, "has_more": True})])
+        manager = _make_manager()
+
+        rows = _rows(_source("team_activity", manager))
+
         assert [r["id"] for r in rows] == ["a"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
 
 class TestOffsetPagination:
-    def _patch_fetch(self, monkeypatch: Any, pages_by_offset: dict[int, list[dict]]) -> list[int]:
-        seen_offsets: list[int] = []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_pages_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": str(i)} for i in range(100)]
+        params = _wire_sequence(session, [_response("data", full_page), _response("data", [{"id": "last"}])])
+        manager = _make_manager()
 
-        def fake_fetch(session: Any, url: str, headers: Any, params: Any, logger: Any) -> dict:
-            offset = params["offset"]
-            seen_offsets.append(offset)
-            return {"data": pages_by_offset.get(offset, [])}
+        rows = _rows(_source("monitors", manager))
 
-        monkeypatch.setattr(firecrawl, "_fetch", fake_fetch)
-        return seen_offsets
+        assert len(rows) == 101
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == 100
+        assert params[1]["offset"] == 100
+        # One checkpoint after the first full page (points at the next offset); the short page ends it.
+        saved = [c.args[0] for c in manager.save_state.call_args_list]
+        assert [s.offset for s in saved] == [100]
 
-    def test_pages_until_short_page(self, monkeypatch: Any) -> None:
-        full_page = [{"id": str(i)} for i in range(firecrawl.PAGE_SIZE)]
-        pages = {0: full_page, firecrawl.PAGE_SIZE: [{"id": "last"}]}
-        seen = self._patch_fetch(monkeypatch, pages)
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire_sequence(session, [_response("data", [{"id": "x"}])])
+        manager = _make_manager()
 
-        rows = _collect(manager, "monitors")
+        rows = _rows(_source("monitors", manager))
 
-        assert len(rows) == firecrawl.PAGE_SIZE + 1
-        assert seen == [0, firecrawl.PAGE_SIZE]  # stopped after the short second page
-        assert [s.offset for s in manager.saved] == [firecrawl.PAGE_SIZE]
-
-    def test_single_short_page_does_not_advance(self, monkeypatch: Any) -> None:
-        seen = self._patch_fetch(monkeypatch, {0: [{"id": "x"}]})
-        manager = _FakeResumableManager()
-        rows = _collect(manager, "monitors")
         assert [r["id"] for r in rows] == ["x"]
-        assert seen == [0]
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire_sequence(session, [_response("data", [{"id": "m_201"}])])
+        manager = _make_manager(FirecrawlResumeConfig(offset=200))
+
+        _rows(_source("monitors", manager))
+
+        assert params[0]["offset"] == 200
 
 
 class TestUnpaginated:
-    @pytest.mark.parametrize(
-        "endpoint,selector",
+    @parameterized.expand(
         [
             ("credit_usage_historical", "periods"),
             ("token_usage_historical", "periods"),
             ("active_crawls", "crawls"),
-        ],
+        ]
     )
-    def test_single_request_reads_the_endpoint_selector(self, endpoint: str, selector: str, monkeypatch: Any) -> None:
-        calls: list[str] = []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_request_reads_the_endpoint_selector(self, endpoint: str, selector: str, MockSession) -> None:
+        session = MockSession.return_value
+        _wire_sequence(session, [_response(selector, [{"id": "1"}, {"id": "2"}])])
+        manager = _make_manager()
 
-        def fake_fetch(session: Any, url: str, headers: Any, params: Any, logger: Any) -> dict:
-            calls.append(url)
-            return {selector: [{"id": "1"}, {"id": "2"}]}
+        rows = _rows(_source(endpoint, manager))
 
-        monkeypatch.setattr(firecrawl, "_fetch", fake_fetch)
-        rows = _collect(_FakeResumableManager(), endpoint)
         assert rows == [{"id": "1"}, {"id": "2"}]
-        assert len(calls) == 1  # unpaginated: exactly one request
+        assert session.send.call_count == 1  # unpaginated: exactly one request
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_selector_raises_loudly(self, MockSession) -> None:
+        # A 200 body without the expected selector means the response shape changed — fail loud rather
+        # than silently replacing warehouse data with zero rows on a full refresh.
+        session = MockSession.return_value
+        _wire_sequence(session, [_response("something_else", [{"id": "1"}])])
+        manager = _make_manager()
+
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source("active_crawls", manager))
 
 
 class TestMonitorChecksFanOut:
@@ -231,50 +234,118 @@ class TestMonitorChecksFanOut:
         assert cfg.should_sync_default is False
         assert "{monitor_id}" in cfg.path
 
-    def test_fans_out_over_every_monitor(self, monkeypatch: Any) -> None:
-        def fake_fetch(session: Any, url: str, headers: Any, params: Any, logger: Any) -> dict:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_over_every_monitor(self, MockSession) -> None:
+        session = MockSession.return_value
+
+        def handler(url: str) -> Response:
             if url.endswith("/v2/monitor"):
-                return {"data": [{"id": "m1"}, {"id": "m2"}]}
-            if "m1" in url:
-                return {"data": [{"id": "chk1", "monitorId": "m1"}]}
-            if "m2" in url:
-                return {"data": [{"id": "chk2", "monitorId": "m2"}]}
+                return _response("data", [{"id": "m1"}, {"id": "m2"}])
+            if "/v2/monitor/m1/checks" in url:
+                return _response("data", [{"id": "chk1", "monitorId": "m1"}])
+            if "/v2/monitor/m2/checks" in url:
+                return _response("data", [{"id": "chk2", "monitorId": "m2"}])
             raise AssertionError(f"unexpected url {url}")
 
-        monkeypatch.setattr(firecrawl, "_fetch", fake_fetch)
-        rows = _collect(_FakeResumableManager(), "monitor_checks")
+        _wire_by_url(session, handler)
+        manager = _make_manager()
+
+        rows = _rows(_source("monitor_checks", manager))
+
+        # Each check row is yielded as the API returns it (it already carries monitorId), in monitor order.
         assert rows == [
             {"id": "chk1", "monitorId": "m1"},
             {"id": "chk2", "monitorId": "m2"},
         ]
 
-    def test_resumes_from_saved_monitor(self, monkeypatch: Any) -> None:
-        fetched: list[str] = []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_past_completed_monitor(self, MockSession) -> None:
+        session = MockSession.return_value
 
-        def fake_fetch(session: Any, url: str, headers: Any, params: Any, logger: Any) -> dict:
-            fetched.append(url)
+        def handler(url: str) -> Response:
             if url.endswith("/v2/monitor"):
-                return {"data": [{"id": "m1"}, {"id": "m2"}]}
-            return {"data": [{"id": "chk2", "monitorId": "m2"}]}
+                return _response("data", [{"id": "m1"}, {"id": "m2"}])
+            if "/v2/monitor/m2/checks" in url:
+                return _response("data", [{"id": "chk2", "monitorId": "m2"}])
+            raise AssertionError(f"unexpected url {url}")
 
-        monkeypatch.setattr(firecrawl, "_fetch", fake_fetch)
-        manager = _FakeResumableManager(FirecrawlResumeConfig(monitor_id="m2", offset=0))
-        rows = _collect(manager, "monitor_checks")
+        requested = _wire_by_url(session, handler)
+        # m1's checks are already checkpointed as complete, so the resume skips straight to m2.
+        manager = _make_manager(
+            FirecrawlResumeConfig(fanout_state={"completed": ["/v2/monitor/m1/checks"], "current": None})
+        )
+
+        rows = _rows(_source("monitor_checks", manager))
 
         assert rows == [{"id": "chk2", "monitorId": "m2"}]
-        # m1's checks are never fetched - we resumed straight to m2.
-        assert not any("m1/checks" in url for url in fetched)
+        assert not any("/v2/monitor/m1/checks" in url for url in requested)
 
-    def test_unknown_saved_monitor_restarts_from_first(self, monkeypatch: Any) -> None:
-        def fake_fetch(session: Any, url: str, headers: Any, params: Any, logger: Any) -> dict:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stale_completed_path_does_not_skip_live_monitor(self, MockSession) -> None:
+        session = MockSession.return_value
+
+        def handler(url: str) -> Response:
             if url.endswith("/v2/monitor"):
-                return {"data": [{"id": "m1"}]}
-            return {"data": [{"id": "chk1", "monitorId": "m1"}]}
+                return _response("data", [{"id": "m1"}])
+            if "/v2/monitor/m1/checks" in url:
+                return _response("data", [{"id": "chk1", "monitorId": "m1"}])
+            raise AssertionError(f"unexpected url {url}")
 
-        monkeypatch.setattr(firecrawl, "_fetch", fake_fetch)
-        manager = _FakeResumableManager(FirecrawlResumeConfig(monitor_id="DELETED", offset=40))
-        rows = _collect(manager, "monitor_checks")
+        _wire_by_url(session, handler)
+        # A checkpoint for a monitor that no longer exists must not suppress the live monitor.
+        manager = _make_manager(
+            FirecrawlResumeConfig(fanout_state={"completed": ["/v2/monitor/DELETED/checks"], "current": None})
+        )
+
+        rows = _rows(_source("monitor_checks", manager))
+
         assert rows == [{"id": "chk1", "monitorId": "m1"}]
+
+
+class TestRetryClassification:
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 502)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_retry_then_succeed(self, _name: str, status_code: int, MockSession) -> None:
+        # 429 (plan rate/concurrency limit) and 5xx must retry rather than fail the sync outright.
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.side_effect = lambda request: mock.MagicMock(url=request.url)
+        session.send.side_effect = [_status_response(status_code), _response("data", [{"id": "a"}])]
+        manager = _make_manager()
+
+        with mock.patch.object(RESTClient._send_request.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
+            rows = _rows(_source("team_activity", manager))
+
+        assert [r["id"] for r in rows] == ["a"]
+        assert session.send.call_count == 2
+
+    @parameterized.expand([("unauthorized", 401, "Unauthorized"), ("forbidden", 403, "Forbidden")])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_surface_immediately(self, _name: str, status_code: int, reason: str, MockSession) -> None:
+        # A 4xx credential/permission error can never be fixed by retrying, so it must surface at once
+        # (and carries the status text get_non_retryable_errors matches on).
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.side_effect = lambda request: mock.MagicMock(url=request.url)
+        session.send.side_effect = [_status_response(status_code, reason=reason)]
+        manager = _make_manager()
+
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("team_activity", manager))
+        assert session.send.call_count == 1
+
+
+class TestValidateCredentials:
+    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("server_error", 500, False)])
+    @mock.patch(FIRECRAWL_SESSION_PATCH)
+    def test_status_maps_to_bool(self, _name: str, status_code: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("fc-test") is expected
+
+    @mock.patch(FIRECRAWL_SESSION_PATCH)
+    def test_network_failure_is_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("fc-test") is False
 
 
 class TestSourceResponseShape:
@@ -288,17 +359,19 @@ class TestSourceResponseShape:
             ("monitor_checks", ["id"], "createdAt", "week"),
         ]
     )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_primary_keys_and_partitioning(
-        self, endpoint: str, expected_pk: list[str], partition_key: str | None, partition_format: str | None
+        self,
+        endpoint: str,
+        expected_pk: list[str],
+        partition_key: str | None,
+        partition_format: str | None,
+        MockSession,
     ) -> None:
         # Locks the primary key + a STABLE (creation-time) partition field per endpoint. A non-unique
         # key or an updated_at partition would rewrite partitions every sync and accumulate duplicates.
-        response = firecrawl_source(
-            api_key="fc-test",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        response = _source(endpoint, _make_manager())
+
         assert response.name == endpoint
         assert response.primary_keys == expected_pk
         assert response.sort_mode == "asc"


### PR DESCRIPTION
## Problem

Batch 16 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **devin_ai**
- **eventbrite**
- **firecrawl** — cursor + offset + single-page paginators and a single-hop resumable monitors→checks fan-out

Not migrated this batch (left hand-rolled, valid blockers — all documented framework gaps):
- **doit** — report rows are positional arrays zipped against a sibling `schema` field with custom per-report pyarrow schema construction.
- **elasticemail** — 200 non-list/non-JSON bodies classified retryable and 400 auth-vs-generic decided by body content (body-level error classification).
- **fastly** — version_resource endpoints need a client-side active-version reduction before hydration.
- **finnhub** — per-symbol fan-out driven by a parsed user-config symbols string (no parent API resource), plus client-side per-batch sort and two-sided incremental date-windowing.
- **fireworks_ai** — AIP list-envelope validation needs missing-key→empty-page but malformed-shape→raise, which the current selector modes can't express both ways.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 3 migrated dirs + `common/rest_source/tests/` — 289 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-15 PR (#71846); merge in order.
