### PR TITLE
refactor(data-warehouse): response_actions body-error classification + migrate aviationstack, cloudbeds, coingecko, elasticemail, granola, greenhouse (batch 20)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aviationstack/aviationstack.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aviationstack/aviationstack.py
@@ -1,36 +1,38 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.aviationstack.settings import (
     AVIATIONSTACK_ENDPOINTS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ResponseAction
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 AVIATIONSTACK_BASE_URL = "https://api.aviationstack.com/v1"
 DEFAULT_PAGE_SIZE = 100
 
-# aviationstack returns HTTP 200 with an error envelope (`{"error": {"code": ...}}`). Transient
-# body-level codes are retried with backoff; every other code (bad/blocked key, plan gating,
-# exhausted monthly quota — e.g. invalid_access_key, missing_access_key, inactive_user,
-# function_access_restricted, https_access_restricted, usage_limit_reached) fails fast and is
-# surfaced as a permanent failure matched by AviationstackSource.get_non_retryable_errors.
-_RETRYABLE_ERROR_CODES = {"rate_limit_reached"}
-
-
-class AviationstackRetryableError(Exception):
-    pass
-
-
-class AviationstackAPIError(Exception):
-    pass
+# aviationstack returns HTTP 200 with an error envelope (`{"error": {"code": ...}}`). The single
+# transient body code is retried in-process; every listed permanent code (bad/blocked key, plan
+# gating, exhausted monthly quota) fails fast and is surfaced with a stable `[code]` token matched by
+# AviationstackSource.get_non_retryable_errors. An unrecognized error code has no `data` key, so the
+# framework fails loud on the missing selector (data_selector_required) rather than syncing 0 rows.
+_RETRYABLE_BODY_CODE = "rate_limit_reached"
+_PERMANENT_BODY_CODES = (
+    "invalid_access_key",
+    "missing_access_key",
+    "inactive_user",
+    "function_access_restricted",
+    "https_access_restricted",
+    "usage_limit_reached",
+)
 
 
 @dataclasses.dataclass
@@ -39,125 +41,111 @@ class AviationstackResumeConfig:
     next_offset: int
 
 
-@retry(
-    retry=retry_if_exception_type((AviationstackRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    # `url` carries no secrets — the access_key lives in `params`, which requests keeps out of the
-    # log line emitted here — so it's safe to log on error.
-    response = session.get(url, params=params, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise AviationstackRetryableError(
-            f"aviationstack API error (retryable): status={response.status_code}, url={url}"
-        )
-
-    if not response.ok:
-        logger.error(f"aviationstack API error: status={response.status_code}, url={url}")
-        # Don't use `response.raise_for_status()` — it embeds `response.url` (which carries the
-        # access_key query param) in the error message, and that exception is later logged via
-        # `str(error)` outside the tracked session's redaction. Strip the query string instead.
-        kind = "Client Error" if response.status_code < 500 else "Server Error"
-        safe_url = response.url.split("?", 1)[0]
-        raise requests.HTTPError(
-            f"{response.status_code} {kind}: {response.reason} for url: {safe_url}", response=response
-        )
-
-    body = response.json()
-    error = body.get("error") if isinstance(body, dict) else None
-    if error:
-        code = error.get("code", "unknown")
-        message = error.get("message", "")
-        if code in _RETRYABLE_ERROR_CODES:
-            raise AviationstackRetryableError(f"aviationstack API error (retryable) [{code}]: {message}")
-        # Permanent codes (and anything unrecognized) fail fast — the keys in
-        # get_non_retryable_errors match on the `[code]` token.
-        raise AviationstackAPIError(f"aviationstack API error [{code}]: {message}")
-
-    return body
-
-
-def get_rows(
-    access_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[AviationstackResumeConfig],
-    page_size: int = DEFAULT_PAGE_SIZE,
-) -> Iterator[Any]:
-    config = AVIATIONSTACK_ENDPOINTS[endpoint]
-    url = f"{AVIATIONSTACK_BASE_URL}{config.path}"
-    # `access_key` is passed as a query param on every request, so mask its value from the
-    # tracked session's logged URLs and captured samples.
-    session = make_tracked_session(redact_values=(access_key,))
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.next_offset if resume is not None else 0
-    if resume is not None:
-        logger.debug(f"aviationstack: resuming {endpoint} from offset={offset}")
-
-    while True:
-        params = {"access_key": access_key, "offset": offset, "limit": page_size}
-        body = _fetch_page(session, url, params, logger)
-
-        items = body.get("data") if isinstance(body, dict) else None
-        if not isinstance(items, list):
-            items = []
-
-        pagination = body.get("pagination") if isinstance(body, dict) else None
-        total = pagination.get("total") if isinstance(pagination, dict) else None
-
-        next_offset = offset + page_size
-        has_more = len(items) >= page_size and (not isinstance(total, int) or next_offset < total)
-
-        for item in items:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save AFTER yielding (and only when more pages remain) so a crash re-yields the last
-                # page rather than skipping it — merge/replace dedupes the re-pulled rows.
-                if has_more:
-                    resumable_source_manager.save_state(AviationstackResumeConfig(next_offset=next_offset))
-
-        if not has_more or len(items) == 0:
-            break
-        offset = next_offset
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+def _response_actions() -> list[ResponseAction]:
+    # The `content` matches the quoted error code as it appears in the JSON body, independent of
+    # whitespace around the colon. Retryable code first; each permanent code raises a secret-free,
+    # non-retryable error whose message carries the `[code]` token get_non_retryable_errors matches.
+    actions: list[ResponseAction] = [
+        {
+            "content": f'"{_RETRYABLE_BODY_CODE}"',
+            "action": "retry",
+            "message": f"aviationstack API error (retryable) [{_RETRYABLE_BODY_CODE}]",
+        }
+    ]
+    actions.extend(
+        {
+            "content": f'"{code}"',
+            "action": "raise",
+            "message": f"aviationstack API error [{code}]",
+        }
+        for code in _PERMANENT_BODY_CODES
+    )
+    # aviationstack also returns hard 401/403 for a bad key / plan gating. Author a secret-free
+    # message (the access_key rides in the query string, so a bare raise_for_status would leak it)
+    # that still matches the stable host prefix in get_non_retryable_errors.
+    actions.append(
+        {
+            "status_code": 401,
+            "action": "raise",
+            "message": "401 Client Error: Unauthorized for url: https://api.aviationstack.com",
+        }
+    )
+    actions.append(
+        {
+            "status_code": 403,
+            "action": "raise",
+            "message": "403 Client Error: Forbidden for url: https://api.aviationstack.com",
+        }
+    )
+    return actions
 
 
 def aviationstack_source(
     access_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[AviationstackResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = AVIATIONSTACK_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": AVIATIONSTACK_BASE_URL,
+            # access_key rides in the query string; the framework auth redacts its value from every
+            # logged URL, captured sample, and raised error message.
+            "auth": {"type": "api_key", "api_key": access_key, "name": "access_key", "location": "query"},
+            "paginator": OffsetPaginator(limit=DEFAULT_PAGE_SIZE, total_path="pagination.total"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "data_selector": "data",
+                    # A 200 body without `data` means an error envelope (recognized codes are caught
+                    # by response_actions first) or a changed shape — fail loud, don't sync 0 rows.
+                    "data_selector_required": True,
+                    "response_actions": _response_actions(),
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.next_offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge/replace dedupes) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(AviationstackResumeConfig(next_offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            access_key=access_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
     )
 
 
 def validate_credentials(access_key: str) -> bool:
     # `/countries` is a static reference endpoint available on every plan (including free), so it's a
-    # cheap probe that the access key is genuine without depending on a paid-tier endpoint.
+    # cheap probe that the access key is genuine without depending on a paid-tier endpoint. A bad key
+    # can surface either as a non-200 status or as an HTTP 200 with a body-level error envelope, so
+    # both are checked here (validate_via_probe only inspects the status).
     url = f"{AVIATIONSTACK_BASE_URL}/countries"
     params: dict[str, Any] = {"access_key": access_key, "limit": 1}
     try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aviationstack/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aviationstack/source.py
@@ -109,8 +109,10 @@ class AviationstackSource(ResumableSource[AviationstackSourceConfig, Aviationsta
         return aviationstack_source(
             access_key=config.access_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # aviationstack has no server-side cursor; full refresh only
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aviationstack/tests/test_aviationstack.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aviationstack/tests/test_aviationstack.py
@@ -1,150 +1,237 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.aviationstack import aviationstack
 from products.warehouse_sources.backend.temporal.data_imports.sources.aviationstack.aviationstack import (
-    AviationstackAPIError,
     AviationstackResumeConfig,
-    AviationstackRetryableError,
-    _fetch_page,
     aviationstack_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.aviationstack.settings import (
     AVIATIONSTACK_ENDPOINTS,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.aviationstack.aviationstack"
-
-
-def _response(
-    *, data: Any = None, total: int | None = None, status: int = 200, ok: bool = True, error: dict | None = None
-) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status
-    response.ok = ok
-    response.reason = "Client Error" if status < 500 else "Server Error"
-    # Real requests responses expose the full URL (access_key included) on `response.url`.
-    response.url = "https://api.aviationstack.com/v1/airlines?access_key=supersecret&limit=1"
-    body: dict[str, Any] = {}
-    if error is not None:
-        body["error"] = error
-    else:
-        body["data"] = data if data is not None else []
-        body["pagination"] = {"limit": 100, "offset": 0, "count": len(data or []), "total": total}
-    response.json.return_value = body
-    return response
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the aviationstack module.
+AVIATIONSTACK_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.aviationstack.aviationstack.make_tracked_session"
+)
 
 
-def _session_returning(responses: list[MagicMock]) -> MagicMock:
-    session = MagicMock()
-    session.get.side_effect = responses
-    return session
+def _page(data: list[dict[str, Any]] | None, *, total: int | None = None, drop_data: bool = False) -> Response:
+    body: dict[str, Any] = {"pagination": {"limit": 100, "offset": 0, "count": len(data or []), "total": total}}
+    if not drop_data:
+        body["data"] = data or []
+    return _response(body)
 
 
-def _resume_manager(saved: AviationstackResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock()
-    manager.can_resume.return_value = saved is not None
-    manager.load_state.return_value = saved
+def _error_body(code: str) -> Response:
+    # aviationstack signals API-level errors with an HTTP 200 body envelope.
+    return _response({"error": {"code": code, "message": "boom"}})
+
+
+def _response(body: Any, *, status: int = 200, reason: str = "OK") -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.reason = reason
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://api.aviationstack.com/v1/airlines?access_key=supersecret&offset=0&limit=100"
+    return resp
+
+
+def _make_manager(resume_state: AviationstackResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-def _collect_rows(tables: Any) -> list[dict]:
-    rows: list[dict] = []
-    for table in tables:
-        rows.extend(table.to_pylist())
-    return rows
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request's params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-class TestFetchPage:
-    def test_returns_body_on_success(self) -> None:
-        session = _session_returning([_response(data=[{"id": 1}], total=1)])
-        body = _fetch_page(session, "https://api.aviationstack.com/v1/airlines", {"access_key": "k"}, MagicMock())
-        assert body["data"] == [{"id": 1}]
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403)])
-    def test_http_client_error_raises(self, _name: str, status: int) -> None:
-        session = _session_returning([_response(status=status, ok=False)])
-        with pytest.raises(requests.HTTPError) as exc:
-            _fetch_page(session, "https://api.aviationstack.com/v1/airlines", {"access_key": "k"}, MagicMock())
-        # The access_key must never appear in the error message — it's logged downstream via str(error).
-        assert "supersecret" not in str(exc.value)
-        assert "access_key" not in str(exc.value)
 
-    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_retryable_status_retries_then_raises(self, _name: str, status: int) -> None:
-        session = _session_returning([_response(status=status, ok=False)] * 5)
-        with patch("time.sleep"), pytest.raises(AviationstackRetryableError):
-            _fetch_page(session, "https://api.aviationstack.com/v1/airlines", {"access_key": "k"}, MagicMock())
-        assert session.get.call_count == 5
+def _source(endpoint: str = "airlines", manager: mock.MagicMock | None = None) -> Any:
+    return aviationstack_source(
+        "supersecret", endpoint, team_id=1, job_id="j", resumable_source_manager=manager or _make_manager()
+    )
 
-    def test_body_error_envelope_raises_permanent(self) -> None:
-        session = _session_returning([_response(error={"code": "invalid_access_key", "message": "bad"})])
-        with pytest.raises(AviationstackAPIError) as exc:
-            _fetch_page(session, "https://api.aviationstack.com/v1/airlines", {"access_key": "k"}, MagicMock())
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_total_reached(self, MockSession) -> None:
+        session = MockSession.return_value
+        page1 = [{"id": i} for i in range(100)]
+        page2 = [{"id": i} for i in range(100, 200)]
+        params = _wire(session, [_page(page1, total=200), _page(page2, total=200)])
+
+        rows = _rows(_source())
+
+        assert [r["id"] for r in rows] == list(range(200))
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == 100
+        assert params[1]["offset"] == 100
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_short_page(self, MockSession) -> None:
+        # A page shorter than the limit means there's no further page, even without a total.
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": 1}], total=None)])
+
+        rows = _rows(_source())
+
+        assert [r["id"] for r in rows] == [1]
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_empty_first_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([], total=0)])
+
+        rows = _rows(_source())
+
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page([{"id": 9}], total=None)])
+
+        _rows(_source(manager=_make_manager(AviationstackResumeConfig(next_offset=200))))
+
+        # The first (and only) request must start from the persisted offset, not 0.
+        assert params[0]["offset"] == 200
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_yielding_a_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        page1 = [{"id": i} for i in range(100)]
+        page2 = [{"id": i} for i in range(100, 200)]
+        _wire(session, [_page(page1, total=200), _page(page2, total=200)])
+
+        manager = _make_manager()
+        _rows(_source(manager=manager))
+
+        # State saved once, with the next offset to resume from, only while more pages remain.
+        manager.save_state.assert_called_once_with(AviationstackResumeConfig(next_offset=100))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_page_saves_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": 1}], total=None)])
+
+        manager = _make_manager()
+        _rows(_source(manager=manager))
+
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page(None, drop_data=True)])
+
+        # A 200 body without "data" (an unrecognized error envelope or changed shape) fails loud
+        # rather than silently syncing 0 rows.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source())
+
+
+class TestBodyErrorEnvelope:
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_permanent_body_code_raises_and_hides_secret(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_error_body("invalid_access_key")])
+
+        with pytest.raises(ValueError) as exc:
+            _rows(_source())
+
         # The stable [code] token is what get_non_retryable_errors matches on.
         assert "[invalid_access_key]" in str(exc.value)
+        # The access_key secret value must never leak into the user-visible error.
+        assert "supersecret" not in str(exc.value)
+        # Permanent: raised on the first response, never retried.
+        assert session.send.call_count == 1
 
-    def test_body_error_envelope_rate_limit_is_retryable(self) -> None:
-        session = _session_returning([_response(error={"code": "rate_limit_reached", "message": "slow down"})] * 5)
-        with patch("time.sleep"), pytest.raises(AviationstackRetryableError):
-            _fetch_page(session, "https://api.aviationstack.com/v1/airlines", {"access_key": "k"}, MagicMock())
-        assert session.get.call_count == 5
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rate_limit_body_code_is_retryable(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.return_value = mock.MagicMock()
+        session.send.return_value = _error_body("rate_limit_reached")
 
-
-class TestGetRows:
-    def test_paginates_until_total_reached(self) -> None:
-        page1 = [{"id": i} for i in range(2)]
-        page2 = [{"id": i} for i in range(2, 4)]
-        session = _session_returning([_response(data=page1, total=4), _response(data=page2, total=4)])
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            rows = _collect_rows(get_rows("k", "airlines", MagicMock(), _resume_manager(), page_size=2))
-        assert [r["id"] for r in rows] == [0, 1, 2, 3]
-        assert session.get.call_count == 2
-
-    def test_stops_on_short_page(self) -> None:
-        # A page shorter than the limit means there's no further page, even without a total.
-        session = _session_returning([_response(data=[{"id": 1}], total=None)])
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            rows = _collect_rows(get_rows("k", "airlines", MagicMock(), _resume_manager(), page_size=100))
-        assert [r["id"] for r in rows] == [1]
-        assert session.get.call_count == 1
-
-    def test_stops_on_empty_first_page(self) -> None:
-        session = _session_returning([_response(data=[], total=0)])
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            rows = _collect_rows(get_rows("k", "airlines", MagicMock(), _resume_manager(), page_size=100))
-        assert rows == []
-        assert session.get.call_count == 1
-
-    def test_resumes_from_saved_offset(self) -> None:
-        session = _session_returning([_response(data=[{"id": 9}], total=None)])
-        manager = _resume_manager(AviationstackResumeConfig(next_offset=200))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            _collect_rows(get_rows("k", "airlines", MagicMock(), manager, page_size=100))
-        # The first (and only) request must start from the persisted offset, not 0.
-        assert session.get.call_args_list[0].kwargs["params"]["offset"] == 200
-
-    def test_saves_state_after_yielding_a_batch(self) -> None:
-        # Batcher flushes at 2000 rows, so two full 2000-row pages force a mid-stream yield + save.
-        page1 = [{"id": i} for i in range(2000)]
-        page2 = [{"id": i} for i in range(2000, 4000)]
-        session = _session_returning([_response(data=page1, total=4000), _response(data=page2, total=4000)])
-        manager = _resume_manager()
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            rows = _collect_rows(get_rows("k", "airlines", MagicMock(), manager, page_size=2000))
-        assert len(rows) == 4000
-        # State is saved with the next offset to resume from, only while more pages remain.
-        manager.save_state.assert_called_once_with(AviationstackResumeConfig(next_offset=2000))
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source())
+        # Retried up to the client's default attempt cap, then re-raised.
+        assert session.send.call_count == 5
 
 
-class TestAviationstackSource:
+class TestHttpErrors:
+    @parameterized.expand([("unauthorized", 401, "401"), ("forbidden", 403, "403")])
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_hard_auth_status_raises_without_leaking_secret(
+        self, _name: str, status: int, expected: str, MockSession, _sleep
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"data": [], "pagination": {}}, status=status, reason=expected)])
+
+        with pytest.raises(ValueError) as exc:
+            _rows(_source())
+
+        assert expected in str(exc.value)
+        assert "supersecret" not in str(exc.value)
+        assert "access_key" not in str(exc.value)
+        # Permanent credential/plan problem — not retried.
+        assert session.send.call_count == 1
+
+    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_retries_then_raises(self, _name: str, status: int, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.return_value = mock.MagicMock()
+        session.send.return_value = _response({}, status=status, reason="err")
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source())
+        assert session.send.call_count == 5
+
+
+class TestSourceResponse:
     @parameterized.expand(
         [
             ("airlines", ["id"]),
@@ -154,14 +241,14 @@ class TestAviationstackSource:
             ("routes", None),
         ]
     )
-    def test_source_response_primary_keys(self, endpoint: str, expected_keys: list[str] | None) -> None:
-        response = aviationstack_source("k", endpoint, MagicMock(), _resume_manager())
+    def test_primary_keys(self, endpoint: str, expected_keys: list[str] | None) -> None:
+        response = _source(endpoint)
         assert response.name == endpoint
         assert response.primary_keys == expected_keys
 
     def test_every_endpoint_builds_a_source_response(self) -> None:
         for endpoint in AVIATIONSTACK_ENDPOINTS:
-            response = aviationstack_source("k", endpoint, MagicMock(), _resume_manager())
+            response = _source(endpoint)
             assert response.name == endpoint
             assert callable(response.items)
 
@@ -174,19 +261,19 @@ class TestValidateCredentials:
             ("ok_status_but_error_body", 200, {"error": {"code": "usage_limit_reached"}}, False),
         ]
     )
