### PR TITLE
fix(stamphog): let CONTRIBUTOR authors fall through to the write gate

### DIFF
--- a/products/stamphog/backend/tasks/tasks.py
+++ b/products/stamphog/backend/tasks/tasks.py
@@ -75,6 +75,17 @@ PR_BODY_EXCERPT_MAX_CHARS = 2000
 # PRs to burn sandbox + LLM credits. (GitHub's association vocabulary; the trusted subset.)
 TRUSTED_AUTHOR_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 
+# CONTRIBUTOR additionally passes the payload gate — not because it is trusted, but because the field
+# is unreliable in App-delivered payloads: GitHub computes author_association with less context than a
+# user-token API call, and org members on private repos arrive downgraded to CONTRIBUTOR (observed on
+# real deliveries with members:read granted and public org membership). Hard-dropping it silently
+# disables reviews for legitimate authors, so CONTRIBUTOR falls through to
+# _author_lacks_write_permission — the authoritative installation-token gate every run must pass
+# anyway. The associations still dropped here (NONE, FIRST_TIME_CONTRIBUTOR, ...) are fork drive-bys
+# with no repo relationship at all; a fall-through would cost only a cached permission lookup, but
+# there is no legitimate case to admit.
+PAYLOAD_GATE_AUTHOR_ASSOCIATIONS = TRUSTED_AUTHOR_ASSOCIATIONS | {"CONTRIBUTOR"}
+
 # The association gate above is necessary but not sufficient: MEMBER says nothing about repo-level
 # access, and COLLABORATOR covers read/triage-only invites. Auto-approval must also require that the
 # author can push — otherwise an under-privileged user gets an approval that satisfies branch
@@ -103,7 +114,7 @@ def _review_skip_reason(pr: dict[str, Any]) -> str | None:
     if user.get("type") == "Bot" or "[bot]" in (user.get("login") or ""):
         # Bot authors (dependabot, renovate, ...) always need a human.
         return "bot_author"
-    if pr.get("author_association") not in TRUSTED_AUTHOR_ASSOCIATIONS:
+    if pr.get("author_association") not in PAYLOAD_GATE_AUTHOR_ASSOCIATIONS:
         return "untrusted_author_association"
     return None
 

--- a/products/stamphog/backend/tests/test_tasks.py
+++ b/products/stamphog/backend/tests/test_tasks.py
@@ -132,17 +132,27 @@ def test_unmatched_events_create_no_review_run(team, repo_config, mutate_payload
         ({"user_type": "Bot"}, False),
         ({"author_login": "renovate[bot]"}, False),
         ({"author_association": "NONE"}, False),
-        ({"author_association": "CONTRIBUTOR"}, False),
+        ({"author_association": "CONTRIBUTOR"}, True),
         ({"author_association": "FIRST_TIME_CONTRIBUTOR"}, False),
         ({"author_association": "MEMBER"}, True),
     ],
-    ids=["draft", "bot_type", "bot_login", "none", "contributor", "first_time_contributor", "member_proceeds"],
+    ids=[
+        "draft",
+        "bot_type",
+        "bot_login",
+        "none",
+        "contributor_falls_through",
+        "first_time_contributor",
+        "member_proceeds",
+    ],
 )
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_review_path_skips_untrusted_bot_or_draft_prs(team, repo_config, pr_kwargs, expect_run):
     # Drafts, bot authors, and fork/external authors must be dropped before a sandbox is spent. The
     # fork/external drop is also a security boundary: an auto-approval must never satisfy required
-    # reviews for a PR no trusted member opened.
+    # reviews for a PR no trusted member opened. CONTRIBUTOR is NOT dropped at the payload gate — App
+    # webhooks downgrade org members on private repos to CONTRIBUTOR, so it defers to the
+    # write-permission gate (write here, via the harness default).
     mock_execute = _run_task(
         _pr_payload(**pr_kwargs), f"delivery-skip-{'-'.join(map(str, pr_kwargs.values()))}", team.id
     )
@@ -158,15 +168,31 @@ def test_review_path_skips_untrusted_bot_or_draft_prs(team, repo_config, pr_kwar
 
 
 @pytest.mark.parametrize(
-    "author_permission,expect_run",
-    [("admin", True), ("write", True), ("read", False), ("none", False)],
-    ids=["admin", "write", "read_only", "no_access"],
+    "author_permission,author_association,expect_run",
+    [
+        ("admin", "MEMBER", True),
+        ("write", "MEMBER", True),
+        ("read", "MEMBER", False),
+        ("none", "MEMBER", False),
+        ("write", "CONTRIBUTOR", True),
+        ("read", "CONTRIBUTOR", False),
+    ],
+    ids=["admin", "write", "read_only", "no_access", "contributor_with_write", "contributor_read_only"],
 )
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
-def test_review_path_requires_author_write_permission(team, repo_config, author_permission, expect_run):
+def test_review_path_requires_author_write_permission(
+    team, repo_config, author_permission, author_association, expect_run
+):
     # author_association alone can't prove push access (org MEMBERs and triage/read COLLABORATORs pass
     # it), so a trusted-association author below write must still be dropped before a run is queued.
-    mock_execute = _run_task(_pr_payload(), f"delivery-perm-{author_permission}", team.id, author_permission)
+    # The CONTRIBUTOR rows pin the payload-gate fall-through to this gate: a downgraded org member with
+    # write gets reviewed, a genuine read-only contributor still never mints a run.
+    mock_execute = _run_task(
+        _pr_payload(author_association=author_association),
+        f"delivery-perm-{author_permission}-{author_association}",
+        team.id,
+        author_permission,
+    )
 
     with team_scope(team.id):
         count = ReviewRun.objects.count()


### PR DESCRIPTION
## Problem

The hosted stamphog review pipeline silently skips PRs from legitimate org members. GitHub computes `author_association` in App webhook payloads with less context than a user-token API call: an org member opening a PR on a private org repo arrives as `CONTRIBUTOR`, even with `members: read` granted to the App, public org membership, and direct collaborator access on the repo. The API reports `MEMBER` for the exact same PR. The payload gate hard-dropped anything below `COLLABORATOR`, so those reviews never ran, with only a log line to show for it.

## Changes

Let `CONTRIBUTOR` pass the payload-only pre-filter and rely on the gate that was always the authoritative one: `_author_lacks_write_permission`, a live installation-token permission lookup that every run must pass before a sandbox is spent. Security outcome is unchanged: a read-only contributor still never mints a run, and fork drive-bys (`NONE`, `FIRST_TIME_CONTRIBUTOR`) still drop for free before any API spend. The association field keeps exactly one job it can do reliably, filtering authors with no repo relationship at all.

## How did you test this code?

Extended the two existing parameterized suites in `test_tasks.py`: the contributor row in the payload-gate matrix flips to "proceeds" (catches anyone re-tightening the gate and re-breaking org members), and the write-gate matrix gains `contributor_with_write → run` / `contributor_read_only → no run` (pins that the fall-through can never bypass the authoritative permission check). No manual prod testing; the diagnosis came from comparing a real App webhook delivery payload against the API response for the same PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in a session driven by @webjunkie, who hit this gate live while enabling the first repo on hosted stamphog. We debugged the skip from Celery logs (`stamphog_pr_event_skipped, reason=untrusted_author_association`), confirmed the payload value from the App's delivery log against the API's `MEMBER` for the same PR, and verified GitHub-side workarounds (public org membership, direct admin collaborator) do not change the payload value before concluding the field itself is unreliable in App deliveries. Invoked /writing-tests before extending the test matrices. This fix is split out of the larger stamphog hardening PR (#71544) so it can deploy independently.
