### PR TITLE
fix(mcp-analytics): skip product intent during impersonation

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -409,9 +409,9 @@ snapshots:
     components-definition-popover--action--light:
         hash: v1.k794b7964.f4bdb784a34e7a4af0c33043858f96c15234c1a161a635ad793ac749159d2fd2.xZjT6j6vvsEbrfG4iwhv0aoiOumGvVSJajzL3CNmZ8w
     components-definition-popover--data-warehouse-column-mapping--dark:
-        hash: v1.k794b7964.c38f182b346c519d1332cfd066782c3b4b9e0b5661fbe926253da902fc3c388b.micG7HfZSdoQxZl9DsRJk9wX2So89qflq-sxr9DYS4A
+        hash: v1.k794b7964.0ee1ae1caf0ca944fb346482ec211be87e2d9d60bdd8a2a9d77dd912ba1d8478.uULoWLevn28NDuEgq5QLrfOFU9pnVjHLjlDscwW9Q9E
     components-definition-popover--data-warehouse-column-mapping--light:
-        hash: v1.k794b7964.3201bcfb76a5bc9e9144f88ccb819af400442196804dc0ab84e1ecac6e141e28.U68Q077AoH6AtdHda3iCWWJelz2JyHqHs8JpJA_Onao
+        hash: v1.k794b7964.af82e8d5620ef50e40b5d55f260024fd9247480883ddd2a2ba2718f7cf8396ba.IcUjNqlNOxFbqF93utorC6_HCChPGXD7bVi7i8YckEE
     components-definition-popover--event--dark:
         hash: v1.k794b7964.4a10c0206e60aa629075aac850bcebdb2b5980a7d6953926911f1ebb7114a96e.Cpyg354rVEyXVrlBzOsJJGSmwPL4-YEhXboxDPMVY_s
     components-definition-popover--event--light:

--- a/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
@@ -3,10 +3,18 @@ import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 import { addProductIntent } from 'lib/utils/product-intents'
+import { userLogic } from 'scenes/userLogic'
 
 import { HogQLQueryResponse, NodeKind, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { asNumber } from './queryResultParsers'
+
+// These intents fire on view, not on a user action, so during impersonation they'd register
+// staff navigation as the team's intent — and the read-only middleware rejects the write (403),
+// toasting on every mount. Skip firing while impersonating.
+function isImpersonatedSession(): boolean {
+    return userLogic.findMounted()?.values.user?.is_impersonated ?? false
+}
 
 export type MCPOnboardingState = 'not-instrumented' | 'connected-no-calls' | 'onboarded'
 
@@ -179,7 +187,11 @@ export const mcpAnalyticsOnboardingLogic = kea<mcpAnalyticsOnboardingLogicType>(
             // tool calls have landed yet. Separates an install problem (never
             // instrumented) from a traffic problem (wired up, but the server isn't
             // being called). Registered once per mount so the poll doesn't repeat it.
-            if (values.onboardingState === 'connected-no-calls' && !cache.registeredConnected) {
+            if (
+                values.onboardingState === 'connected-no-calls' &&
+                !cache.registeredConnected &&
+                !isImpersonatedSession()
+            ) {
                 cache.registeredConnected = true
                 void addProductIntent({
                     product_type: ProductKey.MCP_ANALYTICS,
@@ -197,10 +209,12 @@ export const mcpAnalyticsOnboardingLogic = kea<mcpAnalyticsOnboardingLogicType>(
         actions.loadSignals()
         // Register product intent so activation lands in the standard cross-customer
         // funnel (`has_activated_mcp_analytics` flips once tool calls arrive too).
-        void addProductIntent({
-            product_type: ProductKey.MCP_ANALYTICS,
-            intent_context: ProductIntentContext.MCP_ANALYTICS_VIEWED,
-        })
+        if (!isImpersonatedSession()) {
+            void addProductIntent({
+                product_type: ProductKey.MCP_ANALYTICS,
+                intent_context: ProductIntentContext.MCP_ANALYTICS_VIEWED,
+            })
+        }
         cache.disposables.add(() => {
             const id = window.setInterval(() => actions.loadSignals(), POLL_INTERVAL_MS)
             return () => clearInterval(id)


### PR DESCRIPTION
## Problem

When you impersonate a user (read-only) and open the MCP analytics scene, `mcpAnalyticsOnboardingLogic` registers product intent on view:

`PATCH /api/environments/@current/add_product_intent/`

The `ImpersonationReadOnlyMiddleware` correctly rejects that write with `403` / `code: "impersonation_read_only"`. The rejection is surfaced globally by `apiStatusLogic`, so an error toast ("This action is not allowed during read-only user impersonation.") pops on every mount. The intent fires in `afterMount`, so re-navigating or refreshing repeats the toast.

## Changes

Guard the two fire-on-view intent registrations in `products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts` (`MCP_ANALYTICS_VIEWED` in `afterMount`, `MCP_ANALYTICS_CONNECTED` in `loadSignalsSuccess`) so they no-op while impersonating.

The guard skips the request rather than catching its failure. The toast fires from `apiStatusLogic` reacting to the raw 403 `Response`, so catching the rejection at the call site would silence the unhandled rejection but not the toast. Not firing kills both.

This is not a removal. Product intent is real activation telemetry: `has_activated_mcp_analytics()` reads `contexts["mcp_analytics_viewed"]`, and MCP analytics is still beta-gated behind the `mcp-analytics` flag, so tracking matters for real users. These two calls are unusual in that they fire on view, not on a user action — so during impersonation they register staff navigation as the team's intent. Skipping them also keeps the impersonated team's activation funnel clean, mirroring the backend's `@disallow_if_impersonated` guard.

Kept the fix local to MCP analytics rather than guarding the shared `addProductIntent` helper. Most product-intent calls fire on a user action (a write button), which staff won't trigger while read-only. The fire-on-view registrations here are the ones that break with no user action, so this is the right blast radius.

## How did you test this code?

I (Claude) could not exercise the impersonation flow in a running app from this environment, so the checks below are what I actually ran, plus the manual routine to verify.

Ran locally by the agent:
- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the changed file. The failures in the full run are pre-existing and unrelated (in `posthog_ai`, `replay_vision`, `tracing`).
- Pre-commit lint-staged (oxlint + oxfmt) ran clean on the staged file.

Manual routine to verify:
1. Impersonate a user, open the MCP analytics scene. Expect no `add_product_intent` PATCH in the Network tab and no impersonation toast, even on re-navigation or refresh.
2. As a normal (non-impersonated) user, open MCP analytics. Expect the `add_product_intent` PATCH to still fire and succeed, so activation telemetry is unaffected.

No automated test added. This is a two-line guard on fire-and-forget telemetry in a kea logic; a unit test would mostly assert the guard calls a mocked `userLogic`, which is low regression value. Happy to add one if reviewers want it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) investigated and wrote this fix. Two Explore agents traced the call path: the toast comes from `apiStatusLogic.onApiResponse` reacting to the raw 403, not from the caller, which is why a call-site `.catch()` wouldn't work and the guard has to skip the request.

First draft guarded the shared `addProductIntent` helper globally. On review I narrowed it to MCP analytics: the reported bug is here, the global change would alter telemetry for ~80 callers, and it would pull `userLogic` into a low-level `lib/utils` file. The narrow fix lives in a kea logic where reading `userLogic` is idiomatic. Also considered limiting the guard to read-only impersonation only, but chose any impersonation — read-write impersonation succeeds today yet still records staff navigation as the team's intent.

No skills were required (pure frontend logic change, no serializer/migration/API-type work).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
