### PR TITLE
fix(tasks): only fire PR babysitting follow-up when the PR is actionable

### DIFF
--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -827,7 +827,7 @@ class GitHubIntegrationBase:
     query($owner: String!, $repo: String!, $number: Int!) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $number) {
-          number title url state isDraft mergeable updatedAt headRefName
+          number title url state isDraft mergeable updatedAt headRefName headRefOid
           author { login }
           reviewDecision
           reviewRequests(first: 50) {
@@ -996,6 +996,7 @@ class GitHubIntegrationBase:
             "mergeable": self._map_mergeable(pr.get("mergeable")),
             "author_login": author,
             "head_branch": pr.get("headRefName"),
+            "head_sha": pr.get("headRefOid"),
             "requested_reviewer_logins": reviewer_logins,
             "updated_at": pr.get("updatedAt"),
         }

--- a/products/tasks/backend/temporal/patches.py
+++ b/products/tasks/backend/temporal/patches.py
@@ -1,0 +1,22 @@
+"""Temporal patch gates shared by the task-run workflow stacks.
+
+Patch IDs are scoped to a single workflow execution's history, so the legacy
+``process-task`` workflow and the ``task-management`` orchestrator can share
+one gate without colliding.
+"""
+
+from temporalio import workflow
+
+# Gates the actionable-state check in the CI follow-up decision: a fingerprint
+# change alone no longer wakes the agent — only failing CI or a changes-requested
+# review does. Pre-rollout histories dispatched a follow-up on any change, so the
+# marker keeps their replays deterministic. Standard two-step Temporal patch
+# lifecycle: deprecate_patch once pre-rollout histories drain, then delete.
+PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE = "tasks-ci-follow-up-actionable-gate"
+
+
+def ci_follow_up_actionable_gate() -> bool:
+    # True outside a workflow so direct-invocation unit tests exercise the new path.
+    if not workflow.in_workflow():
+        return True
+    return workflow.patched(PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE)

--- a/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
@@ -32,14 +32,22 @@ class GetPrContextOutput:
     changes_requested: bool = False
 
 
-def is_pr_actionable(ci_status: str, changes_requested: bool) -> bool:
-    """Whether the PR state gives the agent real work to do.
+def decide_ci_follow_up(pr: GetPrContextOutput) -> tuple[bool, str | None]:
+    """Decide whether a changed PR snapshot warrants waking the agent.
 
-    A green or check-less PR is not actionable: waking the agent for it produces a
-    "nothing to report" turn that spams the originating Slack thread and burns one
-    of the limited CI follow-up repetitions.
+    Returns ``(fire, fingerprint_to_store)``; a ``None`` fingerprint means the
+    caller keeps its previous one. Only an actionable state — failing CI or a
+    changes-requested review — fires: waking the agent for a green or check-less
+    PR produces a "nothing to report" turn that spams the originating Slack
+    thread and burns one of the limited CI follow-up repetitions. Pending CI
+    keeps the old fingerprint so the settled state (which may be failing) still
+    registers as a change on the next tick.
     """
-    return changes_requested or ci_status == "failing"
+    if pr.changes_requested or pr.ci_status == "failing":
+        return True, pr.fingerprint
+    if pr.ci_status == "pending":
+        return False, None
+    return False, pr.fingerprint
 
 
 def compute_pr_fingerprint(pr: dict[str, Any]) -> str:
@@ -54,8 +62,8 @@ def compute_pr_fingerprint(pr: dict[str, Any]) -> str:
     For the review signal we key on the boolean ``review_decision == "changes_requested"``
     rather than the raw decision: ``changes_requested`` is the only value that means
     the agent has code to fix, so an ``approved`` or ``review_required`` transition no
-    longer re-pokes it for nothing. Net effect: the follow-up re-fires only when CI
-    changes or a reviewer requests changes.
+    longer re-pokes it for nothing. The fingerprint only detects that these signals
+    changed; whether a change is worth firing on is decided by ``decide_ci_follow_up``.
     """
     changes_requested = pr.get("review_decision") == "changes_requested"
     fingerprint_source = "|".join(

--- a/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
@@ -27,6 +27,19 @@ class GetPrContextOutput:
     pr_url: str
     pr_state: str
     fingerprint: str
+    # Defaults keep replay of pre-rollout activity results deserializable.
+    ci_status: str = "none"
+    changes_requested: bool = False
+
+
+def is_pr_actionable(ci_status: str, changes_requested: bool) -> bool:
+    """Whether the PR state gives the agent real work to do.
+
+    A green or check-less PR is not actionable: waking the agent for it produces a
+    "nothing to report" turn that spams the originating Slack thread and burns one
+    of the limited CI follow-up repetitions.
+    """
+    return changes_requested or ci_status == "failing"
 
 
 def compute_pr_fingerprint(pr: dict[str, Any]) -> str:
@@ -129,4 +142,6 @@ def get_pr_context(input: GetPrContextInput) -> GetPrContextOutput | None:
             pr_url=pr_url,
             pr_state=pull_request.get("state", "unknown"),
             fingerprint=fingerprint,
+            ci_status=pull_request.get("ci_status", "none"),
+            changes_requested=pull_request.get("review_decision") == "changes_requested",
         )

--- a/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
@@ -30,6 +30,7 @@ class GetPrContextOutput:
     # Defaults keep replay of pre-rollout activity results deserializable.
     ci_status: str = "none"
     changes_requested: bool = False
+    unresolved_threads: int = 0
 
 
 def is_pr_actionable(pr: GetPrContextOutput) -> bool:
@@ -152,4 +153,5 @@ def get_pr_context(input: GetPrContextInput) -> GetPrContextOutput | None:
             fingerprint=fingerprint,
             ci_status=pull_request.get("ci_status", "none"),
             changes_requested=pull_request.get("review_decision") == "changes_requested",
+            unresolved_threads=pull_request.get("unresolved_threads", 0),
         )

--- a/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_pr_context.py
@@ -32,22 +32,17 @@ class GetPrContextOutput:
     changes_requested: bool = False
 
 
-def decide_ci_follow_up(pr: GetPrContextOutput) -> tuple[bool, str | None]:
-    """Decide whether a changed PR snapshot warrants waking the agent.
+def is_pr_actionable(pr: GetPrContextOutput) -> bool:
+    """Whether a changed PR snapshot warrants waking the agent.
 
