### PR TITLE
fix(clickhouse): treat SSH gateway connection failure as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -171,6 +171,14 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             "Code: 192": None,  # UNKNOWN_USER
             "Code: 497": None,  # ACCESS_DENIED
             "Authentication failed": None,
+            # Raised by the `sshtunnel` library (via the shared `open_ssh_tunnel` helper) when the
+            # SSH tunnel can't be brought up — the bastion host is unreachable, the host/port is
+            # wrong, the SSH key/credentials are rejected, or a firewall blocks PostHog's IPs. It's
+            # in `Any_Source_Errors`, but the import activity's `_handle_import_error` only consults
+            # this per-source dict, so without the entry a down tunnel retries to the maximum and
+            # reports the customer's gateway misconfig as error-tracking noise. Postgres, MySQL, and
+            # MSSQL already treat this identical error as non-retryable.
+            "Could not establish session to SSH gateway": "Could not connect to your SSH tunnel. Check that the SSH host, port, and credentials are correct, the bastion host is running and reachable, and that PostHog's IP addresses are allowed through its firewall.",
             "Could not resolve the ClickHouse host": None,
             "nodename nor servname provided": None,
             "Name or service not known": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -646,6 +646,9 @@ class TestClickHouseSourceNonRetryableErrors:
             "HTTPDriver for https://host:8443 received ClickHouse error code 50\n Code: 50. "
             "DB::Exception: The type 'AggregateFunction(uniq, String)' of a column 'profile_id' "
             "is not supported for conversion into Arrow data format: While executing Arrow. (UNKNOWN_TYPE)",
+            # SSH tunnel to the customer's bastion couldn't be brought up — the import path only
+            # checks this per-source dict, so the entry must be here to stop it retrying forever.
+            "Could not establish session to SSH gateway",
         ],
     )
     def test_permanent_errors_are_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

Error tracking flagged a ClickHouse data-warehouse import failing repeatedly with `BaseSSHTunnelForwarderError: Could not establish session to SSH gateway`, raised by the `sshtunnel` library when the customer's SSH bastion can't be brought up (unreachable host, wrong host/port, rejected credentials, or a firewall blocking PostHog's IPs). Issue: https://us.posthog.com/project/2/error_tracking/019f6f8a-9804-7d81-bb87-83338e15fd7e

The stack originates in this source's code — `import_data_activity_sync` → `clickhouse/source.py` → `clickhouse/clickhouse.py` → `common/mixins.py` → `sshtunnel`.

This is a user/upstream configuration problem, not something we can recover from by retrying. But the import kept retrying to its maximum, each attempt re-reporting the same error as noise.

## Changes

The import activity's `_handle_import_error` classifies retryability using **only** the source's `get_non_retryable_errors()` dict, not the shared `Any_Source_Errors` list (which does contain this message). ClickHouse's per-source dict omitted the SSH tunnel error, so it never got classified as non-retryable on the import path.

Postgres, MySQL, and MSSQL already carry this exact entry in their per-source dicts for the same reason. This mirrors that: add `"Could not establish session to SSH gateway"` to ClickHouse's `get_non_retryable_errors()` with actionable, user-facing guidance.

I matched on the stable library message, not any volatile host/port/credential values.

## How did you test this code?

Extended the existing parameterized `test_permanent_errors_are_non_retryable` in `test_clickhouse.py` with a case for this message — it guards against the entry being dropped, which would send SSH-gateway failures back to retrying forever. No existing case covered the SSH tunnel error class.

Ran locally (agent-run): `pytest ...::TestClickHouseSourceNonRetryableErrors` — 20 passed. `ruff check` and `ruff format --check` clean on both files. I did not perform manual end-to-end testing against a live ClickHouse SSH tunnel.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the issue and its stack via the PostHog MCP tools, then traced the retry-classification wiring: `_handle_import_error` consults only the per-source dict while `Any_Source_Errors` (which has this message) is merged in elsewhere, so the fix belongs in ClickHouse's own dict to match Postgres/MySQL/MSSQL. Invoked `/writing-tests` before extending the parameterized test. Considered also adding the `_SSH_HANDSHAKE_EOF_ERROR` case the sibling sources carry, but ClickHouse doesn't re-raise the bare paramiko `EOFError`, so that entry would be dead — kept the change scoped to the observed error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
