### PR TITLE
refactor(data-warehouse): migrate freshcaller, freshdesk, freshservice, front to rest_source (batch 17)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshcaller/freshcaller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshcaller/freshcaller.py
@@ -1,53 +1,25 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime, time
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshcaller.settings import (
     DEFAULT_START_DATETIME,
     FRESHCALLER_ENDPOINTS,
     PER_PAGE,
-    FreshcallerEndpointConfig,
 )
 
-REQUEST_TIMEOUT = 60
 VALIDATE_TIMEOUT = 10
-MAX_RETRIES = 5
-MAX_RETRY_WAIT = 60.0
-
-_EXPONENTIAL_WAIT = wait_exponential_jitter(initial=1, max=MAX_RETRY_WAIT)
-
-
-class FreshcallerRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
-
-
-def _parse_retry_after(value: str | None) -> float | None:
-    """Parse a Retry-After header. Freshworks APIs send an integer number of seconds."""
-    if not value:
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
-
-
-def _retry_wait(retry_state: RetryCallState) -> float:
-    """Honor a server-provided Retry-After (capped); otherwise fall back to exponential jitter."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, FreshcallerRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_WAIT)
-    return _EXPONENTIAL_WAIT(retry_state)
 
 
 @dataclasses.dataclass
@@ -86,145 +58,143 @@ def _format_datetime(value: Any) -> str:
     return str(value)
 
 
-def build_base_params(
-    config: FreshcallerEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, str]:
-    """Query params shared across every page of one sync (everything except `page`)."""
-    params: dict[str, str] = {"per_page": str(PER_PAGE)}
-    params.update(config.extra_params)
+class FreshcallerPagePaginator(BasePaginator):
+    """page/per_page paginator matching Freshcaller's `meta` wrapper.
 