-    def test_validate_credentials_status_mapping(self, _name: str, status: int, body: dict, expected: bool) -> None:
-        response = MagicMock()
+    def test_status_and_body_mapping(self, _name: str, status: int, body: dict, expected: bool) -> None:
+        response = mock.MagicMock()
         response.status_code = status
         response.json.return_value = body
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.return_value = response
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
+        with mock.patch(AVIATIONSTACK_SESSION_PATCH, return_value=session):
             assert validate_credentials("k") is expected
 
-    def test_validate_credentials_handles_network_error(self) -> None:
-        session = MagicMock()
+    def test_handles_network_error(self) -> None:
+        session = mock.MagicMock()
         session.get.side_effect = requests.ConnectionError("boom")
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
+        with mock.patch(AVIATIONSTACK_SESSION_PATCH, return_value=session):
             assert validate_credentials("k") is False
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudbeds/cloudbeds.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudbeds/cloudbeds.py
@@ -1,11 +1,8 @@
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Callable
 from typing import Any, Optional
-from urllib.parse import urlsplit
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.settings import (
@@ -13,27 +10,27 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.
     CloudbedsEndpointConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CLOUDBEDS_BASE_URL = "https://api.cloudbeds.com/api/v1.2"
 # List endpoints accept pageSize up to 100 (the default); the largest page minimises round trips
 # against Cloudbeds' 5 req/sec property-credential rate limit.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm a token is genuine. Every credential (API key or OAuth token) can
 # read the properties it is scoped to, so one probe validates the token itself; per-endpoint scopes
 # are handled at sync time via get_non_retryable_errors.
 DEFAULT_PROBE_PATH = "/getHotels"
-
-
-class CloudbedsRetryableError(Exception):
-    pass
-
-
-class CloudbedsApiError(Exception):
-    """Cloudbeds returned HTTP 200 with `success: false` (bad params, missing scope, ...)."""
-
-    pass
 
 
 @dataclasses.dataclass
@@ -44,172 +41,148 @@ class CloudbedsResumeConfig:
     page: int | None = None
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+class CloudbedsPageNumberPaginator(PageNumberPaginator):
+    """1-based ``pageNumber`` pagination with short-page termination.
+
+    Cloudbeds exposes no usable page total, so a page shorter than the requested ``pageSize`` (or an
+    empty one) is the last page — stop there instead of paying one extra empty-page request. Resume
+    is inherited from ``PageNumberPaginator`` (``self.page`` points at the next unfetched page).
+    """
+
+    def __init__(self, page_size: int) -> None:
+        super().__init__(base_page=1, page_param="pageNumber")
+        self._page_size = page_size
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and data is not None and len(data) < self._page_size:
+            self._has_next_page = False
 
 
-def _flatten_rows(rows: list[dict[str, Any]], config: CloudbedsEndpointConfig) -> list[dict[str, Any]]:
-    if not config.flatten_field:
-        return rows
+def _headers() -> dict[str, str]:
+    # Bearer auth is supplied via the framework auth config so the key is redacted from logs and
+    # raised error messages; only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
-    flattened: list[dict[str, Any]] = []
-    for parent in rows:
-        nested = parent.get(config.flatten_field)
+
+def _flatten_map(config: CloudbedsEndpointConfig) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
+    """Explode a parent row's nested list (e.g. getRooms' per-property ``rooms``) into one row each,
+    copying the parent's ``flatten_parent_fields`` in — the 1-to-many form of ``data_map``."""
+    flatten_field = config.flatten_field
+    parent_fields = config.flatten_parent_fields
+
+    def flatten(parent: dict[str, Any]) -> list[dict[str, Any]]:
+        nested = parent.get(flatten_field)
         if not isinstance(nested, list):
-            continue
+            return []
         # Direct access so a missing required parent field (e.g. propertyID) fails fast instead of
         # silently writing None across every flattened child row.
-        parent_fields = {key: parent[key] for key in config.flatten_parent_fields}
-        for row in nested:
-            flattened.append({**row, **parent_fields})
-    return flattened
+        merged = {key: parent[key] for key in parent_fields}
+        return [{**row, **merged} for row in nested]
 
-
-@retry(
-    retry=retry_if_exception_type((CloudbedsRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> list[dict[str, Any]]:
-    response = session.get(f"{CLOUDBEDS_BASE_URL}{path}", params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Exceeding Cloudbeds' rate limit (5 req/sec for property credentials) returns 429; backing off
-    # matters because repeated violations can temporarily suspend the credential.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise CloudbedsRetryableError(f"Cloudbeds API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        # Cloudbeds error bodies can echo guest/reservation data, so log only a short capped
-        # excerpt rather than the full body.
-        logger.error(f"Cloudbeds API error: status={response.status_code}, path={path}, body={response.text[:200]}")
-        # raise_for_status() would embed the full request URL in the exception, which is surfaced as
-        # the schema's latest_error. Cloudbeds authenticates via the Authorization header today, but
-        # rebuild the error from scheme/host/path only so a redirect or future query-param auth can
-        # never leak the api_key into stored error state. The "<status> Client Error: <reason> for
-        # url: https://api.cloudbeds.com" prefix stays stable for get_non_retryable_errors() matching.
-        safe = urlsplit(response.url)
-        raise requests.HTTPError(
-            f"{response.status_code} Client Error: {response.reason} for url: {safe.scheme}://{safe.netloc}{safe.path}",
-            response=response,
-        )
-
-    data = response.json()
-    if not isinstance(data, dict):
-        raise CloudbedsRetryableError(f"Cloudbeds returned an unexpected payload for {path}: {type(data).__name__}")
-
-    # Cloudbeds signals request-level errors (bad params, missing OAuth scope, ...) as HTTP 200 with
-    # success=false and a message - these are not transient, so fail instead of retrying.
-    if data.get("success") is False:
-        raise CloudbedsApiError(f"Cloudbeds API request to {path} failed: {data.get('message', 'unknown error')}")
-
-    rows = data.get("data")
-    if not isinstance(rows, list):
-        raise CloudbedsRetryableError(f"Cloudbeds returned an unexpected data payload for {path}")
-
-    return rows
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CloudbedsResumeConfig],
-    property_id: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = CLOUDBEDS_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-
-    # Group (multi-property) credentials require propertyID to scope reads; single-property
-    # credentials can omit it.
-    base_params: dict[str, Any] = {"propertyID": property_id} if property_id else {}
-
-    if not config.paginated:
-        rows = _fetch_page(session, config.path, base_params, logger)
-        flattened = _flatten_rows(rows, config)
-        if flattened:
-            yield flattened
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if (resume and resume.page) else 1
-    if resume and resume.page:
-        logger.debug(f"Cloudbeds: resuming {endpoint} from page {page}")
-
-    while True:
-        params = {**base_params, "pageNumber": page, "pageSize": PAGE_SIZE}
-        rows = _fetch_page(session, config.path, params, logger)
-        flattened = _flatten_rows(rows, config)
-        if flattened:
-            yield flattened
-
-        # A short (or empty) page means we've reached the end of the collection.
-        if len(rows) < PAGE_SIZE:
-            break
-
-        page += 1
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(CloudbedsResumeConfig(page=page))
+    return flatten
 
 
 def cloudbeds_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CloudbedsResumeConfig],
     property_id: str | None = None,
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = CLOUDBEDS_ENDPOINTS[endpoint]
 
+    # Group (multi-property) credentials require propertyID to scope reads; single-property
+    # credentials can omit it. Sent on every request (the paginator only touches pageNumber).
+    params: dict[str, Any] = {}
+    if property_id:
+        params["propertyID"] = property_id
+
+    paginator: BasePaginator
+    if config.paginated:
+        paginator = CloudbedsPageNumberPaginator(PAGE_SIZE)
+        params["pageSize"] = PAGE_SIZE
+    else:
+        paginator = SinglePagePaginator()
+
+    endpoint_config: EndpointResource = {
+        "name": endpoint,
+        "endpoint": {
+            "path": config.path,
+            "params": params,
+            "data_selector": "data",
+            # Cloudbeds wraps rows under `data`; a 200 body without it — a `success: false` error
+            # envelope (bad params / missing scope) or a changed shape — fails loud instead of
+            # silently syncing 0 rows. A present-but-empty `data` list is still a valid 0-row page.
+            "data_selector_required": True,
+        },
+    }
+    if config.flatten_field:
+        endpoint_config["data_map"] = _flatten_map(config)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": CLOUDBEDS_BASE_URL,
+            "headers": _headers(),
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": paginator,
+        },
+        "resources": [endpoint_config],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.paginated and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.page is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # from the next page (already-yielded pages are persisted) and merge dedupes the re-pull.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(CloudbedsResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            property_id=property_id,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(
-    api_key: str, property_id: str | None = None, path: str = DEFAULT_PROBE_PATH
-) -> tuple[int, Optional[str]]:
+def validate_credentials(api_key: str, property_id: str | None = None) -> tuple[bool, str | None]:
     """Probe a single endpoint to validate the API key or OAuth access token.
 
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
+    One probe validates the token itself; per-endpoint OAuth scopes surface at sync time via
+    get_non_retryable_errors. 401/403 map to an invalid-key message; any other non-200 reports the
+    status; an unreachable probe reports a generic connection failure.
     """
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-    params: dict[str, Any] = {"propertyID": property_id} if property_id else {}
-    try:
-        response = session.get(f"{CLOUDBEDS_BASE_URL}{path}", params=params, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Cloudbeds: {e}"
+    url = f"{CLOUDBEDS_BASE_URL}{DEFAULT_PROBE_PATH}"
+    if property_id:
+        url = f"{url}?propertyID={property_id}"
 
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Cloudbeds returned HTTP {response.status_code}"
-
-    return 200, None
-
-
-def validate_credentials(api_key: str, property_id: str | None = None) -> tuple[bool, str | None]:
-    status, message = check_access(api_key, property_id)
-    if status == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        url,
+        headers={"Authorization": f"Bearer {api_key}", **_headers()},
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid Cloudbeds API key"
-    return False, message or "Could not validate Cloudbeds API key"
+    if status is None:
+        return False, "Could not connect to Cloudbeds"
+    return False, f"Cloudbeds returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudbeds/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudbeds/source.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.settings import (
     CLOUDBEDS_ENDPOINTS,
     ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
@@ -28,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CloudbedsSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -107,21 +111,9 @@ If your account manages multiple properties, enter the ID of the property you wa
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        # Every endpoint is full refresh only for now - see the note in settings.py about the
-        # unverified `modifiedSince` filter on getReservations.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Every endpoint is full refresh only for now (INCREMENTAL_FIELDS is empty) - see the note in
+        # settings.py about the unverified `modifiedSince` filter on getReservations.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CloudbedsSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -145,7 +137,9 @@ If your account manages multiple properties, enter the ID of the property you wa
         return cloudbeds_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             property_id=config.property_id,
+            db_incremental_field_last_value=None,  # every Cloudbeds endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudbeds/tests/test_cloudbeds.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudbeds/tests/test_cloudbeds.py
@@ -1,20 +1,16 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds import cloudbeds
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.cloudbeds import (
     PAGE_SIZE,
-    CloudbedsApiError,
     CloudbedsResumeConfig,
-    CloudbedsRetryableError,
-    check_access,
     cloudbeds_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.settings import (
@@ -22,238 +18,245 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.
     ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = cloudbeds._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the cloudbeds module.
+CLOUDBEDS_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.cloudbeds.make_tracked_session"
+)
 
 
-class _FakeResumableManager:
-    def __init__(self, state: CloudbedsResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[CloudbedsResumeConfig] = []
+def _response(
+    rows: list[dict[str, Any]] | None,
+    *,
+    status: int = 200,
+    drop_data: bool = False,
+    body: dict[str, Any] | None = None,
+    url: str = "https://api.cloudbeds.com/api/v1.2/getReservations",
+    reason: str = "OK",
+) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = url
+    resp.reason = reason
+    if body is not None:
+        payload: Any = body
+    elif drop_data:
+        # A 200 body without `data` — a `success: false` error envelope or a changed shape.
+        payload = {"success": True}
+    else:
+        items = rows or []
+        payload = {"success": True, "data": items, "count": len(items), "total": len(items)}
+    resp._content = json.dumps(payload).encode()
+    return resp
 
-    def can_resume(self) -> bool:
-        return self._state is not None
 
-    def load_state(self) -> CloudbedsResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: CloudbedsResumeConfig) -> None:
-        self.saved.append(data)
+def _make_manager(resume_state: CloudbedsResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-def _full_page(start_id: int) -> list[dict]:
-    return [{"reservationID": str(start_id + i)} for i in range(PAGE_SIZE)]
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        pages: dict[tuple[str, Any], list[Any]],
-        endpoint: str = "reservations",
-        property_id: str | None = None,
-    ) -> tuple[list[dict], list[dict[str, Any]]]:
-        calls: list[dict[str, Any]] = []
+def _source(
+    endpoint: str = "reservations",
+    *,
+    manager: mock.MagicMock | None = None,
+    property_id: str | None = None,
+) -> Any:
+    return cloudbeds_source(
+        api_key="cbat_key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        property_id=property_id,
+    )
 
-        def fake_fetch(session: Any, path: str, params: dict[str, Any], logger: Any) -> list[dict]:
-            calls.append(params)
-            return pages[(path, params.get("pageNumber"))]
 
-        monkeypatch.setattr(cloudbeds, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(cloudbeds, "make_tracked_session", lambda **kwargs: MagicMock())
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="cbat_key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            property_id=property_id,
-        ):
-            rows.extend(batch)
-        return rows, calls
 
-    def test_short_page_yields_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows, _ = self._collect(
-            manager, monkeypatch, {("/getReservations", 1): [{"reservationID": "1"}, {"reservationID": "2"}]}
-        )
-        assert rows == [{"reservationID": "1"}, {"reservationID": "2"}]
-        # The page was short, so we stop without persisting resume state.
-        assert manager.saved == []
+class TestPagination:
+    def _full_page(self, start: int) -> list[dict[str, Any]]:
+        return [{"reservationID": str(start + i)} for i in range(PAGE_SIZE)]
 
-    def test_follows_page_number_pagination_until_short_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            ("/getReservations", 1): _full_page(0),
-            ("/getReservations", 2): [{"reservationID": "999"}],
-        }
-        rows, _ = self._collect(manager, monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_by_page_number_and_checkpoints_after_full_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(self._full_page(0)), _response([{"reservationID": "999"}])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
+
         assert len(rows) == PAGE_SIZE + 1
-        # State is saved after the first page (advancing to page 2), then we stop on the short page.
-        assert [s.page for s in manager.saved] == [2]
+        assert params[0]["pageNumber"] == 1
+        assert params[0]["pageSize"] == PAGE_SIZE
+        assert params[1]["pageNumber"] == 2
+        # Checkpoint saved after the first full page (points at page 2); the short page then ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == CloudbedsResumeConfig(page=2)
 
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(CloudbedsResumeConfig(page=3))
-        # Page 1 must never be fetched on resume.
-        rows, calls = self._collect(manager, monkeypatch, {("/getReservations", 3): [{"reservationID": "5"}]})
-        assert rows == [{"reservationID": "5"}]
-        assert [c["pageNumber"] for c in calls] == [3]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"reservationID": "1"}, {"reservationID": "2"}])])
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows, _ = self._collect(manager, monkeypatch, {("/getReservations", 1): []})
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
+
+        assert [r["reservationID"] for r in rows] == ["1", "2"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
+
         assert rows == []
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_property_id_is_sent_on_every_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            ("/getReservations", 1): _full_page(0),
-            ("/getReservations", 2): [],
-        }
-        _, calls = self._collect(manager, monkeypatch, pages, property_id="12345")
-        assert all(c["propertyID"] == "12345" for c in calls)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"reservationID": "5"}])])
 
