### PR TITLE
refactor(data-warehouse): exception-secret redaction + migrate flowlu, fly_io, fullstory, giphy, gitbook, gocardless (batch 18)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -10,6 +10,7 @@ from requests import Request, Response, Session
 from requests.auth import AuthBase
 from requests.exceptions import (
     ChunkedEncodingError,
+    HTTPError,
     JSONDecodeError as RequestsJSONDecodeError,
 )
 from tenacity import RetryCallState, retry, retry_if_exception_type
@@ -129,18 +130,26 @@ class RESTClient:
             if base_host:
                 hosts.add(base_host.lower())
             self._allowed_hosts = hosts
+        # The auth's credential values, kept for value-based redaction. They feed both the
+        # tracked session's log redaction AND ``_redact`` below, which scrubs them from raised
+        # exception messages — an API that carries its key in a query param would otherwise leak
+        # it via the request URL embedded in ``raise_for_status`` / ``HTTP {status} for {url}``.
+        self._redact_values = tuple(value for value in auth_secret_values(auth) if value)
         # Default to the tracked session so every source built on top of
         # `RESTClient` participates in HTTP logging, metrics, and sample
         # capture. Callers can pass a pre-built `Session` for tests or
         # specialized auth (it should still be a tracked one in prod).
-        # The auth's credential values are registered for value-based redaction
-        # so a key injected into a query param/custom header can't leak into logs.
-        self.session = session or make_tracked_session(redact_values=auth_secret_values(auth))
+        self.session = session or make_tracked_session(redact_values=self._redact_values)
         if self.headers:
             self.session.headers.update(self.headers)
 
     def _join_url(self, path: str) -> str:
         return resolve_request_url(self.base_url, path)
+
+    def _redact(self, text: str) -> str:
+        for secret in self._redact_values:
+            text = text.replace(secret, "***")
+        return text
 
     def _check_allowed_host(self, url: Optional[str]) -> None:
         if self._allowed_hosts is None or not url:
@@ -148,9 +157,11 @@ class RESTClient:
         host = urlsplit(url).hostname
         if host is None or host.lower() not in self._allowed_hosts:
             raise ValueError(
-                f"Refusing to send request to disallowed host {host!r} (url {url!r}); "
-                f"allowed hosts: {sorted(self._allowed_hosts)}. A pagination or resume URL "
-                "pointing off the expected API host is rejected to prevent credential exfiltration."
+                self._redact(
+                    f"Refusing to send request to disallowed host {host!r} (url {url!r}); "
+                    f"allowed hosts: {sorted(self._allowed_hosts)}. A pagination or resume URL "
+                    "pointing off the expected API host is rejected to prevent credential exfiltration."
+                )
             )
 
     def paginate(
@@ -224,20 +235,22 @@ class RESTClient:
         try:
             response = self.session.send(prepared, allow_redirects=self._allow_redirects)
         except ChunkedEncodingError as e:
-            raise RESTClientRetryableError(f"Connection broken while reading response: {e}") from e
+            raise RESTClientRetryableError(self._redact(f"Connection broken while reading response: {e}")) from e
 
         # With redirects disabled, a 3xx is not an error to `raise_for_status` and would fall
         # through to JSON parsing; reject it explicitly so a redirect can't smuggle the request
         # (and credentials) to another origin.
         if not self._allow_redirects and response.is_redirect:
             raise ValueError(
-                f"Unexpected redirect ({response.status_code}) to "
-                f"{response.headers.get('Location')!r} from {prepared.url}; refusing to follow."
+                self._redact(
+                    f"Unexpected redirect ({response.status_code}) to "
+                    f"{response.headers.get('Location')!r} from {prepared.url}; refusing to follow."
+                )
             )
 
         if response.status_code == 429 or response.status_code >= 500:
             raise RESTClientRetryableError(
-                f"HTTP {response.status_code} for {response.url}",
+                self._redact(f"HTTP {response.status_code} for {response.url}"),
                 retry_after=_parse_retry_after(response),
             )
 
@@ -246,7 +259,12 @@ class RESTClient:
             for hook in response_hooks:
                 hook(response, request=request)
         else:
-            response.raise_for_status()
+            # Redact any secret the URL carries (e.g. an api_key query param) out of the raised
+            # HTTPError message before it propagates into a user-visible ``latest_error``.
+            try:
+                response.raise_for_status()
+            except HTTPError as e:
+                raise HTTPError(self._redact(str(e)), response=e.response, request=e.request) from None
 
         # Parse inside the retry so a truncated/partial body is reissued like a 429/5xx
         # instead of bubbling up uncaught and failing the import.
@@ -260,7 +278,7 @@ class RESTClient:
             # read, which stays retryable.
             if not response.content or not response.content.strip():
                 return response, None
-            raise RESTClientRetryableError(f"Malformed JSON response from {response.url}: {e}") from e
+            raise RESTClientRetryableError(self._redact(f"Malformed JSON response from {response.url}: {e}")) from e
 
         return response, body
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_exception_redaction.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_exception_redaction.py
@@ -1,0 +1,88 @@
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client"
+SECRET = "sk_live_super_secret_key"
+
+
+def _make_response(status_code: int, reason: str) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.reason = reason
+    # The credential rides in the query string, so it lands in the URL that raise_for_status /
+    # the retryable-error message embed — exactly the leak this feature closes.
+    resp.url = f"https://api.example.com/items?api_key={SECRET}"
+    resp._content = b'{"error": "nope"}'
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+class TestExceptionRedaction:
+    @parameterized.expand(
+        [
+            # (status_code, reason, keep_marker)
+            ("client_error_400", 400, "Bad Request", "400"),
+            ("server_error_500", 500, "Server Error", "HTTP 500"),
+        ]
+    )
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_query_param_secret_is_redacted_from_error(
+        self, _name: str, status_code: int, reason: str, keep_marker: str, MockSession
+    ) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+
+        def _prep(request: Any) -> MagicMock:
+            prepared = MagicMock()
+            prepared.url = request.url
+            return prepared
+
+        mock_session.prepare_request.side_effect = _prep
+        mock_session.send.return_value = _make_response(status_code, reason)
+
+        client = RESTClient(
+            base_url="https://api.example.com",
+            auth=APIKeyAuth(api_key=SECRET, name="api_key", location="query"),
+            max_retry_attempts=1,
+        )
+
+        with pytest.raises((Exception,)) as excinfo:
+            list(client.paginate(path="/items"))
+
+        message = str(excinfo.value)
+        assert SECRET not in message
+        assert "***" in message
+        # The status information is preserved — only the secret is scrubbed.
+        assert keep_marker in message
+
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_no_auth_leaves_message_untouched(self, MockSession) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+
+        def _prep(request: Any) -> MagicMock:
+            prepared = MagicMock()
+            prepared.url = request.url
+            return prepared
+
+        mock_session.prepare_request.side_effect = _prep
+        mock_session.send.return_value = _make_response(500, "Server Error")
+
+        client = RESTClient(base_url="https://api.example.com", max_retry_attempts=1)
+
+        with pytest.raises(RESTClientRetryableError) as excinfo:
+            list(client.paginate(path="/items"))
+
+        # Without registered secrets there is nothing to redact, so the URL is reported verbatim.
+        assert "api.example.com/items" in str(excinfo.value)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/flowlu/flowlu.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/flowlu/flowlu.py
@@ -1,27 +1,26 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.flowlu.settings import FLOWLU_ENDPOINTS
 
-REQUEST_TIMEOUT_SECONDS = 60
 # Flowlu pages are 1-indexed. List endpoints return ~50 records per page by default; a per-page
 # size param isn't reliably documented, so we only advance `page` and stop on the first empty page.
 BASE_PAGE = 1
 # Cheap list endpoint used to confirm an API key is genuine. Tasks are part of Flowlu's core
 # module set, so the endpoint exists on every account regardless of which apps are enabled.
 DEFAULT_PROBE_PATH = "/task/tasks/list"
-
-
-class FlowluRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -36,152 +35,91 @@ def base_url(subdomain: str) -> str:
     return f"https://{subdomain}.flowlu.com/api/v1/module"
 
 
-@retry(
-    retry=retry_if_exception_type((FlowluRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    api_key: str,
-    subdomain: str,
-    path: str,
-    page: int,
-    logger: FilteringBoundLogger,
-) -> list[dict[str, Any]]:
-    # Flowlu authenticates via the `api_key` query parameter (not a header); the tracked session
-    # redacts it from logged URLs via `redact_values`.
-    params: dict[str, str | int] = {"api_key": api_key, "page": page}
-    response = session.get(
-        f"{base_url(subdomain)}{path}",
-        params=params,
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise FlowluRetryableError(f"Flowlu API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        logger.error(f"Flowlu API error: status={response.status_code}, body={response.text[:500]}, path={path}")
-        # Raise manually instead of `raise_for_status()`: that embeds `response.url`, which carries the
-        # `api_key` query param, and this message reaches sync error logs viewable by users who can't see
-        # secret fields. Keep the "<status> Client Error: <reason> for url" shape that
-        # `get_non_retryable_errors()` matches on, but point it at the query-string-free URL.
-        kind = "Client Error" if response.status_code < 500 else "Server Error"
-        raise requests.HTTPError(
-            f"{response.status_code} {kind}: {response.reason} for url: {base_url(subdomain)}{path}",
-            response=response,
-        )
-
-    data = response.json()
-    # Every list endpoint wraps its payload as `{"response": {"items": [...], "total": ..., ...}}`;
-    # anything else means a malformed response, so fail loudly rather than silently advancing the
-    # cursor past lost rows.
-    if not isinstance(data, dict) or not isinstance(data.get("response"), dict):
-        raise FlowluRetryableError(f"Flowlu returned an unexpected payload for {path}: {type(data).__name__}")
-
-    items = data["response"].get("items")
-    if not isinstance(items, list):
-        raise FlowluRetryableError(f"Flowlu response for {path} is missing the 'items' list")
-
-    return items
-
-
-def get_rows(
-    api_key: str,
-    subdomain: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FlowluResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = FLOWLU_ENDPOINTS[endpoint]
-    # `redact_values` masks the API key in logged URLs and captured samples. `allow_redirects=False`
-    # stops a 30x from replaying the credentialed `api_key` query param off-host (defense-in-depth;
-    # Smokescreen already blocks internal hosts).
-    session = make_tracked_session(
-        headers={"Accept": "application/json"}, redact_values=(api_key,), allow_redirects=False
-    )
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume else BASE_PAGE
-    if resume and resume.next_page > BASE_PAGE:
-        logger.debug(f"Flowlu: resuming {endpoint} from page {page}")
-
-    while True:
-        items = _fetch_page(session, api_key, subdomain, config.path, page, logger)
-
-        # An empty `items` page is the end-of-collection signal (page-number pagination with no
-        # authoritative `has_more` flag).
-        if not items:
-            break
-
-        yield items
-
-        page += 1
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(FlowluResumeConfig(next_page=page))
-
-
 def flowlu_source(
     api_key: str,
     subdomain: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FlowluResumeConfig],
 ) -> SourceResponse:
     config = FLOWLU_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url(subdomain),
+            "headers": {"Accept": "application/json"},
+            # Flowlu authenticates via the `api_key` query param. The framework redacts its value
+            # from logged URLs AND from every raised error message (e.g. a 401 raise_for_status
+            # whose URL carries the key), so the secret never reaches a user-visible latest_error.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "api_key", "location": "query"},
+            # 1-indexed page-number pagination with no authoritative has_more flag: stop on the
+            # first empty page.
+            "paginator": PageNumberPaginator(base_page=BASE_PAGE, page_param="page", total_path=None),
+            # Defense-in-depth: a 30x must not replay the credentialed `api_key` query param off-host.
+            "allow_redirects": False,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # Every list endpoint wraps its payload as `{"response": {"items": [...]}}`.
+                    "data_selector": "response.items",
+                    # A body that doesn't match means a malformed/changed response — fail loud
+                    # rather than silently advancing the cursor past lost rows.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded, pointing at the next page to fetch; a crash re-fetches from
+        # there (merge dedupes on `id`). No save once pagination is exhausted (state is None).
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(FlowluResumeConfig(next_page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            subdomain=subdomain,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
     )
 
 
-def check_access(api_key: str, subdomain: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
+def validate_credentials(api_key: str, subdomain: str) -> tuple[bool, str | None]:
     """Probe a single list endpoint to validate the API key.
 
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
+    Returns ``(is_valid, message)``: 200 valid; 401/403 an auth failure; a connection problem or any
+    other HTTP status a non-retryable message. The api_key is redacted from logs and the probe
+    swallows exceptions, so the secret never leaks.
     """
-    session = make_tracked_session(
-        headers={"Accept": "application/json"}, redact_values=(api_key,), allow_redirects=False
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,), allow_redirects=False),
+        f"{base_url(subdomain)}{DEFAULT_PROBE_PATH}?page={BASE_PAGE}",
+        auth=APIKeyAuth(api_key=api_key, name="api_key", location="query"),
     )
-    try:
-        params: dict[str, str | int] = {"api_key": api_key, "page": BASE_PAGE}
-        response = session.get(
-            f"{base_url(subdomain)}{path}",
-            params=params,
-            timeout=15,
-        )
-    except Exception:
-        # Don't surface the exception text: `requests` transport errors can embed the prepared URL,
-        # which carries the `api_key` query param, and this message can reach editors who can't view secrets.
-        return 0, "Could not connect to Flowlu"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Flowlu returned HTTP {response.status_code}"
-
-    return 200, None
-
-
-def validate_credentials(api_key: str, subdomain: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_key, subdomain)
-    if status == 200:
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid Flowlu API key"
-    return False, message or "Could not validate Flowlu credentials"
+    if status is None:
+        return False, "Could not connect to Flowlu"
+    return False, f"Flowlu returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/flowlu/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/flowlu/source.py
@@ -20,13 +20,20 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.flowlu.flowlu import (
     FlowluResumeConfig,
     flowlu_source,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.flowlu.settings import ENDPOINTS, FLOWLU_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.flowlu.settings import (
+    ENDPOINTS,
+    FLOWLU_ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import FlowluSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -108,20 +115,9 @@ You can create an API key under **Portal Settings → API Settings** in Flowlu. 
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Every endpoint is full refresh only — Flowlu's list endpoints expose no documented
-        # server-side timestamp filter, so there is no incremental cursor to advance.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # server-side timestamp filter, so there is no incremental cursor to advance
+        # (INCREMENTAL_FIELDS is empty, so every schema comes back full-refresh only).
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: FlowluSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -148,6 +144,7 @@ You can create an API key under **Portal Settings → API Settings** in Flowlu. 
             api_key=config.api_key,
             subdomain=config.subdomain,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/flowlu/tests/test_flowlu.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/flowlu/tests/test_flowlu.py
@@ -1,159 +1,197 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import HTTPError, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.flowlu import flowlu
 from products.warehouse_sources.backend.temporal.data_imports.sources.flowlu.flowlu import (
     FlowluResumeConfig,
-    FlowluRetryableError,
-    check_access,
     flowlu_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.flowlu.settings import ENDPOINTS, FLOWLU_ENDPOINTS
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = flowlu._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the flowlu module.
+FLOWLU_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.flowlu.flowlu.make_tracked_session"
+)
+
+_REASONS = {401: "Unauthorized", 403: "Forbidden", 404: "Not Found", 500: "Internal Server Error"}
 
 
-class _FakeResumableManager:
-    def __init__(self, state: FlowluResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[FlowluResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> FlowluResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: FlowluResumeConfig) -> None:
-        self.saved.append(data)
-
-
-def _envelope(items: list[dict], total: int | None = None) -> dict[str, Any]:
+def _envelope(items: list[dict[str, Any]], total: int | None = None) -> dict[str, Any]:
     return {"response": {"items": items, "total": total if total is not None else len(items), "count": len(items)}}
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager, monkeypatch: Any, pages: dict[int, list[dict]], endpoint: str = "accounts"
-    ) -> list[dict]:
-        def fake_fetch(session: Any, api_key: str, subdomain: str, path: str, page: int, logger: Any) -> list[dict]:
-            return pages[page]
+def _response(
+    items: list[dict[str, Any]] | None = None,
+    *,
+    status: int = 200,
+    body: Any = None,
+    url: str | None = None,
+) -> Response:
+    resp = Response()
+    resp.status_code = status
+    if body is not None:
+        resp._content = json.dumps(body).encode()
+    elif items is not None:
+        resp._content = json.dumps(_envelope(items)).encode()
+    else:
+        resp._content = b"{}"
+    resp.url = url or "https://acme.flowlu.com/api/v1/module/crm/account/list?api_key=fl-key&page=1"
+    resp.reason = _REASONS.get(status)
+    return resp
 
-        monkeypatch.setattr(flowlu, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(flowlu, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="fl-key",
-            subdomain="acme",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
+def _make_manager(resume_state: FlowluResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def test_follows_pagination_until_empty_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            1: [{"id": 1}],
-            2: [{"id": 2}],
-            3: [],
-        }
-        rows = self._collect(manager, monkeypatch, pages)
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Wire a mock session; return (param_snapshots, url_snapshots) captured AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so a snapshot copy per
+    prepared request is the only way to see each page's params (see alguna's test).
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[Any] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, url_snapshots
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(manager: Any, endpoint: str = "accounts") -> Any:
+    return flowlu_source(
+        api_key="fl-key",
+        subdomain="acme",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_pagination_until_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response([{"id": 1}]), _response([{"id": 2}]), _response([])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == [{"id": 1}, {"id": 2}]
+        # 1-indexed page param advances one page per request.
+        assert [p["page"] for p in params] == [1, 2, 3]
 
-    def test_saves_next_page_after_yielding_each_batch(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            1: [{"id": 1}],
-            2: [{"id": 2}],
-            3: [],
-        }
-        self._collect(manager, monkeypatch, pages)
-        # State is saved AFTER each non-empty page is yielded, pointing at the next page to fetch.
-        assert [s.next_page for s in manager.saved] == [2, 3]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_page_after_yielding_each_batch(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}]), _response([{"id": 2}]), _response([])])
 
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(FlowluResumeConfig(next_page=2))
-        pages = {
-            # Page 1 must never be fetched on resume.
-            2: [{"id": 2}],
-            3: [],
-        }
-        rows = self._collect(manager, monkeypatch, pages)
+        manager = _make_manager()
+        _rows(_source(manager))
+
+        # State is saved AFTER each non-empty page, pointing at the next page to fetch; the empty
+        # terminating page saves nothing.
+        assert [c.args[0].next_page for c in manager.save_state.call_args_list] == [2, 3]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response([{"id": 2}]), _response([])])
+
+        manager = _make_manager(FlowluResumeConfig(next_page=2))
+        rows = _rows(_source(manager))
+
         assert rows == [{"id": 2}]
+        # Page 1 must never be fetched on resume.
+        assert params[0]["page"] == 2
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {1: []})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing_and_saves_no_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == []
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_request_targets_account_host(self, MockSession) -> None:
+        session = MockSession.return_value
+        _, urls = _wire(session, [_response([])])
+
+        _rows(_source(_make_manager(), endpoint="tasks"))
+        assert urls[0] == "https://acme.flowlu.com/api/v1/module/task/tasks/list"
 
 
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else {}
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
-        )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(FlowluRetryableError):
-            _fetch_page_unwrapped(session, "fl-key", "acme", "/crm/account/list", 1, MagicMock())
-
+class TestErrorHandling:
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "fl-key", "acme", "/crm/account/list", 1, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_http_error(self, _name: str, status: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status=status)])
 