-    if should_use_incremental_field and config.supports_incremental:
-        # `by_time` requires both bounds together; window is [watermark, now]. Without a watermark
-        # (first sync) fall back to the configured backfill floor instead of scanning all history.
-        start = _format_datetime(db_incremental_field_last_value) if db_incremental_field_last_value else None
-        params["by_time[from]"] = start or DEFAULT_START_DATETIME
-        params["by_time[to]"] = _format_datetime(datetime.now(UTC))
+    Freshcaller wraps each list under its plural resource key alongside a `meta` object carrying
+    `current`/`total_pages`. Termination mirrors the hand-rolled source exactly: stop on an empty
+    page; when `total_pages` is present, continue while the current page is below it; when `meta` is
+    unusable, treat a full page as "maybe more" and a short page as the end.
+    """
 
-    return params
+    def __init__(self, per_page: int, page: int = 1, page_param: str = "page") -> None:
+        super().__init__()
+        self.per_page = per_page
+        self.page = page
+        self.page_param = page_param
 
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params[self.page_param] = self.page
 
-def extract_items(data: Any, config: FreshcallerEndpointConfig) -> list[dict]:
-    """Freshcaller wraps each list under its plural resource key (e.g. {"users": [...]})."""
-    if isinstance(data, dict):
-        value = data.get(config.data_key)
-        if isinstance(value, list):
-            return value
-    if isinstance(data, list):
-        return data
-    return []
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
+        if not items:
+            self._has_next_page = False
+            return
 
+        try:
+            meta = response.json().get("meta") or {}
+        except Exception:
+            meta = {}
 
-def extract_meta(data: Any) -> dict:
-    if isinstance(data, dict) and isinstance(data.get("meta"), dict):
-        return data["meta"]
-    return {}
+        total_pages = meta.get("total_pages")
+        if isinstance(total_pages, int):
+            current = meta.get("current")
+            current_page = current if isinstance(current, int) else self.page
+            if current_page < total_pages:
+                self.page += 1
+                self._has_next_page = True
+            else:
+                self._has_next_page = False
+            return
 
+        # No usable meta -> a full page implies there may be more.
+        if len(items) >= self.per_page:
+            self.page += 1
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
 
-def _has_next_page(meta: dict, items: list[dict], page: int) -> bool:
-    if not items:
-        return False
-    total_pages = meta.get("total_pages")
-    if isinstance(total_pages, int):
-        current = meta.get("current")
-        current_page = current if isinstance(current, int) else page
-        return current_page < total_pages
-    # No usable meta -> a full page implies there may be more.
-    return len(items) >= PER_PAGE
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params[self.page_param] = self.page
 
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page already points at the next page to fetch (update_state advanced it).
+        return {"page": self.page} if self._has_next_page else None
 
-def get_rows(
-    api_key: str,
-    subdomain: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FreshcallerResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict]]:
-    config = FRESHCALLER_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    base = _base_url(subdomain)
-    base_params = build_base_params(config, should_use_incremental_field, db_incremental_field_last_value)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume is not None else 1
-    if resume is not None:
-        logger.debug(f"Freshcaller: resuming {endpoint} from page {page}")
-
-    # One session reused across pages so urllib3 keeps the connection alive. `redact_values` masks
-    # the API key from captured HTTP samples: it rides in the `X-Api-Auth` header, which the
-    # name-based sample scrubbers don't recognise.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    @retry(
-        retry=retry_if_exception_type((FreshcallerRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_retry_wait,
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> Any:
-        response = session.get(page_url, headers=headers, timeout=REQUEST_TIMEOUT)
-
-        # Freshcaller throttles per plan tier with 429; honor Retry-After when present.
-        if response.status_code == 429:
-            raise FreshcallerRetryableError(
-                f"Freshcaller API rate limited: url={page_url}",
-                retry_after=_parse_retry_after(response.headers.get("Retry-After")),
-            )
-
-        if response.status_code >= 500:
-            raise FreshcallerRetryableError(
-                f"Freshcaller API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Freshcaller API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        params = {**base_params, "page": str(page)}
-        url = f"{base}{config.path}?{urlencode(params)}"
-
-        data = fetch_page(url)
-        items = extract_items(data, config)
-        if items:
-            yield items
-
-        if not _has_next_page(extract_meta(data), items, page):
-            break
-
-        # Advance and save AFTER yielding so the just-written page is durable before we bookmark
-        # the next one; a crash re-fetches from `page` and merge dedupes on the primary key.
-        page += 1
-        resumable_source_manager.save_state(FreshcallerResumeConfig(page=page))
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._has_next_page = True
 
 
 def freshcaller_source(
     api_key: str,
     subdomain: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FreshcallerResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Any = None,
 ) -> SourceResponse:
     config = FRESHCALLER_ENDPOINTS[endpoint]
 
+    # Query params shared across every page (everything except `page`, which the paginator injects).
+    params: dict[str, Any] = {"per_page": PER_PAGE}
+    params.update(config.extra_params)
+
+    endpoint_config: dict[str, Any] = {
+        "path": config.path,
+        "params": params,
+        # Freshcaller wraps each list under its plural resource key (e.g. {"users": [...]}). A body
+        # without that key degrades to a 0-row page (as the hand-rolled source did), not a hard error.
+        "data_selector": config.data_key,
+        "paginator": FreshcallerPagePaginator(per_page=PER_PAGE),
+    }
+
+    if should_use_incremental_field and config.supports_incremental:
+        # `by_time` requires both bounds together; window is [watermark, now]. Without a watermark
+        # (first sync) the framework falls back to `initial_value` (the configured backfill floor)
+        # instead of scanning all history.
+        endpoint_config["incremental"] = {
+            "start_param": "by_time[from]",
+            "end_param": "by_time[to]",
+            "initial_value": DEFAULT_START_DATETIME,
+            "end_value": _format_datetime(datetime.now(UTC)),
+            "convert": _format_datetime,
+        }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(subdomain),
+            # Only the non-secret Accept header here; the API key rides in framework auth so its
+            # value is registered for log redaction.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-Api-Auth", "location": "header"},
+        },
+        "resources": [{"name": endpoint, "endpoint": endpoint_config}],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # from `page` and merge dedupes on the primary key rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(FreshcallerResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            subdomain=subdomain,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         partition_count=1 if config.partition_key else None,
         partition_size=1 if config.partition_key else None,
@@ -242,12 +212,10 @@ def freshcaller_source(
 
 def validate_credentials(subdomain: str, api_key: str) -> Optional[int]:
     """Probe the Freshcaller API. Returns the HTTP status code, or ``None`` on a connection error."""
-    url = f"{_base_url(subdomain)}/api/v1/users?per_page=1"
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(
-            url, headers=_get_headers(api_key), timeout=VALIDATE_TIMEOUT
-        )
-    except Exception:
-        return None
-
-    return response.status_code
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{_base_url(subdomain)}/api/v1/users?per_page=1",
+        headers=_get_headers(api_key),
+        timeout=VALIDATE_TIMEOUT,
+    )
+    return status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshcaller/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshcaller/source.py
@@ -170,7 +170,8 @@ Your **API key** is on your Freshcaller profile settings page (click your profil
             api_key=config.api_key,
             subdomain=config.subdomain,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshcaller/tests/test_freshcaller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshcaller/tests/test_freshcaller.py
@@ -1,78 +1,84 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
 import requests
-import structlog
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshcaller.freshcaller import (
     FreshcallerResumeConfig,
     _format_datetime,
-    _has_next_page,
-    _parse_retry_after,
-    build_base_params,
-    extract_items,
-    extract_meta,
-    get_rows,
+    freshcaller_source,
     normalize_subdomain,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.freshcaller.settings import (
-    DEFAULT_START_DATETIME,
-    FRESHCALLER_ENDPOINTS,
-)
+from products.warehouse_sources.backend.temporal.data_imports.sources.freshcaller.settings import DEFAULT_START_DATETIME
 
-logger = structlog.get_logger()
-
-PATCH_SESSION = (
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the freshcaller module.
+FRESHCALLER_SESSION_PATCH = (
     "products.warehouse_sources.backend.temporal.data_imports.sources.freshcaller.freshcaller.make_tracked_session"
 )
 
 
-class FakeResponse:
-    def __init__(
-        self,
-        json_data: Any = None,
-        status_code: int = 200,
-        text: str = "",
-        headers: Optional[dict] = None,
-    ) -> None:
-        self._json = json_data
-        self.status_code = status_code
-        self.ok = 200 <= status_code < 400
-        self.text = text
-        self.headers = headers or {}
-
-    def json(self) -> Any:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            real_response = requests.Response()
-            real_response.status_code = self.status_code
-            raise requests.HTTPError(f"{self.status_code} Client Error", response=real_response)
+def _page(
+    data_key: str, items: list[dict], *, current: Optional[int] = None, total_pages: Optional[int] = None
+) -> Response:
+    body: dict[str, Any] = {data_key: items}
+    if total_pages is not None:
+        body["meta"] = {"current": current, "total_pages": total_pages, "total_count": 999}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class FakeResumableManager:
-    def __init__(self, resume: Optional[FreshcallerResumeConfig] = None) -> None:
-        self._resume = resume
-        self.saved: list[FreshcallerResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._resume is not None
-
-    def load_state(self) -> Optional[FreshcallerResumeConfig]:
-        return self._resume
-
-    def save_state(self, data: FreshcallerResumeConfig) -> None:
-        self.saved.append(data)
+def _error(status_code: int) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps({"error": "boom"}).encode()
+    return resp
 
 
-def _page(data_key: str, items: list[dict], current: int, total_pages: int) -> dict:
-    return {data_key: items, "meta": {"current": current, "total_pages": total_pages, "total_count": 999}}
+def _make_manager(resume_state: Optional[FreshcallerResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so a copy must be snapshotted when
+    each request is prepared rather than read after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = "https://acme.freshcaller.com/api/v1/x"
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return freshcaller_source(
+        "key", "acme", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs
+    )
 
 
 class TestNormalizeSubdomain:
@@ -109,190 +115,221 @@ class TestFormatDatetime:
         assert "+00:00" not in _format_datetime(datetime(2026, 3, 4, tzinfo=UTC))
 
 
-class TestParseRetryAfter:
-    @pytest.mark.parametrize(
-        "value, expected",
-        [("30", 30.0), ("0", 0.0), (None, None), ("", None), ("not-a-number", None)],
-    )
-    def test_parse_retry_after(self, value: Optional[str], expected: Optional[float]) -> None:
-        assert _parse_retry_after(value) == expected
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_by_page_number_and_saves_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _page("calls", [{"id": 1}], current=1, total_pages=2),
+                _page("calls", [{"id": 2}], current=2, total_pages=2),
+            ],
+        )
+        manager = _make_manager()
 
+        rows = _rows(_source("calls", manager))
 
-class TestBuildBaseParams:
-    def test_full_refresh_has_per_page_only(self) -> None:
-        params = build_base_params(FRESHCALLER_ENDPOINTS["users"], False, None)
-        assert params == {"per_page": "1000"}
-
-    def test_incremental_calls_uses_by_time_window(self) -> None:
-        params = build_base_params(FRESHCALLER_ENDPOINTS["calls"], True, datetime(2026, 3, 4, tzinfo=UTC))
-        assert params["by_time[from]"] == "2026-03-04T00:00:00Z"
-        # `to` is bounded at "now"; only assert the window is anchored at the watermark.
-        assert "by_time[to]" in params
-
-    def test_incremental_without_watermark_uses_default_floor(self) -> None:
-        params = build_base_params(FRESHCALLER_ENDPOINTS["calls"], True, None)
-        assert params["by_time[from]"] == DEFAULT_START_DATETIME
-
-    def test_call_metrics_includes_life_cycle(self) -> None:
-        params = build_base_params(FRESHCALLER_ENDPOINTS["call_metrics"], True, None)
-        assert params["include"] == "life_cycle"
-        assert "by_time[from]" in params
-
-    def test_full_refresh_endpoint_ignores_incremental_flag(self) -> None:
-        # `teams` exposes no server-side time filter, so it never gets a by_time window.
-        params = build_base_params(FRESHCALLER_ENDPOINTS["teams"], True, datetime(2026, 3, 4, tzinfo=UTC))
-        assert "by_time[from]" not in params
-
-
-class TestExtractItems:
-    @pytest.mark.parametrize("endpoint", ["users", "teams", "calls", "call_metrics"])
-    def test_wrapper_key(self, endpoint: str) -> None:
-        config = FRESHCALLER_ENDPOINTS[endpoint]
-        assert extract_items({config.data_key: [{"id": 1}]}, config) == [{"id": 1}]
-
-    def test_wrong_wrapper_key_returns_empty(self) -> None:
-        assert extract_items({"something_else": [{"id": 1}]}, FRESHCALLER_ENDPOINTS["users"]) == []
-
-    def test_bare_array_fallback(self) -> None:
-        assert extract_items([{"id": 1}], FRESHCALLER_ENDPOINTS["users"]) == [{"id": 1}]
-
-    def test_unknown_shape_returns_empty(self) -> None:
-        assert extract_items({"meta": {}}, FRESHCALLER_ENDPOINTS["users"]) == []
-
-
-class TestExtractMeta:
-    def test_present(self) -> None:
-        assert extract_meta({"users": [], "meta": {"current": 1}}) == {"current": 1}
-
-    def test_absent(self) -> None:
-        assert extract_meta({"users": []}) == {}
-        assert extract_meta([{"id": 1}]) == {}
-
-
-class TestHasNextPage:
-    @pytest.mark.parametrize(
-        "meta, items, page, expected",
-        [
-            ({"current": 1, "total_pages": 3}, [{"id": 1}], 1, True),
-            ({"current": 3, "total_pages": 3}, [{"id": 1}], 3, False),
-            ({}, [{"id": i} for i in range(1000)], 1, True),  # full page, no meta -> maybe more
-            ({}, [{"id": 1}], 1, False),  # short page, no meta -> done
-            ({"current": 1, "total_pages": 2}, [], 1, False),  # empty page always terminates
-        ],
-    )
-    def test_has_next_page(self, meta: dict, items: list[dict], page: int, expected: bool) -> None:
-        assert _has_next_page(meta, items, page) is expected
-
-
-class TestGetRows:
-    def test_paginates_by_page_number_and_saves_state(self) -> None:
-        responses = [
-            FakeResponse(_page("calls", [{"id": 1}], current=1, total_pages=2)),
-            FakeResponse(_page("calls", [{"id": 2}], current=2, total_pages=2)),
-        ]
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = responses
-
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "calls", logger, manager))  # type: ignore[arg-type]
-
-        assert rows == [[{"id": 1}], [{"id": 2}]]
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
         # State saved once, pointing at page 2 (the next page after the first was written).
-        assert manager.saved == [FreshcallerResumeConfig(page=2)]
-        # First request is page 1.
-        first_url = session.get.call_args_list[0].args[0]
-        assert parse_qs(urlparse(first_url).query)["page"] == ["1"]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == FreshcallerResumeConfig(page=2)
 
-    def test_single_page_saves_no_state(self) -> None:
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse(_page("users", [{"id": 1}], current=1, total_pages=1))]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_saves_no_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("users", [{"id": 1}], current=1, total_pages=1)])
+        manager = _make_manager()
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "users", logger, manager))  # type: ignore[arg-type]
+        rows = _rows(_source("users", manager))
 
-        assert rows == [[{"id": 1}]]
-        assert manager.saved == []
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_session_redacts_api_key_from_samples(self) -> None:
-        # The key rides in the X-Api-Auth header, which the name-based sample scrubbers don't
-        # cover, so it must be value-redacted or it leaks into captured HTTP samples.
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse(_page("users", [{"id": 1}], current=1, total_pages=1))]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("calls", [{"id": 50}], current=5, total_pages=5)])
+        manager = _make_manager(FreshcallerResumeConfig(page=5))
 
-        with mock.patch(PATCH_SESSION, return_value=session) as mock_make:
-            list(get_rows("secret-key", "acme", "users", logger, manager))  # type: ignore[arg-type]
+        _rows(_source("calls", manager))
 
-        assert mock_make.call_args.kwargs.get("redact_values") == ("secret-key",)
-
-    def test_resumes_from_saved_page(self) -> None:
-        manager = FakeResumableManager(resume=FreshcallerResumeConfig(page=5))
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse(_page("calls", [{"id": 50}], current=5, total_pages=5))]
-
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "calls", logger, manager))  # type: ignore[arg-type]
-
-        assert rows == [[{"id": 50}]]
         # First request must hit the resumed page, not page 1.
-        first_url = session.get.call_args_list[0].args[0]
-        assert parse_qs(urlparse(first_url).query)["page"] == ["5"]
+        assert params[0]["page"] == 5
 
-    def test_incremental_request_carries_by_time_window(self) -> None:
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse(_page("calls", [{"id": 1}], current=1, total_pages=1))]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_terminates(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("calls", [], current=1, total_pages=3)])
+        manager = _make_manager()
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            list(
-                get_rows(
-                    "key",
-                    "acme",
-                    "calls",
-                    logger,
-                    manager,  # type: ignore[arg-type]
-                    should_use_incremental_field=True,
-                    db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
-                )
-            )
+        rows = _rows(_source("calls", manager))
 
-        query = parse_qs(urlparse(session.get.call_args_list[0].args[0]).query)
-        assert query["by_time[from]"] == ["2026-03-04T00:00:00Z"]
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_without_meta_continues_then_short_page_stops(self, MockSession) -> None:
+        # With no usable meta, a full (per_page-sized) page implies more; a short page ends it.
+        session = MockSession.return_value
+        full = [{"id": i} for i in range(1000)]
+        _wire(session, [_page("users", full), _page("users", [{"id": 1000}])])
+        manager = _make_manager()
+
+        rows = _rows(_source("users", manager))
+
+        assert len(rows) == 1001
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_page_without_meta_single_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("users", [{"id": 1}])])
+        manager = _make_manager()
+
+        rows = _rows(_source("users", manager))
+
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_wrong_wrapper_key_yields_no_rows(self, MockSession) -> None:
+        # A body missing the plural resource key degrades to a 0-row page (the paginator stops).
+        session = MockSession.return_value
+        body = Response()
+        body.status_code = 200
+        body._content = json.dumps({"something_else": [{"id": 1}], "meta": {}}).encode()
+        _wire(session, [body])
+        manager = _make_manager()
+
+        rows = _rows(_source("users", manager))
+
+        assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_session_redacts_api_key(self, MockSession) -> None:
+        # The key rides in the X-Api-Auth header; the tracked session must value-redact it so it
+        # can't leak into captured HTTP samples.
+        session = MockSession.return_value
+        _wire(session, [_page("users", [{"id": 1}], current=1, total_pages=1)])
+
+        _rows(_source("users", _make_manager()))
+
+        assert MockSession.call_args.kwargs.get("redact_values") == ("key",)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_accept_header_set_on_session(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page("users", [{"id": 1}], current=1, total_pages=1)])
+
+        _rows(_source("users", _make_manager()))
+
+        assert session.headers.get("Accept") == "application/json"
 
     @pytest.mark.parametrize("status_code", [401, 403, 404])
-    def test_non_retryable_status_raises(self, status_code: int) -> None:
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse(status_code=status_code, text="boom")]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_retryable_status_raises(self, MockSession, status_code: int) -> None:
+        session = MockSession.return_value
+        _wire(session, [_error(status_code)])
+        manager = _make_manager()
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            with pytest.raises(requests.HTTPError):
-                list(get_rows("key", "acme", "calls", logger, manager))  # type: ignore[arg-type]
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("calls", manager))
+
+
+class TestIncremental:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_carries_by_time_window(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("calls", [{"id": 1}], current=1, total_pages=1)])
+
+        _rows(
+            _source(
+                "calls",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
+        )
+
+        assert params[0]["by_time[from]"] == "2026-03-04T00:00:00Z"
+        assert "by_time[to]" in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_without_watermark_uses_default_floor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("calls", [{"id": 1}], current=1, total_pages=1)])
+
+        _rows(
+            _source("calls", _make_manager(), should_use_incremental_field=True, db_incremental_field_last_value=None)
+        )
+
+        assert params[0]["by_time[from]"] == DEFAULT_START_DATETIME
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_has_per_page_and_no_window(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("users", [{"id": 1}], current=1, total_pages=1)])
+
+        _rows(_source("users", _make_manager()))
+
+        assert params[0]["per_page"] == 1000
+        assert "by_time[from]" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_call_metrics_includes_life_cycle(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page("call_metrics", [{"id": 1}], current=1, total_pages=1)])
+
+        _rows(
+            _source(
+                "call_metrics",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=None,
+            )
+        )
+
+        assert params[0]["include"] == "life_cycle"
+        assert params[0]["by_time[from]"] == DEFAULT_START_DATETIME
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_ignores_incremental_flag(self, MockSession) -> None:
+        # `users` exposes no server-side time filter, so it never gets a by_time window even when
+        # incremental sync is requested.
+        session = MockSession.return_value
+        params = _wire(session, [_page("users", [{"id": 1}], current=1, total_pages=1)])
+
+        _rows(
+            _source(
+                "users",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
+        )
+
+        assert "by_time[from]" not in params[0]
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code", [200, 401, 403])
-    def test_returns_status_code(self, status_code: int) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = FakeResponse(status_code=status_code)
+    @mock.patch(FRESHCALLER_SESSION_PATCH)
+    def test_returns_status_code(self, mock_make, status_code: int) -> None:
+        mock_make.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("acme", "key") == status_code
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            assert validate_credentials("acme", "key") == status_code
+    @mock.patch(FRESHCALLER_SESSION_PATCH)
+    def test_connection_error_returns_none(self, mock_make) -> None:
+        mock_make.return_value.get.side_effect = requests.ConnectionError("nope")
+        assert validate_credentials("acme", "key") is None
 
-    def test_connection_error_returns_none(self) -> None:
-        session = mock.MagicMock()
-        session.get.side_effect = requests.ConnectionError("nope")
-
-        with mock.patch(PATCH_SESSION, return_value=session):
-            assert validate_credentials("acme", "key") is None
-
-    def test_session_redacts_api_key_from_samples(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = FakeResponse(status_code=200)
-
-        with mock.patch(PATCH_SESSION, return_value=session) as mock_make:
-            validate_credentials("acme", "secret-key")
-
+    @mock.patch(FRESHCALLER_SESSION_PATCH)
+    def test_session_redacts_api_key(self, mock_make) -> None:
+        mock_make.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("acme", "secret-key")
         assert mock_make.call_args.kwargs.get("redact_values") == ("secret-key",)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/freshdesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/freshdesk.py
@@ -1,53 +1,27 @@
-import base64
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests.auth import HTTPBasicAuth
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshdesk.settings import (
     FRESHDESK_ENDPOINTS,
     PER_PAGE,
     FreshdeskEndpointConfig,
 )
 
-REQUEST_TIMEOUT = 60
 VALIDATE_TIMEOUT = 10
-MAX_RETRIES = 5
-MAX_RETRY_WAIT = 60.0
-
-_EXPONENTIAL_WAIT = wait_exponential_jitter(initial=1, max=MAX_RETRY_WAIT)
-
-
-class FreshdeskRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
-
-
-def _parse_retry_after(value: str | None) -> float | None:
-    """Parse a Retry-After header. Freshdesk sends an integer number of seconds."""
-    if not value:
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
-
-
-def _retry_wait(retry_state: RetryCallState) -> float:
-    """Honor a server-provided Retry-After (capped); otherwise fall back to exponential jitter."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, FreshdeskRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_WAIT)
-    return _EXPONENTIAL_WAIT(retry_state)
 
 
 @dataclasses.dataclass
