### PR TITLE
refactor(data-warehouse): migrate guardian, guru, height, heroku to rest_source (batch 21)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/guardian.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/guardian.py
@@ -1,16 +1,20 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urlsplit, urlunsplit
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.guardian.settings import (
     GUARDIAN_ENDPOINTS,
     GuardianEndpointConfig,
@@ -21,22 +25,12 @@ GUARDIAN_BASE_URL = "https://content.guardianapis.com"
 # The free developer tier caps page-size at 200; larger values are rejected.
 PAGE_SIZE = 200
 
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class GuardianRetryableError(Exception):
-    pass
-
 
 @dataclasses.dataclass
 class GuardianResumeConfig:
     # The next page number to fetch. The API is 1-indexed. With `order-by=oldest` the result set is
     # ordered ascending and stable within a run, so a page number is a safe resume cursor.
     page: int = 1
-
-
-def _headers() -> dict[str, str]:
-    return {"Accept": "application/json"}
 
 
 def _format_from_date(value: Any) -> str | None:
@@ -55,143 +49,81 @@ def _format_from_date(value: Any) -> str | None:
     return None
 
 
-def _build_base_params(
-    config: GuardianEndpointConfig,
-    api_key: str,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, str]:
-    params: dict[str, str] = {
-        "api-key": api_key,
-        "page-size": str(PAGE_SIZE),
-        "format": "json",
-        **config.extra_params,
-    }
-
-    if config.supports_incremental and should_use_incremental_field:
-        from_date = _format_from_date(db_incremental_field_last_value)
-        if from_date:
-            params["from-date"] = from_date
-
-    return params
-
-
-def _build_url(path: str, params: dict[str, str]) -> str:
-    return f"{GUARDIAN_BASE_URL}{path}?{urlencode(params)}"
-
-
-def _scrub_url(url: str | None) -> str:
-    # The api-key rides in the query string, so strip the query before the URL reaches any error
-    # message or log line — otherwise a non-2xx response would leak the credential into job errors.
-    if not url:
-        return GUARDIAN_BASE_URL
-    parts = urlsplit(url)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            GuardianRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> dict[str, Any]:
-    response = session.get(url, headers=_headers(), timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # 429 (rate limit — the free tier caps ~12 req/s and a daily quota) and 5xx are transient.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise GuardianRetryableError(f"Guardian API error (retryable): status={response.status_code}")
-
-    if not response.ok:
-        logger.error(f"Guardian API error: status={response.status_code}, body={response.text}, url={_scrub_url(url)}")
-        # Raise with the api-key scrubbed from the URL rather than calling raise_for_status(), whose
-        # message embeds the full credential-bearing URL. The base host stays intact so
-        # `get_non_retryable_errors()` can still match on it.
-        raise requests.HTTPError(
-            f"{response.status_code} Client Error: {response.reason} for url: {_scrub_url(response.url)}",
-            response=response,
-        )
-
-    return response.json()
-
-
-def validate_credentials(api_key: str) -> bool:
-    # /sections is a cheap, single-response endpoint — a genuine key returns 200, a bad one 401.
-    url = _build_url("/sections", {"api-key": api_key, "page-size": "1"})
-    try:
-        # The api-key rides in the query string, so redact it from logged URLs and captured samples.
-        response = make_tracked_session(redact_values=(api_key,)).get(url, headers=_headers(), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GuardianResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = GUARDIAN_ENDPOINTS[endpoint]
-    # One session reused across pages so urllib3 keeps the connection alive. The api-key lives in the
-    # query string, so redact it from logged URLs and captured samples.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    base_params = _build_base_params(config, api_key, should_use_incremental_field, db_incremental_field_last_value)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume else 1
-
-    while True:
-        url = _build_url(config.path, {**base_params, "page": str(page)})
-        response = _fetch_page(session, url, logger)["response"]
-
-        results = response.get("results", [])
-        if results:
-            yield results
-
-        # `sections` / `editions` return every row in one response with no pagination metadata,
-        # so default to a single page. `search` / `tags` report `pages` and `currentPage`.
-        total_pages = response.get("pages", 1)
-        current_page = response.get("currentPage", page)
-        if current_page >= total_pages:
-            break
-
-        page = current_page + 1
-        # Save AFTER yielding so a crash re-fetches (and merge-dedupes) the last page rather than
-        # skipping it. We persist the next page to fetch.
-        resumable_source_manager.save_state(GuardianResumeConfig(page=page))
+def _build_paginator(config: GuardianEndpointConfig) -> BasePaginator:
+    if config.paginated:
+        # `search` / `tags` report `pages` (total number of pages) and paginate 1-indexed; stop
+        # after the last page rather than paying one extra empty-page request.
+        return PageNumberPaginator(base_page=1, page_param="page", total_path="response.pages")
+    # `sections` / `editions` return everything in one response with no pagination metadata.
+    return SinglePagePaginator()
 
 
 def guardian_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GuardianResumeConfig],
-    should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = GUARDIAN_ENDPOINTS[endpoint]
 
+    # The api-key rides in the query string via framework auth, so its value is scrubbed from every
+    # raised error message (and logged URL) automatically — no hand-rolled URL redaction needed.
+    params: dict[str, Any] = {"page-size": PAGE_SIZE, "format": "json", **config.extra_params}
+
+    endpoint_config: dict[str, Any] = {
+        "path": config.path,
+        "params": params,
+        "data_selector": "response.results",
+        # A 200 body without the `response` envelope means the shape changed — fail loud instead of
+        # silently syncing 0 rows. A present-but-empty `results` list is still a valid 0-row page.
+        "data_selector_required": True,
+        "paginator": _build_paginator(config),
+    }
+    if config.supports_incremental:
+        # Only /search honors a server-side forward cursor: `from-date` (day granular). `order-by=oldest`
+        # + `order-date=published` (set via extra_params) keeps the watermark advancing.
+        endpoint_config["incremental"] = {"start_param": "from-date", "convert": _format_from_date}
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GUARDIAN_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "api-key", "location": "query"},
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": endpoint_config,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # (and merge-dedupes) the last page rather than skipping it. We persist the next page to fetch.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(GuardianResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -202,4 +134,16 @@ def guardian_source(
         # matching the watermark direction. The full-refresh reference endpoints have no `order-by`, so
         # their row order is unspecified — leave `sort_mode` unset rather than claim ascending.
         sort_mode="asc" if config.supports_incremental else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    # /sections is a cheap, single-response endpoint — a genuine key returns 200, a bad one 401/403.
+    # The api-key rides in the query string, so redact it from logged URLs and captured samples.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{GUARDIAN_BASE_URL}/sections?api-key={api_key}&page-size=1",
+        headers={"Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/settings.py
@@ -18,6 +18,9 @@ class GuardianEndpointConfig:
     extra_params: dict[str, str] = field(default_factory=dict)
     # Only the /search endpoint honors from-date/order-by=oldest as a server-side forward cursor.
     supports_incremental: bool = False
+    # `search` / `tags` report `pages`/`currentPage` and paginate; `sections` / `editions` return
+    # every row in one response with no pagination metadata, so they're a single page.
+    paginated: bool = False
 
 
 # The Guardian Open Platform Content API (https://open-platform.theguardian.com/documentation/).
@@ -29,6 +32,7 @@ GUARDIAN_ENDPOINTS: dict[str, GuardianEndpointConfig] = {
         path="/search",
         partition_key="webPublicationDate",
         supports_incremental=True,
+        paginated=True,
         # `show-fields=all` / `show-tags=all` pull the article body, byline, wordcount, associated
         # tags etc. that the API omits by default. `order-by=oldest` + `order-date=published` yields
         # ascending `webPublicationDate` order so the incremental watermark advances correctly.
@@ -52,6 +56,7 @@ GUARDIAN_ENDPOINTS: dict[str, GuardianEndpointConfig] = {
         name="tags",
         path="/tags",
         incremental_fields=[],
+        paginated=True,
     ),
     "sections": GuardianEndpointConfig(
         name="sections",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GuardianSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.guardian.guardian import (
     GuardianResumeConfig,
@@ -28,7 +31,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.guardian.g
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.guardian.settings import (
     ENDPOINTS,
-    GUARDIAN_ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -94,21 +96,7 @@ You can request a free developer key from the [Guardian Open Platform](https://o
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = GUARDIAN_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=endpoint_config.supports_incremental,
-                supports_append=endpoint_config.supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: GuardianSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -130,9 +118,9 @@ You can request a free developer key from the [Guardian Open Platform](https://o
         return guardian_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/tests/test_guardian.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/tests/test_guardian.py
@@ -1,41 +1,98 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
+from requests import HTTPError, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.guardian import guardian
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.guardian.guardian import (
     GuardianResumeConfig,
-    _build_base_params,
     _format_from_date,
-    _scrub_url,
-    get_rows,
     guardian_source,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.guardian.settings import GUARDIAN_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the guardian module.
+GUARDIAN_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.guardian.guardian.make_tracked_session"
+)
+
+DEFAULT_URL = "https://content.guardianapis.com/search?api-key=k&page=1"
 
 
-class _FakeResumableManager:
-    def __init__(self, state: GuardianResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[GuardianResumeConfig] = []
+def _resp(
+    results: list[dict[str, Any]] | None,
+    *,
+    pages: int | None = 1,
+    current_page: int = 1,
+    status: int = 200,
+    reason: str = "",
+    url: str = DEFAULT_URL,
+    with_envelope: bool = True,
+) -> Response:
+    if with_envelope:
+        inner: dict[str, Any] = {"status": "ok", "results": results or []}
+        # sections/editions omit pagination metadata; content/tags report `pages`/`currentPage`.
+        if pages is not None:
+            inner["pages"] = pages
+            inner["currentPage"] = current_page
+        body: dict[str, Any] = {"response": inner}
+    else:
+        body = {}
+    resp = Response()
+    resp.status_code = status
+    resp.reason = reason
+    resp.url = url
+    resp._content = json.dumps(body).encode()
+    return resp
 
-    def can_resume(self) -> bool:
-        return self._state is not None
 
-    def load_state(self) -> GuardianResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: GuardianResumeConfig) -> None:
-        self.saved.append(data)
+def _make_manager(resume_state: GuardianResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
-def _page(results: list[dict[str, Any]], *, pages: int = 1, current_page: int = 1) -> dict[str, Any]:
-    return {"response": {"status": "ok", "results": results, "pages": pages, "currentPage": current_page}}
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return guardian_source(
+        api_key=kwargs.pop("api_key", "k"),
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
 
 
 class TestFormatFromDate:
@@ -53,183 +110,169 @@ class TestFormatFromDate:
         assert _format_from_date(value) == expected
 
 
-class TestBuildBaseParams:
-    def test_content_incremental_sets_from_date_and_oldest_order(self) -> None:
-        params = _build_base_params(
-            GUARDIAN_ENDPOINTS["content"],
-            api_key="k",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
-        )
-        assert params["from-date"] == "2026-03-04"
+class TestRequestParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_content_incremental_sets_from_date_and_oldest_order(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_resp([{"id": "a"}], pages=1)])
+
+        _rows(_source("content", _make_manager(), db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC)))
+
+        assert params[0]["from-date"] == "2026-03-04"
         # Ascending order is what keeps the incremental watermark advancing correctly.
-        assert params["order-by"] == "oldest"
-        assert params["order-date"] == "published"
-        assert params["show-fields"] == "all"
+        assert params[0]["order-by"] == "oldest"
+        assert params[0]["order-date"] == "published"
+        assert params[0]["show-fields"] == "all"
+        assert params[0]["page-size"] == 200
+        assert params[0]["page"] == 1
 
-    def test_content_full_refresh_has_no_from_date(self) -> None:
-        params = _build_base_params(
-            GUARDIAN_ENDPOINTS["content"],
-            api_key="k",
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=None,
-        )
-        assert "from-date" not in params
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_content_full_refresh_has_no_from_date(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_resp([{"id": "a"}], pages=1)])
 
-    def test_non_incremental_endpoint_never_sets_from_date(self) -> None:
+        _rows(_source("content", _make_manager(), db_incremental_field_last_value=None))
+        assert "from-date" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_incremental_endpoint_never_sets_from_date(self, MockSession) -> None:
         # tags advertises no incremental field, so even an accidental cursor value is ignored.
-        params = _build_base_params(
-            GUARDIAN_ENDPOINTS["tags"],
-            api_key="k",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+        session = MockSession.return_value
+        params = _wire(session, [_resp([{"id": "a"}], pages=1)])
+
+        _rows(_source("tags", _make_manager(), db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC)))
+        assert "from-date" not in params[0]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_last_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _resp([{"id": "a"}, {"id": "b"}], pages=2, current_page=1),
+                _resp([{"id": "c"}], pages=2, current_page=2),
+            ],
         )
-        assert "from-date" not in params
 
-
-class TestScrubUrl:
-    @pytest.mark.parametrize(
-        "url,expected",
-        [
-            (
-                "https://content.guardianapis.com/search?api-key=secret&page=1",
-                "https://content.guardianapis.com/search",
-            ),
-            ("https://content.guardianapis.com/tags", "https://content.guardianapis.com/tags"),
-            (None, "https://content.guardianapis.com"),
-        ],
-    )
-    def test_scrub_url_strips_query(self, url: str | None, expected: str) -> None:
-        assert _scrub_url(url) == expected
-
-
-class TestValidateCredentials:
-    @pytest.mark.parametrize("status_code,expected", [(200, True), (401, False), (403, False)])
-    def test_status_maps_to_bool(self, status_code: int, expected: bool) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(guardian, "make_tracked_session", return_value=session):
-            assert validate_credentials("some-key") is expected
-
-    def test_network_error_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(guardian, "make_tracked_session", return_value=session):
-            assert validate_credentials("some-key") is False
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(manager: _FakeResumableManager, pages: dict[str, dict[str, Any]], **kwargs: Any) -> list[dict]:
-        def fake_fetch(session: Any, url: str, logger: Any) -> dict[str, Any]:
-            # Match by page number embedded in the URL so param ordering doesn't matter.
-            for marker, payload in pages.items():
-                if f"page={marker}" in url:
-                    return payload
-            raise AssertionError(f"unexpected url: {url}")
-
-        with patch.object(guardian, "make_tracked_session", return_value=MagicMock()):
-            with patch.object(guardian, "_fetch_page", side_effect=fake_fetch):
-                rows: list[dict] = []
-                for batch in get_rows(
-                    api_key="k",
-                    endpoint="content",
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,  # type: ignore[arg-type]
-                    **kwargs,
-                ):
-                    rows.extend(batch)
-                return rows
-
-    def test_paginates_until_last_page(self) -> None:
-        pages = {
-            "1": _page([{"id": "a"}, {"id": "b"}], pages=2, current_page=1),
-            "2": _page([{"id": "c"}], pages=2, current_page=2),
-        }
-        rows = self._collect(_FakeResumableManager(), pages)
+        rows = _rows(_source("content", _make_manager()))
         assert [r["id"] for r in rows] == ["a", "b", "c"]
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
 
-    def test_saves_next_page_after_yield(self) -> None:
-        pages = {
-            "1": _page([{"id": "a"}], pages=2, current_page=1),
-            "2": _page([{"id": "b"}], pages=2, current_page=2),
-        }
-        manager = _FakeResumableManager()
-        self._collect(manager, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_page_after_yield(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _resp([{"id": "a"}], pages=2, current_page=1),
+                _resp([{"id": "b"}], pages=2, current_page=2),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("content", manager))
         # State is saved once (after page 1 yields), pointing at page 2. The final page saves nothing.
-        assert manager.saved == [GuardianResumeConfig(page=2)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == GuardianResumeConfig(page=2)
 
-    def test_resumes_from_saved_page(self) -> None:
-        pages = {
-            "1": _page([{"id": "a"}], pages=3, current_page=1),
-            "2": _page([{"id": "b"}], pages=3, current_page=2),
-            "3": _page([{"id": "c"}], pages=3, current_page=3),
-        }
-        manager = _FakeResumableManager(GuardianResumeConfig(page=3))
-        rows = self._collect(manager, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_resp([{"id": "c"}], pages=3, current_page=3)])
+
+        manager = _make_manager(GuardianResumeConfig(page=3))
+        rows = _rows(_source("content", manager))
         # Resuming at page 3 skips the already-synced earlier pages.
         assert [r["id"] for r in rows] == ["c"]
+        assert params[0]["page"] == 3
 
-    def test_single_page_response_without_pagination_metadata(self) -> None:
-        # /sections and /editions omit `pages`/`currentPage`; default to a single page.
-        def fake_fetch(session: Any, url: str, logger: Any) -> dict[str, Any]:
-            return {"response": {"status": "ok", "results": [{"id": "uk"}, {"id": "us"}]}}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_reference_endpoint_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        # /sections and /editions omit `pages`/`currentPage`; a single page ends the sync.
+        session = MockSession.return_value
+        _wire(session, [_resp([{"id": "uk"}, {"id": "us"}], pages=None)])
 
-        manager = _FakeResumableManager()
-        with patch.object(guardian, "make_tracked_session", return_value=MagicMock()):
-            with patch.object(guardian, "_fetch_page", side_effect=fake_fetch):
-                rows = [r for batch in get_rows("k", "editions", MagicMock(), manager) for r in batch]  # type: ignore[arg-type]
+        manager = _make_manager()
+        rows = _rows(_source("editions", manager))
         assert [r["id"] for r in rows] == ["uk", "us"]
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_response_envelope_raises_loudly(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_resp(None, with_envelope=False)])
+
+        # A 200 body without the `response` envelope means the shape changed — fail loud, not 0 rows.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source("content", _make_manager()))
 
 
-class TestFetchPageRetries:
+class TestRetries:
     @pytest.mark.parametrize("status_code", [429, 500, 503])
-    def test_retryable_status_raises_retryable_error(self, status_code: int) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(guardian._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(guardian.GuardianRetryableError):
-                guardian._fetch_page(session, "https://content.guardianapis.com/search?page=1", MagicMock())
-        assert session.get.call_count == 5
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_reraised(self, MockSession, status_code: int) -> None:
+        session = MockSession.return_value
+        _wire(session, [_resp([], status=status_code) for _ in range(5)])
 
-    def test_transient_network_error_is_retried_then_succeeds(self) -> None:
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = _page([{"id": "a"}])
-        session = MagicMock()
-        session.get.side_effect = [requests.ReadTimeout("timed out"), good]
-        with patch.object(guardian._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = guardian._fetch_page(session, "https://content.guardianapis.com/search?page=1", MagicMock())
-        assert result == _page([{"id": "a"}])
-        assert session.get.call_count == 2
+        with mock.patch.object(RESTClient._send_request.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
+            with pytest.raises(RESTClientRetryableError):
+                _rows(_source("content", _make_manager()))
+        assert session.send.call_count == 5
 
-    def test_auth_failure_raises_without_leaking_api_key(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_transient_error_is_retried_then_succeeds(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_resp([], status=500), _resp([{"id": "a"}], pages=1)])
+
+        with mock.patch.object(RESTClient._send_request.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
+            rows = _rows(_source("content", _make_manager()))
+        assert [r["id"] for r in rows] == ["a"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_failure_raises_without_leaking_api_key(self, MockSession) -> None:
         # The api-key rides in the query string; a non-2xx must not surface it in the exception, but
         # the base host must survive so get_non_retryable_errors() can still match.
-        response = MagicMock()
-        response.status_code = 401
-        response.ok = False
-        response.reason = "Unauthorized"
-        response.text = "Unauthorized"
-        response.url = "https://content.guardianapis.com/search?api-key=super-secret&page=1"
-        session = MagicMock()
-        session.get.return_value = response
-        with pytest.raises(requests.HTTPError) as exc_info:
-            guardian._fetch_page(session, response.url, MagicMock())
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _resp(
+                    [],
+                    status=401,
+                    reason="Unauthorized",
+                    url="https://content.guardianapis.com/search?api-key=super-secret&page=1",
+                )
+            ],
+        )
+
+        with pytest.raises(HTTPError) as exc_info:
+            _rows(_source("content", _make_manager(), api_key="super-secret"))
         message = str(exc_info.value)
         assert "super-secret" not in message
         assert "401 Client Error: Unauthorized for url: https://content.guardianapis.com/search" in message
 
 
+class TestValidateCredentials:
+    @pytest.mark.parametrize("status_code,expected", [(200, True), (401, False), (403, False)])
+    @mock.patch(GUARDIAN_SESSION_PATCH)
+    def test_status_maps_to_bool(self, mock_session, status_code: int, expected: bool) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("some-key") is expected
+
+    @mock.patch(GUARDIAN_SESSION_PATCH)
+    def test_network_error_is_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("some-key") is False
+
+
 class TestGuardianSourceResponse:
     def test_content_partitions_on_stable_publication_date(self) -> None:
-        response = guardian_source("k", "content", MagicMock(), MagicMock())
+        response = _source("content", _make_manager())
         assert response.primary_keys == ["id"]
         assert response.partition_keys == ["webPublicationDate"]
         assert response.partition_mode == "datetime"
@@ -237,7 +280,7 @@ class TestGuardianSourceResponse:
 
     @pytest.mark.parametrize("endpoint", ["tags", "sections", "editions"])
     def test_reference_endpoints_are_unpartitioned(self, endpoint: str) -> None:
-        response = guardian_source("k", endpoint, MagicMock(), MagicMock())
+        response = _source(endpoint, _make_manager())
         assert response.primary_keys == ["id"]
         assert response.partition_keys is None
         assert response.partition_mode is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/tests/test_guardian_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guardian/tests/test_guardian_source.py
@@ -122,7 +122,6 @@ class TestGuardianSource:
         _, kwargs = mock_source.call_args
         assert kwargs["endpoint"] == "content"
         assert kwargs["api_key"] == "test-key"
-        assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2026-01-01T00:00:00Z"
 
     def test_source_for_pipeline_omits_incremental_value_when_disabled(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guru/guru.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guru/guru.py
@@ -1,16 +1,20 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urlparse
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests.auth import HTTPBasicAuth
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.guru.settings import (
     GURU_ENDPOINTS,
     GuruEndpointConfig,
@@ -18,30 +22,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.guru.setti
 
 GURU_BASE_URL = "https://api.getguru.com/api/v1"
 GURU_API_HOST = "api.getguru.com"
-REQUEST_TIMEOUT_SECONDS = 60
-# Guru's rate limits are not publicly documented — be conservative and honor 429s.
-MAX_RETRY_ATTEMPTS = 5
-
-
-class GuruRetryableError(Exception):
-    pass
-
-
-class GuruHostNotAllowedError(Exception):
-    pass
-
-
-def _is_same_host(url: str) -> bool:
-    """Whether ``url`` points at the canonical Guru API host.
-
-    Pagination/resume URLs are server-controlled (they arrive in the Link header), so we
-    pin them to the validated host to avoid being redirected at an arbitrary internal
-    address (SSRF) and leaking the Basic auth credentials carried on every request.
-    """
-    try:
-        return (urlparse(url).hostname or "").lower() == GURU_API_HOST
-    except Exception:
-        return False
 
 
 @dataclasses.dataclass
@@ -49,12 +29,6 @@ class GuruResumeConfig:
     # Guru pagination follows a `Link: <url>; rel="next-page"` header whose URL is
     # self-contained (opaque continuation token), so the URL is all we persist.
     next_url: str
-
-
-def _get_session(api_token: str) -> requests.Session:
-    # allow_redirects=False so a 3xx can't silently move the credentialed request off the
-    # validated host (SSRF). See _NoRedirectSession in common/http/transport.py.
-    return make_tracked_session(redact_values=(api_token,), allow_redirects=False)
 
 
 def _format_last_modified(value: Any) -> str:
@@ -97,12 +71,6 @@ def _build_params(
     return params
 
 
-def _build_url(path: str, params: dict[str, str]) -> str:
-    if not params:
-        return f"{GURU_BASE_URL}{path}"
-    return f"{GURU_BASE_URL}{path}?{urlencode(params)}"
-
-
 def _normalize_member(item: dict[str, Any]) -> dict[str, Any]:
     # Team member rows nest the identifying email under `user`; copy it to the top
     # level so it can serve as the primary key. Use direct access so a member missing
@@ -114,99 +82,20 @@ def _normalize_member(item: dict[str, Any]) -> dict[str, Any]:
 
 def validate_credentials(username: str, api_token: str) -> bool:
     """Confirm the user token is valid. /whoami is a cheap authenticated probe."""
-    try:
-        response = _get_session(api_token).get(
-            f"{GURU_BASE_URL}/whoami",
-            auth=(username, api_token),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    username: str,
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[GuruResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = GURU_ENDPOINTS[endpoint]
-    session = _get_session(api_token)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None and _is_same_host(resume_config.next_url):
-        url: str = resume_config.next_url
-        logger.debug(f"Guru: resuming {endpoint} from URL: {url}")
-    else:
-        if resume_config is not None:
-            logger.warning("Guru: ignoring resume URL whose host does not match the Guru API host")
-        url = _build_url(
-            config.path,
-            _build_params(config, should_use_incremental_field, db_incremental_field_last_value, incremental_field),
-        )
-
-    @retry(
-        retry=retry_if_exception_type((GuruRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{GURU_BASE_URL}/whoami",
+        auth=HTTPBasicAuth(username, api_token),
     )
-    def fetch_page(page_url: str) -> requests.Response:
-        response = session.get(page_url, auth=(username, api_token), timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise GuruRetryableError(f"Guru API error (retryable): status={response.status_code}, url={page_url}")
-
-        # A 3xx isn't an error status (`response.ok` is True), so reject it explicitly rather
-        # than silently parsing the redirect body as data — we never follow redirects (SSRF).
-        if response.is_redirect or response.is_permanent_redirect:
-            raise GuruHostNotAllowedError(
-                f"Guru API returned an unexpected redirect (status={response.status_code}); refusing to follow it"
-            )
-
-        if not response.ok:
-            logger.error(f"Guru API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response
-
-    while True:
-        response = fetch_page(url)
-        data = response.json()
-        items = data if isinstance(data, list) else []
-
-        if endpoint == "members":
-            items = [_normalize_member(item) for item in items]
-
-        if items:
-            yield items
-
-        next_url = response.links.get("next-page", {}).get("url")
-        if not next_url:
-            break
-
-        # The next-page URL is server-controlled; only follow it if it stays on the Guru
-        # API host so a tampered response can't aim the credentialed request elsewhere (SSRF).
-        if not _is_same_host(next_url):
-            logger.warning("Guru: stopping pagination, next URL host does not match the Guru API host")
-            break
-
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(GuruResumeConfig(next_url=next_url))
-        url = next_url
+    return ok
 
 
 def guru_source(
     username: str,
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[GuruResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -214,18 +103,62 @@ def guru_source(
 ) -> SourceResponse:
     config = GURU_ENDPOINTS[endpoint]
 
+    params = _build_params(config, should_use_incremental_field, db_incremental_field_last_value, incremental_field)
+
+    resource_config: dict[str, Any] = {
+        "name": endpoint,
+        "endpoint": {
+            "path": config.path,
+            "params": params,
+            # Guru returns a bare JSON array; a non-list 200 body means the response shape
+            # changed — fail loud instead of wrapping the stray object as a single row.
+            "data_selector_required": True,
+        },
+    }
+    if endpoint == "members":
+        resource_config["data_map"] = _normalize_member
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GURU_BASE_URL,
+            "auth": {"type": "http_basic", "username": username, "password": api_token},
+            # Guru paginates via `Link: <url>; rel="next-page"` with an opaque continuation token.
+            "paginator": HeaderLinkPaginator(links_next_key="next-page"),
+            # The next-page/resume URLs are server-controlled; pin them to the Guru API host and
+            # refuse redirects so a tampered link can't move the credentialed request off-host and
+            # leak the Basic auth credentials (SSRF). Empty list => same host as base_url only.
+            "allowed_hosts": [],
+            "allow_redirects": False,
+        },
+        "resources": [resource_config],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(GuruResumeConfig(next_url=state["next_url"]))
+
+    # Incremental filtering is server-side and already baked into `params` above, so the
+    # framework's incremental injection is unused here.
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            username=username,
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
@@ -233,4 +166,5 @@ def guru_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guru/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guru/source.py
@@ -135,7 +135,8 @@ You authenticate with your Guru account email and a user API token. A Guru admin
             username=config.username,
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/guru/tests/test_guru.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/guru/tests/test_guru.py
@@ -1,21 +1,44 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru import (
     GuruResumeConfig,
     _build_params,
-    _build_url,
     _format_last_modified,
     _normalize_member,
-    get_rows,
     guru_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.guru.settings import ENDPOINTS, GURU_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the guru module.
+GURU_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session"
+
+
+def _response(items: Any, next_link: str | None = None) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(items).encode()
+    if next_link:
+        # requests parses `response.links` from the RFC 5988 Link header.
+        resp.headers["Link"] = f'<{next_link}>; rel="next-page"'
+    return resp
+
+
+def _redirect(location: str) -> Response:
+    resp = Response()
+    resp.status_code = 302
+    resp.headers["Location"] = location
+    resp._content = b""
+    return resp
 
 
 def _make_manager(resume_state: GuruResumeConfig | None = None) -> mock.MagicMock:
@@ -25,15 +48,43 @@ def _make_manager(resume_state: GuruResumeConfig | None = None) -> mock.MagicMoc
     return manager
 
 
-def _response(items: list[dict[str, Any]], next_link: str | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = items
-    resp.status_code = 200
-    resp.ok = True
-    resp.is_redirect = False
-    resp.is_permanent_redirect = False
-    resp.links = {"next-page": {"url": next_link}} if next_link else {}
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Wire a mock session, capturing each request's params and URL AT PREPARE TIME.
+
+    ``request.params``/``request.url`` are mutated in place across pages, so snapshot copies when
+    each request is prepared. The returned prepared object carries the real URL so the client's
+    SSRF host check runs against it.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, url_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return guru_source(
+        "user@company.com",
+        "token",
+        endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatLastModified:
@@ -100,16 +151,6 @@ class TestBuildParams:
         assert params == {}
 
 
-class TestBuildUrl:
-    def test_no_params(self):
-        assert _build_url("/collections", {}) == "https://api.getguru.com/api/v1/collections"
-
-    def test_encodes_gql_query(self):
-        url = _build_url("/search/query", {"q": "lastModified >= 2024-01-01T00:00:00+00:00"})
-        parsed = urlparse(url)
-        assert parse_qs(parsed.query)["q"] == ["lastModified >= 2024-01-01T00:00:00+00:00"]
-
-
 class TestNormalizeMember:
     def test_copies_nested_user_email_to_top_level(self):
         item = {"user": {"email": "jane@company.com", "firstName": "Jane"}, "groups": []}
@@ -146,7 +187,7 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
+    @mock.patch(GURU_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
         response = mock.MagicMock()
         response.status_code = status_code
@@ -154,126 +195,123 @@ class TestValidateCredentials:
 
         assert validate_credentials("user@company.com", "token") is expected
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
+    @mock.patch(GURU_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("user@company.com", "token") is False
 
 
 class TestGetRows:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_paginates_via_link_header(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_link_header(self, MockSession):
+        session = MockSession.return_value
         next_url = "https://api.getguru.com/api/v1/collections?token=abc"
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "1"}, {"id": "2"}], next_link=next_url),
-            _response([{"id": "3"}]),
-        ]
+        _wire(session, [_response([{"id": "1"}, {"id": "2"}], next_link=next_url), _response([{"id": "3"}])])
 
         manager = _make_manager()
-        batches = list(get_rows("user@company.com", "token", "collections", mock.MagicMock(), manager))
+        rows = _rows(_source("collections", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["1", "2", "3"]
+        assert [row["id"] for row in rows] == ["1", "2", "3"]
         # State is saved only while a next page exists, after the page is yielded.
         manager.save_state.assert_called_once()
         assert manager.save_state.call_args.args[0].next_url == next_url
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_resumes_from_saved_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "9"}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession):
+        session = MockSession.return_value
+        _, urls = _wire(session, [_response([{"id": "9"}])])
 
         resume_url = "https://api.getguru.com/api/v1/collections?token=resume"
         manager = _make_manager(GuruResumeConfig(next_url=resume_url))
 
-        list(get_rows("user@company.com", "token", "collections", mock.MagicMock(), manager))
+        _rows(_source("collections", manager))
 
-        assert mock_session.return_value.get.call_args_list[0].args[0] == resume_url
+        assert urls[0] == resume_url
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_stops_pagination_when_next_url_host_differs(self, mock_session):
-        # A tampered Link header pointing off-host must not move the credentialed request.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_next_url_with_foreign_host(self, MockSession):
+        # A tampered Link header pointing off-host must not move the credentialed request; the
+        # SSRF host pin rejects it loudly rather than silently exfiltrating the Basic auth header.
+        session = MockSession.return_value
         evil_url = "http://169.254.169.254/latest/meta-data"
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": "1"}], next_link=evil_url),
-        ]
+        _wire(session, [_response([{"id": "1"}], next_link=evil_url), _response([{"id": "2"}])])
 
-        manager = _make_manager()
-        batches = list(get_rows("user@company.com", "token", "collections", mock.MagicMock(), manager))
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("collections", _make_manager()))
 
-        assert [item["id"] for batch in batches for item in batch] == ["1"]
-        # Only one request was made; the off-host next URL was neither followed nor saved.
-        assert mock_session.return_value.get.call_count == 1
-        manager.save_state.assert_not_called()
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_ignores_resume_url_with_foreign_host(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_resume_url_with_foreign_host(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "9"}])])
 
         manager = _make_manager(GuruResumeConfig(next_url="http://169.254.169.254/latest/meta-data"))
-        list(get_rows("user@company.com", "token", "collections", mock.MagicMock(), manager))
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("collections", manager))
 
-        # Falls back to the canonical built URL rather than the foreign resume URL.
-        assert mock_session.return_value.get.call_args.args[0].startswith("https://api.getguru.com/api/v1/collections")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_redirect_response(self, MockSession):
+        # Redirects are disabled so a 3xx can't silently move the credentialed request off-host.
+        session = MockSession.return_value
+        _wire(session, [_redirect("http://169.254.169.254/latest/meta-data")])
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_members_rows_are_normalized(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"user": {"email": "jane@company.com"}}])
+        with pytest.raises(ValueError, match="[Rr]edirect"):
+            _rows(_source("collections", _make_manager()))
 
-        manager = _make_manager()
-        batches = list(get_rows("user@company.com", "token", "members", mock.MagicMock(), manager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_members_rows_are_normalized(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"user": {"email": "jane@company.com"}}])])
 
-        assert batches == [[{"user": {"email": "jane@company.com"}, "email": "jane@company.com"}]]
+        rows = _rows(_source("members", _make_manager()))
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_incremental_request_includes_gql_filter(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+        assert rows == [{"user": {"email": "jane@company.com"}, "email": "jane@company.com"}]
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "user@company.com",
-                "token",
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_includes_gql_filter(self, MockSession):
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response([])])
+
+        _rows(
+            _source(
                 "cards",
-                mock.MagicMock(),
-                manager,
+                _make_manager(),
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2024, 1, 1, tzinfo=UTC),
                 incremental_field="lastModified",
             )
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        query = parse_qs(urlparse(url).query)
-        assert query["q"] == ["lastModified >= 2024-01-01T00:00:00+00:00"]
-        assert query["sortField"] == ["lastModified"]
-        assert query["sortOrder"] == ["asc"]
+        assert params[0]["q"] == "lastModified >= 2024-01-01T00:00:00+00:00"
+        assert params[0]["sortField"] == "lastModified"
+        assert params[0]["sortOrder"] == "asc"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_empty_response_stops_without_saving_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops_without_saving_state(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
         manager = _make_manager()
-        batches = list(get_rows("user@company.com", "token", "cards", mock.MagicMock(), manager))
+        rows = _rows(_source("cards", manager))
 
-        assert batches == []
+        assert rows == []
         manager.save_state.assert_not_called()
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.guru.guru.make_tracked_session")
-    def test_non_list_response_yields_nothing(self, mock_session):
-        resp = _response([])
-        resp.json.return_value = {"error": "unexpected"}
-        mock_session.return_value.get.return_value = resp
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_response_fails_loud(self, MockSession):
+        # A 200 body that isn't a bare array means the response shape changed — fail loud rather
+        # than wrapping the stray object as a single row.
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unexpected"})])
 
-        manager = _make_manager()
-        batches = list(get_rows("user@company.com", "token", "cards", mock.MagicMock(), manager))
-
-        assert batches == []
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source("cards", _make_manager()))
 
 
 class TestGuruSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = GURU_ENDPOINTS[endpoint]
-        response = guru_source("user@company.com", "token", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/height/height.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/height/height.py
@@ -1,115 +1,90 @@
-from collections.abc import Iterator
-from typing import Any, Optional
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.height.settings import HEIGHT_ENDPOINTS
 
 HEIGHT_BASE_URL = "https://api.height.app"
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm an API key is genuine. The key is workspace-wide, so one probe
 # validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/users"
 
 
-class HeightRetryableError(Exception):
-    pass
+class HeightAPIKeyAuth(APIKeyAuth):
+    """Height's Authorization scheme is the literal word ``api-key`` followed by the secret, not a
+    Bearer token. Passing the composite value through the framework auth keeps the credential out of
+    logged errors; the raw key is redacted too so it never leaks on its own."""
 
+    def __init__(self, api_key: str) -> None:
+        super().__init__(api_key=f"api-key {api_key}", name="Authorization", location="header")
+        self._raw_api_key = api_key
 
-def _headers(api_key: str) -> dict[str, str]:
-    # Height's scheme is the literal word `api-key` followed by the secret, not a Bearer token.
-    return {"Authorization": f"api-key {api_key}", "Accept": "application/json"}
-
-
-@retry(
-    retry=retry_if_exception_type((HeightRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_list(
-    session: requests.Session,
-    path: str,
-    logger: FilteringBoundLogger,
-) -> list[dict[str, Any]]:
-    response = session.get(
-        f"{HEIGHT_BASE_URL}{path}",
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise HeightRetryableError(f"Height API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        logger.error(f"Height API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
-
-    data = response.json()
-    # Height list endpoints wrap records in a top-level `list` key.
-    if not isinstance(data, dict) or not isinstance(data.get("list"), list):
-        raise HeightRetryableError(f"Height returned an unexpected payload for {path}: {type(data).__name__}")
-    return data["list"]
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = HEIGHT_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-
-    # These endpoints are unpaginated single-shot lists, so one request returns the full collection.
-    rows = _fetch_list(session, config.path, logger)
-    if rows:
-        yield rows
+    def secret_values(self) -> tuple[str, ...]:
+        # Redact both the composite header value and the raw key on its own.
+        return tuple(value for value in (self.api_key, self._raw_api_key) if value)
 
 
 def height_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     config = HEIGHT_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": HEIGHT_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": HeightAPIKeyAuth(api_key),
+            # Height list endpoints are unpaginated single-shot lists, so one request returns the
+            # full collection.
+            "paginator": SinglePagePaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # Height list endpoints wrap records in a top-level `list` key; require it so a
+                    # 200 with an unexpected shape (bare array / missing key) fails loud instead of
+                    # silently syncing 0 rows.
+                    "data_selector": "list",
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_key=api_key, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the API key.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-    try:
-        response = session.get(f"{HEIGHT_BASE_URL}{path}", timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Height: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Height returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_key)
-    if status == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{HEIGHT_BASE_URL}{DEFAULT_PROBE_PATH}",
+        auth=HeightAPIKeyAuth(api_key),
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid Height API key"
-    return False, message or "Could not validate Height API key"
+    if status is None:
+        return False, "Could not validate Height API key"
+    return False, f"Height returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/height/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/height/source.py
@@ -116,5 +116,6 @@ You can create an API key on the **Settings → API** page in [Height](https://h
         return height_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/height/tests/test_height.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/height/tests/test_height.py
@@ -1,164 +1,116 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
-from unittest.mock import MagicMock
 
-import requests
 from parameterized import parameterized
+from requests import PreparedRequest, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.height import height
 from products.warehouse_sources.backend.temporal.data_imports.sources.height.height import (
-    HeightRetryableError,
-    check_access,
-    get_rows,
+    HeightAPIKeyAuth,
     height_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.height.settings import ENDPOINTS, HEIGHT_ENDPOINTS
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_list_unwrapped = height._fetch_list.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the height module.
+HEIGHT_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.height.height.make_tracked_session"
+)
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(monkeypatch: Any, rows: list[dict], endpoint: str = "users") -> list[dict]:
-        def fake_fetch(session: Any, path: str, logger: Any) -> list[dict]:
-            return rows
+def _response(body: Any) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
-        monkeypatch.setattr(height, "_fetch_list", fake_fetch)
-        monkeypatch.setattr(height, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        collected: list[dict] = []
-        for batch in get_rows(api_key="secret_key", endpoint=endpoint, logger=MagicMock()):
-            collected.extend(batch)
-        return collected
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[str]:
+    """Wire a mock session; capture each request's URL AT SEND TIME.
 
-    def test_yields_single_batch(self, monkeypatch: Any) -> None:
-        rows = self._collect(monkeypatch, [{"id": "a"}, {"id": "b"}])
+    The request object is mutated in place, so snapshot the URL when each request is prepared.
+    """
+    session.headers = {}
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return url_snapshots
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestHeightAuth:
+    def test_authorization_header_uses_api_key_scheme(self) -> None:
+        auth = HeightAPIKeyAuth("secret_abc")
+        request = PreparedRequest()
+        request.prepare(method="GET", url="https://api.height.app/users")
+        auth(request)
+        # Height's scheme is the literal word `api-key` followed by the secret, not a Bearer token.
+        assert request.headers["Authorization"] == "api-key secret_abc"
+
+    def test_redacts_both_composite_and_raw_key(self) -> None:
+        # Both the header value and the raw key on its own are scrubbed from logged errors.
+        auth = HeightAPIKeyAuth("secret_abc")
+        assert set(auth.secret_values()) == {"api-key secret_abc", "secret_abc"}
+
+
+class TestHeightSourceRows:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_yields_rows_from_list_key(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"list": [{"id": "a"}, {"id": "b"}]})])
+
+        rows = _rows(height_source(api_key="secret_key", endpoint="users", team_id=1, job_id="j"))
         assert rows == [{"id": "a"}, {"id": "b"}]
+        # Height list endpoints are single-shot; exactly one request pulls the whole collection.
+        assert session.send.call_count == 1
 
-    def test_empty_list_yields_nothing(self, monkeypatch: Any) -> None:
-        assert self._collect(monkeypatch, []) == []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_list_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"list": []})])
+
+        rows = _rows(height_source(api_key="secret_key", endpoint="users", team_id=1, job_id="j"))
+        assert rows == []
 
     @parameterized.expand([(e,) for e in ENDPOINTS])
-    def test_every_endpoint_fetches_its_path(self, endpoint: str) -> None:
-        captured: dict[str, str] = {}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_every_endpoint_targets_its_path(self, endpoint: str, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        urls = _wire(session, [_response({"list": []})])
 
-        def fake_fetch(session: Any, path: str, logger: Any) -> list[dict]:
-            captured["path"] = path
-            return []
-
-        # Patch on the module so get_rows uses the fake, bypassing the network.
-        with mock.patch.object(height, "_fetch_list", fake_fetch):
-            list(get_rows(api_key="secret_key", endpoint=endpoint, logger=MagicMock()))
-
-        assert captured["path"] == HEIGHT_ENDPOINTS[endpoint].path
-
-
-class TestFetchList:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else {"list": []}
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
-        )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(HeightRetryableError):
-            _fetch_list_unwrapped(session, "/users", MagicMock())
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_list_unwrapped(session, "/users", MagicMock())
-
-    def test_success_returns_list_key(self) -> None:
-        session = self._session_returning(200, {"list": [{"id": "x"}]})
-        result = _fetch_list_unwrapped(session, "/users", MagicMock())
-        assert result == [{"id": "x"}]
-
-    @parameterized.expand([("bare_array", [{"id": 1}]), ("missing_list_key", {"data": []}), ("null_body", None)])
-    def test_unexpected_payload_is_retryable(self, _name: str, body: Any) -> None:
-        # `None` maps to a body without a `list` key via the fixture default.
-        session = self._session_returning(200, body if body is not None else {"data": []})
-        with pytest.raises(HeightRetryableError):
-            _fetch_list_unwrapped(session, "/users", MagicMock())
-
-    def test_request_targets_base_url_and_path(self) -> None:
-        session = self._session_returning(200, {"list": []})
-        _fetch_list_unwrapped(session, "/lists", MagicMock())
-        args, _ = session.get.call_args
-        assert args[0] == "https://api.height.app/lists"
-
-
-class TestCheckAccess:
-    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        monkeypatch.setattr(height, "make_tracked_session", lambda **kwargs: session)
-        return session
+        _rows(height_source(api_key="secret_key", endpoint=endpoint, team_id=1, job_id="j"))
+        assert urls[0] == f"https://api.height.app{HEIGHT_ENDPOINTS[endpoint].path}"
 
     @parameterized.expand(
         [
-            (200, True, 200, None),
-            (401, False, 401, None),
-            (403, False, 403, None),
-            (500, False, 500, "Height returned HTTP 500"),
+            ("bare_array", [{"id": 1}]),
+            ("missing_list_key", {"data": []}),
+            ("null_body", None),
         ]
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.height.height.make_tracked_session")
-    def test_status_mapping(
-        self,
-        status: int,
-        ok: bool,
-        expected_status: int,
-        expected_message: str | None,
-        mock_make_session: mock.MagicMock,
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        session = MagicMock()
-        session.get.return_value = response
-        mock_make_session.return_value = session
-        assert check_access("secret_key") == (expected_status, expected_message)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unexpected_payload_fails_loud(self, _name: str, body: Any, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
 
-    def test_authorization_header_uses_api_key_scheme(self, monkeypatch: Any) -> None:
-        captured: dict[str, Any] = {}
+        # A 200 body without a `list` key means the response shape changed — fail loud, not 0 rows.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(height_source(api_key="secret_key", endpoint="users", team_id=1, job_id="j"))
 
-        def fake_make_session(headers: dict[str, str], redact_values: Any) -> MagicMock:
-            captured["headers"] = headers
-            response = MagicMock()
-            response.status_code = 200
-            response.ok = True
-            session = MagicMock()
-            session.get.return_value = response
-            return session
 
-        monkeypatch.setattr(height, "make_tracked_session", fake_make_session)
-        check_access("secret_abc")
-        assert captured["headers"]["Authorization"] == "api-key secret_abc"
-
-    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
-        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
-        status, message = check_access("secret_key")
-        assert status == 0
-        assert message is not None and "boom" in message
-
+class TestValidateCredentials:
     @parameterized.expand(
         [
             (200, True, None),
@@ -167,27 +119,28 @@ class TestCheckAccess:
             (500, False, "Height returned HTTP 500"),
         ]
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.height.height.make_tracked_session")
-    def test_validate_credentials(
+    @mock.patch(HEIGHT_SESSION_PATCH)
+    def test_status_mapping(
         self,
         status: int,
         expected_valid: bool,
         expected_message: str | None,
         mock_make_session: mock.MagicMock,
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        session = MagicMock()
-        session.get.return_value = response
-        mock_make_session.return_value = session
+        mock_make_session.return_value.get.return_value = mock.MagicMock(status_code=status)
         assert validate_credentials("secret_key") == (expected_valid, expected_message)
+
+    @mock.patch(HEIGHT_SESSION_PATCH)
+    def test_connection_error_is_not_validated(self, mock_make_session: mock.MagicMock) -> None:
+        mock_make_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("secret_key") == (False, "Could not validate Height API key")
 
 
 class TestHeightSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        response = height_source(api_key="secret_key", endpoint=endpoint, logger=MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, _MockSession: mock.MagicMock) -> None:
+        response = height_source(api_key="secret_key", endpoint=endpoint, team_id=1, job_id="j")
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         # No stable creation timestamp is guaranteed across every object, so we don't partition.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/heroku.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/heroku.py
@@ -1,14 +1,19 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.heroku.settings import (
     DEFAULT_PAGE_SIZE,
     HEROKU_BASE_URL,
@@ -17,236 +22,244 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.heroku.set
     HerokuEndpointConfig,
 )
 
-
-class HerokuRetryableError(Exception):
-    pass
+# Every Platform API request must pin version 3 via the Accept header. Non-secret, so it rides
+# in the client headers; the Bearer token goes through the framework auth config (redacted).
+HEROKU_API_ACCEPT = "application/vnd.heroku+json; version=3"
 
 
 @dataclasses.dataclass
 class HerokuResumeConfig:
-    # Verbatim `Next-Range` header value to resume pagination from. None means "start the
-    # list at its first page".
+    # Verbatim `Next-Range` header value to resume a top-level list from. None means "start at
+    # the first page".
     next_range: str | None = None
-    # For fan-out endpoints: the app currently being processed. A stable app-ID bookmark
-    # (not a positional index) so apps created/deleted between a crash and the retry can't
-    # resume us into the wrong app. None for top-level endpoints.
+    # Retained only so pre-migration saved state (which bookmarked a fan-out app here) still
+    # parses via `dataclass(**saved)`. New runs never populate it; fan-out resume now lives in
+    # `fanout_state`. Old-shape state (this set, `fanout_state` None) restarts the fan-out.
     app_id: str | None = None
+    # Framework fan-out resume snapshot ({"completed": [...], "current": ..., "child_state": ...})
+    # for the parent-app -> child-endpoint dependent resource.
+    fanout_state: dict[str, Any] | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    # Every Platform API request must pin version 3 via the Accept header.
+class RangeHeaderPaginator(BasePaginator):
+    """Heroku paginates via the `Range` request header and `Next-Range` response header.
+
+    Each request carries a `Range` header; a 206 response carries a `Next-Range` header holding
+    the opaque cursor for the following page. Its absence marks the final page. A page cap stops
+    a runaway cursor from scanning unbounded history (per list, or per app for fan-out).
+    """
+
+    def __init__(self, range_attribute: str, page_size: int, max_pages: int) -> None:
+        super().__init__()
+        self.range_attribute = range_attribute
+        self.page_size = page_size
+        self.max_pages = max_pages
+        # None until a resume cursor is seeded or the first page is walked; the initial range is
+        # derived lazily so a fresh paginator and a resumed one share one code path.
+        self._range: Optional[str] = None
+        self._pages_fetched = 0
+
+    def _initial_range(self) -> str:
+        # Explicit ascending order on a stable attribute keeps page boundaries deterministic while
+        # rows are inserted mid-sync.
+        return f"{self.range_attribute} ..; order=asc,max={self.page_size}"
+
+    def init_request(self, request: Request) -> None:
+        request.headers["Range"] = self._range or self._initial_range()
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        self._pages_fetched += 1
+        next_range = response.headers.get("Next-Range")
+        if not next_range or self._pages_fetched >= self.max_pages:
+            self._has_next_page = False
+        else:
+            self._range = next_range
+            self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        if self._range is not None:
+            request.headers["Range"] = self._range
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"next_range": self._range} if self._has_next_page and self._range is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_range = state.get("next_range")
+        if next_range is not None:
+            self._range = next_range
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"RangeHeaderPaginator(range_attribute={self.range_attribute})"
+
+
+def _make_redactor(paths: list[str]) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Null out capability URLs (dotted paths) so they never land in the warehouse.
+
+    These URLs grant access (source downloads, output streams, dyno attach) without Heroku auth,
+    so they must not reach the warehouse where any member with query access could read them.
+    """
+
+    def _redact(row: dict[str, Any]) -> dict[str, Any]:
+        for path in paths:
+            *parents, leaf = path.split(".")
+            node: Any = row
+            for key in parents:
+                node = node.get(key) if isinstance(node, dict) else None
+                if node is None:
+                    break
+            if isinstance(node, dict) and leaf in node:
+                node[leaf] = None
+        return row
+
+    return _redact
+
+
+def _client_config(api_key: str) -> dict[str, Any]:
+    # Capture is disabled because several endpoints return capability URLs carrying secrets
+    # (builds' `source_blob.url`, dynos' `attach_url`) that the name-based sample scrubbers can't
+    # recognise; `_make_redactor` only scrubs the yielded rows, not the raw captured response.
     return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/vnd.heroku+json; version=3",
+        "base_url": HEROKU_BASE_URL,
+        "headers": {"Accept": HEROKU_API_ACCEPT},
+        "auth": {"type": "bearer", "token": api_key},
+        "session": make_tracked_session(capture=False, redact_values=(api_key,)),
     }
 
 
-def _initial_range_header(config: HerokuEndpointConfig) -> str:
-    # Explicit ascending order on a stable attribute keeps page boundaries deterministic
-    # while rows are inserted mid-sync. Default page size is 200; 1000 is the hard max.
-    return f"{config.range_attribute} ..; order=asc,max={DEFAULT_PAGE_SIZE}"
+def _paginator(config: HerokuEndpointConfig) -> RangeHeaderPaginator:
+    return RangeHeaderPaginator(config.range_attribute, DEFAULT_PAGE_SIZE, MAX_PAGES_PER_LIST)
 
 
-def validate_credentials(api_key: str) -> bool:
-    url = f"{HEROKU_BASE_URL}/account"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            HerokuRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(6),
-    wait=wait_exponential_jitter(initial=2, max=60),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    range_header: str,
-    logger: FilteringBoundLogger,
-) -> tuple[list[dict[str, Any]], str | None]:
-    """Fetch one page of a Heroku list endpoint.
-
-    Heroku paginates via headers: the request carries a `Range` header, and a 206 response
-    carries a `Next-Range` header holding the opaque cursor for the following page. Returns
-    the page's rows and the `Next-Range` value (None on the final page).
-    """
-    response = session.get(url, headers={**headers, "Range": range_header}, timeout=60)
-
-    # Token bucket of 4,500 requests/hour per account refills continuously (~75/min), so
-    # backing off and retrying a 429 is enough — no Retry-After header to honor.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise HerokuRetryableError(f"Heroku API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # 404 is expected during fan-out (an app deleted mid-sync) and handled by the caller.
-        log = logger.warning if response.status_code == 404 else logger.error
-        log(f"Heroku API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    if not isinstance(data, list):
-        raise ValueError(f"Unexpected Heroku response shape (expected a list): url={url}")
-
-    return data, response.headers.get("Next-Range")
-
-
-def _redact_sensitive_fields(row: dict[str, Any], paths: list[str]) -> dict[str, Any]:
-    """Null out capability URLs (dotted paths) so they never land in the warehouse."""
-    for path in paths:
-        *parents, leaf = path.split(".")
-        node: Any = row
-        for key in parents:
-            node = node.get(key) if isinstance(node, dict) else None
-            if node is None:
-                break
-        if isinstance(node, dict) and leaf in node:
-            node[leaf] = None
-    return row
-
-
-def _iter_pages(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
+def _flat_source(
+    api_key: str,
     config: HerokuEndpointConfig,
-    logger: FilteringBoundLogger,
-    start_range: str | None = None,
-) -> Iterator[tuple[list[dict[str, Any]], str | None]]:
-    """Walk a list endpoint page by page, yielding (rows, next_range) tuples."""
-    range_header = start_range or _initial_range_header(config)
-    for _page_number in range(MAX_PAGES_PER_LIST):
-        rows, next_range = _fetch_page(session, url, headers, range_header, logger)
-        if config.sensitive_fields:
-            rows = [_redact_sensitive_fields(row, config.sensitive_fields) for row in rows]
-        yield rows, next_range
-        if not next_range:
-            return
-        range_header = next_range
-    logger.warning(
-        f"Heroku: page cap reached, list truncated. endpoint={config.name}, url={url}, max_pages={MAX_PAGES_PER_LIST}"
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[HerokuResumeConfig],
+) -> Any:
+    endpoint: dict[str, Any] = {
+        "path": config.path,
+        "paginator": _paginator(config),
+        # A non-list 200 body means the response shape changed — fail loud instead of wrapping the
+        # stray object as a single row.
+        "data_selector_required": True,
+    }
+    resource: dict[str, Any] = {"name": config.name, "endpoint": endpoint}
+    if config.sensitive_fields:
+        resource["data_map"] = _make_redactor(config.sensitive_fields)
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [resource],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_range:
+            initial_paginator_state = {"next_range": resume.next_range}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("next_range"):
+            resumable_source_manager.save_state(HerokuResumeConfig(next_range=state["next_range"]))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
     )
 
 
-def _iter_app_ids(session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger) -> Iterator[str]:
-    """Page through /apps and yield each app's id."""
-    for rows, _next_range in _iter_pages(session, f"{HEROKU_BASE_URL}/apps", headers, HEROKU_ENDPOINTS["apps"], logger):
-        for row in rows:
-            yield row["id"]
-
-
-def _get_fan_out_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[HerokuResumeConfig],
-    config: HerokuEndpointConfig,
-) -> Iterator[list[dict[str, Any]]]:
-    """Fan out over every app, yielding pages of the per-app child endpoint.
-
-    Rows already embed the parent as a nested `app` object ({id, name}), so no extra parent
-    column is injected; Heroku ids are globally unique UUIDs, so `id` stays a valid table-wide
-    primary key across apps.
-    """
-    app_ids = list(_iter_app_ids(session, headers, logger))
-
-    # Resolve the saved app-ID bookmark to the slice of apps still to process. If the
-    # bookmarked app no longer exists (deleted between attempts), start over from the first
-    # app — the full refresh just re-fetches rows it already wrote.
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    remaining = app_ids
-    resume_range: str | None = None
-    if resume is not None and resume.app_id is not None and resume.app_id in app_ids:
-        remaining = app_ids[app_ids.index(resume.app_id) :]
-        resume_range = resume.next_range
-        logger.debug(f"Heroku: resuming {config.name} from app_id={resume.app_id}")
-
-    for index, app_id in enumerate(remaining):
-        url = f"{HEROKU_BASE_URL}{config.path.format(app_id=app_id)}"
-        start_range = resume_range
-        resume_range = None  # only the resumed-into app uses the saved cursor
-
-        try:
-            for rows, next_range in _iter_pages(session, url, headers, config, logger, start_range=start_range):
-                if rows:
-                    yield rows
-                    # Save AFTER yielding (and only when more pages remain) so a crash
-                    # re-yields the last page rather than skipping it.
-                    if next_range:
-                        resumable_source_manager.save_state(HerokuResumeConfig(next_range=next_range, app_id=app_id))
-        except requests.HTTPError as exc:
-            # An app deleted between enumeration and this fetch 404s. Skip it rather than
-            # failing the whole sync — the data is genuinely gone. Anything else re-raises.
-            if exc.response is not None and exc.response.status_code == 404:
-                logger.warning(f"Heroku: app {app_id} not found while fetching {config.name}, skipping")
-            else:
-                raise
-
-        # Advance the bookmark to the next app so a crash between apps resumes correctly.
-        if index + 1 < len(remaining):
-            resumable_source_manager.save_state(HerokuResumeConfig(next_range=None, app_id=remaining[index + 1]))
-
-
-def get_rows(
+def _fanout_source(
     api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
+    config: HerokuEndpointConfig,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[HerokuResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = HEROKU_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every page (and, for fan-out, every app) so urllib3 keeps
-    # the connection alive instead of re-handshaking per request. Capture is disabled because
-    # several endpoints return capability URLs carrying secrets (builds' `source_blob.url`,
-    # dynos' `rendezvous://.../secret` `attach_url`) that the name-based sample scrubbers
-    # can't recognise — `_redact_sensitive_fields` only scrubs the yielded rows, not the raw
-    # response the transport would otherwise capture.
-    session = make_tracked_session(capture=False)
+) -> Any:
+    apps_config = HEROKU_ENDPOINTS["apps"]
 
-    if config.fan_out_over_apps:
-        yield from _get_fan_out_rows(session, headers, logger, resumable_source_manager, config)
-        return
+    child_endpoint: dict[str, Any] = {
+        "path": config.path,
+        "params": {"app_id": {"type": "resolve", "resource": "apps", "field": "id"}},
+        "paginator": _paginator(config),
+        "data_selector_required": True,
+        # An app deleted between enumeration and this fetch 404s; treat it as an empty page and stop
+        # this app rather than failing the whole sync — the data is genuinely gone. A 401/403 still
+        # falls through to raise_for_status.
+        "response_actions": [{"status_code": 404, "action": "ignore"}],
+    }
+    child_resource: dict[str, Any] = {
+        "name": config.name,
+        "endpoint": child_endpoint,
+        "include_from_parent": [],
+    }
+    if config.sensitive_fields:
+        child_resource["data_map"] = _make_redactor(config.sensitive_fields)
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_range = resume.next_range if resume else None
-    if start_range:
-        logger.debug(f"Heroku: resuming {endpoint} from saved Next-Range cursor")
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": "apps",
+                # Rows already embed the parent as a nested `app` object, so nothing is injected from
+                # the parent; Heroku ids are globally unique UUIDs, so `id` stays a table-wide key.
+                "endpoint": {
+                    "path": apps_config.path,
+                    "paginator": _paginator(apps_config),
+                    "data_selector_required": True,
+                },
+            },
+            child_resource,
+        ],
+    }
 
-    url = f"{HEROKU_BASE_URL}{config.path}"
-    for rows, next_range in _iter_pages(session, url, headers, config, logger, start_range=start_range):
-        if rows:
-            yield rows
-            if next_range:
-                resumable_source_manager.save_state(HerokuResumeConfig(next_range=next_range))
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        # Only a framework-shaped fan-out snapshot can be resumed; pre-migration positional
+        # bookmarks (app_id/next_range) can't be reconstructed here, so restart the fan-out.
+        if resume is not None and resume.fanout_state:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state is not None:
+            resumable_source_manager.save_state(HerokuResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(resource for resource in resources if getattr(resource, "name", None) == config.name)
 
 
 def heroku_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[HerokuResumeConfig],
 ) -> SourceResponse:
     config = HEROKU_ENDPOINTS[endpoint]
 
+    if config.fan_out_over_apps:
+        resource = _fanout_source(api_key, config, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _flat_source(api_key, config, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -254,3 +267,12 @@ def heroku_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{HEROKU_BASE_URL}/account",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": HEROKU_API_ACCEPT},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/source.py
@@ -143,6 +143,7 @@ You can find your API key in your [Heroku account settings](https://dashboard.he
         return heroku_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/tests/test_heroku.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/tests/test_heroku.py
@@ -1,14 +1,16 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.heroku.heroku import (
+    HEROKU_API_ACCEPT,
     HerokuResumeConfig,
-    get_rows,
     heroku_source,
     validate_credentials,
 )
@@ -18,185 +20,245 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.heroku.set
     MAX_PAGES_PER_LIST,
 )
 
-PATCH_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.heroku.heroku.make_tracked_session"
+# heroku_source builds the client session (capture=False) via make_tracked_session in the heroku
+# module, and validate_credentials builds its probe session there too — one patch covers both.
+SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.heroku.heroku.make_tracked_session"
+
+INITIAL_RANGE = f"id ..; order=asc,max={DEFAULT_PAGE_SIZE}"
 
 
 def _response(
     status_code: int = 200, json_data: list[dict[str, Any]] | None = None, next_range: str | None = None
-) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.headers = {"Next-Range": next_range} if next_range else {}
-    response.json.return_value = json_data if json_data is not None else []
-    response.text = ""
-    if status_code >= 400:
-        error = requests.HTTPError(f"{status_code} Client Error: for url: https://api.heroku.com", response=response)
-        response.raise_for_status.side_effect = error
-    return response
+) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(json_data if json_data is not None else []).encode()
+    if next_range:
+        resp.headers["Next-Range"] = next_range
+    return resp
 
 
-def _manager(resume: HerokuResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock()
+def _make_manager(resume: HerokuResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
     manager.can_resume.return_value = resume is not None
     manager.load_state.return_value = resume
     return manager
 
 
+def _wire(session: mock.MagicMock, responses: list[Response] | Any) -> tuple[list[dict[str, Any]], list[str]]:
+    """Wire a mock session; capture each request's headers and URL AT PREPARE TIME.
+
+    The Range header is mutated in place on the shared request across pages, so snapshot a copy
+    when each request is prepared rather than inspecting the final state.
+    """
+    session.headers = {}
+    header_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        header_snapshots.append(dict(request.headers or {}))
+        url_snapshots.append(request.url)
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        prepared.is_redirect = False
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return header_snapshots, url_snapshots
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock) -> Any:
+    return heroku_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+
+
 class TestPagination:
-    def test_follows_next_range_header_until_absent(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            _response(206, [{"id": "a"}], next_range="id ]a..; order=asc,max=1000"),
-            _response(200, [{"id": "b"}]),
-        ]
-        manager = _manager()
+    @mock.patch(SESSION_PATCH)
+    def test_follows_next_range_header_until_absent(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        headers, _urls = _wire(
+            session,
+            [
+                _response(206, [{"id": "a"}], next_range="id ]a..; order=asc,max=1000"),
+                _response(200, [{"id": "b"}]),
+            ],
+        )
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "apps", MagicMock(), manager))
+        rows = _rows(_source("apps", _make_manager()))
 
-        assert pages == [[{"id": "a"}], [{"id": "b"}]]
-        first_headers = session.get.call_args_list[0].kwargs["headers"]
-        second_headers = session.get.call_args_list[1].kwargs["headers"]
-        assert first_headers["Range"] == f"id ..; order=asc,max={DEFAULT_PAGE_SIZE}"
-        assert second_headers["Range"] == "id ]a..; order=asc,max=1000"
-        assert first_headers["Accept"] == "application/vnd.heroku+json; version=3"
-        assert first_headers["Authorization"] == "Bearer key"
+        assert rows == [{"id": "a"}, {"id": "b"}]
+        assert headers[0]["Range"] == INITIAL_RANGE
+        assert headers[1]["Range"] == "id ]a..; order=asc,max=1000"
+        assert session.headers.get("Accept") == HEROKU_API_ACCEPT
 
-    def test_saves_state_after_yield_only_when_more_pages_remain(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            _response(206, [{"id": "a"}], next_range="id ]a..; order=asc,max=1000"),
-            _response(200, [{"id": "b"}]),
-        ]
-        manager = _manager()
+    @mock.patch(SESSION_PATCH)
+    def test_saves_cursor_once_and_only_while_pages_remain(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(206, [{"id": "a"}], next_range="id ]a..; order=asc,max=1000"),
+                _response(200, [{"id": "b"}]),
+            ],
+        )
+        manager = _make_manager()
 
-        with patch(PATCH_PATH, return_value=session):
-            iterator = get_rows("key", "apps", MagicMock(), manager)
-            next(iterator)
-            manager.save_state.assert_not_called()
-            next(iterator)
+        _rows(_source("apps", manager))
 
+        # One checkpoint pointing at the next page after the first (206) page; the final page saves
+        # nothing (no next range).
         manager.save_state.assert_called_once_with(HerokuResumeConfig(next_range="id ]a..; order=asc,max=1000"))
 
-    def test_resumes_top_level_endpoint_from_saved_cursor(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [_response(200, [{"id": "b"}])]
-        manager = _manager(HerokuResumeConfig(next_range="id ]a..; order=asc,max=1000"))
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_top_level_from_saved_cursor(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        headers, _urls = _wire(session, [_response(200, [{"id": "b"}])])
+        manager = _make_manager(HerokuResumeConfig(next_range="id ]a..; order=asc,max=1000"))
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "apps", MagicMock(), manager))
+        rows = _rows(_source("apps", manager))
 
-        assert pages == [[{"id": "b"}]]
-        assert session.get.call_args_list[0].kwargs["headers"]["Range"] == "id ]a..; order=asc,max=1000"
+        assert rows == [{"id": "b"}]
+        assert headers[0]["Range"] == "id ]a..; order=asc,max=1000"
 
-    def test_page_cap_stops_unbounded_scans_and_warns(self) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(206, [{"id": "a"}], next_range="id ]a..; order=asc,max=1000")
-        logger = MagicMock()
+    @mock.patch(SESSION_PATCH)
+    def test_page_cap_stops_unbounded_scans(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.side_effect = lambda request: mock.MagicMock(url=request.url, is_redirect=False)
+        session.send.side_effect = lambda *a, **k: _response(
+            206, [{"id": "a"}], next_range="id ]a..; order=asc,max=1000"
+        )
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "apps", logger, _manager()))
+        pages = list(_source("apps", _make_manager()).items())
 
         assert len(pages) == MAX_PAGES_PER_LIST
-        assert session.get.call_count == MAX_PAGES_PER_LIST
-        logger.warning.assert_called_once()
+        assert session.send.call_count == MAX_PAGES_PER_LIST
 
 
 class TestRetries:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 502)])
-    def test_retries_transient_statuses_then_succeeds(self, _name: str, status_code: int) -> None:
-        session = MagicMock()
-        session.get.side_effect = [_response(status_code), _response(200, [{"id": "a"}])]
+    @mock.patch("time.sleep")
+    @mock.patch(SESSION_PATCH)
+    def test_retries_transient_statuses_then_succeeds(
+        self, _name: str, status_code: int, MockSession: mock.MagicMock, _sleep: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status_code), _response(200, [{"id": "a"}])])
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "apps", MagicMock(), _manager()))
+        rows = _rows(_source("apps", _make_manager()))
 
-        assert pages == [[{"id": "a"}]]
-        assert session.get.call_count == 2
+        assert rows == [{"id": "a"}]
+        assert session.send.call_count == 2
 
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403)])
-    def test_credential_errors_raise_without_retry(self, _name: str, status_code: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status_code)
+    @mock.patch(SESSION_PATCH)
+    def test_credential_errors_raise_without_retry(
+        self, _name: str, status_code: int, MockSession: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status_code)])
 