-    def test_client_error_message_omits_api_key_and_keeps_status_prefix(self) -> None:
-        # `raise_for_status()` would embed the full request URL (with the `api_key` query param) in the
-        # error text, which surfaces in sync error logs; the raised message must drop the query string
-        # while keeping the "<status> Client Error: <reason> for url" prefix `get_non_retryable_errors`
-        # matches on.
-        response = MagicMock()
-        response.status_code = 401
-        response.ok = False
-        response.reason = "Unauthorized"
-        response.url = "https://acme.flowlu.com/api/v1/module/crm/account/list?api_key=fl-key&page=1"
-        response.json.return_value = {}
-        response.text = ""
-        session = MagicMock()
-        session.get.return_value = response
+        with pytest.raises(HTTPError):
+            _rows(_source(_make_manager()))
 
-        with pytest.raises(requests.HTTPError) as exc_info:
-            _fetch_page_unwrapped(session, "fl-key", "acme", "/crm/account/list", 1, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_message_omits_api_key_and_keeps_status_prefix(self, MockSession) -> None:
+        # The 401 raise_for_status embeds the request URL, which carries the `api_key` query param.
+        # The framework redacts the key's VALUE from the raised message while preserving the
+        # "<status> Client Error: <reason> for url" prefix that get_non_retryable_errors matches on.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response(status=401, url="https://acme.flowlu.com/api/v1/module/crm/account/list?api_key=fl-key&page=1")],
+        )
+
+        with pytest.raises(HTTPError) as exc_info:
+            _rows(_source(_make_manager()))
 
         message = str(exc_info.value)
         assert "fl-key" not in message
-        assert "api_key" not in message
         assert message.startswith("401 Client Error: Unauthorized for url")
 
