### PR TITLE
fix(bigquery): retry transient max-queued-jobs quota at job creation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -189,16 +189,41 @@ def _is_transient_rate_quota_exceeded(exc: Exception) -> bool:
     return "per second" in message and "Custom quota exceeded" not in message
 
 
-def _query_job_should_retry(exc: Exception) -> bool:
+def _is_transient_queued_jobs_quota_exceeded(exc: Exception) -> bool:
+    """True for BigQuery's "maximum number of queued jobs" quota, which is transient.
+
+    When a project already has the maximum number of query jobs queued, BigQuery rejects a fresh
+    `jobs.insert` with a `Forbidden` (403, reason `quotaExceeded`, location `max_queued_jobs`) whose
+    message reads "Quota exceeded: ... exceeded quota for max number of jobs that can be queued per
+    project.". The queue drains as running jobs finish, so resubmitting a moment later succeeds — but
+    the library's own retry predicates only cover `rateLimitExceeded` / `backendError` /
+    `internalError`, not `quotaExceeded`, so the insert isn't retried and the whole sync crashes.
+    Unlike the per-second rate quota this is rejected at job creation rather than
+    `jobs.getQueryResults`, so the `retry` on `client.query()` — not just its `job_retry` — has to
+    cover it. Distinct from the administrator-set "Custom quota exceeded" daily cost cap (kept
+    non-retryable in `get_non_retryable_errors`). Matched on the stable queue-quota wording rather
+    than the volatile project/job id.
+    """
+    return "max number of jobs that can be queued" in str(exc)
+
+
+def _query_should_retry(exc: Exception) -> bool:
     # Defer to the library's own default predicate for the reasons it already covers; importing it
     # directly (rather than reading the private `Retry._predicate`) means a library rename fails
     # loudly at import instead of silently dropping that default coverage.
     return (
-        _BIGQUERY_JOB_RETRY_RECOMMENDED in str(exc) or _is_transient_rate_quota_exceeded(exc) or _job_should_retry(exc)
+        _BIGQUERY_JOB_RETRY_RECOMMENDED in str(exc)
+        or _is_transient_rate_quota_exceeded(exc)
+        or _is_transient_queued_jobs_quota_exceeded(exc)
+        or _job_should_retry(exc)
     )
 
 
-BIGQUERY_QUERY_JOB_RETRY = DEFAULT_JOB_RETRY.with_predicate(_query_job_should_retry)
+# `job_retry` recovers a failed query *job* (a retryable reason surfaced from `jobs.getQueryResults`);
+# `retry` recovers the job-*creation* API call (`jobs.insert`). BigQuery's transient queued-jobs quota
+# is rejected at insert, which `job_retry` never wraps, so the create path needs its own retry.
+BIGQUERY_QUERY_JOB_RETRY = DEFAULT_JOB_RETRY.with_predicate(_query_should_retry)
+BIGQUERY_QUERY_CREATE_RETRY = bigquery.DEFAULT_RETRY.with_predicate(_query_should_retry)
 
 
 # The Storage Read API can drop a ReadRows stream mid-flight with a transient gRPC INTERNAL error
@@ -624,7 +649,7 @@ def _get_primary_keys_for_table(table: bigquery.Table, client: bigquery.Client) 
     """
 
     job_config = QueryJobConfig()
-    job = client.query(query, job_config=job_config, project=table.project)
+    job = client.query(query, job_config=job_config, project=table.project, retry=BIGQUERY_QUERY_CREATE_RETRY)
 
     primary_keys = []
     for row in job.result(job_retry=BIGQUERY_QUERY_JOB_RETRY):
@@ -997,7 +1022,7 @@ def _run_destination_query_with_job_retry(
     )
 
     def _run() -> None:
-        job = client.query(query, job_config=job_config, project=project)
+        job = client.query(query, job_config=job_config, project=project, retry=BIGQUERY_QUERY_CREATE_RETRY)
         job.result(job_retry=BIGQUERY_QUERY_JOB_RETRY)
 
     _with_job_not_found_retry(_run)
@@ -1020,7 +1045,7 @@ def _query_result_with_job_retry(
     """
 
     def _run() -> RowIterator:
-        job = client.query(query, job_config=job_config, project=project)
+        job = client.query(query, job_config=job_config, project=project, retry=BIGQUERY_QUERY_CREATE_RETRY)
         return job.result(page_size=page_size, job_retry=BIGQUERY_QUERY_JOB_RETRY)
 
     return _with_job_not_found_retry(_run)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -24,6 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     BIGQUERY_INVALID_IDENTIFIER_ERROR,
     BIGQUERY_INVALID_KEY_FILE_ERROR,
     BIGQUERY_MISSING_KEY_FILE_FIELDS_ERROR,
+    BIGQUERY_QUERY_CREATE_RETRY,
     BIGQUERY_QUERY_JOB_RETRY,
     BIGQUERY_READ_ROWS_RETRY,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
@@ -1344,6 +1345,14 @@ def test_has_duplicate_primary_keys_captures_unexpected_errors():
             "exceeded quota for tabledata.list bytes per second per project. For more information, "
             "see https://cloud.google.com/bigquery/docs/troubleshoot-quotas"
         ),
+        # The queued-jobs quota (reason `quotaExceeded`, location `max_queued_jobs`) is transient —
+        # the queue drains as running jobs finish — so it must be retried rather than crashing the
+        # sync. Volatile ids redacted.
+        Forbidden(
+            "Quota exceeded: Your project_and_region exceeded quota for max number of jobs that can "
+            "be queued per project. For more information, see "
+            "https://cloud.google.com/bigquery/docs/troubleshoot-quotas"
+        ),
     ],
 )
 def test_bigquery_query_job_retry_retries_transient_job_errors(exc):