@@ -66,13 +40,6 @@ def _base_url(subdomain: str) -> str:
     return f"https://{normalize_subdomain(subdomain)}.freshdesk.com"
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    # Freshdesk uses HTTP Basic auth with the API key as the username and any
-    # non-empty string as the password.
-    token = base64.b64encode(f"{api_key}:X".encode("ascii")).decode("ascii")
-    return {"Authorization": f"Basic {token}", "Content-Type": "application/json"}
-
-
 def _format_updated_since(value: Any) -> str:
     """Format an incremental cursor value as the ISO 8601 UTC string Freshdesk expects."""
     if isinstance(value, datetime):
@@ -83,120 +50,80 @@ def _format_updated_since(value: Any) -> str:
     return str(value)
 
 
-def build_initial_url(
-    subdomain: str,
+def _build_params(
     config: FreshdeskEndpointConfig,
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Any,
-) -> str:
-    params: dict[str, str] = {"per_page": str(PER_PAGE)}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"per_page": PER_PAGE}
     params.update(config.extra_params)
 
     if should_use_incremental_field and config.updated_since_param and db_incremental_field_last_value:
         params[config.updated_since_param] = _format_updated_since(db_incremental_field_last_value)
 
-    return f"{_base_url(subdomain)}{config.path}?{urlencode(params)}"
-
-
-def extract_items(data: Any, config: FreshdeskEndpointConfig) -> list[dict]:
-    """Most Freshdesk list endpoints return a bare JSON array; a few wrap it in an object."""
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict):
-        if config.data_key and isinstance(data.get(config.data_key), list):
-            return data[config.data_key]
-        # `results` is used by Freshdesk's search endpoints; defensive fallback.
-        if isinstance(data.get("results"), list):
-            return data["results"]
-    return []
-
-
-def get_rows(
-    api_key: str,
-    subdomain: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FreshdeskResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict]]:
-    config = FRESHDESK_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None:
-        url: Optional[str] = resume.next_url
-        logger.debug(f"Freshdesk: resuming from URL: {url}")
-    else:
-        url = build_initial_url(subdomain, config, should_use_incremental_field, db_incremental_field_last_value)
-
-    @retry(
-        retry=retry_if_exception_type((FreshdeskRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_retry_wait,
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> tuple[Any, Optional[str]]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT)
-
-        # Freshdesk throttles with 429 and a Retry-After header; honor it when present.
-        if response.status_code == 429:
-            raise FreshdeskRetryableError(
-                f"Freshdesk API rate limited: url={page_url}",
-                retry_after=_parse_retry_after(response.headers.get("Retry-After")),
-            )
-
-        # Transient upstream issues surface as 5xx.
-        if response.status_code >= 500:
-            raise FreshdeskRetryableError(
-                f"Freshdesk API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Freshdesk API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        next_url = response.links.get("next", {}).get("url")
-        return response.json(), next_url
-
-    while url:
-        data, next_url = fetch_page(url)
-
-        items = extract_items(data, config)
-        if items:
-            yield items
-
-        if not next_url:
-            break
-
-        # Save state AFTER yielding so a crash re-yields the last page (merge dedupes on
-        # primary key) rather than skipping it.
-        resumable_source_manager.save_state(FreshdeskResumeConfig(next_url=next_url))
-        url = next_url
+    return params
 
 
 def freshdesk_source(
     api_key: str,
     subdomain: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FreshdeskResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = FRESHDESK_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(subdomain),
+            "headers": {"Content-Type": "application/json"},
+            # Freshdesk uses HTTP Basic auth with the API key as the username and any
+            # non-empty string as the password. Supplied via framework auth so the value
+            # is redacted from logs.
+            "auth": {"type": "http_basic", "username": api_key, "password": "X"},
+            # Freshdesk paginates with an RFC 5988 `Link: ...; rel="next"` header.
+            "paginator": HeaderLinkPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": _build_params(config, should_use_incremental_field, db_incremental_field_last_value),
+                    # Most list endpoints return a bare array; a few (e.g. skills) wrap it in an object.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(FreshdeskResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            subdomain=subdomain,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         partition_count=1 if config.partition_key else None,
         partition_size=1 if config.partition_key else None,
@@ -209,9 +136,10 @@ def freshdesk_source(
 def validate_credentials(subdomain: str, api_key: str) -> Optional[int]:
     """Probe the Freshdesk API. Returns the HTTP status code, or ``None`` on a connection error."""
     url = f"{_base_url(subdomain)}/api/v2/tickets?per_page=1"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=VALIDATE_TIMEOUT)
-    except Exception:
-        return None
-
-    return response.status_code
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        url,
+        auth=HTTPBasicAuth(api_key, "X"),
+        timeout=VALIDATE_TIMEOUT,
+    )
+    return status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/source.py
@@ -173,7 +173,8 @@ Your **API key** is on your Freshdesk profile settings page (click your profile 
             api_key=config.api_key,
             subdomain=config.subdomain,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/tests/test_freshdesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/tests/test_freshdesk.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
@@ -5,66 +6,85 @@ import pytest
 from unittest import mock
 
 import requests
-import structlog
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshdesk.freshdesk import (
     FreshdeskResumeConfig,
     _format_updated_since,
-    _parse_retry_after,
-    build_initial_url,
-    extract_items,
-    get_rows,
+    freshdesk_source,
     normalize_subdomain,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.freshdesk.settings import FRESHDESK_ENDPOINTS
 
-logger = structlog.get_logger()
-
-PATCH_SESSION = (
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the freshdesk module.
+FRESHDESK_SESSION_PATCH = (
     "products.warehouse_sources.backend.temporal.data_imports.sources.freshdesk.freshdesk.make_tracked_session"
 )
 
 
-class FakeResponse:
-    def __init__(
-        self,
-        json_data: Any = None,
-        status_code: int = 200,
-        links: Optional[dict] = None,
-        text: str = "",
-        headers: Optional[dict] = None,
-    ) -> None:
-        self._json = json_data
-        self.status_code = status_code
-        self.ok = 200 <= status_code < 400
-        self.links = links or {}
-        self.text = text
-        self.headers = headers or {}
-
-    def json(self) -> Any:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            real_response = requests.Response()
-            real_response.status_code = self.status_code
-            raise requests.HTTPError(f"{self.status_code} Client Error", response=real_response)
+def _response(
+    body: Any,
+    *,
+    next_url: Optional[str] = None,
+    status_code: int = 200,
+) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    if next_url is not None:
+        resp.headers["Link"] = f'<{next_url}>; rel="next"'
+    return resp
 
 
-class FakeResumableManager:
-    def __init__(self, resume: Optional[FreshdeskResumeConfig] = None) -> None:
-        self._resume = resume
-        self.saved: list[FreshdeskResumeConfig] = []
+def _make_manager(resume_state: Optional[FreshdeskResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def can_resume(self) -> bool:
-        return self._resume is not None
 
-    def load_state(self) -> Optional[FreshdeskResumeConfig]:
-        return self._resume
+class _Wired:
+    def __init__(self, params: list[dict[str, Any]], urls: list[Optional[str]]) -> None:
+        self.params = params
+        self.urls = urls
 
-    def save_state(self, data: FreshdeskResumeConfig) -> None:
-        self.saved.append(data)
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> _Wired:
+    """Wire a mock session and capture each request's params and URL AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when
+    each request is prepared rather than inspecting the final state.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[Optional[str]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return _Wired(param_snapshots, url_snapshots)
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str = "tickets", manager: Optional[mock.MagicMock] = None, **kwargs: Any):
+    return freshdesk_source(
+        api_key="key",
+        subdomain="acme",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        **kwargs,
+    )
 
 
 class TestNormalizeSubdomain:
@@ -100,127 +120,176 @@ class TestFormatUpdatedSince:
         assert "+00:00" not in _format_updated_since(datetime(2026, 3, 4, tzinfo=UTC))
 
 
-class TestParseRetryAfter:
-    @pytest.mark.parametrize(
-        "value, expected",
-        [
-            ("30", 30.0),
-            ("0", 0.0),
-            (None, None),
-            ("", None),
-            ("not-a-number", None),
-        ],
-    )
-    def test_parse_retry_after(self, value: Optional[str], expected: Optional[float]) -> None:
-        assert _parse_retry_after(value) == expected
+class TestRequestParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_has_per_page_only(self, MockSession) -> None:
+        session = MockSession.return_value
+        wired = _wire(session, [_response([{"id": 1}])])
 
+        _rows(_source("companies"))
 
-class TestBuildInitialUrl:
-    def test_full_refresh_has_per_page_only(self) -> None:
-        url = build_initial_url("acme", FRESHDESK_ENDPOINTS["companies"], False, None)
-        assert url.startswith("https://acme.freshdesk.com/api/v2/companies?")
-        assert "per_page=100" in url
-        assert "updated_since" not in url
+        assert wired.params[0]["per_page"] == 100
+        assert "updated_since" not in wired.params[0]
+        assert "_updated_since" not in wired.params[0]
 
-    def test_tickets_incremental_uses_updated_since_and_ordering(self) -> None:
-        url = build_initial_url("acme", FRESHDESK_ENDPOINTS["tickets"], True, datetime(2026, 3, 4, tzinfo=UTC))
-        assert "updated_since=2026-03-04T00%3A00%3A00Z" in url
-        assert "order_by=updated_at" in url
-        assert "order_type=asc" in url
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tickets_incremental_uses_updated_since_and_ordering(self, MockSession) -> None:
+        session = MockSession.return_value
+        wired = _wire(session, [_response([{"id": 1}])])
 
-    def test_contacts_incremental_uses_underscore_param(self) -> None:
-        url = build_initial_url("acme", FRESHDESK_ENDPOINTS["contacts"], True, datetime(2026, 3, 4, tzinfo=UTC))
-        assert "_updated_since=2026-03-04T00%3A00%3A00Z" in url
+        _rows(
+            _source(
+                "tickets",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
+        )
 
-    def test_incremental_without_last_value_omits_filter(self) -> None:
-        url = build_initial_url("acme", FRESHDESK_ENDPOINTS["tickets"], True, None)
-        assert "updated_since" not in url
+        assert wired.params[0]["updated_since"] == "2026-03-04T00:00:00Z"
+        assert wired.params[0]["order_by"] == "updated_at"
+        assert wired.params[0]["order_type"] == "asc"
 
-    def test_full_refresh_endpoint_ignores_incremental_flag(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_contacts_incremental_uses_underscore_param(self, MockSession) -> None:
+        session = MockSession.return_value
+        wired = _wire(session, [_response([{"id": 1}])])
+
+        _rows(
+            _source(
+                "contacts",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
+        )
+
+        assert wired.params[0]["_updated_since"] == "2026-03-04T00:00:00Z"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_without_last_value_omits_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        wired = _wire(session, [_response([{"id": 1}])])
+
+        _rows(_source("tickets", should_use_incremental_field=True, db_incremental_field_last_value=None))
+
+        assert "updated_since" not in wired.params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_ignores_incremental_flag(self, MockSession) -> None:
         # `companies` has no server-side filter, so it never gets an updated_since param.
-        url = build_initial_url("acme", FRESHDESK_ENDPOINTS["companies"], True, datetime(2026, 3, 4, tzinfo=UTC))
-        assert "updated_since" not in url
+        session = MockSession.return_value
+        wired = _wire(session, [_response([{"id": 1}])])
+
+        _rows(
+            _source(
+                "companies",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
+        )
+
+        assert "updated_since" not in wired.params[0]
 
 
-class TestExtractItems:
-    def test_bare_array(self) -> None:
-        assert extract_items([{"id": 1}], FRESHDESK_ENDPOINTS["tickets"]) == [{"id": 1}]
+class TestExtraction:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_bare_array_yields_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}, {"id": 2}])])
 
-    def test_data_key_object(self) -> None:
-        assert extract_items({"skills": [{"id": 1}]}, FRESHDESK_ENDPOINTS["skills"]) == [{"id": 1}]
+        rows = _rows(_source("tickets"))
 
-    def test_results_fallback(self) -> None:
-        assert extract_items({"results": [{"id": 9}]}, FRESHDESK_ENDPOINTS["tickets"]) == [{"id": 9}]
+        assert [r["id"] for r in rows] == [1, 2]
 
-    def test_unknown_shape_returns_empty(self) -> None:
-        assert extract_items({"meta": {}}, FRESHDESK_ENDPOINTS["tickets"]) == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_data_key_object_yields_rows(self, MockSession) -> None:
+        # `skills` wraps its list under a "skills" key rather than returning a bare array.
+        session = MockSession.return_value
+        _wire(session, [_response({"skills": [{"id": 7}]})])
+
+        rows = _rows(_source("skills"))
+
+        assert [r["id"] for r in rows] == [7]
 
 
-class TestGetRows:
-    def test_paginates_via_link_header_and_saves_state(self) -> None:
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_link_header_and_saves_state(self, MockSession) -> None:
+        session = MockSession.return_value
         next_url = "https://acme.freshdesk.com/api/v2/tickets?per_page=100&page=2"
-        responses = [
-            FakeResponse([{"id": 1}], links={"next": {"url": next_url}}),
-            FakeResponse([{"id": 2}], links={}),
-        ]
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = responses
+        _wire(
+            session,
+            [
+                _response([{"id": 1}], next_url=next_url),
+                _response([{"id": 2}]),
+            ],
+        )
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "tickets", logger, manager))  # type: ignore[arg-type]
+        manager = _make_manager()
+        rows = _rows(_source("tickets", manager=manager))
 
-        assert rows == [[{"id": 1}], [{"id": 2}]]
+        assert [r["id"] for r in rows] == [1, 2]
         # State saved once, after the first (only non-terminal) page.
-        assert manager.saved == [FreshdeskResumeConfig(next_url=next_url)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == FreshdeskResumeConfig(next_url=next_url)
 
-    def test_single_page_saves_no_state(self) -> None:
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse([{"id": 1}], links={})]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_second_request_targets_the_next_link(self, MockSession) -> None:
+        session = MockSession.return_value
+        next_url = "https://acme.freshdesk.com/api/v2/tickets?per_page=100&page=2"
+        wired = _wire(
+            session,
+            [
+                _response([{"id": 1}], next_url=next_url),
+                _response([{"id": 2}]),
+            ],
+        )
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "agents", logger, manager))  # type: ignore[arg-type]
+        _rows(_source("tickets"))
 
-        assert rows == [[{"id": 1}]]
-        assert manager.saved == []
+        assert wired.urls[1] == next_url
 
-    def test_resumes_from_saved_state(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_saves_no_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}])])
+
+        manager = _make_manager()
+        rows = _rows(_source("agents", manager=manager))
+
+        assert [r["id"] for r in rows] == [1]
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession) -> None:
+        session = MockSession.return_value
         resume_url = "https://acme.freshdesk.com/api/v2/tickets?per_page=100&page=5"
-        manager = FakeResumableManager(resume=FreshdeskResumeConfig(next_url=resume_url))
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse([{"id": 50}], links={})]
+        wired = _wire(session, [_response([{"id": 50}])])
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "tickets", logger, manager))  # type: ignore[arg-type]
+        manager = _make_manager(FreshdeskResumeConfig(next_url=resume_url))
+        rows = _rows(_source("tickets", manager=manager))
 
-        assert rows == [[{"id": 50}]]
-        # First request must hit the resumed URL, not a freshly-built initial URL.
-        assert session.get.call_args_list[0].args[0] == resume_url
+        assert [r["id"] for r in rows] == [50]
+        # First request must target the resumed URL, not a freshly-built initial URL.
+        assert wired.urls[0] == resume_url
 
     @pytest.mark.parametrize("status_code", [401, 403, 404])
-    def test_non_retryable_status_raises(self, status_code: int) -> None:
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse(status_code=status_code, text="boom")]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_retryable_status_raises(self, MockSession, status_code: int) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=status_code)])
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            with pytest.raises(requests.HTTPError):
-                list(get_rows("key", "acme", "tickets", logger, manager))  # type: ignore[arg-type]
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("tickets"))
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code", [200, 401, 403])
-    def test_returns_status_code(self, status_code: int) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = FakeResponse(status_code=status_code)
+    @mock.patch(FRESHDESK_SESSION_PATCH)
+    def test_returns_status_code(self, mock_session, status_code: int) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("acme", "key") == status_code
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            assert validate_credentials("acme", "key") == status_code
-
-    def test_connection_error_returns_none(self) -> None:
-        session = mock.MagicMock()
-        session.get.side_effect = requests.ConnectionError("nope")
-
-        with mock.patch(PATCH_SESSION, return_value=session):
-            assert validate_credentials("acme", "key") is None
+    @mock.patch(FRESHDESK_SESSION_PATCH)
+    def test_connection_error_returns_none(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("nope")
+        assert validate_credentials("acme", "key") is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshservice/freshservice.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshservice/freshservice.py
@@ -1,53 +1,30 @@
-import base64
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests.auth import HTTPBasicAuth
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshservice.settings import (
     FRESHSERVICE_ENDPOINTS,
     PER_PAGE,
-    FreshserviceEndpointConfig,
 )
 
-REQUEST_TIMEOUT = 60
 VALIDATE_TIMEOUT = 10
-MAX_RETRIES = 5
-MAX_RETRY_WAIT = 60.0
 
-_EXPONENTIAL_WAIT = wait_exponential_jitter(initial=1, max=MAX_RETRY_WAIT)
-
-
-class FreshserviceRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
-
-
-def _parse_retry_after(value: str | None) -> float | None:
-    """Parse a Retry-After header. Freshservice sends an integer number of seconds on 429."""
-    if not value:
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
-
-
-def _retry_wait(retry_state: RetryCallState) -> float:
-    """Honor a server-provided Retry-After (capped); otherwise fall back to exponential jitter."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, FreshserviceRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_WAIT)
-    return _EXPONENTIAL_WAIT(retry_state)
+# Freshservice uses HTTP Basic auth with the API key as the username and any non-empty
+# string as the password.
+_BASIC_AUTH_PASSWORD = "X"
 
 
 @dataclasses.dataclass
@@ -66,13 +43,6 @@ def _base_url(domain: str) -> str:
     return f"https://{normalize_domain(domain)}.freshservice.com"
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    # Freshservice uses HTTP Basic auth with the API key as the username and any
-    # non-empty string as the password.
-    token = base64.b64encode(f"{api_key}:X".encode("ascii")).decode("ascii")
-    return {"Authorization": f"Basic {token}", "Content-Type": "application/json"}
-
-
 def _format_updated_since(value: Any) -> str:
     """Format an incremental cursor value as the ISO 8601 UTC string Freshservice expects."""
     if isinstance(value, datetime):
@@ -83,134 +53,89 @@ def _format_updated_since(value: Any) -> str:
     return str(value)
 
 
-def build_initial_url(
-    domain: str,
-    config: FreshserviceEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> str:
-    params: dict[str, str] = {"per_page": str(PER_PAGE)}
-    params.update(config.extra_params)
-
-    if should_use_incremental_field and config.updated_since_param and db_incremental_field_last_value:
-        params[config.updated_since_param] = _format_updated_since(db_incremental_field_last_value)
-
-    return f"{_base_url(domain)}{config.path}?{urlencode(params)}"
-
-
-def extract_items(data: Any, config: FreshserviceEndpointConfig) -> list[dict]:
-    """Every Freshservice v2 list endpoint wraps its results under a resource-named key
-    (e.g. {"tickets": [...]}). Fall back to a bare array defensively."""
-    if isinstance(data, dict):
-        if isinstance(data.get(config.data_key), list):
-            return data[config.data_key]
-        return []
-    if isinstance(data, list):
-        return data
-    return []
-
-
-def get_rows(
-    api_key: str,
-    domain: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FreshserviceResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict]]:
-    config = FRESHSERVICE_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None:
-        url: Optional[str] = resume.next_url
-        logger.debug(f"Freshservice: resuming from URL: {url}")
-    else:
-        url = build_initial_url(domain, config, should_use_incremental_field, db_incremental_field_last_value)
-
-    @retry(
-        retry=retry_if_exception_type((FreshserviceRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_retry_wait,
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> tuple[Any, Optional[str]]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT)
-
-        # Freshservice throttles with 429 and a Retry-After header; honor it when present.
-        if response.status_code == 429:
-            raise FreshserviceRetryableError(
-                f"Freshservice API rate limited: url={page_url}",
-                retry_after=_parse_retry_after(response.headers.get("Retry-After")),
-            )
-
-        # Transient upstream issues surface as 5xx.
-        if response.status_code >= 500:
-            raise FreshserviceRetryableError(
-                f"Freshservice API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Freshservice API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        next_url = response.links.get("next", {}).get("url")
-        return response.json(), next_url
-
-    while url:
-        data, next_url = fetch_page(url)
-
-        items = extract_items(data, config)
-        if items:
-            yield items
-
-        if not next_url:
-            break
-
-        # Save state AFTER yielding so a crash re-yields the last page (merge dedupes on
-        # primary key) rather than skipping it.
-        resumable_source_manager.save_state(FreshserviceResumeConfig(next_url=next_url))
-        url = next_url
-
-
 def freshservice_source(
     api_key: str,
     domain: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FreshserviceResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = FRESHSERVICE_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {"per_page": PER_PAGE}
+    params.update(config.extra_params)
+    # Server-side incremental filter: only endpoints with a documented `updated_since` param
+    # narrow the window, and only once a watermark exists.
+    if should_use_incremental_field and config.updated_since_param and db_incremental_field_last_value:
+        params[config.updated_since_param] = _format_updated_since(db_incremental_field_last_value)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(domain),
+            "headers": {"Content-Type": "application/json"},
+            # Auth (HTTP Basic) is supplied via the framework auth config so the credential is
+            # redacted from logs rather than hand-built into an Authorization header.
+            "auth": {"type": "http_basic", "username": api_key, "password": _BASIC_AUTH_PASSWORD},
+            # Freshservice v2 paginates via RFC 5988 Link headers (rel="next").
+            "paginator": HeaderLinkPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Every Freshservice v2 list endpoint wraps its results under a resource-named
+                    # key (e.g. {"tickets": [...]}). A response missing that key yields 0 rows.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(FreshserviceResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            domain=domain,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         partition_count=1 if config.partition_key else None,
         partition_size=1 if config.partition_key else None,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
 def validate_credentials(domain: str, api_key: str) -> Optional[int]:
     """Probe the Freshservice API. Returns the HTTP status code, or ``None`` on a connection error."""
-    url = f"{_base_url(domain)}/api/v2/tickets?per_page=1"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=VALIDATE_TIMEOUT)
-    except Exception:
-        return None
-
-    return response.status_code
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{_base_url(domain)}/api/v2/tickets?per_page=1",
+        auth=HTTPBasicAuth(api_key, _BASIC_AUTH_PASSWORD),
+        timeout=VALIDATE_TIMEOUT,
+    )
+    return status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshservice/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshservice/source.py
@@ -20,7 +20,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshservice.freshservice import (
     FreshserviceResumeConfig,
     freshservice_source,
@@ -28,7 +31,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.freshservi
     validate_credentials as validate_freshservice_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshservice.settings import (
-    FRESHSERVICE_ENDPOINTS,
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import FreshserviceSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -116,21 +120,10 @@ Your **API key** is on your Freshservice profile settings page (click your profi
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=name,
-                # Only the endpoints with a genuine server-side `updated_since` filter
-                # support incremental sync; everything else is full refresh.
-                supports_incremental=endpoint.updated_since_param is not None,
-                supports_append=endpoint.updated_since_param is not None,
-                incremental_fields=endpoint.incremental_fields,
-            )
-            for name, endpoint in FRESHSERVICE_ENDPOINTS.items()
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Only the endpoints with a genuine server-side `updated_since` filter carry incremental
+        # fields, so they alone default to supports_incremental / supports_append; the rest are
+        # full refresh.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: FreshserviceSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -173,7 +166,8 @@ Your **API key** is on your Freshservice profile settings page (click your profi
             api_key=config.api_key,
             domain=config.domain,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshservice/tests/test_freshservice.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshservice/tests/test_freshservice.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
@@ -5,68 +6,78 @@ import pytest
 from unittest import mock
 
 import requests
-import structlog
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.freshservice.freshservice import (
     FreshserviceResumeConfig,
     _format_updated_since,
-    _parse_retry_after,
-    build_initial_url,
-    extract_items,
-    get_rows,
+    freshservice_source,
     normalize_domain,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.freshservice.settings import (
-    FRESHSERVICE_ENDPOINTS,
-)
 
-logger = structlog.get_logger()
-
-PATCH_SESSION = (
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the freshservice module.
+FRESHSERVICE_SESSION_PATCH = (
     "products.warehouse_sources.backend.temporal.data_imports.sources.freshservice.freshservice.make_tracked_session"
 )
 
 
-class FakeResponse:
-    def __init__(
-        self,
-        json_data: Any = None,
-        status_code: int = 200,
-        links: Optional[dict] = None,
-        text: str = "",
-        headers: Optional[dict] = None,
-    ) -> None:
-        self._json = json_data
-        self.status_code = status_code
-        self.ok = 200 <= status_code < 400
-        self.links = links or {}
-        self.text = text
-        self.headers = headers or {}
-
-    def json(self) -> Any:
-        return self._json
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            real_response = requests.Response()
-            real_response.status_code = self.status_code
-            raise requests.HTTPError(f"{self.status_code} Client Error", response=real_response)
+def _response(body: Any, *, status: int = 200, next_url: Optional[str] = None) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://acme.freshservice.com/api/v2/tickets"
+    if next_url:
+        # RFC 5988 Link header — requests parses this into Response.links.
+        resp.headers["Link"] = f'<{next_url}>; rel="next"'
+    return resp
 
 
-class FakeResumableManager:
-    def __init__(self, resume: Optional[FreshserviceResumeConfig] = None) -> None:
-        self._resume = resume
-        self.saved: list[FreshserviceResumeConfig] = []
+def _make_manager(resume_state: Optional[FreshserviceResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def can_resume(self) -> bool:
-        return self._resume is not None
 
-    def load_state(self) -> Optional[FreshserviceResumeConfig]:
-        return self._resume
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
 
-    def save_state(self, data: FreshserviceResumeConfig) -> None:
-        self.saved.append(data)
+    ``request.params`` is one dict mutated in place across pages, so snapshot a copy when each
+    request is prepared rather than inspecting the final state.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _run(
+    endpoint: str,
+    *,
+    manager: Optional[mock.MagicMock] = None,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> list[dict[str, Any]]:
+    source_response = freshservice_source(
+        api_key="key",
+        domain="acme",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
+    return [row for page in source_response.items() for row in page]
 
 
 class TestNormalizeDomain:
@@ -102,128 +113,155 @@ class TestFormatUpdatedSince:
         assert "+00:00" not in _format_updated_since(datetime(2026, 3, 4, tzinfo=UTC))
 
 
-class TestParseRetryAfter:
-    @pytest.mark.parametrize(
-        "value, expected",
-        [
-            ("30", 30.0),
-            ("0", 0.0),
-            (None, None),
-            ("", None),
-            ("not-a-number", None),
-        ],
-    )
-    def test_parse_retry_after(self, value: Optional[str], expected: Optional[float]) -> None:
-        assert _parse_retry_after(value) == expected
+class TestRequestParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_sends_per_page_only(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"agents": [{"id": 1}]})])
 
+        _run("agents")
 
-class TestBuildInitialUrl:
-    def test_full_refresh_has_per_page_only(self) -> None:
-        url = build_initial_url("acme", FRESHSERVICE_ENDPOINTS["agents"], False, None)
-        assert url.startswith("https://acme.freshservice.com/api/v2/agents?")
-        assert "per_page=100" in url
-        assert "updated_since" not in url
+        assert snapshots[0]["params"]["per_page"] == 100
+        assert "updated_since" not in snapshots[0]["params"]
 
-    def test_tickets_incremental_uses_updated_since_and_ordering(self) -> None:
-        url = build_initial_url("acme", FRESHSERVICE_ENDPOINTS["tickets"], True, datetime(2026, 3, 4, tzinfo=UTC))
-        assert "updated_since=2026-03-04T00%3A00%3A00Z" in url
-        assert "order_by=updated_at" in url
-        assert "order_type=asc" in url
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tickets_incremental_sends_updated_since_and_ordering(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"tickets": [{"id": 1}]})])
 
-    def test_incremental_without_last_value_omits_filter(self) -> None:
-        url = build_initial_url("acme", FRESHSERVICE_ENDPOINTS["tickets"], True, None)
-        assert "updated_since" not in url
+        _run(
+            "tickets",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+        )
 
-    def test_full_refresh_endpoint_ignores_incremental_flag(self) -> None:
+        params = snapshots[0]["params"]
+        assert params["updated_since"] == "2026-03-04T00:00:00Z"
+        assert params["order_by"] == "updated_at"
+        assert params["order_type"] == "asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_without_last_value_omits_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"tickets": [{"id": 1}]})])
+
+        _run("tickets", should_use_incremental_field=True, db_incremental_field_last_value=None)
+
+        assert "updated_since" not in snapshots[0]["params"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_ignores_incremental_flag(self, MockSession) -> None:
         # `problems` has no server-side filter, so it never gets an updated_since param even when
         # the pipeline requests incremental.
-        url = build_initial_url("acme", FRESHSERVICE_ENDPOINTS["problems"], True, datetime(2026, 3, 4, tzinfo=UTC))
-        assert "updated_since" not in url
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"problems": [{"id": 1}]})])
+
+        _run(
+            "problems",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+        )
+
+        assert "updated_since" not in snapshots[0]["params"]
 
 
-class TestExtractItems:
-    def test_unwraps_resource_envelope(self) -> None:
-        assert extract_items({"tickets": [{"id": 1}]}, FRESHSERVICE_ENDPOINTS["tickets"]) == [{"id": 1}]
+class TestDataSelector:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unwraps_resource_envelope(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"tickets": [{"id": 1}, {"id": 2}]})])
 
-    def test_software_uses_applications_key(self) -> None:
+        assert _run("tickets") == [{"id": 1}, {"id": 2}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_software_uses_applications_key(self, MockSession) -> None:
         # The software table maps to /api/v2/applications, which wraps rows under "applications".
-        assert extract_items({"applications": [{"id": 7}]}, FRESHSERVICE_ENDPOINTS["software"]) == [{"id": 7}]
+        session = MockSession.return_value
+        _wire(session, [_response({"applications": [{"id": 7}]})])
 
-    def test_agent_groups_uses_groups_key(self) -> None:
-        assert extract_items({"groups": [{"id": 3}]}, FRESHSERVICE_ENDPOINTS["agent_groups"]) == [{"id": 3}]
+        assert _run("software") == [{"id": 7}]
 
-    def test_wrong_key_returns_empty(self) -> None:
-        assert extract_items({"problems": [{"id": 1}]}, FRESHSERVICE_ENDPOINTS["tickets"]) == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_agent_groups_uses_groups_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"groups": [{"id": 3}]})])
 
-    def test_bare_array_fallback(self) -> None:
-        assert extract_items([{"id": 1}], FRESHSERVICE_ENDPOINTS["tickets"]) == [{"id": 1}]
+        assert _run("agent_groups") == [{"id": 3}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_wrong_key_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"problems": [{"id": 1}]})])
+
+        assert _run("tickets") == []
 
 
-class TestGetRows:
-    def test_paginates_via_link_header_and_saves_state(self) -> None:
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_link_header_and_saves_state(self, MockSession) -> None:
+        session = MockSession.return_value
         next_url = "https://acme.freshservice.com/api/v2/tickets?per_page=100&page=2"
