### PR TITLE
fix(data-imports): treat custom REST source 400 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -759,6 +759,10 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
         return {
             "401 Client Error": "The upstream API rejected the request with HTTP 401. Check that the configured auth credentials are correct.",
             "403 Client Error": "The upstream API rejected the request with HTTP 403. The configured credentials may lack the required permissions.",
+            # The request shape — path, query params, and the incremental cursor's wire format —
+            # is entirely manifest-driven, so a 400 is deterministic: the same request recurs on
+            # every retry. Stop retrying and point at the config the user can actually change.
+            "400 Client Error": "The upstream API rejected the request with HTTP 400. Check the resource's path, query params, and — for an incremental sync — the cursor's date format in the manifest, then try again.",
             # A schema points to a resource the manifest no longer defines (renamed or removed
             # in an edit while the table's sync stayed scheduled). Permanent until the config is
             # fixed — match the stable suffix, not the variable resource name in the message.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -1735,6 +1735,21 @@ class TestCustomSourceNonRetryableErrors(SimpleTestCase):
         assert "not found in config" in str(ctx.exception)
         assert "not found in config" in CustomSource().get_non_retryable_errors()
 
+    def test_http_400_bad_request_is_classified_non_retryable(self):
+        # A custom source's request is entirely manifest-driven, so a 400 is deterministic —
+        # retrying can't fix it. Build the real requests HTTPError message the REST client
+        # raises via raise_for_status(), so this breaks if the matched substring drifts from
+        # what requests actually produces. The URL is a placeholder, never a real customer host.
+        response = Response()
+        response.status_code = 400
+        response.reason = "Bad Request"
+        response.url = "https://api.example.com/opportunities?filter=2026-07-14T03:25:15.495000+00:00"
+        with self.assertRaises(requests.exceptions.HTTPError) as ctx:
+            response.raise_for_status()
+
+        non_retryable = CustomSource().get_non_retryable_errors()
+        assert any(key in str(ctx.exception) for key in non_retryable)
+
     @parameterized.expand(["invalid_client", "invalid_grant"])
     def test_oauth2_permanent_errors_are_classified_non_retryable(self, error_code):
         # A permanent OAuth2 token rejection (invalid_client / invalid_grant) surfaces the


### PR DESCRIPTION
## Problem

Error tracking flagged a recurring `HTTPError` from the data-warehouse import pipeline:

> `400 Client Error: Bad Request for url: <redacted host>/rest/opportunities?filter=<redacted timestamp>`

Issue: [019f6f49-5fbc-7363-8dd3-54ad8f66647a](https://us.posthog.com/project/2/error_tracking/019f6f49-5fbc-7363-8dd3-54ad8f66647a)

It surfaces from the shared REST client (`common/rest_source/rest_client.py`, `_send_request` → `raise_for_status()`) and originates in the **Custom REST source**. That source sends the incremental cursor as a query param, ISO-8601 by default, and the user-configured upstream API rejected the request with a 400.

For a custom source the entire request shape — path, query params, and the incremental cursor's wire format — comes from the user's manifest. A 400 there is deterministic: the same request recurs on every attempt, so Temporal retries a failure that can never succeed, burning the retry budget and surfacing no actionable message.

## Changes

Add `400 Client Error` to `CustomSource.get_non_retryable_errors()`, alongside the existing `401`/`403` entries. The classifier now stops the job fast and shows a message pointing at the manifest fields the user can change (path, query params, and — for incremental syncs — the cursor's date format via `endpoint.incremental.datetime_format`).

Scoped to the custom source only. A 400 from a built-in source is more likely a bug in our own request building (worth fixing per-source, as done recently for Plausible), so this deliberately does not go in the shared client.

## How did you test this code?

Added one regression test to `TestCustomSourceNonRetryableErrors`. It builds the real `requests` HTTPError message via `raise_for_status()` on a 400 response and asserts the source's classifier matches it — so it breaks if the entry is dropped or the matched substring drifts from what `requests` actually raises. No existing test covered HTTP-status-code classification for this source.

Ran locally: `TestCustomSourceNonRetryableErrors` — 4 passed. Ruff check + format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above by Claude (Claude Code). Read the stack trace into the shared REST client and traced the failing request back to the Custom source's incremental cursor handling. Invoked `/writing-tests` before adding the test.

Decision: user/upstream vs. fixable bug. Since a custom source's request is fully manifest-driven, a 400 is a user-config/upstream problem with nothing sensible to retry, so the fix extends `NonRetryableErrors` (mirroring the Stripe/`401`/`403` pattern) rather than changing pipeline logic. Considered adding the rule to the shared `rest_client`, but rejected it: a 400 from a built-in source can be our bug, and a blanket rule would mask it. Confirmed this isn't a duplicate of #71651 (Plausible-specific, different files/root cause).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
