### PR TITLE
fix(bing_ads): treat invalid app client secret as internal config error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
@@ -83,6 +83,14 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
         )
         return {
             "AADSTS650052": service_principal_friendly,
+            # PostHog's own Azure AD application secret (BING_ADS_CLIENT_SECRET) is invalid or expired —
+            # Microsoft rejects the token request with AADSTS7000215 for the app itself, not the connected
+            # account. Reconnecting the integration can't fix it; only rotating PostHog's app secret can, so
+            # this is internal config (None message), not customer-actionable. Wrapped by the SDK as
+            # `OAuthTokenRequestException: invalid_client AADSTS7000215: …`, so it shares those two generic
+            # substrings — it must precede both so handle_non_retryable doesn't surface the misleading
+            # "reconnect your integration" message.
+            "AADSTS7000215": None,
             # OAuth grant rejection by Microsoft (the bingads SDK raises OAuthTokenRequestException
             # whose str() format is "<error_code> <error_description>").
             "OAuthTokenRequestException": auth_friendly,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -271,6 +271,12 @@ class TestBingAdsSource:
                 "Failed to fetch customer ID: OAuthTokenRequestException: invalid_client AADSTS650052: "
                 "The app is trying to access a service that your organization lacks a service principal for.",
             ),
+            # PostHog's own app secret is invalid/expired — internal config, not customer-actionable.
+            (
+                "AADSTS7000215",
+                "Failed to fetch customer ID: OAuthTokenRequestException: error_code: invalid_client, "
+                "error_description: AADSTS7000215: Invalid client secret provided.",
+            ),
             # Bing rejects the request as invalid after auth succeeds (e.g. wrong/inaccessible Account ID).
             # The SDK raises suds.WebFault whose str() embeds a volatile TrackingId — match the stable phrase.
             (
@@ -342,6 +348,25 @@ class TestBingAdsSource:
         assert friendly_errors[0] is not None
         assert "AADSTS650052" in friendly_errors[0]
         assert "service principal" in friendly_errors[0]
+
+    def test_aadsts7000215_is_internal_config_not_customer_actionable(self):
+        # AADSTS7000215 means PostHog's own app secret is invalid/expired. The message also contains
+        # "OAuthTokenRequestException" and "invalid_client", both of which map to the customer-facing
+        # "reconnect your integration" toast — so AADSTS7000215 must precede them and resolve to None,
+        # keeping the misleading toast off an error only a PostHog config change can fix.
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        keys = list(non_retryable_errors.keys())
+
+        aadsts_index = keys.index("AADSTS7000215")
+        assert aadsts_index < keys.index("OAuthTokenRequestException")
+        assert aadsts_index < keys.index("invalid_client")
+
+        error_message = (
+            "Failed to fetch customer ID: OAuthTokenRequestException: error_code: invalid_client, "
+            "error_description: AADSTS7000215: Invalid client secret provided."
+        )
+        friendly_errors = [msg for pattern, msg in non_retryable_errors.items() if pattern in error_message]
+        assert friendly_errors[0] is None
 
     def test_invalid_client_data_maps_to_account_guidance(self):
         # The dominant cause is a wrong/inaccessible Account ID (auth has already succeeded by this point),


### PR DESCRIPTION
## Problem

Bing Ads imports are surfacing a `ValueError` from `get_customer_id`:

```
Failed to fetch customer ID: OAuthTokenRequestException: error_code: invalid_client,
error_description: AADSTS7000215: Invalid client secret provided. Ensure the secret being
sent in the request is the client secret value, not the client secret ID, for a secret
added to app '<redacted app id>'. ...
```

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f6f96-5d34-75e0-94aa-375e20d069ec

The failure originates in this source's code (`bing_ads/client.py:get_customer_id`, wrapped via `_wrap_with_fault_detail`). The underlying chain is a `401` from Microsoft's token endpoint → `OAuthTokenRequestException` with `AADSTS7000215`.

`AADSTS7000215` means the client secret in the OAuth token request is invalid or expired. That secret is PostHog's own `BING_ADS_CLIENT_SECRET` for our registered Azure AD application (the app id in the message is PostHog's, not the customer's). It is a global config value, not a per-customer credential, and it hit several teams at once in the same short window - the signature of a PostHog-side secret problem, not customer credential rot.

Today the message contains `OAuthTokenRequestException` and `invalid_client`, both of which map to the customer-facing "reconnect your Bing Ads integration" message. That is misleading: reconnecting cannot fix an expired app secret - only rotating PostHog's secret can.

## Changes

Add `AADSTS7000215` → `None` to `BingAdsSource.get_non_retryable_errors`, ordered ahead of the generic `OAuthTokenRequestException` / `invalid_client` wrappers so it wins the first-match lookup in `handle_non_retryable`. A `None` friendly message classifies this as internal config (not customer-actionable), mirroring the existing `AADSTS650052` ordering precedent and the `None`-mapped app-config entries already in this dict.

The error stays non-retryable (retrying a bad app secret never succeeds) but no longer tells customers to reconnect.

## How did you test this code?

Automated only - I (Claude) did not do manual testing.

- Extended `test_get_non_retryable_errors_pattern_recognised` with an `AADSTS7000215` case (recognition).
- Added `test_aadsts7000215_is_internal_config_not_customer_actionable`: asserts `AADSTS7000215` precedes both generic wrappers and resolves to `None` for the real error string. This catches a reorder or removal that would resurface the misleading "reconnect" toast on an error only a PostHog config change can fix - a regression no existing test covered (the `AADSTS650052` test asserts a non-`None` message and different ordering).

Ran the source's non-retryable suite: `22 passed`. Ruff check + format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the issue via the error-tracking MCP tools (stack trace, exception chain, impact), read the `bing_ads` source and shared retry-classification path, and checked open PRs (including the maintainer's) to rule out a duplicate.

Decision: this is neither a customer/upstream error nor a code bug in the request path - it is a PostHog-side OAuth app config problem (expired/invalid `BING_ADS_CLIENT_SECRET`). It was already non-retryable via the generic wrappers, so the fix is purely about correcting the classification so we stop telling customers to reconnect. Scoped strictly to this error; no retry-policy or unrelated changes.

Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
