### PR TITLE
fix(replay-vision): time out hung tag-suggestion model calls

### DIFF
--- a/products/replay_vision/backend/tag_suggestions.py
+++ b/products/replay_vision/backend/tag_suggestions.py
@@ -35,6 +35,7 @@ logger = structlog.get_logger(__name__)
 
 # Cheap, fast model — this is an interactive form helper, not a recording scan.
 _SUGGESTION_MODEL = "gemini-3.1-flash-lite-preview"
+_MODEL_CALL_TIMEOUT_MS = 90_000
 _MAX_SUGGESTIONS = 8
 # Bounds on assembled context so a large team/scanner can't blow up the prompt.
 _MAX_REASONING_SAMPLES = 15
@@ -252,7 +253,12 @@ def suggest_classifier_tags(
 def _generate(*, user_content: str, team_id: int, distinct_id: str) -> _LlmSuggestions:
     # Inline the key resolution (rather than importing the temporal helper) to keep this off the temporal import path.
     api_key = settings.REPLAY_VISION_GEMINI_API_KEY or settings.GEMINI_API_KEY
-    client = genai.Client(api_key=api_key, posthog_client=posthoganalytics.default_client)
+    # Runs inline on the interactive request path, so a hung provider call must time out.
+    client = genai.Client(
+        api_key=api_key,
+        posthog_client=posthoganalytics.default_client,
+        http_options={"timeout": _MODEL_CALL_TIMEOUT_MS},
+    )
     config = GenerateContentConfig(
         system_instruction=_SYSTEM_PROMPT,
         response_mime_type="application/json",

--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -7,7 +7,7 @@ is written onto `VisionActionRun` inside the activity — it never crosses the T
 
 import re
 from datetime import UTC, datetime, timedelta, tzinfo
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import Any, NamedTuple
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
@@ -37,9 +37,6 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
 
 from ee.billing.quota_limiting import is_team_over_ai_credit_budget
 from ee.hogai.utils.untrusted import as_untrusted_data
-
-if TYPE_CHECKING:
-    pass
 
 logger = structlog.get_logger(__name__)
 


### PR DESCRIPTION
## Problem

The interactive tag-suggestion helper (`suggest_classifier_tags`) builds its Gemini client without an HTTP timeout. That helper runs inline on the request path, so a hung provider call had nothing to bound it and could stall the request indefinitely. Its two sibling web-path helpers (feedback themes and prompt suggestions) already set a 90s timeout, so this was an oversight rather than a deliberate choice.

## Changes

- `tag_suggestions.py`: pass `http_options={"timeout": _MODEL_CALL_TIMEOUT_MS}` (90s) when building the Gemini client, matching the two sibling helpers.
- `synthesis.py`: remove a dead `if TYPE_CHECKING: pass` block and the now-unused `TYPE_CHECKING` import. Pure dead-code removal, no behavior change.

## How did you test this code?

No new automated tests. The timeout change is a config-parity fix that mirrors two existing sibling helpers, and there are no existing unit tests around these LLM helper calls to extend. A new test would only assert the kwarg we just set (a change-detector), so it would not earn its place. I (Claude) ran `ruff check`, `ruff format`, `ty check` (via the pre-commit hook), and `python -m py_compile` on both files, all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change. Internal helper behavior with no user-facing API or config change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Arno asked me (Claude) to find safe cleanups across session replay and replay vision. I ran two read-only exploration passes and verified every dead-code claim with a repo-wide reference search before acting. From the resulting menu, Arno picked the replay-vision quick wins: the missing timeout (a real latent hang, not just a chore) and the dead TYPE_CHECKING guard. I left the larger session-replay dead-code sweep, a Gemini-client dedup refactor, and the migration-gated deprecated model/field removals as separate follow-ups. No repo skills were required for these two changes, and I intentionally skipped adding a test per the repo's "tests must earn their place" bar.