-    def test_non_paginated_endpoint_fetches_once_and_never_saves_state(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {("/getHotels", None): [{"propertyID": "1"}, {"propertyID": "2"}]}
-        rows, calls = self._collect(manager, monkeypatch, pages, endpoint="hotels")
+        rows = _rows(_source(manager=_make_manager(CloudbedsResumeConfig(page=3))))
+
+        assert rows == [{"reservationID": "5"}]
+        # Page 1 and 2 must never be fetched on resume.
+        assert [p["pageNumber"] for p in params] == [3]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_property_id_is_sent_on_every_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(self._full_page(0)), _response([])])
+
+        _rows(_source(manager=_make_manager(), property_id="12345"))
+
+        assert all(p["propertyID"] == "12345" for p in params)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_endpoint_fetches_once_without_page_params(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"propertyID": "1"}, {"propertyID": "2"}])])
+
+        manager = _make_manager()
+        rows = _rows(_source("hotels", manager=manager))
+
         assert rows == [{"propertyID": "1"}, {"propertyID": "2"}]
-        assert len(calls) == 1
-        assert "pageNumber" not in calls[0]
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        assert "pageNumber" not in params[0]
+        assert "pageSize" not in params[0]
+        manager.save_state.assert_not_called()
 
-    def test_rooms_are_flattened_with_property_id(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {
-            ("/getRooms", None): [
-                {
-                    "propertyID": "1",
-                    "propertyName": "Hotel One",
-                    "rooms": [{"roomID": "r1", "roomName": "101"}, {"roomID": "r2", "roomName": "102"}],
-                },
-                {"propertyID": "2", "propertyName": "Hotel Two", "rooms": []},
-            ]
-        }
-        rows, _ = self._collect(manager, monkeypatch, pages, endpoint="rooms")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rooms_are_flattened_with_property_id(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(
+                    [
+                        {
+                            "propertyID": "1",
+                            "propertyName": "Hotel One",
+                            "rooms": [{"roomID": "r1", "roomName": "101"}, {"roomID": "r2", "roomName": "102"}],
+                        },
+                        {"propertyID": "2", "propertyName": "Hotel Two", "rooms": []},
+                    ]
+                )
+            ],
+        )
+
+        rows = _rows(_source("rooms", manager=_make_manager()))
+
+        # Each nested room becomes its own row with the parent propertyID copied in; the parent with
+        # an empty `rooms` list contributes nothing.
         assert rows == [
             {"roomID": "r1", "roomName": "101", "propertyID": "1"},
             {"roomID": "r2", "roomName": "102", "propertyID": "1"},
         ]
 
 
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else {"success": True, "data": []}
-        response.text = ""
-        response.reason = "Unauthorized"
-        response.url = "https://api.cloudbeds.com/api/v1.2/getReservations?propertyID=1"
-        session = MagicMock()
-        session.get.return_value = response
-        return session
+class TestFailLoud:
+    @parameterized.expand(
+        [("missing_data_key", {"success": True}), ("success_false", {"success": False, "message": "Access denied"})]
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_fails_loud(self, _name: str, body: dict[str, Any], MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, body=body)])
 
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(CloudbedsRetryableError):
-            _fetch_page_unwrapped(session, "/getReservations", {}, MagicMock())
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_sanitized_http_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError) as exc_info:
-            _fetch_page_unwrapped(session, "/getReservations", {}, MagicMock())
-        message = str(exc_info.value)
-        # Keeps the prefix get_non_retryable_errors() matches on, but drops the query string so a
-        # future credential-bearing URL can never leak into persisted error state.
-        assert message.startswith(f"{status} Client Error:")
-        assert "for url: https://api.cloudbeds.com/api/v1.2/getReservations" in message
-        assert "?" not in message
-
-    def test_success_returns_data_rows(self) -> None:
-        body = {"success": True, "data": [{"reservationID": "1"}], "count": 1, "total": 1}
-        session = self._session_returning(200, body)
-        rows = _fetch_page_unwrapped(session, "/getReservations", {}, MagicMock())
-        assert rows == [{"reservationID": "1"}]
-
-    def test_success_false_raises_api_error_not_retryable(self) -> None:
-        # Cloudbeds signals bad params / missing scopes as HTTP 200 + success=false; retrying would
-        # loop forever, so it must surface as a distinct non-retryable error.
-        body = {"success": False, "message": "Access denied for this endpoint"}
-        session = self._session_returning(200, body)
-        with pytest.raises(CloudbedsApiError, match="Access denied"):
-            _fetch_page_unwrapped(session, "/getReservations", {}, MagicMock())
+        # A 200 body without `data` (a `success: false` envelope or a changed shape) must fail loud,
+        # not silently sync 0 rows.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(manager=_make_manager()))
 
     @parameterized.expand(
         [
-            ("non_dict_body", [{"reservationID": "1"}]),
-            ("missing_data_key", {"success": True}),
-            ("non_list_data", {"success": True, "data": {"reservationID": "1"}}),
+            ("unauthorized", 401, "Unauthorized"),
+            ("forbidden", 403, "Forbidden"),
         ]
     )