-        with patch(PATCH_PATH, return_value=session):
-            with pytest.raises(requests.HTTPError):
-                list(get_rows("key", "apps", MagicMock(), _manager()))
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("apps", _make_manager()))
 
-        assert session.get.call_count == 1
+        assert session.send.call_count == 1
 
 
 class TestFanOut:
-    def test_fans_out_over_every_app(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            _response(200, [{"id": "app-1"}, {"id": "app-2"}]),
-            _response(200, [{"id": "rel-1", "app": {"id": "app-1"}}]),
-            _response(200, [{"id": "rel-2", "app": {"id": "app-2"}}]),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_fans_out_over_every_app(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _headers, urls = _wire(
+            session,
+            [
+                _response(200, [{"id": "app-1"}, {"id": "app-2"}]),
+                _response(200, [{"id": "rel-1", "app": {"id": "app-1"}}]),
+                _response(200, [{"id": "rel-2", "app": {"id": "app-2"}}]),
+            ],
+        )
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "releases", MagicMock(), _manager()))
+        rows = _rows(_source("releases", _make_manager()))
 
-        assert pages == [
-            [{"id": "rel-1", "app": {"id": "app-1"}}],
-            [{"id": "rel-2", "app": {"id": "app-2"}}],
+        assert rows == [
+            {"id": "rel-1", "app": {"id": "app-1"}},
+            {"id": "rel-2", "app": {"id": "app-2"}},
         ]
-        urls = [call.args[0] for call in session.get.call_args_list]
         assert urls == [
             "https://api.heroku.com/apps",
             "https://api.heroku.com/apps/app-1/releases",
             "https://api.heroku.com/apps/app-2/releases",
         ]
 
-    def test_app_deleted_mid_sync_is_skipped(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            _response(200, [{"id": "app-1"}, {"id": "app-2"}]),
-            _response(404),
-            _response(200, [{"id": "rel-2", "app": {"id": "app-2"}}]),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_app_deleted_mid_sync_is_skipped(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(200, [{"id": "app-1"}, {"id": "app-2"}]),
+                _response(404),
+                _response(200, [{"id": "rel-2", "app": {"id": "app-2"}}]),
+            ],
+        )
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "releases", MagicMock(), _manager()))
+        rows = _rows(_source("releases", _make_manager()))
 
