### PR TITLE
refactor(data-warehouse): migrate ding_connect, eventee, ezofficeinventory, float_app, gainsight_px, goldcast (batch 19)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/ding_connect.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/ding_connect.py
@@ -1,14 +1,20 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.ding_connect.settings import (
     DING_CONNECT_ENDPOINTS,
     DingConnectEndpointConfig,
@@ -24,62 +30,10 @@ TRANSFER_RECORDS_PAGE_SIZE = 100
 _ENVELOPE_KEYS = ("ResultCode", "ErrorCodes", "ThereAreMoreItems")
 
 
-class DingConnectRetryableError(Exception):
-    pass
-
-
-@dataclasses.dataclass
-class DingConnectResumeConfig:
-    # Number of TransferRecords rows already returned; the Skip value the next page resumes from.
-    # Only the paginated TransferRecords endpoint persists this; reference endpoints complete in a
-    # single request and never save state.
-    skip: int = 0
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "api_key": api_key,
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
-
-
-@retry(
-    retry=retry_if_exception_type((DingConnectRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _request(
-    session: requests.Session,
-    method: str,
-    url: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    json_body: Optional[dict[str, Any]] = None,
-) -> dict[str, Any]:
-    response = session.request(method, url, headers=headers, json=json_body, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise DingConnectRetryableError(f"DingConnect API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Truncate the body: DingConnect error responses can echo row data (e.g. AccountNumber from
-        # TransferRecords), so we log only a short preview to avoid persisting PII in logs.
-        logger.error(f"DingConnect API error: status={response.status_code}, body={response.text[:500]}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def validate_credentials(api_key: str) -> bool:
-    # GetBalance is the cheapest call that proves both the key is valid and an account is attached.
-    url = f"{DING_CONNECT_BASE_URL}/api/V1/GetBalance"
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(url, headers=_get_headers(api_key), timeout=30)
-        return response.status_code == 200
-    except Exception:
-        return False
+def _non_secret_headers() -> dict[str, str]:
+    # The api_key travels via the framework `api_key` auth so its value is redacted from logs and
+    # raised error messages; only the non-secret content-negotiation headers are set here.
+    return {"Accept": "application/json", "Content-Type": "application/json"}
 
 
 def _flatten_transfer_record(record: dict[str, Any]) -> dict[str, Any]:
@@ -97,96 +51,130 @@ def _row_from_single_object(body: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in body.items() if key not in _ENVELOPE_KEYS}
 
 
-def _get_reference_rows(
-    session: requests.Session,
-    config: DingConnectEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    url = f"{DING_CONNECT_BASE_URL}{config.path}"
-    body = _request(session, config.method, url, headers, logger)
+class DingConnectTransferRecordsPaginator(BasePaginator):
+    """Skip/Take offset paging carried in the POST body.
 
-    if config.data_selector == "":
-        yield [_row_from_single_object(body)]
-        return
+    ListTransferRecords paginates via ``{"Skip": n, "Take": page_size}`` in the JSON payload and
+    signals continuation with the documented ``ThereAreMoreItems`` flag; when that flag is absent we
+    fall back to "a full page implies more". No built-in paginator reads a body-level boolean, so this
+    keeps the exact termination the hand-rolled source had while remaining resumable.
+    """
 
-    items = body.get(config.data_selector, []) or []
-    if items:
-        yield items
+    def __init__(self, skip: int = 0) -> None:
+        super().__init__()
+        self._skip = skip
 
+    def _inject(self, request: Request) -> None:
+        if request.json is None:
+            request.json = {}
+        request.json["Skip"] = self._skip
+        request.json["Take"] = TRANSFER_RECORDS_PAGE_SIZE
 
-def _get_transfer_record_rows(
-    session: requests.Session,
-    config: DingConnectEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DingConnectResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    url = f"{DING_CONNECT_BASE_URL}{config.path}"
+    def init_request(self, request: Request) -> None:
+        self._inject(request)
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    skip = resume.skip if resume is not None else 0
-    if skip:
-        logger.debug(f"DingConnect: resuming TransferRecords from skip={skip}")
-
-    while True:
-        body = _request(
-            session,
-            config.method,
-            url,
-            headers,
-            logger,
-            json_body={"Skip": skip, "Take": TRANSFER_RECORDS_PAGE_SIZE},
-        )
-
-        items = body.get(config.data_selector, []) or []
-        if items:
-            yield [_flatten_transfer_record(item) for item in items]
-
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        there_are_more = body.get("ThereAreMoreItems") if isinstance(body, dict) else None
         # `ThereAreMoreItems` is the documented continuation flag; fall back to a short final page.
-        there_are_more = body.get("ThereAreMoreItems")
-        has_next = there_are_more if there_are_more is not None else len(items) == TRANSFER_RECORDS_PAGE_SIZE
+        has_next = bool(there_are_more) if there_are_more is not None else len(items) == TRANSFER_RECORDS_PAGE_SIZE
         if not items or not has_next:
-            break
+            self._has_next_page = False
+            return
+        self._skip += TRANSFER_RECORDS_PAGE_SIZE
+        self._has_next_page = True
 
-        skip += TRANSFER_RECORDS_PAGE_SIZE
-        # Save AFTER yielding so a crash re-yields the last page rather than skipping it; the
-        # full-refresh replace plus the TransferRef primary key dedupe any re-pulled rows.
-        resumable_source_manager.save_state(DingConnectResumeConfig(skip=skip))
+    def update_request(self, request: Request) -> None:
+        self._inject(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self._skip already points at the next page to fetch (update_state advanced it).
+        return {"skip": self._skip} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        skip = state.get("skip")
+        if skip is not None:
+            self._skip = int(skip)
+            self._has_next_page = True
 
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[DingConnectResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = DING_CONNECT_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    session = make_tracked_session(redact_values=(api_key,))
+@dataclasses.dataclass
+class DingConnectResumeConfig:
+    # Number of TransferRecords rows already returned; the Skip value the next page resumes from.
+    # Only the paginated TransferRecords endpoint persists this; reference endpoints complete in a
+    # single request and never save state.
+    skip: int = 0
+
+
+def _build_resource(endpoint: str, config: DingConnectEndpointConfig) -> dict[str, Any]:
+    endpoint_config: dict[str, Any] = {"path": config.path, "method": config.method}
+    resource: dict[str, Any] = {"name": endpoint, "endpoint": endpoint_config}
 
     if config.paginated:
-        yield from _get_transfer_record_rows(session, config, headers, logger, resumable_source_manager)
+        # TransferRecords: paged POST; the paginator injects Skip/Take into the JSON body.
+        endpoint_config["data_selector"] = config.data_selector
+        endpoint_config["paginator"] = DingConnectTransferRecordsPaginator()
+        resource["data_map"] = _flatten_transfer_record
+    elif config.data_selector == "":
+        # GetBalance returns a single object at the top level; wrap it as one row and strip the
+        # envelope keys so only the balance fields land.
+        endpoint_config["paginator"] = SinglePagePaginator()
+        resource["data_map"] = _row_from_single_object
     else:
-        yield from _get_reference_rows(session, config, headers, logger)
+        # Reference/catalog lookups return their whole bounded list under `Items` in one response.
+        endpoint_config["data_selector"] = config.data_selector
+        endpoint_config["paginator"] = SinglePagePaginator()
+
+    return resource
 
 
 def ding_connect_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[DingConnectResumeConfig],
 ) -> SourceResponse:
     config = DING_CONNECT_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": DING_CONNECT_BASE_URL,
+            "headers": _non_secret_headers(),
+            "auth": {"type": "api_key", "api_key": api_key, "name": "api_key", "location": "header"},
+        },
+        "resources": [_build_resource(endpoint, config)],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"skip": resume.skip}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (the full-refresh replace plus the primary key dedupe any re-pulled rows)
+        # rather than skipping it. Only the paginated TransferRecords endpoint ever produces state.
+        if state and state.get("skip") is not None:
+            resumable_source_manager.save_state(DingConnectResumeConfig(skip=int(state["skip"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # full refresh only — no DingConnect endpoint exposes a server-side timestamp filter
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1 if config.partition_key else None,
         partition_size=1 if config.partition_key else None,
@@ -194,3 +182,13 @@ def ding_connect_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    # GetBalance is the cheapest call that proves both the key is valid and an account is attached.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{DING_CONNECT_BASE_URL}/api/V1/GetBalance",
+        headers={"api_key": api_key, **_non_secret_headers()},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.ding_connect.ding_connect import (
     DingConnectResumeConfig,
     ding_connect_source,
@@ -65,34 +68,20 @@ class DingConnectSource(ResumableSource[DingConnectSourceConfig, DingConnectResu
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _description(endpoint: str) -> str | None:
-            if endpoint == "TransferRecords":
-                # DingConnect only retains transfer history for ~2 months, so each full-refresh
-                # sync reflects the currently-retained window.
-                return "Transfer history is only retained upstream for ~2 months. Full refresh only"
-            if endpoint == "Balance":
-                return "Current account balance per currency. Full refresh only"
-            return None
-
         # No DingConnect endpoint exposes a server-side timestamp filter, so every table is full
         # refresh: the catalog endpoints are static lookups and ListTransferRecords only offers
-        # Skip/Take offset paging.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                description=_description(endpoint),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # Skip/Take offset paging. No incremental fields => every schema is full-refresh only.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions={
+                # DingConnect only retains transfer history for ~2 months, so each full-refresh
+                # sync reflects the currently-retained window.
+                "TransferRecords": "Transfer history is only retained upstream for ~2 months. Full refresh only",
+                "Balance": "Current account balance per currency. Full refresh only",
+            },
+        )
 
     def validate_credentials(
         self, config: DingConnectSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -114,7 +103,8 @@ class DingConnectSource(ResumableSource[DingConnectSourceConfig, DingConnectResu
         return ding_connect_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/tests/test_ding_connect.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/tests/test_ding_connect.py
@@ -1,53 +1,69 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.ding_connect import ding_connect
 from products.warehouse_sources.backend.temporal.data_imports.sources.ding_connect.ding_connect import (
     DingConnectResumeConfig,
     _flatten_transfer_record,
     _row_from_single_object,
     ding_connect_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.ding_connect.settings import (
     DING_CONNECT_ENDPOINTS,
 )
 
-
-class _FakeResumableManager:
-    def __init__(self, state: DingConnectResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[DingConnectResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> DingConnectResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: DingConnectResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the ding_connect module.
+DING_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.ding_connect.ding_connect.make_tracked_session"
+)
 
 
-def _collect(endpoint: str, responses: list[dict[str, Any]], manager: _FakeResumableManager, monkeypatch: Any) -> list:
-    """Run get_rows against a queue of canned envelope responses, flattening yielded pages to rows."""
-    queue = list(responses)
+def _response(body: dict[str, Any]) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
-    def fake_request(session: Any, method: str, url: str, headers: dict, logger: Any, json_body: Any = None) -> dict:
-        return queue.pop(0)
 
-    monkeypatch.setattr(ding_connect, "_request", fake_request)
-    monkeypatch.setattr(ding_connect, "make_tracked_session", lambda **kwargs: MagicMock())
+def _make_manager(resume_state: DingConnectResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    rows: list = []
-    for page in get_rows("key", endpoint, MagicMock(), manager):  # type: ignore[arg-type]
-        rows.extend(page)
-    return rows
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's JSON body AT SEND TIME.
+
+    ``request.json`` is a single dict the paginator mutates in place across pages, so inspecting it
+    after the run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    json_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        json_snapshots.append(dict(request.json or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return json_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, api_key: str = "key"):
+    return ding_connect_source(api_key, endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
 
 
 class TestFlattenTransferRecord:
@@ -76,132 +92,139 @@ class TestRowFromSingleObject:
 
 
 class TestReferenceEndpoints:
-    def test_list_endpoint_yields_items(self, monkeypatch: Any) -> None:
-        responses = [{"Items": [{"CountryIso": "GB"}, {"CountryIso": "US"}], "ResultCode": 1, "ErrorCodes": []}]
-        rows = _collect("Countries", responses, _FakeResumableManager(), monkeypatch)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_list_endpoint_yields_items(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Items": [{"CountryIso": "GB"}, {"CountryIso": "US"}], "ResultCode": 1})])
+
+        rows = _rows(_source("Countries", _make_manager()))
         assert rows == [{"CountryIso": "GB"}, {"CountryIso": "US"}]
+        # A bounded catalog list comes back in exactly one request.
+        assert session.send.call_count == 1
 
-    def test_empty_list_yields_nothing(self, monkeypatch: Any) -> None:
-        responses = [{"Items": [], "ResultCode": 1, "ErrorCodes": []}]
-        rows = _collect("Currencies", responses, _FakeResumableManager(), monkeypatch)
-        assert rows == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_list_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Items": [], "ResultCode": 1})])
 
-    def test_single_object_endpoint_wraps_one_row(self, monkeypatch: Any) -> None:
-        responses = [{"Balance": 42.0, "CurrencyIso": "EUR", "ResultCode": 1, "ErrorCodes": []}]
-        rows = _collect("Balance", responses, _FakeResumableManager(), monkeypatch)
-        assert rows == [{"Balance": 42.0, "CurrencyIso": "EUR"}]
+        assert _rows(_source("Currencies", _make_manager())) == []
 
-    def test_reference_endpoint_does_not_save_resume_state(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        responses = [{"Items": [{"ProviderCode": "P1"}], "ResultCode": 1, "ErrorCodes": []}]
-        _collect("Providers", responses, manager, monkeypatch)
-        assert manager.saved == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_object_endpoint_wraps_one_row(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Balance": 42.0, "CurrencyIso": "EUR", "ResultCode": 1, "ErrorCodes": []})])
+
+        # GetBalance carries its payload at the top level; it becomes one row with envelope keys stripped.
+        assert _rows(_source("Balance", _make_manager())) == [{"Balance": 42.0, "CurrencyIso": "EUR"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_reference_endpoint_does_not_save_resume_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Items": [{"ProviderCode": "P1"}], "ResultCode": 1})])
+
+        manager = _make_manager()
+        _rows(_source("Providers", manager))
+        manager.save_state.assert_not_called()
 
 
 class TestTransferRecordsPagination:
-    def _page(self, refs: list[str], there_are_more: bool) -> dict[str, Any]:
-        return {
-            "Items": [{"TransferId": {"TransferRef": r, "DistributorRef": f"d-{r}"}} for r in refs],
-            "ThereAreMoreItems": there_are_more,
-            "ResultCode": 1,
-            "ErrorCodes": [],
-        }
+    def _page(self, refs: list[str], there_are_more: bool) -> Response:
+        return _response(
+            {
+                "Items": [{"TransferId": {"TransferRef": r, "DistributorRef": f"d-{r}"}} for r in refs],
+                "ThereAreMoreItems": there_are_more,
+                "ResultCode": 1,
+                "ErrorCodes": [],
+            }
+        )
 
-    def test_single_page_flattens_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = _collect("TransferRecords", [self._page(["TR1", "TR2"], there_are_more=False)], manager, monkeypatch)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_flattens_and_stops(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(session, [self._page(["TR1", "TR2"], there_are_more=False)])
+
+        manager = _make_manager()
+        rows = _rows(_source("TransferRecords", manager))
         assert [r["TransferRef"] for r in rows] == ["TR1", "TR2"]
+        # The flatten lifts DistributorRef alongside TransferRef.
+        assert rows[0]["DistributorRef"] == "d-TR1"
+        # First page requests Skip=0 with the fixed page size in the POST body.
+        assert bodies[0] == {"Skip": 0, "Take": 100}
+        assert session.send.call_count == 1
         # Only one page, so there's nothing further to resume to.
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_follows_pagination_until_there_are_no_more_items(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        responses = [
-            self._page(["TR1"], there_are_more=True),
-            self._page(["TR2"], there_are_more=True),
-            self._page(["TR3"], there_are_more=False),
-        ]
-        rows = _collect("TransferRecords", responses, manager, monkeypatch)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_pagination_until_there_are_no_more_items(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Single-item pages (shorter than the page size) keep paging purely on the ThereAreMoreItems
+        # flag — proving termination follows the body flag, not page length.
+        bodies = _wire(
+            session,
+            [
+                self._page(["TR1"], there_are_more=True),
+                self._page(["TR2"], there_are_more=True),
+                self._page(["TR3"], there_are_more=False),
+            ],
+        )
+
+        rows = _rows(_source("TransferRecords", _make_manager()))
         assert [r["TransferRef"] for r in rows] == ["TR1", "TR2", "TR3"]
+        assert [b["Skip"] for b in bodies] == [0, 100, 200]
 
-    def test_saves_advancing_skip_after_each_non_final_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        responses = [
-            self._page(["TR1"], there_are_more=True),
-            self._page(["TR2"], there_are_more=False),
-        ]
-        _collect("TransferRecords", responses, manager, monkeypatch)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_advancing_skip_after_each_non_final_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [self._page(["TR1"], there_are_more=True), self._page(["TR2"], there_are_more=False)])
+
+        manager = _make_manager()
+        _rows(_source("TransferRecords", manager))
         # State saved once (after the first page), advancing skip by the page size; the final page
         # saves nothing so a completed sync leaves no stale resume cursor.
-        assert [c.skip for c in manager.saved] == [ding_connect.TRANSFER_RECORDS_PAGE_SIZE]
+        saved = [c.args[0] for c in manager.save_state.call_args_list]
+        assert saved == [DingConnectResumeConfig(skip=100)]
 
-    def test_resumes_from_saved_skip(self, monkeypatch: Any) -> None:
-        seen_skips: list[int] = []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_skip(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(session, [self._page(["TR9"], there_are_more=False)])
 
-        def fake_request(
-            session: Any, method: str, url: str, headers: dict, logger: Any, json_body: Any = None
-        ) -> dict:
-            seen_skips.append(json_body["Skip"])
-            return self._page(["TR9"], there_are_more=False)
-
-        monkeypatch.setattr(ding_connect, "_request", fake_request)
-        monkeypatch.setattr(ding_connect, "make_tracked_session", lambda **kwargs: MagicMock())
-
-        manager = _FakeResumableManager(DingConnectResumeConfig(skip=200))
-        list(get_rows("key", "TransferRecords", MagicMock(), manager))  # type: ignore[arg-type]
-        assert seen_skips == [200]
-
-
-class TestValidateCredentials:
-    def test_status_maps_to_validity(self, monkeypatch: Any) -> None:
-        # 200 means the api_key was accepted; any other status (401 bad key, 500 transient) is treated
-        # as not-yet-valid at source-create.
-        for status_code, expected in [(200, True), (401, False), (500, False)]:
-            session = MagicMock()
-            session.get.return_value = MagicMock(status_code=status_code)
-            monkeypatch.setattr(ding_connect, "make_tracked_session", lambda *args, session=session, **kwargs: session)
-            assert validate_credentials("key") is expected
-
-    def test_network_error_is_invalid(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("boom")
-        monkeypatch.setattr(ding_connect, "make_tracked_session", lambda **kwargs: session)
-        assert validate_credentials("key") is False
+        manager = _make_manager(DingConnectResumeConfig(skip=200))
+        _rows(_source("TransferRecords", manager))
+        assert bodies[0]["Skip"] == 200
 
 
 class TestApiKeyRedaction:
     # The api_key travels in a request header, so every tracked session that carries it must
-    # redact it from HTTP observer logs and captures.
-    def test_get_rows_redacts_api_key(self, monkeypatch: Any) -> None:
-        captured: dict[str, Any] = {}
+    # redact its value from HTTP observer logs, captures, and raised error messages.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_session_redacts_api_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Items": [], "ResultCode": 1})])
 
-        def fake_make_tracked_session(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            return MagicMock()
+        _rows(_source("Countries", _make_manager(), api_key="secret-key"))
+        assert MockSession.call_args.kwargs["redact_values"] == ("secret-key",)
 
-        monkeypatch.setattr(ding_connect, "make_tracked_session", fake_make_tracked_session)
-        monkeypatch.setattr(
-            ding_connect,
-            "_request",
-            lambda *args, **kwargs: {"Items": [], "ResultCode": 1, "ErrorCodes": []},
-        )
-
-        list(get_rows("secret-key", "Countries", MagicMock(), _FakeResumableManager()))  # type: ignore[arg-type]
-        assert captured["redact_values"] == ("secret-key",)
-
-    def test_validate_credentials_redacts_api_key(self, monkeypatch: Any) -> None:
-        captured: dict[str, Any] = {}
-
-        def fake_make_tracked_session(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            session = MagicMock()
-            session.get.return_value = MagicMock(status_code=200)
-            return session
-
-        monkeypatch.setattr(ding_connect, "make_tracked_session", fake_make_tracked_session)
-
+    @mock.patch(DING_SESSION_PATCH)
+    def test_validate_credentials_redacts_api_key(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("secret-key")
-        assert captured["redact_values"] == ("secret-key",)
+        assert mock_session.call_args.kwargs["redact_values"] == ("secret-key",)
+
+
+class TestValidateCredentials:
+    @parameterized.expand([(200, True), (401, False), (500, False)])
+    @mock.patch(DING_SESSION_PATCH)
+    def test_status_maps_to_validity(self, status_code: int, expected: bool, mock_session) -> None:
+        # 200 means the api_key was accepted; any other status (401 bad key, 500 transient) is treated
+        # as not-yet-valid at source-create.
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("key") is expected
+
+    @mock.patch(DING_SESSION_PATCH)
+    def test_network_error_is_invalid(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key") is False
 
 
 class TestSourceResponse:
@@ -219,7 +242,7 @@ class TestSourceResponse:
     def test_primary_keys_and_partitioning(
         self, endpoint: str, primary_keys: list[str], partition_key: str | None
     ) -> None:
-        response = ding_connect_source("key", endpoint, MagicMock(), MagicMock())
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == primary_keys
         assert response.partition_keys == ([partition_key] if partition_key else None)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/tests/test_ding_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ding_connect/tests/test_ding_connect_source.py
@@ -90,12 +90,14 @@ class TestSourceForPipeline:
         monkeypatch.setattr(source_module, "ding_connect_source", fake_ding_connect_source)
 
         manager = MagicMock()
-        inputs = MagicMock(schema_name="TransferRecords", logger=MagicMock())
+        inputs = MagicMock(schema_name="TransferRecords", team_id=7, job_id="job-1")
         result = DingConnectSource().source_for_pipeline(MagicMock(api_key="key"), manager, inputs)
 
         assert result is sentinel
         assert captured["api_key"] == "key"
         assert captured["endpoint"] == "TransferRecords"
+        assert captured["team_id"] == 7
+        assert captured["job_id"] == "job-1"
         assert captured["resumable_source_manager"] is manager
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/eventee/eventee.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/eventee/eventee.py
@@ -1,104 +1,63 @@
-from collections.abc import Iterator
-from typing import Any
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.eventee.settings import EVENTEE_ENDPOINTS
 
 # The base URL is fixed: the Bearer token scopes to a single event, so there's no per-tenant host.
 EVENTEE_BASE_URL = "https://api.eventee.com/public/v1"
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
 
 
-class EventeeRetryableError(Exception):
-    pass
-
-
-def _get_session(api_key: str) -> requests.Session:
-    return make_tracked_session(
-        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
-        redact_values=(api_key,),
-    )
-
-
-def validate_credentials(api_key: str) -> bool:
-    """Confirm the token is genuine with a cheap probe. A valid token returns 200; an invalid or
-    expired one returns 401 (`token_invalid`)."""
-    try:
-        response = _get_session(api_key).get(f"{EVENTEE_BASE_URL}/groups", timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _extract_rows(data: Any, data_key: str | None) -> list[dict[str, Any]]:
-    """Normalize an Eventee response into a list of row dicts.
-
-    `/content` returns an object bundling several lists, so a table sourced from it reads its rows
-    from `data[data_key]`. The standalone endpoints return their list directly; `/registrations`
-    can return a single object, so a bare dict is wrapped into a one-element list.
-    """
-    if data_key is not None:
-        if isinstance(data, dict):
-            value = data.get(data_key) or []
-            return value if isinstance(value, list) else [value]
-        return []
-
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict):
-        return [data]
-    return []
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = EVENTEE_ENDPOINTS[endpoint]
-    session = _get_session(api_key)
-
-    @retry(
-        retry=retry_if_exception_type((EventeeRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=2, max=60),
-        reraise=True,
-    )
-    def fetch(path: str) -> Any:
-        url = f"{EVENTEE_BASE_URL}{path}"
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise EventeeRetryableError(f"Eventee API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"Eventee API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    # Every endpoint returns its whole collection in a single response — no pagination.
-    rows = _extract_rows(fetch(config.path), config.data_key)
-    if rows:
-        yield rows
+def _client_config(api_key: str) -> ClientConfig:
+    # The token travels via framework bearer auth (not a hand-built header) so its value is registered
+    # for redaction wherever it surfaces in logs or raised error messages; only the non-secret Accept
+    # header goes here. Every endpoint returns its whole collection in one response — no pagination.
+    return {
+        "base_url": EVENTEE_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_key},
+        "paginator": SinglePagePaginator(),
+    }
 
 
 def eventee_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     config = EVENTEE_ENDPOINTS[endpoint]
 
+    # `/content` bundles several lists, so a table sourced from it reads its rows from `data_key`; the
+    # standalone endpoints return their list directly (data_key None -> the whole body is the rows).
+    # The selector is deliberately NOT required: a missing/empty data key yields 0 rows (matching the
+    # old `_extract_rows`), and `/registrations` returning a bare object is wrapped into one row.
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "data_selector": config.data_key,
+                    "paginator": SinglePagePaginator(),
+                },
+            }
+        ],
+    }
+
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_key=api_key, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1 if config.partition_key else None,
         partition_size=1 if config.partition_key else None,
@@ -106,4 +65,16 @@ def eventee_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Confirm the token is genuine with a cheap probe. A valid token returns 200; an invalid or
+    expired one returns 401 (`token_invalid`)."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{EVENTEE_BASE_URL}/groups",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/eventee/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/eventee/source.py
@@ -18,7 +18,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.eventee.eventee import (
     eventee_source,
     validate_credentials as validate_eventee_credentials,
@@ -96,23 +99,14 @@ All Eventee tables are full refresh only — the API exposes no incremental sync
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Every endpoint is a snapshot with no server-side timestamp filter, so all are full refresh
-        # only (no incremental/append).
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                description="Full refresh only — Eventee exposes no incremental sync filter",
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # only (no incremental/append) — INCREMENTAL_FIELDS is empty, so build_endpoint_schemas
+        # produces supports_incremental=False/supports_append=False for every table.
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            descriptions=dict.fromkeys(ENDPOINTS, "Full refresh only — Eventee exposes no incremental sync filter"),
+        )
 
     def validate_credentials(
         self, config: EventeeSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -126,5 +120,6 @@ All Eventee tables are full refresh only — the API exposes no incremental sync
         return eventee_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/eventee/tests/test_eventee.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/eventee/tests/test_eventee.py
@@ -1,15 +1,20 @@
+import json
 from typing import Any
 from urllib.parse import urlparse
 
 import pytest
 from unittest import mock
 
+from requests import Response
+from requests.exceptions import HTTPError
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    DEFAULT_RETRY_ATTEMPTS,
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.eventee.eventee import (
     EVENTEE_BASE_URL,
-    MAX_RETRY_ATTEMPTS,
-    EventeeRetryableError,
     eventee_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.eventee.settings import (
@@ -17,94 +22,75 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.eventee.se
     EVENTEE_ENDPOINTS,
 )
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.eventee.eventee"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the eventee module.
+EVENTEE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.eventee.eventee.make_tracked_session"
+)
 
 
-def _json_response(body: Any) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = body
-    resp.status_code = 200
-    resp.ok = True
-    return resp
-
-
-def _error_response(status_code: int) -> mock.MagicMock:
-    resp = mock.MagicMock()
+def _response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
     resp.status_code = status_code
-    resp.ok = False
-    resp.text = "error"
+    resp.reason = "OK" if status_code == 200 else "Error"
+    resp.url = f"{EVENTEE_BASE_URL}/content"
+    resp._content = json.dumps(body).encode()
     return resp
 
 
-class TestValidateCredentials:
-    @pytest.mark.parametrize(
-        "status_code, expected",
-        [
-            (200, True),
-            (401, False),
-            (403, False),
-            (500, False),
-        ],
-    )
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
-        response = mock.MagicMock()
-        response.status_code = status_code
-        mock_session.return_value.get.return_value = response
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[str]:
+    """Wire a mock session and capture each request's URL AT SEND TIME (prepare_request is mocked, so
+    the real prepared URL isn't built — snapshot ``request.url`` when the request is prepared)."""
+    session.headers = {}
+    url_snapshots: list[str] = []
 
-        assert validate_credentials("tok") is expected
+    def _prepare(request: Any) -> mock.MagicMock:
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_validate_sends_bearer_token(self, mock_session):
-        response = mock.MagicMock()
-        response.status_code = 200
-        mock_session.return_value.get.return_value = response
-
-        validate_credentials("tok")
-
-        headers = mock_session.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer tok"
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_validate_credentials_swallows_exceptions(self, mock_session):
-        mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("tok") is False
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return url_snapshots
 
 
-class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_content_subresource_extracted_by_data_key(self, mock_session):
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestRowExtraction:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_content_subresource_extracted_by_data_key(self, MockSession) -> None:
         # /content bundles several lists; the `halls` table reads its rows from the `halls` key and
         # must not pick up rows from sibling keys.
-        content = {
-            "halls": [{"id": 1, "name": "Main"}],
-            "lectures": [{"id": 99, "name": "Keynote"}],
-        }
-        mock_session.return_value.get.return_value = _json_response(content)
+        session = MockSession.return_value
+        content = {"halls": [{"id": 1, "name": "Main"}], "lectures": [{"id": 99, "name": "Keynote"}]}
+        urls = _wire(session, [_response(content)])
 
-        batches = list(get_rows("tok", "halls", mock.MagicMock()))
+        rows = _rows(eventee_source("tok", "halls", team_id=1, job_id="j"))
 
-        assert batches == [[{"id": 1, "name": "Main"}]]
-        url = mock_session.return_value.get.call_args.args[0]
-        assert urlparse(url).path == "/public/v1/content"
+        assert rows == [{"id": 1, "name": "Main"}]
+        assert urlparse(urls[0]).path == "/public/v1/content"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_standalone_array_endpoint(self, mock_session):
-        mock_session.return_value.get.return_value = _json_response([{"id": 7}, {"id": 8}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_standalone_array_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        urls = _wire(session, [_response([{"id": 7}, {"id": 8}])])
 
-        batches = list(get_rows("tok", "groups", mock.MagicMock()))
+        rows = _rows(eventee_source("tok", "groups", team_id=1, job_id="j"))
 
-        assert batches == [[{"id": 7}, {"id": 8}]]
-        assert urlparse(mock_session.return_value.get.call_args.args[0]).path == "/public/v1/groups"
+        assert rows == [{"id": 7}, {"id": 8}]
+        assert urlparse(urls[0]).path == "/public/v1/groups"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_single_object_response_wrapped_in_list(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_object_response_wrapped_in_list(self, MockSession) -> None:
         # /registrations can return a bare object rather than an array.
-        mock_session.return_value.get.return_value = _json_response({"id": 420, "email": "a@b.com"})
+        session = MockSession.return_value
+        _wire(session, [_response({"id": 420, "email": "a@b.com"})])
 
-        batches = list(get_rows("tok", "registrations", mock.MagicMock()))
+        rows = _rows(eventee_source("tok", "registrations", team_id=1, job_id="j"))
 
-        assert batches == [[{"id": 420, "email": "a@b.com"}]]
+        assert rows == [{"id": 420, "email": "a@b.com"}]
 
     @pytest.mark.parametrize(
         "endpoint, body",
@@ -115,56 +101,82 @@ class TestGetRows:
             ("groups", None),
         ],
     )
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_or_missing_data_yields_nothing(self, mock_session, endpoint, body):
-        mock_session.return_value.get.return_value = _json_response(body)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_or_missing_data_yields_no_rows(self, MockSession, endpoint, body) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
 
-        assert list(get_rows("tok", endpoint, mock.MagicMock())) == []
+        assert _rows(eventee_source("tok", endpoint, team_id=1, job_id="j")) == []
+
+
+class TestRetries:
+    @mock.patch("time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_retryable_status_then_succeeds(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, 500), _response({}, 429), _response([{"id": 1}])])
+
+        rows = _rows(eventee_source("tok", "groups", team_id=1, job_id="j"))
+
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 3
 
     @mock.patch("time.sleep")
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_retries_retryable_status_then_succeeds(self, mock_session, _mock_sleep):
-        mock_session.return_value.get.side_effect = [
-            _error_response(500),
-            _error_response(429),
-            _json_response([{"id": 1}]),
-        ]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_exhausted_raises(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.return_value = mock.MagicMock()
+        session.send.return_value = _response({}, 503)
 
-        batches = list(get_rows("tok", "groups", mock.MagicMock()))
+        with pytest.raises(RESTClientRetryableError):
+            _rows(eventee_source("tok", "groups", team_id=1, job_id="j"))
 
-        assert batches == [[{"id": 1}]]
-        assert mock_session.return_value.get.call_count == 3
-
-    @mock.patch("time.sleep")
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_retries_exhausted_raises(self, mock_session, _mock_sleep):
-        mock_session.return_value.get.return_value = _error_response(503)
-
-        with pytest.raises(EventeeRetryableError):
-            list(get_rows("tok", "groups", mock.MagicMock()))
-
-        assert mock_session.return_value.get.call_count == MAX_RETRY_ATTEMPTS
+        assert session.send.call_count == DEFAULT_RETRY_ATTEMPTS
 
     @mock.patch("time.sleep")
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_client_error_raises_for_status(self, mock_session, _mock_sleep):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises_for_status_without_retry(self, MockSession, _sleep) -> None:
         # A 401 is not retryable — it must propagate via raise_for_status so the source can mark it
         # non-retryable rather than burning retries on a bad token.
-        resp = _error_response(401)
-        resp.raise_for_status.side_effect = Exception("401 Client Error")
-        mock_session.return_value.get.return_value = resp
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.return_value = mock.MagicMock()
+        session.send.return_value = _response({"error": "token_invalid"}, 401)
 
-        with pytest.raises(Exception, match="401 Client Error"):
-            list(get_rows("tok", "groups", mock.MagicMock()))
+        with pytest.raises(HTTPError):
+            _rows(eventee_source("tok", "groups", team_id=1, job_id="j"))
 
-        assert mock_session.return_value.get.call_count == 1
+        assert session.send.call_count == 1
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
+    @mock.patch(EVENTEE_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status_code, expected) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("tok") is expected
+
+    @mock.patch(EVENTEE_SESSION_PATCH)
+    def test_sends_bearer_token(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+
+        validate_credentials("tok")
+
+        headers = mock_session.return_value.get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer tok"
+
+    @mock.patch(EVENTEE_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("tok") is False
 
 
 class TestEventeeSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    def test_response_metadata_per_endpoint(self, endpoint) -> None:
         config = EVENTEE_ENDPOINTS[endpoint]
-        response = eventee_source("tok", endpoint, mock.MagicMock())
+        response = eventee_source("tok", endpoint, team_id=1, job_id="j")
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -179,11 +191,11 @@ class TestEventeeSourceResponse:
             assert response.partition_keys is None
 
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_partition_keys_are_stable_creation_fields(self, endpoint):
+    def test_partition_keys_are_stable_creation_fields(self, endpoint) -> None:
         # Partitioning on a mutable field (updated_at / checked_at) rewrites partitions every sync.
         config = EVENTEE_ENDPOINTS[endpoint]
         if config.partition_key:
             assert config.partition_key in ("created_at", "registered_at")
 
-    def test_base_url_is_fixed(self):
+    def test_base_url_is_fixed(self) -> None:
         assert EVENTEE_BASE_URL == "https://api.eventee.com/public/v1"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/ezofficeinventory.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/ezofficeinventory.py
@@ -1,17 +1,21 @@
 import re
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from collections.abc import Callable
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 from urllib3.util.retry import Retry
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.ezofficeinventory.settings import (
     EZOFFICEINVENTORY_ENDPOINTS,
     EZOfficeInventoryEndpointConfig,
@@ -20,12 +24,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.ezofficein
 # EZOfficeInventory enforces a per-account hostname, so only the subdomain label is user-supplied.
 # Restricting it to host-safe characters keeps the request pinned to *.ezofficeinventory.com.
 SUBDOMAIN_REGEX = re.compile(r"^[a-zA-Z0-9-]+$")
-
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class EZOfficeInventoryRetryableError(Exception):
-    """Raised for transient API responses (429 / 5xx) so tenacity retries them."""
 
 
 @dataclasses.dataclass
@@ -38,117 +36,90 @@ def base_url(subdomain: str) -> str:
     return f"https://{subdomain}.ezofficeinventory.com"
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    return {"token": api_key, "Accept": "application/json"}
+def _make_unwrap_map(unwrap_key: str) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Some list endpoints wrap each record in a single-key object (e.g. groups returns
+    `{"groups": [{"group": {...}}]}`); unwrap it, falling back to the row untouched when the
+    inner key is absent (a row already shaped like the unwrapped object)."""
+
+    def _unwrap(item: dict[str, Any]) -> dict[str, Any]:
+        if isinstance(item, dict) and unwrap_key in item:
+            return item[unwrap_key]
+        return item
+
+    return _unwrap
 
 
-def _extract_items(data: dict[str, Any], config: EZOfficeInventoryEndpointConfig) -> list[dict[str, Any]]:
-    """Pull the record list out of the response, unwrapping single-key item objects where needed."""
-    items = data.get(config.data_selector) or []
-    if not isinstance(items, list):
-        return []
+def _rest_config(subdomain: str, api_key: str, config: EZOfficeInventoryEndpointConfig) -> RESTAPIConfig:
+    endpoint: dict[str, Any] = {
+        "path": config.path,
+        "params": dict(config.extra_params),
+        "data_selector": config.data_selector,
+        # `total_pages` is the total number of PAGES; the paginator stops after it. When the API
+        # omits it, an empty page terminates instead (stop_after_empty_page).
+        "paginator": PageNumberPaginator(base_page=1, page=1, page_param="page", total_path="total_pages"),
+    }
+    resource: dict[str, Any] = {"name": config.name, "endpoint": endpoint}
     if config.unwrap_key:
-        unwrapped = []
-        for item in items:
-            if isinstance(item, dict) and config.unwrap_key in item:
-                unwrapped.append(item[config.unwrap_key])
-            else:
-                unwrapped.append(item)
-        return unwrapped
-    return items
+        resource["data_map"] = _make_unwrap_map(config.unwrap_key)
 
-
-@retry(
-    retry=retry_if_exception_type((EZOfficeInventoryRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(6),
-    wait=wait_exponential_jitter(initial=2, max=70),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> dict[str, Any]:
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Fair-use limit is ~60 req/min; the API returns 429 with a Retry-After header. Treat 429 and
-    # 5xx as transient and let tenacity back off (max ~70s covers a full rate-limit window reset).
-    if response.status_code == 429 or response.status_code >= 500:
-        raise EZOfficeInventoryRetryableError(
-            f"EZOfficeInventory API error (retryable): status={response.status_code}, url={url}"
-        )
-
-    if not response.ok:
-        logger.error(f"EZOfficeInventory API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _build_url(subdomain: str, config: EZOfficeInventoryEndpointConfig, page: int) -> str:
-    params: dict[str, Any] = dict(config.extra_params)
-    params["page"] = page
-    return f"{base_url(subdomain)}/{config.path}?{urlencode(params)}"
-
-
-def get_rows(
-    api_key: str,
-    subdomain: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[EZOfficeInventoryResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = EZOFFICEINVENTORY_ENDPOINTS[endpoint]
-    headers = _headers(api_key)
-    # One session reused across pages so urllib3 keeps the connection alive.
-    # Redirects are pinned off so the user-supplied token can't be replayed to a
-    # cross-host redirect target (SSRF / credential-exfiltration defense-in-depth).
-    # urllib3 retries are disabled so tenacity (on `_fetch_page`) is the single retry
-    # layer — otherwise 429/5xx would be retried by both, compounding the backoff.
-    session = make_tracked_session(
-        headers=headers, redact_values=(api_key,), allow_redirects=False, retry=Retry(total=0)
-    )
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume else 1
-
-    while True:
-        data = _fetch_page(session, _build_url(subdomain, config, page), logger)
-        items = _extract_items(data, config)
-        if not items:
-            break
-
-        yield items
-
-        total_pages = data.get("total_pages")
-        has_more = total_pages is None or page < total_pages
-        if not has_more:
-            break
-
-        # Checkpoint AFTER yielding so a crash re-fetches the page we just emitted rather than
-        # skipping it — merge dedupes the re-yielded rows on the primary key.
-        page += 1
-        resumable_source_manager.save_state(EZOfficeInventoryResumeConfig(next_page=page))
+    return {
+        "client": {
+            "base_url": base_url(subdomain),
+            # Auth (token header) is supplied via the framework auth config so its value is redacted
+            # from logs and raised error messages; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "token", "location": "header"},
+            # Pin every request (including paginator/resume URLs) to the subdomain host and reject
+            # cross-host redirects — the user-supplied token must not be replayable off-host
+            # (SSRF / credential-exfiltration defense-in-depth). `allowed_hosts=[]` means
+            # "same host as base_url only".
+            "allowed_hosts": [],
+            "allow_redirects": False,
+        },
+        "resources": [resource],
+    }
 
 
 def ezofficeinventory_source(
     api_key: str,
     subdomain: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[EZOfficeInventoryResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = EZOFFICEINVENTORY_ENDPOINTS[endpoint]
 
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # the page we just emitted rather than skipping it — merge dedupes the re-yielded rows.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(EZOfficeInventoryResumeConfig(next_page=int(state["page"])))
+
+    resource = rest_api_resource(
+        _rest_config(subdomain, api_key, config),
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            subdomain=subdomain,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
@@ -158,22 +129,20 @@ def validate_credentials(api_key: str, subdomain: str) -> tuple[bool, str | None
     misreported as bad credentials."""
     if not SUBDOMAIN_REGEX.match(subdomain):
         return False, None
-    try:
-        response = make_tracked_session(
-            headers=_headers(api_key), redact_values=(api_key,), allow_redirects=False, retry=Retry(total=0)
-        ).get(
-            f"{base_url(subdomain)}/assets.api?page=1",
-            timeout=10,
-        )
-    except Exception:
-        return False, None
 
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        # Redirects pinned off and urllib3 retries disabled so the token can't be replayed to a
+        # cross-host redirect target during a single-shot probe.
+        lambda: make_tracked_session(redact_values=(api_key,), allow_redirects=False, retry=Retry(total=0)),
+        f"{base_url(subdomain)}/assets.api?page=1",
+        headers={"token": api_key, "Accept": "application/json"},
+    )
+    if ok:
         return True, None
 
     # The fair-use cap is ~60 req/min; a 429 here means we couldn't verify the token, not that it's
     # wrong. Surface that distinctly so the user isn't told their credentials are invalid.
-    if response.status_code == 429:
+    if status == 429:
         return (
             False,
             "EZOfficeInventory rate limit reached while validating credentials. Please wait a minute and try again.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/source.py
@@ -120,8 +120,10 @@ class EZOfficeInventorySource(ResumableSource[EZOfficeInventorySourceConfig, EZO
             api_key=config.api_key,
             subdomain=config.subdomain,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every EZOfficeInventory endpoint is full refresh
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/tests/test_ezofficeinventory.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/tests/test_ezofficeinventory.py
@@ -2,174 +2,230 @@ import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.ezofficeinventory import ezofficeinventory
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient
 from products.warehouse_sources.backend.temporal.data_imports.sources.ezofficeinventory.ezofficeinventory import (
     EZOfficeInventoryResumeConfig,
-    _build_url,
-    _extract_items,
     ezofficeinventory_source,
-    get_rows,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.ezofficeinventory.settings import (
-    EZOFFICEINVENTORY_ENDPOINTS,
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the ezofficeinventory module.
+EZO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.ezofficeinventory.ezofficeinventory."
+    "make_tracked_session"
 )
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.ezofficeinventory.ezofficeinventory"
 
-
-def _http_response(body: dict[str, Any], status_code: int = 200) -> Response:
+def _response(body: dict[str, Any], status_code: int = 200) -> Response:
     resp = Response()
     resp.status_code = status_code
     resp._content = json.dumps(body).encode()
     resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://acme.ezofficeinventory.com/assets.api"
     return resp
 
 
-def _manager(*, can_resume: bool = False, state: EZOfficeInventoryResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock()
-    manager.can_resume.return_value = can_resume
-    manager.load_state.return_value = state
+def _make_manager(resume_state: EZOfficeInventoryResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-class TestExtractItems:
-    def test_simple_selector(self) -> None:
-        config = EZOFFICEINVENTORY_ENDPOINTS["assets"]
-        assert _extract_items({"assets": [{"identifier": 1}, {"identifier": 2}]}, config) == [
-            {"identifier": 1},
-            {"identifier": 2},
-        ]
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
 
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared instead of inspecting the final state after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = "https://acme.ezofficeinventory.com/assets.api"
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return ezofficeinventory_source(
+        api_key="tok",
+        subdomain="acme",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job",
+        resumable_source_manager=manager,
+    )
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_total_pages(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response({"assets": [{"identifier": 1}], "total_pages": 2}),
+                _response({"assets": [{"identifier": 2}], "total_pages": 2}),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("assets", manager))
+
+        assert rows == [{"identifier": 1}, {"identifier": 2}]
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
+        # State saved once (after page 1), pointing at page 2 — never after the terminal page.
+        manager.save_state.assert_called_once_with(EZOfficeInventoryResumeConfig(next_page=2))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_empty_page_when_total_pages_absent(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"assets": [{"identifier": 1}]}), _response({"assets": []})])
+
+        manager = _make_manager()
+        rows = _rows(_source("assets", manager))
+
+        assert rows == [{"identifier": 1}]
+        assert session.send.call_count == 2
+        manager.save_state.assert_called_once_with(EZOfficeInventoryResumeConfig(next_page=2))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_first_page_empty_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response({"assets": []})])
+
+        manager = _make_manager()
+        rows = _rows(_source("assets", manager))
+
+        assert rows == []
+        assert params[0]["page"] == 1
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response({"assets": [{"identifier": 30}], "total_pages": 3})])
+
+        manager = _make_manager(EZOfficeInventoryResumeConfig(next_page=3))
+        rows = _rows(_source("assets", manager))
+
+        assert rows == [{"identifier": 30}]
+        # Picks up at page 3 (the saved cursor), not page 1.
+        assert params[0]["page"] == 3
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_extra_params_are_sent(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response({"assets": [{"identifier": 1}], "total_pages": 1})])
+
+        _rows(_source("checked_out_assets", manager=_make_manager()))
+        assert params[0]["status"] == "checked_out"
+        assert params[0]["page"] == 1
+
+
+class TestUnwrap:
+    @mock.patch(CLIENT_SESSION_PATCH)
     @pytest.mark.parametrize(
         ("endpoint", "body", "expected"),
         [
-            ("groups", {"groups": [{"group": {"id": 1}}, {"group": {"id": 2}}]}, [{"id": 1}, {"id": 2}]),
-            ("vendors", {"vendors": [{"vendor": {"id": 9}}]}, [{"id": 9}]),
+            (
+                "groups",
+                {"groups": [{"group": {"id": 1}}, {"group": {"id": 2}}], "total_pages": 1},
+                [{"id": 1}, {"id": 2}],
+            ),
+            ("vendors", {"vendors": [{"vendor": {"id": 9}}], "total_pages": 1}, [{"id": 9}]),
+            # A row already shaped like the unwrapped object passes through untouched.
+            ("groups", {"groups": [{"id": 5}], "total_pages": 1}, [{"id": 5}]),
         ],
     )
-    def test_unwraps_single_key_items(self, endpoint: str, body: dict[str, Any], expected: list[dict]) -> None:
-        assert _extract_items(body, EZOFFICEINVENTORY_ENDPOINTS[endpoint]) == expected
+    def test_unwraps_single_key_items(
+        self, MockSession, endpoint: str, body: dict[str, Any], expected: list[dict]
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
 
-    def test_unwrap_falls_back_when_inner_key_absent(self) -> None:
-        # A row already shaped like the unwrapped object is passed through untouched.
-        config = EZOFFICEINVENTORY_ENDPOINTS["groups"]
-        assert _extract_items({"groups": [{"id": 5}]}, config) == [{"id": 5}]
+        rows = _rows(_source(endpoint, _make_manager()))
+        assert rows == expected
 
-    @pytest.mark.parametrize("body", [{}, {"assets": None}, {"assets": "not-a-list"}, {"other": [1]}])
-    def test_missing_or_malformed_selector_returns_empty(self, body: dict[str, Any]) -> None:
-        assert _extract_items(body, EZOFFICEINVENTORY_ENDPOINTS["assets"]) == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_selector_yields_nothing(self, MockSession) -> None:
+        # A response missing the data_selector key is treated as an empty page (full-refresh sources
+        # don't fail loud here — they stop), mirroring the old _extract_items returning [].
+        session = MockSession.return_value
+        _wire(session, [_response({"other": [1]})])
 
-
-class TestBuildUrl:
-    def test_includes_page_and_extra_params(self) -> None:
-        url = _build_url("acme", EZOFFICEINVENTORY_ENDPOINTS["checked_out_assets"], 3)
-        assert url == "https://acme.ezofficeinventory.com/assets/filter.api?status=checked_out&page=3"
-
-    def test_plain_endpoint_only_has_page(self) -> None:
-        url = _build_url("acme", EZOFFICEINVENTORY_ENDPOINTS["assets"], 1)
-        assert url == "https://acme.ezofficeinventory.com/assets.api?page=1"
+        rows = _rows(_source("assets", _make_manager()))
+        assert rows == []
 
 
-class TestGetRows:
-    def _drive(
-        self, endpoint: str, manager: MagicMock, responses: list[Response]
-    ) -> tuple[list[list[dict]], list[str]]:
-        requested_urls: list[str] = []
-        response_iter = iter(responses)
+class TestRetryableFetch:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    @pytest.mark.parametrize("status_code", [429, 500, 503])
+    def test_retryable_status_retries_then_succeeds(self, MockSession, status_code: int) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status_code=status_code),
+                _response({"assets": [{"identifier": 1}], "total_pages": 1}),
+            ],
+        )
 
-        def fake_get(url: str, **_kwargs: Any) -> Response:
-            requested_urls.append(url)
-            return next(response_iter)
+        # Skip the client's real backoff sleep so the test stays fast.
+        with mock.patch.object(RESTClient._send_request.retry, "sleep"):  # type: ignore[attr-defined]
+            rows = _rows(_source("assets", _make_manager()))
 
-        session = MagicMock()
-        session.get.side_effect = fake_get
+        assert rows == [{"identifier": 1}]
+        assert session.send.call_count == 2
 
-        with patch(f"{_MODULE}.make_tracked_session", return_value=session):
-            batches = list(
-                get_rows(
-                    api_key="tok",
-                    subdomain="acme",
-                    endpoint=endpoint,
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,
-                )
-            )
-        return batches, requested_urls
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_fails_loud(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unauthorized"}, status_code=401)])
 
-    def test_sync_session_disables_redirects_and_urllib3_retries(self) -> None:
-        manager = _manager()
-        session = MagicMock()
-        session.get.return_value = _http_response({"assets": []})
-        with patch(f"{_MODULE}.make_tracked_session", return_value=session) as mocked:
-            list(
-                get_rows(
-                    api_key="tok",
-                    subdomain="acme",
-                    endpoint="assets",
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,
-                )
-            )
-            assert mocked.call_args.kwargs["allow_redirects"] is False
-            # urllib3 retries off so tenacity is the only retry layer (no compounded backoff).
-            assert mocked.call_args.kwargs["retry"].total == 0
+        with pytest.raises(Exception):
+            _rows(_source("assets", _make_manager()))
 
-    def test_paginates_until_total_pages(self) -> None:
-        manager = _manager()
-        responses = [
-            _http_response({"assets": [{"identifier": 1}], "total_pages": 2}),
-            _http_response({"assets": [{"identifier": 2}], "total_pages": 2}),
-        ]
-        batches, urls = self._drive("assets", manager, responses)
 
-        assert batches == [[{"identifier": 1}], [{"identifier": 2}]]
-        assert urls == [
-            "https://acme.ezofficeinventory.com/assets.api?page=1",
-            "https://acme.ezofficeinventory.com/assets.api?page=2",
-        ]
-        # State is saved once (after page 1), pointing at page 2 — never after the terminal page.
-        manager.save_state.assert_called_once_with(EZOfficeInventoryResumeConfig(next_page=2))
+class TestSourceResponse:
+    def test_partitioned_endpoint_sets_datetime_partitioning(self) -> None:
+        response = _source("assets", _make_manager())
+        assert response.name == "assets"
+        assert response.primary_keys == ["identifier"]
+        assert response.partition_mode == "datetime"
+        assert response.partition_keys == ["created_at"]
+        assert response.partition_format == "month"
 
-    def test_stops_on_empty_page_when_total_pages_absent(self) -> None:
-        manager = _manager()
-        responses = [
-            _http_response({"assets": [{"identifier": 1}]}),
-            _http_response({"assets": []}),
-        ]
-        batches, urls = self._drive("assets", manager, responses)
-
-        assert batches == [[{"identifier": 1}]]
-        assert len(urls) == 2
-        manager.save_state.assert_called_once_with(EZOfficeInventoryResumeConfig(next_page=2))
-
-    def test_first_page_empty_yields_nothing(self) -> None:
-        manager = _manager()
-        batches, urls = self._drive("assets", manager, [_http_response({"assets": []})])
-
-        assert batches == []
-        assert urls == ["https://acme.ezofficeinventory.com/assets.api?page=1"]
-        manager.save_state.assert_not_called()
-
-    def test_resumes_from_saved_page(self) -> None:
-        manager = _manager(can_resume=True, state=EZOfficeInventoryResumeConfig(next_page=3))
-        responses = [_http_response({"assets": [{"identifier": 30}], "total_pages": 3})]
-        batches, urls = self._drive("assets", manager, responses)
-
-        assert batches == [[{"identifier": 30}]]
-        # Picks up at page 3 (the saved cursor), not page 1.
-        assert urls == ["https://acme.ezofficeinventory.com/assets.api?page=3"]
-        manager.save_state.assert_not_called()
+    def test_unpartitioned_endpoint_has_no_partitioning(self) -> None:
+        response = _source("labels", _make_manager())
+        assert response.primary_keys == ["id"]
+        assert response.partition_mode is None
+        assert response.partition_keys is None
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("bad_subdomain", ["", "has space", "bad/slash", "a.b", "http://x"])
     def test_rejects_unsafe_subdomain_without_network(self, bad_subdomain: str) -> None:
-        with patch(f"{_MODULE}.make_tracked_session") as mocked:
+        with mock.patch(EZO_SESSION_PATCH) as mocked:
             assert validate_credentials("tok", bad_subdomain) == (False, None)
             mocked.assert_not_called()
 
@@ -178,87 +234,32 @@ class TestValidateCredentials:
         [(200, True), (401, False), (403, False), (500, False)],
     )
     def test_maps_status_code(self, status_code: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = _http_response({}, status_code=status_code)
-        with patch(f"{_MODULE}.make_tracked_session", return_value=session):
+        session = mock.MagicMock()
+        session.get.return_value = _response({}, status_code=status_code)
+        with mock.patch(EZO_SESSION_PATCH, return_value=session):
             is_valid, _ = validate_credentials("tok", "acme")
             assert is_valid is expected
 
     def test_rate_limit_returns_specific_message(self) -> None:
-        session = MagicMock()
-        session.get.return_value = _http_response({}, status_code=429)
-        with patch(f"{_MODULE}.make_tracked_session", return_value=session):
+        session = mock.MagicMock()
+        session.get.return_value = _response({}, status_code=429)
+        with mock.patch(EZO_SESSION_PATCH, return_value=session):
             is_valid, error = validate_credentials("tok", "acme")
             assert is_valid is False
             assert error is not None
             assert "rate limit" in error.lower()
 
     def test_validation_session_disables_redirects_and_urllib3_retries(self) -> None:
-        session = MagicMock()
-        session.get.return_value = _http_response({}, status_code=200)
-        with patch(f"{_MODULE}.make_tracked_session", return_value=session) as mocked:
+        session = mock.MagicMock()
+        session.get.return_value = _response({}, status_code=200)
+        with mock.patch(EZO_SESSION_PATCH, return_value=session) as mocked:
             validate_credentials("tok", "acme")
             assert mocked.call_args.kwargs["allow_redirects"] is False
             # Single-shot validation handles status codes itself; urllib3 retries stay off.
             assert mocked.call_args.kwargs["retry"].total == 0
 
     def test_network_error_is_false(self) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = Exception("boom")
-        with patch(f"{_MODULE}.make_tracked_session", return_value=session):
+        with mock.patch(EZO_SESSION_PATCH, return_value=session):
             assert validate_credentials("tok", "acme") == (False, None)
-
-
-class TestSourceResponse:
-    def test_partitioned_endpoint_sets_datetime_partitioning(self) -> None:
-        response = ezofficeinventory_source(
-            api_key="tok",
-            subdomain="acme",
-            endpoint="assets",
-            logger=MagicMock(),
-            resumable_source_manager=_manager(),
-        )
-        assert response.name == "assets"
-        assert response.primary_keys == ["identifier"]
-        assert response.partition_mode == "datetime"
-        assert response.partition_keys == ["created_at"]
-        assert response.partition_format == "month"
-
-    def test_unpartitioned_endpoint_has_no_partitioning(self) -> None:
-        response = ezofficeinventory_source(
-            api_key="tok",
-            subdomain="acme",
-            endpoint="labels",
-            logger=MagicMock(),
-            resumable_source_manager=_manager(),
-        )
-        assert response.primary_keys == ["id"]
-        assert response.partition_mode is None
-        assert response.partition_keys is None
-
-
-class TestRetryableFetch:
-    @pytest.mark.parametrize("status_code", [429, 500, 503])
-    def test_retryable_status_raises_then_succeeds(self, status_code: int) -> None:
-        # The first response is retryable; tenacity retries and the second succeeds.
-        session = MagicMock()
-        session.get.side_effect = [
-            _http_response({}, status_code=status_code),
-            _http_response({"assets": [{"identifier": 1}], "total_pages": 1}),
-        ]
-        # Skip tenacity's real backoff sleep so the test stays fast.
-        with (
-            patch.object(ezofficeinventory._fetch_page.retry, "sleep"),  # type: ignore[attr-defined]
-            patch(f"{_MODULE}.make_tracked_session", return_value=session),
-        ):
-            batches = list(
-                get_rows(
-                    api_key="tok",
-                    subdomain="acme",
-                    endpoint="assets",
-                    logger=MagicMock(),
-                    resumable_source_manager=_manager(),
-                )
-            )
-        assert batches == [[{"identifier": 1}]]
-        assert session.get.call_count == 2

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/tests/test_ezofficeinventory_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ezofficeinventory/tests/test_ezofficeinventory_source.py
@@ -116,7 +116,8 @@ class TestResumableWiring:
     def test_source_for_pipeline_plumbs_arguments(self) -> None:
         inputs = MagicMock()
         inputs.schema_name = "members"
-        inputs.logger = MagicMock()
+        inputs.team_id = 7
+        inputs.job_id = "job-1"
         manager = MagicMock()
 
         with patch(f"{_MODULE}.ezofficeinventory_source") as mocked:
@@ -126,6 +127,8 @@ class TestResumableWiring:
             api_key="tok",
             subdomain="acme",
             endpoint="members",
-            logger=inputs.logger,
+            team_id=7,
+            job_id="job-1",
             resumable_source_manager=manager,
+            db_incremental_field_last_value=None,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/float_app.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/float_app.py
@@ -1,31 +1,27 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.float_app.settings import (
     DELETE_LOG_LIMIT,
     FLOAT_ENDPOINTS,
     PER_PAGE,
-    FloatEndpointConfig,
 )
 
 FLOAT_BASE_URL = "https://api.float.com/v3"
 # Float rejects requests without a User-Agent that identifies the app and a contact email. This is a
 # static integration identifier, not user data, so it's hardcoded rather than surfaced as a form field.
 USER_AGENT = "PostHog Data Warehouse (hey@posthog.com)"
-
-
-class FloatRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -36,18 +32,10 @@ class FloatAppResumeConfig:
     next_cursor: str | None = None
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-        "User-Agent": USER_AGENT,
-    }
-
-
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    if not params:
-        return f"{FLOAT_BASE_URL}{path}"
-    return f"{FLOAT_BASE_URL}{path}?{urlencode(params)}"
+def _non_auth_headers() -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs and
+    # raised errors; only the non-secret accept/user-agent headers are set here.
+    return {"Accept": "application/json", "User-Agent": USER_AGENT}
 
 
 def _header_int(headers: Any, name: str) -> int | None:
@@ -60,178 +48,182 @@ def _header_int(headers: Any, name: str) -> int | None:
         return None
 
 
-def _extract_items(payload: Any) -> list[dict[str, Any]]:
-    """Float list endpoints return a bare JSON array. Guard against a wrapped shape defensively."""
-    if isinstance(payload, list):
-        return payload
-    if isinstance(payload, dict):
-        for key in ("data", "items"):
-            value = payload.get(key)
-            if isinstance(value, list):
-                return value
-    return []
+class FloatPagePaginator(BasePaginator):
+    """Page-number pagination for Float's core resources.
 
+    Total pages come from the `X-Pagination-Pages` response header; when it's absent we fall back to a
+    full-page heuristic (a page of exactly `per-page` items may be followed by another). Resumes from a
+    saved 1-indexed page.
+    """
 
-@retry(
-    retry=retry_if_exception_type((FloatRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> requests.Response:
-    response = session.get(url, headers=headers, timeout=60)
+    def __init__(self, per_page: int = PER_PAGE) -> None:
+        super().__init__()
+        self.per_page = per_page
+        self.page = 1
 
-    # Float enforces 200 GET/min (burst 10/sec) and returns 429 with a `ratelimit-reset` header on
-    # exceed. Back off and retry rather than failing the sync; transient 5xx are retryable too.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise FloatRetryableError(f"Float API error (retryable): status={response.status_code}, url={url}")
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["per-page"] = self.per_page
+        request.params["page"] = self.page
 
-    if not response.ok:
-        logger.error(f"Float API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response
-
-
-def _get_page_rows(
-    session: requests.Session,
-    config: FloatEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[FloatAppResumeConfig],
-    resume: FloatAppResumeConfig | None,
-) -> Iterator[Any]:
-    page = resume.next_page if resume is not None and resume.next_page else 1
-    if page > 1:
-        logger.debug(f"Float: resuming {config.name} from page {page}")
-
-    while True:
-        response = _fetch_page(session, _build_url(config.path, {"per-page": PER_PAGE, "page": page}), headers, logger)
-        items = _extract_items(response.json())
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
         if not items:
-            break
+            self._has_next_page = False
+            return
 
-        # Prefer Float's `X-Pagination-Pages` header; fall back to a full-page heuristic if it's absent.
         total_pages = _header_int(response.headers, "X-Pagination-Pages")
-        has_more = page < total_pages if total_pages is not None else len(items) >= PER_PAGE
+        has_more = self.page < total_pages if total_pages is not None else len(items) >= self.per_page
+        self._has_next_page = has_more
+        if has_more:
+            self.page += 1
 
-        for item in items:
-            batcher.batch(item)
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
 
-        # Yield and save state only after the whole page is batched, so the resume pointer never
-        # advances past a page whose items are still buffered — a mid-page save could skip the
-        # remaining items of the current page on a crash-resume. Save AFTER yielding so a crash
-        # re-yields rather than skips (merge dedupes on the primary key).
-        if batcher.should_yield():
-            yield batcher.get_table()
-            if has_more:
-                resumable_source_manager.save_state(FloatAppResumeConfig(next_page=page + 1))
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"next_page": self.page} if self._has_next_page else None
 
-        if not has_more:
-            break
-        page += 1
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_page = state.get("next_page")
+        if next_page is not None:
+            self.page = int(next_page)
+            self._has_next_page = True
 
 
-def _get_cursor_rows(
-    session: requests.Session,
-    config: FloatEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[FloatAppResumeConfig],
-    resume: FloatAppResumeConfig | None,
-) -> Iterator[Any]:
-    """Walk the cursor-paginated Delete Log endpoints.
+class FloatCursorPaginator(BasePaginator):
+    """Cursor pagination for Float's Delete Log endpoints.
 
-    Termination is defensive: we stop on a missing/blank/repeated `X-Pagination-Next-Cursor`, an explicit
+    Termination is defensive: stop on a missing/blank/repeated `X-Pagination-Next-Cursor`, an explicit
     `X-Pagination-Has-More=false`, or a short page. That guarantees the loop ends even if the delete-log
     pagination header names differ from the documented ones (they can't be verified without a live token).
     """
-    cursor = resume.next_cursor if resume is not None else None
 
-    while True:
-        params: dict[str, Any] = {"limit": DELETE_LOG_LIMIT}
-        if cursor:
-            params["cursor"] = cursor
-        response = _fetch_page(session, _build_url(config.path, params), headers, logger)
-        items = _extract_items(response.json())
+    def __init__(self, limit: int = DELETE_LOG_LIMIT) -> None:
+        super().__init__()
+        self.limit = limit
+        # Cursor to send on the NEXT request (None on the first page); the cursor actually sent on the
+        # current request is tracked separately so we can detect a non-advancing cursor.
+        self._cursor: Optional[str] = None
+        self._current_cursor: Optional[str] = None
 
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["limit"] = self.limit
+        if self._cursor is not None:
+            request.params["cursor"] = self._cursor
+        self._current_cursor = self._cursor
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
         next_cursor = response.headers.get("X-Pagination-Next-Cursor") or None
         has_more_header = response.headers.get("X-Pagination-Has-More")
         has_more_false = has_more_header is not None and str(has_more_header).strip().lower() in ("false", "0", "no")
 
-        page_full = len(items) >= DELETE_LOG_LIMIT
-        advances = bool(next_cursor) and next_cursor != cursor
+        page_full = len(items) >= self.limit
+        advances = bool(next_cursor) and next_cursor != self._current_cursor
         keep_going = page_full and advances and not has_more_false
 
-        if page_full and not advances:
-            logger.warning(
-                f"Float: {config.name} returned a full page with no advancing cursor; stopping to avoid a loop"
-            )
+        self._has_next_page = keep_going
+        if keep_going:
+            self._cursor = next_cursor
 
-        for item in items:
-            batcher.batch(item)
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["limit"] = self.limit
+        if self._cursor is not None:
+            request.params["cursor"] = self._cursor
+        self._current_cursor = self._cursor
 
-        # Same page-boundary discipline as the page paginator: only advance the saved cursor after
-        # the whole page has been batched, so a crash-resume can't skip the current page's tail.
-        if batcher.should_yield():
-            yield batcher.get_table()
-            if keep_going:
-                resumable_source_manager.save_state(FloatAppResumeConfig(next_cursor=next_cursor))
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"next_cursor": self._cursor} if self._has_next_page and self._cursor is not None else None
 
-        if not keep_going:
-            break
-        cursor = next_cursor
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[FloatAppResumeConfig],
-) -> Iterator[Any]:
-    config = FLOAT_ENDPOINTS[endpoint]
-    headers = _headers(api_key)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = make_tracked_session()
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if config.pagination == "cursor":
-        yield from _get_cursor_rows(session, config, headers, logger, batcher, resumable_source_manager, resume)
-    else:
-        yield from _get_page_rows(session, config, headers, logger, batcher, resumable_source_manager, resume)
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_cursor = state.get("next_cursor")
+        if next_cursor is not None:
+            self._cursor = str(next_cursor)
+            self._has_next_page = True
 
 
 def float_app_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[FloatAppResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = FLOAT_ENDPOINTS[endpoint]
 
+    paginator: BasePaginator
+    if config.pagination == "cursor":
+        paginator = FloatCursorPaginator(limit=DELETE_LOG_LIMIT)
+    else:
+        paginator = FloatPagePaginator(per_page=PER_PAGE)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": FLOAT_BASE_URL,
+            "headers": _non_auth_headers(),
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # Float list endpoints return a bare JSON array; the whole body is the row list.
+                    "data_selector": None,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            if config.pagination == "cursor":
+                if resume.next_cursor is not None:
+                    initial_paginator_state = {"next_cursor": resume.next_cursor}
+            elif resume.next_page is not None:
+                initial_paginator_state = {"next_page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes on the primary key) rather than skipping it.
+        if not state:
+            return
+        if state.get("next_page") is not None:
+            resumable_source_manager.save_state(FloatAppResumeConfig(next_page=int(state["next_page"])))
+        elif state.get("next_cursor") is not None:
+            resumable_source_manager.save_state(FloatAppResumeConfig(next_cursor=str(state["next_cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
@@ -241,9 +233,8 @@ def validate_credentials(api_key: str) -> tuple[bool, int | None]:
     Returns ``(ok, status_code)``. ``status_code`` is ``None`` on a transport error. Float uses a single
     account-owner token with full access, so a 200 means the whole API is reachable.
     """
-    url = _build_url("/accounts", {"per-page": 1})
-    try:
-        response = make_tracked_session().get(url, headers=_headers(api_key), timeout=10)
-    except Exception:
-        return False, None
-    return response.status_code == 200, response.status_code
+    return validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{FLOAT_BASE_URL}/accounts?per-page=1",
+        headers={"Authorization": f"Bearer {api_key}", **_non_auth_headers()},
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/source.py
@@ -136,6 +136,8 @@ All streams sync via full refresh — Float's API exposes no server-side modifie
         return float_app_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Float endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/tests/test_float_app.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/tests/test_float_app.py
@@ -1,294 +1,231 @@
+import json
 from typing import Any
 
-import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
-from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.float_app import float_app
 from products.warehouse_sources.backend.temporal.data_imports.sources.float_app.float_app import (
     DELETE_LOG_LIMIT,
     PER_PAGE,
     FloatAppResumeConfig,
-    _build_url,
-    _extract_items,
-    _header_int,
-    get_rows,
+    float_app_source,
     validate_credentials,
 )
 
-
-class TestExtractItems:
-    @parameterized.expand(
-        [
-            ("bare_list", [{"people_id": 1}], [{"people_id": 1}]),
-            ("wrapped_data", {"data": [{"a": 1}]}, [{"a": 1}]),
-            ("wrapped_items", {"items": [{"b": 2}]}, [{"b": 2}]),
-            ("unexpected_dict", {"x": 1}, []),
-            ("empty_list", [], []),
-        ]
-    )
-    def test_extract_items(self, _name: str, payload: Any, expected: list) -> None:
-        assert _extract_items(payload) == expected
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the float_app module.
+FLOAT_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.float_app.float_app.make_tracked_session"
+)
 
 
-class TestHeaderInt:
-    @parameterized.expand(
-        [
-            ("valid", {"X-Pagination-Pages": "5"}, 5),
-            ("missing", {}, None),
-            ("non_numeric", {"X-Pagination-Pages": "abc"}, None),
-        ]
-    )
-    def test_header_int(self, _name: str, headers: dict, expected: int | None) -> None:
-        assert _header_int(headers, "X-Pagination-Pages") == expected
+def _response(items: list[dict[str, Any]], headers: dict[str, str] | None = None) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(items).encode()
+    if headers:
+        resp.headers.update(headers)
+    return resp
 
 
-class TestBuildUrl:
-    def test_no_params(self) -> None:
-        assert _build_url("/people", {}) == "https://api.float.com/v3/people"
+def _make_manager(resume_state: FloatAppResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def test_encodes_params(self) -> None:
-        assert (
-            _build_url("/people", {"per-page": 200, "page": 2}) == "https://api.float.com/v3/people?per-page=200&page=2"
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return float_app_source("tok", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+class TestPagePagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_last_page_via_header(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response([{"people_id": "1"}, {"people_id": "2"}], {"X-Pagination-Pages": "2"}),
+                _response([{"people_id": "3"}], {"X-Pagination-Pages": "2"}),
+            ],
         )
 
-
-class _FakeResponse:
-    def __init__(self, items: Any, headers: dict[str, str]) -> None:
-        self._items = items
-        self.headers = headers
-        self.status_code = 200
-        self.ok = True
-
-    def json(self) -> Any:
-        return self._items
-
-
-class _FakeResumableManager:
-    def __init__(self, state: FloatAppResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[FloatAppResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> FloatAppResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: FloatAppResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class _FakeBatcher:
-    """Accumulates rows and only yields once a full chunk is buffered, like the real Batcher.
-
-    ``chunk_size`` defaults to 1 (yield per item) so most tests observe save-after-yield behavior
-    without thousands of rows. A larger ``chunk_size`` lets a chunk fill partway through a page, which
-    exercises the mid-page-save scenario: the yield/save happens after the page is fully batched, so the
-    resume pointer must still advance exactly once per page boundary — never mid-page.
-    """
-
-    def __init__(self, *args: Any, chunk_size: int = 1, **kwargs: Any) -> None:
-        self._rows: list[dict] = []
-        self._chunk_size = chunk_size
-
-    def batch(self, row: dict) -> None:
-        self._rows.append(row)
-
-    def should_yield(self, include_incomplete_chunk: bool = False) -> bool:
-        if include_incomplete_chunk:
-            return len(self._rows) > 0
-        return len(self._rows) >= self._chunk_size
-
-    def get_table(self) -> list[dict]:
-        rows = self._rows
-        self._rows = []
-        return rows
-
-
-def _patch_fetch(monkeypatch: Any, pages: dict[str, _FakeResponse]) -> list[str]:
-    fetched: list[str] = []
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> _FakeResponse:
-        fetched.append(url)
-        return pages[url]
-
-    monkeypatch.setattr(float_app, "_fetch_page", fake_fetch)
-    return fetched
-
-
-def _collect(monkeypatch: Any, manager: _FakeResumableManager, endpoint: str, chunk_size: int = 1) -> list[dict]:
-    # Ignore the real chunk_size get_rows passes; drive it from the test so a chunk can span a page.
-    monkeypatch.setattr(float_app, "Batcher", lambda *a, **k: _FakeBatcher(chunk_size=chunk_size))
-    rows: list[dict] = []
-    for batch in get_rows(api_key="tok", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=manager):  # type: ignore[arg-type]
-        rows.extend(batch)
-    return rows
-
-
-class TestGetRowsPagePagination:
-    def test_paginates_until_last_page_via_header(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.float.com/v3/people?per-page=200&page=1": _FakeResponse(
-                [{"people_id": "1"}, {"people_id": "2"}], {"X-Pagination-Pages": "2"}
-            ),
-            "https://api.float.com/v3/people?per-page=200&page=2": _FakeResponse(
-                [{"people_id": "3"}], {"X-Pagination-Pages": "2"}
-            ),
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(), "people")
+        manager = _make_manager()
+        rows = _rows(_source("people", manager))
 
         assert [r["people_id"] for r in rows] == ["1", "2", "3"]
-        assert fetched == list(pages)
+        assert params[0]["per-page"] == PER_PAGE
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
+        assert session.send.call_count == 2
 
-    def test_falls_back_to_full_page_heuristic_when_header_absent(self, monkeypatch: Any) -> None:
-        # No X-Pagination-Pages header: a full page (== PER_PAGE) implies another page may follow;
-        # a short page ends the walk. Without this fallback a header-less response truncates at page 1.
-        pages = {
-            "https://api.float.com/v3/roles?per-page=200&page=1": _FakeResponse(
-                [{"id": str(i)} for i in range(PER_PAGE)], {}
-            ),
-            "https://api.float.com/v3/roles?per-page=200&page=2": _FakeResponse([{"id": "last"}], {}),
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(), "roles")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_falls_back_to_full_page_heuristic_when_header_absent(self, MockSession) -> None:
+        # No X-Pagination-Pages header: a full page (== PER_PAGE) implies another page may follow; a
+        # short page ends the walk. Without this fallback a header-less response truncates at page 1.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": str(i)} for i in range(PER_PAGE)], {}),
+                _response([{"id": "last"}], {}),
+            ],
+        )
+
+        rows = _rows(_source("roles", _make_manager()))
 
         assert len(rows) == PER_PAGE + 1
-        assert fetched == list(pages)
+        assert session.send.call_count == 2
 
-    def test_saves_resume_state_after_each_page_except_last(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.float.com/v3/people?per-page=200&page=1": _FakeResponse(
-                [{"people_id": "1"}], {"X-Pagination-Pages": "2"}
-            ),
-            "https://api.float.com/v3/people?per-page=200&page=2": _FakeResponse(
-                [{"people_id": "2"}], {"X-Pagination-Pages": "2"}
-            ),
-        }
-        _patch_fetch(monkeypatch, pages)
-        manager = _FakeResumableManager()
-        _collect(monkeypatch, manager, "people")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], {"X-Pagination-Pages": "1"})])
 
-        assert manager.saved == [FloatAppResumeConfig(next_page=2)]
+        assert _rows(_source("projects", _make_manager())) == []
+        assert session.send.call_count == 1
 
-    def test_saves_state_once_per_page_when_chunk_spans_page(self, monkeypatch: Any) -> None:
-        # The resume pointer must advance exactly once per page boundary. Page 1 has four items against
-        # chunk_size=2, so the buffer crosses a chunk boundary twice within the page. If the save were
-        # mid-page (inside the item loop) it would fire on each crossing, writing next_page=2 twice;
-        # done once after the page is fully batched, it writes next_page=2 exactly once.
-        pages = {
-            "https://api.float.com/v3/people?per-page=200&page=1": _FakeResponse(
-                [{"people_id": str(i)} for i in range(4)], {"X-Pagination-Pages": "2"}
-            ),
-            "https://api.float.com/v3/people?per-page=200&page=2": _FakeResponse(
-                [{"people_id": "4"}], {"X-Pagination-Pages": "2"}
-            ),
-        }
-        _patch_fetch(monkeypatch, pages)
-        manager = _FakeResumableManager()
-        _collect(monkeypatch, manager, "people", chunk_size=2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_resume_state_after_each_page_except_last(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"people_id": "1"}], {"X-Pagination-Pages": "2"}),
+                _response([{"people_id": "2"}], {"X-Pagination-Pages": "2"}),
+            ],
+        )
 
-        assert manager.saved == [FloatAppResumeConfig(next_page=2)]
+        manager = _make_manager()
+        _rows(_source("people", manager))
 
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.float.com/v3/people?per-page=200&page=2": _FakeResponse(
-                [{"people_id": "2"}], {"X-Pagination-Pages": "2"}
-            ),
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(FloatAppResumeConfig(next_page=2)), "people")
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [FloatAppResumeConfig(next_page=2)]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"people_id": "2"}], {"X-Pagination-Pages": "2"})])
+
+        rows = _rows(_source("people", _make_manager(FloatAppResumeConfig(next_page=2))))
 
         assert [r["people_id"] for r in rows] == ["2"]
-        assert fetched == ["https://api.float.com/v3/people?per-page=200&page=2"]
-
-    def test_stops_on_empty_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.float.com/v3/projects?per-page=200&page=1": _FakeResponse([], {"X-Pagination-Pages": "1"}),
-        }
-        _patch_fetch(monkeypatch, pages)
-        assert _collect(monkeypatch, _FakeResumableManager(), "projects") == []
+        assert params[0]["page"] == 2
+        assert session.send.call_count == 1
 
 
-class TestGetRowsCursorPagination:
-    def test_advances_via_cursor_and_stops_on_short_page(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.float.com/v3/deleted/tasks?limit=500": _FakeResponse(
-                [{"task_id": i} for i in range(DELETE_LOG_LIMIT)],
-                {"X-Pagination-Next-Cursor": "c2", "X-Pagination-Has-More": "true"},
-            ),
-            "https://api.float.com/v3/deleted/tasks?limit=500&cursor=c2": _FakeResponse(
-                [{"task_id": 999}], {"X-Pagination-Next-Cursor": "", "X-Pagination-Has-More": "false"}
-            ),
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(), "deleted_tasks")
+class TestCursorPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_advances_via_cursor_and_stops_on_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(
+                    [{"task_id": i} for i in range(DELETE_LOG_LIMIT)],
+                    {"X-Pagination-Next-Cursor": "c2", "X-Pagination-Has-More": "true"},
+                ),
+                _response(
+                    [{"task_id": 999}],
+                    {"X-Pagination-Next-Cursor": "", "X-Pagination-Has-More": "false"},
+                ),
+            ],
+        )
+
+        rows = _rows(_source("deleted_tasks", _make_manager()))
 
         assert len(rows) == DELETE_LOG_LIMIT + 1
-        assert fetched == list(pages)
+        assert params[0]["limit"] == DELETE_LOG_LIMIT
+        assert "cursor" not in params[0]
+        assert params[1]["cursor"] == "c2"
+        assert session.send.call_count == 2
 
-    def test_terminates_when_full_page_has_no_advancing_cursor(self, monkeypatch: Any) -> None:
-        # A full page whose cursor header is missing (or unchanged) must NOT loop forever — the
-        # defensive guard stops after one page rather than re-requesting the same cursor endlessly.
-        pages = {
-            "https://api.float.com/v3/deleted/tasks?limit=500": _FakeResponse(
-                [{"task_id": i} for i in range(DELETE_LOG_LIMIT)], {}
-            ),
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(), "deleted_tasks")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_terminates_when_full_page_has_no_advancing_cursor(self, MockSession) -> None:
+        # A full page whose cursor header is missing must NOT loop forever — the defensive guard stops
+        # after one page rather than re-requesting the same cursor endlessly.
+        session = MockSession.return_value
+        _wire(session, [_response([{"task_id": i} for i in range(DELETE_LOG_LIMIT)], {})])
+
+        rows = _rows(_source("deleted_tasks", _make_manager()))
 
         assert len(rows) == DELETE_LOG_LIMIT
-        assert fetched == list(pages)
+        assert session.send.call_count == 1
 
-    def test_saves_next_cursor_after_yield(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.float.com/v3/deleted/tasks?limit=500": _FakeResponse(
-                [{"task_id": i} for i in range(DELETE_LOG_LIMIT)],
-                {"X-Pagination-Next-Cursor": "c2", "X-Pagination-Has-More": "true"},
-            ),
-            "https://api.float.com/v3/deleted/tasks?limit=500&cursor=c2": _FakeResponse([{"task_id": 999}], {}),
-        }
-        _patch_fetch(monkeypatch, pages)
-        manager = _FakeResumableManager()
-        _collect(monkeypatch, manager, "deleted_tasks")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_cursor_after_yield(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(
+                    [{"task_id": i} for i in range(DELETE_LOG_LIMIT)],
+                    {"X-Pagination-Next-Cursor": "c2", "X-Pagination-Has-More": "true"},
+                ),
+                _response([{"task_id": 999}], {}),
+            ],
+        )
 
-        assert FloatAppResumeConfig(next_cursor="c2") in manager.saved
+        manager = _make_manager()
+        _rows(_source("deleted_tasks", manager))
 
-    def test_resumes_from_saved_cursor(self, monkeypatch: Any) -> None:
-        pages = {
-            "https://api.float.com/v3/deleted/tasks?limit=500&cursor=c2": _FakeResponse([{"task_id": 999}], {}),
-        }
-        fetched = _patch_fetch(monkeypatch, pages)
-        rows = _collect(monkeypatch, _FakeResumableManager(FloatAppResumeConfig(next_cursor="c2")), "deleted_tasks")
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert FloatAppResumeConfig(next_cursor="c2") in saved
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"task_id": 999}], {})])
+
+        rows = _rows(_source("deleted_tasks", _make_manager(FloatAppResumeConfig(next_cursor="c2"))))
 
         assert [r["task_id"] for r in rows] == [999]
-        assert fetched == ["https://api.float.com/v3/deleted/tasks?limit=500&cursor=c2"]
+        assert params[0]["cursor"] == "c2"
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
-    @pytest.mark.parametrize(
-        "status_code, expected",
-        [
-            (200, (True, 200)),
-            (401, (False, 401)),
-            (403, (False, 403)),
-        ],
-    )
-    def test_maps_status_code(self, status_code: int, expected: tuple, monkeypatch: Any) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-        monkeypatch.setattr(float_app, "make_tracked_session", lambda *a, **k: session)
+    @mock.patch(FLOAT_SESSION_PATCH)
+    def test_ok(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("tok") == (True, 200)
 
-        assert validate_credentials("tok") == expected
+    @mock.patch(FLOAT_SESSION_PATCH)
+    def test_unauthorized(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=401)
+        assert validate_credentials("tok") == (False, 401)
 
-    def test_transport_error_returns_none_status(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = Exception("connection reset")
-        monkeypatch.setattr(float_app, "make_tracked_session", lambda *a, **k: session)
+    @mock.patch(FLOAT_SESSION_PATCH)
+    def test_forbidden(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=403)
+        assert validate_credentials("tok") == (False, 403)
 
+    @mock.patch(FLOAT_SESSION_PATCH)
+    def test_transport_error_returns_none_status(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("connection reset")
         assert validate_credentials("tok") == (False, None)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/gainsight_px.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/gainsight_px.py
@@ -1,32 +1,28 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-from urllib3.util.retry import Retry
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.settings import (
     EPOCH_MILLIS_FIELDS,
     GAINSIGHT_PX_ENDPOINTS,
     GAINSIGHT_PX_HOSTS,
 )
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-# A defensive upper bound on pages fetched per endpoint. The loops terminate on the API's own
-# last-page signals; this only guards against a mis-signalling API scrolling forever.
-MAX_PAGES = 100_000
-
-
-class GainsightPxRetryableError(Exception):
-    pass
+# Gainsight PX carries the API key in this custom header. Passing it through the framework `auth`
+# (api_key/header) means its value is scrubbed from every raised error and captured sample.
+API_KEY_HEADER = "X-APTRINSIC-API-KEY"
 
 
 @dataclasses.dataclass
@@ -35,10 +31,6 @@ class GainsightPxResumeConfig:
     scroll_id: str | None = None
     # Next page index for page-number-paginated endpoints (features/segments/…). None starts at 0.
     page_number: int | None = None
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {"X-APTRINSIC-API-KEY": api_key, "Accept": "application/json"}
 
 
 def _base_url(region: str) -> str:
@@ -63,168 +55,187 @@ def _normalize_row(item: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
-@retry(
-    retry=retry_if_exception_type(
-        (
-            GainsightPxRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+class _ScrollPaginator(BasePaginator):
+    """Scroll (cursor) pagination for users/accounts.
 
-    # 429 (rate limit) and 5xx are transient — retry. Everything else (401/403/400/404) is terminal;
-    # `raise_for_status` surfaces it and `get_non_retryable_errors` maps auth failures to a message.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise GainsightPxRetryableError(f"Gainsight PX API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Gainsight PX API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def validate_credentials(api_key: str, region: str) -> bool:
-    url = _build_url(f"{_base_url(region)}/accounts", {"pageSize": 1})
-    try:
-        # `retry=Retry(total=0)` leaves retries to tenacity elsewhere; `redact_values` masks the API
-        # key in captured samples since `X-APTRINSIC-API-KEY` isn't a name-redacted auth header.
-        session = make_tracked_session(retry=Retry(total=0), redact_values=(api_key,))
-        response = session.get(url, headers=_get_headers(api_key), timeout=REQUEST_TIMEOUT_SECONDS)
-        return response.status_code == 200
-    except (requests.ConnectionError, requests.Timeout):
-        # Only transient network failures should read as "invalid credentials"; programming errors
-        # (TypeError, AttributeError, …) must surface rather than being masked as a bad key.
-        return False
-
-
-def _iter_scroll_pages(
-    session: requests.Session,
-    base: str,
-    endpoint: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GainsightPxResumeConfig],
-    resume: GainsightPxResumeConfig | None,
-) -> Iterator[list[dict[str, Any]]]:
-    """Page a scroll-paginated endpoint (users/accounts), yielding one page of rows at a time.
-
-    Gainsight PX warns not to rely on `scrollId` becoming null, so the loop stops when a page returns
-    fewer records than requested. State is saved AFTER yielding each page so a crash re-yields the
-    last page (merge dedupes on the primary key) rather than skipping it.
+    Gainsight PX warns not to rely on `scrollId` becoming null, so the loop also stops when a page
+    returns fewer records than requested. State points at the next scroll cursor; it is only offered
+    for resume while another page remains, so a crash re-yields the last page (merge dedupes).
     """
-    config = GAINSIGHT_PX_ENDPOINTS[endpoint]
-    scroll_id = resume.scroll_id if resume else None
 
-    for _ in range(MAX_PAGES):
-        params: dict[str, Any] = {"pageSize": config.page_size}
-        if scroll_id:
-            params["scrollId"] = scroll_id
+    def __init__(self, page_size: int, scroll_id: Optional[str] = None) -> None:
+        super().__init__()
+        self._page_size = page_size
+        self._scroll_id = scroll_id
 
-        data = _fetch_page(session, _build_url(f"{base}{config.path}", params), headers, logger)
-        records = data.get(config.data_key) or []
-        if records:
-            yield [_normalize_row(record) for record in records]
+    def init_request(self, request: Request) -> None:
+        # Honour a seeded resume cursor on the first request.
+        if self._scroll_id is not None:
+            if request.params is None:
+                request.params = {}
+            request.params["scrollId"] = self._scroll_id
 
-        next_scroll_id = data.get("scrollId")
-        if len(records) < config.page_size or not next_scroll_id:
-            return
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            next_scroll_id = response.json().get("scrollId")
+        except Exception:
+            next_scroll_id = None
 
-        scroll_id = next_scroll_id
-        resumable_source_manager.save_state(GainsightPxResumeConfig(scroll_id=scroll_id))
-    else:
-        logger.warning(f"Gainsight PX: hit MAX_PAGES page cap for endpoint={endpoint}")
+        records = data or []
+        if len(records) < self._page_size or not next_scroll_id:
+            self._has_next_page = False
+            self._scroll_id = None
+        else:
+            self._scroll_id = next_scroll_id
+            self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        if self._scroll_id is not None:
+            request.params["scrollId"] = self._scroll_id
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        if self._has_next_page and self._scroll_id is not None:
+            return {"scroll_id": self._scroll_id}
+        return None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        scroll_id = state.get("scroll_id")
+        if scroll_id is not None:
+            self._scroll_id = scroll_id
+            self._has_next_page = True
 
 
-def _iter_numbered_pages(
-    session: requests.Session,
-    base: str,
-    endpoint: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GainsightPxResumeConfig],
-    resume: GainsightPxResumeConfig | None,
-) -> Iterator[list[dict[str, Any]]]:
-    """Page a page-number-paginated endpoint (features/segments/engagements/articles/kcbot).
+class _PageNumberPaginator(BasePaginator):
+    """Page-number pagination for features/segments/engagements/articles/kc_bots.
 
     These responses carry an `isLastPage` flag; we also stop on a short page as a belt-and-braces
-    guard. State (the next page index) is saved after each yielded page for the same reason as scroll.
+    guard. State (the next page index) is offered for resume only while another page remains.
     """
-    config = GAINSIGHT_PX_ENDPOINTS[endpoint]
-    page_number = resume.page_number if resume and resume.page_number is not None else 0
 
-    for _ in range(MAX_PAGES):
-        params = {"pageSize": config.page_size, "pageNumber": page_number}
-        data = _fetch_page(session, _build_url(f"{base}{config.path}", params), headers, logger)
-        records = data.get(config.data_key) or []
-        if records:
-            yield [_normalize_row(record) for record in records]
+    def __init__(self, page_size: int, page_number: int = 0) -> None:
+        super().__init__()
+        self._page_size = page_size
+        self._page_number = page_number
 
-        if data.get("isLastPage") or len(records) < config.page_size:
-            return
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["pageNumber"] = self._page_number
 
-        page_number += 1
-        resumable_source_manager.save_state(GainsightPxResumeConfig(page_number=page_number))
-    else:
-        logger.warning(f"Gainsight PX: hit MAX_PAGES page cap for endpoint={endpoint}")
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            is_last_page = bool(response.json().get("isLastPage"))
+        except Exception:
+            is_last_page = False
 
+        records = data or []
+        if is_last_page or len(records) < self._page_size:
+            self._has_next_page = False
+        else:
+            self._page_number += 1
+            self._has_next_page = True
 
-def get_rows(
-    api_key: str,
-    region: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GainsightPxResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = GAINSIGHT_PX_ENDPOINTS[endpoint]
-    base = _base_url(region)
-    headers = _get_headers(api_key)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    # `retry=Retry(total=0)` leaves retries to tenacity in `_fetch_page` (rather than stacking urllib3
-    # retries under them); `redact_values` masks the API key in captured samples since the custom
-    # `X-APTRINSIC-API-KEY` header isn't one of the name-redacted auth headers.
-    session = make_tracked_session(retry=Retry(total=0), redact_values=(api_key,))
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["pageNumber"] = self._page_number
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"page_number": self._page_number} if self._has_next_page else None
 
-    if config.pagination == "scroll":
-        yield from _iter_scroll_pages(session, base, endpoint, headers, logger, resumable_source_manager, resume)
-    else:
-        yield from _iter_numbered_pages(session, base, endpoint, headers, logger, resumable_source_manager, resume)
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page_number = state.get("page_number")
+        if page_number is not None:
+            self._page_number = int(page_number)
+            self._has_next_page = True
 
 
 def gainsight_px_source(
     api_key: str,
     region: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GainsightPxResumeConfig],
 ) -> SourceResponse:
     config = GAINSIGHT_PX_ENDPOINTS[endpoint]
     partition_key = config.partition_key
 
+    paginator: BasePaginator
+    if config.pagination == "scroll":
+        paginator = _ScrollPaginator(page_size=config.page_size)
+    else:
+        paginator = _PageNumberPaginator(page_size=config.page_size)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(region),
+            # Only the non-secret Accept header goes here; the API key rides on framework `auth` so
+            # its value is redacted from errors and samples.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": API_KEY_HEADER, "location": "header"},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"pageSize": config.page_size},
+                    "data_selector": config.data_key,
+                },
+                "data_map": _normalize_row,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            if config.pagination == "scroll" and resume.scroll_id is not None:
+                initial_paginator_state = {"scroll_id": resume.scroll_id}
+            elif config.pagination == "page" and resume.page_number is not None:
+                initial_paginator_state = {"page_number": resume.page_number}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if not state:
+            return
+        if config.pagination == "scroll" and state.get("scroll_id") is not None:
+            resumable_source_manager.save_state(GainsightPxResumeConfig(scroll_id=str(state["scroll_id"])))
+        elif config.pagination == "page" and state.get("page_number") is not None:
+            resumable_source_manager.save_state(GainsightPxResumeConfig(page_number=int(state["page_number"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # every Gainsight PX endpoint is full refresh
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            region=region,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if partition_key else None,
         partition_format="month" if partition_key else None,
         partition_keys=[partition_key] if partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str, region: str) -> bool:
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        _build_url(f"{_base_url(region)}/accounts", {"pageSize": 1}),
+        headers={API_KEY_HEADER: api_key, "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/source.py
@@ -109,7 +109,8 @@ class GainsightPxSource(ResumableSource[GainsightPxSourceConfig, GainsightPxResu
             api_key=config.api_key,
             region=config.region,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/tests/test_gainsight_px.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/tests/test_gainsight_px.py
@@ -1,26 +1,77 @@
+import json
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any
 
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px import gainsight_px
 from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.gainsight_px import (
     GainsightPxResumeConfig,
-    GainsightPxRetryableError,
     _base_url,
     _build_url,
     _normalize_row,
     gainsight_px_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.settings import (
     GAINSIGHT_PX_ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the gainsight_px module.
+GAINSIGHT_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.gainsight_px.make_tracked_session"
+)
+
+
+def _response(data_key: str, records: list[dict[str, Any]], *, status_code: int = 200, **extra: Any) -> Response:
+    body: dict[str, Any] = {data_key: records, **extra}
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: GainsightPxResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so snapshot a copy per prepare.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock) -> Any:
+    return gainsight_px_source(
+        api_key="secret-key",
+        region="us",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
 
 
 class TestBaseUrl:
@@ -61,253 +112,186 @@ class TestNormalizeRow:
         assert row["releaseDate"] == "2021-01-01"
 
 
-class TestFetchPage:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_status_codes_are_retried(self, _name: str, status_code: int) -> None:
-        retryable = MagicMock(status_code=status_code)
-        good = MagicMock(status_code=200, ok=True)
-        good.json.return_value = {"users": []}
-
-        session = MagicMock()
-        session.get.side_effect = [retryable, good]
-
-        with patch.object(gainsight_px._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = gainsight_px._fetch_page(session, "https://api.aptrinsic.com/v1/users", {}, MagicMock())
-
-        assert result == {"users": []}
-        assert session.get.call_count == 2
-
-    @parameterized.expand(
-        [
-            ("read_timeout", requests.ReadTimeout("timed out")),
-            ("connection_error", requests.ConnectionError("reset")),
-        ]
-    )
-    def test_transient_network_errors_are_retried(self, _name: str, error: Exception) -> None:
-        good = MagicMock(status_code=200, ok=True)
-        good.json.return_value = {"users": []}
-        session = MagicMock()
-        session.get.side_effect = [error, good]
-
-        with patch.object(gainsight_px._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = gainsight_px._fetch_page(session, "https://api.aptrinsic.com/v1/users", {}, MagicMock())
-
-        assert result == {"users": []}
-        assert session.get.call_count == 2
-
-    def test_auth_error_is_not_retried(self) -> None:
-        response = MagicMock(status_code=401, ok=False, text="unauthorized")
-        response.raise_for_status.side_effect = requests.HTTPError(
-            "401 Client Error: Unauthorized", response=cast(requests.Response, response)
-        )
-        session = MagicMock()
-        session.get.return_value = response
-
-        with patch.object(gainsight_px._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(requests.HTTPError):
-                gainsight_px._fetch_page(session, "https://api.aptrinsic.com/v1/users", {}, MagicMock())
-
-        assert session.get.call_count == 1
-
-    def test_retry_exhausts_and_reraises(self) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=500)
-
-        with patch.object(gainsight_px._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(GainsightPxRetryableError):
-                gainsight_px._fetch_page(session, "https://api.aptrinsic.com/v1/users", {}, MagicMock())
-
-        assert session.get.call_count == 5
-
-
-class _FakeResumableManager:
-    def __init__(self, state: GainsightPxResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[GainsightPxResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> GainsightPxResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: GainsightPxResumeConfig) -> None:
-        self.saved.append(data)
-
-
-def _collect(endpoint: str, manager: _FakeResumableManager, monkeypatch: Any, responses: list[dict]) -> list[dict]:
-    """Run get_rows with a canned sequence of API responses and flatten the yielded pages."""
-    it = iter(responses)
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-        return next(it)
-
-    monkeypatch.setattr(gainsight_px, "_fetch_page", fake_fetch)
-    monkeypatch.setattr(gainsight_px, "make_tracked_session", lambda *a, **k: MagicMock())
-
-    rows: list[dict] = []
-    for page in get_rows(
-        api_key="key",
-        region="us",
-        endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        rows.extend(page)
-    return rows
-
-
 class TestScrollPagination:
-    def test_follows_scroll_id_and_stops_on_short_page(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_scroll_id_and_stops_on_short_page(self, MockSession, monkeypatch) -> None:
         # users caps at a large pageSize; shrink it so a 2-then-1 record run terminates.
         monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["users"], "page_size", 2)
-        manager = _FakeResumableManager()
-
-        rows = _collect(
-            "users",
-            manager,
-            monkeypatch,
+        session = MockSession.return_value
+        params = _wire(
+            session,
             [
-                {"users": [{"id": "1"}, {"id": "2"}], "scrollId": "s1"},
-                {"users": [{"id": "3"}], "scrollId": "s2"},  # short page → stop
+                _response("users", [{"id": "1"}, {"id": "2"}], scrollId="s1"),
+                _response("users", [{"id": "3"}], scrollId="s2"),  # short page → stop
             ],
         )
 
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
         assert [r["id"] for r in rows] == ["1", "2", "3"]
+        # First request carries only pageSize; the second carries the scroll cursor.
+        assert params[0] == {"pageSize": 2}
+        assert params[1]["scrollId"] == "s1"
         # State saved after the first (full) page only, carrying the next scroll cursor.
-        assert [s.scroll_id for s in manager.saved] == ["s1"]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == GainsightPxResumeConfig(scroll_id="s1")
 
-    def test_stops_when_scroll_id_absent(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_scroll_id_absent(self, MockSession, monkeypatch) -> None:
+        # A full page whose scrollId is null still terminates — the null cursor ends it.
         monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["accounts"], "page_size", 2)
-        manager = _FakeResumableManager()
+        session = MockSession.return_value
+        _wire(session, [_response("accounts", [{"id": "1"}, {"id": "2"}], scrollId=None)])
 
-        rows = _collect(
-            "accounts",
-            manager,
-            monkeypatch,
-            [{"accounts": [{"id": "1"}, {"id": "2"}], "scrollId": None}],
-        )
+        manager = _make_manager()
+        rows = _rows(_source("accounts", manager))
 
         assert [r["id"] for r in rows] == ["1", "2"]
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resumes_from_saved_scroll_id(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_scroll_id(self, MockSession, monkeypatch) -> None:
         monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["users"], "page_size", 2)
-        seen_urls: list[str] = []
+        session = MockSession.return_value
+        params = _wire(session, [_response("users", [{"id": "9"}], scrollId=None)])
 
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            seen_urls.append(url)
-            return {"users": [{"id": "9"}], "scrollId": None}
+        manager = _make_manager(GainsightPxResumeConfig(scroll_id="saved-cursor"))
+        _rows(_source("users", manager))
 
-        monkeypatch.setattr(gainsight_px, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(gainsight_px, "make_tracked_session", lambda *a, **k: MagicMock())
+        assert params[0]["scrollId"] == "saved-cursor"
 
-        manager = _FakeResumableManager(GainsightPxResumeConfig(scroll_id="saved-cursor"))
-        list(
-            get_rows(
-                api_key="key",
-                region="us",
-                endpoint="users",
-                logger=MagicMock(),
-                resumable_source_manager=manager,  # type: ignore[arg-type]
-            )
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows_and_stops(self, MockSession, monkeypatch) -> None:
+        # These endpoints don't fail loud on a missing key (parity with the hand-rolled `or []`).
+        monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["users"], "page_size", 2)
+        session = MockSession.return_value
+        _wire(session, [_response("wrongKey", [{"id": "x"}], scrollId="s1")])
 
-        assert "scrollId=saved-cursor" in seen_urls[0]
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
 
 class TestPageNumberPagination:
-    def test_stops_on_is_last_page(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_is_last_page(self, MockSession, monkeypatch) -> None:
         # page_size 1 keeps each page "full", so isLastPage (not the short-page guard) is what stops us.
         monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["features"], "page_size", 1)
-        manager = _FakeResumableManager()
-
-        rows = _collect(
-            "features",
-            manager,
-            monkeypatch,
+        session = MockSession.return_value
+        params = _wire(
+            session,
             [
-                {"features": [{"id": "f1"}], "isLastPage": False},
-                {"features": [{"id": "f2"}], "isLastPage": True},
+                _response("features", [{"id": "f1"}], isLastPage=False),
+                _response("features", [{"id": "f2"}], isLastPage=True),
             ],
         )
 
+        manager = _make_manager()
+        rows = _rows(_source("features", manager))
+
         assert [r["id"] for r in rows] == ["f1", "f2"]
-        assert [s.page_number for s in manager.saved] == [1]
+        assert params[0]["pageNumber"] == 0
+        assert params[1]["pageNumber"] == 1
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == GainsightPxResumeConfig(page_number=1)
 
-    def test_stops_on_short_page(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_short_page(self, MockSession, monkeypatch) -> None:
         monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["segments"], "page_size", 2)
-        manager = _FakeResumableManager()
+        session = MockSession.return_value
+        # short page → stop even though isLastPage is False.
+        _wire(session, [_response("segments", [{"id": "s1"}], isLastPage=False)])
 
-        rows = _collect(
-            "segments",
-            manager,
-            monkeypatch,
-            [{"segments": [{"id": "s1"}], "isLastPage": False}],  # short page → stop even without isLastPage
-        )
+        manager = _make_manager()
+        rows = _rows(_source("segments", manager))
 
         assert [r["id"] for r in rows] == ["s1"]
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resumes_from_saved_page_number(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page_number(self, MockSession, monkeypatch) -> None:
         monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["features"], "page_size", 100)
-        seen_urls: list[str] = []
+        session = MockSession.return_value
+        params = _wire(session, [_response("features", [{"id": "f"}], isLastPage=True)])
 
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            seen_urls.append(url)
-            return {"features": [{"id": "f"}], "isLastPage": True}
+        manager = _make_manager(GainsightPxResumeConfig(page_number=4))
+        _rows(_source("features", manager))
 
-        monkeypatch.setattr(gainsight_px, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(gainsight_px, "make_tracked_session", lambda *a, **k: MagicMock())
+        assert params[0]["pageNumber"] == 4
 
-        manager = _FakeResumableManager(GainsightPxResumeConfig(page_number=4))
-        list(
-            get_rows(
-                api_key="key",
-                region="us",
-                endpoint="features",
-                logger=MagicMock(),
-                resumable_source_manager=manager,  # type: ignore[arg-type]
-            )
+
+class TestRowNormalization:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_epoch_millis_fields_are_converted_during_iteration(self, MockSession, monkeypatch) -> None:
+        monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["accounts"], "page_size", 2)
+        session = MockSession.return_value
+        _wire(session, [_response("accounts", [{"id": "a1", "createDate": 1609459200000}], scrollId=None)])
+
+        rows = _rows(_source("accounts", _make_manager()))
+
+        assert rows[0]["createDate"] == datetime(2021, 1, 1, tzinfo=UTC)
+
+
+class TestRetries:
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried(self, MockSession, _mock_sleep, monkeypatch) -> None:
+        monkeypatch.setattr(GAINSIGHT_PX_ENDPOINTS["accounts"], "page_size", 2)
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response("accounts", [], status_code=429),
+                _response("accounts", [{"id": "1"}, {"id": "2"}], status_code=200, scrollId=None),
+            ],
         )
 
-        assert "pageNumber=4" in seen_urls[0]
+        rows = _rows(_source("accounts", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["1", "2"]
+        assert session.send.call_count == 2
+
+
+class TestSessionHardening:
+    """The API key travels in a custom header the sample-capture denylist can't recognise, so the
+    framework auth registers its value for redaction across errors, logs, and captured samples."""
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_registers_api_key_for_redaction(self, MockSession) -> None:
+        _source("users", _make_manager())
+        assert MockSession.call_args.kwargs["redact_values"] == ("secret-key",)
+
+    @mock.patch(GAINSIGHT_SESSION_PATCH)
+    def test_validate_credentials_masks_key(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("secret-key", "us")
+        assert mock_session.call_args.kwargs["redact_values"] == ("secret-key",)
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    def test_maps_status_to_bool(self, _name: str, status_code: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status_code)
-        with patch.object(gainsight_px, "make_tracked_session", return_value=session):
-            assert validate_credentials("key", "us") is expected
+    @mock.patch(GAINSIGHT_SESSION_PATCH)
+    def test_maps_status_to_bool(self, _name: str, status_code: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("key", "us") is expected
 
-    def test_network_error_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(gainsight_px, "make_tracked_session", return_value=session):
-            assert validate_credentials("key", "us") is False
+    @mock.patch(GAINSIGHT_SESSION_PATCH)
+    def test_network_error_is_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key", "us") is False
 
-
-class TestSessionHardening:
-    """The API key travels in a custom `X-APTRINSIC-API-KEY` header, which the sample-capture
-    denylist can't recognise. Every session must value-mask the key and leave retries to tenacity."""
-
-    @staticmethod
-    def _assert_hardened(call: Any) -> None:
-        assert call.kwargs["redact_values"] == ("secret-key",)
-        assert call.kwargs["retry"].total == 0
-
-    def test_validate_credentials_masks_key_and_disables_adapter_retry(self) -> None:
-        with patch.object(gainsight_px, "make_tracked_session", return_value=MagicMock()) as make_session:
-            validate_credentials("secret-key", "us")
-        self._assert_hardened(make_session.call_args)
-
-    def test_get_rows_masks_key_and_disables_adapter_retry(self, monkeypatch: Any) -> None:
-        monkeypatch.setattr(gainsight_px, "_fetch_page", lambda *a, **k: {"users": [], "scrollId": None})
-        with patch.object(gainsight_px, "make_tracked_session", return_value=MagicMock()) as make_session:
-            list(get_rows("secret-key", "us", "users", MagicMock(), MagicMock()))
-        self._assert_hardened(make_session.call_args)
+    @mock.patch(GAINSIGHT_SESSION_PATCH)
+    def test_probes_accounts_endpoint(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("key", "eu")
+        called_url = mock_session.return_value.get.call_args.args[0]
+        assert called_url == "https://api-eu.aptrinsic.com/v1/accounts?pageSize=1"
 
 
 class TestSourceResponse:
@@ -322,14 +306,11 @@ class TestSourceResponse:
             ("kc_bots", ["id"], "createdDate"),
         ]
     )
-    def test_source_response_shape(self, endpoint: str, primary_keys: list[str], partition_key: str | None) -> None:
-        response = gainsight_px_source(
-            api_key="key",
-            region="us",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(
+        self, endpoint: str, primary_keys: list[str], partition_key: str | None, MockSession
+    ) -> None:
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/tests/test_gainsight_px_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/tests/test_gainsight_px_source.py
@@ -127,7 +127,8 @@ class TestGainsightPxSource:
             api_key="key",
             region="us",
             endpoint="users",
-            logger=logger,
+            team_id=self.team_id,
+            job_id="job-1",
             resumable_source_manager=manager,
         )
         assert response is mock_gainsight_source.return_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/goldcast/goldcast.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/goldcast/goldcast.py
@@ -1,12 +1,20 @@
-from collections.abc import Iterator
 from typing import Any
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    rename_parent_fields,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.goldcast.settings import (
     GOLDCAST_ENDPOINTS,
     GoldcastEndpointConfig,
@@ -14,154 +22,110 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.goldcast.s
 
 GOLDCAST_BASE_URL = "https://customapi.goldcast.io"
 
-REQUEST_TIMEOUT_SECONDS = 60
+# The parent list every fan-out endpoint iterates over. Its rows only drive the per-event child
+# requests; the `events` schema itself is synced by its own top-level resource.
+_EVENTS_PARENT = "events"
 
 
-class GoldcastRetryableError(Exception):
-    pass
+def _headers() -> dict[str, str]:
+    # Auth (the non-standard `Token` scheme) is supplied via the framework auth config so its value
+    # is redacted from logs and errors; only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
 
-def _get_headers(access_key: str) -> dict[str, str]:
-    # Goldcast uses a static personal access token with the non-standard `Token` scheme
-    # (not `Bearer`), created by an org admin in Studio Settings > Tokens.
+def _auth(access_key: str) -> dict[str, str]:
+    # Goldcast uses a static personal access token with the non-standard `Token` scheme (not
+    # `Bearer`), created by an org admin in Studio Settings > Tokens. The whole `Token <key>` value
+    # is the credential the framework redacts wherever it surfaces.
+    return {"type": "api_key", "api_key": f"Token {access_key}", "name": "Authorization", "location": "header"}
+
+
+def _require_event_id(row: dict[str, Any]) -> dict[str, Any]:
+    # `id` is the required fan-out key: a missing or falsy value must raise loudly rather than
+    # silently under-syncing that event's webinars/event_members with no signal in the logs.
+    event_id = row["id"]
+    if not event_id:
+        raise ValueError(f"Goldcast event is missing a valid id: {row}")
+    return row
+
+
+def _events_parent_resource() -> EndpointResource:
     return {
-        "Authorization": f"Token {access_key}",
-        "Accept": "application/json",
+        "name": _EVENTS_PARENT,
+        "endpoint": {
+            "path": GOLDCAST_ENDPOINTS["events"].path,
+            "paginator": SinglePagePaginator(),
+        },
+        "data_map": _require_event_id,
     }
 
 
-@retry(
-    retry=retry_if_exception_type(
-        (
-            GoldcastRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise GoldcastRetryableError(f"Goldcast API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Only a tightly capped excerpt of the body is logged: Goldcast error bodies can echo
-        # customer tenant records, so the full response must never land verbatim in our logs.
-        body_excerpt = response.text[:200]
-        logger.error(f"Goldcast API error: status={response.status_code}, body_excerpt={body_excerpt!r}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+def _top_level_resource(config: GoldcastEndpointConfig) -> EndpointResource:
+    # Collection endpoints return a bare JSON array; the organization endpoint returns a single
+    # object, which the framework wraps as a one-row page. No data_selector, so a dict body is kept
+    # as a single row exactly as the old normalization did.
+    return {
+        "name": config.name,
+        "endpoint": {
+            "path": config.path,
+            "paginator": SinglePagePaginator(),
+        },
+    }
 
 
-def _extract_rows(data: Any) -> list[dict[str, Any]]:
-    """Normalize a Goldcast response into a list of row dicts.
-
-    Collection endpoints return a bare JSON array; the single-object organization endpoint may
-    return an object. Some deployments could wrap results in a `results`/`data` envelope, so those
-    are unwrapped defensively.
-    """
-    if isinstance(data, list):
-        return [row for row in data if isinstance(row, dict)]
-    if isinstance(data, dict):
-        for key in ("results", "data"):
-            inner = data.get(key)
-            if isinstance(inner, list):
-                return [row for row in inner if isinstance(row, dict)]
-        return [data]
-    return []
-
-
-def validate_credentials(access_key: str) -> bool:
-    # `/core/organization/` is the cheapest authenticated probe (a single org object). A 200 means
-    # the token is genuine and API access is enabled for the account.
-    url = f"{GOLDCAST_BASE_URL}/core/organization/"
-    try:
-        # `redact_values` masks the token from any captured HTTP sample — it rides in the
-        # non-standard `Token` auth header the name-based scrubbers can't recognise.
-        response = make_tracked_session(redact_values=(access_key,)).get(
-            url, headers=_get_headers(access_key), timeout=10
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def _iter_event_ids(session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger) -> Iterator[str]:
-    """Yield every event id, used to drive the per-event fan-out endpoints."""
-    data = _fetch(session, f"{GOLDCAST_BASE_URL}/event/", headers, logger)
-    for event in _extract_rows(data):
-        # `id` is the required fan-out key: a missing or empty value must raise loudly rather than
-        # silently under-syncing its webinars/event_members with no signal in the logs.
-        event_id = event["id"]
-        if not event_id:
-            raise ValueError(f"Goldcast event is missing a valid id: {event}")
-        yield str(event_id)
-
-
-def _get_fan_out_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    config: GoldcastEndpointConfig,
-) -> Iterator[list[dict[str, Any]]]:
-    """Fetch a child endpoint once per event, stamping the parent event id onto each row."""
-    for event_id in _iter_event_ids(session, headers, logger):
-        url = f"{GOLDCAST_BASE_URL}{config.path.format(event=event_id)}"
-        try:
-            data = _fetch(session, url, headers, logger)
-        except requests.HTTPError as exc:
+def _fan_out_resource(config: GoldcastEndpointConfig) -> EndpointResource:
+    # One request per event id. `{event}` is bound from the parent event's `id` — for `webinars` it
+    # sits in the URL path, for `event_members` in a query string carried on the path template. The
+    # event id is injected into each child row under `event` to form the composite primary key
+    # (child ids are only unique per parent); for `event_members`, which already carries a possibly
+    # stale `event`, this re-stamps it to the parent id.
+    return {
+        "name": config.name,
+        "include_from_parent": ["id"],
+        "endpoint": {
+            "path": config.path,
+            "params": {"event": {"type": "resolve", "resource": _EVENTS_PARENT, "field": "id"}},
+            "paginator": SinglePagePaginator(),
             # An event with no child resources (or one deleted between enumeration and this fetch)
-            # can 404. Skip it rather than failing the whole sync; any other error is re-raised.
-            if exc.response is not None and exc.response.status_code == 404:
-                logger.warning(f"Goldcast: {config.name} not found for event {event_id}, skipping")
-                continue
-            raise
-
-        rows = _extract_rows(data)
-        for row in rows:
-            row[config.parent_event_field] = event_id
-        if rows:
-            yield rows
+            # can 404. Skip it rather than failing the whole sync; any other error still raises.
+            "response_actions": [{"status_code": 404, "action": "ignore"}],
+        },
+        "data_map": rename_parent_fields(_EVENTS_PARENT, {"id": "event"}),
+    }
 
 
-def get_rows(
-    access_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
+def _resources_for(endpoint: str) -> list[EndpointResource]:
     config = GOLDCAST_ENDPOINTS[endpoint]
-    headers = _get_headers(access_key)
-    # One session reused across every request so urllib3 keeps the connection alive.
-    # `redact_values` masks the token from captured samples — it rides in the non-standard
-    # `Token` auth header the name-based scrubbers can't recognise.
-    session = make_tracked_session(redact_values=(access_key,))
-
     if config.fan_out_over_events:
-        yield from _get_fan_out_rows(session, headers, logger, config)
-        return
-
-    data = _fetch(session, f"{GOLDCAST_BASE_URL}{config.path}", headers, logger)
-    rows = _extract_rows(data)
-    if rows:
-        yield rows
+        return [_events_parent_resource(), _fan_out_resource(config)]
+    return [_top_level_resource(config)]
 
 
 def goldcast_source(
     access_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     endpoint_config = GOLDCAST_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GOLDCAST_BASE_URL,
+            "headers": _headers(),
+            "auth": _auth(access_key),
+            "paginator": SinglePagePaginator(),
+        },
+        "resource_defaults": {},
+        "resources": _resources_for(endpoint),
+    }
+
+    resources = rest_api_resources(rest_config, team_id, job_id, None)
+    resource: Resource = next(r for r in resources if r.name == endpoint)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(access_key=access_key, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=endpoint_config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -169,3 +133,16 @@ def goldcast_source(
         partition_format="week" if endpoint_config.partition_key else None,
         partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
     )
+
+
+def validate_credentials(access_key: str) -> bool:
+    # `/core/organization/` is the cheapest authenticated probe (a single org object). A 200 means
+    # the token is genuine and API access is enabled for the account. `redact_values` masks the token
+    # from any captured HTTP sample — it rides in the non-standard `Token` header name-based scrubbers
+    # can't recognise.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_key,)),
+        f"{GOLDCAST_BASE_URL}/core/organization/",
+        headers={"Authorization": f"Token {access_key}", **_headers()},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/goldcast/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/goldcast/source.py
@@ -122,5 +122,6 @@ API access requires a Pro, Premium, or Enterprise plan, and the token feature mu
         return goldcast_source(
             access_key=config.access_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/goldcast/tests/test_goldcast.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/goldcast/tests/test_goldcast.py
@@ -1,251 +1,181 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.goldcast import goldcast
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.goldcast.goldcast import (
-    GoldcastRetryableError,
-    _extract_rows,
-    get_rows,
     goldcast_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.goldcast.settings import GOLDCAST_ENDPOINTS
 
-
-class TestExtractRows:
-    @parameterized.expand(
-        [
-            ("bare_list", [{"id": "a"}, {"id": "b"}], [{"id": "a"}, {"id": "b"}]),
-            # The organization endpoint returns a single object, not a collection.
-            ("single_object", {"id": "org1"}, [{"id": "org1"}]),
-            # Defensive: unwrap a results/data envelope if a deployment ever wraps collections.
-            ("results_envelope", {"results": [{"id": "a"}]}, [{"id": "a"}]),
-            ("data_envelope", {"data": [{"id": "a"}]}, [{"id": "a"}]),
-            # Non-dict entries (e.g. stray ids) are dropped so downstream row handling stays safe.
-            ("filters_non_dicts", [{"id": "a"}, "junk", 5], [{"id": "a"}]),
-            ("empty_list", [], []),
-            ("unexpected_scalar", "nope", []),
-        ]
-    )
-    def test_normalizes_response_shapes(self, _name: str, payload: Any, expected: list[dict]) -> None:
-        assert _extract_rows(payload) == expected
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the goldcast module.
+GOLDCAST_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.goldcast.goldcast.make_tracked_session"
+)
 
 
-class TestFetchRetries:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_status_codes_are_retried(self, _name: str, status_code: int) -> None:
-        # A 429/5xx must retry rather than fail the whole sync.
-        bad = MagicMock()
-        bad.status_code = status_code
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = [{"id": "a"}]
-
-        session = MagicMock()
-        session.get.side_effect = [bad, good]
-
-        with patch.object(goldcast._fetch.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = goldcast._fetch(session, "https://customapi.goldcast.io/event/", {}, MagicMock())
-
-        assert result == [{"id": "a"}]
-        assert session.get.call_count == 2
-
-    @parameterized.expand(
-        [
-            ("chunked_encoding", requests.exceptions.ChunkedEncodingError("Connection broken")),
-            ("read_timeout", requests.ReadTimeout("Read timed out.")),
-            ("connection_error", requests.ConnectionError("Connection reset by peer")),
-        ]
-    )
-    def test_transient_network_errors_are_retried(self, _name: str, transient_error: Exception) -> None:
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = []
-
-        session = MagicMock()
-        session.get.side_effect = [transient_error, good]
-
-        with patch.object(goldcast._fetch.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = goldcast._fetch(session, "https://customapi.goldcast.io/event/", {}, MagicMock())
-
-        assert result == []
-        assert session.get.call_count == 2
-
-    def test_client_error_raises_and_is_not_retried(self) -> None:
-        # A 401/403 is a credential problem; it must raise immediately, not burn retries.
-        resp = MagicMock()
-        resp.status_code = 401
-        resp.ok = False
-        resp.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=resp)
-
-        session = MagicMock()
-        session.get.return_value = resp
-
-        with patch.object(goldcast._fetch.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(requests.HTTPError):
-                goldcast._fetch(session, "https://customapi.goldcast.io/event/", {}, MagicMock())
-
-        assert session.get.call_count == 1
-
-    def test_error_body_is_not_logged_verbatim(self) -> None:
-        # Goldcast error bodies can echo customer tenant records, so a full body must never land
-        # in our logs — only a tightly capped excerpt is allowed.
-        sensitive_body = "SECRET-TENANT-RECORD-" + "x" * 5000
-        resp = MagicMock()
-        resp.status_code = 400
-        resp.ok = False
-        resp.text = sensitive_body
-        resp.raise_for_status.side_effect = requests.HTTPError("400 Client Error", response=resp)
-
-        session = MagicMock()
-        session.get.return_value = resp
-        logger = MagicMock()
-
-        with pytest.raises(requests.HTTPError):
-            goldcast._fetch(session, "https://customapi.goldcast.io/event/", {}, logger)
-
-        logged = " ".join(str(call.args[0]) for call in logger.error.call_args_list)
-        assert sensitive_body not in logged
-        assert len(logged) < 500
-
-    def test_retryable_error_reraised_after_exhausting_attempts(self) -> None:
-        bad = MagicMock()
-        bad.status_code = 500
-        session = MagicMock()
-        session.get.return_value = bad
-
-        with patch.object(goldcast._fetch.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(GoldcastRetryableError):
-                goldcast._fetch(session, "https://customapi.goldcast.io/event/", {}, MagicMock())
-
-        assert session.get.call_count == 5
+def _response(payload: Any, *, status: int = 200, url: str = "https://customapi.goldcast.io/") -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = url
+    resp.reason = "OK" if status == 200 else "Error"
+    resp._content = json.dumps(payload).encode() if payload is not None else b""
+    return resp
 
 
-def _patch_fetch(monkeypatch: Any, pages: dict[str, Any]) -> None:
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> Any:
-        result = pages[url]
-        if isinstance(result, Exception):
-            raise result
-        return result
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request (url/params/auth) AT SEND TIME.
 
-    monkeypatch.setattr(goldcast, "_fetch", fake_fetch)
-    monkeypatch.setattr(goldcast, "make_tracked_session", lambda *a, **k: MagicMock())
+    ``request.params`` is a single dict mutated in place across pages, so a copy is snapshotted when
+    each request is prepared rather than inspected afterwards.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
 
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "auth": request.auth})
+        return mock.MagicMock()
 
-class TestGetRowsTopLevel:
-    def test_yields_all_rows_from_a_collection_endpoint(self, monkeypatch: Any) -> None:
-        _patch_fetch(monkeypatch, {"https://customapi.goldcast.io/event/": [{"id": "e1"}, {"id": "e2"}]})
-
-        batches = list(get_rows(access_key="tok", endpoint="events", logger=MagicMock()))
-
-        assert batches == [[{"id": "e1"}, {"id": "e2"}]]
-
-    def test_empty_collection_yields_nothing(self, monkeypatch: Any) -> None:
-        _patch_fetch(monkeypatch, {"https://customapi.goldcast.io/event/": []})
-
-        assert list(get_rows(access_key="tok", endpoint="events", logger=MagicMock())) == []
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-class TestGetRowsFanOut:
-    def test_stamps_parent_event_id_onto_each_child_row(self, monkeypatch: Any) -> None:
+def _rows(access_key: str, endpoint: str) -> list[dict[str, Any]]:
+    response = goldcast_source(access_key=access_key, endpoint=endpoint, team_id=1, job_id="j")
+    return [row for page in response.items() for row in page]
+
+
+class TestTopLevelEndpoints:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_collection_endpoint_yields_all_rows(self, MockSession) -> None:
+        _wire(MockSession.return_value, [_response([{"id": "e1"}, {"id": "e2"}])])
+        assert _rows("tok", "events") == [{"id": "e1"}, {"id": "e2"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_object_endpoint_yields_one_row(self, MockSession) -> None:
+        # The organization endpoint returns a single object, not a collection — it must sync as one row.
+        _wire(MockSession.return_value, [_response({"id": "org1"})])
+        assert _rows("tok", "organizations") == [{"id": "org1"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_collection_yields_nothing(self, MockSession) -> None:
+        _wire(MockSession.return_value, [_response([])])
+        assert _rows("tok", "events") == []
+
+
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stamps_parent_event_id_onto_each_child_row(self, MockSession) -> None:
         # The parent event id must be injected so the composite ["event", "id"] key is unique
         # table-wide — webinar rows carry no `event` field of their own.
-        _patch_fetch(
-            monkeypatch,
-            {
-                "https://customapi.goldcast.io/event/": [{"id": "e1"}, {"id": "e2"}],
-                "https://customapi.goldcast.io/event/webinars/e1/": [{"id": "w1"}],
-                "https://customapi.goldcast.io/event/webinars/e2/": [{"id": "w2"}, {"id": "w3"}],
-            },
+        _wire(
+            MockSession.return_value,
+            [
+                _response([{"id": "e1"}, {"id": "e2"}]),
+                _response([{"id": "w1"}]),
+                _response([{"id": "w2"}, {"id": "w3"}]),
+            ],
         )
 
-        rows = [row for batch in get_rows(access_key="tok", endpoint="webinars", logger=MagicMock()) for row in batch]
-
-        assert rows == [
+        assert _rows("tok", "webinars") == [
             {"id": "w1", "event": "e1"},
             {"id": "w2", "event": "e2"},
             {"id": "w3", "event": "e2"},
         ]
 
-    def test_event_members_query_param_path_and_stamping(self, monkeypatch: Any) -> None:
-        _patch_fetch(
-            monkeypatch,
-            {
-                "https://customapi.goldcast.io/event/": [{"id": "e1"}],
-                # event_members already carries `event`; stamping re-affirms it to the parent id.
-                "https://customapi.goldcast.io/event/event-members/?event=e1": [{"id": "m1", "event": "stale"}],
-            },
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_webinars_request_uses_event_in_path(self, MockSession) -> None:
+        snaps = _wire(MockSession.return_value, [_response([{"id": "e1"}]), _response([{"id": "w1"}])])
+        _rows("tok", "webinars")
+        assert snaps[1]["url"] == "https://customapi.goldcast.io/event/webinars/e1/"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_event_members_query_param_path_and_restamping(self, MockSession) -> None:
+        # event_members already carries `event`; the parent id re-stamps it via an `?event=` query.
+        snaps = _wire(
+            MockSession.return_value,
+            [_response([{"id": "e1"}]), _response([{"id": "m1", "event": "stale"}])],
         )
 
-        rows = [
-            row for batch in get_rows(access_key="tok", endpoint="event_members", logger=MagicMock()) for row in batch
-        ]
+        assert _rows("tok", "event_members") == [{"id": "m1", "event": "e1"}]
+        assert snaps[1]["url"] == "https://customapi.goldcast.io/event/event-members/?event=e1"
 
-        assert rows == [{"id": "m1", "event": "e1"}]
-
-    def test_child_404_for_one_event_is_skipped_not_fatal(self, monkeypatch: Any) -> None:
-        not_found = requests.HTTPError("404 Client Error", response=MagicMock(status_code=404))
-        _patch_fetch(
-            monkeypatch,
-            {
-                "https://customapi.goldcast.io/event/": [{"id": "e1"}, {"id": "e2"}],
-                "https://customapi.goldcast.io/event/webinars/e1/": not_found,
-                "https://customapi.goldcast.io/event/webinars/e2/": [{"id": "w2"}],
-            },
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_child_404_for_one_event_is_skipped_not_fatal(self, MockSession) -> None:
+        _wire(
+            MockSession.return_value,
+            [
+                _response([{"id": "e1"}, {"id": "e2"}]),
+                _response({"detail": "Not found"}, status=404),
+                _response([{"id": "w2"}]),
+            ],
         )
+        assert _rows("tok", "webinars") == [{"id": "w2", "event": "e2"}]
 
-        rows = [row for batch in get_rows(access_key="tok", endpoint="webinars", logger=MagicMock()) for row in batch]
-
-        assert rows == [{"id": "w2", "event": "e2"}]
-
-    def test_child_non_404_error_propagates(self, monkeypatch: Any) -> None:
-        # 5xx/429 are retried inside _fetch and surface as GoldcastRetryableError, so the case that
-        # actually reaches the fan-out's `except HTTPError` branch is a non-404 4xx (e.g. a 403).
-        forbidden = requests.HTTPError("403 Client Error", response=MagicMock(status_code=403))
-        _patch_fetch(
-            monkeypatch,
-            {
-                "https://customapi.goldcast.io/event/": [{"id": "e1"}],
-                "https://customapi.goldcast.io/event/webinars/e1/": forbidden,
-            },
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_child_non_404_error_propagates(self, MockSession) -> None:
+        _wire(
+            MockSession.return_value,
+            [_response([{"id": "e1"}]), _response({"detail": "Forbidden"}, status=403)],
         )
-
         with pytest.raises(requests.HTTPError):
-            list(get_rows(access_key="tok", endpoint="webinars", logger=MagicMock()))
+            _rows("tok", "webinars")
 
-    def test_event_missing_id_key_fails_loudly(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_event_missing_id_key_fails_loudly(self, MockSession) -> None:
         # A malformed parent event (missing the required `id` fan-out key) must raise rather than
         # silently under-sync that event's children with no signal.
-        _patch_fetch(
-            monkeypatch,
-            {"https://customapi.goldcast.io/event/": [{"name": "no id"}]},
-        )
-
+        _wire(MockSession.return_value, [_response([{"name": "no id"}])])
         with pytest.raises(KeyError):
-            list(get_rows(access_key="tok", endpoint="webinars", logger=MagicMock()))
+            _rows("tok", "webinars")
 
     @parameterized.expand([("empty_string", ""), ("none", None), ("zero", 0)])
-    def test_event_with_falsy_id_fails_loudly(self, _name: str, falsy_id: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_event_with_falsy_id_fails_loudly(self, _name: str, falsy_id: Any, MockSession) -> None:
         # A falsy `id` (empty string, None, 0) must raise too — silently skipping it would
         # under-sync that event's children exactly like a missing key would.
-        with pytest.MonkeyPatch.context() as monkeypatch:
-            _patch_fetch(
-                monkeypatch,
-                {"https://customapi.goldcast.io/event/": [{"id": falsy_id}]},
-            )
-
-            with pytest.raises(ValueError):
-                list(get_rows(access_key="tok", endpoint="webinars", logger=MagicMock()))
+        _wire(MockSession.return_value, [_response([{"id": falsy_id}])])
+        with pytest.raises(ValueError):
+            _rows("tok", "webinars")
 
 
-class TestGoldcastSourceResponse:
+class TestAuthAndRedaction:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_uses_non_standard_token_scheme(self, MockSession) -> None:
+        # Goldcast uses `Authorization: Token <key>`, not Bearer.
+        snaps = _wire(MockSession.return_value, [_response([{"id": "e1"}])])
+        _rows("super-secret", "events")
+
+        auth = snaps[0]["auth"]
+        assert isinstance(auth, APIKeyAuth)
+        assert auth.name == "Authorization"
+        assert auth.location == "header"
+        assert auth.api_key == "Token super-secret"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sync_session_registers_token_for_redaction(self, MockSession) -> None:
+        # The token rides in the non-standard `Token` auth header the name-based scrubbers can't
+        # recognise, so it must be registered for value-based redaction on the tracked session.
+        MockSession.return_value.headers = {}
+        MockSession.return_value.prepare_request.side_effect = lambda r: mock.MagicMock()
+        MockSession.return_value.send.side_effect = [_response([])]
+
+        _rows("super-secret", "events")
+
+        assert MockSession.call_args.kwargs.get("redact_values") == ("Token super-secret",)
+
+
+class TestSourceResponse:
     @parameterized.expand(
         [
             ("events", ["id"], "created_at"),
@@ -257,10 +187,11 @@ class TestGoldcastSourceResponse:
             ("event_members", ["event", "id"], "created_at"),
         ]
     )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_partition_and_primary_keys_per_endpoint(
-        self, endpoint: str, expected_keys: list[str], partition_key: str | None
+        self, endpoint: str, expected_keys: list[str], partition_key: str | None, MockSession
     ) -> None:
-        response = goldcast_source(access_key="tok", endpoint=endpoint, logger=MagicMock())
+        response = goldcast_source(access_key="tok", endpoint=endpoint, team_id=1, job_id="j")
 
         assert response.name == endpoint
         assert response.primary_keys == expected_keys
@@ -278,55 +209,27 @@ class TestGoldcastSourceResponse:
 
 
 class TestValidateCredentials:
-    def test_valid_token_returns_true(self) -> None:
-        session = MagicMock()
-        session.get.return_value.status_code = 200
-        with patch.object(goldcast, "make_tracked_session", return_value=session):
-            assert validate_credentials("tok") is True
+    @mock.patch(GOLDCAST_SESSION_PATCH)
+    def test_valid_token_returns_true(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("tok") is True
 
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_non_200_returns_false(self, _name: str, status_code: int) -> None:
-        session = MagicMock()
-        session.get.return_value.status_code = status_code
-        with patch.object(goldcast, "make_tracked_session", return_value=session):
-            assert validate_credentials("tok") is False
+    @mock.patch(GOLDCAST_SESSION_PATCH)
+    def test_non_200_returns_false(self, _name: str, status_code: int, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("tok") is False
 
-    def test_network_error_returns_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(goldcast, "make_tracked_session", return_value=session):
-            assert validate_credentials("tok") is False
+    @mock.patch(GOLDCAST_SESSION_PATCH)
+    def test_network_error_returns_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("tok") is False
 
-
-class TestTokenRedaction:
-    # The token rides in a non-standard `Token` auth header the name-based scrubbers can't
-    # recognise, so every tracked session must register it with `redact_values` or it leaks
-    # into captured HTTP samples.
-    def test_get_rows_registers_token_for_redaction(self, monkeypatch: Any) -> None:
-        captured: dict[str, Any] = {}
-
-        def spy_session(*_a: Any, **kwargs: Any) -> MagicMock:
-            captured.update(kwargs)
-            return MagicMock()
-
-        monkeypatch.setattr(goldcast, "make_tracked_session", spy_session)
-        monkeypatch.setattr(goldcast, "_fetch", lambda *_a, **_k: [])
-
-        list(get_rows(access_key="super-secret", endpoint="events", logger=MagicMock()))
-
-        assert captured.get("redact_values") == ("super-secret",)
-
-    def test_validate_credentials_registers_token_for_redaction(self, monkeypatch: Any) -> None:
-        captured: dict[str, Any] = {}
-
-        def spy_session(*_a: Any, **kwargs: Any) -> MagicMock:
-            captured.update(kwargs)
-            session = MagicMock()
-            session.get.return_value.status_code = 200
-            return session
-
-        monkeypatch.setattr(goldcast, "make_tracked_session", spy_session)
-
+    @mock.patch(GOLDCAST_SESSION_PATCH)
+    def test_probe_registers_token_for_redaction_and_uses_token_scheme(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("super-secret")
 
-        assert captured.get("redact_values") == ("super-secret",)
+        assert mock_session.call_args.kwargs.get("redact_values") == ("super-secret",)
+        _, get_kwargs = mock_session.return_value.get.call_args
+        assert get_kwargs["headers"]["Authorization"] == "Token super-secret"


### PR DESCRIPTION
## Problem

Batch 19 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **ding_connect**
- **eventee**
- **ezofficeinventory**
- **float_app**
- **gainsight_px**
- **goldcast**

Not migrated this batch (left hand-rolled, valid blockers):
- **decagon** — stateful cross-page client-side dedup (`seen_ids`) is essential (full-refresh appends with no PK merge); the framework has only a per-item `data_map` reshape.
- **gorgias** — client-side watermark early-termination (no server-side time filter; sorts desc then stops once a page predates the watermark).

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 6 migrated dirs + `common/rest_source/tests/` — 421 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-18 PR (#71864); merge in order.