-    Returns ``(fire, fingerprint_to_store)``; a ``None`` fingerprint means the
-    caller keeps its previous one. Only an actionable state — failing CI or a
-    changes-requested review — fires: waking the agent for a green or check-less
-    PR produces a "nothing to report" turn that spams the originating Slack
-    thread and burns one of the limited CI follow-up repetitions. Pending CI
-    keeps the old fingerprint so the settled state (which may be failing) still
-    registers as a change on the next tick.
+    Only failing CI or a changes-requested review gives the agent real work to
+    do. Waking it for a green, pending, or check-less PR produces a "nothing to
+    report" turn that spams the originating Slack thread and burns one of the
+    limited CI follow-up repetitions. Pending needs no special handling: the
+    head SHA and CI status are both in the fingerprint, so the settled state
+    (which may be failing) registers as its own change on a later tick.
     """
-    if pr.changes_requested or pr.ci_status == "failing":
-        return True, pr.fingerprint
-    if pr.ci_status == "pending":
-        return False, None
-    return False, pr.fingerprint
+    return pr.changes_requested or pr.ci_status == "failing"
 
 
 def compute_pr_fingerprint(pr: dict[str, Any]) -> str:
@@ -62,12 +57,17 @@ def compute_pr_fingerprint(pr: dict[str, Any]) -> str:
     For the review signal we key on the boolean ``review_decision == "changes_requested"``
     rather than the raw decision: ``changes_requested`` is the only value that means
     the agent has code to fix, so an ``approved`` or ``review_required`` transition no
-    longer re-pokes it for nothing. The fingerprint only detects that these signals
-    changed; whether a change is worth firing on is decided by ``decide_ci_follow_up``.
+    longer re-pokes it for nothing.
+
+    The head SHA is included so that a new commit failing with the same coarse
+    ``ci_status`` as its predecessor still reads as a change — without it, an
+    agent push that fails again would hash identically to the previous failure
+    and the follow-up would never re-fire. The fingerprint only detects change;
+    whether a change is worth firing on is decided by ``is_pr_actionable``.
     """
     changes_requested = pr.get("review_decision") == "changes_requested"
     fingerprint_source = "|".join(
-        [str(pr.get(key, "")) for key in ("url", "state", "ci_status")] + [str(changes_requested)]
+        [str(pr.get(key, "")) for key in ("url", "state", "ci_status", "head_sha")] + [str(changes_requested)]
     )
     return hashlib.sha256(fingerprint_source.encode()).hexdigest()
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_pr_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_pr_context.py
@@ -155,7 +155,7 @@ class TestGetPrContextActivity:
             "url": pr_url,
             "state": "open",
             "ci_status": "failing",
-            "review_decision": None,
+            "review_decision": "changes_requested",
             "unresolved_threads": 1,
         }
         integration = MagicMock()
@@ -169,6 +169,10 @@ class TestGetPrContextActivity:
         assert result.pr_url == pr_url
         assert result.pr_state == "open"
         assert result.fingerprint == compute_pr_fingerprint(snapshot)
+        # The actionable signals must flow through — the CI follow-up loop keys
+        # its fire/skip decision on them.
+        assert result.ci_status == "failing"
+        assert result.changes_requested is True
         integration.get_pull_request_snapshot.assert_called_once_with(pr_url)
 
     @pytest.mark.django_db

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_pr_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_pr_context.py
@@ -178,6 +178,7 @@ class TestGetPrContextActivity:
         # its fire/skip decision on them.
         assert result.ci_status == "failing"
         assert result.changes_requested is True
+        assert result.unresolved_threads == 1
         integration.get_pull_request_snapshot.assert_called_once_with(pr_url)
 
     @pytest.mark.django_db

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_pr_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_pr_context.py
@@ -45,6 +45,11 @@ class TestComputePrFingerprint:
             ("ci_status", "pending", "failing"),
             ("review_decision", None, "changes_requested"),
             ("state", "open", "closed"),
+            # A new head commit failing with the same coarse ci_status as its
+            # predecessor must still read as a change — without the SHA, an agent
+            # push that fails again would hash identically to the previous failure
+            # and the follow-up would never re-fire.
+            ("head_sha", "aaa111", "bbb222"),
         ]
     )
     def test_changes_when_actionable_field_changes(self, field, before, after):