-        assert pages == [[{"id": "rel-2", "app": {"id": "app-2"}}]]
+        assert rows == [{"id": "rel-2", "app": {"id": "app-2"}}]
 
-    def test_resumes_from_bookmarked_app_with_saved_cursor(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            _response(200, [{"id": "app-1"}, {"id": "app-2"}, {"id": "app-3"}]),
-            _response(200, [{"id": "rel-2"}]),
-            _response(200, [{"id": "rel-3"}]),
-        ]
+    @mock.patch(SESSION_PATCH)
+    def test_resumes_from_bookmarked_app_with_saved_cursor(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        headers, urls = _wire(
+            session,
+            [
+                _response(200, [{"id": "app-1"}, {"id": "app-2"}, {"id": "app-3"}]),
+                _response(200, [{"id": "rel-2"}]),
+                _response(200, [{"id": "rel-3"}]),
+            ],
+        )
         saved_cursor = "id ]rel-1..; order=asc,max=1000"
-        manager = _manager(HerokuResumeConfig(next_range=saved_cursor, app_id="app-2"))
+        manager = _make_manager(
+            HerokuResumeConfig(
+                fanout_state={
+                    "completed": ["/apps/app-1/releases"],
+                    "current": "/apps/app-2/releases",
+                    "child_state": {"next_range": saved_cursor},
+                }
+            )
+        )
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "releases", MagicMock(), manager))
+        rows = _rows(_source("releases", manager))
 