-        responses = [
-            FakeResponse({"tickets": [{"id": 1}]}, links={"next": {"url": next_url}}),
-            FakeResponse({"tickets": [{"id": 2}]}, links={}),
-        ]
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = responses
+        snapshots = _wire(
+            session,
+            [
+                _response({"tickets": [{"id": 1}]}, next_url=next_url),
+                _response({"tickets": [{"id": 2}]}),
+            ],
+        )
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "tickets", logger, manager))  # type: ignore[arg-type]
+        manager = _make_manager()
+        rows = _run("tickets", manager=manager)
 
-        assert rows == [[{"id": 1}], [{"id": 2}]]
+        assert rows == [{"id": 1}, {"id": 2}]
+        # Second request follows the Link-header next URL.
+        assert snapshots[1]["url"] == next_url
         # State saved once, after the first (only non-terminal) page.
-        assert manager.saved == [FreshserviceResumeConfig(next_url=next_url)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == FreshserviceResumeConfig(next_url=next_url)
 
-    def test_single_page_saves_no_state(self) -> None:
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse({"agents": [{"id": 1}]}, links={})]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_saves_no_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"agents": [{"id": 1}]})])
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "agents", logger, manager))  # type: ignore[arg-type]
+        manager = _make_manager()
+        rows = _run("agents", manager=manager)
 