--- a/products/tasks/backend/temporal/process_task/tests/test_ci_follow_up_decision.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_ci_follow_up_decision.py
@@ -19,15 +19,16 @@ class TestShouldRunCIFollowUpDecision:
     @pytest.mark.parametrize(
         "ci_status,changes_requested,expected_decision,expected_fingerprint",
         [
-            # Actionable changes fire and persist the fingerprint.
+            # Actionable changes fire.
             ("failing", False, CIFollowUpDecision.FIRE, "fp-1"),
             ("passing", True, CIFollowUpDecision.FIRE, "fp-1"),
-            # Green or check-less changes persist the fingerprint but stay quiet.
+            # Non-actionable changes persist the fingerprint but stay quiet.
+            # Pending needs no deferral: the settled state hashes differently
+            # (CI status and head SHA are both in the fingerprint), so it still
+            # registers as a change on a later tick.
             ("passing", False, CIFollowUpDecision.SKIP, "fp-1"),
             ("none", False, CIFollowUpDecision.SKIP, "fp-1"),
-            # Pending keeps the old fingerprint so the settled state (which may
-            # be failing) still registers as a change on the next tick.
-            ("pending", False, CIFollowUpDecision.SKIP, "fp-0"),
+            ("pending", False, CIFollowUpDecision.SKIP, "fp-1"),
         ],
     )
     async def test_fingerprint_change_fires_only_when_actionable(

--- a/products/tasks/backend/temporal/process_task/tests/test_ci_follow_up_decision.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_ci_follow_up_decision.py
@@ -69,3 +69,58 @@ class TestShouldRunCIFollowUpDecision:
 
         assert decision is expected_decision
         assert wf._pr_fingerprint == expected_fingerprint
+
+    @pytest.mark.parametrize(
+        "prev_threads,new_threads,fingerprint,expected_decision",
+        [
+            # New review threads are feedback — fire even when the fingerprint
+            # hasn't moved.
+            (0, 2, "fp-0", CIFollowUpDecision.FIRE),
+            # Resolving threads is not feedback.
+            (2, 1, "fp-0", CIFollowUpDecision.SKIP),
+            # A green change with a stable thread count stays quiet.
+            (2, 2, "fp-1", CIFollowUpDecision.SKIP),
+            # A green change accompanied by new feedback fires.
+            (0, 3, "fp-1", CIFollowUpDecision.FIRE),
+        ],
+    )
+    async def test_new_review_threads_fire_follow_up(
+        self,
+        monkeypatch,
+        prev_threads,
+        new_threads,
+        fingerprint,
+        expected_decision,
+    ):
+        wf = ProcessTaskWorkflow()
+        wf._context = TaskProcessingContext(
+            task_id="task-1",
+            run_id="run-1",
+            team_id=1,
+            team_uuid=str(uuid.uuid4()),
+            organization_id=str(uuid.uuid4()),
+            github_integration_id=1,
+            repository="org/repo",
+            distinct_id="user-1",
+        )
+        wf._pr_fingerprint = "fp-0"
+        wf._pr_unresolved_threads = prev_threads
+        wf._pr_progress_emitted = True
+
+        async def fake_execute_activity(activity_fn, *args, **kwargs):
+            return GetPrContextOutput(
+                pr_url="https://github.com/org/repo/pull/1",
+                pr_state="open",
+                fingerprint=fingerprint,
+                ci_status="passing",
+                unresolved_threads=new_threads,
+            )
+
+        monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
+        monkeypatch.setattr(process_task_workflow_module.workflow, "logger", Mock())
+
+        decision = await wf._should_run_ci_follow_up()
+
+        assert decision is expected_decision
+        # The count must track last-seen (not max) so post-resolve feedback re-fires.
+        assert wf._pr_unresolved_threads == new_threads

--- a/products/tasks/backend/temporal/process_task/tests/test_ci_follow_up_decision.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_ci_follow_up_decision.py
@@ -1,0 +1,70 @@
+import uuid
+
+import pytest
+from unittest.mock import Mock
+
+from products.tasks.backend.temporal.process_task import workflow as process_task_workflow_module
+from products.tasks.backend.temporal.process_task.activities.get_pr_context import GetPrContextOutput
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
+from products.tasks.backend.temporal.process_task.workflow import CIFollowUpDecision, ProcessTaskWorkflow
+
+pytestmark = [pytest.mark.asyncio]
+
+
+class TestShouldRunCIFollowUpDecision:
+    # Direct decision tests for ProcessTaskWorkflow's copy of the CI follow-up
+    # gate (task_management has its own copy with an equivalent suite). Guards
+    # against re-introducing "nothing to report" wake-ups: a fingerprint change
+    # must only fire when the PR state is actionable.
+    @pytest.mark.parametrize(
+        "ci_status,changes_requested,expected_decision,expected_fingerprint",
+        [
+            # Actionable changes fire and persist the fingerprint.
+            ("failing", False, CIFollowUpDecision.FIRE, "fp-1"),
+            ("passing", True, CIFollowUpDecision.FIRE, "fp-1"),
+            # Green or check-less changes persist the fingerprint but stay quiet.
+            ("passing", False, CIFollowUpDecision.SKIP, "fp-1"),
+            ("none", False, CIFollowUpDecision.SKIP, "fp-1"),
+            # Pending keeps the old fingerprint so the settled state (which may
+            # be failing) still registers as a change on the next tick.
+            ("pending", False, CIFollowUpDecision.SKIP, "fp-0"),
+        ],
+    )
+    async def test_fingerprint_change_fires_only_when_actionable(
+        self,
+        monkeypatch,
+        ci_status,
+        changes_requested,
+        expected_decision,
+        expected_fingerprint,
+    ):
+        wf = ProcessTaskWorkflow()
+        wf._context = TaskProcessingContext(
+            task_id="task-1",
+            run_id="run-1",
+            team_id=1,
+            team_uuid=str(uuid.uuid4()),
+            organization_id=str(uuid.uuid4()),
+            github_integration_id=1,
+            repository="org/repo",
+            distinct_id="user-1",
+        )
+        wf._pr_fingerprint = "fp-0"
+        wf._pr_progress_emitted = True
+
+        async def fake_execute_activity(activity_fn, *args, **kwargs):
+            return GetPrContextOutput(
+                pr_url="https://github.com/org/repo/pull/1",
+                pr_state="open",
+                fingerprint="fp-1",
+                ci_status=ci_status,
+                changes_requested=changes_requested,
+            )
+
+        monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
+        monkeypatch.setattr(process_task_workflow_module.workflow, "logger", Mock())
+
+        decision = await wf._should_run_ci_follow_up()
+
+        assert decision is expected_decision
+        assert wf._pr_fingerprint == expected_fingerprint

--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -197,6 +197,10 @@ def _mock_send_followup_records(input: SendFollowupToSandboxInput) -> None:
 
 @activity.defn(name="get_pr_context")
 def _mock_get_pr_context(_input) -> GetPrContextOutput | None:
+    # Defaults to failing CI: a fingerprint change alone no longer dispatches a
+    # follow-up — only an actionable state (failing CI or a changes-requested
+    # review) does. Overridable per test via the "ci_status" key.
+    ci_status = _pr_context_overrides.get("ci_status", "failing")
     behavior = _pr_context_overrides.get("behavior", "changing")
     if behavior == "missing":
         _pr_context_overrides["_call_count"] = _pr_context_overrides.get("_call_count", 0) + 1
@@ -206,6 +210,7 @@ def _mock_get_pr_context(_input) -> GetPrContextOutput | None:
             pr_url="https://github.com/org/repo/pull/1",
             pr_state="closed",
             fingerprint="closed-fp",
+            ci_status=ci_status,
         )
     if behavior == "unchanged":
         _pr_context_overrides["_call_count"] = _pr_context_overrides.get("_call_count", 0) + 1
@@ -213,6 +218,7 @@ def _mock_get_pr_context(_input) -> GetPrContextOutput | None:
             pr_url="https://github.com/org/repo/pull/1",
             pr_state="open",
             fingerprint="stable-fp",
+            ci_status=ci_status,
         )
     if behavior == "sequence":
         # Returns fingerprints from a configured list, repeating the last value
@@ -225,6 +231,7 @@ def _mock_get_pr_context(_input) -> GetPrContextOutput | None:
             pr_url="https://github.com/org/repo/pull/1",
             pr_state="open",
             fingerprint=sequence[idx],
+            ci_status=ci_status,
         )
     # Default "changing": unique fingerprint per call so CI follow-up always fires
     _pr_context_overrides["_call_count"] = _pr_context_overrides.get("_call_count", 0) + 1
@@ -232,6 +239,7 @@ def _mock_get_pr_context(_input) -> GetPrContextOutput | None:
         pr_url="https://github.com/org/repo/pull/1",
         pr_state="open",
         fingerprint=f"fp-{_pr_context_overrides['_call_count']}",