-        assert pages == [[{"id": "rel-2"}], [{"id": "rel-3"}]]
-        urls = [call.args[0] for call in session.get.call_args_list]
+        assert rows == [{"id": "rel-2"}, {"id": "rel-3"}]
+        # The already-completed app is never re-fetched.
         assert "https://api.heroku.com/apps/app-1/releases" not in urls
-        assert session.get.call_args_list[1].kwargs["headers"]["Range"] == saved_cursor
-        # The next app starts from a fresh first page, not the resumed cursor.
-        assert session.get.call_args_list[2].kwargs["headers"]["Range"] == f"id ..; order=asc,max={DEFAULT_PAGE_SIZE}"
-        manager.save_state.assert_called_with(HerokuResumeConfig(next_range=None, app_id="app-3"))
+        # The resumed app starts from the saved cursor; the next app starts from a fresh first page.
+        assert headers[1]["Range"] == saved_cursor
+        assert headers[2]["Range"] == INITIAL_RANGE
 
-    def test_deleted_bookmark_app_restarts_from_first_app(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            _response(200, [{"id": "app-1"}]),
-            _response(200, [{"id": "rel-1"}]),
-        ]
-        manager = _manager(HerokuResumeConfig(next_range="id ]x..; order=asc,max=1000", app_id="app-gone"))
+    @mock.patch(SESSION_PATCH)
+    def test_pre_migration_bookmark_restarts_fan_out(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        headers, urls = _wire(
+            session,
+            [
+                _response(200, [{"id": "app-1"}]),
+                _response(200, [{"id": "rel-1"}]),
+            ],
+        )
+        # Old-shape state (positional app bookmark, no fanout snapshot) can't be reconstructed, so the
+        # fan-out restarts from the first app on a fresh first page.
+        manager = _make_manager(HerokuResumeConfig(next_range="id ]x..; order=asc,max=1000", app_id="app-gone"))
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", "releases", MagicMock(), manager))
+        rows = _rows(_source("releases", manager))
 
-        assert pages == [[{"id": "rel-1"}]]
-        assert session.get.call_args_list[1].kwargs["headers"]["Range"] == f"id ..; order=asc,max={DEFAULT_PAGE_SIZE}"
+        assert rows == [{"id": "rel-1"}]
+        assert "https://api.heroku.com/apps/app-1/releases" in urls
+        assert headers[1]["Range"] == INITIAL_RANGE
 
 
 class TestSensitiveFieldRedaction:
@@ -232,42 +294,38 @@ class TestSensitiveFieldRedaction:
             ),
         ]
     )