@@ -1366,6 +1375,22 @@ def test_bigquery_query_job_retry_retries_transient_job_errors(exc):
 )
 def test_bigquery_query_job_retry_does_not_retry_deterministic_errors(exc):
     assert BIGQUERY_QUERY_JOB_RETRY._predicate(exc) is False
+
+
+def test_bigquery_query_create_retry_retries_queued_jobs_quota():
+    """The queued-jobs quota is rejected at `jobs.insert`, which `job_retry` never wraps — only the
+    `retry` on `client.query()` can wait it out — so the create retry must cover it while still
+    leaving the administrator-set daily cost cap to surface non-retryably."""
+    queued_jobs = Forbidden(
+        "Quota exceeded: Your project_and_region exceeded quota for max number of jobs that can be "
+        "queued per project. For more information, see https://cloud.google.com/bigquery/docs/troubleshoot-quotas"
+    )
+    custom_quota = Forbidden(
+        "Custom quota exceeded: Your usage exceeded the custom quota for QueryUsagePerDay, "
+        "which is set by your administrator.; reason: quotaExceeded"
+    )
+    assert BIGQUERY_QUERY_CREATE_RETRY._predicate(queued_jobs) is True
+    assert BIGQUERY_QUERY_CREATE_RETRY._predicate(custom_quota) is False
 
 
 @pytest.mark.parametrize(
@@ -1408,6 +1433,7 @@ def test_bigquery_get_primary_keys_for_table_passes_job_retry():
     _get_primary_keys_for_table(table, client)
 
     assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
+    assert client.query.call_args.kwargs["retry"] is BIGQUERY_QUERY_CREATE_RETRY
 
 
 def test_run_destination_query_passes_job_retry():
@@ -1421,6 +1447,7 @@ def test_run_destination_query_passes_job_retry():
     )
 
     assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
+    assert client.query.call_args.kwargs["retry"] is BIGQUERY_QUERY_CREATE_RETRY
 
 
 def test_query_result_passes_job_retry():
@@ -1431,6 +1458,7 @@ def test_query_result_passes_job_retry():
     _query_result_with_job_retry(client, "SELECT COUNT(*)", job_config=mock.MagicMock(), project="prj")
 
     assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
+    assert client.query.call_args.kwargs["retry"] is BIGQUERY_QUERY_CREATE_RETRY
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

BigQuery imports were crashing on a transient quota. When a customer's project already has the maximum number of query jobs queued, BigQuery rejects a fresh `jobs.insert` with a `Forbidden` (403, reason `quotaExceeded`, location `max_queued_jobs`):

> Quota exceeded: Your project_and_region exceeded quota for max number of jobs that can be queued per project.

This surfaced from `_get_primary_keys_for_table` in the BigQuery source and failed the whole sync. It is a queue-depth limit that drains on its own as running jobs finish, so it is transient and should be retried, not treated as a hard failure. But the google-cloud-bigquery client's default retry predicates only cover `rateLimitExceeded` / `backendError` / `internalError` — not `quotaExceeded` — so the insert wasn't retried.

Observed via error tracking: [issue 019f6f4d-f92d-75e2-9cdb-8e44906ffa92](https://us.posthog.com/project/2/error_tracking/019f6f4d-f92d-75e2-9cdb-8e44906ffa92).

## Changes

The existing per-second rate-quota handling only sat on `job_retry`, which BigQuery applies when polling `jobs.getQueryResults`. The queued-jobs quota is rejected earlier, at job creation (`jobs.insert`), which `job_retry` never wraps — only the `retry` on `client.query()` can wait it out.

- Added `_is_transient_queued_jobs_quota_exceeded`, matching the stable "max number of jobs that can be queued" wording (no volatile project/job ids).
- Folded it into the shared query-retry predicate, and added a create-time retry object `BIGQUERY_QUERY_CREATE_RETRY` wired into the `client.query()` calls in `_get_primary_keys_for_table`, `_run_destination_query_with_job_retry`, and `_query_result_with_job_retry`.

The administrator-set "Custom quota exceeded" daily cost cap stays non-retryable — it resets only on Google's daily schedule, so retrying it in place would just hammer the endpoint.

> [!NOTE]
> This keeps the error retryable rather than adding it to `NonRetryableErrors`. The queued-jobs quota is a transient concurrency limit, not a customer config or credential problem.

## How did you test this code?

Automated tests in `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py` (145 pass locally):

- Extended the retry-predicate parameterization so the queued-jobs `Forbidden` is recognized as retryable — catches a regression that drops the new predicate branch and lets the transient quota crash the sync again.
- Added `test_bigquery_query_create_retry_retries_queued_jobs_quota` asserting the create-time retry retries the queued-jobs quota but still leaves the daily cost cap non-retryable — guards the insert path the observed error hit, and the boundary against over-widening.
- Extended the three query-wiring tests to assert `client.query()` receives `retry=BIGQUERY_QUERY_CREATE_RETRY` — if a call site drops the kwarg, the insert-time quota falls back to the default retry that doesn't cover it, silently defeating the fix.

I (Claude) did not run a live BigQuery sync; verification is the automated tests above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the BigQuery data-warehouse source. I (Claude) pulled the issue's stack trace and representative event, confirmed the failure originates in the source's own code (`_get_primary_keys_for_table` → `client.query()` / `job.result()`), and read the google-cloud-bigquery internals (`_job_helpers.query_jobs_insert`, `retry._should_retry`) to confirm the initial `jobs.insert` is governed by `retry`, not `job_retry` — so the fix had to add a create-time retry, mirroring the existing per-second rate-quota precedent that only covered the result path. Considered adding the error to `NonRetryableErrors` but rejected it: this is a transient queue-depth limit, not a config/credential error. Invoked `/writing-tests` before touching the test file.


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
