### PR TITLE
fix(bing_ads): treat invalid client secret (AADSTS7000215) as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
@@ -83,6 +83,13 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
         )
         return {
             "AADSTS650052": service_principal_friendly,
+            # PostHog's own OAuth application client secret (BING_ADS_CLIENT_SECRET) is invalid — expired,
+            # rotated, or misconfigured on our side. Affects every Bing Ads customer, not one account, so
+            # reconnecting the integration can't fix it. Surfaced by the SDK as
+            # `OAuthTokenRequestException: invalid_client AADSTS7000215: …`, so it shares substrings with the
+            # generic wrappers below — it must come first so handle_non_retryable picks this internal-config
+            # entry (None message) instead of telling the customer to reconnect.
+            "AADSTS7000215": None,
             # OAuth grant rejection by Microsoft (the bingads SDK raises OAuthTokenRequestException
             # whose str() format is "<error_code> <error_description>").
             "OAuthTokenRequestException": auth_friendly,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -343,6 +343,26 @@ class TestBingAdsSource:
         assert "AADSTS650052" in friendly_errors[0]
         assert "service principal" in friendly_errors[0]
 
+    def test_aadsts7000215_is_internal_config_not_reconnect(self):
+        # AADSTS7000215 = PostHog's own OAuth app client secret is invalid (our config, every customer),
+        # surfaced as "OAuthTokenRequestException: invalid_client AADSTS7000215: Invalid client secret".
+        # It must be matched before the generic wrappers and map to None so we don't surface the futile
+        # "reconnect your integration" message for a failure the customer can't fix.
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        keys = list(non_retryable_errors.keys())
+
+        aadsts_index = keys.index("AADSTS7000215")
+        assert aadsts_index < keys.index("OAuthTokenRequestException")
+        assert aadsts_index < keys.index("invalid_client")
+
+        error_message = (
+            "Failed to fetch customer ID: OAuthTokenRequestException: error_code: invalid_client, "
+            "error_description: AADSTS7000215: Invalid client secret provided. Ensure the secret being "
+            "sent in the request is the client secret value, not the client secret ID."
+        )
+        friendly_errors = [msg for pattern, msg in non_retryable_errors.items() if pattern in error_message]
+        assert friendly_errors[0] is None
+
     def test_invalid_client_data_maps_to_account_guidance(self):
         # The dominant cause is a wrong/inaccessible Account ID (auth has already succeeded by this point),
         # so the toast must point at the Account ID rather than telling the user to reconnect OAuth.


### PR DESCRIPTION
## Problem

Bing Ads imports were failing with a `NonRetryableException` whose root cause is Microsoft returning `AADSTS7000215: Invalid client secret provided` during the OAuth token request (surfaced from `BingAdsClient.get_customer_id`).

That Azure AD code means the OAuth **application** client secret PostHog sends to Microsoft is invalid — expired, rotated, or misconfigured on our side. It is a PostHog-wide configuration issue, not a per-account credential problem. But the error currently matches the generic `OAuthTokenRequestException` / `invalid_client` entries in the source's non-retryable map, so the customer sees "reconnect your Bing Ads integration" — guidance they cannot act on, since reconnecting an account can't fix our app secret.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f6f96-81d5-7351-8c13-d07071af61aa

## Changes

Add `AADSTS7000215` to `BingAdsSource.get_non_retryable_errors`, positioned **before** the generic `OAuthTokenRequestException` and `invalid_client` wrappers (the real message contains all three as substrings, and `handle_non_retryable` picks the first matching entry). It maps to `None`, marking it an internal-config failure so the sync stays non-retryable but we don't surface the misleading reconnect message.

This mirrors the existing `AADSTS650052` special-case and the `"...OAuth application credentials not configured": None` precedent — both cases where reconnecting can't help.

> [!NOTE]
> This does not change retryability. The error was already classified non-retryable via `invalid_client`; the only behavior change is that we no longer tell the customer to reconnect for a failure they can't fix.

## How did you test this code?

Automated only (I'm Claude; I did not do manual testing). Added one focused test, `test_aadsts7000215_is_internal_config_not_reconnect`, that guards the regression the existing suite missed: it asserts `AADSTS7000215` is ordered before both generic wrappers and that the real error string maps first to an entry with a `None` friendly message (so no reconnect toast is surfaced). Without the fix, reordering or dropping the entry would silently reintroduce the misleading message.

Ran the full `TestBingAdsSource` suite locally: 35 passed. Ruff check + format clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the `bing_ads` warehouse source. Pulled the issue and a representative event via the PostHog error-tracking tools to confirm the failure genuinely originates in `get_customer_id` (client.py:132) and to read the exact `AADSTS7000215` message chain. Decided it's a misclassification bug rather than a customer/upstream error: the invalid secret is PostHog's own OAuth app credential, so "reconnect your integration" is the wrong remedy. Chose to mirror the established `AADSTS650052` ordering pattern and the `None` internal-config convention instead of inventing a new message. Invoked the `/writing-tests` skill before adding the test to keep it to a single, regression-specific case.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