+        ci_status=ci_status,
     )
 
 

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -23,8 +23,8 @@ from products.tasks.backend.temporal.create_snapshot.workflow import CreateSnaps
 from products.tasks.backend.temporal.patches import ci_follow_up_actionable_gate
 from products.tasks.backend.temporal.process_task.activities.get_pr_context import (
     GetPrContextInput,
-    decide_ci_follow_up,
     get_pr_context,
+    is_pr_actionable,
 )
 
 from .activities.cleanup_sandbox import (
@@ -496,13 +496,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
             return CIFollowUpDecision.SKIP
+        self._pr_fingerprint = pr_context.fingerprint
         if not ci_follow_up_actionable_gate():
             # Legacy replay path: any fingerprint change fires.
-            self._pr_fingerprint = pr_context.fingerprint
             return CIFollowUpDecision.FIRE
-        fire, fingerprint_to_store = decide_ci_follow_up(pr_context)
-        if fingerprint_to_store is not None:
-            self._pr_fingerprint = fingerprint_to_store
+        fire = is_pr_actionable(pr_context)
         workflow.logger.info(
             "PR context has changed, deciding CI follow-up",
             extra={

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -119,6 +119,8 @@ class ResumedSandboxState:
     first_user_message_received: bool
     is_agent_design_enabled: bool
     last_active_time: Optional[str]  # ISO8601, or None if never active
+    # Defaulted so continue_as_new payloads from pre-rollout runs deserialize.
+    pr_unresolved_threads: int = 0
 
 
 @dataclass
@@ -274,6 +276,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         # exception handler onto the right card.
         self._current_progress_step: Optional[tuple[str, str, str]] = None
         self._pr_fingerprint: Optional[str] = None
+        # Last observed unresolved review-thread count. Starting at 0 means
+        # feedback posted before the first poll still reads as new.
+        self._pr_unresolved_threads: int = 0
         # Emit the "PR opened / keeping CI green" progress once, the first time we observe a PR — the
         # agent opens it mid-run and then keeps it green, so without this the UI dead-ends at "Started agent".
         self._pr_progress_emitted: bool = False
@@ -486,7 +491,19 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
             return CIFollowUpDecision.SKIP
-        if self._pr_fingerprint == pr_context.fingerprint:
+        fingerprint_changed = self._pr_fingerprint != pr_context.fingerprint
+        if not ci_follow_up_actionable_gate():
+            # Legacy replay path: any fingerprint change fires; feedback is not consulted.
+            if not fingerprint_changed:
+                return CIFollowUpDecision.SKIP
+            self._pr_fingerprint = pr_context.fingerprint
+            return CIFollowUpDecision.FIRE
+        # New unresolved review threads are feedback for the agent, and comparing
+        # against the last-seen count means its own thread replies (which never
+        # resolve anything) can't re-trigger it.
+        new_feedback = pr_context.unresolved_threads > self._pr_unresolved_threads
+        self._pr_unresolved_threads = pr_context.unresolved_threads
+        if not fingerprint_changed and not new_feedback:
             workflow.logger.info(
                 "PR context has not changed, skipping CI follow-up",
                 extra={
@@ -497,10 +514,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             )
             return CIFollowUpDecision.SKIP
         self._pr_fingerprint = pr_context.fingerprint
-        if not ci_follow_up_actionable_gate():
-            # Legacy replay path: any fingerprint change fires.
-            return CIFollowUpDecision.FIRE
-        fire = is_pr_actionable(pr_context)
+        fire = (fingerprint_changed and is_pr_actionable(pr_context)) or new_feedback
         workflow.logger.info(
             "PR context has changed, deciding CI follow-up",
             extra={
@@ -509,6 +523,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 "pr_state": pr_context.pr_state,
                 "ci_status": pr_context.ci_status,
                 "changes_requested": pr_context.changes_requested,
+                "unresolved_threads": pr_context.unresolved_threads,
+                "new_feedback": new_feedback,
                 "fire": fire,
             },
         )
@@ -961,6 +977,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 connect_token=self._sandbox_connect_token,
                 ci_repetitions=self._ci_repetitions,
                 pr_fingerprint=self._pr_fingerprint,
+                pr_unresolved_threads=self._pr_unresolved_threads,
                 pr_progress_emitted=self._pr_progress_emitted,
                 first_user_message_received=self._first_user_message_received,
                 is_agent_design_enabled=self._is_agent_design_enabled,
@@ -972,6 +989,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         self._is_agent_design_enabled = resumed.is_agent_design_enabled
         self._ci_repetitions = resumed.ci_repetitions
         self._pr_fingerprint = resumed.pr_fingerprint
+        self._pr_unresolved_threads = resumed.pr_unresolved_threads
         self._pr_progress_emitted = resumed.pr_progress_emitted
         self._first_user_message_received = resumed.first_user_message_received
         self._last_active_time = datetime.fromisoformat(resumed.last_active_time) if resumed.last_active_time else None

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -20,7 +20,11 @@ from products.tasks.backend.constants import SNAPSHOT_KIND_FILESYSTEM
 from products.tasks.backend.error_telemetry import truncate_error_message
 from products.tasks.backend.logic.services.sandbox import is_public_sandbox_repo
 from products.tasks.backend.temporal.create_snapshot.workflow import CreateSnapshotForRepositoryInput
-from products.tasks.backend.temporal.process_task.activities.get_pr_context import GetPrContextInput, get_pr_context
+from products.tasks.backend.temporal.process_task.activities.get_pr_context import (
+    GetPrContextInput,
+    get_pr_context,
+    is_pr_actionable,
+)
 
 from .activities.cleanup_sandbox import (
     CleanupSandboxInput,
@@ -224,9 +228,21 @@ _PATCH_ID_SKIP_LOCAL_ENVIRONMENT_RUNS = "tasks-skip-local-environment-runs"
 _PATCH_ID_DEFER_RUN_STREAM_COMPLETION = "tasks-defer-run-stream-completion"
 _PATCH_ID_COMPLETE_STREAM_AFTER_CLEANUP_FAILURE = "tasks-complete-stream-after-cleanup-failure"
 
+# Gates the actionable-state check in the CI follow-up decision: a fingerprint
+# change alone no longer wakes the agent — only failing CI or a changes-requested
+# review does. Pre-rollout histories dispatched a follow-up on any change, so the
+# marker keeps their replays deterministic. Same two-step cleanup lifecycle as above.
+_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE = "tasks-ci-follow-up-actionable-gate"
+
 
 def _deprecate_ci_follow_up_pr_context_patch() -> None:
     workflow.deprecate_patch(_PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT)
+
+
+def _ci_follow_up_actionable_gate() -> bool:
+    if not workflow.in_workflow():
+        return True
+    return workflow.patched(_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE)
 
 
 def _defer_run_stream_completion() -> bool:
@@ -481,18 +497,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
             return CIFollowUpDecision.SKIP
-        if self._pr_fingerprint != pr_context.fingerprint:
-            workflow.logger.info(
-                "PR context has changed, running CI follow-up",
-                extra={
-                    "run_id": self.context.run_id,
-                    "pr_url": pr_context.pr_url,
-                    "pr_state": pr_context.pr_state,
-                },
-            )
-            self._pr_fingerprint = pr_context.fingerprint
-            return CIFollowUpDecision.FIRE
-        else:
+        if self._pr_fingerprint == pr_context.fingerprint:
             workflow.logger.info(
                 "PR context has not changed, skipping CI follow-up",
                 extra={
@@ -502,6 +507,46 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
             return CIFollowUpDecision.SKIP
+        if not _ci_follow_up_actionable_gate():
+            self._pr_fingerprint = pr_context.fingerprint
+            return CIFollowUpDecision.FIRE
+        if is_pr_actionable(pr_context.ci_status, pr_context.changes_requested):
+            workflow.logger.info(
+                "PR context has changed and is actionable, running CI follow-up",
+                extra={
+                    "run_id": self.context.run_id,
+                    "pr_url": pr_context.pr_url,
+                    "pr_state": pr_context.pr_state,
+                    "ci_status": pr_context.ci_status,
+                    "changes_requested": pr_context.changes_requested,
+                },
+            )
+            self._pr_fingerprint = pr_context.fingerprint
+            return CIFollowUpDecision.FIRE
+        if pr_context.ci_status == "pending":
+            # CI hasn't settled — keep the old fingerprint so the settled state
+            # (which may be failing) is still seen as a change on the next tick.
+            workflow.logger.info(
+                "PR CI is pending, deferring CI follow-up decision",
+                extra={
+                    "run_id": self.context.run_id,
+                    "pr_url": pr_context.pr_url,
+                },
+            )
+            return CIFollowUpDecision.SKIP
+        # Changed but green (or check-less): nothing for the agent to do. Record the
+        # fingerprint so this state doesn't re-trigger the comparison every tick.
+        workflow.logger.info(
+            "PR context has changed but is not actionable, skipping CI follow-up",
+            extra={
+                "run_id": self.context.run_id,
+                "pr_url": pr_context.pr_url,
+                "pr_state": pr_context.pr_state,
+                "ci_status": pr_context.ci_status,
+            },
+        )
+        self._pr_fingerprint = pr_context.fingerprint
+        return CIFollowUpDecision.SKIP
 
     async def _dispatch_ci_follow_up(self) -> None:
         self._ci_repetitions += 1

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -20,10 +20,11 @@ from products.tasks.backend.constants import SNAPSHOT_KIND_FILESYSTEM
 from products.tasks.backend.error_telemetry import truncate_error_message
 from products.tasks.backend.logic.services.sandbox import is_public_sandbox_repo
 from products.tasks.backend.temporal.create_snapshot.workflow import CreateSnapshotForRepositoryInput
+from products.tasks.backend.temporal.patches import ci_follow_up_actionable_gate
 from products.tasks.backend.temporal.process_task.activities.get_pr_context import (
     GetPrContextInput,
+    decide_ci_follow_up,
     get_pr_context,
-    is_pr_actionable,
 )
 
 from .activities.cleanup_sandbox import (
@@ -228,21 +229,9 @@ _PATCH_ID_SKIP_LOCAL_ENVIRONMENT_RUNS = "tasks-skip-local-environment-runs"
 _PATCH_ID_DEFER_RUN_STREAM_COMPLETION = "tasks-defer-run-stream-completion"
 _PATCH_ID_COMPLETE_STREAM_AFTER_CLEANUP_FAILURE = "tasks-complete-stream-after-cleanup-failure"
 
-# Gates the actionable-state check in the CI follow-up decision: a fingerprint
-# change alone no longer wakes the agent — only failing CI or a changes-requested
-# review does. Pre-rollout histories dispatched a follow-up on any change, so the
-# marker keeps their replays deterministic. Same two-step cleanup lifecycle as above.
-_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE = "tasks-ci-follow-up-actionable-gate"
-
 
 def _deprecate_ci_follow_up_pr_context_patch() -> None:
     workflow.deprecate_patch(_PATCH_ID_CI_FOLLOW_UP_PR_CONTEXT)
-
-
-def _ci_follow_up_actionable_gate() -> bool:
-    if not workflow.in_workflow():
-        return True
-    return workflow.patched(_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE)
 
 
 def _defer_run_stream_completion() -> bool:
@@ -507,46 +496,25 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
             return CIFollowUpDecision.SKIP
-        if not _ci_follow_up_actionable_gate():
+        if not ci_follow_up_actionable_gate():
+            # Legacy replay path: any fingerprint change fires.
             self._pr_fingerprint = pr_context.fingerprint
             return CIFollowUpDecision.FIRE
-        if is_pr_actionable(pr_context.ci_status, pr_context.changes_requested):
-            workflow.logger.info(
-                "PR context has changed and is actionable, running CI follow-up",
-                extra={
-                    "run_id": self.context.run_id,
-                    "pr_url": pr_context.pr_url,
-                    "pr_state": pr_context.pr_state,
-                    "ci_status": pr_context.ci_status,
-                    "changes_requested": pr_context.changes_requested,
-                },
-            )
-            self._pr_fingerprint = pr_context.fingerprint
-            return CIFollowUpDecision.FIRE
-        if pr_context.ci_status == "pending":
-            # CI hasn't settled — keep the old fingerprint so the settled state
-            # (which may be failing) is still seen as a change on the next tick.
-            workflow.logger.info(
-                "PR CI is pending, deferring CI follow-up decision",
-                extra={
-                    "run_id": self.context.run_id,
-                    "pr_url": pr_context.pr_url,
-                },
-            )
-            return CIFollowUpDecision.SKIP
-        # Changed but green (or check-less): nothing for the agent to do. Record the
-        # fingerprint so this state doesn't re-trigger the comparison every tick.
+        fire, fingerprint_to_store = decide_ci_follow_up(pr_context)
+        if fingerprint_to_store is not None:
+            self._pr_fingerprint = fingerprint_to_store
         workflow.logger.info(
-            "PR context has changed but is not actionable, skipping CI follow-up",
+            "PR context has changed, deciding CI follow-up",
             extra={
                 "run_id": self.context.run_id,
                 "pr_url": pr_context.pr_url,
                 "pr_state": pr_context.pr_state,
                 "ci_status": pr_context.ci_status,
+                "changes_requested": pr_context.changes_requested,
+                "fire": fire,
             },
         )
-        self._pr_fingerprint = pr_context.fingerprint
-        return CIFollowUpDecision.SKIP
+        return CIFollowUpDecision.FIRE if fire else CIFollowUpDecision.SKIP
 
     async def _dispatch_ci_follow_up(self) -> None:
         self._ci_repetitions += 1

--- a/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
+++ b/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
@@ -327,6 +327,51 @@ class TestShouldRunCIFollowUp:
         assert decision is expected_decision
         assert workflow._pr_fingerprint == expected_fingerprint
 
+    @pytest.mark.parametrize(
+        "prev_threads,new_threads,fingerprint,expected_decision",
+        [
+            # New review threads are feedback — fire even when the fingerprint
+            # hasn't moved.
+            (0, 2, "fp-0", CIFollowUpDecision.FIRE),
+            # Resolving threads is not feedback.
+            (2, 1, "fp-0", CIFollowUpDecision.SKIP),
+            # A green change with a stable thread count stays quiet.
+            (2, 2, "fp-1", CIFollowUpDecision.SKIP),
+            # A green change accompanied by new feedback fires.
+            (0, 3, "fp-1", CIFollowUpDecision.FIRE),
+        ],
+    )
+    async def test_new_review_threads_fire_follow_up(
+        self,
+        monkeypatch,
+        silent_workflow_logger,
+        prev_threads,
+        new_threads,
+        fingerprint,
+        expected_decision,
+    ):
+        workflow = TaskManagementWorkflow()
+        workflow._context = _build_context()
+        workflow._pr_fingerprint = "fp-0"
+        workflow._pr_unresolved_threads = prev_threads
+
+        async def fake_execute_activity(activity_fn, *args, **kwargs):
+            return GetPrContextOutput(
+                pr_url="https://github.com/org/repo/pull/1",
+                pr_state="open",
+                fingerprint=fingerprint,
+                ci_status="passing",
+                unresolved_threads=new_threads,
+            )
+
+        monkeypatch.setattr(task_management_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+        decision = await workflow._should_run_ci_follow_up()
+
+        assert decision is expected_decision
+        # The count must track last-seen (not max) so post-resolve feedback re-fires.
+        assert workflow._pr_unresolved_threads == new_threads
+
     async def test_returns_skip_when_fingerprint_unchanged(self, monkeypatch, silent_workflow_logger):
         workflow = TaskManagementWorkflow()
         workflow._context = _build_context()

--- a/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
+++ b/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
@@ -282,24 +282,49 @@ class TestShouldRunCIFollowUp:
         decision = await workflow._should_run_ci_follow_up()
         assert decision is CIFollowUpDecision.SKIP
 
-    async def test_returns_fire_when_fingerprint_changes_and_persists_it(self, monkeypatch, silent_workflow_logger):
+    @pytest.mark.parametrize(
+        "ci_status,changes_requested,expected_decision,expected_fingerprint",
+        [
+            # Actionable changes fire and persist the fingerprint.
+            ("failing", False, CIFollowUpDecision.FIRE, "fp-1"),
+            ("passing", True, CIFollowUpDecision.FIRE, "fp-1"),
+            # Green or check-less changes persist the fingerprint but stay quiet —
+            # waking the agent here produced "nothing to report" Slack spam.
+            ("passing", False, CIFollowUpDecision.SKIP, "fp-1"),
+            ("none", False, CIFollowUpDecision.SKIP, "fp-1"),
+            # Pending keeps the old fingerprint so the settled state (which may be
+            # failing) still registers as a change on the next tick.
+            ("pending", False, CIFollowUpDecision.SKIP, "fp-0"),
+        ],
+    )
+    async def test_fingerprint_change_fires_only_when_actionable(
+        self,
+        monkeypatch,
+        silent_workflow_logger,
+        ci_status,
+        changes_requested,
+        expected_decision,
+        expected_fingerprint,
+    ):
         workflow = TaskManagementWorkflow()
         workflow._context = _build_context()
+        workflow._pr_fingerprint = "fp-0"
 
         async def fake_execute_activity(activity_fn, *args, **kwargs):
             return GetPrContextOutput(
                 pr_url="https://github.com/org/repo/pull/1",
                 pr_state="open",
                 fingerprint="fp-1",
+                ci_status=ci_status,
+                changes_requested=changes_requested,
             )
 
         monkeypatch.setattr(task_management_workflow_module.workflow, "execute_activity", fake_execute_activity)
 
         decision = await workflow._should_run_ci_follow_up()
 
-        assert decision is CIFollowUpDecision.FIRE
-        # Fingerprint must persist so the next tick with the same fp returns SKIP.
-        assert workflow._pr_fingerprint == "fp-1"
+        assert decision is expected_decision
+        assert workflow._pr_fingerprint == expected_fingerprint
 
     async def test_returns_skip_when_fingerprint_unchanged(self, monkeypatch, silent_workflow_logger):
         workflow = TaskManagementWorkflow()

--- a/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
+++ b/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
@@ -285,16 +285,17 @@ class TestShouldRunCIFollowUp:
     @pytest.mark.parametrize(
         "ci_status,changes_requested,expected_decision,expected_fingerprint",
         [
-            # Actionable changes fire and persist the fingerprint.
+            # Actionable changes fire.
             ("failing", False, CIFollowUpDecision.FIRE, "fp-1"),
             ("passing", True, CIFollowUpDecision.FIRE, "fp-1"),
-            # Green or check-less changes persist the fingerprint but stay quiet —
+            # Non-actionable changes persist the fingerprint but stay quiet —
             # waking the agent here produced "nothing to report" Slack spam.
+            # Pending needs no deferral: the settled state hashes differently
+            # (CI status and head SHA are both in the fingerprint), so it still
+            # registers as a change on a later tick.
             ("passing", False, CIFollowUpDecision.SKIP, "fp-1"),
             ("none", False, CIFollowUpDecision.SKIP, "fp-1"),
-            # Pending keeps the old fingerprint so the settled state (which may be
-            # failing) still registers as a change on the next tick.
-            ("pending", False, CIFollowUpDecision.SKIP, "fp-0"),
+            ("pending", False, CIFollowUpDecision.SKIP, "fp-1"),
         ],
     )
     async def test_fingerprint_change_fires_only_when_actionable(

--- a/products/tasks/backend/temporal/task_management/workflow.py
+++ b/products/tasks/backend/temporal/task_management/workflow.py
@@ -37,8 +37,8 @@ from products.tasks.backend.temporal.execute_sandbox.workflow import (
 from products.tasks.backend.temporal.patches import ci_follow_up_actionable_gate
 from products.tasks.backend.temporal.process_task.activities.get_pr_context import (
     GetPrContextInput,
-    decide_ci_follow_up,
     get_pr_context,
+    is_pr_actionable,
 )
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
@@ -927,13 +927,11 @@ class TaskManagementWorkflow(PostHogWorkflow):
                 pr_url=pr_context.pr_url,
             )
             return CIFollowUpDecision.SKIP
+        self._pr_fingerprint = pr_context.fingerprint
         if not ci_follow_up_actionable_gate():
             # Legacy replay path: any fingerprint change fires.
-            self._pr_fingerprint = pr_context.fingerprint
             return CIFollowUpDecision.FIRE
-        fire, fingerprint_to_store = decide_ci_follow_up(pr_context)
-        if fingerprint_to_store is not None:
-            self._pr_fingerprint = fingerprint_to_store
+        fire = is_pr_actionable(pr_context)
         workflow.logger.info(
             "task_management_ci_decision",
             run_id=self._run_id,

--- a/products/tasks/backend/temporal/task_management/workflow.py
+++ b/products/tasks/backend/temporal/task_management/workflow.py
@@ -34,7 +34,11 @@ from products.tasks.backend.temporal.execute_sandbox.workflow import (
     ChildCompletionPayload,
     ExecuteSandboxInput,
 )
-from products.tasks.backend.temporal.process_task.activities.get_pr_context import GetPrContextInput, get_pr_context
+from products.tasks.backend.temporal.process_task.activities.get_pr_context import (
+    GetPrContextInput,
+    get_pr_context,
+    is_pr_actionable,
+)
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
@@ -142,6 +146,20 @@ class CIFollowUpDecision(StrEnum):
     FIRE = "fire"
     SKIP = "skip"
     NO_PR = "no_pr"
+
+
+# Gates the actionable-state check in the CI follow-up decision: a fingerprint
+# change alone no longer wakes the agent — only failing CI or a changes-requested
+# review does. Pre-rollout histories dispatched a follow-up on any change, so the
+# marker keeps their replays deterministic. Standard two-step Temporal patch
+# lifecycle: deprecate_patch once pre-rollout histories drain, then delete.
+_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE = "tasks-ci-follow-up-actionable-gate"
+
+
+def _ci_follow_up_actionable_gate() -> bool:
+    if not workflow.in_workflow():
+        return True
+    return workflow.patched(_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE)
 
 
 @temporalio.workflow.defn(name="task-management")
@@ -915,19 +933,44 @@ class TaskManagementWorkflow(PostHogWorkflow):
                 pr_url=pr_context.pr_url,
             )
             return CIFollowUpDecision.SKIP
-        if self._pr_fingerprint != pr_context.fingerprint:
+        if self._pr_fingerprint == pr_context.fingerprint:
+            workflow.logger.info(
+                "task_management_ci_skipped_pr_unchanged",
+                run_id=self._run_id,
+                pr_url=pr_context.pr_url,
+            )
+            return CIFollowUpDecision.SKIP
+        if not _ci_follow_up_actionable_gate():
+            self._pr_fingerprint = pr_context.fingerprint
+            return CIFollowUpDecision.FIRE
+        if is_pr_actionable(pr_context.ci_status, pr_context.changes_requested):
             self._pr_fingerprint = pr_context.fingerprint
             workflow.logger.info(
                 "task_management_ci_fire",
                 run_id=self._run_id,
                 pr_url=pr_context.pr_url,
+                ci_status=pr_context.ci_status,
+                changes_requested=pr_context.changes_requested,
                 repetitions=self._ci_repetitions,
             )
             return CIFollowUpDecision.FIRE
+        if pr_context.ci_status == "pending":
+            # CI hasn't settled — keep the old fingerprint so the settled state
+            # (which may be failing) is still seen as a change on the next tick.
+            workflow.logger.info(
+                "task_management_ci_skipped_pr_pending",
+                run_id=self._run_id,
+                pr_url=pr_context.pr_url,
+            )
+            return CIFollowUpDecision.SKIP
+        # Changed but green (or check-less): nothing for the agent to do. Record the
+        # fingerprint so this state doesn't re-trigger the comparison every tick.
+        self._pr_fingerprint = pr_context.fingerprint
         workflow.logger.info(
-            "task_management_ci_skipped_pr_unchanged",
+            "task_management_ci_skipped_pr_not_actionable",
             run_id=self._run_id,
             pr_url=pr_context.pr_url,
+            ci_status=pr_context.ci_status,
         )
         return CIFollowUpDecision.SKIP
 

--- a/products/tasks/backend/temporal/task_management/workflow.py
+++ b/products/tasks/backend/temporal/task_management/workflow.py
@@ -34,10 +34,11 @@ from products.tasks.backend.temporal.execute_sandbox.workflow import (
     ChildCompletionPayload,
     ExecuteSandboxInput,
 )
+from products.tasks.backend.temporal.patches import ci_follow_up_actionable_gate
 from products.tasks.backend.temporal.process_task.activities.get_pr_context import (
     GetPrContextInput,
+    decide_ci_follow_up,
     get_pr_context,
-    is_pr_actionable,
 )
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
@@ -146,20 +147,6 @@ class CIFollowUpDecision(StrEnum):
     FIRE = "fire"
     SKIP = "skip"
     NO_PR = "no_pr"
-
-
-# Gates the actionable-state check in the CI follow-up decision: a fingerprint
-# change alone no longer wakes the agent — only failing CI or a changes-requested
-# review does. Pre-rollout histories dispatched a follow-up on any change, so the
-# marker keeps their replays deterministic. Standard two-step Temporal patch
-# lifecycle: deprecate_patch once pre-rollout histories drain, then delete.
-_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE = "tasks-ci-follow-up-actionable-gate"
-
-
-def _ci_follow_up_actionable_gate() -> bool:
-    if not workflow.in_workflow():
-        return True
-    return workflow.patched(_PATCH_ID_CI_FOLLOW_UP_ACTIONABLE_GATE)
 
 
 @temporalio.workflow.defn(name="task-management")
@@ -940,39 +927,23 @@ class TaskManagementWorkflow(PostHogWorkflow):
                 pr_url=pr_context.pr_url,
             )
             return CIFollowUpDecision.SKIP
-        if not _ci_follow_up_actionable_gate():
+        if not ci_follow_up_actionable_gate():
+            # Legacy replay path: any fingerprint change fires.
             self._pr_fingerprint = pr_context.fingerprint
             return CIFollowUpDecision.FIRE
-        if is_pr_actionable(pr_context.ci_status, pr_context.changes_requested):
-            self._pr_fingerprint = pr_context.fingerprint
-            workflow.logger.info(
-                "task_management_ci_fire",
-                run_id=self._run_id,
-                pr_url=pr_context.pr_url,
-                ci_status=pr_context.ci_status,
-                changes_requested=pr_context.changes_requested,
-                repetitions=self._ci_repetitions,
-            )
-            return CIFollowUpDecision.FIRE
-        if pr_context.ci_status == "pending":
-            # CI hasn't settled — keep the old fingerprint so the settled state
-            # (which may be failing) is still seen as a change on the next tick.
-            workflow.logger.info(
-                "task_management_ci_skipped_pr_pending",
-                run_id=self._run_id,
-                pr_url=pr_context.pr_url,
-            )
-            return CIFollowUpDecision.SKIP
-        # Changed but green (or check-less): nothing for the agent to do. Record the
-        # fingerprint so this state doesn't re-trigger the comparison every tick.
-        self._pr_fingerprint = pr_context.fingerprint
+        fire, fingerprint_to_store = decide_ci_follow_up(pr_context)
+        if fingerprint_to_store is not None:
+            self._pr_fingerprint = fingerprint_to_store
         workflow.logger.info(
-            "task_management_ci_skipped_pr_not_actionable",
+            "task_management_ci_decision",
             run_id=self._run_id,
             pr_url=pr_context.pr_url,
             ci_status=pr_context.ci_status,
+            changes_requested=pr_context.changes_requested,
+            fire=fire,
+            repetitions=self._ci_repetitions,
         )
-        return CIFollowUpDecision.SKIP
+        return CIFollowUpDecision.FIRE if fire else CIFollowUpDecision.SKIP
 
     async def _dispatch_ci_follow_up(self) -> None:
         self._ci_repetitions += 1

--- a/products/tasks/backend/temporal/task_management/workflow.py
+++ b/products/tasks/backend/temporal/task_management/workflow.py
@@ -204,6 +204,9 @@ class TaskManagementWorkflow(PostHogWorkflow):
         self._last_active_time: Optional[datetime] = None
         self._ci_repetitions: int = 0
         self._pr_fingerprint: Optional[str] = None
+        # Last observed unresolved review-thread count. Starting at 0 means
+        # feedback posted before the first poll still reads as new.
+        self._pr_unresolved_threads: int = 0
 
     # ------------------------------------------------------------------
     # Input parsing
@@ -645,6 +648,7 @@ class TaskManagementWorkflow(PostHogWorkflow):
         self._sandbox_alive = False
         self._ci_repetitions = 0
         self._pr_fingerprint = None
+        self._pr_unresolved_threads = 0
         self._heartbeat_received = False
         self._last_active_time = None
 
@@ -920,7 +924,19 @@ class TaskManagementWorkflow(PostHogWorkflow):
                 pr_url=pr_context.pr_url,
             )
             return CIFollowUpDecision.SKIP
-        if self._pr_fingerprint == pr_context.fingerprint:
+        fingerprint_changed = self._pr_fingerprint != pr_context.fingerprint
+        if not ci_follow_up_actionable_gate():
+            # Legacy replay path: any fingerprint change fires; feedback is not consulted.
+            if not fingerprint_changed:
+                return CIFollowUpDecision.SKIP
+            self._pr_fingerprint = pr_context.fingerprint
+            return CIFollowUpDecision.FIRE
+        # New unresolved review threads are feedback for the agent, and comparing
+        # against the last-seen count means its own thread replies (which never
+        # resolve anything) can't re-trigger it.
+        new_feedback = pr_context.unresolved_threads > self._pr_unresolved_threads
+        self._pr_unresolved_threads = pr_context.unresolved_threads
+        if not fingerprint_changed and not new_feedback:
             workflow.logger.info(
                 "task_management_ci_skipped_pr_unchanged",
                 run_id=self._run_id,
@@ -928,16 +944,15 @@ class TaskManagementWorkflow(PostHogWorkflow):
             )
             return CIFollowUpDecision.SKIP
         self._pr_fingerprint = pr_context.fingerprint
-        if not ci_follow_up_actionable_gate():
-            # Legacy replay path: any fingerprint change fires.
-            return CIFollowUpDecision.FIRE
-        fire = is_pr_actionable(pr_context)
+        fire = (fingerprint_changed and is_pr_actionable(pr_context)) or new_feedback
         workflow.logger.info(
             "task_management_ci_decision",
             run_id=self._run_id,
             pr_url=pr_context.pr_url,
             ci_status=pr_context.ci_status,
             changes_requested=pr_context.changes_requested,
+            unresolved_threads=pr_context.unresolved_threads,
+            new_feedback=new_feedback,
             fire=fire,
             repetitions=self._ci_repetitions,
         )


### PR DESCRIPTION
## Problem

The PR babysitting loop (CI follow-up) wakes the agent on any PR fingerprint change - including the first poll after the PR opens and pending-to-passing transitions. Each pointless wake-up posts a full "everything is green, nothing to fix" summary into the originating Slack thread and burns one of the 3 CI repetitions. Meanwhile review comments were never a wake-up signal at all, so bot findings and human inline feedback were only addressed if a CI transition happened to coincide. Context: [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1784233097090179).

## Changes

- Dispatch a CI follow-up only when the changed PR state is actionable: failing CI or a changes-requested review. Green, pending, or check-less changes record the fingerprint silently.
- Key the fingerprint on the head SHA too (found by Greptile): without it, a new commit failing the same way as its predecessor hashed identically and the follow-up never re-fired after the agent's own failed fix attempt.
- Wake the agent when new unresolved review threads appear (suggested by Georgiy): the loop tracks the last-seen thread count and fires on increase, so resolving threads or the agent's own replies can't re-trigger it.
- Applied to both `process_task` and `task_management` via a shared `is_pr_actionable` predicate, gated with `workflow.patched` for replay determinism (gate lives in a shared `temporal/patches.py`).

## How did you test this code?

Parameterized decision tests for both workflow copies (fire on failing/changes-requested/new feedback, quiet skip on green/pending/thread-resolve) plus a fingerprint case pinning the repeated-failure scenario - catches a regression back to fire-on-any-change, SHA-less hashing, or comment-blind polling, which no existing test did. Ran the affected suites locally: 83 passed. The Temporal time-skipping e2e tests run in CI only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, /writing-tests invoked. Earlier revisions tried a NO_UPDATES reply sentinel matched at the Slack relay (removed as fragile prose matching) and a pending-defer that kept the old fingerprint while CI ran (removed - it caused the repeated-failure suppression Greptile flagged; the head SHA in the fingerprint makes it unnecessary). A determinism review against the temporalio SDK source confirmed the patch gate replays pre-rollout histories safely; the review-thread signal rides the same gate.