### PR TITLE
fix(conversations): keep mailgun stripped-signature in inbound email

### DIFF
--- a/products/conversations/backend/api/email_events.py
+++ b/products/conversations/backend/api/email_events.py
@@ -368,8 +368,16 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
         sender_email=sender_email,
     )
 
-    # 7. Get content (stripped by Mailgun to remove quotes/signatures)
-    content = (request.POST.get("stripped-text", "") or request.POST.get("body-plain", ""))[:MAX_EMAIL_BODY_LENGTH]
+    # 7. Get content. Mailgun's stripped-text removes quoted replies, but its signature
+    # detection also cuts real content (e.g. a trailing list of bare emails/links), so we
+    # reattach stripped-signature to keep quote-stripping without losing customer text.
+    stripped_text = request.POST.get("stripped-text", "")
+    stripped_signature = request.POST.get("stripped-signature", "")
+    if stripped_text:
+        content = f"{stripped_text}\n\n{stripped_signature}" if stripped_signature else stripped_text
+    else:
+        content = request.POST.get("body-plain", "")
+    content = content[:MAX_EMAIL_BODY_LENGTH]
     subject = request.POST.get("subject", "")[:500]
 
     # 7b. Detect team member sender — only trust From when DKIM passes

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -829,6 +829,62 @@ class TestEmailInboundMultiConfig(BaseTest):
         assert ticket.email_config_id == config2.id
 
 
+class TestEmailInboundContent(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        self.team.conversations_settings = {"email_enabled": True}
+        self.team.save()
+        EmailChannel.objects.create(
+            team=self.team,
+            inbound_token="cc00dd11ee2233ff",
+            from_email="support@example.com",
+            from_name="Support",
+            domain="example.com",
+            domain_verified=True,
+        )
+
+    @parameterized.expand(
+        [
+            # Mailgun sometimes mis-classifies trailing content (e.g. a list of bare emails)
+            # as a signature — it must be reattached, not dropped.
+            (
+                "signature_reattached",
+                {"stripped-text": "Missing recordings for:", "stripped-signature": "a@gmail.com\nb@gmail.com"},
+                "Missing recordings for:\n\na@gmail.com\nb@gmail.com",
+            ),
+            (
+                "stripped_text_only",
+                {"stripped-text": "Just a question"},
+                "Just a question",
+            ),
+            (
+                "falls_back_to_body_plain",
+                {"body-plain": "Full body text"},
+                "Full body text",
+            ),
+        ]
+    )
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_content_extraction(
+        self, _name: str, body_fields: dict[str, str], expected_content: str, _mock_sig: MagicMock
+    ):
+        response = self.client.post(
+            "/api/conversations/v1/email/inbound",
+            {
+                "recipient": "team-cc00dd11ee2233ff@mg.posthog.com",
+                "from": "customer@test.com",
+                "Message-Id": f"<content-{_name}@test.com>",
+                "subject": "Help",
+                **body_fields,
+            },
+        )
+        assert response.status_code == 200
+
+        comment = Comment.objects.get(team=self.team, scope="conversations_ticket")
+        assert comment.content == expected_content
+
+
 class TestSendEmailReplyMultiConfig(BaseTest):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Problem

Inbound email tickets were dropping real customer content at the end of messages. Mailgun's `stripped-text` removes quoted replies, but its signature detector also cuts trailing content that looks like a signature (e.g. a list of bare email addresses / `mailto:` links). We only stored `stripped-text`, so that content never made it onto the ticket.

## Changes

- When Mailgun provides `stripped-text`, reattach `stripped-signature` before saving the comment
- Still fall back to `body-plain` when `stripped-text` is empty
- Keep the existing body length cap