-        assert rows == [[{"id": 1}]]
-        assert manager.saved == []
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resumes_from_saved_state(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession) -> None:
+        session = MockSession.return_value
         resume_url = "https://acme.freshservice.com/api/v2/tickets?per_page=100&page=5"
-        manager = FakeResumableManager(resume=FreshserviceResumeConfig(next_url=resume_url))
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse({"tickets": [{"id": 50}]}, links={})]
+        snapshots = _wire(session, [_response({"tickets": [{"id": 50}]})])
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            rows = list(get_rows("key", "acme", "tickets", logger, manager))  # type: ignore[arg-type]
+        manager = _make_manager(resume_state=FreshserviceResumeConfig(next_url=resume_url))
+        rows = _run("tickets", manager=manager)
 
-        assert rows == [[{"id": 50}]]
+        assert rows == [{"id": 50}]
         # First request must hit the resumed URL, not a freshly-built initial URL.
-        assert session.get.call_args_list[0].args[0] == resume_url
+        assert snapshots[0]["url"] == resume_url
 
     @pytest.mark.parametrize("status_code", [401, 403, 404])
-    def test_non_retryable_status_raises(self, status_code: int) -> None:
-        manager = FakeResumableManager()
-        session = mock.MagicMock()
-        session.get.side_effect = [FakeResponse(status_code=status_code, text="boom")]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_retryable_status_raises(self, MockSession, status_code: int) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "boom"}, status=status_code)])
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            with pytest.raises(requests.HTTPError):
-                list(get_rows("key", "acme", "tickets", logger, manager))  # type: ignore[arg-type]
+        with pytest.raises(requests.HTTPError):
+            _run("tickets")
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code", [200, 401, 403])
-    def test_returns_status_code(self, status_code: int) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = FakeResponse(status_code=status_code)
+    @mock.patch(FRESHSERVICE_SESSION_PATCH)
+    def test_returns_status_code(self, mock_session, status_code: int) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("acme", "key") == status_code
 