-    def test_success_returns_items(self) -> None:
-        session = self._session_returning(200, _envelope([{"id": 1}]))
-        items = _fetch_page_unwrapped(session, "fl-key", "acme", "/crm/account/list", 1, MagicMock())
-        assert items == [{"id": 1}]
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    @mock.patch("time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_transient_statuses_are_retried_then_recover(self, _name: str, status: int, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        # First page 500s once, then succeeds on retry; an empty page terminates.
+        _wire(session, [_response(status=status), _response([{"id": 1}]), _response([])])
 
+        rows = _rows(_source(_make_manager()))
+
+        # A 429/5xx is transient: the client retries and recovers rather than failing loudly.
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 3
+
+
+class TestMalformedPayload:
     @parameterized.expand(
         [
             ("bare_array", [{"id": 1}]),
@@ -162,77 +200,49 @@ class TestFetchPage:
             ("missing_items", {"response": {"total": 0}}),
         ]
     )
-    def test_malformed_payload_is_retryable(self, _name: str, body: Any) -> None:
-        session = self._session_returning(200, body)
-        with pytest.raises(FlowluRetryableError):
-            _fetch_page_unwrapped(session, "fl-key", "acme", "/crm/account/list", 1, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unexpected_shape_fails_loudly(self, _name: str, body: Any, MockSession) -> None:
+        # A 200 body that doesn't match `response.items` means the shape changed — fail loud
+        # instead of silently syncing 0 rows.
+        session = MockSession.return_value
+        _wire(session, [_response(body=body)])
 
-    def test_request_targets_account_host_with_api_key_param(self) -> None:
-        session = self._session_returning(200, _envelope([]))
-        _fetch_page_unwrapped(session, "fl-key", "acme", "/task/tasks/list", 3, MagicMock())
-        args, kwargs = session.get.call_args
-        assert args[0] == "https://acme.flowlu.com/api/v1/module/task/tasks/list"
-        assert kwargs["params"] == {"api_key": "fl-key", "page": 3}
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(_make_manager()))
 
 
-class TestCheckAccess:
-    def _patch_session(self, response: Any) -> Any:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
+class TestValidateCredentials:
+    def _probe(self, response_or_exc: Any) -> Any:
+        session = mock.MagicMock()
+        if isinstance(response_or_exc, Exception):
+            session.get.side_effect = response_or_exc
         else:
-            session.get.return_value = response
-        return patch.object(flowlu, "make_tracked_session", lambda **kwargs: session)
+            session.get.return_value = response_or_exc
+        return mock.patch(FLOWLU_SESSION_PATCH, return_value=session)
 
     @parameterized.expand(
         [
-            (200, True, 200, None),
-            (401, False, 401, None),
-            (403, False, 403, None),
-            (500, False, 500, "Flowlu returned HTTP 500"),
+            ("valid", 200, (True, None)),
+            ("unauthorized", 401, (False, "Invalid Flowlu API key")),
+            ("forbidden", 403, (False, "Invalid Flowlu API key")),
+            ("server_error", 500, (False, "Flowlu returned HTTP 500")),
         ]
     )
-    def test_status_mapping(self, status: int, ok: bool, expected_status: int, expected_message: str | None) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        with self._patch_session(response):
-            assert check_access("fl-key", "acme") == (expected_status, expected_message)
+    def test_status_mapping(self, _name: str, status: int, expected: tuple[bool, str | None]) -> None:
+        with self._probe(mock.MagicMock(status_code=status)):
+            assert validate_credentials("fl-key", "acme") == expected
 
-    def test_connection_error_maps_to_zero(self) -> None:
-        # The message must be a fixed string: `requests` exceptions can embed the prepared URL
-        # (carrying the `api_key` query param), so the raw exception text must never be surfaced.
-        with self._patch_session(requests.ConnectionError("https://acme.flowlu.com/...?api_key=fl-key")):
-            status, message = check_access("fl-key", "acme")
-        assert status == 0
-        assert message == "Could not connect to Flowlu"
-
-    @parameterized.expand(
-        [
-            (200, True, None),
-            (401, False, "Invalid Flowlu API key"),
-            (403, False, "Invalid Flowlu API key"),
-            (500, False, "Flowlu returned HTTP 500"),
-        ]
-    )
-    def test_validate_credentials(self, status: int, expected_valid: bool, expected_message: str | None) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        with self._patch_session(response):
-            assert validate_credentials("fl-key", "acme") == (expected_valid, expected_message)
+    def test_connection_error_maps_to_generic_message(self) -> None:
+        # The probe swallows the exception (which could embed the api_key-carrying URL) and returns
+        # a fixed message, so the raw exception text is never surfaced.
+        with self._probe(RuntimeError("https://acme.flowlu.com/...?api_key=fl-key")):
+            assert validate_credentials("fl-key", "acme") == (False, "Could not connect to Flowlu")
 
 
 class TestFlowluSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
     def test_source_response_shape(self, endpoint: str) -> None:
-        response = flowlu_source(
-            api_key="fl-key",
-            subdomain="acme",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         # No stable creation timestamp could be verified across every object, so we don't partition.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/fly_io.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/fly_io.py
@@ -1,13 +1,17 @@
-from collections.abc import Iterator
 from typing import Any
-from urllib.parse import quote, urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from urllib.parse import quote
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.fly_io.settings import (
     FLY_IO_ENDPOINTS,
     FlyIoEndpointConfig,
@@ -17,9 +21,6 @@ FLY_IO_BASE_URL = "https://api.machines.dev/v1"
 
 # Advisory page size for the cursor-paginated org endpoints (the API caps it at 1000).
 _PAGE_SIZE = 1000
-
-# Hard cap on pages walked per stream so a misbehaving cursor can't loop forever.
-_MAX_PAGES = 1000
 
 # A Fly machine's `config` can embed deployment secrets, so we sync only an operational
 # allowlist (the "overview" the canonical description promises) rather than the raw object.
@@ -65,10 +66,6 @@ _SAFE_METADATA_KEYS = frozenset(
 )
 
 
-class FlyIoRetryableError(Exception):
-    pass
-
-
 def _strip_headers(value: Any) -> Any:
     """Recursively drop every `headers` mapping from a nested structure. Fly service and check
     definitions can carry request headers (e.g. a health-check `Authorization`), a credential
@@ -109,149 +106,98 @@ def _sanitize_machine(row: dict[str, Any]) -> dict[str, Any]:
     return row
 
 
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_token}",
-        "Accept": "application/json",
-    }
-
-
-def _build_url(config: FlyIoEndpointConfig, org_slug: str, params: dict[str, Any]) -> str:
-    """Build the request URL for an endpoint. Org-scoped endpoints carry the org in the path;
-    the apps endpoint takes it as a required query param instead."""
+def _endpoint_path(config: FlyIoEndpointConfig, org_slug: str) -> str:
+    """The org-scoped endpoints carry the org in the path; encode the slug so a reserved
+    character (e.g. `/`) can't retarget the request to a different API path than the one
+    credential validation checked. The apps endpoint takes org_slug as a query param instead."""
     if "{org_slug}" in config.path:
-        # Encode the slug so a reserved character (e.g. `/`) can't retarget the request to a
-        # different API path than the one credential validation checked.
-        path = config.path.format(org_slug=quote(org_slug, safe=""))
-        query = dict(params)
-    else:
-        path = config.path
-        query = {"org_slug": org_slug, **params}
-    url = f"{FLY_IO_BASE_URL}{path}"
-    if query:
-        url = f"{url}?{urlencode(query)}"
-    return url
+        return config.path.format(org_slug=quote(org_slug, safe=""))
+    return config.path
 
 
-@retry(
-    # ChunkedEncodingError is a mid-stream connection break (a truncated chunked body); it's
-    # transient like ConnectionError/ReadTimeout but not a ConnectionError subclass.
-    retry=retry_if_exception_type(
-        (
-            FlyIoRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=60)
-
-    # 429 (rate limited) and 5xx are transient — retry with backoff.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise FlyIoRetryableError(f"Fly.io API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Fly.io API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    # Every list endpoint we sync wraps its rows in an object ({"apps": [...]} etc.). A bare list
-    # or scalar is an unexpected shape: fail loudly rather than silently syncing zero rows, which
-    # would look like a successful-but-empty sync if Fly.io ever changed the wrapper.
-    if not isinstance(data, dict):
-        raise ValueError(f"Fly.io API returned an unexpected response shape: {type(data).__name__}")
-    return data
+def _endpoint_params(config: FlyIoEndpointConfig, org_slug: str) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+    if "{org_slug}" not in config.path:
+        params["org_slug"] = org_slug
+    if config.paginated:
+        params["limit"] = _PAGE_SIZE
+    return params
 
 
 def validate_credentials(api_token: str, org_slug: str) -> tuple[bool, str | None]:
     """Probe the apps endpoint to confirm the token is genuine and the org is reachable."""
-    url = _build_url(FLY_IO_ENDPOINTS["apps"], org_slug, {})
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_token), timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
-
-    if response.status_code == 200:
+    url = f"{FLY_IO_BASE_URL}/apps?org_slug={quote(org_slug, safe='')}"
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        url,
+        headers={"Authorization": f"Bearer {api_token}", "Accept": "application/json"},
+    )
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status == 401:
         return False, "Invalid Fly.io API token. Create a new token with `fly tokens create org` and reconnect."
-    if response.status_code in (403, 404):
+    if status in (403, 404):
         return False, f"Organization '{org_slug}' was not found or is not accessible with this token."
-
-    try:
-        message = response.json().get("error", response.text)
-    except ValueError:
-        message = response.text
-    return False, message
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    org_slug: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    """Yield one page of rows at a time. The org machines/volumes endpoints paginate with an
-    opaque `next_cursor`; the apps endpoint returns everything in a single response. Rows are
-    yielded in the shape the API returns them (flat objects, with nested config/organization kept
-    as-is) — the pipeline batches and writes them."""
-    config = FLY_IO_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-    # One session reused across pages so urllib3 keeps the connection alive between requests.
-    # A stream whose bodies can carry secrets opts out of HTTP sample capture (still logged
-    # and metered) so those secrets never land in the sample-capture pipeline.
-    session = make_tracked_session(capture=not config.redact_secrets)
-
-    params: dict[str, Any] = {"limit": _PAGE_SIZE} if config.paginated else {}
-    url = _build_url(config, org_slug, params)
-
-    pages = 0
-    while True:
-        data = _fetch_page(session, url, headers, logger)
-
-        items = data.get(config.response_data_path) or []
-        if config.redact_secrets:
-            items = [_sanitize_machine(item) for item in items]
-        if items:
-            yield items
-
-        if not config.paginated:
-            break
-
-        next_cursor = data.get("next_cursor")
-        if not next_cursor:
-            break
-
-        pages += 1
-        if pages >= _MAX_PAGES:
-            logger.warning(
-                "Fly.io: pagination cap reached; remaining pages skipped",
-                endpoint=endpoint,
-                max_pages=_MAX_PAGES,
-            )
-            break
-
-        url = _build_url(config, org_slug, {**params, "cursor": next_cursor})
+    if status is None:
+        return False, "Could not reach the Fly.io API to validate the token."
+    return False, f"Fly.io API returned an unexpected status ({status})."
 
 
 def fly_io_source(
     api_token: str,
     endpoint: str,
     org_slug: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
+    """Build the rest_source resource for a Fly.io stream. The org machines/volumes endpoints
+    paginate with an opaque `next_cursor`; the apps endpoint returns everything in one response.
+    Rows are yielded in the shape the API returns them, except the machines stream, whose rows can
+    embed deployment secrets: those are reduced to a safe operational allowlist and the stream opts
+    out of HTTP sample capture, so secrets reach neither the warehouse nor the sample pipeline."""
     config = FLY_IO_ENDPOINTS[endpoint]
+
+    paginator = (
+        JSONResponseCursorPaginator(cursor_path="next_cursor", cursor_param="cursor")
+        if config.paginated
+        else SinglePagePaginator()
+    )
+
+    client_config: dict[str, Any] = {
+        "base_url": FLY_IO_BASE_URL,
+        # Auth (Bearer) is supplied via the framework auth config so its value is redacted from
+        # logs and raised errors; only the non-secret Accept header is set here.
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_token},
+    }
+    if config.redact_secrets:
+        # A stream whose bodies can carry secrets opts out of HTTP sample capture (still logged
+        # and metered) so those secrets never land in the sample-capture pipeline. The token is
+        # still masked in whatever remains logged.
+        client_config["session"] = make_tracked_session(capture=False, redact_values=(api_token,))
+
+    endpoint_config: dict[str, Any] = {
+        "path": _endpoint_path(config, org_slug),
+        "params": _endpoint_params(config, org_slug),
+        "paginator": paginator,
+        "data_selector": config.response_data_path,
+        # Every list endpoint wraps its rows in an object ({"apps": [...]} etc.). A 200 body that
+        # isn't that shape (a bare list, or the wrapper key gone) means the API changed — fail loud
+        # rather than silently syncing zero rows, which would look like a successful-but-empty sync.
+        "data_selector_required": True,
+    }
+
+    resource_config: dict[str, Any] = {"name": endpoint, "endpoint": endpoint_config}
+    if config.redact_secrets:
+        resource_config["data_map"] = _sanitize_machine
+
+    rest_config: RESTAPIConfig = {"client": client_config, "resources": [resource_config]}
+
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_token=api_token, endpoint=endpoint, org_slug=org_slug, logger=logger),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         sort_mode="asc",
         partition_count=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/settings.py
@@ -9,7 +9,7 @@ class FlyIoEndpointConfig:
     name: str
     # Path template relative to the API base. `{org_slug}` is substituted with the configured
     # organization for the org-scoped endpoints; the apps endpoint takes org_slug as a query
-    # param instead (see `_build_url` in fly_io.py).
+    # param instead (see `_endpoint_path`/`_endpoint_params` in fly_io.py).
     path: str
     # Body key the list of rows lives under (e.g. {"apps": [...]}, {"machines": [...]}).
     response_data_path: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/source.py
@@ -89,9 +89,9 @@ Create an organization-scoped token with `fly tokens create org` (or from the **
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # An invalid, revoked, or expired token surfaces as an HTTPError when `_fetch_page`
-            # calls `raise_for_status()`. Retrying can never satisfy a credential problem, so stop
-            # the sync. Match the stable status text and base host, not the per-request path.
+            # An invalid, revoked, or expired token surfaces as an HTTPError when the rest_source
+            # client calls `raise_for_status()`. Retrying can never satisfy a credential problem, so
+            # stop the sync. Match the stable status text and base host, not the per-request path.
             "401 Client Error: Unauthorized for url: https://api.machines.dev": "Your Fly.io API token is invalid or expired. Create a new token with `fly tokens create org` and reconnect.",
             "403 Client Error: Forbidden for url: https://api.machines.dev": "Your Fly.io API token does not have access to this organization or resource. Check the token's scope and reconnect.",
         }
@@ -130,5 +130,6 @@ Create an organization-scoped token with `fly tokens create org` (or from the **
             api_token=config.api_token,
             endpoint=inputs.schema_name,
             org_slug=config.organization_slug,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/tests/test_fly_io.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fly_io/tests/test_fly_io.py
@@ -1,173 +1,197 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.fly_io import fly_io
 from products.warehouse_sources.backend.temporal.data_imports.sources.fly_io.fly_io import (
-    FLY_IO_ENDPOINTS,
-    _build_url,
     _sanitize_machine,
     fly_io_source,
-    get_rows,
     validate_credentials,
 )
 
+# RESTClient builds its own tracked session here when no custom session is passed (apps, volumes).
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# The machines stream builds a capture-disabled session in the fly_io module; validate_credentials
+# builds its probe session here too.
+FLY_IO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.fly_io.fly_io.make_tracked_session"
+)
 
-class TestBuildUrl:
+
+def _response(body: dict[str, Any], status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPaginationAndUrls:
     @parameterized.expand(
         [
-            # Org-scoped endpoints carry the org in the path; getting this wrong (leaving the
-            # {org_slug} placeholder, or putting the org in a query param) 404s every request.
-            ("machines", "https://api.machines.dev/v1/orgs/acme/machines?limit=1000"),
-            ("volumes", "https://api.machines.dev/v1/orgs/acme/volumes?limit=1000"),
+            # Org-scoped endpoints carry the org in the path; the apps endpoint takes it as a query param.
+            ("machines", "https://api.machines.dev/v1/orgs/acme/machines", {"limit": 1000}),
+            ("volumes", "https://api.machines.dev/v1/orgs/acme/volumes", {"limit": 1000}),
         ]
     )
-    def test_org_scoped_endpoint_puts_org_in_path(self, endpoint: str, expected: str) -> None:
-        config = FLY_IO_ENDPOINTS[endpoint]
-        url = _build_url(config, "acme", {"limit": 1000})
-        assert url == expected
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_org_scoped_endpoint_puts_org_in_path(
+        self, endpoint: str, expected_url: str, expected_params: dict, MockClientSession, MockFlyIoSession
+    ) -> None:
+        session = MockClientSession.return_value
+        MockFlyIoSession.return_value = session
+        snaps = _wire(session, [_response({endpoint: [{"id": "x"}], "next_cursor": None})])
 
-    def test_apps_endpoint_puts_org_in_query(self) -> None:
-        # The apps endpoint takes org_slug as a required query param, not a path segment.
-        url = _build_url(FLY_IO_ENDPOINTS["apps"], "acme", {})
-        assert url == "https://api.machines.dev/v1/apps?org_slug=acme"
+        _rows(fly_io_source("tok", endpoint, "acme", team_id=1, job_id="j"))
 
-    def test_reserved_char_in_slug_is_encoded_in_path(self) -> None:
+        assert snaps[0]["url"] == expected_url
+        assert snaps[0]["params"] == expected_params
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_apps_endpoint_puts_org_in_query(self, MockClientSession) -> None:
+        session = MockClientSession.return_value
+        snaps = _wire(session, [_response({"apps": [{"id": "a"}]})])
+
+        _rows(fly_io_source("tok", "apps", "acme", team_id=1, job_id="j"))
+
+        assert snaps[0]["url"] == "https://api.machines.dev/v1/apps"
+        assert snaps[0]["params"] == {"org_slug": "acme"}
+
+    @parameterized.expand([("machines",), ("volumes",)])
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_reserved_char_in_slug_is_encoded_in_path(self, endpoint: str, MockClientSession, MockFlyIoSession) -> None:
         # A slug carrying a path-reserved char must be percent-encoded, otherwise it could retarget
         # the request to a different API path than the one credential validation checked.
-        url = _build_url(FLY_IO_ENDPOINTS["machines"], "ac/me", {"limit": 1000})
-        assert url == "https://api.machines.dev/v1/orgs/ac%2Fme/machines?limit=1000"
+        session = MockClientSession.return_value
+        MockFlyIoSession.return_value = session
+        snaps = _wire(session, [_response({endpoint: [], "next_cursor": None})])
 
+        _rows(fly_io_source("tok", endpoint, "ac/me", team_id=1, job_id="j"))
 
-class TestValidateCredentials:
-    @parameterized.expand(
-        [
-            (200, True),
-            (401, False),
-            (403, False),
-            (404, False),
-            (500, False),
-        ]
-    )
-    def test_status_maps_to_validity(self, status_code: int, expected_valid: bool) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        response.json.return_value = {"error": "boom"}
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(fly_io, "make_tracked_session", return_value=session):
-            valid, error = validate_credentials("tok", "acme")
-        assert valid is expected_valid
-        assert (error is None) is expected_valid
+        assert snaps[0]["url"] == f"https://api.machines.dev/v1/orgs/ac%2Fme/{endpoint}"
 
-    def test_network_error_is_not_valid(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("no route")
-        with patch.object(fly_io, "make_tracked_session", return_value=session):
-            valid, error = validate_credentials("tok", "acme")
-        assert valid is False
-        assert error is not None
-
-
-class TestFetchPageRetries:
-    @parameterized.expand(
-        [
-            ("rate_limited", 429),
-            ("server_error", 503),
-        ]
-    )
-    def test_retryable_status_retries_then_succeeds(self, _name: str, bad_status: int) -> None:
-        # A 429/5xx on the first attempt must retry rather than fail the whole sync.
-        bad = MagicMock()
-        bad.status_code = bad_status
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = {"machines": []}
-        session = MagicMock()
-        session.get.side_effect = [bad, good]
-
-        with patch.object(fly_io._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = fly_io._fetch_page(session, "https://api.machines.dev/v1/orgs/a/machines", {}, MagicMock())
-
-        assert result == {"machines": []}
-        assert session.get.call_count == 2
-
-    def test_client_error_raises_and_is_not_retried(self) -> None:
-        # A 401 is a credential problem — surface it immediately (get_non_retryable_errors handles it),
-        # never burn 5 retries on it.
-        response = MagicMock()
-        response.status_code = 401
-        response.ok = False
-        response.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=response)
-        session = MagicMock()
-        session.get.return_value = response
-
-        with pytest.raises(requests.HTTPError):
-            fly_io._fetch_page(session, "https://api.machines.dev/v1/orgs/a/machines", {}, MagicMock())
-        assert session.get.call_count == 1
-
-    def test_unexpected_response_shape_raises(self) -> None:
-        # A bare list where an object wrapper is expected must fail loudly, not silently sync zero rows.
-        response = MagicMock()
-        response.status_code = 200
-        response.ok = True
-        response.json.return_value = [{"id": "x"}]
-        session = MagicMock()
-        session.get.return_value = response
-
-        with pytest.raises(ValueError):
-            fly_io._fetch_page(session, "https://api.machines.dev/v1/apps", {}, MagicMock())
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(endpoint: str, pages: dict[str, dict[str, Any]]) -> list[dict]:
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            return pages[url]
-
-        rows: list[dict] = []
-        with patch.object(fly_io, "make_tracked_session", return_value=MagicMock()):
-            with patch.object(fly_io, "_fetch_page", side_effect=fake_fetch):
-                for batch in get_rows(api_token="tok", endpoint=endpoint, org_slug="acme", logger=MagicMock()):
-                    rows.extend(batch)
-        return rows
-
-    def test_apps_is_single_request_and_ignores_cursor(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_apps_is_single_request_and_ignores_cursor(self, MockClientSession) -> None:
         # The apps endpoint isn't paginated; a stray next_cursor must not trigger a second request
         # against a cursor the endpoint doesn't accept.
-        pages = {
-            "https://api.machines.dev/v1/apps?org_slug=acme": {
-                "apps": [{"id": "app1"}, {"id": "app2"}],
-                "next_cursor": "should-be-ignored",
-            },
-        }
-        assert self._collect("apps", pages) == [{"id": "app1"}, {"id": "app2"}]
+        session = MockClientSession.return_value
+        _wire(session, [_response({"apps": [{"id": "app1"}, {"id": "app2"}], "next_cursor": "should-be-ignored"})])
 
-    def test_machines_follows_cursor_until_exhausted(self) -> None:
+        rows = _rows(fly_io_source("tok", "apps", "acme", team_id=1, job_id="j"))
+
+        assert [r["id"] for r in rows] == ["app1", "app2"]
+        assert session.send.call_count == 1
+
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_machines_follows_cursor_until_exhausted(self, MockClientSession, MockFlyIoSession) -> None:
         # Not advancing the cursor loops forever; not following it silently drops later pages.
-        pages = {
-            "https://api.machines.dev/v1/orgs/acme/machines?limit=1000": {
-                "machines": [{"id": "m1", "app_name": "app1"}],
-                "next_cursor": "c2",
-            },
-            "https://api.machines.dev/v1/orgs/acme/machines?limit=1000&cursor=c2": {
-                "machines": [{"id": "m2", "app_name": "app2"}],
-                "next_cursor": "",
-            },
-        }
-        rows = self._collect("machines", pages)
-        assert [r["id"] for r in rows] == ["m1", "m2"]
+        session = MockClientSession.return_value
+        MockFlyIoSession.return_value = session
+        snaps = _wire(
+            session,
+            [
+                _response({"machines": [{"id": "m1", "app_name": "app1"}], "next_cursor": "c2"}),
+                _response({"machines": [{"id": "m2", "app_name": "app2"}], "next_cursor": ""}),
+            ],
+        )
 
-    def test_empty_response_yields_no_rows(self) -> None:
-        pages: dict[str, dict[str, Any]] = {
-            "https://api.machines.dev/v1/orgs/acme/volumes?limit=1000": {"volumes": [], "next_cursor": None},
-        }
-        assert self._collect("volumes", pages) == []
+        rows = _rows(fly_io_source("tok", "machines", "acme", team_id=1, job_id="j"))
+
+        assert [r["id"] for r in rows] == ["m1", "m2"]
+        # The second request carries the cursor returned by the first page.
+        assert "cursor" not in snaps[0]["params"]
+        assert snaps[1]["params"]["cursor"] == "c2"
+
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_no_rows(self, MockClientSession, MockFlyIoSession) -> None:
+        session = MockClientSession.return_value
+        MockFlyIoSession.return_value = session
+        _wire(session, [_response({"volumes": [], "next_cursor": None})])
+
+        assert _rows(fly_io_source("tok", "volumes", "acme", team_id=1, job_id="j")) == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unexpected_response_shape_raises(self, MockClientSession) -> None:
+        # A bare list where an object wrapper is expected must fail loudly, not silently sync zero rows.
+        session = MockClientSession.return_value
+        _wire(session, [_response([{"id": "x"}])])  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError):
+            _rows(fly_io_source("tok", "apps", "acme", team_id=1, job_id="j"))
+
+
+class TestSampleCaptureAndRedaction:
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_machines_stream_sanitizes_rows_and_disables_sample_capture(
+        self, MockClientSession, MockFlyIoSession
+    ) -> None:
+        # End-to-end wiring: the machines stream must both redact secrets from every yielded row and
+        # opt out of HTTP sample capture, so secrets reach neither the warehouse nor the sample pipeline.
+        session = MockClientSession.return_value
+        MockFlyIoSession.return_value = session
+        _wire(
+            session,
+            [
+                _response(
+                    {
+                        "machines": [{"id": "m1", "config": {"image": "app", "env": {"SECRET": "x"}}}],
+                        "next_cursor": None,
+                    }
+                )
+            ],
+        )
+
+        rows = _rows(fly_io_source("tok", "machines", "acme", team_id=1, job_id="j"))
+
+        assert rows == [{"id": "m1", "config": {"image": "app"}}]
+        # The machines session is built with sample capture disabled and the token masked.
+        MockFlyIoSession.assert_called_once_with(capture=False, redact_values=("tok",))
+
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_secret_stream_keeps_sample_capture_and_rows_verbatim(
+        self, MockClientSession, MockFlyIoSession
+    ) -> None:
+        # Volumes carry no secrets, so no capture-disabled session is built and rows pass through unchanged.
+        session = MockClientSession.return_value
+        MockFlyIoSession.return_value = session
+        _wire(session, [_response({"volumes": [{"id": "v1", "encrypted": True}], "next_cursor": None})])
+
+        rows = _rows(fly_io_source("tok", "volumes", "acme", team_id=1, job_id="j"))
+
+        assert rows == [{"id": "v1", "encrypted": True}]
+        # No custom session is built for a non-secret stream; RESTClient builds the (capturing) one.
+        MockFlyIoSession.assert_not_called()
 
 
 class TestMachineSecretRedaction:
@@ -247,48 +271,30 @@ class TestMachineSecretRedaction:
         row = {"id": "m1", "state": "started"}
         assert _sanitize_machine(row) == row
 
-    def test_machines_stream_sanitizes_rows_and_disables_sample_capture(self) -> None:
-        # End-to-end wiring: the machines stream must both redact secrets from every yielded row and
-        # opt out of HTTP sample capture, so secrets reach neither the warehouse nor the sample pipeline.
-        pages = {
-            "https://api.machines.dev/v1/orgs/acme/machines?limit=1000": {
-                "machines": [{"id": "m1", "config": {"image": "app", "env": {"SECRET": "x"}}}],
-                "next_cursor": None,
-            },
-        }
 
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            return pages[url]
+class TestValidateCredentials:
+    @parameterized.expand(
+        [
+            (200, True),
+            (401, False),
+            (403, False),
+            (404, False),
+            (500, False),
+        ]
+    )
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    def test_status_maps_to_validity(self, status_code: int, expected_valid: bool, MockFlyIoSession) -> None:
+        MockFlyIoSession.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        valid, error = validate_credentials("tok", "acme")
+        assert valid is expected_valid
+        assert (error is None) is expected_valid
 
-        rows: list[dict] = []
-        with patch.object(fly_io, "make_tracked_session", return_value=MagicMock()) as mock_session:
-            with patch.object(fly_io, "_fetch_page", side_effect=fake_fetch):
-                for batch in get_rows(api_token="tok", endpoint="machines", org_slug="acme", logger=MagicMock()):
-                    rows.extend(batch)
-
-        assert rows == [{"id": "m1", "config": {"image": "app"}}]
-        mock_session.assert_called_once_with(capture=False)
-
-    def test_non_secret_stream_keeps_sample_capture_and_rows_verbatim(self) -> None:
-        # Volumes carry no secrets, so their session must keep capture on and rows pass through unchanged.
-        pages = {
-            "https://api.machines.dev/v1/orgs/acme/volumes?limit=1000": {
-                "volumes": [{"id": "v1", "encrypted": True}],
-                "next_cursor": None,
-            },
-        }
-
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            return pages[url]
-
-        rows: list[dict] = []
-        with patch.object(fly_io, "make_tracked_session", return_value=MagicMock()) as mock_session:
-            with patch.object(fly_io, "_fetch_page", side_effect=fake_fetch):
-                for batch in get_rows(api_token="tok", endpoint="volumes", org_slug="acme", logger=MagicMock()):
-                    rows.extend(batch)
-
-        assert rows == [{"id": "v1", "encrypted": True}]
-        mock_session.assert_called_once_with(capture=True)
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    def test_network_error_is_not_valid(self, MockFlyIoSession) -> None:
+        MockFlyIoSession.return_value.get.side_effect = Exception("no route")
+        valid, error = validate_credentials("tok", "acme")
+        assert valid is False
+        assert error is not None
 
 
 class TestFlyIoSourceResponse:
@@ -298,15 +304,21 @@ class TestFlyIoSourceResponse:
             ("volumes", "created_at"),
         ]
     )
-    def test_timestamped_endpoints_partition_on_created_at(self, endpoint: str, partition_key: str) -> None:
-        response = fly_io_source(api_token="tok", endpoint=endpoint, org_slug="acme", logger=MagicMock())
+    @mock.patch(FLY_IO_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_timestamped_endpoints_partition_on_created_at(
+        self, endpoint: str, partition_key: str, MockClientSession, MockFlyIoSession
+    ) -> None:
+        MockFlyIoSession.return_value = MockClientSession.return_value
+        response = fly_io_source("tok", endpoint, "acme", team_id=1, job_id="j")
         assert response.partition_mode == "datetime"
         assert response.partition_keys == [partition_key]
         assert response.primary_keys == ["id"]
 
-    def test_apps_has_no_partitioning(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_apps_has_no_partitioning(self, MockClientSession) -> None:
         # App objects carry no timestamp, so partitioning on a nonexistent column would break the sync.
-        response = fly_io_source(api_token="tok", endpoint="apps", org_slug="acme", logger=MagicMock())
+        response = fly_io_source("tok", "apps", "acme", team_id=1, job_id="j")
         assert response.partition_mode is None
         assert response.partition_keys is None
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fullstory/fullstory.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fullstory/fullstory.py
@@ -1,27 +1,25 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 FULLSTORY_BASE_URL = "https://api.fullstory.com"
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
 
 # Session/event data only exists behind Fullstory's async Data Export jobs;
 # the v2 users listing is the one directly listable surface.
 ENDPOINTS = ("users",)
-
-
-class FullStoryRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -30,88 +28,92 @@ class FullStoryResumeConfig:
     next_page_token: str
 
 
-def _get_session(api_key: str) -> requests.Session:
+class FullStoryCursorPaginator(JSONResponseCursorPaginator):
+    """v2 cursor paginator that also halts on an empty page.
+
+    Fullstory carries the next cursor in the body (``next_page_token``) and the cursor in the
+    ``page_token`` query param. Beyond the base "no cursor => stop", this also stops when a page
+    returns no rows even if a cursor is present — mirroring the old ``not next_token or not items``
+    guard against a cursor that never clears.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(cursor_path="next_page_token", cursor_param="page_token")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if not data:
+            self._has_next_page = False
+
+
+def _auth_header(api_key: str) -> str:
     # Fullstory's scheme is the raw API key after "Basic" (not base64 creds).
-    return make_tracked_session(headers={"Authorization": f"Basic {api_key}"}, redact_values=(api_key,))
+    return f"Basic {api_key}"
 
 
 def validate_credentials(api_key: str) -> bool:
     """Confirm the API key is valid with a cheap one-user listing probe."""
-    try:
-        response = _get_session(api_key).get(
-            f"{FULLSTORY_BASE_URL}/v2/users",
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FullStoryResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    session = _get_session(api_key)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page_token: Optional[str] = resume_config.next_page_token if resume_config is not None else None
-    if page_token is not None:
-        logger.debug(f"Fullstory: resuming {endpoint} from page token")
-
-    @retry(
-        retry=retry_if_exception_type((FullStoryRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{FULLSTORY_BASE_URL}/v2/users",
+        headers={"Authorization": _auth_header(api_key)},
     )
-    def fetch_page(token: Optional[str]) -> dict[str, Any]:
-        url = f"{FULLSTORY_BASE_URL}/v2/{endpoint}"
-        if token:
-            url = f"{url}?{urlencode({'page_token': token})}"
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise FullStoryRetryableError(f"Fullstory API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"Fullstory API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(page_token)
-        items = data.get("results", []) or []
-
-        if items:
-            yield items
-
-        next_token = data.get("next_page_token")
-        if not next_token or not items:
-            break
-
-        page_token = next_token
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(FullStoryResumeConfig(next_page_token=page_token))
+    return ok
 
 
 def fullstory_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FullStoryResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": FULLSTORY_BASE_URL,
+            # The raw key rides in the Authorization header value; framework auth redacts it from
+            # any raised error message. Only non-secret headers would go in client `headers`.
+            "auth": {"type": "api_key", "api_key": _auth_header(api_key), "name": "Authorization"},
+            "paginator": FullStoryCursorPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": f"/v2/{endpoint}",
+                    # A missing `results` key is treated as an empty page (not an error), matching the
+                    # old `data.get("results", []) or []`.
+                    "data_selector": "results",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"cursor": resume.next_page_token}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(FullStoryResumeConfig(next_page_token=state["cursor"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fullstory/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fullstory/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.fullstory.fullstory import (
     ENDPOINTS,
     FullStoryResumeConfig,
@@ -90,23 +93,9 @@ You can create an API key in Fullstory under Settings > Integrations & API Keys 
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        # The users listing has no updated-since filter; session/event data
-        # only exists behind async Data Export jobs (a follow-up).
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # The users listing has no updated-since filter (no incremental fields), so it is
+        # full-refresh only; session/event data only exists behind async Data Export jobs (a follow-up).
+        return build_endpoint_schemas(ENDPOINTS, {}, names)
 
     def validate_credentials(
         self, config: FullStorySourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -128,6 +117,7 @@ You can create an API key in Fullstory under Settings > Integrations & API Keys 
         return fullstory_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fullstory/tests/test_fullstory.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fullstory/tests/test_fullstory.py
@@ -1,17 +1,37 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.fullstory.fullstory import (
     FullStoryResumeConfig,
     fullstory_source,
-    get_rows,
     validate_credentials,
 )
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.fullstory.fullstory"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the fullstory module.
+FULLSTORY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.fullstory.fullstory.make_tracked_session"
+)
+
+
+def _response(
+    items: list[dict[str, Any]] | None, *, next_token: str | None = None, drop_results: bool = False
+) -> Response:
+    body: dict[str, Any] = {}
+    if not drop_results:
+        body["results"] = items or []
+    if next_token:
+        body["next_page_token"] = next_token
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: FullStoryResumeConfig | None = None) -> mock.MagicMock:
@@ -21,97 +41,141 @@ def _make_manager(resume_state: FullStoryResumeConfig | None = None) -> mock.Mag
     return manager
 
 
-def _response(items: list[dict[str, Any]], next_token: str | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    body: dict[str, Any] = {"results": items}
-    if next_token:
-        body["next_page_token"] = next_token
-    resp.json.return_value = body
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-class TestValidateCredentials:
-    @pytest.mark.parametrize(
-        "status_code, expected",
-        [
-            (200, True),
-            (401, False),
-            (403, False),
-            (500, False),
-        ],
-    )
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
-        response = mock.MagicMock()
-        response.status_code = status_code
-        mock_session.return_value.get.return_value = response
-
-        assert validate_credentials("key") is expected
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_validate_credentials_swallows_exceptions(self, mock_session):
-        mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("key") is False
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_auth_header_uses_raw_key_after_basic(self, mock_session):
-        response = mock.MagicMock()
-        response.status_code = 200
-        mock_session.return_value.get.return_value = response
-
-        validate_credentials("key123")
-
-        headers = mock_session.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Basic key123"
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
-class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_paginates_via_page_token(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "u1"}], next_token="tok1"),
-            _response([{"id": "u2"}]),
-        ]
+def _source(manager: mock.MagicMock):
+    return fullstory_source("key", "users", team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_page_token(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "u1"}], next_token="tok1"), _response([{"id": "u2"}])])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "users", mock.MagicMock(), manager))
+        rows = _rows(_source(manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["u1", "u2"]
+        assert [r["id"] for r in rows] == ["u1", "u2"]
+        # First page has no cursor; second page carries the saved token.
+        assert "page_token" not in params[0]
+        assert params[1]["page_token"] == "tok1"
+        # Checkpoint saved once after the first page (points at the next page); the tokenless page ends it.
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].next_page_token == "tok1"
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert parse_qs(urlparse(second_url).query)["page_token"] == ["tok1"]
+        assert manager.save_state.call_args.args[0] == FullStoryResumeConfig(next_page_token="tok1")
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resumes_from_saved_token(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_token(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "u_resumed"}])])
 
         manager = _make_manager(FullStoryResumeConfig(next_page_token="tok_resume"))
