### PR TITLE
fix(personhog): fail team/person deletion fast when personhog unconfigured

### DIFF
--- a/posthog/personhog_client/client.py
+++ b/posthog/personhog_client/client.py
@@ -92,6 +92,17 @@ from posthog.personhog_client.proto import (
 
 logger = structlog.get_logger(__name__)
 
+
+class PersonHogNotConfiguredError(RuntimeError):
+    """Raised when the personhog client is required but ``PERSONHOG_ADDR`` is unset.
+
+    This is a permanent misconfiguration, not a transient outage: it can only change with a
+    redeploy, so callers that retry (e.g. Temporal deletion activities) treat this type as
+    non-retryable to fail fast instead of looping forever. Subclasses ``RuntimeError`` to keep
+    existing ``except RuntimeError`` handlers working.
+    """
+
+
 # -- Channel-level metrics --
 
 PERSONHOG_DJANGO_CHANNEL_STATE = Enum(
@@ -416,7 +427,7 @@ def get_personhog_client() -> Optional[PersonHogClient]:
 def require_personhog_client() -> PersonHogClient:
     client = get_personhog_client()
     if client is None:
-        raise RuntimeError("personhog client not configured")
+        raise PersonHogNotConfiguredError("personhog client not configured")
     return client
 
 

--- a/posthog/personhog_client/test_require_client.py
+++ b/posthog/personhog_client/test_require_client.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from posthog.personhog_client.client import PersonHogNotConfiguredError, require_personhog_client
+
+
+class TestRequirePersonHogClient(SimpleTestCase):
+    def test_raises_typed_error_when_not_configured(self) -> None:
+        with patch("posthog.personhog_client.client.get_personhog_client", return_value=None):
+            with self.assertRaises(PersonHogNotConfiguredError):
+                require_personhog_client()
+
+    def test_typed_error_is_runtime_error_subclass(self) -> None:
+        # Existing `except RuntimeError` handlers must keep catching it.
+        self.assertTrue(issubclass(PersonHogNotConfiguredError, RuntimeError))
+
+    def test_error_name_matches_non_retryable_retry_policy_entries(self) -> None:
+        # Temporal matches non_retryable_error_types on the exception class name, so a rename of
+        # PersonHogNotConfiguredError must stay in sync with these strings or team/person deletions
+        # would retry the permanent misconfiguration forever and flood error tracking.
+        from posthog.temporal.delete_teams.workflows import DELETE_RETRY_POLICY
+
+        self.assertIn(PersonHogNotConfiguredError.__name__, DELETE_RETRY_POLICY.non_retryable_error_types or [])

--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -34,12 +34,12 @@ def _delete_specific_persons_via_personhog(team_id: int, person_ids: list[int]) 
     cohortpeople cleanup, so no separate cohort delete is needed here.
     """
     from posthog.personhog_client.caller_tag import personhog_caller_tag
-    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.client import PersonHogNotConfiguredError, get_personhog_client
     from posthog.personhog_client.proto import DeletePersonsRequest, GetPersonsRequest
 
     client = get_personhog_client()
     if client is None:
-        raise RuntimeError("personhog client not configured")
+        raise PersonHogNotConfiguredError("personhog client not configured")
 
     with personhog_caller_tag("delete-persons/by-ids"):
         uuids: list[str] = []
@@ -57,12 +57,12 @@ def _delete_specific_persons_via_personhog(team_id: int, person_ids: list[int]) 
 def _delete_team_persons_batch_via_personhog(team_id: int, batch_size: int) -> int:
     """Delete up to `batch_size` of a team's persons via personhog, returning the count."""
     from posthog.personhog_client.caller_tag import personhog_caller_tag
-    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.client import PersonHogNotConfiguredError, get_personhog_client
     from posthog.personhog_client.proto import DeletePersonsBatchForTeamRequest
 
     client = get_personhog_client()
     if client is None:
-        raise RuntimeError("personhog client not configured")
+        raise PersonHogNotConfiguredError("personhog client not configured")
 
     with personhog_caller_tag("delete-persons/by-team"):
         resp = client.delete_persons_batch_for_team(
@@ -207,7 +207,9 @@ class DeletePersonsWorkflow(PostHogWorkflow):
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(seconds=360),
                     maximum_attempts=0,
-                    non_retryable_error_types=[],
+                    # A missing PERSONHOG_ADDR is a permanent misconfiguration, not a transient
+                    # outage — fail fast instead of retrying forever and flooding error tracking.
+                    non_retryable_error_types=["PersonHogNotConfiguredError"],
                 ),
             )
 
@@ -231,7 +233,9 @@ class DeletePersonsWorkflow(PostHogWorkflow):
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(seconds=360),
                     maximum_attempts=0,
-                    non_retryable_error_types=[],
+                    # A missing PERSONHOG_ADDR is a permanent misconfiguration, not a transient
+                    # outage — fail fast instead of retrying forever and flooding error tracking.
+                    non_retryable_error_types=["PersonHogNotConfiguredError"],
                 ),
             )
 