-    def test_unexpected_payloads_are_retryable(self, _name: str, body: Any) -> None:
-        session = self._session_returning(200, body)
-        with pytest.raises(CloudbedsRetryableError):
-            _fetch_page_unwrapped(session, "/getReservations", {}, MagicMock())
-
-
-class TestCheckAccess:
-    @staticmethod
-    def _session(response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        return session
-
-    @parameterized.expand(
-        [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "Cloudbeds returned HTTP 500"),
-        ]
-    )
-    @patch(f"{cloudbeds.__name__}.make_tracked_session")
-    def test_status_mapping(
-        self,
-        _name: str,
-        status: int,
-        ok: bool,
-        expected_status: int,
-        expected_message: str | None,
-        mock_session: MagicMock,
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_failure_raises_matchable_error(
+        self, _name: str, status: int, reason: str, MockSession: mock.MagicMock
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        mock_session.return_value = self._session(response)
-        assert check_access("cbat_key") == (expected_status, expected_message)
+        from products.warehouse_sources.backend.temporal.data_imports.sources.cloudbeds.source import CloudbedsSource
 
-    @patch(f"{cloudbeds.__name__}.make_tracked_session")
-    def test_connection_error_maps_to_zero(self, mock_session: MagicMock) -> None:
-        mock_session.return_value = self._session(requests.ConnectionError("boom"))
-        status, message = check_access("cbat_key")
-        assert status == 0
-        assert message is not None and "boom" in message
+        session = MockSession.return_value
+        url = f"https://api.cloudbeds.com/api/v1.2/getReservations?pageNumber=1&pageSize={PAGE_SIZE}"
+        _wire(session, [_response(None, status=status, url=url, reason=reason)])
 
-    @patch(f"{cloudbeds.__name__}.make_tracked_session")
-    def test_probe_scopes_to_property_when_configured(self, mock_session: MagicMock) -> None:
-        response = MagicMock()
-        response.status_code = 200
-        response.ok = True
-        session = self._session(response)
-        mock_session.return_value = session
-        check_access("cbat_key", property_id="12345")
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"propertyID": "12345"}
+        with pytest.raises(Exception) as exc_info:
+            _rows(_source(manager=_make_manager()))
 
+        message = str(exc_info.value)
+        # The stable "<status> Client Error: <reason> for url: https://api.cloudbeds.com" prefix is
+        # what get_non_retryable_errors matches on to surface an actionable message.
+        assert message.startswith(f"{status} Client Error: {reason} for url: https://api.cloudbeds.com")
+        assert any(key in message for key in CloudbedsSource().get_non_retryable_errors())
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_api_key_is_never_leaked_into_error(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        # Even if a future credential rides in the query string, the framework redacts the configured
+        # secret value out of every raised error message.
+        url = "https://api.cloudbeds.com/api/v1.2/getReservations?api_key=cbat_key&pageNumber=1"
+        _wire(session, [_response(None, status=401, url=url, reason="Unauthorized")])
+
+        with pytest.raises(Exception) as exc_info:
+            _rows(_source(manager=_make_manager()))
+
+        assert "cbat_key" not in str(exc_info.value)
+
+
+class TestValidateCredentials:
     @parameterized.expand(
         [
             ("ok", 200, True, None),
@@ -262,31 +265,35 @@ class TestCheckAccess:
             ("server_error", 500, False, "Cloudbeds returned HTTP 500"),
         ]
     )
-    @patch(f"{cloudbeds.__name__}.make_tracked_session")
-    def test_validate_credentials(
+    @mock.patch(CLOUDBEDS_SESSION_PATCH)
+    def test_status_mapping(
         self,
         _name: str,
         status: int,
         expected_valid: bool,
         expected_message: str | None,
-        mock_session: MagicMock,
+        mock_session: mock.MagicMock,
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        mock_session.return_value = self._session(response)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
         assert validate_credentials("cbat_key") == (expected_valid, expected_message)
+
+    @mock.patch(CLOUDBEDS_SESSION_PATCH)
+    def test_connection_error_is_not_valid(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("cbat_key") == (False, "Could not connect to Cloudbeds")
+
+    @mock.patch(CLOUDBEDS_SESSION_PATCH)
+    def test_probe_scopes_to_property_when_configured(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("cbat_key", property_id="12345")
+        called_url = mock_session.return_value.get.call_args.args[0]
+        assert "propertyID=12345" in called_url
 
 
 class TestCloudbedsSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
     def test_source_response_shape(self, endpoint: str) -> None:
-        response = cloudbeds_source(
-            api_key="cbat_key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        response = _source(endpoint, manager=_make_manager())
         assert response.name == endpoint
         assert response.primary_keys == CLOUDBEDS_ENDPOINTS[endpoint].primary_keys
         # No creation timestamp is verified stable across every object, so we don't partition.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coingecko/coingecko.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coingecko/coingecko.py
@@ -1,16 +1,21 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.settings import COINGECKO_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 # Two distinct hosts: the free Demo plan (and keyless public access) live on api.coingecko.com,
 # paid Pro plans on pro-api.coingecko.com. The plan also selects which API-key header to send.
@@ -22,12 +27,14 @@ PLAN_PRO = "pro"
 
 # /coins/markets allows up to 250 per page; other paginated endpoints accept it too.
 PAGE_SIZE = 250
-REQUEST_TIMEOUT_SECONDS = 60
 MAX_RETRY_ATTEMPTS = 6
 
-
-class CoinGeckoRetryableError(Exception):
-    pass
+# CoinGecko signals rate limiting via a 429 status (retried by the client on status alone) and, on the
+# keyless/demo tier, via a 200/4xx body carrying ``{"status":{"error_code":429}}``. The client only
+# retries on 429/5xx status, so classify that in-body envelope as retryable by content substring. Both
+# whitespace variants are matched so the classification survives a compact- vs spaced-JSON server, the
+# same way the old structural ``status.error_code == 429`` check was whitespace-agnostic.
+RATE_LIMIT_BODY_MARKERS = ('"error_code":429', '"error_code": 429')
 
 
 @dataclasses.dataclass
@@ -40,133 +47,118 @@ def _base_url(plan: str) -> str:
     return PRO_BASE_URL if plan == PLAN_PRO else DEMO_BASE_URL
 
 
+def _api_key_header(plan: str) -> str:
+    return "x-cg-pro-api-key" if plan == PLAN_PRO else "x-cg-demo-api-key"
+
+
 def _headers(plan: str, api_key: str) -> dict[str, str]:
-    header_name = "x-cg-pro-api-key" if plan == PLAN_PRO else "x-cg-demo-api-key"
     headers = {"Accept": "application/json"}
     if api_key:
-        headers[header_name] = api_key
+        headers[_api_key_header(plan)] = api_key
     return headers
 
 
-def _build_url(base_url: str, path: str, params: dict[str, Any]) -> str:
-    if not params:
-        return f"{base_url}{path}"
-    return f"{base_url}{path}?{urlencode(params)}"
+class CoinGeckoPagePaginator(PageNumberPaginator):
+    """CoinGecko paginates with ``page``/``per_page``. A short page (fewer than ``per_page`` items) or
+    an empty page is the last one — stop without paying an extra empty-page request, since the free
+    tier's tight rate limits make sparing that request worthwhile. Resume replays the last full page
+    (merge dedupes on the primary key)."""
 
+    def __init__(self, page_size: int) -> None:
+        super().__init__(base_page=1, page_param="page")
+        self._page_size = page_size
 
-def _is_rate_limited(response: requests.Response) -> bool:
-    """CoinGecko signals rate limiting both via a 429 status and, on the keyless/demo tier, via a
-    200/4xx body carrying ``{"status": {"error_code": 429}}``. Treat both as retryable."""
-    if response.status_code == 429:
-        return True
-    try:
-        body = response.json()
-    except ValueError:
-        return False
-    if isinstance(body, dict):
-        status = body.get("status")
-        if isinstance(status, dict) and status.get("error_code") == 429:
-            return True
-    return False
-
-
-def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if _is_rate_limited(response) or response.status_code >= 500:
-        raise CoinGeckoRetryableError(f"CoinGecko API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"CoinGecko API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def validate_credentials(plan: str, api_key: str) -> bool:
-    """Confirm the key is genuine by pinging with the plan's auth header. A valid key returns 200;
-    an invalid one returns 401."""
-    url = f"{_base_url(plan)}/ping"
-    try:
-        session = make_tracked_session(redact_values=(api_key,) if api_key else ())
-        response = session.get(url, headers=_headers(plan, api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    plan: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[CoinGeckoResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = COINGECKO_ENDPOINTS[endpoint]
-    session = make_tracked_session(redact_values=(api_key,) if api_key else ())
-    headers = _headers(plan, api_key)
-    base_url = _base_url(plan)
-
-    @retry(
-        retry=retry_if_exception_type((CoinGeckoRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=2, max=120),
-        reraise=True,
-    )
-    def fetch(url: str) -> Any:
-        return _fetch(session, url, headers, logger)
-
-    if not config.paginated:
-        data = fetch(_build_url(base_url, config.path, dict(config.extra_params)))
-        if isinstance(data, list) and data:
-            yield data
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume is not None else 1
-    if resume is not None:
-        logger.debug(f"CoinGecko: resuming {endpoint} from page {page}")
-
-    while True:
-        params: dict[str, Any] = {**config.extra_params, "per_page": PAGE_SIZE, "page": page}
-        data = fetch(_build_url(base_url, config.path, params))
-
-        # An empty list means we've paged past the end of the collection.
-        if not isinstance(data, list) or not data:
-            break
-
-        yield data
-
-        # A short page is the last page; stop without an extra empty request.
-        if len(data) < PAGE_SIZE:
-            break
-
-        page += 1
-        # Save AFTER yielding so a crash re-yields the last page (merge dedupes on the primary key)
-        # rather than skipping it.
-        resumable_source_manager.save_state(CoinGeckoResumeConfig(page=page))
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and data is not None and len(data) < self._page_size:
+            self._has_next_page = False
 
 
 def coingecko_source(
     plan: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[CoinGeckoResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = COINGECKO_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = dict(config.extra_params)
+    if config.paginated:
+        params["per_page"] = PAGE_SIZE
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": _base_url(plan),
+            # Only non-secret headers here; the API key rides in the framework auth config below so
+            # its value is redacted from logs and raised error messages.
+            "headers": {"Accept": "application/json"},
+            "auth": {
+                "type": "api_key",
+                "api_key": api_key,
+                "name": _api_key_header(plan),
+                "location": "header",
+            },
+            "max_retries": MAX_RETRY_ATTEMPTS,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Bare-array bodies. A non-list body means the response shape changed (or an
+                    # unexpected error envelope) — fail loud rather than syncing a garbage row.
+                    "data_selector_required": True,
+                    "paginator": CoinGeckoPagePaginator(PAGE_SIZE) if config.paginated else SinglePagePaginator(),
+                    # The keyless/demo tier reports rate limiting inside a success-status body; the
+                    # client retries on status only, so promote that in-body signal to a retry.
+                    "response_actions": [{"content": marker, "action": "retry"} for marker in RATE_LIMIT_BODY_MARKERS],
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.paginated and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(CoinGeckoResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            plan=plan,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # Snapshot/reference endpoints expose no stable created_at, so there's nothing to partition on.
         partition_count=None,
         partition_size=None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(plan: str, api_key: str) -> bool:
+    """Confirm the key is genuine by pinging with the plan's auth header. A valid key returns 200;
+    an invalid one returns 401. Transient/network failures also map to False (not validated)."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,) if api_key else ()),
+        f"{_base_url(plan)}/ping",
+        headers=_headers(plan, api_key),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coingecko/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coingecko/source.py
@@ -32,7 +32,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import CoinGeckoSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -111,22 +114,9 @@ CoinGecko enforces tight per-minute rate limits and monthly credit caps, especia
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Every exposed endpoint is a catalog/snapshot with no server-side timestamp filter, so all
-        # are full refresh only (no incremental/append).
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # are full refresh only — no endpoint carries incremental fields, so build_endpoint_schemas
+        # leaves supports_incremental/supports_append False.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: CoinGeckoSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -154,6 +144,8 @@ CoinGecko enforces tight per-minute rate limits and monthly credit caps, especia
             plan=config.plan,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every CoinGecko endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/coingecko/tests/test_coingecko.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/coingecko/tests/test_coingecko.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -5,8 +6,8 @@ from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.coingecko import coingecko
 from products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko import (
     DEMO_BASE_URL,
     PAGE_SIZE,
@@ -14,231 +15,285 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.
     PLAN_PRO,
     PRO_BASE_URL,
     CoinGeckoResumeConfig,
-    CoinGeckoRetryableError,
-    _base_url,
-    _build_url,
-    _headers,
-    _is_rate_limited,
     coingecko_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.settings import COINGECKO_ENDPOINTS
 
-
-class _FakeResponse:
-    def __init__(self, status_code: int = 200, json_data: Any = None, text: str = ""):
-        self.status_code = status_code
-        self._json_data = json_data
-        self.text = text
-
-    @property
-    def ok(self) -> bool:
-        return self.status_code < 400
-
-    def json(self) -> Any:
-        if isinstance(self._json_data, Exception):
-            raise self._json_data
-        return self._json_data
-
-    def raise_for_status(self) -> None:
-        if not self.ok:
-            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)  # type: ignore[arg-type]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the coingecko module.
+COINGECKO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session"
+)
+# Neuter tenacity's backoff so retry tests don't actually sleep.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeSession:
-    """Returns queued responses in order; records the URLs requested."""
-
-    def __init__(self, responses: list[_FakeResponse]):
-        self._responses = list(responses)
-        self.requested_urls: list[str] = []
-
-    def get(self, url: str, **kwargs: Any) -> _FakeResponse:
-        self.requested_urls.append(url)
-        return self._responses.pop(0)
+def _response(body: Any, *, status: int = 200, compact: bool = False) -> Response:
+    resp = Response()
+    resp.status_code = status
+    separators = (",", ":") if compact else None
+    resp._content = json.dumps(body, separators=separators).encode()
+    resp.url = "https://api.coingecko.com/api/v3/x"
+    return resp
 
 
-def _manager(can_resume: bool = False, state: CoinGeckoResumeConfig | None = None) -> mock.MagicMock:
+def _rate_limit_body(*, compact: bool) -> Response:
+    # CoinGecko's keyless/demo tier reports rate limiting inside a 200 body.
+    return _response({"status": {"error_code": 429, "error_message": "rate limited"}}, compact=compact)
+
+
+def _manager(resume_state: CoinGeckoResumeConfig | None = None) -> mock.MagicMock:
     manager = mock.MagicMock()
-    manager.can_resume.return_value = can_resume
-    manager.load_state.return_value = state
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-class TestBaseUrlAndHeaders:
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's URL/params/auth AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so snapshot a copy per request.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        auth = request.auth
+        snapshots.append(
+            {
+                "url": request.url,
+                "params": dict(request.params or {}),
+                "auth_name": getattr(auth, "name", None),
+                "auth_key": getattr(auth, "api_key", None),
+            }
+        )
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(plan: str, api_key: str, endpoint: str, manager: mock.MagicMock):
+    return coingecko_source(
+        plan=plan,
+        api_key=api_key,
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestReferenceEndpoints:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_request_yields_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows = [{"id": "bitcoin", "symbol": "btc", "name": "Bitcoin"}]
+        _wire(session, [_response(rows)])
+
+        assert _rows(_source(PLAN_DEMO, "key", "coins_list", _manager())) == rows
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_body_yields_nothing_and_no_extra_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        assert _rows(_source(PLAN_DEMO, "key", "coins_list", _manager())) == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_fails_loud(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A 200 that isn't a bare array is an unexpected/changed shape — fail loud, not a garbage row.
+        _wire(session, [_response({"unexpected": "object"})])
+
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source(PLAN_DEMO, "key", "coins_list", _manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_reference_endpoint_never_checkpoints(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "eth"}])])
+
+        manager = _manager()
+        _rows(_source(PLAN_DEMO, "key", "asset_platforms", manager))
+        manager.save_state.assert_not_called()
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_walks_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": f"c{i}"} for i in range(PAGE_SIZE)]
+        short_page = [{"id": "last"}]
+        snaps = _wire(session, [_response(full_page), _response(short_page)])
+
+        manager = _manager()
+        rows = _rows(_source(PLAN_DEMO, "key", "coins_markets", manager))
+
+        assert rows == [*full_page, *short_page]
+        # Page number progresses 1 -> 2; the short page ends it without a third request.
+        assert session.send.call_count == 2
+        assert snaps[0]["params"]["page"] == 1
+        assert snaps[0]["params"]["per_page"] == PAGE_SIZE
+        assert snaps[1]["params"]["page"] == 2
+        # Checkpoint saved once after the first full page, pointing at the next page.
+        manager.save_state.assert_called_once_with(CoinGeckoResumeConfig(page=2))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_terminates_on_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": f"c{i}"} for i in range(PAGE_SIZE)]
+        _wire(session, [_response(full_page), _response([])])
+
+        manager = _manager()
+        rows = _rows(_source(PLAN_DEMO, "key", "coins_markets", manager))
+
+        assert rows == full_page
+        assert session.send.call_count == 2
+        manager.save_state.assert_called_once_with(CoinGeckoResumeConfig(page=2))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "a"}, {"id": "b"}])])
+
+        manager = _manager()
+        rows = _rows(_source(PLAN_DEMO, "key", "coins_markets", manager))
+
+        assert [r["id"] for r in rows] == ["a", "b"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response([{"id": "x"}])])
+
+        manager = _manager(CoinGeckoResumeConfig(page=3))
+        _rows(_source(PLAN_DEMO, "key", "coins_markets", manager))
+
+        assert snaps[0]["params"]["page"] == 3
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sends_static_extra_params(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response([{"id": "btc"}])])
+
+        _rows(_source(PLAN_DEMO, "key", "coins_markets", _manager()))
+        assert snaps[0]["params"]["vs_currency"] == "usd"
+
+
+class TestRateLimitAndErrors:
+    @parameterized.expand([("compact", True), ("spaced", False)])
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_in_body_rate_limit_is_retried(self, _name: str, compact: bool, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        good = [{"id": "btc"}]
+        # A 200 body carrying the rate-limit envelope must be retried, then the retry succeeds —
+        # regardless of the server's JSON whitespace.
+        _wire(session, [_rate_limit_body(compact=compact), _response(good)])
+
+        rows = _rows(_source(PLAN_DEMO, "key", "coins_list", _manager()))
+        assert rows == good
+        assert session.send.call_count == 2
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_http_429_status_is_retried(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        good = [{"id": "btc"}]
+        _wire(session, [_response({}, status=429), _response(good)])
+
+        rows = _rows(_source(PLAN_DEMO, "key", "coins_list", _manager()))
+        assert rows == good
+        assert session.send.call_count == 2
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_http_500_status_is_retried(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        good = [{"id": "btc"}]
+        _wire(session, [_response({}, status=500), _response(good)])
+
+        rows = _rows(_source(PLAN_DEMO, "key", "coins_list", _manager()))
+        assert rows == good
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_401_surfaces_as_http_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        # 401 is a genuine, non-retryable auth error — it must surface (get_non_retryable_errors
+        # matches on the "401 ... for url: <host>" message).
+        resp = _response({"status": {"error_code": 10011, "error_message": "invalid key"}}, status=401)
+        _wire(session, [resp])
+
+        with pytest.raises(requests.HTTPError, match="401"):
+            _rows(_source(PLAN_DEMO, "key", "coins_list", _manager()))
+        assert session.send.call_count == 1
+
+
+class TestHostHeaderAndRedaction:
     @parameterized.expand(
         [
-            (PLAN_DEMO, DEMO_BASE_URL),
-            (PLAN_PRO, PRO_BASE_URL),
-            ("anything_else", DEMO_BASE_URL),
+            (PLAN_DEMO, DEMO_BASE_URL, "x-cg-demo-api-key"),
+            (PLAN_PRO, PRO_BASE_URL, "x-cg-pro-api-key"),
         ]
     )
-    def test_base_url(self, plan: str, expected: str) -> None:
-        assert _base_url(plan) == expected
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_plan_selects_host_and_key_header(self, plan: str, base_url: str, header_name: str, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response([{"id": "btc"}])])
 
-    @parameterized.expand(
-        [
-            (PLAN_DEMO, "x-cg-demo-api-key"),
-            (PLAN_PRO, "x-cg-pro-api-key"),
-        ]
-    )
-    def test_headers_use_plan_specific_key_name(self, plan: str, header_name: str) -> None:
-        headers = _headers(plan, "secret-key")
-        assert headers[header_name] == "secret-key"
-        assert headers["Accept"] == "application/json"
+        _rows(_source(plan, "secret", "coins_list", _manager()))
+        assert snaps[0]["url"].startswith(base_url)
+        # The key rides in the plan-specific header via framework auth (redacted by value).
+        assert snaps[0]["auth_name"] == header_name
+        assert snaps[0]["auth_key"] == "secret"
 
-    def test_headers_omit_key_when_blank(self) -> None:
-        headers = _headers(PLAN_DEMO, "")
-        assert "x-cg-demo-api-key" not in headers
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_api_key_registered_for_redaction(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "btc"}])])
 
-    def test_build_url_without_params(self) -> None:
-        assert _build_url(DEMO_BASE_URL, "/coins/list", {}) == f"{DEMO_BASE_URL}/coins/list"
-
-    def test_build_url_encodes_params(self) -> None:
-        url = _build_url(DEMO_BASE_URL, "/coins/markets", {"vs_currency": "usd", "per_page": 250, "page": 1})
-        assert url == f"{DEMO_BASE_URL}/coins/markets?vs_currency=usd&per_page=250&page=1"
-
-
-class TestIsRateLimited:
-    @parameterized.expand(
-        [
-            ("http_429", 429, None, True),
-            ("ok_200", 200, [{"id": "btc"}], False),
-            ("body_envelope_429", 200, {"status": {"error_code": 429}}, True),
-            ("body_envelope_other_error", 200, {"status": {"error_code": 10002}}, False),
-            ("non_json_body", 200, ValueError("not json"), False),
-        ]
-    )
-    def test_is_rate_limited(self, _name: str, status: int, body: Any, expected: bool) -> None:
-        assert _is_rate_limited(_FakeResponse(status_code=status, json_data=body)) is expected  # type: ignore[arg-type]
-
-
-class TestFetch:
-    @parameterized.expand([(429,), (500,), (503,)])
-    def test_retryable_statuses_raise_retryable_error(self, status: int) -> None:
-        session = _FakeSession([_FakeResponse(status_code=status, json_data=None)])
-        with pytest.raises(CoinGeckoRetryableError):
-            coingecko._fetch(session, "http://x", {}, mock.MagicMock())  # type: ignore[arg-type]
-
-    def test_body_embedded_rate_limit_is_retryable(self) -> None:
-        session = _FakeSession([_FakeResponse(status_code=200, json_data={"status": {"error_code": 429}})])
-        with pytest.raises(CoinGeckoRetryableError):
-            coingecko._fetch(session, "http://x", {}, mock.MagicMock())  # type: ignore[arg-type]
-
-    def test_client_error_raises_http_error(self) -> None:
-        session = _FakeSession([_FakeResponse(status_code=401, json_data=None, text="unauthorized")])
-        with pytest.raises(requests.HTTPError):
-            coingecko._fetch(session, "http://x", {}, mock.MagicMock())  # type: ignore[arg-type]
+        _rows(_source(PLAN_DEMO, "secret", "coins_list", _manager()))
+        # RESTClient builds its tracked session with the auth secret in redact_values.
+        assert MockSession.call_args.kwargs["redact_values"] == ("secret",)
 
 
 class TestValidateCredentials:
-    @parameterized.expand(
-        [
-            ("valid", 200, True),
-            ("unauthorized", 401, False),
-        ]
-    )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session"
-    )
+    @parameterized.expand([("valid", 200, True), ("unauthorized", 401, False)])
+    @mock.patch(COINGECKO_SESSION_PATCH)
     def test_status_mapping(self, _name: str, status: int, expected: bool, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _FakeResponse(status_code=status)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
         assert validate_credentials(PLAN_DEMO, "key") is expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session"
-    )
-    def test_exception_returns_false(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(COINGECKO_SESSION_PATCH)
+    def test_transient_error_returns_false(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
         assert validate_credentials(PLAN_PRO, "key") is False
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session"
-    )
-    def test_pings_plan_host_with_key(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(COINGECKO_SESSION_PATCH)
+    def test_pings_plan_host_with_key_and_redaction(self, mock_session: mock.MagicMock) -> None:
         get = mock_session.return_value.get
-        get.return_value = _FakeResponse(status_code=200)
+        get.return_value = mock.MagicMock(status_code=200)
         validate_credentials(PLAN_PRO, "secret")
-        url = get.call_args.args[0]
-        assert url == f"{PRO_BASE_URL}/ping"
+
+        assert get.call_args.args[0] == f"{PRO_BASE_URL}/ping"
         assert get.call_args.kwargs["headers"]["x-cg-pro-api-key"] == "secret"
-        # The key rides in a custom header the sampler can't predict, so it must be redacted by value.
         assert mock_session.call_args.kwargs["redact_values"] == ("secret",)
 
 
-class TestGetRows:
-    def _run(self, endpoint: str, responses: list[_FakeResponse], manager: mock.MagicMock) -> list[list[dict]]:
-        session = _FakeSession(responses)
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session",
-            return_value=session,
-        ):
-            return list(get_rows(PLAN_DEMO, "key", endpoint, mock.MagicMock(), manager))
-
-    def test_single_request_endpoint_yields_once(self) -> None:
-        manager = _manager()
-        rows = [{"id": "bitcoin", "symbol": "btc", "name": "Bitcoin"}]
-        batches = self._run("coins_list", [_FakeResponse(json_data=rows)], manager)
-        assert batches == [rows]
-        manager.save_state.assert_not_called()
-
-    def test_single_request_empty_yields_nothing(self) -> None:
-        batches = self._run("coins_list", [_FakeResponse(json_data=[])], _manager())
-        assert batches == []
-
-    def test_paginated_walks_until_short_page(self) -> None:
-        manager = _manager()
-        full_page = [{"id": f"c{i}"} for i in range(PAGE_SIZE)]
-        short_page = [{"id": "last"}]
-        batches = self._run(
-            "coins_markets", [_FakeResponse(json_data=full_page), _FakeResponse(json_data=short_page)], manager
-        )
-        assert batches == [full_page, short_page]
-        # State saved once after the first full page so a crash resumes at page 2.
-        manager.save_state.assert_called_once_with(CoinGeckoResumeConfig(page=2))
-
-    def test_paginated_terminates_on_empty_page(self) -> None:
-        manager = _manager()
-        full_page = [{"id": f"c{i}"} for i in range(PAGE_SIZE)]
-        batches = self._run("coins_markets", [_FakeResponse(json_data=full_page), _FakeResponse(json_data=[])], manager)
-        assert batches == [full_page]
-        manager.save_state.assert_called_once_with(CoinGeckoResumeConfig(page=2))
-
-    def test_paginated_resumes_from_saved_page(self) -> None:
-        manager = _manager(can_resume=True, state=CoinGeckoResumeConfig(page=3))
-        short_page = [{"id": "x"}]
-        session = _FakeSession([_FakeResponse(json_data=short_page)])
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session",
-            return_value=session,
-        ):
-            batches = list(get_rows(PLAN_DEMO, "key", "coins_markets", mock.MagicMock(), manager))
-        assert batches == [short_page]
-        assert "page=3" in session.requested_urls[0]
-
-    def test_paginated_sends_extra_params(self) -> None:
-        manager = _manager()
-        session = _FakeSession([_FakeResponse(json_data=[{"id": "btc"}])])
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session",
-            return_value=session,
-        ):
-            list(get_rows(PLAN_DEMO, "key", "coins_markets", mock.MagicMock(), manager))
-        assert "vs_currency=usd" in session.requested_urls[0]
-
-    def test_redacts_api_key_in_samples(self) -> None:
-        manager = _manager()
-        session = _FakeSession([_FakeResponse(json_data=[{"id": "btc"}])])
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.coingecko.coingecko.make_tracked_session",
-            return_value=session,
-        ) as mock_session:
-            list(get_rows(PLAN_DEMO, "secret", "coins_markets", mock.MagicMock(), manager))
-        # The key rides in a custom header the sampler can't predict, so it must be redacted by value.
-        assert mock_session.call_args.kwargs["redact_values"] == ("secret",)
-
-
-class TestCoinGeckoSource:
+class TestSourceResponse:
     @parameterized.expand(
         [
             ("coins_list", ["id"]),
@@ -251,12 +306,12 @@ class TestCoinGeckoSource:
         ]
     )
     def test_primary_keys_per_endpoint(self, endpoint: str, expected_keys: list[str]) -> None:
-        response = coingecko_source(PLAN_DEMO, "key", endpoint, mock.MagicMock(), mock.MagicMock())
+        response = _source(PLAN_DEMO, "key", endpoint, _manager())
         assert response.name == endpoint
         assert response.primary_keys == expected_keys
 
     def test_every_settings_endpoint_builds_a_source_response(self) -> None:
         for endpoint in COINGECKO_ENDPOINTS:
-            response = coingecko_source(PLAN_DEMO, "key", endpoint, mock.MagicMock(), mock.MagicMock())
+            response = _source(PLAN_DEMO, "key", endpoint, _manager())
             assert response.name == endpoint
             assert response.primary_keys == COINGECKO_ENDPOINTS[endpoint].primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
@@ -21,6 +21,7 @@ from .paginators import (
     SinglePagePaginator,
     single_entity_path,
 )
+from .rest_client import RESTClientRetryableError
 from .typing import (
     AuthConfig,
     AuthType,
@@ -336,25 +337,24 @@ def _find_resolved_params(endpoint_config: Endpoint) -> list[ResolvedParam]:
     ]
 
 
-def _handle_response_actions(response: Response, actions: list[ResponseAction]) -> Optional[str]:
+def _handle_response_actions(response: Response, actions: list[ResponseAction]) -> Optional[ResponseAction]:
     content = response.text
 
     for action in actions:
         status_code = action.get("status_code")
         content_substr = action.get("content")
-        action_type = action.get("action")
-        if action_type is None:
+        if action.get("action") is None:
             continue
 
         if status_code is not None and content_substr is not None:
             if response.status_code == status_code and content_substr in content:
-                return action_type
+                return action
         elif status_code is not None:
             if response.status_code == status_code:
-                return action_type
+                return action
         elif content_substr is not None:
             if content_substr in content:
-                return action_type
+                return action
 
     return None
 
@@ -363,10 +363,25 @@ def _create_response_actions_hook(
     response_actions: list[ResponseAction],
 ) -> Callable[[Response, Any, Any], None]:
     def response_actions_hook(response: Response, *args: Any, **kwargs: Any) -> None:
-        action_type = _handle_response_actions(response, response_actions)
+        matched = _handle_response_actions(response, response_actions)
+        action_type = matched.get("action") if matched else None
+
         if action_type == "ignore":
             logger.info(f"Ignoring response with code {response.status_code} and content '{response.json()}'.")
             raise IgnoreResponseException
+
+        # Re-issue the request. This is how a source classifies an HTTP-200 body-level error
+        # envelope (e.g. an in-body rate-limit signal) or a non-5xx status as retryable, since the
+        # client's own retry check only fires on 429/5xx status codes.
+        if action_type == "retry":
+            raise RESTClientRetryableError(
+                (matched and matched.get("message")) or f"Retryable response (HTTP {response.status_code})"
+            )
+
+        # Fail loud with a permanent, non-retryable error — for a success-status body error envelope
+        # that should surface an actionable message rather than silently syncing 0 rows.
+        if action_type == "raise":
+            raise ValueError((matched and matched.get("message")) or f"Error response (HTTP {response.status_code})")
 
         if not action_type and response.status_code >= 400:
             response.raise_for_status()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_response_action_classification.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_response_action_classification.py
@@ -1,0 +1,99 @@
+import json
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from requests import Response
+from requests.exceptions import HTTPError
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.config_setup import (
+    create_response_hooks,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client"
+
+
+def _make_response(body: Any, status_code: int = 200, reason: str = "OK") -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.reason = reason
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://api.example.com/items"
+    return resp
+
+
+class TestResponseActionClassification:
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_retry_action_on_200_body_then_succeeds(self, MockSession, _sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        # HTTP 200 carrying an in-body rate-limit signal, then a clean page.
+        mock_session.send.side_effect = [
+            _make_response({"status": {"error_code": 429}}),
+            _make_response({"results": [{"id": 1}]}),
+        ]
+        hooks = create_response_hooks([{"content": '"error_code": 429', "action": "retry"}])
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(
+            client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator(), hooks=hooks)
+        )
+
+        assert pages == [[{"id": 1}]]
+        assert mock_session.send.call_count == 2
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_retry_action_persistent_reraises_retryable(self, MockSession, _sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_response({"status": {"error_code": 429}})
+        hooks = create_response_hooks([{"content": "error_code", "action": "retry", "message": "rate limited"}])
+
+        client = RESTClient(base_url="https://api.example.com", max_retry_attempts=3)
+        with pytest.raises(RESTClientRetryableError, match="rate limited"):
+            list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator(), hooks=hooks))
+        assert mock_session.send.call_count == 3
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_raise_action_is_permanent_with_message(self, MockSession, _sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_response({"error": {"code": "InvalidWindow"}})
+        hooks = create_response_hooks(
+            [{"content": "InvalidWindow", "action": "raise", "message": "Window too old — trigger a full resync"}]
+        )
+
+        client = RESTClient(base_url="https://api.example.com", max_retry_attempts=3)
+        with pytest.raises(ValueError, match="trigger a full resync"):
+            list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator(), hooks=hooks))
+        # Permanent: raised on the first response, never retried.
+        assert mock_session.send.call_count == 1
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_unmatched_4xx_still_raises_for_status(self, MockSession, _sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_response({"error": "not found"}, status_code=404, reason="Not Found")
+        # A rule that doesn't match this response must not swallow the 404.
+        hooks = create_response_hooks([{"status_code": 400, "action": "ignore"}])
+
+        client = RESTClient(base_url="https://api.example.com", max_retry_attempts=1)
+        with pytest.raises(HTTPError):
+            list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator(), hooks=hooks))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -223,7 +223,19 @@ class ResolvedParam:
 class ResponseAction(TypedDict, total=False):
     status_code: Optional[int | str]
     content: Optional[str]
+    # One of:
+    #  - "ignore" — treat the matched response as a valid empty page and stop pagination.
+    #  - "retry"  — raise a retryable error so the request is re-issued (for an HTTP-200 body-level
+    #               error envelope, e.g. a rate-limit signal carried in the JSON, or to promote a
+    #               non-5xx status like 408 to retryable). The framework retries on HTTP status only,
+    #               so this is the hook for content-classified retries.
+    #  - "raise"  — raise a permanent (non-retryable) error with ``message``, for a success-status
+    #               body error envelope that should fail loud with an actionable message that
+    #               ``get_non_retryable_errors`` can match.
     action: str
+    # Message for the "raise" action (and, optionally, "retry"). Authored in the manifest, so it
+    # carries no secret — kept out of any URL. Falls back to a status-only default when unset.
+    message: Optional[str]
 
 
 class Endpoint(TypedDict, total=False):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/elasticemail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/elasticemail.py
@@ -1,16 +1,20 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ResponseAction
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticemail.settings import (
     ELASTICEMAIL_ENDPOINTS,
@@ -20,23 +24,23 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.elasticema
 
 ELASTICEMAIL_BASE_URL = "https://api.elasticemail.com/v4"
 
-# Marker carried by ElasticEmailAuthError so `get_non_retryable_errors` can match credential failures.
+# Marker carried by the auth-failure error so `get_non_retryable_errors` can match credential failures.
 # Elastic Email returns these as HTTP 400 with an `{"Error": "APIKey Expired"}` style body rather than
 # the more usual 401/403, so we can't match on the status line alone.
 AUTH_ERROR_MARKER = "Elastic Email API authentication failed"
 
+# User-facing message raised on an auth failure during a sync. Carries AUTH_ERROR_MARKER so the
+# pipeline's non-retryable classifier stops hammering a dead key instead of retrying it.
+AUTH_ERROR_MESSAGE = f"{AUTH_ERROR_MARKER}: the API key is invalid, expired, or missing read permissions."
+
 # A cheap, parameter-free endpoint used to confirm a key is genuine at source-create time.
 VALIDATION_PATH = "/statistics"
 
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class ElasticEmailRetryableError(Exception):
-    pass
-
-
-class ElasticEmailAuthError(Exception):
-    pass
+# Substrings that mark a 400 body as a credential problem (Elastic Email signals a bad/expired/
+# under-scoped key with HTTP 400, not 401/403). `_is_auth_error_body` matches these case-insensitively;
+# `_auth_response_actions` matches the common casings the API actually returns, since the framework's
+# response-action content match is case-sensitive.
+_AUTH_BODY_TOKENS = ("apikey", "api key", "access token", "unauthorized", "expired")
 
 
 @dataclasses.dataclass
@@ -74,23 +78,6 @@ def _clamp_future_value_to_now(value: Any) -> Any:
     return value
 
 
-def _build_params(
-    config: ElasticEmailEndpointConfig,
-    offset: int,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, Any]:
-    """Assemble the query params for one page request."""
-    params: dict[str, Any] = {"limit": PAGE_SIZE, "offset": offset}
-    params.update(config.extra_params)
-
-    # Only endpoints that advertise an incremental field have a server-side `from` time filter.
-    if should_use_incremental_field and config.incremental_fields and db_incremental_field_last_value:
-        params["from"] = _format_datetime(_clamp_future_value_to_now(db_incremental_field_last_value))
-
-    return params
-
-
 def _build_url(path: str, params: dict[str, Any]) -> str:
     # doseq=True expands list values (e.g. scopeType=Personal&scopeType=Global) into repeated params.
     return f"{ELASTICEMAIL_BASE_URL}{path}?{urlencode(params, doseq=True)}"
@@ -102,45 +89,48 @@ def _is_auth_error_body(status_code: int, body: str) -> bool:
     if status_code != 400:
         return False
     lowered = body.lower()
-    return any(token in lowered for token in ("apikey", "api key", "access token", "unauthorized", "expired"))
+    return any(token in lowered for token in _AUTH_BODY_TOKENS)
 
 
-@retry(
-    retry=retry_if_exception_type((ElasticEmailRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[dict[str, Any]]:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+def _static_params(
+    config: ElasticEmailEndpointConfig,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+) -> dict[str, Any]:
+    """Non-pagination query params for an endpoint (limit/offset are added by the paginator).
 
-    if response.status_code == 429 or response.status_code >= 500:
-        raise ElasticEmailRetryableError(
-            f"Elastic Email API error (retryable): status={response.status_code}, url={url}"
-        )
+    Mirrors the old `_build_params`: static per-endpoint params plus, for an incremental endpoint with
+    a cursor, the server-side `from` time filter (future cursors clamped to now).
+    """
+    params: dict[str, Any] = dict(config.extra_params)
 
-    if not response.ok:
-        body = response.text or ""
-        # Elastic Email signals a bad/expired/under-scoped key with HTTP 400, not 401/403. Surface it as a
-        # distinct, non-retryable error so the sync stops instead of hammering the API with a dead key.
-        if _is_auth_error_body(response.status_code, body):
-            raise ElasticEmailAuthError(f"{AUTH_ERROR_MARKER} (HTTP {response.status_code}): {body}")
-        logger.error(f"Elastic Email API error: status={response.status_code}, body={body}, url={url}")
-        response.raise_for_status()
+    # Only endpoints that advertise an incremental field have a server-side `from` time filter.
+    if should_use_incremental_field and config.incremental_fields and db_incremental_field_last_value:
+        params["from"] = _format_datetime(_clamp_future_value_to_now(db_incremental_field_last_value))
 
-    try:
-        data = response.json()
-    except ValueError as exc:
-        # A 200 with a non-JSON body (e.g. an HTML error page from a CDN/proxy) raises JSONDecodeError,
-        # which isn't a retryable type by default. Treat it as transient so the page is retried.
-        raise ElasticEmailRetryableError(f"Non-JSON Elastic Email response: url={url}") from exc
+    return params
 
-    # Every v4 list endpoint returns a bare JSON array. Guard against an unexpected object payload.
-    if not isinstance(data, list):
-        raise ElasticEmailRetryableError(f"Unexpected Elastic Email response shape (expected list): url={url}")
-    return data
+
+def _auth_response_actions() -> list[ResponseAction]:
+    """Response actions that raise a permanent, non-retryable auth error carrying AUTH_ERROR_MARKER.
+
+    401/403 are auth failures regardless of body; a 400 is an auth failure only when its body names a
+    credential problem. Non-auth 4xx match nothing here and fall through to `raise_for_status` (an
+    HTTPError the pipeline retries), exactly as the old `_fetch_page` did.
+    """
+    actions: list[ResponseAction] = [
+        {"status_code": 401, "action": "raise", "message": AUTH_ERROR_MESSAGE},
+        {"status_code": 403, "action": "raise", "message": AUTH_ERROR_MESSAGE},
+    ]
+    # The content match is case-sensitive, so expand each token to the casings Elastic Email returns.
+    seen: set[str] = set()
+    for token in _AUTH_BODY_TOKENS:
+        for variant in (token, token.upper(), token.title(), "API key", "APIKey"):
+            if variant in seen:
+                continue
+            seen.add(variant)
+            actions.append({"status_code": 400, "content": variant, "action": "raise", "message": AUTH_ERROR_MESSAGE})
+    return actions
 
 
 def validate_credentials(
@@ -162,72 +152,67 @@ def validate_credentials(
     return not _is_auth_error_body(response.status_code, response.text or "")
 
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ElasticEmailResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[Any]:
-    config = ELASTICEMAIL_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # One session reused across every page so urllib3 keeps the connection alive between requests.
-    # redact_values masks the API key in logged URLs and captured HTTP samples; the X-ElasticEmail-ApiKey
-    # header name isn't in the transport's generic auth denylist, so we redact the value explicitly.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume is not None else 0
-    if resume is not None:
-        logger.debug(f"Elastic Email: resuming {endpoint} from offset={offset}")
-
-    while True:
-        params = _build_params(config, offset, should_use_incremental_field, db_incremental_field_last_value)
-        url = _build_url(config.path, params)
-        items = _fetch_page(session, url, headers, logger)
-
-        for item in items:
-            batcher.batch(item)
-
-        offset += len(items)
-        last_page = len(items) < PAGE_SIZE
-
-        if batcher.should_yield():
-            yield batcher.get_table()
-            # Save AFTER yielding so a crash re-fetches from the last persisted offset rather than skipping
-            # rows. Only persist when more pages remain; the final flush below needs no checkpoint.
-            if not last_page:
-                resumable_source_manager.save_state(ElasticEmailResumeConfig(offset=offset))
-
-        if last_page:
-            break
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
-
 def elasticemail_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ElasticEmailResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = ELASTICEMAIL_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ELASTICEMAIL_BASE_URL,
+            # Elastic Email carries the key in the X-ElasticEmail-ApiKey header; framework auth redacts it.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "X-ElasticEmail-ApiKey", "location": "header"},
+            "headers": {"Accept": "application/json"},
+            # limit/offset pagination over a bare JSON array; a short page (data < limit) ends it, just
+            # like the old `len(items) < PAGE_SIZE` check. No total is reported in body or header.
+            "paginator": OffsetPaginator(limit=PAGE_SIZE, total_path=None),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": _static_params(config, should_use_incremental_field, db_incremental_field_last_value),
+                    # Every v4 list endpoint returns a bare JSON array; require a list so an unexpected
+                    # object payload fails loud instead of being synced as a single row.
+                    "data_selector_required": True,
+                    # Surface a bad/expired/under-scoped key (HTTP 400/401/403) as a permanent auth error.
+                    "response_actions": _auth_response_actions(),
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # OffsetPaginator only reports state while more pages remain, so the final short page saves
+        # nothing — a crash re-fetches from the last persisted offset rather than skipping rows.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(ElasticEmailResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/source.py
@@ -139,7 +139,8 @@ Grant the key read access to the data you want to sync (Contacts, Campaigns, Tem
         return elasticemail_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/tests/test_elasticemail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/tests/test_elasticemail.py
@@ -1,30 +1,38 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock
+from unittest import mock
 
 import requests
 from parameterized import parameterized
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticemail import elasticemail
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticemail.elasticemail import (
     AUTH_ERROR_MARKER,
-    ElasticEmailAuthError,
     ElasticEmailResumeConfig,
-    ElasticEmailRetryableError,
-    _build_params,
     _build_url,
     _clamp_future_value_to_now,
     _format_datetime,
     _is_auth_error_body,
+    _static_params,
     elasticemail_source,
-    get_rows,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticemail.settings import (
     ELASTICEMAIL_ENDPOINTS,
+)
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the elasticemail module.
+ELASTICEMAIL_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.elasticemail.elasticemail.make_tracked_session"
 )
 
 
@@ -62,22 +70,19 @@ class TestClampFutureValueToNow:
         assert _clamp_future_value_to_now("cursor") == "cursor"
 
 
-class TestBuildParams:
+class TestStaticParams:
     def test_events_incremental_adds_from_filter(self) -> None:
-        params = _build_params(
+        params = _static_params(
             ELASTICEMAIL_ENDPOINTS["events"],
-            offset=0,
             should_use_incremental_field=True,
             db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
         )
         assert params["from"] == "2026-03-04T02:58:14"
         assert params["orderBy"] == "DateAscending"
-        assert params["limit"] == elasticemail.PAGE_SIZE
 
     def test_events_without_cursor_has_no_from(self) -> None:
-        params = _build_params(
+        params = _static_params(
             ELASTICEMAIL_ENDPOINTS["events"],
-            offset=0,
             should_use_incremental_field=True,
             db_incremental_field_last_value=None,
         )
@@ -85,19 +90,16 @@ class TestBuildParams:
 
     def test_full_refresh_endpoint_never_adds_from(self) -> None:
         # Contacts has no server-side time filter, so a cursor value must not leak into the request.
-        params = _build_params(
+        params = _static_params(
             ELASTICEMAIL_ENDPOINTS["contacts"],
-            offset=40,
             should_use_incremental_field=True,
             db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
         )
         assert "from" not in params
-        assert params["offset"] == 40
 
     def test_templates_carries_required_scope_type(self) -> None:
-        params = _build_params(
+        params = _static_params(
             ELASTICEMAIL_ENDPOINTS["templates"],
-            offset=0,
             should_use_incremental_field=False,
             db_incremental_field_last_value=None,
         )
@@ -130,56 +132,200 @@ def _make_response(status_code: int, *, json_body: Any = None, text: str | None 
     response = requests.Response()
     response.status_code = status_code
     if json_body is not None:
-        import json
-
         response._content = json.dumps(json_body).encode()
     elif text is not None:
         response._content = text.encode()
     return response
 
 
-class _FakeSession:
-    def __init__(self, response: requests.Response) -> None:
-        self._response = response
-        self.requested_urls: list[str] = []
-
-    def get(self, url: str, headers: dict[str, str], timeout: int) -> requests.Response:
-        self.requested_urls.append(url)
-        return self._response
+def _make_manager(resume_state: ElasticEmailResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-class TestFetchPage:
-    # Call the undecorated body so tests exercise the status handling without tenacity's retry/backoff.
-    _fetch = staticmethod(elasticemail._fetch_page.__wrapped__)  # type: ignore[attr-defined]
-    _url = "https://api.elasticemail.com/v4/contacts"
+def _wire(session: mock.MagicMock, responses: list[requests.Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
 
-    def test_returns_list_on_ok(self) -> None:
-        session = _FakeSession(_make_response(200, json_body=[{"Email": "a@b.com"}]))
-        assert self._fetch(session, self._url, {}, MagicMock()) == [{"Email": "a@b.com"}]
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared rather than reading the shared dict after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
 
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any) -> Any:
+    return elasticemail_source(
+        api_key="key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession: Any) -> None:
+        session = MockSession.return_value
+        full_page = [{"Email": f"c{i}@x.com"} for i in range(elasticemail.PAGE_SIZE)]
+        params = _wire(
+            session,
+            [_make_response(200, json_body=full_page), _make_response(200, json_body=[{"Email": "last@x.com"}])],
+        )
+
+        rows = _rows(_source("contacts", _make_manager()))
+
+        assert [r["Email"] for r in rows] == [*(f"c{i}@x.com" for i in range(elasticemail.PAGE_SIZE)), "last@x.com"]
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == elasticemail.PAGE_SIZE
+        assert params[1]["offset"] == elasticemail.PAGE_SIZE
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession: Any) -> None:
+        session = MockSession.return_value
+        _wire(session, [_make_response(200, json_body=[{"Email": "a@x.com"}, {"Email": "b@x.com"}])])
+
+        manager = _make_manager()
+        rows = _rows(_source("contacts", manager))
+
+        assert [r["Email"] for r in rows] == ["a@x.com", "b@x.com"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_offset_after_each_non_final_page(self, MockSession: Any) -> None:
+        session = MockSession.return_value
+        full_page = [{"Email": f"c{i}@x.com"} for i in range(elasticemail.PAGE_SIZE)]
+        _wire(
+            session,
+            [_make_response(200, json_body=full_page), _make_response(200, json_body=[{"Email": "last@x.com"}])],
+        )
+
+        manager = _make_manager()
+        _rows(_source("contacts", manager))
+
+        # State is saved after the full page (points at the next page); the short final page saves nothing.
+        assert [c.args[0] for c in manager.save_state.call_args_list] == [
+            ElasticEmailResumeConfig(offset=elasticemail.PAGE_SIZE)
+        ]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession: Any) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_make_response(200, json_body=[{"Email": "resumed@x.com"}])])
+
+        manager = _make_manager(ElasticEmailResumeConfig(offset=2000))
+        rows = _rows(_source("contacts", manager))
+
+        assert params[0]["offset"] == 2000
+        assert [r["Email"] for r in rows] == ["resumed@x.com"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_terminates(self, MockSession: Any) -> None:
+        session = MockSession.return_value
+        _wire(session, [_make_response(200, json_body=[])])
+
+        manager = _make_manager()
+        rows = _rows(_source("contacts", manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_events_incremental_from_filter_reaches_request(self, MockSession: Any) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_make_response(200, json_body=[{"MsgID": "m1"}])])
+
+        _rows(
+            _source(
+                "events",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            )
+        )
+
+        assert params[0]["from"] == "2026-03-04T02:58:14"
+        assert params[0]["orderBy"] == "DateAscending"
+
+
+def _wire_repeating(session: mock.MagicMock, response: requests.Response) -> None:
+    """Return the same response for every send — a retryable status is re-issued until attempts run out."""
+    session.headers = {}
+    session.prepare_request.side_effect = lambda request: mock.MagicMock()
+    session.send.return_value = response
+
+
+class TestErrorClassification:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 502)])
-    def test_retryable_statuses_raise_retryable(self, _name: str, status: int) -> None:
-        session = _FakeSession(_make_response(status, text="boom"))
-        with pytest.raises(ElasticEmailRetryableError):
-            self._fetch(session, self._url, {}, MagicMock())
+    @mock.patch("time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_raise_retryable(self, _name: str, status: int, MockSession: Any, _sleep: Any) -> None:
+        session = MockSession.return_value
+        _wire_repeating(session, _make_response(status, text="boom"))
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source("contacts", _make_manager()))
 
-    @parameterized.expand([("expired_key", 400, '{"Error":"APIKey Expired"}'), ("unauthorized", 401, "")])
-    def test_auth_failures_raise_auth_error(self, _name: str, status: int, body: str) -> None:
-        session = _FakeSession(_make_response(status, text=body))
-        with pytest.raises(ElasticEmailAuthError) as exc:
-            self._fetch(session, self._url, {}, MagicMock())
+    @parameterized.expand(
+        [
+            ("expired_key_400", 400, '{"Error":"APIKey Expired"}'),
+            ("incorrect_key_400", 400, '{"Error":"Incorrect API key."}'),
+            ("unauthorized_401", 401, ""),
+            ("forbidden_403", 403, ""),
+        ]
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_failures_raise_marked_error(self, _name: str, status: int, body: str, MockSession: Any) -> None:
+        # A bad/expired/under-scoped key surfaces a permanent, marker-carrying error so the pipeline's
+        # non-retryable classifier stops the sync instead of hammering the dead key.
+        session = MockSession.return_value
+        _wire(session, [_make_response(status, text=body)])
+        with pytest.raises(ValueError) as exc:
+            _rows(_source("contacts", _make_manager()))
         assert AUTH_ERROR_MARKER in str(exc.value)
 
-    def test_non_list_payload_raises_retryable(self) -> None:
-        session = _FakeSession(_make_response(200, json_body={"Error": "unexpected"}))
-        with pytest.raises(ElasticEmailRetryableError):
-            self._fetch(session, self._url, {}, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_generic_400_is_not_marked_as_auth(self, MockSession: Any) -> None:
+        # A non-credential 400 raises an HTTPError with no auth marker, so the pipeline retries it as usual.
+        session = MockSession.return_value
+        _wire(session, [_make_response(400, text='{"Error":"Invalid date range"}')])
+        with pytest.raises(requests.HTTPError) as exc:
+            _rows(_source("contacts", _make_manager()))
+        assert AUTH_ERROR_MARKER not in str(exc.value)
 
-    def test_non_json_body_raises_retryable(self) -> None:
-        # A 200 with an HTML/proxy body must not propagate a raw JSONDecodeError past the retry layer.
-        session = _FakeSession(_make_response(200, text="<html>gateway timeout</html>"))
-        with pytest.raises(ElasticEmailRetryableError):
-            self._fetch(session, self._url, {}, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_payload_raises_shape_error(self, MockSession: Any) -> None:
+        # A 200 object payload is an unexpected shape; fail loud rather than sync the object as a row.
+        # The error carries no auth marker, so the pipeline retries it as a transient shape change.
+        session = MockSession.return_value
+        _wire(session, [_make_response(200, json_body={"Error": "unexpected"})])
+        with pytest.raises(ValueError) as exc:
+            _rows(_source("contacts", _make_manager()))
+        assert AUTH_ERROR_MARKER not in str(exc.value)
+
+    @mock.patch("time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_json_body_raises_retryable(self, MockSession: Any, _sleep: Any) -> None:
+        # A 200 with an HTML/proxy body must not propagate a raw JSONDecodeError; it is retried.
+        session = MockSession.return_value
+        _wire_repeating(session, _make_response(200, text="<html>gateway timeout</html>"))
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source("contacts", _make_manager()))
 
 
 class TestValidateCredentials:
@@ -194,116 +340,28 @@ class TestValidateCredentials:
         ]
     )
     def test_status_mapping(self, _name: str, status: int, body: str, expected: bool) -> None:
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                elasticemail,
-                "make_tracked_session",
-                lambda **_: _FakeSession(_make_response(status, text=body)),
-            )
+        with mock.patch.object(
+            elasticemail,
+            "make_tracked_session",
+            lambda **_: _FakeSession(_make_response(status, text=body)),
+        ):
             assert validate_credentials("key") is expected
 
-    def test_transport_exception_is_invalid(self, monkeypatch: Any) -> None:
+    def test_transport_exception_is_invalid(self) -> None:
         class _Boom:
             def get(self, *a: Any, **k: Any) -> Any:
                 raise requests.ConnectionError("down")
 
-        monkeypatch.setattr(elasticemail, "make_tracked_session", lambda **_: _Boom())
-        assert validate_credentials("key") is False
+        with mock.patch.object(elasticemail, "make_tracked_session", lambda **_: _Boom()):
+            assert validate_credentials("key") is False
 
 
-class _FakeBatcher:
-    """Yields after every page so the save-after-batch contract is testable without 2000+ rows."""
+class _FakeSession:
+    def __init__(self, response: requests.Response) -> None:
+        self._response = response
 
-    def __init__(self, **_kwargs: Any) -> None:
-        self._rows: list[dict] = []
-
-    def batch(self, item: dict) -> None:
-        self._rows.append(item)
-
-    def should_yield(self, include_incomplete_chunk: bool = False) -> bool:
-        return len(self._rows) > 0
-
-    def get_table(self) -> list[dict]:
-        rows = self._rows
-        self._rows = []
-        return rows
-
-
-class _FakeManager:
-    def __init__(self, state: ElasticEmailResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[ElasticEmailResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> ElasticEmailResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: ElasticEmailResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class TestGetRows:
-    def _patch(self, monkeypatch: Any, pages: dict[int, list[dict]]) -> list[int]:
-        requested_offsets: list[int] = []
-
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> list[dict]:
-            # Offset is the last query param built by _build_params/_build_url.
-            offset = int(url.split("offset=")[1].split("&")[0])
-            requested_offsets.append(offset)
-            return pages[offset]
-
-        monkeypatch.setattr(elasticemail, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(elasticemail, "Batcher", _FakeBatcher)
-        monkeypatch.setattr(elasticemail, "PAGE_SIZE", 2)
-        return requested_offsets
-
-    def _collect(self, manager: _FakeManager) -> list[dict]:
-        rows: list[dict] = []
-        for table in get_rows(
-            api_key="key",
-            endpoint="contacts",
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(table)
-        return rows
-
-    def test_paginates_until_short_page(self, monkeypatch: Any) -> None:
-        offsets = self._patch(
-            monkeypatch,
-            {
-                0: [{"Email": "a"}, {"Email": "b"}],
-                2: [{"Email": "c"}, {"Email": "d"}],
-                4: [{"Email": "e"}],  # short page → terminate
-            },
-        )
-        rows = self._collect(_FakeManager())
-        assert [r["Email"] for r in rows] == ["a", "b", "c", "d", "e"]
-        assert offsets == [0, 2, 4]
-
-    def test_saves_offset_after_each_non_final_page(self, monkeypatch: Any) -> None:
-        self._patch(
-            monkeypatch,
-            {0: [{"Email": "a"}, {"Email": "b"}], 2: [{"Email": "c"}, {"Email": "d"}], 4: [{"Email": "e"}]},
-        )
-        manager = _FakeManager()
-        self._collect(manager)
-        # State is saved after the two full pages (next offsets 2 and 4); the short final page saves nothing.
-        assert [s.offset for s in manager.saved] == [2, 4]
-
-    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
-        offsets = self._patch(monkeypatch, {2: [{"Email": "c"}, {"Email": "d"}], 4: [{"Email": "e"}]})
-        rows = self._collect(_FakeManager(ElasticEmailResumeConfig(offset=2)))
-        assert offsets[0] == 2
-        assert [r["Email"] for r in rows] == ["c", "d", "e"]
-
-    def test_empty_first_page_terminates(self, monkeypatch: Any) -> None:
-        offsets = self._patch(monkeypatch, {0: []})
-        rows = self._collect(_FakeManager())
-        assert rows == []
-        assert offsets == [0]
+    def get(self, url: str, headers: dict[str, str], timeout: int) -> requests.Response:
+        return self._response
 
 
 class TestElasticemailSource:
@@ -319,12 +377,7 @@ class TestElasticemailSource:
         ]
     )
     def test_source_response_shape(self, endpoint: str, primary_keys: list[str], partition_key: str | None) -> None:
-        response = elasticemail_source(
-            api_key="key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == primary_keys
         assert response.sort_mode == "asc"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/tests/test_elasticemail_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticemail/tests/test_elasticemail_source.py
@@ -125,13 +125,17 @@ class TestResumableAndCanonical:
     def test_source_for_pipeline_plumbs_arguments(self) -> None:
         inputs = SimpleNamespace(
             schema_name="events",
+            team_id=1,
+            job_id="job",
             logger=MagicMock(),
             should_use_incremental_field=True,
             db_incremental_field_last_value="2026-01-01T00:00:00",
         )
+        manager = MagicMock()
+        manager.can_resume.return_value = False
         response = ElasticemailSource().source_for_pipeline(
             SimpleNamespace(api_key="key"),  # type: ignore[arg-type]
-            MagicMock(),
+            manager,
             inputs,  # type: ignore[arg-type]
         )
         assert response.name == "events"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/granola/granola.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/granola/granola.py
@@ -1,16 +1,22 @@
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BaseNextUrlPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.granola.settings import (
     GRANOLA_ENDPOINTS,
     GranolaEndpointConfig,
@@ -22,18 +28,37 @@ GRANOLA_BASE_URL = "https://public-api.granola.ai"
 # 5 req/s sustained / 25-per-5s burst rate limit.
 PAGE_SIZE = 30
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
-
-
-class GranolaRetryableError(Exception):
-    pass
-
 
 @dataclasses.dataclass
 class GranolaResumeConfig:
     # Full, self-contained next-page URL (base + filters + cursor) so a resume can GET it directly.
     next_url: str
+
+
+class GranolaCursorPaginator(BaseNextUrlPaginator):
+    """Cursor pagination gated on BOTH ``hasMore`` and ``cursor`` in the response body.
+
+    Granola returns an opaque ``cursor`` plus a ``hasMore`` flag; a page only has a successor when
+    both are truthy. The built-in cursor paginator keys off the cursor alone, so this small subclass
+    reproduces the exact stop condition. It builds a self-contained next-page URL (base + page_size +
+    incremental filter + cursor) via the injected builder, which keeps the resume state a single
+    ``next_url`` string — the same shape the hand-rolled source persisted.
+    """
+
+    def __init__(self, next_url_builder: Callable[[str], str]) -> None:
+        super().__init__()
+        self._next_url_builder = next_url_builder
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        if isinstance(body, dict) and body.get("hasMore") and body.get("cursor"):
+            self._next_url = self._next_url_builder(body["cursor"])
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
 
 
 def _get_headers(api_key: str) -> dict[str, str]:
@@ -86,90 +111,32 @@ def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tup
     endpoint = GRANOLA_ENDPOINTS.get(schema_name) if schema_name else None
     path = endpoint.path if endpoint else GRANOLA_ENDPOINTS["notes"].path
     url = _build_url(path, {"page_size": 1})
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=REQUEST_TIMEOUT_SECONDS)
-    except Exception:
+
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        url,
+        headers=_get_headers(api_key),
+    )
+
+    if status == 200:
+        return True, None
+    if status == 401:
+        return False, "Invalid Granola API key"
+    if status == 403 and schema_name is None:
+        return True, None
+    if status == 403:
+        return False, "Your Granola API key does not have access to this data"
+    if status is None:
         return False, "Could not reach the Granola API. Please try again."
 
-    if response.status_code == 200:
-        return True, None
-    if response.status_code == 401:
-        return False, "Invalid Granola API key"
-    if response.status_code == 403 and schema_name is None:
-        return True, None
-    if response.status_code == 403:
-        return False, "Your Granola API key does not have access to this data"
-
-    return False, f"Granola API returned an unexpected status code: {response.status_code}"
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GranolaResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = GRANOLA_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-
-    params = _build_initial_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
-    )
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url = resume_config.next_url
-        logger.debug(f"Granola: resuming {endpoint} from URL: {url}")
-    else:
-        url = _build_url(config.path, params)
-
-    @retry(
-        retry=retry_if_exception_type((GranolaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise GranolaRetryableError(f"Granola API error (retryable): status={response.status_code}, url={page_url}")
-
-        if not response.ok:
-            logger.error(f"Granola API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-
-        items = data.get(config.data_key, [])
-
-        # Compute the next-page URL before yielding so we can checkpoint after the batch.
-        next_url: str | None = None
-        if data.get("hasMore") and data.get("cursor"):
-            next_url = _build_url(config.path, {**params, "cursor": data["cursor"]})
-
-        if items:
-            yield items
-
-        if not next_url:
-            break
-
-        # Save state AFTER yielding so a crash re-yields the last batch (merge dedupes on id)
-        # rather than skipping it.
-        resumable_source_manager.save_state(GranolaResumeConfig(next_url=next_url))
-        url = next_url
+    return False, f"Granola API returned an unexpected status code: {status}"
 
 
 def granola_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GranolaResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -177,17 +144,63 @@ def granola_source(
 ) -> SourceResponse:
     config = GRANOLA_ENDPOINTS[endpoint]
 
+    params = _build_initial_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+
+    def build_next_url(cursor: str) -> str:
+        # Self-contained next-page URL carrying page_size + any incremental filter + cursor.
+        return _build_url(config.path, {**params, "cursor": cursor})
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GRANOLA_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted from
+            # logs and raised errors; only the non-secret accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": GranolaCursorPaginator(build_next_url),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # The list lives under a wrapper key (e.g. {"notes": [...]}). A missing key is
+                    # treated as an empty page (not a hard error), matching the hand-rolled source.
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on id) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(GranolaResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        # Incremental filtering is applied as a computed static query param above, so the framework
+        # has no server-side cursor param to inject.
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         # Granola's list endpoints have no sort parameter, so within-page ordering is
         # undefined. "desc" here is the pipeline's "commit the incremental watermark only

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/granola/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/granola/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GranolaSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.granola.granola import (
     GranolaResumeConfig,
@@ -92,20 +95,7 @@ Only notes with a generated AI summary and transcript are returned by the API.
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint) is not None
-                and len(INCREMENTAL_FIELDS[endpoint]) > 0,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint) is not None and len(INCREMENTAL_FIELDS[endpoint]) > 0,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: GranolaSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -130,7 +120,8 @@ Only notes with a generated AI summary and transcript are returned by the API.
         return granola_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/granola/tests/test_granola.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/granola/tests/test_granola.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import pytest
 from unittest import mock
 
-import structlog
+from requests import HTTPError, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.granola.granola import (
     GRANOLA_BASE_URL,
@@ -14,39 +14,63 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.granola.gr
     _build_initial_params,
     _build_url,
     _format_timestamp,
-    get_rows,
     granola_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.granola.settings import GRANOLA_ENDPOINTS
 
 MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.granola.granola"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
 
 
-def _response(status: int = 200, body: Optional[dict[str, Any]] = None) -> mock.MagicMock:
+def _mock_response(status: int = 200) -> mock.MagicMock:
     resp = mock.MagicMock()
     resp.status_code = status
-    resp.ok = 200 <= status < 300
-    resp.json.return_value = body or {}
-    resp.text = json.dumps(body or {})
     return resp
 
 
-class _StubManager:
-    """Minimal stand-in for ResumableSourceManager that records saved state."""
+def _response(body: dict[str, Any], status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = f"{GRANOLA_BASE_URL}/v1/notes"
+    return resp
 
-    def __init__(self, resume_state: Optional[GranolaResumeConfig] = None) -> None:
-        self._resume_state = resume_state
-        self.saved: list[GranolaResumeConfig] = []
 
-    def can_resume(self) -> bool:
-        return self._resume_state is not None
+def _make_manager(resume_state: Optional[GranolaResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def load_state(self) -> Optional[GranolaResumeConfig]:
-        return self._resume_state
 
-    def save_state(self, data: GranolaResumeConfig) -> None:
-        self.saved.append(data)
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    The client mutates a single ``Request`` object in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    seen: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        seen.append({"url": request.url, "params": dict(request.params or {})})
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return seen
+
+
+def _pages(source_response) -> list[list[dict[str, Any]]]:
+    return list(source_response.items())
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatTimestamp:
@@ -127,7 +151,7 @@ class TestValidateCredentials:
     )
     def test_status_mapping(self, status, schema_name, expected_valid) -> None:
         with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(status)
+            mock_session.return_value.get.return_value = _mock_response(status)
 
             is_valid, _ = validate_credentials("grn_test", schema_name)
 
@@ -153,7 +177,7 @@ class TestValidateCredentials:
     )
     def test_probes_path_matching_schema(self, schema_name, expected_path) -> None:
         with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.return_value = _response(200)
+            mock_session.return_value.get.return_value = _mock_response(200)
 
             validate_credentials("grn_test", schema_name)
 
@@ -162,83 +186,132 @@ class TestValidateCredentials:
         assert called_url.startswith(f"{GRANOLA_BASE_URL}{expected_path}?")
 
 
-class TestGetRows:
-    def _run(self, manager: _StubManager, pages: list[dict[str, Any]], **kwargs: Any) -> list[list[dict[str, Any]]]:
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.side_effect = [_response(200, page) for page in pages]
-            return list(
-                get_rows(
-                    api_key="grn_test",
-                    endpoint="notes",
-                    logger=structlog.get_logger(),
-                    resumable_source_manager=manager,  # type: ignore[arg-type]
-                    **kwargs,
-                )
-            )
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_yields_each_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"notes": [{"id": "not_1"}, {"id": "not_2"}], "hasMore": True, "cursor": "c1"}),
+                _response({"notes": [{"id": "not_3"}], "hasMore": False, "cursor": None}),
+            ],
+        )
 
-    def test_paginates_and_yields_each_page(self) -> None:
-        manager = _StubManager()
-        pages = [
-            {"notes": [{"id": "not_1"}, {"id": "not_2"}], "hasMore": True, "cursor": "c1"},
-            {"notes": [{"id": "not_3"}], "hasMore": False, "cursor": None},
-        ]
+        pages = _pages(
+            granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
 
-        batches = self._run(manager, pages)
+        assert pages == [[{"id": "not_1"}, {"id": "not_2"}], [{"id": "not_3"}]]
 
-        assert batches == [[{"id": "not_1"}, {"id": "not_2"}], [{"id": "not_3"}]]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_yielding_each_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({"notes": [{"id": "not_1"}], "hasMore": True, "cursor": "c1"}),
+                _response({"notes": [{"id": "not_2"}], "hasMore": False, "cursor": None}),
+            ],
+        )
 
-    def test_saves_state_after_yielding_each_page(self) -> None:
-        manager = _StubManager()
-        pages = [
-            {"notes": [{"id": "not_1"}], "hasMore": True, "cursor": "c1"},
-            {"notes": [{"id": "not_2"}], "hasMore": False, "cursor": None},
-        ]
-
-        self._run(manager, pages)
+        manager = _make_manager()
+        _rows(granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=manager))
 
         # Only one checkpoint - the final page has no next cursor.
-        assert len(manager.saved) == 1
-        assert "cursor=c1" in manager.saved[0].next_url
+        manager.save_state.assert_called_once()
+        saved = manager.save_state.call_args.args[0]
+        assert isinstance(saved, GranolaResumeConfig)
+        assert "cursor=c1" in saved.next_url
 
-    def test_stops_when_cursor_missing_even_if_has_more(self) -> None:
-        manager = _StubManager()
-        pages = [{"notes": [{"id": "not_1"}], "hasMore": True, "cursor": None}]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_cursor_missing_even_if_has_more(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"notes": [{"id": "not_1"}], "hasMore": True, "cursor": None})])
 
-        batches = self._run(manager, pages)
+        manager = _make_manager()
+        rows = _rows(granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert batches == [[{"id": "not_1"}]]
-        assert manager.saved == []
+        assert rows == [{"id": "not_1"}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resumes_from_saved_url(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_url(self, MockSession) -> None:
+        session = MockSession.return_value
         resume_url = f"{GRANOLA_BASE_URL}/v1/notes?page_size=30&cursor=resume_token"
-        manager = _StubManager(resume_state=GranolaResumeConfig(next_url=resume_url))
+        seen = _wire(session, [_response({"notes": [{"id": "not_9"}], "hasMore": False, "cursor": None})])
 
-        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
-            mock_session.return_value.get.side_effect = [
-                _response(200, {"notes": [{"id": "not_9"}], "hasMore": False, "cursor": None})
-            ]
-            list(
-                get_rows(
-                    api_key="grn_test",
-                    endpoint="notes",
-                    logger=structlog.get_logger(),
-                    resumable_source_manager=manager,  # type: ignore[arg-type]
-                )
+        manager = _make_manager(GranolaResumeConfig(next_url=resume_url))
+        _rows(granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert seen[0]["url"] == resume_url
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_first_page_carries_page_size(self, MockSession) -> None:
+        session = MockSession.return_value
+        seen = _wire(session, [_response({"notes": [{"id": "not_1"}], "hasMore": False, "cursor": None})])
+
+        _rows(granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+
+        assert seen[0]["params"]["page_size"] == PAGE_SIZE
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_in_first_request_and_next_url(self, MockSession) -> None:
+        session = MockSession.return_value
+        seen = _wire(
+            session,
+            [
+                _response({"notes": [{"id": "not_1"}], "hasMore": True, "cursor": "c1"}),
+                _response({"notes": [{"id": "not_2"}], "hasMore": False, "cursor": None}),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(
+            granola_source(
+                "grn_test",
+                "notes",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 27, 15, 30, 0, tzinfo=UTC),
+                incremental_field="updated_at",
             )
+        )
 
-            called_url = mock_session.return_value.get.call_args[0][0]
+        # Server-side filter is present on the initial request...
+        assert seen[0]["params"]["updated_after"] == "2026-01-27T15:30:00Z"
+        # ...and persists into the self-contained next-page URL so it isn't dropped after page 1.
+        saved = manager.save_state.call_args.args[0]
+        assert "updated_after=2026-01-27T15%3A30%3A00Z" in saved.next_url
 
-        assert called_url == resume_url
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A body without the wrapper key is treated as an empty page (not a hard error).
+        _wire(session, [_response({"hasMore": False, "cursor": None})])
+
+        rows = _rows(
+            granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+
+        assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_forbidden_status_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "forbidden"}, status=403)])
+
+        with pytest.raises(HTTPError):
+            _rows(granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
 
 class TestGranolaSource:
-    def test_notes_response_has_datetime_partition(self) -> None:
-        response = granola_source(
-            api_key="grn_test",
-            endpoint="notes",
-            logger=structlog.get_logger(),
-            resumable_source_manager=mock.MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_notes_response_has_datetime_partition(self, MockSession) -> None:
+        response = granola_source("grn_test", "notes", team_id=1, job_id="j", resumable_source_manager=_make_manager())
 
         assert response.name == "notes"
         assert response.primary_keys == ["id"]
@@ -248,12 +321,10 @@ class TestGranolaSource:
         assert response.partition_keys == ["created_at"]
         assert response.partition_format == "week"
 
-    def test_folders_response_has_no_partition(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_folders_response_has_no_partition(self, MockSession) -> None:
         response = granola_source(
-            api_key="grn_test",
-            endpoint="folders",
-            logger=structlog.get_logger(),
-            resumable_source_manager=mock.MagicMock(),
+            "grn_test", "folders", team_id=1, job_id="j", resumable_source_manager=_make_manager()
         )
 
         assert response.name == "folders"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/granola/tests/test_granola_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/granola/tests/test_granola_source.py
@@ -144,7 +144,8 @@ class TestGranolaSource:
         mock_granola_source.assert_called_once_with(
             api_key="grn_test",
             endpoint="notes",
-            logger=inputs.logger,
+            team_id=123,
+            job_id="job-id",
             resumable_source_manager=manager,
             should_use_incremental_field=True,
             db_incremental_field_last_value=last_value,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/greenhouse/greenhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/greenhouse/greenhouse.py
@@ -1,29 +1,29 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
-import requests  # used for exception types in the tenacity retry predicate
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests.auth import HTTPBasicAuth
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse.settings import (
     GREENHOUSE_ENDPOINTS,
     GreenhouseEndpointConfig,
 )
 
 GREENHOUSE_BASE_URL = "https://harvest.greenhouse.io/v1"
-REQUEST_TIMEOUT_SECONDS = 60
 # Harvest's documented maximum page size. Fewer requests keeps us comfortably under the
 # per-10-second rate limit advertised via the `X-RateLimit-*` response headers.
 PAGE_SIZE = 500
-
-
-class GreenhouseRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -34,11 +34,6 @@ class GreenhouseResumeConfig:
     next_url: str
 
 
-def _auth(api_key: str) -> tuple[str, str]:
-    # Harvest uses HTTP Basic auth with the API key as the username and a blank password.
-    return (api_key, "")
-
-
 def _format_datetime(value: Any) -> str:
     """Format an incremental cursor value as the ISO 8601 string Harvest's `*_after` filters expect."""
     if isinstance(value, datetime):
@@ -47,39 +42,6 @@ def _format_datetime(value: Any) -> str:
     if isinstance(value, date):
         return value.strftime("%Y-%m-%dT00:00:00.000Z")
     return str(value)
-
-
-def validate_credentials(
-    api_key: str, path: str = "/candidates", accept_forbidden: bool = True
-) -> tuple[bool, str | None]:
-    """Probe a Harvest endpoint to confirm the API key is genuine.
-
-    Harvest keys are scoped per-resource: a valid key may still 403 on an endpoint it wasn't
-    granted. At source-create time (``accept_forbidden=True``) we treat 403 as success so users
-    can connect with keys scoped only to the endpoints they want; per-schema checks pass
-    ``accept_forbidden=False`` to surface a missing-scope error for that specific endpoint.
-    """
-    url = f"{GREENHOUSE_BASE_URL}{path}"
-    session = make_tracked_session()
-    try:
-        response = session.get(url, auth=_auth(api_key), params={"per_page": 1}, timeout=10)
-    except Exception as e:
-        return False, str(e)
-    finally:
-        session.close()
-
-    if response.status_code == 200:
-        return True, None
-
-    if response.status_code == 403:
-        if accept_forbidden:
-            return True, None
-        return False, "Your Greenhouse API key does not have permission to access this endpoint."
-
-    if response.status_code == 401:
-        return False, "Invalid Greenhouse API key. Please check your key and try again."
-
-    return False, f"Greenhouse API returned an unexpected status code: {response.status_code}"
 
 
 def _build_initial_params(
@@ -99,75 +61,44 @@ def _build_initial_params(
     return params
 
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GreenhouseResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = GREENHOUSE_ENDPOINTS[endpoint]
-    session = make_tracked_session()
+def validate_credentials(
+    api_key: str, path: str = "/candidates", accept_forbidden: bool = True
+) -> tuple[bool, str | None]:
+    """Probe a Harvest endpoint to confirm the API key is genuine.
 
-    base_params = _build_initial_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    Harvest keys are scoped per-resource: a valid key may still 403 on an endpoint it wasn't
+    granted. At source-create time (``accept_forbidden=True``) we treat 403 as success so users
+    can connect with keys scoped only to the endpoints they want; per-schema checks pass
+    ``accept_forbidden=False`` to surface a missing-scope error for that specific endpoint.
+    """
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{GREENHOUSE_BASE_URL}{path}?per_page=1",
+        auth=HTTPBasicAuth(api_key, ""),
     )
 
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    next_url: str | None = resume_config.next_url if resume_config else None
-    if next_url:
-        logger.debug(f"Greenhouse: resuming {endpoint} from saved page URL")
+    if status == 200:
+        return True, None
 
-    @retry(
-        retry=retry_if_exception_type((GreenhouseRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(url: str, params: dict[str, Any] | None) -> requests.Response:
-        response = session.get(url, auth=_auth(api_key), params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+    if status == 403:
+        if accept_forbidden:
+            return True, None
+        return False, "Your Greenhouse API key does not have permission to access this endpoint."
 
-        if response.status_code == 429 or response.status_code >= 500:
-            raise GreenhouseRetryableError(
-                f"Greenhouse API error (retryable): status={response.status_code}, url={url}"
-            )
+    if status == 401:
+        return False, "Invalid Greenhouse API key. Please check your key and try again."
 
-        if not response.ok:
-            logger.error(f"Greenhouse API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
+    if status is None:
+        return False, "Could not reach the Greenhouse API. Please try again."
 
-        return response
-
-    try:
-        while True:
-            if next_url:
-                # The `Link` URL already encodes per_page + filters; sending params again would
-                # duplicate the query string, so we follow it verbatim.
-                response = fetch_page(next_url, None)
-            else:
-                response = fetch_page(f"{GREENHOUSE_BASE_URL}{config.path}", base_params)
-
-            items = response.json()
-            if items:
-                yield items
-
-            next_url = response.links.get("next", {}).get("url")
-            if not next_url:
-                break
-
-            # Save state after yielding so a crash re-yields the last batch (merge dedupes on
-            # the primary key) rather than skipping it.
-            resumable_source_manager.save_state(GreenhouseResumeConfig(next_url=next_url))
-    finally:
-        session.close()
+    return False, f"Greenhouse API returned an unexpected status code: {status}"
 
 
 def greenhouse_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GreenhouseResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -175,17 +106,55 @@ def greenhouse_source(
 ) -> SourceResponse:
     config = GREENHOUSE_ENDPOINTS[endpoint]
 
+    params = _build_initial_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GREENHOUSE_BASE_URL,
+            # Harvest uses HTTP Basic auth with the API key as the username and a blank password.
+            # Supplied via framework auth so the key is redacted from logs and error messages.
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            # Harvest paginates with RFC 5988 `Link` headers; the paginator follows the
+            # `rel="next"` URL verbatim (it already encodes per_page + filters).
+            "paginator": HeaderLinkPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(GreenhouseResumeConfig(next_url=str(state["next_url"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -197,4 +166,5 @@ def greenhouse_source(
         # max cursor value seen) and rely on the resumable `Link` cursor to make in-run retries
         # safe; merge semantics dedupe re-fetched rows.
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/greenhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/greenhouse/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GreenhouseSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse.greenhouse import (
     GreenhouseResumeConfig,
@@ -90,21 +93,7 @@ Grant the key read (`GET`) access to the resources you want to sync — for exam
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [schema for schema in schemas if schema.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: GreenhouseSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -137,7 +126,8 @@ Grant the key read (`GET`) access to the resources you want to sync — for exam
         return greenhouse_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/greenhouse/tests/test_greenhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/greenhouse/tests/test_greenhouse.py
@@ -1,11 +1,11 @@
 import json
 import dataclasses
-from collections.abc import Iterable
 from datetime import UTC, date, datetime
-from typing import Any, cast
+from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
+from unittest.mock import MagicMock
 
 from requests import Response
 
@@ -20,6 +20,13 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse.settings import ENDPOINTS
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the greenhouse module.
+GREENHOUSE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse.greenhouse.make_tracked_session"
+)
+
 
 def _make_response(body: Any, status_code: int = 200, next_url: str | None = None) -> Response:
     resp = Response()
@@ -30,6 +37,13 @@ def _make_response(body: Any, status_code: int = 200, next_url: str | None = Non
         # RFC 5988 Link header, as Harvest returns it. requests parses this into `resp.links`.
         resp.headers["Link"] = f'<{next_url}>; rel="next"'
     return resp
+
+
+def _make_manager(resume_state: GreenhouseResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
 class TestFormatDatetime:
@@ -94,39 +108,52 @@ class TestValidateCredentials:
             (500, True, False),
         ],
     )
-    @patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse.greenhouse.make_tracked_session"
-    )
+    @mock.patch(GREENHOUSE_SESSION_PATCH)
     def test_status_code_mapping(
         self, mock_session_factory: MagicMock, status_code: int, accept_forbidden: bool, expected_valid: bool
     ) -> None:
-        mock_session = mock_session_factory.return_value
-        mock_session.get.return_value = _make_response({}, status_code=status_code)
+        mock_session_factory.return_value.get.return_value = MagicMock(status_code=status_code)
 
         is_valid, error = validate_credentials("test_key", accept_forbidden=accept_forbidden)
 
         assert is_valid is expected_valid
         assert (error is None) is expected_valid
 
-    @patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse.greenhouse.make_tracked_session"
-    )
+    @mock.patch(GREENHOUSE_SESSION_PATCH)
+    def test_per_schema_forbidden_surfaces_scope_error(self, mock_session_factory: MagicMock) -> None:
+        mock_session_factory.return_value.get.return_value = MagicMock(status_code=403)
+        is_valid, error = validate_credentials("test_key", path="/candidates", accept_forbidden=False)
+        assert is_valid is False
+        assert error is not None and "permission" in error
+
+    @mock.patch(GREENHOUSE_SESSION_PATCH)
     def test_network_error_is_not_valid(self, mock_session_factory: MagicMock) -> None:
+        # validate_via_probe swallows transport errors and reports "not validated".
         mock_session_factory.return_value.get.side_effect = Exception("boom")
         is_valid, error = validate_credentials("test_key")
         assert is_valid is False
-        assert error == "boom"
+        assert error is not None
+
+    @mock.patch(GREENHOUSE_SESSION_PATCH)
+    def test_uses_http_basic_auth_with_blank_password(self, mock_session_factory: MagicMock) -> None:
+        mock_get = mock_session_factory.return_value.get
+        mock_get.return_value = MagicMock(status_code=200)
+
+        validate_credentials("test_key")
+
+        auth = mock_get.call_args.kwargs["auth"]
+        assert (auth.username, auth.password) == ("test_key", "")
 
 
 class TestGreenhouseSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_primary_keys_match_settings(self, endpoint: str) -> None:
-        response = greenhouse_source("key", endpoint, MagicMock(), MagicMock())
+        response = greenhouse_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.primary_keys == GREENHOUSE_ENDPOINTS[endpoint].primary_keys
 
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_partitioning_only_when_partition_key_present(self, endpoint: str) -> None:
-        response = greenhouse_source("key", endpoint, MagicMock(), MagicMock())
+        response = greenhouse_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
         partition_key = GREENHOUSE_ENDPOINTS[endpoint].partition_key
 
         if partition_key:
@@ -141,93 +168,125 @@ class TestGreenhouseSourceResponse:
         assert GREENHOUSE_ENDPOINTS[endpoint].partition_key not in ("updated_at", "last_activity_at")
 
     def test_sort_mode_is_ascending(self) -> None:
-        assert greenhouse_source("key", "candidates", MagicMock(), MagicMock()).sort_mode == "asc"
+        response = greenhouse_source(
+            "key", "candidates", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
+        assert response.sort_mode == "asc"
 
 
 class TestGreenhousePaginationAndResume:
-    """Drive ``get_rows`` (via ``greenhouse_source``) with a mocked HTTP session."""
+    """Drive the rest_source transport (via ``greenhouse_source``) with a mocked HTTP session."""
 
-    def _drive(
-        self, endpoint: str, manager: MagicMock, responses: list[Response]
-    ) -> tuple[list[tuple[str, dict[str, Any] | None]], list[Any]]:
-        """Returns (per-request (url, params) tuples, batches yielded by the source)."""
-        sent: list[tuple[str, dict[str, Any] | None]] = []
-        yielded: list[Any] = []
-        response_iter = iter(responses)
+    def _wire(self, session: MagicMock, responses: list[Response]) -> list[tuple[str, dict[str, Any]]]:
+        """Snapshot each request's (url, params) at prepare time and feed ``responses`` to send."""
+        session.headers = {}
+        sent: list[tuple[str, dict[str, Any]]] = []
 
-        def fake_get(url: str, *_args: Any, **kwargs: Any) -> Response:
-            sent.append((url, kwargs.get("params")))
-            return next(response_iter)
+        def _prepare(request: Any) -> MagicMock:
+            sent.append((request.url, dict(request.params or {})))
+            prepared = MagicMock()
+            prepared.url = request.url
+            return prepared
 
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.greenhouse.greenhouse.make_tracked_session"
-        ) as mock_factory:
-            mock_factory.return_value.get.side_effect = fake_get
+        session.prepare_request.side_effect = _prepare
+        session.send.side_effect = responses
+        return sent
 
-            response = greenhouse_source("key", endpoint, MagicMock(), manager)
-            yielded.extend(cast(Iterable[Any], response.items()))
+    def _rows(self, source_response: Any) -> list[Any]:
+        return [row for page in source_response.items() for row in page]
 
-        return sent, yielded
-
-    def test_fresh_run_follows_link_header(self) -> None:
-        manager = MagicMock()
-        manager.can_resume.return_value = False
-
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fresh_run_follows_link_header(self, mock_factory: MagicMock) -> None:
+        session = mock_factory.return_value
         next_url = "https://harvest.greenhouse.io/v1/candidates?per_page=500&page=2"
-        responses = [
-            _make_response([{"id": 1}], next_url=next_url),
-            _make_response([{"id": 2}]),  # no Link header -> last page
-        ]
+        sent = self._wire(
+            session,
+            [
+                _make_response([{"id": 1}], next_url=next_url),
+                _make_response([{"id": 2}]),  # no Link header -> last page
+            ],
+        )
 
-        sent, yielded = self._drive("candidates", manager, responses)
+        rows = self._rows(
+            greenhouse_source("key", "candidates", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
 
         # First request hits the path with params; second follows the Link URL verbatim (no params).
-        assert sent[0][0] == "https://harvest.greenhouse.io/v1/candidates"
-        assert sent[0][1] == {"per_page": PAGE_SIZE}
-        assert sent[1] == (next_url, None)
+        assert sent[0] == ("https://harvest.greenhouse.io/v1/candidates", {"per_page": PAGE_SIZE})
+        assert sent[1] == (next_url, {})
+        assert rows == [{"id": 1}, {"id": 2}]
 
-        flat = [row for batch in yielded for row in batch]
-        assert flat == [{"id": 1}, {"id": 2}]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_applied_to_first_request(self, mock_factory: MagicMock) -> None:
+        session = mock_factory.return_value
+        sent = self._wire(session, [_make_response([{"id": 1}])])
 
-    def test_saves_next_url_after_each_non_terminal_page(self) -> None:
-        manager = MagicMock()
-        manager.can_resume.return_value = False
+        watermark = datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC)
+        self._rows(
+            greenhouse_source(
+                "key",
+                "candidates",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=watermark,
+                incremental_field="updated_at",
+            )
+        )
 
+        assert sent[0][1] == {"per_page": PAGE_SIZE, "updated_after": "2026-03-04T02:58:14.000Z"}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_url_after_each_non_terminal_page(self, mock_factory: MagicMock) -> None:
+        session = mock_factory.return_value
         url2 = "https://harvest.greenhouse.io/v1/jobs?per_page=500&page=2"
         url3 = "https://harvest.greenhouse.io/v1/jobs?per_page=500&page=3"
-        responses = [
-            _make_response([{"id": 1}], next_url=url2),
-            _make_response([{"id": 2}], next_url=url3),
-            _make_response([{"id": 3}]),
-        ]
-        self._drive("jobs", manager, responses)
+        self._wire(
+            session,
+            [
+                _make_response([{"id": 1}], next_url=url2),
+                _make_response([{"id": 2}], next_url=url3),
+                _make_response([{"id": 3}]),
+            ],
+        )
+
+        manager = _make_manager()
+        self._rows(greenhouse_source("key", "jobs", team_id=1, job_id="j", resumable_source_manager=manager))
 
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [GreenhouseResumeConfig(next_url=url2), GreenhouseResumeConfig(next_url=url3)]
 
-    def test_terminal_single_page_does_not_save_state(self) -> None:
-        manager = MagicMock()
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_terminal_single_page_does_not_save_state(self, mock_factory: MagicMock) -> None:
+        session = mock_factory.return_value
+        self._wire(session, [_make_response([{"id": 1}])])
 
-        self._drive("jobs", manager, [_make_response([{"id": 1}])])
+        manager = _make_manager()
+        self._rows(greenhouse_source("key", "jobs", team_id=1, job_id="j", resumable_source_manager=manager))
         manager.save_state.assert_not_called()
 
-    def test_resume_seeds_first_request_with_saved_next_url(self) -> None:
-        manager = MagicMock()
-        manager.can_resume.return_value = True
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_seeds_first_request_with_saved_next_url(self, mock_factory: MagicMock) -> None:
+        session = mock_factory.return_value
         saved_url = "https://harvest.greenhouse.io/v1/candidates?per_page=500&page=5"
-        manager.load_state.return_value = GreenhouseResumeConfig(next_url=saved_url)
+        sent = self._wire(session, [_make_response([{"id": 9}])])
 
-        sent, _ = self._drive("candidates", manager, [_make_response([{"id": 9}])])
+        manager = _make_manager(GreenhouseResumeConfig(next_url=saved_url))
+        self._rows(greenhouse_source("key", "candidates", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert sent[0] == (saved_url, None)
+        assert sent[0] == (saved_url, {})
 
-    def test_empty_page_yields_nothing_and_stops(self) -> None:
-        manager = MagicMock()
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_yields_nothing_and_stops(self, mock_factory: MagicMock) -> None:
+        session = mock_factory.return_value
+        sent = self._wire(session, [_make_response([])])
 
-        sent, yielded = self._drive("jobs", manager, [_make_response([])])
-        assert yielded == []
+        rows = self._rows(
+            greenhouse_source("key", "jobs", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert rows == []
+        assert session.send.call_count == 1
         assert len(sent) == 1
 
 


### PR DESCRIPTION
## Problem

Batch 20 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

This batch also lands a generic framework capability — **body-error classification in `response_actions`** — so sources that classify success-status response bodies as retryable-vs-permanent no longer need bespoke transport code.

## Changes

Framework:
- `response_actions` now supports two new actions alongside `ignore`: `retry` (raise a retryable error so the request is re-issued — for an HTTP-200 body-level error envelope such as an in-body rate-limit signal, or to promote a non-5xx status to retryable) and `raise` (raise a permanent, non-retryable error with a manifest-authored `message` that `get_non_retryable_errors` can match). Both are matched on `status_code` and/or a `content` substring. The client's own retry check still fires on 429/5xx before hooks run, so this targets HTTP-200 (and other non-429/5xx) bodies.

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **aviationstack** — 200-body error envelope: `rate_limit_reached` → retry, permanent codes → raise with a code-tagged message
- **cloudbeds**
- **coingecko** — 200-body `{"status":{"error_code":429}}` rate-limit envelope → retry
- **elasticemail** — 200 non-list/non-JSON body → retry, 400 auth-body → raise
- **granola**
- **greenhouse**

Not migrated this batch (left hand-rolled, valid blockers):
- **alpha_vantage** — compounding blockers beyond body-error: config-list symbol fan-out, five response modes, and dict-to-rows explosion.
- **groq** — classifies *structural* HTTP-200 body malformations (non-dict body, non-list `data`) as retryable, with no stable content string for `response_actions` to match.

## How did you test this code?

- New framework capability: 4 cases in `test_response_action_classification.py` — retry action recovers on a later success, persistent retry reraises retryable, raise action is permanent with its message, and an unmatched 4xx still raises for status.
- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 6 migrated dirs + `common/rest_source/tests/` — 493 passed. Additive framework change: all existing `rest_source` tests plus the existing `response_actions` "ignore" consumers (campayn, beamer, baseten, cloudflare, chameleon, goldcast) stay green.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-19 PR (#71872); merge in order.