-        with mock.patch(PATCH_SESSION, return_value=session):
-            assert validate_credentials("acme", "key") == status_code
-
-    def test_connection_error_returns_none(self) -> None:
-        session = mock.MagicMock()
-        session.get.side_effect = requests.ConnectionError("nope")
-
-        with mock.patch(PATCH_SESSION, return_value=session):
-            assert validate_credentials("acme", "key") is None
+    @mock.patch(FRESHSERVICE_SESSION_PATCH)
+    def test_connection_error_returns_none(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("nope")
+        assert validate_credentials("acme", "key") is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/front/front.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/front/front.py
@@ -1,33 +1,28 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.front.settings import (
     FRONT_ENDPOINTS,
     FrontEndpointConfig,
 )
 
 FRONT_BASE_URL = "https://api2.frontapp.com"
-REQUEST_TIMEOUT_SECONDS = 60
+# Front cursors are absolute next-page links carried in ``_pagination.next``.
+FRONT_NEXT_URL_PATH = "_pagination.next"
 MAX_RETRIES = 6
-MAX_RETRY_WAIT_SECONDS = 60
-
-
-class FrontRetryableError(Exception):
-    """Raised for retryable Front responses (429 rate limiting, 5xx)."""
-
-    def __init__(self, message: str, retry_after: Optional[float] = None):
-        super().__init__(message)
-        self.retry_after = retry_after
 
 
 @dataclasses.dataclass
@@ -35,19 +30,18 @@ class FrontResumeConfig:
     next_url: str
 
 
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_token}",
-        "Accept": "application/json",
-    }
+def _accept_headers() -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so the token is redacted from logs;
+    # only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def _to_unix_seconds(value: Any) -> Any:
     """Coerce an incremental cursor value into Unix epoch seconds for Front's q[after] filter.
 
     Front stores timestamps as Unix epoch seconds; the warehouse may hand the value back as a
-    datetime/date or as the raw numeric column, so normalize both into something urlencode can
-    serialize as a number.
+    datetime/date or as the raw numeric column, so normalize both into something serializable as
+    a number.
     """
     if isinstance(value, datetime):
         dt = value if value.tzinfo else value.replace(tzinfo=UTC)