+    @mock.patch(SESSION_PATCH)
     def test_capability_urls_never_reach_the_warehouse(
-        self, _name: str, endpoint: str, row: dict[str, Any], expected: dict[str, Any]
+        self, _name: str, endpoint: str, row: dict[str, Any], expected: dict[str, Any], MockSession: mock.MagicMock
     ) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            _response(200, [{"id": "app-1"}]),
-            _response(200, [row]),
-        ]
+        session = MockSession.return_value
+        _wire(session, [_response(200, [{"id": "app-1"}]), _response(200, [row])])
 
-        with patch(PATCH_PATH, return_value=session):
-            pages = list(get_rows("key", endpoint, MagicMock(), _manager()))
+        rows = _rows(_source(endpoint, _make_manager()))
 
-        assert pages == [[expected]]
+        assert rows == [expected]
 
 
 class TestValidateCredentials:
     @parameterized.expand([("valid", 200, True), ("unauthorized", 401, False)])
-    def test_maps_account_probe_status(self, _name: str, status_code: int, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = _response(status_code)
+    @mock.patch(SESSION_PATCH)
+    def test_maps_account_probe_status(
+        self, _name: str, status_code: int, expected: bool, MockSession: mock.MagicMock
+    ) -> None:
+        MockSession.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("key") is expected
 
-        with patch(PATCH_PATH, return_value=session):
-            assert validate_credentials("key") is expected
-
-    def test_network_error_is_invalid(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-
-        with patch(PATCH_PATH, return_value=session):
-            assert validate_credentials("key") is False
+    @mock.patch(SESSION_PATCH)
+    def test_network_error_is_invalid(self, MockSession: mock.MagicMock) -> None:
+        MockSession.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("key") is False
 
 
 class TestSourceResponse:
     @parameterized.expand([(name,) for name in HEROKU_ENDPOINTS])
-    def test_source_response_matches_endpoint_settings(self, endpoint: str) -> None:
-        response = heroku_source("key", endpoint, MagicMock(), _manager())
+    @mock.patch(SESSION_PATCH)
+    def test_source_response_matches_endpoint_settings(self, endpoint: str, MockSession: mock.MagicMock) -> None:
+        response = _source(endpoint, _make_manager())
         config = HEROKU_ENDPOINTS[endpoint]
 
         assert response.name == endpoint

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/tests/test_heroku_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/heroku/tests/test_heroku_source.py
@@ -98,7 +98,8 @@ class TestHerokuSource:
         mocked_source.assert_called_once_with(
             api_key="key",
             endpoint="releases",
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=manager,
         )
 


### PR DESCRIPTION
## Problem

Batch 21 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **guardian**
- **guru**
- **height**
- **heroku**

Not migrated this batch (left hand-rolled, valid blockers):
- **gridly** — scrubs the whole query string (non-secret `page=` blob included) from raised error messages; the framework redacts only auth secrets.
- **hatchet** — dynamic DNS/private-IP SSRF guard (beyond static host-pinning) plus a run-start-pinned incremental time window in resume state.
- **healthchecks** — needs HTTP sample capture disabled and dynamically-discovered per-check ping credentials redacted from telemetry; the framework has no capture toggle and redacts only static auth secrets.
- **helicone** — pins a run-start-captured incremental window (`created_after`, `end_time_unix_ms`) in resume state; the framework re-derives the incremental filter from the current watermark on every restart.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 4 migrated dirs + `common/rest_source/tests/` — 331 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-20 PR (#71881); merge in order.