--- a/posthog/temporal/delete_teams/workflows.py
+++ b/posthog/temporal/delete_teams/workflows.py
@@ -35,13 +35,14 @@ from posthog.temporal.delete_teams.types import (
 # The bulky deletes are idempotent ("delete next N rows for this team until empty"), so they
 # can retry indefinitely on transient DB errors — the data only ever shrinks, and a restarted
 # activity just resumes. Deterministic failures (e.g. a ProtectedError from a PROTECT FK the
-# phase ordering doesn't account for, or a RecursionError decoding a deeply-nested JSON column on
-# a cascaded row) are non-retryable so the workflow fails fast and surfaces instead of looping forever.
+# phase ordering doesn't account for, a RecursionError decoding a deeply-nested JSON column on
+# a cascaded row, or a PersonHogNotConfiguredError when the worker has no PERSONHOG_ADDR) are
+# non-retryable so the workflow fails fast and surfaces instead of looping forever.
 DELETE_RETRY_POLICY = temporalio.common.RetryPolicy(
     initial_interval=dt.timedelta(seconds=10),
     maximum_interval=dt.timedelta(seconds=360),
     maximum_attempts=0,
-    non_retryable_error_types=["ProtectedError", "RecursionError"],
+    non_retryable_error_types=["ProtectedError", "RecursionError", "PersonHogNotConfiguredError"],
 )
 # Bounded retries for the lighter orchestration / side-effect activities.
 SIDE_EFFECT_RETRY_POLICY = temporalio.common.RetryPolicy(

--- a/products/cohorts/backend/models/util.py
+++ b/products/cohorts/backend/models/util.py
@@ -1354,12 +1354,14 @@ _DELETE_BULK_MAX_ITERATIONS = 10_000
 def _delete_cohort_members_bulk_via_personhog(
     cohort_ids: list[int], batch_size: int, timeout: float | None = None
 ) -> int:
-    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.client import PersonHogNotConfiguredError, get_personhog_client
     from posthog.personhog_client.proto import DeleteCohortMembersBulkRequest
 
     client = get_personhog_client()
     if client is None:
-        raise RuntimeError("personhog client not configured")
+        # Permanent misconfiguration (no PERSONHOG_ADDR) — deletion callers treat this type as
+        # non-retryable so they fail fast rather than looping forever. See PersonHogNotConfiguredError.
+        raise PersonHogNotConfiguredError("personhog client not configured")
 
     total_deleted = 0
     for _ in range(_DELETE_BULK_MAX_ITERATIONS):


### PR DESCRIPTION
## Problem

Error tracking issue: [personhog client not configured](https://us.posthog.com/project/2/error_tracking/019f28dd-b7d7-7801-a561-094cb5620784)

A Temporal worker without `PERSONHOG_ADDR` set raises `RuntimeError("personhog client not configured")` from `require_personhog_client()`. The team- and person-deletion activities run under an infinite retry policy (`maximum_attempts=0`) intended for idempotent bulky deletes that should retry through transient DB blips.

A missing `PERSONHOG_ADDR` is not transient though. It cannot change without a redeploy, so the activity retried the same failure forever. Each attempt is captured by the Temporal exception interceptor with a fresh distinct id, which is why this single deterministic misconfiguration shows up in error tracking as a flood of events rather than one clear signal.

The underlying fix is operational: the general-purpose Temporal worker running these deletion workflows needs `PERSONHOG_ADDR`. This PR makes the code fail fast and loud when that config is missing, so the problem surfaces cleanly instead of looping.

## Changes

- Add `PersonHogNotConfiguredError` in `posthog/personhog_client/client.py`, a `RuntimeError` subclass raised by `require_personhog_client()` (and the manual `get_personhog_client() is None` checks in the delete paths). Being a `RuntimeError` subclass, every existing `except RuntimeError` handler and fallback keeps working unchanged.
- Mark `PersonHogNotConfiguredError` non-retryable in the `delete-teams` and `delete-persons` retry policies. A permanent misconfiguration now fails the activity fast and surfaces, rather than retrying indefinitely.

A genuinely transient personhog outage is unaffected: that surfaces as a gRPC error from inside the RPC call, not as "not configured", and keeps retrying as before.

> [!NOTE]
> This changes deletion behavior in a misconfigured environment from "retry forever" to "fail fast". Once `PERSONHOG_ADDR` is set, the deletion is re-triggered and proceeds normally.

## How did you test this code?

Added `posthog/personhog_client/test_require_client.py` (no-DB `SimpleTestCase`):

- `require_personhog_client()` raises `PersonHogNotConfiguredError` when the client is unconfigured.
- the error is a `RuntimeError` subclass, so existing handlers still catch it.
- the class name matches the string in `DELETE_RETRY_POLICY.non_retryable_error_types` — Temporal matches `non_retryable_error_types` on the exception class name, so a rename that desyncs the two would silently bring the infinite-retry flood back. This test guards that coupling.

I (Claude) ran the new tests and the existing `test_group_type_mapping.py` fallback test (which patches an unconfigured client) — both pass. The broader deletion suites need a Postgres test DB that isn't available in this sandbox, so I did not run them here.

## Docs update

- [ ] No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from an error-tracking issue (`personhog client not configured`) whose stack trace pointed at `delete_misc_small_tables_activity`. Traced the raise to `require_personhog_client()` and found the delete-teams and delete-persons activities retry it forever under `maximum_attempts=0`, which matches the retry policy's own documented intent to make deterministic failures non-retryable (it already lists `ProtectedError` and `RecursionError`).

Considered an ORM fallback but rejected it: persons/groups/hash-key-overrides live in the persons DB and personhog is the sole path by design, so there's no ORM route to fall back to. The typed-error + non-retryable approach fixes the observable harm (retry flood) and surfaces the real cause without violating that boundary. Changing `retry_policy` on existing `execute_activity` calls is safe for in-flight workflows — it's an activity-schedule attribute, not a workflow command-sequence change.

Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