@@ -93,130 +87,88 @@ def _build_initial_params(
     return params
 
 
-def _build_url(base_url: str, params: dict[str, Any]) -> str:
-    if not params:
-        return base_url
-    return f"{base_url}?{urlencode(params)}"
-
-
-def _parse_retry_after(value: Optional[str]) -> Optional[float]:
-    if not value:
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        return None
-
-
-def _retry_wait(retry_state: RetryCallState) -> float:
-    """Honor Front's retry-after header on 429 when present; fall back to exponential backoff."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, FrontRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_WAIT_SECONDS)
-    return wait_exponential_jitter(initial=1, max=30)(retry_state)
-
-
 def validate_credentials(api_token: str, path: str, require_scope: bool) -> tuple[bool, str | None]:
     """Probe a Front endpoint with the token.
 
     401 always fails (bad token). 403 means the token is valid but lacks scope for that endpoint:
     we accept it at source-create (``require_scope=False``) and only reject it when validating a
-    specific schema (``require_scope=True``).
+    specific schema (``require_scope=True``). Any other response (200, 404, ...) means the token
+    is genuine.
     """
-    try:
-        response = make_tracked_session().get(f"{FRONT_BASE_URL}{path}", headers=_get_headers(api_token), timeout=10)
-    except Exception as e:
-        return False, f"Could not connect to Front: {e}"
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{FRONT_BASE_URL}{path}",
+        headers={"Authorization": f"Bearer {api_token}", **_accept_headers()},
+    )
 
-    if response.status_code == 401:
+    if status is None:
+        return False, "Could not connect to Front. Please try again."
+    if status == 401:
         return False, "Invalid Front API token. Please reconnect with a valid token."
-    if response.status_code == 403 and require_scope:
+    if status == 403 and require_scope:
         return False, "Your Front API token does not have permission to access this resource."
     return True, None
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FrontResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = FRONT_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-
-    params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url: str | None = resume_config.next_url
-        logger.debug(f"Front: resuming {endpoint} from URL: {url}")
-    else:
-        url = _build_url(f"{FRONT_BASE_URL}{config.path}", params)
-
-    @retry(
-        retry=retry_if_exception_type((FrontRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_retry_wait,
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429:
-            raise FrontRetryableError(
-                f"Front rate limited: url={page_url}",
-                retry_after=_parse_retry_after(response.headers.get("retry-after")),
-            )
-        if response.status_code >= 500:
-            raise FrontRetryableError(f"Front server error: status={response.status_code}, url={page_url}")
-        if not response.ok:
-            logger.error(f"Front API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while url:
-        data = fetch_page(url)
-
-        results = data.get("_results") or []
-        # Never infer the end from an empty/short page — deleted resources can shrink a page
-        # while more pages remain. Only `_pagination.next == null` terminates the cursor.
-        next_url = (data.get("_pagination") or {}).get("next")
-
-        if results:
-            yield results
-
-        if not next_url:
-            break
-
-        # Save state after yielding the page so a crash re-yields the last page (merge dedupes on
-        # primary key) rather than skipping it.
-        resumable_source_manager.save_state(FrontResumeConfig(next_url=next_url))
-        url = next_url
 
 
 def front_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FrontResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = FRONT_ENDPOINTS[endpoint]
 
+    params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
+
+    resource_config: EndpointResource = {
+        "name": endpoint,
+        "endpoint": {
+            "path": config.path,
+            "params": params,
+            # Front pages carry rows under ``_results``; a missing key is a legit empty page
+            # (deleted resources can shrink a page), so this is not data_selector_required.
+            "data_selector": "_results",
+            "paginator": JSONResponsePaginator(next_url_path=FRONT_NEXT_URL_PATH),
+        },
+    }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": FRONT_BASE_URL,
+            "headers": _accept_headers(),
+            "auth": {"type": "bearer", "token": api_token},
+            "max_retries": MAX_RETRIES,
+        },
+        "resources": [resource_config],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(FrontResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -224,4 +176,5 @@ def front_source(
         partition_format=config.partition_format if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/front/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/front/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.front.front import (
     FrontResumeConfig,
     front_source,
@@ -94,20 +97,12 @@ Grant read scopes for the resources you want to sync (e.g. `shared_resources:rea
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=FRONT_ENDPOINTS[endpoint].supports_incremental,
-                supports_append=FRONT_ENDPOINTS[endpoint].supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                description="Only syncs the last 365 days on initial sync" if endpoint == "events" else None,
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions={"events": "Only syncs the last 365 days on initial sync"},
+        )
 
     def validate_credentials(
         self, config: FrontSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -133,7 +128,8 @@ Grant read scopes for the resources you want to sync (e.g. `shared_resources:rea
         return front_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/front/tests/test_front.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/front/tests/test_front.py
@@ -1,39 +1,35 @@
 import json
-from collections.abc import Iterator
-from contextlib import contextmanager
 from datetime import UTC, datetime
-from types import SimpleNamespace
-from typing import Any, Optional
+from typing import Any
 
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import structlog
 from parameterized import parameterized
 from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.front import front as front_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.front.front import (
     FrontResumeConfig,
-    FrontRetryableError,
     _build_initial_params,
-    _build_url,
-    _parse_retry_after,
     _resolve_after_value,
-    _retry_wait,
     _to_unix_seconds,
     front_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.front.settings import FRONT_ENDPOINTS
 
-logger = structlog.get_logger()
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the front module.
+FRONT_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.front.front.make_tracked_session"
+)
 
 
 def _response(
+    json_body: dict[str, Any] | None = None,
+    *,
     status_code: int = 200,
-    json_body: Optional[dict[str, Any]] = None,
-    headers: Optional[dict[str, str]] = None,
+    headers: dict[str, str] | None = None,
 ) -> Response:
     resp = Response()
     resp.status_code = status_code
@@ -44,36 +40,35 @@ def _response(
     return resp
 
 
-class _FakeSession:
-    def __init__(self, responses: list[Response]):
-        self._responses = list(responses)
-        self.requested_urls: list[str] = []
-
-    def get(self, url: str, **kwargs: Any) -> Response:
-        self.requested_urls.append(url)
-        return self._responses.pop(0)
+def _make_manager(resume_state: FrontResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-@contextmanager
-def _patched_session(session: Any) -> Iterator[None]:
-    with patch.object(front_module, "make_tracked_session", return_value=session):
-        yield
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's URL + params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared instead of inspecting the final state.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-class TestBuildUrl:
-    def test_no_params_returns_base(self) -> None:
-        assert _build_url("https://api2.frontapp.com/tags", {}) == "https://api2.frontapp.com/tags"
-
-    def test_encodes_params(self) -> None:
-        url = _build_url("https://api2.frontapp.com/events", {"limit": 15, "sort_order": "asc"})
-        assert url.startswith("https://api2.frontapp.com/events?")
-        assert "limit=15" in url
-        assert "sort_order=asc" in url
-
-    def test_encodes_bracketed_query_filter(self) -> None:
-        url = _build_url("https://api2.frontapp.com/events", {"q[after]": 1700000000})
-        # urlencode percent-encodes brackets; Front decodes them server-side.
-        assert "q%5Bafter%5D=1700000000" in url
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestToUnixSeconds:
@@ -103,7 +98,6 @@ class TestResolveAfterValue:
         assert result < datetime.now(UTC).timestamp()
 
     def test_no_lookback_no_last_value_returns_none(self) -> None:
-        # A config without a lookback (and not incremental) yields no "after" value
         assert _resolve_after_value(FRONT_ENDPOINTS["contacts"], True, None) is None
 
 
@@ -124,31 +118,7 @@ class TestBuildInitialParams:
         assert params == {"limit": 100, "sort_by": "id", "sort_order": "asc"}
 
     def test_teammates_sends_no_params(self) -> None:
-        # teammates takes no documented query params
         assert _build_initial_params(FRONT_ENDPOINTS["teammates"], False, None) == {}
-
-
-class TestParseRetryAfter:
-    @parameterized.expand([("seconds", "5", 5.0), ("none", None, None), ("non_numeric", "abc", None)])
-    def test_parse(self, _name: str, value: Optional[str], expected: Optional[float]) -> None:
-        assert _parse_retry_after(value) == expected
-
-
-class TestRetryWait:
-    def test_honors_retry_after(self) -> None:
-        state = SimpleNamespace(outcome=SimpleNamespace(exception=lambda: FrontRetryableError("x", retry_after=10)))
-        assert _retry_wait(state) == 10.0  # type: ignore[arg-type]
-
-    def test_caps_retry_after(self) -> None:
-        state = SimpleNamespace(outcome=SimpleNamespace(exception=lambda: FrontRetryableError("x", retry_after=120)))
-        assert _retry_wait(state) == 60.0  # type: ignore[arg-type]
-
-    def test_falls_back_to_backoff(self) -> None:
-        state = SimpleNamespace(
-            attempt_number=1,
-            outcome=SimpleNamespace(exception=lambda: FrontRetryableError("x")),
-        )
-        assert _retry_wait(state) >= 0  # type: ignore[arg-type]
 
 
 class TestValidateCredentials:
@@ -161,97 +131,112 @@ class TestValidateCredentials:
             ("not_found_token_valid", 404, False, True),
         ]
     )
-    def test_status_mapping(self, _name: str, status: int, require_scope: bool, expected_ok: bool) -> None:
-        with _patched_session(_FakeSession([_response(status_code=status)])):
-            ok, _msg = validate_credentials("tok", "/teammates", require_scope=require_scope)
+    @mock.patch(FRONT_SESSION_PATCH)
+    def test_status_mapping(
+        self, _name: str, status: int, require_scope: bool, expected_ok: bool, mock_session: mock.MagicMock
+    ) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        ok, _msg = validate_credentials("tok", "/teammates", require_scope=require_scope)
         assert ok is expected_ok
 
-    def test_connection_error_fails(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        with _patched_session(session):
-            ok, msg = validate_credentials("tok", "/teammates", require_scope=False)
+    @mock.patch(FRONT_SESSION_PATCH)
+    def test_connection_error_fails(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        ok, msg = validate_credentials("tok", "/teammates", require_scope=False)
         assert ok is False
         assert msg is not None
 
 
-class TestGetRows:
-    def _manager(self, resume: Optional[FrontResumeConfig] = None) -> MagicMock:
-        manager = MagicMock()
-        manager.can_resume.return_value = resume is not None
-        manager.load_state.return_value = resume
-        return manager
-
-    def test_paginates_and_saves_state(self) -> None:
-        session = _FakeSession(
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_saves_state(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        next_url = "https://api2.frontapp.com/events?page_token=p2"
+        snapshots = _wire(
+            session,
             [
-                _response(
-                    json_body={
-                        "_results": [{"id": "evt_1"}],
-                        "_pagination": {"next": "https://api2.frontapp.com/events?page_token=p2"},
-                    }
-                ),
-                _response(json_body={"_results": [{"id": "evt_2"}], "_pagination": {"next": None}}),
-            ]
+                _response({"_results": [{"id": "evt_1"}], "_pagination": {"next": next_url}}),
+                _response({"_results": [{"id": "evt_2"}], "_pagination": {"next": None}}),
+            ],
         )
-        manager = self._manager()
+        manager = _make_manager()
 
-        with _patched_session(session):
-            batches = list(get_rows("tok", "events", logger, manager))
+        rows = _rows(front_source("tok", "events", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert batches == [[{"id": "evt_1"}], [{"id": "evt_2"}]]
-        manager.save_state.assert_called_once_with(
-            FrontResumeConfig(next_url="https://api2.frontapp.com/events?page_token=p2")
-        )
-        assert session.requested_urls[1] == "https://api2.frontapp.com/events?page_token=p2"
+        assert [r["id"] for r in rows] == ["evt_1", "evt_2"]
+        # Checkpoint saved after the first page (points at the next link); the null next ends it.
+        manager.save_state.assert_called_once_with(FrontResumeConfig(next_url=next_url))
+        # The self-contained next link drives page 2 (original query params dropped).
+        assert snapshots[1]["url"] == next_url
 
-    def test_resumes_from_saved_state(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         resume_url = "https://api2.frontapp.com/events?page_token=resume"
-        session = _FakeSession([_response(json_body={"_results": [{"id": "evt_9"}], "_pagination": {"next": None}})])
-        manager = self._manager(resume=FrontResumeConfig(next_url=resume_url))
+        snapshots = _wire(session, [_response({"_results": [{"id": "evt_9"}], "_pagination": {"next": None}})])
+        manager = _make_manager(FrontResumeConfig(next_url=resume_url))
 
-        with _patched_session(session):
-            batches = list(get_rows("tok", "events", logger, manager))
+        rows = _rows(front_source("tok", "events", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert batches == [[{"id": "evt_9"}]]
-        assert session.requested_urls[0] == resume_url
+        assert [r["id"] for r in rows] == ["evt_9"]
+        assert snapshots[0]["url"] == resume_url
 
-    def test_empty_page_does_not_terminate(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_does_not_terminate(self, MockSession: mock.MagicMock) -> None:
         # An empty `_results` page with a next link must keep paginating (deleted resources can
         # leave a page short without it being the last page).
-        session = _FakeSession(
+        session = MockSession.return_value
+        _wire(
+            session,
             [
-                _response(
-                    json_body={
-                        "_results": [],
-                        "_pagination": {"next": "https://api2.frontapp.com/tags?page_token=p2"},
-                    }
-                ),
-                _response(json_body={"_results": [{"id": "tag_1"}], "_pagination": {"next": None}}),
-            ]
+                _response({"_results": [], "_pagination": {"next": "https://api2.frontapp.com/tags?page_token=p2"}}),
+                _response({"_results": [{"id": "tag_1"}], "_pagination": {"next": None}}),
+            ],
         )
-        manager = self._manager()
+        manager = _make_manager()
 
-        with _patched_session(session):
-            batches = list(get_rows("tok", "tags", logger, manager))
+        rows = _rows(front_source("tok", "tags", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert batches == [[{"id": "tag_1"}]]
-        assert len(session.requested_urls) == 2
+        assert [r["id"] for r in rows] == ["tag_1"]
+        assert session.send.call_count == 2
 
-    def test_retries_on_429(self) -> None:
-        session = _FakeSession(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_on_429(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
             [
                 _response(status_code=429, headers={"retry-after": "0"}),
-                _response(json_body={"_results": [{"id": "tag_1"}], "_pagination": {"next": None}}),
-            ]
+                _response({"_results": [{"id": "tag_1"}], "_pagination": {"next": None}}),
+            ],
         )
-        manager = self._manager()
+        manager = _make_manager()
 
-        with _patched_session(session):
-            batches = list(get_rows("tok", "tags", logger, manager))
+        rows = _rows(front_source("tok", "tags", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert batches == [[{"id": "tag_1"}]]
-        assert len(session.requested_urls) == 2
+        assert [r["id"] for r in rows] == ["tag_1"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_events_incremental_sends_q_after(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response({"_results": [{"id": "evt_1"}], "_pagination": {"next": None}})])
+        manager = _make_manager()
+
+        _rows(
+            front_source(
+                "tok",
+                "events",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=1700000000,
+            )
+        )
+
+        assert snapshots[0]["params"]["q[after]"] == 1700000000
+        assert snapshots[0]["params"]["limit"] == 15
 
 
 class TestFrontSourceResponse:
@@ -266,7 +251,7 @@ class TestFrontSourceResponse:
     def test_partitioned_endpoints(
         self, endpoint: str, partition_key: str, partition_format: str, sort_mode: str
     ) -> None:
-        response = front_source("tok", endpoint, logger, MagicMock())
+        response = front_source("tok", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         assert response.partition_mode == "datetime"
@@ -276,7 +261,7 @@ class TestFrontSourceResponse:
 
     @parameterized.expand([("contacts",), ("teammates",), ("inboxes",), ("channels",), ("teams",)])
     def test_non_partitioned_endpoints(self, endpoint: str) -> None:
-        response = front_source("tok", endpoint, logger, MagicMock())
+        response = front_source("tok", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.primary_keys == ["id"]
         assert response.partition_mode is None
         assert response.partition_keys is None


### PR DESCRIPTION
## Problem

Batch 17 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **freshcaller**
- **freshdesk**
- **freshservice**
- **front**

Not migrated this batch (left hand-rolled, valid blockers — all documented framework gaps):
- **exchange_rates_api** — client-side date-windowing + watermark-derived range, an HTTP-200 functional error envelope, and dict-to-rows normalization.
- **flowlu** — api_key travels in the query param, so it appears in the raised error's URL; the framework redacts logs but not exception messages.
- **formbricks** — self-hosted-instance security controls (streaming body size/time caps, dynamic DNS/private-IP SSRF guard) beyond static host-pinning, plus a 200-body retryable envelope.
- **freshsales** — view-based endpoints need a preparatory `/filters` request plus a global client-side view reduction (prefer the "All"-named view, else first) before listing.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 4 migrated dirs + `common/rest_source/tests/` — 352 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-16 PR (#71852); merge in order.