-        list(get_rows("key", "users", mock.MagicMock(), manager))
+        _rows(_source(manager))
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["page_token"] == ["tok_resume"]
+        assert params[0]["page_token"] == "tok_resume"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_response_stops_without_saving_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response([], next_token="tok_loop")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_stops_even_with_cursor_and_no_checkpoint(self, MockSession) -> None:
+        # A tokened-but-empty page must not loop; stop after one request without saving state.
+        session = MockSession.return_value
+        _wire(session, [_response([], next_token="tok_loop")])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "users", mock.MagicMock(), manager))
+        rows = _rows(_source(manager))
 
-        assert batches == []
-        assert mock_session.return_value.get.call_count == 1
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tokenless_page_stops_without_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "u1"}])])
 
-class TestFullStorySourceResponse:
-    def test_response_metadata(self):
-        response = fullstory_source("key", "users", mock.MagicMock(), _make_manager())
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert [r["id"] for r in rows] == ["u1"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_results_key_is_empty_page(self, MockSession) -> None:
+        # Matches the old `data.get("results", []) or []` — a missing key is 0 rows, not an error.
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_results=True)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == []
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_data_path_authorizes_with_basic_scheme(self, MockSession) -> None:
+        # The api_key auth carries the "Basic <raw key>" value onto the Authorization header when
+        # requests prepares the request. Prove the RESTClient session is constructed with the raw
+        # key registered for redaction (which is derived from the same auth value).
+        _wire(MockSession.return_value, [_response([{"id": "u1"}])])
+
+        _rows(_source(_make_manager()))
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("Basic key",)
+
+
+class TestSourceResponse:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata(self, MockSession) -> None:
+        _wire(MockSession.return_value, [_response([{"id": "u1"}])])
+        response = _source(_make_manager())
 
         assert response.name == "users"
         assert response.primary_keys == ["id"]
         assert response.sort_mode == "asc"
         assert response.partition_mode is None
         assert response.partition_keys is None
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [(200, True), (401, False), (403, False), (500, False)],
+    )
+    @mock.patch(FULLSTORY_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status_code, expected) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("key") is expected
+
+    @mock.patch(FULLSTORY_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key") is False
+
+    @mock.patch(FULLSTORY_SESSION_PATCH)
+    def test_probe_sends_basic_auth_header(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+
+        validate_credentials("key123")
+
+        headers = mock_session.return_value.get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Basic key123"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/giphy/giphy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/giphy/giphy.py
@@ -1,15 +1,18 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-from urllib.parse import urlencode, urlsplit
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.giphy.settings import (
     GIPHY_ENDPOINTS,
     GiphyEndpointConfig,
@@ -19,13 +22,6 @@ GIPHY_BASE_URL = "https://api.giphy.com/v1"
 # Beta keys cap search at limit=50; 50 is within every documented endpoint cap
 # (trending/search) and works for both beta and production keys.
 PAGE_SIZE = 50
-REQUEST_TIMEOUT_SECONDS = 60
-# GIPHY beta keys are rate limited to 100 calls/hour; back off generously on 429.
-MAX_RETRY_ATTEMPTS = 5
-
-
-class GiphyRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -33,77 +29,51 @@ class GiphyResumeConfig:
     # GIPHY paginates with a numeric offset. The endpoint and (for search) query
     # are rebuilt deterministically from job inputs on resume, so only the offset
     # needs persisting.
-    offset: int
+    offset: int = 0
 
 
-def _get_session(api_key: str) -> requests.Session:
-    # The API key rides in the query string (GIPHY has no header auth), so register it for
-    # value-based redaction — otherwise it leaks into tracked request URLs and captured samples.
-    return make_tracked_session(headers={"Accept": "application/json"}, redact_values=(api_key,))
+def _explode_search_terms(body: dict[str, Any]) -> list[dict[str, Any]]:
+    # `/trending/searches` returns `{"data": ["cats", ...]}` — a flat list of strings. The framework's
+    # per-item map only fires on dict rows, so the whole body is selected (data_selector=None) and
+    # exploded here into one `search_term` row per string (matching the old primary-key column).
+    terms = body.get("data") or []
+    return [{"search_term": term} for term in terms]
 
 
-def _build_url(api_key: str, config: GiphyEndpointConfig, offset: int, search_query: str | None) -> str:
-    params: dict[str, Any] = {"api_key": api_key}
-    if not config.is_term_list:
-        params["limit"] = PAGE_SIZE
-        params["offset"] = offset
-    if config.requires_query:
-        params["q"] = search_query
-    return f"{GIPHY_BASE_URL}{config.path}?{urlencode(params)}"
-
-
-def validate_credentials(api_key: str) -> bool:
-    """Confirm the API key is genuine with one cheap trending request."""
-    url = _build_url(api_key, GIPHY_ENDPOINTS["gifs_trending"], offset=0, search_query=None)
-    try:
-        response = _get_session(api_key).get(url, timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type((GiphyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=5, max=120),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> dict[str, Any]:
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise GiphyRetryableError(f"GIPHY API error (retryable): status={response.status_code}")
-
-    if not response.ok:
-        logger.error("GIPHY API error", status=response.status_code, body=response.text)
-        # raise_for_status() would embed the full request URL — including the api_key
-        # query param — in the exception, which surfaces in the schema's latest_error.
-        # Rebuild the error from the path only so the key never leaks.
-        safe = urlsplit(response.url)
-        raise requests.HTTPError(
-            f"{response.status_code} Client Error: {response.reason} for url: {safe.scheme}://{safe.netloc}{safe.path}",
-            response=response,
-        )
-
-    return response.json()
-
-
-def _normalize_items(config: GiphyEndpointConfig, data: dict[str, Any]) -> list[dict[str, Any]]:
-    items = data.get(config.data_key, []) or []
+def _build_endpoint_config(config: GiphyEndpointConfig, search_query: str | None) -> dict[str, Any]:
     if config.is_term_list:
-        # `/trending/searches` returns a flat list of strings; wrap each so the
-        # row has the `search_term` primary-key column.
-        return [{"search_term": term} for term in items]
-    return list(items)
+        # No pagination and no offset/limit params; explode the string list into search_term rows.
+        return {
+            "path": config.path,
+            "paginator": SinglePagePaginator(),
+        }
+
+    endpoint: dict[str, Any] = {
+        "path": config.path,
+        # GIPHY caps the offset it serves (trending 499, search 4999); requesting beyond it 400s, so
+        # stop at the cap rather than fail the sync. `total_count`/short/empty page also terminate.
+        "paginator": OffsetPaginator(
+            limit=PAGE_SIZE,
+            offset_param="offset",
+            limit_param="limit",
+            total_path="pagination.total_count",
+            maximum_offset=config.max_offset,
+        ),
+        "data_selector": config.data_key,
+    }
+    if config.requires_query:
+        endpoint["params"] = {"q": search_query}
+    return endpoint
 
 
-def get_rows(
+def giphy_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GiphyResumeConfig],
-    search_query: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
+    search_query: Optional[str] = None,
+) -> SourceResponse:
     config = GIPHY_ENDPOINTS[endpoint]
 
     if config.requires_query and not (search_query or "").strip():
@@ -111,69 +81,60 @@ def get_rows(
             f"GIPHY endpoint '{endpoint}' requires a search query. Set the search query on the source and reconnect."
         )
 
-    session = _get_session(api_key)
+    resource_config: dict[str, Any] = {
+        "name": endpoint,
+        "endpoint": _build_endpoint_config(config, search_query),
+    }
+    if config.is_term_list:
+        resource_config["data_map"] = _explode_search_terms
 
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume_config.offset if resume_config is not None else 0
-    if resume_config is not None:
-        logger.debug("GIPHY: resuming from offset", endpoint=endpoint, offset=offset)
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GIPHY_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # The key rides in the query string (GIPHY has no header auth). Supplying it via the
+            # framework auth registers it for value-based redaction so it never leaks into tracked
+            # request URLs, captured samples, or raised error messages.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "api_key", "location": "query"},
+        },
+        "resources": [resource_config],
+    }
 
-    while True:
-        url = _build_url(api_key, config, offset, search_query)
-        data = _fetch_page(session, url, logger)
-        items = _normalize_items(config, data)
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
 
-        if items:
-            yield items
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(GiphyResumeConfig(offset=int(state["offset"])))
 
-        # Term lists and any empty page terminate immediately.
-        if config.is_term_list or not items:
-            break
-
-        pagination = data.get("pagination") or {}
-        count = pagination.get("count")
-        page_len = count if isinstance(count, int) else len(items)
-        next_offset = offset + page_len
-
-        total_count = pagination.get("total_count")
-        if isinstance(total_count, int) and next_offset >= total_count:
-            break
-
-        # A short page means we've reached the end of the result set.
-        if page_len < PAGE_SIZE:
-            break
-
-        # GIPHY caps the offset it will serve; requesting beyond it 400s, so stop
-        # rather than fail the sync.
-        if config.max_offset is not None and next_offset > config.max_offset:
-            logger.debug("GIPHY: reached offset cap", endpoint=endpoint, max_offset=config.max_offset)
-            break
-
-        offset = next_offset
-        # Save state AFTER yielding so a crash re-yields the last page (merge
-        # dedupes on the primary key) rather than skipping it.
-        resumable_source_manager.save_state(GiphyResumeConfig(offset=offset))
-
-
-def giphy_source(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GiphyResumeConfig],
-    search_query: Optional[str] = None,
-) -> SourceResponse:
-    config = GIPHY_ENDPOINTS[endpoint]
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # every GIPHY endpoint is full refresh — the API has no incremental filter
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            search_query=search_query,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Confirm the API key is genuine with one cheap trending request."""
+    config = GIPHY_ENDPOINTS["gifs_trending"]
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(headers={"Accept": "application/json"}, redact_values=(api_key,)),
+        f"{GIPHY_BASE_URL}{config.path}?api_key={api_key}&limit={PAGE_SIZE}&offset=0",
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/giphy/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/giphy/source.py
@@ -148,7 +148,8 @@ The search tables (`gifs_search`, `stickers_search`) only appear once you set a 
         return giphy_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             search_query=config.search_query,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/giphy/tests/test_giphy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/giphy/tests/test_giphy.py
@@ -1,205 +1,276 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import HTTPError, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.giphy import giphy
 from products.warehouse_sources.backend.temporal.data_imports.sources.giphy.giphy import (
     PAGE_SIZE,
     GiphyResumeConfig,
-    _build_url,
-    _fetch_page,
-    _normalize_items,
-    get_rows,
     giphy_source,
+    validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.giphy.settings import GIPHY_ENDPOINTS
 
-
-class _FakeResumableManager:
-    def __init__(self, state: GiphyResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[GiphyResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> GiphyResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: GiphyResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the giphy module.
+GIPHY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.giphy.giphy.make_tracked_session"
+)
 
 
-def _gif_page(ids: list[str], offset: int, total_count: int) -> dict[str, Any]:
-    return {
-        "data": [{"id": i, "type": "gif"} for i in ids],
-        "pagination": {"offset": offset, "count": len(ids), "total_count": total_count},
-        "meta": {"status": 200, "msg": "OK"},
-    }
+def _response(
+    body: dict[str, Any],
+    *,
+    status_code: int = 200,
+    url: str = "https://api.giphy.com/v1/gifs/trending",
+    reason: str = "OK",
+) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.reason = reason
+    resp.url = url
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-class TestBuildUrl:
-    def test_trending_has_limit_and_offset_no_query(self) -> None:
-        url = _build_url("KEY", GIPHY_ENDPOINTS["gifs_trending"], offset=50, search_query=None)
-        parsed = urlparse(url)
-        params = parse_qs(parsed.query)
-        assert parsed.path == "/v1/gifs/trending"
-        assert params["api_key"] == ["KEY"]
-        assert params["limit"] == [str(PAGE_SIZE)]
-        assert params["offset"] == ["50"]
-        assert "q" not in params
-
-    def test_search_includes_query(self) -> None:
-        url = _build_url("KEY", GIPHY_ENDPOINTS["gifs_search"], offset=0, search_query="cats")
-        params = parse_qs(urlparse(url).query)
-        assert params["q"] == ["cats"]
-        assert params["limit"] == [str(PAGE_SIZE)]
-
-    def test_term_list_has_no_pagination_params(self) -> None:
-        url = _build_url("KEY", GIPHY_ENDPOINTS["trending_search_terms"], offset=0, search_query=None)
-        params = parse_qs(urlparse(url).query)
-        assert params["api_key"] == ["KEY"]
-        assert "limit" not in params
-        assert "offset" not in params
-
-
-class TestNormalizeItems:
-    def test_object_endpoint_passthrough(self) -> None:
-        data = {"data": [{"id": "a"}, {"id": "b"}]}
-        assert _normalize_items(GIPHY_ENDPOINTS["gifs_trending"], data) == [{"id": "a"}, {"id": "b"}]
-
-    def test_term_list_wraps_strings(self) -> None:
-        data = {"data": ["cats", "dogs"]}
-        assert _normalize_items(GIPHY_ENDPOINTS["trending_search_terms"], data) == [
-            {"search_term": "cats"},
-            {"search_term": "dogs"},
-        ]
-
-    def test_missing_data_key_is_empty(self) -> None:
-        assert _normalize_items(GIPHY_ENDPOINTS["gifs_trending"], {"meta": {}}) == []
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(manager: _FakeResumableManager, monkeypatch: Any, pages: dict[str, Any], **kwargs: Any) -> list[dict]:
-        def fake_fetch(session: Any, url: str, logger: Any) -> dict:
-            # Key the fake pages by the offset query param so tests stay URL-order agnostic.
-            offset = parse_qs(urlparse(url).query).get("offset", ["0"])[0]
-            return pages[offset]
-
-        monkeypatch.setattr(giphy, "_fetch_page", fake_fetch)
-
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="KEY",
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(batch)
-        return rows
-
-    def test_paginates_until_total_count_reached(self, monkeypatch: Any) -> None:
-        pages = {
-            "0": _gif_page([str(i) for i in range(PAGE_SIZE)], offset=0, total_count=PAGE_SIZE + 2),
-            str(PAGE_SIZE): _gif_page(["x", "y"], offset=PAGE_SIZE, total_count=PAGE_SIZE + 2),
+def _gif_page(ids: list[str], total_count: int) -> Response:
+    return _response(
+        {
+            "data": [{"id": i, "type": "gif"} for i in ids],
+            "pagination": {"count": len(ids), "total_count": total_count},
+            "meta": {"status": 200, "msg": "OK"},
         }
-        rows = self._collect(_FakeResumableManager(), monkeypatch, pages, endpoint="gifs_trending")
+    )
+
+
+def _make_manager(resume_state: GiphyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's query params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so inspecting it after the run shows
+    only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(endpoint: str, manager: mock.MagicMock, **kwargs: Any) -> list[dict[str, Any]]:
+    return _rows(
+        giphy_source(
+            api_key="KEY",
+            endpoint=endpoint,
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=manager,
+            **kwargs,
+        )
+    )
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_total_count_reached(self, MockSession) -> None:
+        session = MockSession.return_value
+        full = [str(i) for i in range(PAGE_SIZE)]
+        params = _wire(
+            session, [_gif_page(full, total_count=PAGE_SIZE + 2), _gif_page(["x", "y"], total_count=PAGE_SIZE + 2)]
+        )
+
+        rows = _run("gifs_trending", _make_manager())
+
         assert len(rows) == PAGE_SIZE + 2
         assert rows[-1] == {"id": "y", "type": "gif"}
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == PAGE_SIZE
+        assert params[1]["offset"] == PAGE_SIZE
 
-    def test_stops_on_short_page(self, monkeypatch: Any) -> None:
-        # A page shorter than PAGE_SIZE means the result set is exhausted.
-        pages = {"0": _gif_page(["a", "b"], offset=0, total_count=999)}
-        rows = self._collect(_FakeResumableManager(), monkeypatch, pages, endpoint="gifs_trending")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_gif_page(["a", "b"], total_count=999)])
+
+        rows = _run("gifs_trending", _make_manager())
+
         assert [r["id"] for r in rows] == ["a", "b"]
+        assert session.send.call_count == 1
 
-    def test_stops_on_empty_page(self, monkeypatch: Any) -> None:
-        pages = {"0": _gif_page([], offset=0, total_count=0)}
-        rows = self._collect(_FakeResumableManager(), monkeypatch, pages, endpoint="gifs_trending")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_gif_page([], total_count=0)])
+
+        rows = _run("gifs_trending", _make_manager())
+
         assert rows == []
+        assert session.send.call_count == 1
 
-    def test_stops_at_offset_cap(self, monkeypatch: Any) -> None:
-        # gifs_trending caps at offset 499. A full page lands next_offset at 500 > 499, so we stop
-        # without ever requesting an offset GIPHY would reject, even though total_count is far larger.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_at_offset_cap_without_requesting_beyond_it(self, MockSession) -> None:
+        # gifs_trending caps at offset 499. Every page is full and total_count is far larger, so only
+        # the offset cap can stop us — and it must stop before an offset GIPHY would reject is requested.
+        session = MockSession.return_value
         cap = GIPHY_ENDPOINTS["gifs_trending"].max_offset
         assert cap == 499
-        requested_offsets: list[int] = []
-
-        def fake_fetch(session: Any, url: str, logger: Any) -> dict:
-            offset = int(parse_qs(urlparse(url).query)["offset"][0])
-            requested_offsets.append(offset)
-            return _gif_page([f"{offset}_{i}" for i in range(PAGE_SIZE)], offset=offset, total_count=10_000)
-
-        monkeypatch.setattr(giphy, "_fetch_page", fake_fetch)
-        list(
-            get_rows(
-                api_key="KEY",
-                endpoint="gifs_trending",
-                logger=MagicMock(),
-                resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-            )
+        # offsets 0, 50, ..., 450 -> 10 full pages, then 500 >= 499 halts pagination.
+        params = _wire(
+            session,
+            [_gif_page([f"{o}_{i}" for i in range(PAGE_SIZE)], total_count=10_000) for o in range(0, 500, PAGE_SIZE)],
         )
-        assert max(requested_offsets) <= cap
-        assert max(requested_offsets) + PAGE_SIZE > cap
 
-    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
-        pages = {
-            str(PAGE_SIZE): _gif_page(["x", "y"], offset=PAGE_SIZE, total_count=PAGE_SIZE + 2),
-        }
-        manager = _FakeResumableManager(GiphyResumeConfig(offset=PAGE_SIZE))
-        rows = self._collect(manager, monkeypatch, pages, endpoint="gifs_trending")
+        _run("gifs_trending", _make_manager())
+
+        requested = [p["offset"] for p in params]
+        assert max(requested) <= cap
+        assert max(requested) + PAGE_SIZE > cap
+
+
+class TestResume:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_gif_page(["x", "y"], total_count=PAGE_SIZE + 2)])
+
+        rows = _run("gifs_trending", _make_manager(GiphyResumeConfig(offset=PAGE_SIZE)))
+
         assert [r["id"] for r in rows] == ["x", "y"]
+        assert params[0]["offset"] == PAGE_SIZE
 
-    def test_saves_state_after_each_batch(self, monkeypatch: Any) -> None:
-        pages = {
-            "0": _gif_page([str(i) for i in range(PAGE_SIZE)], offset=0, total_count=PAGE_SIZE + 1),
-            str(PAGE_SIZE): _gif_page(["last"], offset=PAGE_SIZE, total_count=PAGE_SIZE + 1),
-        }
-        manager = _FakeResumableManager()
-        self._collect(manager, monkeypatch, pages, endpoint="gifs_trending")
-        # State is saved once, advancing to the second page's offset, before that page is fetched.
-        assert [s.offset for s in manager.saved] == [PAGE_SIZE]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoint_saved_after_full_page_then_short_page_ends(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _gif_page([str(i) for i in range(PAGE_SIZE)], total_count=PAGE_SIZE + 1),
+                _gif_page(["last"], total_count=PAGE_SIZE + 1),
+            ],
+        )
 
-    def test_term_list_single_fetch(self, monkeypatch: Any) -> None:
-        def fake_fetch(session: Any, url: str, logger: Any) -> dict:
-            return {"data": ["cats", "dogs", "memes"], "meta": {"status": 200}}
+        manager = _make_manager()
+        _run("gifs_trending", manager)
 
-        monkeypatch.setattr(giphy, "_fetch_page", fake_fetch)
-        manager = _FakeResumableManager()
-        rows = [
-            r
-            for batch in get_rows(
-                api_key="KEY",
-                endpoint="trending_search_terms",
-                logger=MagicMock(),
-                resumable_source_manager=manager,  # type: ignore[arg-type]
-            )
-            for r in batch
-        ]
-        assert rows == [{"search_term": "cats"}, {"search_term": "dogs"}, {"search_term": "memes"}]
-        assert manager.saved == []
+        # Saved once, advancing to the second page's offset, before that page ends the sync.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == GiphyResumeConfig(offset=PAGE_SIZE)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_saves_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_gif_page(["a", "b"], total_count=999)])
+
+        manager = _make_manager()
+        _run("gifs_trending", manager)
+
+        manager.save_state.assert_not_called()
+
+
+class TestSearch:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_search_includes_query_param(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_gif_page(["a"], total_count=1)])
+
+        _run("gifs_search", _make_manager(), search_query="cats")
+
+        assert params[0]["q"] == "cats"
+        assert params[0]["limit"] == PAGE_SIZE
+        assert params[0]["offset"] == 0
 
     @parameterized.expand(["gifs_search", "stickers_search"])
     def test_search_without_query_raises(self, endpoint: str) -> None:
         with pytest.raises(ValueError, match="requires a search query"):
-            list(
-                get_rows(
-                    api_key="KEY",
-                    endpoint=endpoint,
-                    logger=MagicMock(),
-                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-                    search_query="   ",
+            _run(endpoint, _make_manager(), search_query="   ")
+
+
+class TestTermList:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_term_list_explodes_strings_single_fetch(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"data": ["cats", "dogs", "memes"], "meta": {"status": 200}})])
+
+        manager = _make_manager()
+        rows = _run("trending_search_terms", manager)
+
+        assert rows == [{"search_term": "cats"}, {"search_term": "dogs"}, {"search_term": "memes"}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_term_list_missing_data_key_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"meta": {"status": 200}})])
+
+        rows = _run("trending_search_terms", _make_manager())
+
+        assert rows == []
+
+
+class TestRedaction:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_api_key_registered_for_value_redaction(self, MockSession) -> None:
+        # The key rides in the query string, so it must reach make_tracked_session as a redacted value
+        # or it leaks into tracked URLs, samples, and raised error messages.
+        session = MockSession.return_value
+        _wire(session, [_gif_page(["a"], total_count=1)])
+
+        _run("gifs_trending", _make_manager())
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("KEY",)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_message_does_not_leak_api_key(self, MockSession) -> None:
+        api_key = "super-secret-key"
+        session = MockSession.return_value
+        session.headers = {}
+        error = _response(
+            {"meta": {"status": 400, "msg": "Bad Request"}},
+            status_code=400,
+            reason="Bad Request",
+            url=f"https://api.giphy.com/v1/gifs/search?api_key={api_key}&q=cats&limit=50&offset=0",
+        )
+        session.prepare_request.side_effect = lambda request: mock.MagicMock()
+        session.send.side_effect = [error]
+
+        with pytest.raises(HTTPError) as exc_info:
+            _rows(
+                giphy_source(
+                    api_key=api_key,
+                    endpoint="gifs_search",
+                    team_id=1,
+                    job_id="j",
+                    resumable_source_manager=_make_manager(),
+                    search_query="cats",
                 )
             )
 
+        assert api_key not in str(exc_info.value)
+        assert "api.giphy.com/v1/gifs/search" in str(exc_info.value)
 
-class TestGiphySourceResponse:
+
+class TestSourceResponse:
     @parameterized.expand(
         [
             ("gifs_trending", ["id"]),
@@ -214,8 +285,9 @@ class TestGiphySourceResponse:
         response = giphy_source(
             api_key="KEY",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
             search_query="cats",
         )
         assert response.name == endpoint
@@ -225,59 +297,21 @@ class TestGiphySourceResponse:
         response = giphy_source(
             api_key="KEY",
             endpoint="gifs_trending",
-            logger=MagicMock(),
-            resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+            team_id=1,
+            job_id="j",
+            resumable_source_manager=_make_manager(),
         )
         assert response.sort_mode == "asc"
 
 
-class TestFetchPageErrorHandling:
-    def test_client_error_does_not_leak_api_key(self) -> None:
-        # The api_key rides in the query string, so raise_for_status() would put it in
-        # the exception message, which lands in the schema's latest_error.
-        api_key = "super-secret-key"
-        response = MagicMock()
-        response.status_code = 400
-        response.ok = False
-        response.reason = "Bad Request"
-        response.text = "invalid request"
-        response.url = f"https://api.giphy.com/v1/gifs/search?api_key={api_key}&q=cats"
-
-        session = MagicMock()
-        session.get.return_value = response
-
-        with pytest.raises(requests.HTTPError) as exc_info:
-            _fetch_page(session, response.url, MagicMock())
-
-        assert api_key not in str(exc_info.value)
-        assert "api.giphy.com/v1/gifs/search" in str(exc_info.value)
-
-
 class TestValidateCredentials:
-    @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
-    def test_status_maps_to_validity(self, monkeypatch: Any, status_code: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status_code)
-        monkeypatch.setattr(giphy, "_get_session", lambda *_: session)
-        assert giphy.validate_credentials("KEY") is expected
+    @parameterized.expand([(200, True), (401, False), (403, False), (500, False)])
+    @mock.patch(GIPHY_SESSION_PATCH)
+    def test_status_maps_to_validity(self, status_code: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("KEY") is expected
 
-    def test_network_error_is_invalid(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        monkeypatch.setattr(giphy, "_get_session", lambda *_: session)
-        assert giphy.validate_credentials("KEY") is False
-
-
-class TestSessionRedaction:
-    def test_api_key_registered_for_redaction(self, monkeypatch: Any) -> None:
-        # The key travels in the query string, so it must be passed to make_tracked_session as a
-        # redacted value — otherwise it leaks into tracked URLs/samples.
-        captured: dict[str, Any] = {}
-
-        def fake_make_session(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            return MagicMock()
-
-        monkeypatch.setattr(giphy, "make_tracked_session", fake_make_session)
-        giphy._get_session("super-secret-key")
-        assert captured["redact_values"] == ("super-secret-key",)
+    @mock.patch(GIPHY_SESSION_PATCH)
+    def test_network_error_is_invalid(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("KEY") is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitbook/gitbook.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitbook/gitbook.py
@@ -1,211 +1,221 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    rename_parent_fields,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.gitbook.settings import GITBOOK_ENDPOINTS
 
 GITBOOK_BASE_URL = "https://api.gitbook.com/v1"
 # List endpoints accept a `limit` of up to 1000 per the OpenAPI spec; a moderate page keeps
 # individual payloads small (change requests and comments embed document bodies).
 PAGE_SIZE = 250
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm an API token is genuine. The token inherits its owner's
 # permissions, so per-endpoint access is validated lazily at sync time.
 DEFAULT_PROBE_PATH = "/user"
 
-
-class GitBookRetryableError(Exception):
-    pass
+# Every list response is `{"items": [...], "next": {"page": "..."}}`; `next` is omitted on the last
+# page. The parent list of a space-scoped endpoint is enumerated per organization (orgs -> spaces).
+_ORGS_PATH = "/orgs"
+_SPACES_PATH = "/orgs/{parent_id}/spaces"
 
 
 @dataclasses.dataclass
 class GitBookResumeConfig:
-    # Fan-out parents (organization or space ids) whose pages have all been yielded already.
+    # Legacy fan-out checkpoint fields, retained so pre-migration saved state still parses. The
+    # framework now owns fan-out resume via `fanout_state`; these are only read for the top-level
+    # `organizations` cursor (`next_page`) and are otherwise left at their defaults.
     completed_parent_ids: list[str] = dataclasses.field(default_factory=list)
-    # Parent currently being paginated; `None` for the top-level organizations endpoint.
     current_parent_id: Optional[str] = None
-    # Opaque `next.page` token for the next page within the current parent (or the top-level
-    # list). A crashed full-refresh sync resumes from the page after the last one yielded; merge
-    # dedupes the re-pulled page on the primary key.
+    # Opaque `next.page` token for the next page of the top-level `organizations` list.
     next_page: Optional[str] = None
+    # Framework fan-out resume snapshot for single-hop endpoints:
+    # `{"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}`.
+    fanout_state: Optional[dict[str, Any]] = None
 
 
-def _headers(api_token: str) -> dict[str, str]:
+def _auth_headers(api_token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {api_token}", "Accept": "application/json"}
 
 
-@retry(
-    retry=retry_if_exception_type((GitBookRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    page: Optional[str],
-    logger: FilteringBoundLogger,
-) -> tuple[list[dict[str, Any]], Optional[str]]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE}
-    if page is not None:
-        params["page"] = page
-
-    response = session.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # GitBook enforces per-method rate limits surfaced via X-RateLimit-* headers and HTTP 429.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise GitBookRetryableError(f"GitBook API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"GitBook API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    # Every list response is `{"items": [...], "next": {"page": "..."}}`; `next` is omitted on
-    # the last page.
-    if not isinstance(data, dict) or not isinstance(data.get("items"), list):
-        raise GitBookRetryableError(f"GitBook returned an unexpected payload for {url}: {type(data).__name__}")
-
-    next_obj = data.get("next")
-    next_page = next_obj.get("page") if isinstance(next_obj, dict) else None
-    return data["items"], next_page
+def _paginator() -> JSONResponseCursorPaginator:
+    return JSONResponseCursorPaginator(cursor_path="next.page", cursor_param="page")
 
 
-def _list_all_ids(session: requests.Session, path: str, logger: FilteringBoundLogger) -> list[str]:
-    ids: list[str] = []
-    page: Optional[str] = None
-    while True:
-        items, page = _fetch_page(session, f"{GITBOOK_BASE_URL}{path}", page, logger)
-        ids.extend(item["id"] for item in items)
-        if not page:
-            return ids
+def _client_config(api_token: str) -> ClientConfig:
+    return {
+        "base_url": GITBOOK_BASE_URL,
+        # Bearer auth goes through the framework auth config so the token is redacted from logs and
+        # raised error messages; only the non-secret Accept header is set here.
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_token},
+        "paginator": _paginator(),
+        # GitBook returns opaque page tokens (never full URLs), so every request stays on the API
+        # host; pin pagination/resume to it and reject anything off-host defensively.
+        "allowed_hosts": [],
+    }
 
 
-def _parent_ids(session: requests.Session, parent: str, logger: FilteringBoundLogger) -> list[str]:
-    org_ids = _list_all_ids(session, "/orgs", logger)
-    if parent == "organization":
-        return org_ids
-    # Spaces are enumerated per organization: orgs -> spaces.
-    space_ids: list[str] = []
-    for org_id in org_ids:
-        space_ids.extend(_list_all_ids(session, f"/orgs/{org_id}/spaces", logger))
-    return space_ids
+def _list_resource(name: str, path: str) -> EndpointResource:
+    return {
+        "name": name,
+        "endpoint": {
+            "path": path,
+            "params": {"limit": PAGE_SIZE},
+            "data_selector": "items",
+            # A 200 body that isn't `{"items": [...]}` means the response shape changed — fail loud
+            # instead of silently syncing 0 rows.
+            "data_selector_required": True,
+        },
+    }
 
 
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GitBookResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = GITBOOK_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(api_token), redact_values=(api_token,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if config.parent is None:
-        page = resume.next_page if resume else None
-        if page:
-            logger.debug(f"GitBook: resuming {endpoint} from page token {page}")
-        while True:
-            items, next_page = _fetch_page(session, f"{GITBOOK_BASE_URL}{config.path}", page, logger)
-            if items:
-                yield items
-            if not next_page:
-                return
-            page = next_page
-            # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages
-            # are persisted); merge dedupes the re-pulled page on the primary key.
-            resumable_source_manager.save_state(GitBookResumeConfig(next_page=next_page))
-
-    else:
-        completed = set(resume.completed_parent_ids) if resume else set()
-        if completed:
-            logger.debug(f"GitBook: resuming {endpoint}, skipping {len(completed)} completed parents")
-
-        for parent_id in _parent_ids(session, config.parent, logger):
-            if parent_id in completed:
-                continue
-
-            url = f"{GITBOOK_BASE_URL}{config.path.format(parent_id=parent_id)}"
-            page = resume.next_page if (resume and resume.current_parent_id == parent_id) else None
-            while True:
-                items, next_page = _fetch_page(session, url, page, logger)
-                if items:
-                    if config.parent_id_key:
-                        yield [{**item, config.parent_id_key: parent_id} for item in items]
-                    else:
-                        yield items
-                if not next_page:
-                    break
-                page = next_page
-                resumable_source_manager.save_state(
-                    GitBookResumeConfig(
-                        completed_parent_ids=sorted(completed),
-                        current_parent_id=parent_id,
-                        next_page=next_page,
-                    )
-                )
-
-            completed.add(parent_id)
-            resumable_source_manager.save_state(GitBookResumeConfig(completed_parent_ids=sorted(completed)))
+def _child_resource(name: str, child_path: str, parent_name: str, inject_as: Optional[str]) -> EndpointResource:
+    resource: EndpointResource = {
+        "name": name,
+        "endpoint": {
+            "path": child_path,
+            "params": {
+                "limit": PAGE_SIZE,
+                "parent_id": {"type": "resolve", "resource": parent_name, "field": "id"},
+            },
+            "data_selector": "items",
+            "data_selector_required": True,
+        },
+    }
+    if inject_as is not None:
+        # Inject the parent's id into every row so rows from different parents stay distinguishable
+        # (and usable in composite primary keys), matching the old `parent_id_key` behavior.
+        resource["include_from_parent"] = ["id"]
+        resource["data_map"] = rename_parent_fields(parent_name, {"id": inject_as})
+    return resource
 
 
 def gitbook_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GitBookResumeConfig],
 ) -> SourceResponse:
     config = GITBOOK_ENDPOINTS[endpoint]
+    client = _client_config(api_token)
 
+    if config.parent is None:
+        # Top-level list (organizations): a single non-dependent resource with full cursor resume.
+        rest_config: RESTAPIConfig = {"client": client, "resources": [_list_resource(endpoint, config.path)]}
+
+        initial_state: Optional[dict[str, Any]] = None
+        if resumable_source_manager.can_resume():
+            resume = resumable_source_manager.load_state()
+            if resume is not None and resume.next_page:
+                initial_state = {"cursor": resume.next_page}
+
+        def save_cursor(state: Optional[dict[str, Any]]) -> None:
+            # Save AFTER yielding a page so a crash re-fetches from the next page (merge dedupes the
+            # re-pulled page on the primary key); only persist while a next page remains.
+            if state and state.get("cursor"):
+                resumable_source_manager.save_state(GitBookResumeConfig(next_page=state["cursor"]))
+
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            None,
+            resume_hook=save_cursor,
+            initial_paginator_state=initial_state,
+        )
+        return _source_response(endpoint, config.primary_keys, resource)
+
+    if config.parent == "organization":
+        # Single-hop fan-out (orgs -> child). One dependent resource, so the framework checkpoints
+        # each parent's child pagination: a restart skips fully-synced parents and resumes the one
+        # in progress at its saved cursor.
+        rest_config = {
+            "client": client,
+            "resources": [
+                _list_resource("orgs", _ORGS_PATH),
+                _child_resource(endpoint, config.path, parent_name="orgs", inject_as=config.parent_id_key),
+            ],
+        }
+
+        fanout_initial: Optional[dict[str, Any]] = None
+        if resumable_source_manager.can_resume():
+            resume = resumable_source_manager.load_state()
+            if resume is not None and resume.fanout_state:
+                fanout_initial = resume.fanout_state
+
+        def save_fanout(state: Optional[dict[str, Any]]) -> None:
+            if state is not None:
+                resumable_source_manager.save_state(GitBookResumeConfig(fanout_state=state))
+
+        built = rest_api_resources(
+            rest_config,
+            team_id,
+            job_id,
+            None,
+            resume_hook=save_fanout,
+            initial_paginator_state=fanout_initial,
+        )
+        resource = next(r for r in built if r.name == endpoint)
+        return _source_response(endpoint, config.primary_keys, resource)
+
+    # Space-scoped fan-out (comments): a two-level chain orgs -> spaces -> comments. With more than
+    # one dependent resource the framework disables resume; a retry re-fetches and the merge dedupes
+    # on the primary key.
+    rest_config = {
+        "client": client,
+        "resources": [
+            _list_resource("orgs", _ORGS_PATH),
+            _child_resource("spaces", _SPACES_PATH, parent_name="orgs", inject_as=None),
+            _child_resource(endpoint, config.path, parent_name="spaces", inject_as=config.parent_id_key),
+        ],
+    }
+    built = rest_api_resources(rest_config, team_id, job_id, None)
+    resource = next(r for r in built if r.name == endpoint)
+    return _source_response(endpoint, config.primary_keys, resource)
+
+
+def _source_response(endpoint: str, primary_keys: list[str], resource: Any) -> SourceResponse:
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=config.primary_keys,
+        items=lambda: resource,
+        primary_keys=primary_keys,
+        # No stable creation timestamp exists on every object, so we don't partition by datetime.
         partition_count=1,
         partition_size=1,
     )
 
 
-def check_access(api_token: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the API token.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(headers=_headers(api_token), redact_values=(api_token,))
-    try:
-        response = session.get(f"{GITBOOK_BASE_URL}{path}", timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to GitBook: {e}"
-
-    # GitBook answers 401 for an invalid token and 403 for a missing/unauthorized one.
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"GitBook returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(api_token: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_token)
-    if status == 200:
+    # A single probe of `/user` confirms the token is genuine; per-endpoint access follows the token
+    # owner's permissions and is surfaced at sync time via get_non_retryable_errors.
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{GITBOOK_BASE_URL}{DEFAULT_PROBE_PATH}",
+        headers=_auth_headers(api_token),
+    )
+    if ok:
         return True, None
+    # GitBook answers 401 for an invalid token and 403 for a missing/unauthorized one.
     if status in (401, 403):
         return False, "Invalid GitBook API token"
-    return False, message or "Could not validate GitBook API token"
+    if status is not None:
+        return False, f"GitBook returned HTTP {status}"
+    return False, "Could not validate GitBook API token"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitbook/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitbook/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GitBookSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.gitbook.gitbook import (
     GitBookResumeConfig,
@@ -29,6 +32,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.gitbook.gi
 from products.warehouse_sources.backend.temporal.data_imports.sources.gitbook.settings import (
     ENDPOINTS,
     GITBOOK_ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -93,19 +97,9 @@ You can create a personal access token under **Account settings → Developer** 
     ) -> list[SourceSchema]:
         # Every endpoint is full refresh only — GitBook's list endpoints expose no server-side
         # updated-after/since filter, so there is no timestamp cursor to advance an incremental sync.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # INCREMENTAL_FIELDS is empty, so build_endpoint_schemas yields supports_incremental=False,
+        # supports_append=False, incremental_fields=[] for every endpoint.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: GitBookSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -129,6 +123,7 @@ You can create a personal access token under **Account settings → Developer** 
         return gitbook_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitbook/tests/test_gitbook.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitbook/tests/test_gitbook.py
@@ -1,20 +1,19 @@
-from collections.abc import Mapping
+import json
+from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
+from unittest.mock import MagicMock
 
-import requests
 from parameterized import parameterized
+from requests import Response
+from requests.exceptions import HTTPError
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.gitbook import gitbook
 from products.warehouse_sources.backend.temporal.data_imports.sources.gitbook.gitbook import (
     GITBOOK_BASE_URL,
     PAGE_SIZE,
     GitBookResumeConfig,
-    GitBookRetryableError,
-    check_access,
-    get_rows,
     gitbook_source,
     validate_credentials,
 )
@@ -23,13 +22,36 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.gitbook.se
     GITBOOK_ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = gitbook._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the gitbook module.
+GITBOOK_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.gitbook.gitbook.make_tracked_session"
+)
 
 PageKey = tuple[str, Optional[str]]
 
 
-class _FakeResumableManager:
+def _u(path: str) -> str:
+    return f"{GITBOOK_BASE_URL}{path}"
+
+
+def _response(
+    items: Optional[list[dict]], *, next_page: Optional[str] = None, status: int = 200, raw_body: Any = None
+) -> Response:
+    if raw_body is not None:
+        body: Any = raw_body
+    else:
+        body = {"items": items or []}
+        if next_page is not None:
+            body["next"] = {"page": next_page}
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+class _FakeManager:
     def __init__(self, state: GitBookResumeConfig | None = None) -> None:
         self._state = state
         self.saved: list[GitBookResumeConfig] = []
@@ -44,180 +66,80 @@ class _FakeResumableManager:
         self.saved.append(data)
 
 
-def _collect(
-    manager: _FakeResumableManager,
-    monkeypatch: Any,
-    pages: Mapping[PageKey, tuple[list[dict], Optional[str]]],
-    endpoint: str,
-) -> list[dict]:
-    def fake_fetch(session: Any, url: str, page: Optional[str], logger: Any) -> tuple[list[dict], Optional[str]]:
-        return pages[(url, page)]
+def _wire(session: MagicMock, pages: dict[PageKey, Response]) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session that dispatches each request to a response keyed by (url, page token).
 
-    monkeypatch.setattr(gitbook, "_fetch_page", fake_fetch)
-    monkeypatch.setattr(gitbook, "make_tracked_session", lambda **kwargs: MagicMock())
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy at
+    prepare-request time to observe what each page actually sent.
+    """
+    session.headers = {}
+    snapshots: list[tuple[str, dict[str, Any]]] = []
 
-    rows: list[dict] = []
-    for batch in get_rows(
-        api_token="gb-token",
-        endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        rows.extend(batch)
-    return rows
+    def _prepare(request: Any) -> SimpleNamespace:
+        params = dict(request.params or {})
+        snapshots.append((request.url, params))
+        return SimpleNamespace(url=request.url, _page=params.get("page"), is_redirect=False)
+
+    def _send(prepared: Any, **kwargs: Any) -> Response:
+        key = (prepared.url, prepared._page)
+        if key not in pages:
+            raise AssertionError(f"unexpected request {key}; known keys: {sorted(pages)}")
+        return pages[key]
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = _send
+    return snapshots
 
 
-class TestGetRowsTopLevel:
-    ORGS_URL = f"{GITBOOK_BASE_URL}/orgs"
-
-    def test_single_page_yields_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = _collect(
-            manager, monkeypatch, {(self.ORGS_URL, None): ([{"id": "org1"}, {"id": "org2"}], None)}, "organizations"
+def _drive(
+    endpoint: str, pages: dict[PageKey, Response], manager: _FakeManager
+) -> tuple[list[dict], list[tuple[str, dict[str, Any]]]]:
+    with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+        session = MockSession.return_value
+        snapshots = _wire(session, pages)
+        response = gitbook_source(
+            api_token="gb-token",
+            endpoint=endpoint,
+            team_id=1,
+            job_id="job-1",
+            resumable_source_manager=manager,  # type: ignore[arg-type]
         )
+        rows = [row for page in response.items() for row in page]
+    return rows, snapshots
+
+
+class TestTopLevel:
+    ORGS = _u("/orgs")
+
+    def test_single_page_yields_and_stops(self) -> None:
+        manager = _FakeManager()
+        rows, _ = _drive("organizations", {(self.ORGS, None): _response([{"id": "org1"}, {"id": "org2"}])}, manager)
         assert rows == [{"id": "org1"}, {"id": "org2"}]
         # No next page means the sync ends without persisting resume state.
         assert manager.saved == []
 
-    def test_follows_page_token_until_exhausted(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages: dict[PageKey, tuple[list[dict], Optional[str]]] = {
-            (self.ORGS_URL, None): ([{"id": "org1"}], "tok2"),
-            (self.ORGS_URL, "tok2"): ([{"id": "org2"}], None),
+    def test_follows_page_token_until_exhausted(self) -> None:
+        manager = _FakeManager()
+        pages = {
+            (self.ORGS, None): _response([{"id": "org1"}], next_page="tok2"),
+            (self.ORGS, "tok2"): _response([{"id": "org2"}]),
         }
-        rows = _collect(manager, monkeypatch, pages, "organizations")
+        rows, _ = _drive("organizations", pages, manager)
         assert rows == [{"id": "org1"}, {"id": "org2"}]
         # State is saved once — after the first page yields, pointing at the next token.
         assert [s.next_page for s in manager.saved] == ["tok2"]
 
-    def test_resumes_from_saved_page_token(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(GitBookResumeConfig(next_page="tok2"))
-        # The first page must never be fetched on resume.
-        rows = _collect(manager, monkeypatch, {(self.ORGS_URL, "tok2"): ([{"id": "org2"}], None)}, "organizations")
+    def test_resumes_from_saved_page_token(self) -> None:
+        manager = _FakeManager(GitBookResumeConfig(next_page="tok2"))
+        # Only the tok2 page is wired; fetching the first page would raise from the mock.
+        rows, _ = _drive("organizations", {(self.ORGS, "tok2"): _response([{"id": "org2"}])}, manager)
         assert rows == [{"id": "org2"}]
 
-    def test_empty_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, {(self.ORGS_URL, None): ([], None)}, "organizations")
+    def test_empty_page_yields_nothing(self) -> None:
+        manager = _FakeManager()
+        rows, _ = _drive("organizations", {(self.ORGS, None): _response([])}, manager)
         assert rows == []
         assert manager.saved == []
-
-
-class TestGetRowsFanOut:
-    ORGS_URL = f"{GITBOOK_BASE_URL}/orgs"
-
-    def test_org_fanout_injects_parent_id_into_rows(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages: dict[PageKey, tuple[list[dict], Optional[str]]] = {
-            (self.ORGS_URL, None): ([{"id": "org1"}, {"id": "org2"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org1/members", None): ([{"id": "user1"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org2/members", None): ([{"id": "user1"}, {"id": "user2"}], None),
-        }
-        rows = _collect(manager, monkeypatch, pages, "members")
-        # The same user id in two orgs stays distinguishable via the injected organization_id.
-        assert rows == [
-            {"id": "user1", "organization_id": "org1"},
-            {"id": "user1", "organization_id": "org2"},
-            {"id": "user2", "organization_id": "org2"},
-        ]
-
-    def test_spaces_rows_keep_api_shape_without_injection(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages: dict[PageKey, tuple[list[dict], Optional[str]]] = {
-            (self.ORGS_URL, None): ([{"id": "org1"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org1/spaces", None): ([{"id": "sp1", "organization": "org1"}], None),
-        }
-        rows = _collect(manager, monkeypatch, pages, "spaces")
-        assert rows == [{"id": "sp1", "organization": "org1"}]
-
-    def test_comments_fan_out_through_orgs_then_spaces(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages: dict[PageKey, tuple[list[dict], Optional[str]]] = {
-            (self.ORGS_URL, None): ([{"id": "org1"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org1/spaces", None): ([{"id": "sp1"}, {"id": "sp2"}], None),
-            (f"{GITBOOK_BASE_URL}/spaces/sp1/comments", None): ([{"id": "c1"}], None),
-            (f"{GITBOOK_BASE_URL}/spaces/sp2/comments", None): ([{"id": "c2"}], None),
-        }
-        rows = _collect(manager, monkeypatch, pages, "comments")
-        assert rows == [{"id": "c1", "space_id": "sp1"}, {"id": "c2", "space_id": "sp2"}]
-
-    def test_saves_completed_parents_and_mid_parent_page_token(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages: dict[PageKey, tuple[list[dict], Optional[str]]] = {
-            (self.ORGS_URL, None): ([{"id": "org1"}, {"id": "org2"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org1/teams", None): ([{"id": "t1"}], "tok2"),
-            (f"{GITBOOK_BASE_URL}/orgs/org1/teams", "tok2"): ([{"id": "t2"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org2/teams", None): ([{"id": "t3"}], None),
-        }
-        _collect(manager, monkeypatch, pages, "teams")
-        assert [(s.completed_parent_ids, s.current_parent_id, s.next_page) for s in manager.saved] == [
-            ([], "org1", "tok2"),
-            (["org1"], None, None),
-            (["org1", "org2"], None, None),
-        ]
-
-    def test_resume_skips_completed_parents_and_resumes_current_at_token(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(
-            GitBookResumeConfig(completed_parent_ids=["org1"], current_parent_id="org2", next_page="tok2")
-        )
-        # org1's pages and org2's first page must never be fetched on resume.
-        pages: dict[PageKey, tuple[list[dict], Optional[str]]] = {
-            (self.ORGS_URL, None): ([{"id": "org1"}, {"id": "org2"}, {"id": "org3"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org2/teams", "tok2"): ([{"id": "t2"}], None),
-            (f"{GITBOOK_BASE_URL}/orgs/org3/teams", None): ([{"id": "t3"}], None),
-        }
-        rows = _collect(manager, monkeypatch, pages, "teams")
-        assert rows == [
-            {"id": "t2", "organization_id": "org2"},
-            {"id": "t3", "organization_id": "org3"},
-        ]
-
-
-class TestFetchPage:
-    URL = f"{GITBOOK_BASE_URL}/orgs"
-
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else {"items": []}
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
-        )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(GitBookRetryableError):
-            _fetch_page_unwrapped(session, self.URL, None, MagicMock())
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, self.URL, None, MagicMock())
-
-    def test_success_returns_items_and_next_page_token(self) -> None:
-        body = {"items": [{"id": "org1"}], "next": {"page": "tok2"}, "count": 5}
-        session = self._session_returning(200, body)
-        rows, next_page = _fetch_page_unwrapped(session, self.URL, None, MagicMock())
-        assert rows == [{"id": "org1"}]
-        assert next_page == "tok2"
-
-    def test_missing_next_returns_none(self) -> None:
-        session = self._session_returning(200, {"items": [{"id": "org1"}]})
-        _, next_page = _fetch_page_unwrapped(session, self.URL, None, MagicMock())
-        assert next_page is None
-
-    @parameterized.expand([("bare_list", [{"id": "a"}]), ("missing_items", {"count": 1})])
-    def test_unexpected_payload_is_retryable(self, _name: str, body: Any) -> None:
-        session = self._session_returning(200, body)
-        with pytest.raises(GitBookRetryableError):
-            _fetch_page_unwrapped(session, self.URL, None, MagicMock())
 
     @parameterized.expand(
         [
@@ -226,48 +148,108 @@ class TestFetchPage:
         ]
     )
     def test_request_params_carry_limit_and_page_token(
-        self, _name: str, page: Optional[str], expected_params: dict
+        self, _name: str, page: Optional[str], expected: dict[str, Any]
     ) -> None:
-        session = self._session_returning(200, {"items": []})
-        _fetch_page_unwrapped(session, self.URL, page, MagicMock())
-        args, kwargs = session.get.call_args
-        assert args[0] == self.URL
-        assert kwargs["params"] == expected_params
+        pages = {
+            (self.ORGS, None): _response([{"id": "org1"}], next_page="tok2"),
+            (self.ORGS, "tok2"): _response([{"id": "org2"}]),
+        }
+        _, snapshots = _drive("organizations", pages, _FakeManager())
+        index = 0 if page is None else 1
+        url, params = snapshots[index]
+        assert url == self.ORGS
+        assert params == expected
 
 
-class TestCheckAccess:
-    def _session(self, response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        return session
+class TestFanOut:
+    ORGS = _u("/orgs")
 
-    @parameterized.expand(
-        [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "GitBook returned HTTP 500"),
+    def test_org_fanout_injects_parent_id_into_rows(self) -> None:
+        pages = {
+            (self.ORGS, None): _response([{"id": "org1"}, {"id": "org2"}]),
+            (_u("/orgs/org1/members"), None): _response([{"id": "user1"}]),
+            (_u("/orgs/org2/members"), None): _response([{"id": "user1"}, {"id": "user2"}]),
+        }
+        rows, _ = _drive("members", pages, _FakeManager())
+        # The same user id in two orgs stays distinguishable via the injected organization_id.
+        assert rows == [
+            {"id": "user1", "organization_id": "org1"},
+            {"id": "user1", "organization_id": "org2"},
+            {"id": "user2", "organization_id": "org2"},
         ]
-    )
-    def test_status_mapping(
-        self, _name: str, status: int, ok: bool, expected_status: int, expected_message: str | None
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        with patch.object(gitbook, "make_tracked_session", return_value=self._session(response)):
-            assert check_access("gb-token") == (expected_status, expected_message)
 
-    def test_connection_error_maps_to_zero(self) -> None:
-        session = self._session(requests.ConnectionError("boom"))
-        with patch.object(gitbook, "make_tracked_session", return_value=session):
-            status, message = check_access("gb-token")
-        assert status == 0
-        assert message is not None and "boom" in message
+    def test_spaces_rows_keep_api_shape_without_injection(self) -> None:
+        pages = {
+            (self.ORGS, None): _response([{"id": "org1"}]),
+            (_u("/orgs/org1/spaces"), None): _response([{"id": "sp1", "organization": "org1"}]),
+        }
+        rows, _ = _drive("spaces", pages, _FakeManager())
+        assert rows == [{"id": "sp1", "organization": "org1"}]
 
+    def test_comments_fan_out_through_orgs_then_spaces(self) -> None:
+        pages = {
+            (self.ORGS, None): _response([{"id": "org1"}]),
+            (_u("/orgs/org1/spaces"), None): _response([{"id": "sp1"}, {"id": "sp2"}]),
+            (_u("/spaces/sp1/comments"), None): _response([{"id": "c1"}]),
+            (_u("/spaces/sp2/comments"), None): _response([{"id": "c2"}]),
+        }
+        rows, _ = _drive("comments", pages, _FakeManager())
+        assert rows == [{"id": "c1", "space_id": "sp1"}, {"id": "c2", "space_id": "sp2"}]
+
+    def test_saves_completed_parents_and_mid_parent_page_token(self) -> None:
+        manager = _FakeManager()
+        pages = {
+            (self.ORGS, None): _response([{"id": "org1"}, {"id": "org2"}]),
+            (_u("/orgs/org1/teams"), None): _response([{"id": "t1"}], next_page="tok2"),
+            (_u("/orgs/org1/teams"), "tok2"): _response([{"id": "t2"}]),
+            (_u("/orgs/org2/teams"), None): _response([{"id": "t3"}]),
+        }
+        _drive("teams", pages, manager)
+        states = [s.fanout_state for s in manager.saved]
+        # A mid-parent checkpoint pins org1's next child page before org1 is marked complete.
+        assert {"completed": [], "current": "/orgs/org1/teams", "child_state": {"cursor": "tok2"}} in states
+        # Once every parent is walked, all child paths are recorded complete.
+        assert states[-1]["completed"] == ["/orgs/org1/teams", "/orgs/org2/teams"]
+
+    def test_resume_skips_completed_parents_and_resumes_current_at_token(self) -> None:
+        manager = _FakeManager(
+            GitBookResumeConfig(
+                fanout_state={
+                    "completed": ["/orgs/org1/teams"],
+                    "current": "/orgs/org2/teams",
+                    "child_state": {"cursor": "tok2"},
+                }
+            )
+        )
+        # org1's pages and org2's first page are not wired: fetching either would raise from the mock.
+        pages = {
+            (self.ORGS, None): _response([{"id": "org1"}, {"id": "org2"}, {"id": "org3"}]),
+            (_u("/orgs/org2/teams"), "tok2"): _response([{"id": "t2"}]),
+            (_u("/orgs/org3/teams"), None): _response([{"id": "t3"}]),
+        }
+        rows, _ = _drive("teams", pages, manager)
+        assert rows == [
+            {"id": "t2", "organization_id": "org2"},
+            {"id": "t3", "organization_id": "org3"},
+        ]
+
+
+class TestFailLoud:
+    ORGS = _u("/orgs")
+
+    @parameterized.expand([("bare_list", [{"id": "a"}]), ("missing_items", {"count": 1})])
+    def test_unexpected_payload_fails_loud(self, _name: str, raw_body: Any) -> None:
+        # A 200 body that isn't {"items": [...]} means the response shape changed — fail loud.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _drive("organizations", {(self.ORGS, None): _response(None, raw_body=raw_body)}, _FakeManager())
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    def test_client_errors_raise(self, _name: str, status: int) -> None:
+        with pytest.raises(HTTPError):
+            _drive("organizations", {(self.ORGS, None): _response([], status=status)}, _FakeManager())
+
+
+class TestValidateCredentials:
     @parameterized.expand(
         [
             ("ok", 200, True, None),
@@ -276,17 +258,25 @@ class TestCheckAccess:
             ("server_error", 500, False, "GitBook returned HTTP 500"),
         ]
     )
-    def test_validate_credentials(
-        self, _name: str, status: int, expected_valid: bool, expected_message: str | None
+    @mock.patch(GITBOOK_SESSION_PATCH)
+    def test_status_mapping(
+        self,
+        _name: str,
+        status: int,
+        expected_valid: bool,
+        expected_message: str | None,
+        mock_session: MagicMock,
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        with patch.object(gitbook, "make_tracked_session", return_value=self._session(response)):
-            assert validate_credentials("gb-token") == (expected_valid, expected_message)
+        mock_session.return_value.get.return_value = MagicMock(status_code=status)
+        assert validate_credentials("gb-token") == (expected_valid, expected_message)
+
+    @mock.patch(GITBOOK_SESSION_PATCH)
+    def test_connection_error_is_not_validated(self, mock_session: MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("gb-token") == (False, "Could not validate GitBook API token")
 
 
-class TestGitBookSourceResponse:
+class TestSourceResponse:
     @parameterized.expand(
         [
             ("organizations", ["id"]),
@@ -299,12 +289,16 @@ class TestGitBookSourceResponse:
             ("comments", ["space_id", "id"]),
         ]
     )
-    def test_source_response_shape(self, endpoint: str, expected_primary_keys: list[str]) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(
+        self, endpoint: str, expected_primary_keys: list[str], _mock_session: MagicMock
+    ) -> None:
         response = gitbook_source(
             api_token="gb-token",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
+            team_id=1,
+            job_id="job-1",
+            resumable_source_manager=_FakeManager(),  # type: ignore[arg-type]
         )
         assert response.name == endpoint
         assert response.primary_keys == expected_primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/gocardless.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/gocardless.py
@@ -1,20 +1,22 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.settings import (
-    GOCARDLESS_ENDPOINTS,
-    GoCardlessEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.settings import GOCARDLESS_ENDPOINTS
 
 GOCARDLESS_HOSTS = {
     "live": "https://api.gocardless.com",
@@ -24,13 +26,6 @@ GOCARDLESS_HOSTS = {
 GOCARDLESS_VERSION = "2015-07-06"
 # GoCardless list pages cap at 500 items.
 PAGE_SIZE = 500
-REQUEST_TIMEOUT_SECONDS = 60
-# 1000 req/min rate limit; 429s carry ratelimit headers but backoff suffices.
-MAX_RETRY_ATTEMPTS = 5
-
-
-class GoCardlessRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -40,14 +35,21 @@ class GoCardlessResumeConfig:
     after: str
 
 
-def _get_session(access_token: str) -> requests.Session:
-    return make_tracked_session(
-        headers={
-            "Authorization": f"Bearer {access_token}",
-            "GoCardless-Version": GOCARDLESS_VERSION,
-        },
-        redact_values=(access_token,),
-    )
+class GoCardlessCursorPaginator(JSONResponseCursorPaginator):
+    """GoCardless cursor pagination via ``meta.cursors.after`` (``after=<id>``).
+
+    Also stops on an empty page even when the response still carries an ``after``
+    cursor, so a run can never loop on a stale cursor that points at no rows.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(cursor_path="meta.cursors.after", cursor_param="after")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+        super().update_state(response, data)
 
 
 def _base_url(environment: str) -> str:
@@ -67,115 +69,89 @@ def _format_created_at(value: Any) -> str:
     return str(value)
 
 
-def _build_params(
-    config: GoCardlessEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-    after: Optional[str],
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE}
-
-    if config.incremental_fields and should_use_incremental_field and db_incremental_field_last_value is not None:
-        # `gte` re-fetches the boundary row (merge dedupes on primary key) so
-        # records sharing the watermark timestamp are never skipped.
-        params["created_at[gte]"] = _format_created_at(db_incremental_field_last_value)
-
-    if after is not None:
-        params["after"] = after
-
-    return params
-
-
 def validate_credentials(environment: str, access_token: str) -> bool:
     """Confirm the access token is valid with a cheap one-customer probe."""
     try:
-        response = _get_session(access_token).get(
-            f"{_base_url(environment)}/customers?{urlencode({'limit': 1})}",
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
+        base_url = _base_url(environment)
+    except ValueError:
         return False
 
-
-def get_rows(
-    environment: str,
-    access_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GoCardlessResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = GOCARDLESS_ENDPOINTS[endpoint]
-    session = _get_session(access_token)
-    base_url = _base_url(environment)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    after: Optional[str] = resume_config.after if resume_config is not None else None
-    if after is not None:
-        logger.debug(f"GoCardless: resuming {endpoint} from cursor {after}")
-
-    @retry(
-        retry=retry_if_exception_type((GoCardlessRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_token,)),
+        f"{base_url}/customers?{urlencode({'limit': 1})}",
+        headers={"Authorization": f"Bearer {access_token}", "GoCardless-Version": GOCARDLESS_VERSION},
     )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise GoCardlessRetryableError(
-                f"GoCardless API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"GoCardless API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        params = _build_params(config, should_use_incremental_field, db_incremental_field_last_value, after)
-        data = fetch_page(f"{base_url}{config.path}?{urlencode(params)}")
-        items = data.get(config.data_key, []) or []
-
-        if items:
-            yield items
-
-        next_after = ((data.get("meta") or {}).get("cursors") or {}).get("after")
-        if not next_after or not items:
-            break
-
-        after = next_after
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(GoCardlessResumeConfig(after=after))
+    return ok
 
 
 def gocardless_source(
     environment: str,
     access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GoCardlessResumeConfig],
-    should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = GOCARDLESS_ENDPOINTS[endpoint]
+    base_url = _base_url(environment)
+
+    params: dict[str, Any] = {"limit": PAGE_SIZE}
+    if config.incremental_fields and db_incremental_field_last_value is not None:
+        # `gte` re-fetches the boundary row (merge dedupes on primary key) so
+        # records sharing the watermark timestamp are never skipped.
+        params["created_at[gte]"] = _format_created_at(db_incremental_field_last_value)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted
+            # from logs and raised errors; only the non-secret version header is set here.
+            "headers": {"GoCardless-Version": GOCARDLESS_VERSION},
+            "auth": {"type": "bearer", "token": access_token},
+            "paginator": GoCardlessCursorPaginator(),
+            # Cursor pagination stays on the base host; pin every request (including a seeded
+            # resume cursor) to it so a spoofed response can't redirect the token off-host.
+            "allowed_hosts": [],
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # GoCardless wraps rows under a per-resource key; a missing key is treated
+                    # as an empty page (not fail-loud), matching the hand-rolled behavior.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"cursor": resume.after}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("cursor") is not None:
+            resumable_source_manager.save_state(GoCardlessResumeConfig(after=str(state["cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            environment=environment,
-            access_token=access_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
@@ -185,4 +161,5 @@ def gocardless_source(
         # GoCardless lists are reverse-chronological with no sort param; the
         # pipeline commits desc-sort watermarks only when a run completes.
         sort_mode="desc" if config.incremental_fields else "asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/source.py
@@ -21,7 +21,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GoCardlessSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless import (
     GoCardlessResumeConfig,
@@ -107,21 +110,7 @@ Create a read-only access token in the [GoCardless dashboard](https://manage.goc
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: GoCardlessSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -144,9 +133,9 @@ Create a read-only access token in the [GoCardless dashboard](https://manage.goc
             environment=config.environment,
             access_token=config.access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/tests/test_gocardless.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/tests/test_gocardless.py
@@ -1,16 +1,17 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless import (
     GoCardlessResumeConfig,
     _base_url,
-    _build_params,
     _format_created_at,
-    get_rows,
     gocardless_source,
     validate_credentials,
 )
@@ -18,6 +19,21 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.gocardless
     ENDPOINTS,
     GOCARDLESS_ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the gocardless module.
+GOCARDLESS_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
+)
+
+
+def _response(data_key: str, items: list[dict[str, Any]], after: str | None = None) -> Response:
+    body = {data_key: items, "meta": {"cursors": {"before": None, "after": after}, "limit": 500}}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: GoCardlessResumeConfig | None = None) -> mock.MagicMock:
@@ -27,12 +43,51 @@ def _make_manager(resume_state: GoCardlessResumeConfig | None = None) -> mock.Ma
     return manager
 
 
-def _response(data_key: str, items: list[dict[str, Any]], after: str | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {data_key: items, "meta": {"cursors": {"before": None, "after": after}, "limit": 500}}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Wire a mock session, capturing each request's params and URL at prepare time.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy per page.
+    The returned prepared object exposes a real ``.url`` so the client's host-pinning check passes.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        prepared.is_redirect = False
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, url_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(
+    session: mock.MagicMock,
+    environment: str,
+    endpoint: str,
+    manager: mock.MagicMock,
+    db_incremental_field_last_value: Any = None,
+) -> list[dict[str, Any]]:
+    return _rows(
+        gocardless_source(
+            environment=environment,
+            access_token="token",
+            endpoint=endpoint,
+            team_id=1,
+            job_id="job-1",
+            resumable_source_manager=manager,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        )
+    )
 
 
 class TestBaseUrl:
@@ -65,40 +120,6 @@ class TestFormatCreatedAt:
         assert _format_created_at(value) == expected
 
 
-class TestBuildParams:
-    def test_incremental_events_filters_on_created_at(self):
-        params = _build_params(
-            GOCARDLESS_ENDPOINTS["events"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
-            after=None,
-        )
-
-        assert params["created_at[gte]"] == "2024-01-02T00:00:00.000Z"
-        assert params["limit"] == 500
-
-    def test_full_refresh_has_no_filter(self):
-        params = _build_params(
-            GOCARDLESS_ENDPOINTS["payments"],
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=None,
-            after="CU123",
-        )
-
-        assert "created_at[gte]" not in params
-        assert params["after"] == "CU123"
-
-    def test_non_incremental_endpoint_ignores_watermark(self):
-        params = _build_params(
-            GOCARDLESS_ENDPOINTS["payments"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
-            after=None,
-        )
-
-        assert "created_at[gte]" not in params
-
-
 class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected",
@@ -109,112 +130,131 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
+    @mock.patch(GOCARDLESS_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
-        response = mock.MagicMock()
-        response.status_code = status_code
-        mock_session.return_value.get.return_value = response
-
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("live", "token") is expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
+    @mock.patch(GOCARDLESS_SESSION_PATCH)
     def test_validate_credentials_rejects_bad_environment_without_request(self, mock_session):
         assert validate_credentials("evil", "token") is False
         mock_session.return_value.get.assert_not_called()
 
+    @mock.patch(GOCARDLESS_SESSION_PATCH)
+    def test_validate_credentials_swallows_transport_errors(self, mock_session):
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("live", "token") is False
 
-class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
-    def test_paginates_via_meta_cursors(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _response("payments", [{"id": "PM1"}], after="PM1"),
-            _response("payments", [{"id": "PM2"}], after=None),
-        ]
 
-        manager = _make_manager()
-        batches = list(get_rows("live", "token", "payments", mock.MagicMock(), manager))
-
-        assert [item["id"] for batch in batches for item in batch] == ["PM1", "PM2"]
-        manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].after == "PM1"
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert parse_qs(urlparse(second_url).query)["after"] == ["PM1"]
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
-    def test_requests_carry_version_header(self, mock_session):
-        mock_session.return_value.get.return_value = _response("payments", [])
-
-        manager = _make_manager()
-        list(get_rows("live", "token", "payments", mock.MagicMock(), manager))
-
-        headers = mock_session.call_args.kwargs["headers"]
-        assert headers["GoCardless-Version"] == "2015-07-06"
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
-    def test_sandbox_uses_sandbox_host(self, mock_session):
-        mock_session.return_value.get.return_value = _response("payments", [])
-
-        manager = _make_manager()
-        list(get_rows("sandbox", "token", "payments", mock.MagicMock(), manager))
-
-        url = mock_session.return_value.get.call_args.args[0]
-        assert urlparse(url).netloc == "api-sandbox.gocardless.com"
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
-    def test_incremental_request_includes_filter(self, mock_session):
-        mock_session.return_value.get.return_value = _response("events", [])
-
-        manager = _make_manager()
-        list(
-            get_rows(
-                "live",
-                "token",
-                "events",
-                mock.MagicMock(),
-                manager,
-                should_use_incremental_field=True,
-                db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
-            )
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_meta_cursors(self, MockSession):
+        session = MockSession.return_value
+        params, _ = _wire(
+            session,
+            [
+                _response("payments", [{"id": "PM1"}], after="PM1"),
+                _response("payments", [{"id": "PM2"}], after=None),
+            ],
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["created_at[gte]"] == ["2024-01-02T00:00:00.000Z"]
+        manager = _make_manager()
+        rows = _run(session, "live", "payments", manager)
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
-    def test_resumes_from_saved_cursor(self, mock_session):
-        mock_session.return_value.get.return_value = _response("payments", [])
+        assert [r["id"] for r in rows] == ["PM1", "PM2"]
+        assert params[0]["limit"] == 500
+        assert "after" not in params[0]
+        assert params[1]["after"] == "PM1"
+        # Checkpoint saved after the first page (points at the next cursor); the null cursor ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == GoCardlessResumeConfig(after="PM1")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_requests_carry_version_header(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response("payments", [{"id": "PM1"}])])
+
+        _run(session, "live", "payments", _make_manager())
+
+        assert session.headers.get("GoCardless-Version") == "2015-07-06"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sandbox_uses_sandbox_host(self, MockSession):
+        session = MockSession.return_value
+        _, urls = _wire(session, [_response("payments", [{"id": "PM1"}])])
+
+        _run(session, "sandbox", "payments", _make_manager())
+
+        assert urlparse(urls[0]).netloc == "api-sandbox.gocardless.com"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_live_uses_live_host(self, MockSession):
+        session = MockSession.return_value
+        _, urls = _wire(session, [_response("payments", [{"id": "PM1"}])])
+
+        _run(session, "live", "payments", _make_manager())
+
+        assert urlparse(urls[0]).netloc == "api.gocardless.com"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_includes_filter(self, MockSession):
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response("events", [{"id": "EV1"}])])
+
+        _run(
+            session,
+            "live",
+            "events",
+            _make_manager(),
+            db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
+        )
+
+        assert params[0]["created_at[gte]"] == "2024-01-02T00:00:00.000Z"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_omits_filter(self, MockSession):
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response("events", [{"id": "EV1"}])])
+
+        _run(session, "live", "events", _make_manager())
+
+        assert "created_at[gte]" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_incremental_endpoint_ignores_watermark(self, MockSession):
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response("payments", [{"id": "PM1"}])])
+
+        _run(
+            session,
+            "live",
+            "payments",
+            _make_manager(),
+            db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
+        )
+
+        assert "created_at[gte]" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession):
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response("payments", [{"id": "PM9"}])])
 
         manager = _make_manager(GoCardlessResumeConfig(after="PM_RESUME"))
-        list(get_rows("live", "token", "payments", mock.MagicMock(), manager))
+        _run(session, "live", "payments", manager)
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["after"] == ["PM_RESUME"]
+        assert params[0]["after"] == "PM_RESUME"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.gocardless.make_tracked_session"
-    )
-    def test_empty_page_with_cursor_stops(self, mock_session):
-        mock_session.return_value.get.return_value = _response("payments", [], after="PM_LOOP")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_with_cursor_stops(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response("payments", [], after="PM_LOOP")])
 
         manager = _make_manager()
-        batches = list(get_rows("live", "token", "payments", mock.MagicMock(), manager))
+        rows = _run(session, "live", "payments", manager)
 
-        assert batches == []
-        assert mock_session.return_value.get.call_count == 1
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
 
@@ -222,7 +262,14 @@ class TestGoCardlessSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = GOCARDLESS_ENDPOINTS[endpoint]
-        response = gocardless_source("live", "token", endpoint, mock.MagicMock(), _make_manager())
+        response = gocardless_source(
+            environment="live",
+            access_token="token",
+            endpoint=endpoint,
+            team_id=1,
+            job_id="job-1",
+            resumable_source_manager=_make_manager(),
+        )
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/tests/test_gocardless_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gocardless/tests/test_gocardless_source.py
@@ -130,6 +130,8 @@ class TestGoCardlessSource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_gc_source):
         inputs = mock.MagicMock()
         inputs.schema_name = "events"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2024-01-02T03:04:05.000Z"
         manager = mock.MagicMock()
@@ -141,8 +143,9 @@ class TestGoCardlessSource:
         assert kwargs["environment"] == "live"
         assert kwargs["access_token"] == "access-token"
         assert kwargs["endpoint"] == "events"
+        assert kwargs["team_id"] == 123
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
-        assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2024-01-02T03:04:05.000Z"
 
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.gocardless.source.gocardless_source")


### PR DESCRIPTION
## Problem

Batch 18 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

This batch also lands a generic framework capability — **auth-secret redaction in raised exception messages** — so a source whose API key rides in a query param no longer leaks it into the user-visible error.

## Changes

Framework:
- `common/rest_source` now scrubs the configured auth's secret values out of every raised error message (`raise_for_status` HTTPError, `HTTP {status} for {url}`, malformed-JSON, redirect, and off-host errors). An API that carries its key in the URL query string (e.g. `?api_key=...`) previously leaked it via the request URL embedded in those messages; the secret is now replaced with `***` while the status/prefix text is preserved. Reuses the same `auth_secret_values` already registered for log redaction.

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **flowlu** — now expressible: its api_key rides in the query param, and the new exception redaction keeps the key out of `latest_error`
- **fly_io**
- **fullstory**
- **giphy** — query-param api_key, redaction-covered
- **gitbook**
- **gocardless**

Not migrated this batch (left hand-rolled, valid blockers):
- **gladly** — bulk data ships as streamed JSONL export files (`iter_lines` + per-line decode tolerance) with client-side job-watermark filtering and two transport modes.
- **gnews** — classifies a 403 by page number (graceful-stop on page > 1, fail-loud on page 1), not expressible via status/content-only response actions.

## How did you test this code?

- New framework capability: 3 cases in `test_exception_redaction.py` — a query-param secret is scrubbed from both a 4xx HTTPError and a 5xx retryable error (status prefix preserved), and messages are untouched when no auth secret is registered.
- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 6 migrated dirs + `common/rest_source/tests/` — 429 passed. Additive framework change: all existing `rest_source` tests plus auth-carrying consumer smoke (alguna, apify_dataset, delighted, checkout_com) stay green.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-17 PR (#71856); merge in order.
