### PR TITLE
feat(agent_platform): shared memory spaces with per-agent grants

### DIFF
--- a/products/agent_platform/docs/overview.md
+++ b/products/agent_platform/docs/overview.md
@@ -26,7 +26,7 @@ flowchart TB
     pg[("POSTHOG_DB<br/>applications · revisions<br/>(spec + bundle_uri)")]
     ag[("AGENT_DB<br/>session queue · users · identities")]
     bundles[("Bundle store · S3")]
-    memory[("Memory store · S3<br/>per team + app")]
+    memory[("Memory store · S3<br/>per team + app, or shared space")]
 
     authors -->|author spec + tools| django
     django <-->|bundle ops| janitor

--- a/products/agent_platform/services/agent-runner/src/loop/build-agent-tools.ts
+++ b/products/agent_platform/services/agent-runner/src/loop/build-agent-tools.ts
@@ -596,6 +596,15 @@ function buildToolContext(deps: AgentToolDeps, resolvedIdentities?: ToolContext[
         },
         memoryStore: deps.memoryStore,
         tabularStore: deps.tabularStore,
+        // Shared memory space grants, straight off the frozen spec — no DB lookup
+        // and no enumerating other agents. The memory/table tools resolve their
+        // optional `space` arg against this map.
+        memorySpaceGrants: new Map(
+            deps.rev.spec.memory_spaces.map((g): [string, { access: 'read' | 'read_write' }] => [
+                g.space,
+                { access: g.access },
+            ])
+        ),
         webSearchProviders: deps.webSearchProviders,
         credentials: credentialBroker
             ? {

--- a/products/agent_platform/services/agent-shared/src/memory/store.test.ts
+++ b/products/agent_platform/services/agent-shared/src/memory/store.test.ts
@@ -13,7 +13,15 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { serializeMemoryDoc } from './format'
 import { S3MemoryStore } from './s3-store'
 import { searchMemory } from './search'
-import { keyFor, MemoryConflictError, MemoryNotFoundError, MemoryScope, prefixFor, validateMemoryPath } from './store'
+import {
+    keyFor,
+    MemoryConflictError,
+    MemoryNotFoundError,
+    MemoryScope,
+    prefixFor,
+    validateMemoryPath,
+    validateMemorySpaceSlug,
+} from './store'
 import { buildTestStore, newTestPrefix, wipeTestPrefix } from './test-helpers'
 
 const scopeA: MemoryScope = { teamId: 42, applicationId: 'app-triager' }
@@ -63,6 +71,29 @@ describe('keyFor + prefixFor', () => {
 
     it('rejects a sub-prefix containing ..', () => {
         expect(() => prefixFor(scopeA, 'agent_memory', '../escape/')).toThrow()
+    })
+})
+
+describe('keyFor + prefixFor — shared memory spaces', () => {
+    const spaceScope: MemoryScope = { teamId: 42, applicationId: 'app-triager', space: 'team-runbooks' }
+
+    it('keys a shared space under team/<id>/space/<slug>/ (not the agent prefix)', () => {
+        expect(keyFor(spaceScope, 'a/b.md', 'agent_memory')).toBe('agent_memory/team/42/space/team-runbooks/a/b.md')
+        expect(prefixFor(spaceScope, 'agent_memory')).toBe('agent_memory/team/42/space/team-runbooks/')
+    })
+
+    it('teamId always comes from the scope, so a space slug is team-local', () => {
+        const otherTeam: MemoryScope = { ...spaceScope, teamId: 7 }
+        expect(keyFor(otherTeam, 'x.md', 'agent_memory')).toBe('agent_memory/team/7/space/team-runbooks/x.md')
+    })
+
+    it('validates the space slug and rejects a traversing/bad slug', () => {
+        expect(validateMemorySpaceSlug('team-runbooks_1')).toBe('team-runbooks_1')
+        for (const bad of ['Bad Slug', '../escape', 'a/b', 'UPPER', '', '-leading']) {
+            expect(() => validateMemorySpaceSlug(bad)).toThrow()
+        }
+        // keyFor routes through the validator, so a bad slug can't compose a key.
+        expect(() => keyFor({ ...spaceScope, space: 'a/b' }, 'x.md', 'agent_memory')).toThrow()
     })
 })
 

--- a/products/agent_platform/services/agent-shared/src/memory/store.ts
+++ b/products/agent_platform/services/agent-shared/src/memory/store.ts
@@ -2,11 +2,15 @@
  * MemoryStore — the cross-process surface for agent memory files.
  *
  * Files are markdown with YAML frontmatter (see format.ts), keyed at
- *   agent_memory/team/<team_id>/agent/<application_slug>/<path>.md
+ *   agent_memory/team/<team_id>/agent/<application_id>/<path>.md   (private)
+ *   agent_memory/team/<team_id>/space/<slug>/<path>.md             (shared space)
  *
- * The store enforces the team/app prefix on every read and write — callers
- * pass `{ teamId, applicationId }` and a relative `<path>.md` and never
- * see the bucket prefix directly.
+ * The store enforces the team + owner prefix on every read and write — callers
+ * pass `{ teamId, applicationId, space? }` and a relative `<path>.md` and never
+ * see the bucket prefix directly. `space` redirects storage to a team-local
+ * shared space (owned by the space, not any one agent); omit it for the agent's
+ * own private memory. `teamId` is always the session's team — never derived from
+ * a tool arg — so cross-team access is impossible by construction.
  *
  * Two impls:
  *   - InMemoryMemoryStore — Map-backed. Used by tests + dev when no bucket
@@ -18,7 +22,15 @@ import { MemoryFrontmatter } from './format'
 
 export interface MemoryScope {
     teamId: number
+    /** The calling agent — the private space key used when `space` is unset. */
     applicationId: string
+    /**
+     * Optional shared memory space slug. When set, storage keys under the team's
+     * `space/<slug>/` prefix instead of the agent's own `agent/<applicationId>/`
+     * prefix, so the data is owned by the space rather than any single agent.
+     * Team-local; validated by `validateMemorySpaceSlug`.
+     */
+    space?: string
 }
 
 /** Metadata-only view, used by list + search ranking without paying for a full GET. */
@@ -78,14 +90,39 @@ export function validateMemoryPath(path: string): string {
  * Compose the full bucket key. Exported so the S3 impl can use it and tests
  * can assert against the wire format.
  */
+const SPACE_SLUG_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+/**
+ * Validate a shared memory space slug. Lowercase ascii/digits/`_`/`-`, first
+ * char alphanumeric, no slashes or dots — so a space can never traverse out of
+ * its `space/<slug>/` prefix. Returns the slug unchanged or throws.
+ */
+export function validateMemorySpaceSlug(slug: string): string {
+    if (!SPACE_SLUG_RE.test(slug)) {
+        throw new Error(
+            `invalid memory space "${slug}" — must match ${SPACE_SLUG_RE} (lowercase a-z 0-9 _ -, no slashes)`
+        )
+    }
+    return slug
+}
+
+/**
+ * The owner path segment for a scope: `space/<slug>` for a shared space,
+ * `agent/<applicationId>` for the agent's own private memory (unchanged from the
+ * pre-spaces layout, so existing objects keep resolving without a migration).
+ */
+export function memoryOwnerSegment(scope: MemoryScope): string {
+    return scope.space !== undefined ? `space/${validateMemorySpaceSlug(scope.space)}` : `agent/${scope.applicationId}`
+}
+
 export function keyFor(scope: MemoryScope, path: string, bucketPrefix: string): string {
     const trimmedPrefix = bucketPrefix.replace(/^\/+|\/+$/g, '')
-    return `${trimmedPrefix}/team/${scope.teamId}/agent/${scope.applicationId}/${path}`
+    return `${trimmedPrefix}/team/${scope.teamId}/${memoryOwnerSegment(scope)}/${path}`
 }
 
 export function prefixFor(scope: MemoryScope, bucketPrefix: string, subPrefix?: string): string {
     const trimmedPrefix = bucketPrefix.replace(/^\/+|\/+$/g, '')
-    const base = `${trimmedPrefix}/team/${scope.teamId}/agent/${scope.applicationId}/`
+    const base = `${trimmedPrefix}/team/${scope.teamId}/${memoryOwnerSegment(scope)}/`
     if (!subPrefix) {
         return base
     }

--- a/products/agent_platform/services/agent-shared/src/memory/tabular-store.ts
+++ b/products/agent_platform/services/agent-shared/src/memory/tabular-store.ts
@@ -6,7 +6,8 @@
  * logs, dedup, and simple lookups (seen-sets, archive logs, etc.) live here.
  *
  * Storage: one JSONL object per table at
- *   <bucketPrefix>/team/<team_id>/agent/<application_slug>/tables/<name>.jsonl
+ *   <bucketPrefix>/team/<team_id>/agent/<application_id>/tables/<name>.jsonl (private)
+ *   <bucketPrefix>/team/<team_id>/space/<slug>/tables/<name>.jsonl           (shared space)
  * Rows are JSON objects. The determinism lives in THIS code (Node), not in S3
  * and not in the model: each op GETs the whole object, computes in-process, and
  * conditionally PUTs back. S3 is a blob store, so whole-object read-modify-write
@@ -19,7 +20,7 @@
  * Where the backend ignores conditionals it degrades to last-write-wins.
  */
 
-import { MemoryScope } from './store'
+import { MemoryScope, memoryOwnerSegment } from './store'
 
 export type TableScalar = string | number | boolean | null
 export type TableRow = Record<string, unknown>
@@ -126,7 +127,7 @@ export function tableKeyFor(scope: MemoryScope, name: string, bucketPrefix: stri
 
 export function tablesPrefixFor(scope: MemoryScope, bucketPrefix: string): string {
     const trimmed = bucketPrefix.replace(/^\/+|\/+$/g, '')
-    return `${trimmed}/team/${scope.teamId}/agent/${scope.applicationId}/tables/`
+    return `${trimmed}/team/${scope.teamId}/${memoryOwnerSegment(scope)}/tables/`
 }
 
 /** Parse JSONL into rows, skipping blank/corrupt lines (graceful degradation). */

--- a/products/agent_platform/services/agent-shared/src/spec/spec.test.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/spec.test.ts
@@ -1157,4 +1157,28 @@ describe('authoritative_provider trigger gating (fail-closed)', () => {
             })
         ).toThrow(/not yet enforced/)
     })
+
+    describe('memory_spaces grants', () => {
+        it('parses grants and defaults access to read', () => {
+            const spec = AgentSpecSchema.parse({ memory_spaces: [{ space: 'team-runbooks' }] })
+            expect(spec.memory_spaces).toEqual([{ space: 'team-runbooks', access: 'read' }])
+        })
+
+        it('accepts read_write and rejects an invalid slug', () => {
+            expect(
+                AgentSpecSchema.safeParse({ memory_spaces: [{ space: 'audit', access: 'read_write' }] }).success
+            ).toBe(true)
+            expect(AgentSpecSchema.safeParse({ memory_spaces: [{ space: 'Bad Slug' }] }).success).toBe(false)
+        })
+
+        it('rejects duplicate space grants', () => {
+            const res = AgentSpecSchema.safeParse({
+                memory_spaces: [{ space: 'dup' }, { space: 'dup', access: 'read_write' }],
+            })
+            expect(res.success).toBe(false)
+            if (!res.success) {
+                expect(res.error.issues.some((i) => i.path.includes('memory_spaces'))).toBe(true)
+            }
+        })
+    })
 })

--- a/products/agent_platform/services/agent-shared/src/spec/spec.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/spec.ts
@@ -984,6 +984,27 @@ export const IdentityProviderConfigSchema = z.discriminatedUnion('kind', [
 export type IdentityProviderConfig = z.infer<typeof IdentityProviderConfigSchema>
 
 /**
+ * A grant of access to a shared memory space. `space` is a team-local slug; the
+ * space is owned by the space itself — not any agent — and several agents can be
+ * granted access to it, decoupling the data from any single agent. `access` is
+ * read-only or read+write. The runner builds the grant map straight off the
+ * frozen spec (no team-wide scan of other agents). `teamId` is always the
+ * session's team, so a grant can only reach spaces in the agent's own team
+ * (cross-team impossible). (Prefix/"folder"-scoped grants are a planned follow-up.)
+ */
+export const MemorySpaceGrantSchema = z.object({
+    space: z
+        .string()
+        .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/, 'space must be a slug: lowercase a-z 0-9 _ - , no slashes')
+        .describe('Team-local shared memory space slug this agent may access.'),
+    access: z
+        .enum(['read', 'read_write'])
+        .default('read')
+        .describe('read = list/search/read only; read_write = also write/append/mutate within the space.'),
+})
+export type MemorySpaceGrant = z.infer<typeof MemorySpaceGrantSchema>
+
+/**
  * Base object shape, before the cross-field superRefine. Exported so the
  * author-facing `TypedSpecSchema` (storage/typed-bundle.ts) can guard its key
  * set against this single source of truth — a top-level field added here that
@@ -1055,6 +1076,13 @@ export const AgentSpecObjectSchema = z.object({
             'Secret names this agent can resolve from its encrypted env. Bare string = resolvable but no network-egress authority; object form pins the secret to allowed_hosts so @posthog/http-request may send it there.'
         )
         .default([]),
+    memory_spaces: z
+        .array(MemorySpaceGrantSchema)
+        .max(50)
+        .describe(
+            "Shared memory spaces this agent may use, beyond its own private memory. Each grant names a team-local space slug + access level (read or read_write). The memory/table tools take an optional `space` arg resolved against these grants; omit it to use the agent's own private memory. Empty = private memory only."
+        )
+        .default([]),
     limits: SpecLimitsSchema.default({
         max_turns: 50,
         max_tool_calls: 200,
@@ -1083,6 +1111,22 @@ export const AgentSpecObjectSchema = z.object({
 const ADMISSION_WIRED_TRIGGER_TYPES: readonly Trigger['type'][] = ['slack', 'chat']
 
 export const AgentSpecSchema = AgentSpecObjectSchema.superRefine((spec, ctx) => {
+    // Reject duplicate memory_spaces slugs so the runner's grant map can't have an
+    // ambiguous entry (slug FORMAT is enforced by the field regex).
+    const spaceSlugs = spec.memory_spaces.map((g) => g.space)
+    const dupSpace = spaceSlugs.find((s, i) => spaceSlugs.indexOf(s) !== i)
+    if (dupSpace) {
+        ctx.addIssue({
+            code: 'custom',
+            path: ['memory_spaces'],
+            message: `duplicate memory_spaces grant for "${dupSpace}" — declare each space at most once.`,
+        })
+    }
+    // NOTE: gating shared-space grants on agents reachable by untrusted callers
+    // (a posthog `authenticated` audience or `public` auth) is intentionally NOT
+    // handled here — that belongs with the untrusted-caller envelope in the
+    // authentication work, not this memory mechanism. See the PR description.
+
     // authoritative_provider must reference an identity_providers[] entry that can
     // prove a subject (posthog, or oauth2 with userinfo_url) — else admission
     // either 500s (unknown) or soft-locks (no subject) at runtime.

--- a/products/agent_platform/services/agent-shared/src/spec/tool.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/tool.ts
@@ -112,6 +112,17 @@ export interface ToolContext {
      */
     tabularStore?: TabularStore
     /**
+     * Shared memory spaces this agent's spec grants access to, keyed by space
+     * slug → { access }. Built once at session start straight from
+     * `spec.memory_spaces` — no DB lookup, no enumerating other agents. The
+     * memory/table tools accept an optional `space` arg and consult this map:
+     * reads need a `read` or `read_write` grant, writes need `read_write`; an
+     * ungranted space returns `access_denied`. `teamId` is never taken from a
+     * tool arg, so a grant only reaches spaces in the agent's own team.
+     * Absent/empty → the agent can use only its own private memory.
+     */
+    memorySpaceGrants?: ReadonlyMap<string, { access: 'read' | 'read_write' }>
+    /**
      * Resolve a per-session credential by target name. Set by ingress at
      * /run + /send (see `CredentialBroker`); returns null when the broker
      * isn't wired or the target isn't bound. Convention names:

--- a/products/agent_platform/services/agent-shared/src/storage/typed-bundle.ts
+++ b/products/agent_platform/services/agent-shared/src/storage/typed-bundle.ts
@@ -141,6 +141,9 @@ export const TypedSpecSchema = z
         // source of truth) rather than re-spelling it — the old string-only
         // array silently rejected host-scoped secrets at bundle PUT.
         secrets: z.array(SecretRefSchema).optional(),
+        // Shared memory space grants — author-written, passed through here and
+        // validated in full by AgentSpecSchema at freeze (see MemorySpaceGrantSchema).
+        memory_spaces: z.array(z.unknown()).optional(),
         limits: z.unknown().optional(),
         reasoning: z.string().optional(),
         framework_prompt: z.unknown().optional(),

--- a/products/agent_platform/services/agent-tests/src/cases/memory.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/memory.test.ts
@@ -345,3 +345,87 @@ describe('memory: janitor + runner share one bucket', () => {
         expect(text).toContain('new description after patch')
     })
 })
+
+describe('memory: shared memory spaces', () => {
+    let c: Cluster
+
+    beforeEach(async () => {
+        c = await buildCluster()
+    })
+
+    afterEach(async () => {
+        await c.teardown()
+    })
+
+    afterAll(async () => {
+        await closeSharedPool()
+    })
+
+    // Pull the memory-read tool_result text out of a completed session.
+    function readToolResult(conversation: { role: string; content?: unknown; isError?: boolean }[]): {
+        text: string
+        isError: boolean
+    } {
+        const tr = conversation.find((m) => m.role === 'toolResult') as
+            | { role: 'toolResult'; content: Array<{ type: string; text?: string }>; isError?: boolean }
+            | undefined
+        const text = tr?.content?.find((b) => b.type === 'text')?.text ?? ''
+        return { text, isError: !!tr?.isError }
+    }
+
+    it('a reader granted a shared space reads what a writer put there; an ungranted space is denied', async () => {
+        // Writer A is granted read_write on the shared space and writes into it.
+        c.setScript([
+            fauxCallTool('@posthog/memory-write', {
+                path: 'onboarding.md',
+                description: 'shared runbook',
+                content: 'SENTINEL-SHARED-SPACE-42',
+                space: 'team-runbooks',
+            }),
+            fauxText('stored'),
+        ])
+        await c.deployAgent({
+            slug: 'writer-a',
+            spec: {
+                tools: [{ kind: 'native', id: '@posthog/memory-write' }],
+                memory_spaces: [{ space: 'team-runbooks', access: 'read_write' }],
+            },
+        })
+        const runA = await request(c.ingress).post('/agents/writer-a/run').send({ message: 'remember' })
+        expect(runA.status).toBe(200)
+        await c.drain()
+
+        // Reader B (same team) is granted read on the same space.
+        await c.deployAgent({
+            slug: 'reader-b',
+            spec: {
+                tools: [{ kind: 'native', id: '@posthog/memory-read' }],
+                memory_spaces: [{ space: 'team-runbooks', access: 'read' }],
+            },
+        })
+        c.setScript([
+            fauxCallTool('@posthog/memory-read', { path: 'onboarding.md', space: 'team-runbooks' }),
+            fauxText('read it'),
+        ])
+        const runAllow = await request(c.ingress).post('/agents/reader-b/run').send({ message: 'read shared' })
+        expect(runAllow.status).toBe(200)
+        await c.drain()
+        const allow = readToolResult((await c.queue.get(runAllow.body.session_id))!.conversation)
+        // Granted space → the read resolves the writer's file content.
+        expect(allow.isError).toBe(false)
+        expect(allow.text).toContain('SENTINEL-SHARED-SPACE-42')
+
+        // Same reader, a space it was NOT granted → access_denied (grants come off
+        // the frozen spec; there is no team-wide scan of other agents).
+        c.setScript([
+            fauxCallTool('@posthog/memory-read', { path: 'onboarding.md', space: 'not-granted' }),
+            fauxText('tried'),
+        ])
+        const runDeny = await request(c.ingress).post('/agents/reader-b/run').send({ message: 'read ungranted' })
+        expect(runDeny.status).toBe(200)
+        await c.drain()
+        const deny = readToolResult((await c.queue.get(runDeny.body.session_id))!.conversation)
+        expect(deny.text).toContain('access_denied')
+        expect(deny.text).not.toContain('SENTINEL-SHARED-SPACE-42')
+    })
+})

--- a/products/agent_platform/services/agent-tools/src/tools/memory-scope.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/memory-scope.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared scope resolution for the memory + table tools. Both families take an
+ * optional `space` arg and resolve it the same way against the agent's spec
+ * grants (`ToolContext.memorySpaceGrants`), so the logic lives here once rather
+ * than duplicated per tool file. The per-family `access_denied` envelope differs
+ * (memory has no `code`, table does), so each file keeps its own tiny `denied`
+ * helper and calls `resolveMemoryScope` for the decision.
+ */
+import { MemoryScope, ToolContext, Type } from '@posthog/agent-shared'
+
+/** The optional `space` arg exposed by every memory + table tool. */
+export const SPACE = Type.Optional(
+    Type.String({
+        description:
+            'Use a shared memory space instead of your own private data: the space slug. Works only when your agent is granted access to that space (same team). Reads need a read grant; writes need read_write. Omit to use your own private data.',
+    })
+)
+
+/**
+ * Resolve the storage scope for a memory/table op. `space` targets a shared
+ * memory space; it's honoured only when the agent's spec grants access — reads
+ * (`needWrite=false`) need any grant, writes need `read_write`. Omitting `space`
+ * = the agent's own private scope (always allowed). `teamId` is NEVER taken from
+ * an arg, so a grant can only reach spaces in the agent's own team. Returns the
+ * scope, or null = access denied (caller maps to its `access_denied` envelope).
+ */
+export function resolveMemoryScope(ctx: ToolContext, space: string | undefined, needWrite: boolean): MemoryScope | null {
+    if (space === undefined) {
+        return { teamId: ctx.teamId, applicationId: ctx.applicationId }
+    }
+    const grant = ctx.memorySpaceGrants?.get(space)
+    if (!grant || (needWrite && grant.access !== 'read_write')) {
+        return null
+    }
+    return { teamId: ctx.teamId, applicationId: ctx.applicationId, space }
+}

--- a/products/agent_platform/services/agent-tools/src/tools/memory.test.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/memory.test.ts
@@ -117,6 +117,65 @@ describe('memory tools (real S3 / SeaweedFS)', () => {
         })
     })
 
+    describe('shared memory space access', () => {
+        const SPACE = 'team-runbooks'
+        const grantCtx = (
+            applicationId: string,
+            grants: [string, { access: 'read' | 'read_write' }][]
+        ): ToolContext => ({
+            ...makeCtx(store),
+            applicationId,
+            memorySpaceGrants: new Map(grants),
+        })
+
+        it('a read_write grantee writes to the space; a read grantee (different agent) reads it back', async () => {
+            const write = (await memoryWriteV1.run(
+                { path: 'onboarding.md', description: 'shared', content: 'SHARED-BODY', space: SPACE },
+                grantCtx('writer', [[SPACE, { access: 'read_write' }]])
+            )) as Envelope
+            expect(write.ok).toBe(true)
+
+            const read = (await memoryReadV1.run(
+                { path: 'onboarding.md', space: SPACE },
+                grantCtx('reader', [[SPACE, { access: 'read' }]])
+            )) as Envelope
+            expect(read.ok).toBe(true)
+            expect(read.data?.content).toBe('SHARED-BODY')
+        })
+
+        it('denies a read of an ungranted space even though the file exists', async () => {
+            await memoryWriteV1.run(
+                { path: 'onboarding.md', description: 'shared', content: 'SHARED-BODY', space: SPACE },
+                grantCtx('writer', [[SPACE, { access: 'read_write' }]])
+            )
+            const read = (await memoryReadV1.run(
+                { path: 'onboarding.md', space: SPACE },
+                grantCtx('reader', [])
+            )) as Envelope
+            expect(read.ok).toBe(false)
+            expect(read.error).toMatch(/access_denied/)
+        })
+
+        it('denies a write to a space granted only read (read_write required)', async () => {
+            const write = (await memoryWriteV1.run(
+                { path: 'onboarding.md', description: 'shared', content: 'x', space: SPACE },
+                grantCtx('reader', [[SPACE, { access: 'read' }]])
+            )) as Envelope
+            expect(write.ok).toBe(false)
+            expect(write.error).toMatch(/access_denied/)
+        })
+
+        it('a space file is separate from the agent private memory (no space arg → not found)', async () => {
+            await memoryWriteV1.run(
+                { path: 'onboarding.md', description: 'shared', content: 'SHARED-BODY', space: SPACE },
+                grantCtx('writer', [[SPACE, { access: 'read_write' }]])
+            )
+            const read = (await memoryReadV1.run({ path: 'onboarding.md' }, makeCtx(store))) as Envelope
+            expect(read.ok).toBe(false)
+            expect(read.error).toMatch(/not_found/)
+        })
+    })
+
     describe('memoryUpdateV1', () => {
         it('overwrites and preserves createdAt', async () => {
             const ctx = makeCtx(store)

--- a/products/agent_platform/services/agent-tools/src/tools/memory.test.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/memory.test.ts
@@ -121,9 +121,11 @@ describe('memory tools (real S3 / SeaweedFS)', () => {
         const SPACE = 'team-runbooks'
         const grantCtx = (
             applicationId: string,
-            grants: [string, { access: 'read' | 'read_write' }][]
+            grants: [string, { access: 'read' | 'read_write' }][],
+            teamId = 42
         ): ToolContext => ({
             ...makeCtx(store),
+            teamId,
             applicationId,
             memorySpaceGrants: new Map(grants),
         })
@@ -173,6 +175,53 @@ describe('memory tools (real S3 / SeaweedFS)', () => {
             const read = (await memoryReadV1.run({ path: 'onboarding.md' }, makeCtx(store))) as Envelope
             expect(read.ok).toBe(false)
             expect(read.error).toMatch(/not_found/)
+        })
+
+        it('a space is team-scoped — the same slug in another team is a different store', async () => {
+            await memoryWriteV1.run(
+                { path: 'onboarding.md', description: 'shared', content: 'TEAM-42-ONLY', space: SPACE },
+                grantCtx('writer', [[SPACE, { access: 'read_write' }]], 42)
+            )
+            // Same space slug + same path but a DIFFERENT team → no leak. teamId is
+            // taken from the session, never a tool arg; keyFor namespaces by team.
+            const read = (await memoryReadV1.run(
+                { path: 'onboarding.md', space: SPACE },
+                grantCtx('reader', [[SPACE, { access: 'read' }]], 7)
+            )) as Envelope
+            expect(read.ok).toBe(false)
+            expect(read.error).toMatch(/not_found/)
+        })
+
+        it('search is scoped to the space — never surfaces private files, and private search never surfaces space files', async () => {
+            const ctx = grantCtx('agent', [[SPACE, { access: 'read_write' }]])
+            await memoryWriteV1.run(
+                { path: 'private-doc.md', description: 'incident notes', content: 'incident PRIVATE-MARKER' },
+                ctx
+            )
+            await memoryWriteV1.run(
+                { path: 'space-doc.md', description: 'incident notes', content: 'incident SPACE-MARKER', space: SPACE },
+                ctx
+            )
+
+            const inSpace = (await memorySearchV1.run({ cue: 'incident', space: SPACE }, ctx)) as Envelope
+            const spacePaths = (inSpace.data as { results: { path: string }[] }).results.map((r) => r.path)
+            expect(spacePaths).toContain('space-doc.md')
+            expect(spacePaths).not.toContain('private-doc.md')
+
+            const inPrivate = (await memorySearchV1.run({ cue: 'incident' }, ctx)) as Envelope
+            const privatePaths = (inPrivate.data as { results: { path: string }[] }).results.map((r) => r.path)
+            expect(privatePaths).toContain('private-doc.md')
+            expect(privatePaths).not.toContain('space-doc.md')
+        })
+
+        it('list is scoped to the space', async () => {
+            const ctx = grantCtx('agent', [[SPACE, { access: 'read_write' }]])
+            await memoryWriteV1.run({ path: 'private-doc.md', description: 'p', content: 'x' }, ctx)
+            await memoryWriteV1.run({ path: 'space-doc.md', description: 's', content: 'y', space: SPACE }, ctx)
+
+            const listed = (await memoryListV1.run({ space: SPACE }, ctx)) as Envelope
+            const paths = (listed.data as { entries: { path: string }[] }).entries.map((e) => e.path)
+            expect(paths).toEqual(['space-doc.md'])
         })
     })
 

--- a/products/agent_platform/services/agent-tools/src/tools/memory.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/memory.ts
@@ -33,6 +33,8 @@ import {
     type ToolContext,
 } from '@posthog/agent-shared'
 
+import { resolveMemoryScope, SPACE } from './memory-scope'
+
 // =====================================================================
 // Shared envelope shape — all memory tool returns share { ok, error?, data? }
 // for consistent surface to the model (matches the PG-era shape, keeps any
@@ -57,28 +59,6 @@ function err(error: string): Result<never> {
 // Scope + store resolution
 // =====================================================================
 
-type Scope = { teamId: number; applicationId: string; space?: string }
-// Resolve the storage scope. `space` targets a shared memory space (see
-// MemoryStore); it's honoured only when the agent's spec grants access — reads
-// need any grant, writes need `read_write`. Omitting `space` = the agent's own
-// private memory (always allowed). `teamId` is NEVER taken from an arg, so a
-// grant can only reach spaces in the agent's own team. null = access denied.
-function resolveScope(ctx: ToolContext, space: string | undefined, needWrite: boolean): Scope | null {
-    if (space === undefined) {
-        return { teamId: ctx.teamId, applicationId: ctx.applicationId }
-    }
-    const grant = ctx.memorySpaceGrants?.get(space)
-    if (!grant || (needWrite && grant.access !== 'read_write')) {
-        return null
-    }
-    return { teamId: ctx.teamId, applicationId: ctx.applicationId, space }
-}
-const SPACE = Type.Optional(
-    Type.String({
-        description:
-            'Use a shared memory space instead of your own private memory: the space slug. Works only when your agent is granted access to that space (same team). Reads need a read grant; writes need read_write. Omit to use your own private memory.',
-    })
-)
 function denied(space: string | undefined): Result<never> {
     return err(`access_denied: no memory access to space '${space}'`)
 }
@@ -124,7 +104,7 @@ export const memoryListV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
-        const sc = resolveScope(ctx, args.space, false)
+        const sc = resolveMemoryScope(ctx, args.space, false)
         if (!sc) {
             return denied(args.space)
         }
@@ -163,7 +143,7 @@ export const memorySearchV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
-        const sc = resolveScope(ctx, args.space, false)
+        const sc = resolveMemoryScope(ctx, args.space, false)
         if (!sc) {
             return denied(args.space)
         }
@@ -195,7 +175,7 @@ export const memoryReadV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
-        const sc = resolveScope(ctx, args.space, false)
+        const sc = resolveMemoryScope(ctx, args.space, false)
         if (!sc) {
             return denied(args.space)
         }
@@ -248,7 +228,7 @@ export const memoryWriteV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
-        const sc = resolveScope(ctx, args.space, true)
+        const sc = resolveMemoryScope(ctx, args.space, true)
         if (!sc) {
             return denied(args.space)
         }
@@ -291,7 +271,7 @@ export const memoryUpdateV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
-        const sc = resolveScope(ctx, args.space, true)
+        const sc = resolveMemoryScope(ctx, args.space, true)
         if (!sc) {
             return denied(args.space)
         }
@@ -334,7 +314,7 @@ export const memoryDeleteV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
-        const sc = resolveScope(ctx, args.space, true)
+        const sc = resolveMemoryScope(ctx, args.space, true)
         if (!sc) {
             return denied(args.space)
         }

--- a/products/agent_platform/services/agent-tools/src/tools/memory.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/memory.ts
@@ -9,10 +9,12 @@
  *   memory-update   — overwrite an existing file (approval-gated by default)
  *   memory-delete   — hard delete one file (approval-gated by default)
  *
- * Cross-agent share is intentionally not implemented in v0 — every tool
- * operates inside the calling agent's own slug prefix. Surfacing it as a
- * runtime error means the model sees a clear "not_implemented" envelope
- * rather than silent absence.
+ * Every tool accepts an optional `space` (a shared memory space slug): the op
+ * runs against that space instead of the agent's own private memory, but only
+ * when the agent's spec grants access to it — reads need a `read` grant, writes
+ * need `read_write`. `teamId` is never taken from the arg, so a grant can only
+ * reach spaces in the agent's own team. An ungranted space returns access_denied.
+ * Omit `space` for the agent's own private memory.
  */
 
 import {
@@ -55,8 +57,30 @@ function err(error: string): Result<never> {
 // Scope + store resolution
 // =====================================================================
 
-function scope(ctx: ToolContext): { teamId: number; applicationId: string } {
-    return { teamId: ctx.teamId, applicationId: ctx.applicationId }
+type Scope = { teamId: number; applicationId: string; space?: string }
+// Resolve the storage scope. `space` targets a shared memory space (see
+// MemoryStore); it's honoured only when the agent's spec grants access — reads
+// need any grant, writes need `read_write`. Omitting `space` = the agent's own
+// private memory (always allowed). `teamId` is NEVER taken from an arg, so a
+// grant can only reach spaces in the agent's own team. null = access denied.
+function resolveScope(ctx: ToolContext, space: string | undefined, needWrite: boolean): Scope | null {
+    if (space === undefined) {
+        return { teamId: ctx.teamId, applicationId: ctx.applicationId }
+    }
+    const grant = ctx.memorySpaceGrants?.get(space)
+    if (!grant || (needWrite && grant.access !== 'read_write')) {
+        return null
+    }
+    return { teamId: ctx.teamId, applicationId: ctx.applicationId, space }
+}
+const SPACE = Type.Optional(
+    Type.String({
+        description:
+            'Use a shared memory space instead of your own private memory: the space slug. Works only when your agent is granted access to that space (same team). Reads need a read grant; writes need read_write. Omit to use your own private memory.',
+    })
+)
+function denied(space: string | undefined): Result<never> {
+    return err(`access_denied: no memory access to space '${space}'`)
 }
 
 function storeOrError(ctx: ToolContext): MemoryStore | { error: string } {
@@ -91,6 +115,7 @@ export const memoryListV1 = defineNativeTool({
                 description: "Path prefix to scope the list, e.g. 'incidents/' or 'runbooks/oncall/'.",
             })
         ),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -99,8 +124,12 @@ export const memoryListV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
+        const sc = resolveScope(ctx, args.space, false)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            const headers = await s.list(scope(ctx), { prefix: args.prefix })
+            const headers = await s.list(sc, { prefix: args.prefix })
             return ok({
                 count: headers.length,
                 entries: headers.map((h: MemoryHeader) => ({
@@ -125,6 +154,7 @@ export const memorySearchV1 = defineNativeTool({
         cue: Type.String({ minLength: 1, description: 'What to look for. Plain natural language is fine.' }),
         prefix: Type.Optional(Type.String({ description: 'Optional path prefix scope.' })),
         limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 50 })),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'medium',
@@ -133,8 +163,12 @@ export const memorySearchV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
+        const sc = resolveScope(ctx, args.space, false)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            const results = await searchMemory(s, scope(ctx), args.cue, {
+            const results = await searchMemory(s, sc, args.cue, {
                 prefix: args.prefix,
                 limit: args.limit,
             })
@@ -152,6 +186,7 @@ export const memoryReadV1 = defineNativeTool({
         'Read one memory file in full — returns its description, tags, timestamps, and full markdown body. Use after `memory-list` or `memory-search` returns a path.',
     args: Type.Object({
         path: Type.String({ description: 'Path returned by list/search, e.g. "incidents/2026/db-pool.md".' }),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -160,8 +195,12 @@ export const memoryReadV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
+        const sc = resolveScope(ctx, args.space, false)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            const file: MemoryFile = await s.read(scope(ctx), args.path)
+            const file: MemoryFile = await s.read(sc, args.path)
             return ok({
                 path: file.path,
                 description: file.frontmatter.description,
@@ -200,6 +239,7 @@ export const memoryWriteV1 = defineNativeTool({
                 description: 'Optional flat tags for search ranking. lowercase a-z 0-9 _ - only.',
             })
         ),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -207,6 +247,10 @@ export const memoryWriteV1 = defineNativeTool({
         const s = storeOrError(ctx)
         if ('error' in s) {
             return err(s.error)
+        }
+        const sc = resolveScope(ctx, args.space, true)
+        if (!sc) {
+            return denied(args.space)
         }
         try {
             validateMemoryPath(args.path)
@@ -219,7 +263,7 @@ export const memoryWriteV1 = defineNativeTool({
                 createdAt: now,
                 updatedAt: now,
             })
-            await s.put(scope(ctx), args.path, raw, { failIfExists: true })
+            await s.put(sc, args.path, raw, { failIfExists: true })
             ctx.log('info', 'memory.write', { path: args.path })
             return ok({ path: args.path, created_at: now })
         } catch (e) {
@@ -238,6 +282,7 @@ export const memoryUpdateV1 = defineNativeTool({
         description: Type.Optional(Type.String({ description: `One-line summary, max ${MAX_DESCRIPTION_LEN} chars.` })),
         content: Type.Optional(Type.String({ description: 'New markdown body (replaces existing).' })),
         tags: Type.Optional(Type.Array(Type.String())),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -246,9 +291,13 @@ export const memoryUpdateV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
+        const sc = resolveScope(ctx, args.space, true)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
             validateMemoryPath(args.path)
-            const existing = await s.read(scope(ctx), args.path)
+            const existing = await s.read(sc, args.path)
             const description = args.description ?? existing.frontmatter.description
             const tags = args.tags ?? existing.frontmatter.tags
             const content = args.content ?? existing.content
@@ -261,7 +310,7 @@ export const memoryUpdateV1 = defineNativeTool({
                 createdAt: existing.frontmatter.createdAt,
                 updatedAt: now,
             })
-            await s.put(scope(ctx), args.path, raw, { failIfMissing: true })
+            await s.put(sc, args.path, raw, { failIfMissing: true })
             ctx.log('info', 'memory.update', { path: args.path })
             return ok({ path: args.path, updated_at: now })
         } catch (e) {
@@ -276,6 +325,7 @@ export const memoryDeleteV1 = defineNativeTool({
     description: 'Hard-delete a memory file. APPROVAL-GATED BY DEFAULT.',
     args: Type.Object({
         path: Type.String(),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -284,9 +334,13 @@ export const memoryDeleteV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error)
         }
+        const sc = resolveScope(ctx, args.space, true)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
             validateMemoryPath(args.path)
-            await s.delete(scope(ctx), args.path)
+            await s.delete(sc, args.path)
             ctx.log('info', 'memory.delete', { path: args.path })
             return ok({ path: args.path, deleted: true })
         } catch (e) {

--- a/products/agent_platform/services/agent-tools/src/tools/table.test.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/table.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Table-tool shared-space tests — exercise the @posthog/table-* tools' `space`
+ * arg against a real S3JsonlTabularStore (SeaweedFS). Focus: grant resolution
+ * (read vs read_write) and that scope stays limited per (team, space) — a space
+ * table is invisible across teams and separate from the agent's private tables.
+ * No skip-if-unreachable; bring up SeaweedFS before running.
+ */
+import { S3Client } from '@aws-sdk/client-s3'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+    buildTestS3Client,
+    HttpClient,
+    newTestPrefix,
+    S3JsonlTabularStore,
+    TEST_S3_BUCKET,
+    type ToolContext,
+    wipeTestPrefix,
+} from '@posthog/agent-shared'
+
+import { tableAppendV1, tableCountV1, tableDeleteV1, tableMembershipV1, tableQueryV1 } from './table'
+
+interface Envelope {
+    ok: boolean
+    error?: string
+    code?: string
+    data?: Record<string, unknown>
+}
+
+describe('table tools — shared memory space access (real S3 / SeaweedFS)', () => {
+    let client: S3Client
+    let store: S3JsonlTabularStore
+    let prefix: string
+
+    const SPACE = 'team-tables'
+
+    const ctxFor = (
+        applicationId: string,
+        grants: [string, { access: 'read' | 'read_write' }][],
+        teamId = 42
+    ): ToolContext => ({
+        teamId,
+        applicationId,
+        sessionId: 'sess-1',
+        secret: () => undefined,
+        secretAllowedHosts: () => undefined,
+        log: () => undefined,
+        tabularStore: store,
+        memorySpaceGrants: new Map(grants),
+        http: new HttpClient(),
+        posthogApiBaseUrl: 'http://localhost:8010',
+    })
+
+    beforeAll(() => {
+        prefix = newTestPrefix('agent_table_tools_test')
+        client = buildTestS3Client()
+        store = new S3JsonlTabularStore({ client, bucket: TEST_S3_BUCKET, bucketPrefix: prefix, maxRetries: 30 })
+    })
+
+    afterEach(async () => {
+        await wipeTestPrefix(client, prefix)
+    })
+
+    afterAll(async () => {
+        await wipeTestPrefix(client, prefix)
+        client.destroy()
+    })
+
+    it('a read_write grantee appends to a space; a read grantee (different agent) queries it back', async () => {
+        const append = (await tableAppendV1.run(
+            { table: 'seen', rows: [{ id: 'a' }, { id: 'b' }], space: SPACE },
+            ctxFor('writer', [[SPACE, { access: 'read_write' }]])
+        )) as Envelope
+        expect(append.ok).toBe(true)
+
+        const query = (await tableQueryV1.run(
+            { table: 'seen', space: SPACE },
+            ctxFor('reader', [[SPACE, { access: 'read' }]])
+        )) as Envelope
+        expect(query.ok).toBe(true)
+        expect((query.data as { count: number }).count).toBe(2)
+    })
+
+    it('denies read of an ungranted space', async () => {
+        const query = (await tableQueryV1.run({ table: 'seen', space: SPACE }, ctxFor('reader', []))) as Envelope
+        expect(query.ok).toBe(false)
+        expect(query.code).toBe('access_denied')
+    })
+
+    it('a read-only grant cannot append or delete in the space', async () => {
+        const append = (await tableAppendV1.run(
+            { table: 'seen', rows: [{ id: 'a' }], space: SPACE },
+            ctxFor('reader', [[SPACE, { access: 'read' }]])
+        )) as Envelope
+        expect(append.ok).toBe(false)
+        expect(append.code).toBe('access_denied')
+
+        const del = (await tableDeleteV1.run(
+            { table: 'seen', where: { id: 'a' }, space: SPACE },
+            ctxFor('reader', [[SPACE, { access: 'read' }]])
+        )) as Envelope
+        expect(del.ok).toBe(false)
+        expect(del.code).toBe('access_denied')
+    })
+
+    it('a space table is team-scoped — another team sees nothing under the same slug', async () => {
+        await tableAppendV1.run(
+            { table: 'seen', rows: [{ id: 'a' }], space: SPACE },
+            ctxFor('writer', [[SPACE, { access: 'read_write' }]], 42)
+        )
+        // Same space slug + same table, DIFFERENT team → isolated by teamId.
+        const count = (await tableCountV1.run(
+            { table: 'seen', space: SPACE },
+            ctxFor('reader', [[SPACE, { access: 'read' }]], 7)
+        )) as Envelope
+        expect(count.ok).toBe(true)
+        expect((count.data as { count: number }).count).toBe(0)
+    })
+
+    it('a space table is separate from the agent private tables (no space arg)', async () => {
+        await tableAppendV1.run(
+            { table: 'seen', rows: [{ id: 'a' }], space: SPACE },
+            ctxFor('writer', [[SPACE, { access: 'read_write' }]])
+        )
+        // Membership against the agent's OWN (private) table — the space rows must
+        // not appear, so 'a' is reported as new.
+        const membership = (await tableMembershipV1.run(
+            { table: 'seen', key_column: 'id', values: ['a'] },
+            ctxFor('writer', [[SPACE, { access: 'read_write' }]])
+        )) as Envelope
+        expect(membership.ok).toBe(true)
+        expect((membership.data as { new: string[] }).new).toEqual(['a'])
+    })
+})

--- a/products/agent_platform/services/agent-tools/src/tools/table.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/table.ts
@@ -13,6 +13,12 @@
  *
  * `where` is a map of column → value (equality) or a predicate object:
  *   { in: [...] } | { gt|gte|lt|lte: <number|string> }   (conditions AND together)
+ *
+ * Every tool accepts an optional `space` (a shared memory space slug): the op
+ * runs against that space's tables instead of the agent's own, but only when the
+ * agent's spec grants access — reads need a `read` grant, writes need
+ * `read_write`. `teamId` is never taken from the arg, so a grant can only reach
+ * spaces in the agent's own team. Omit `space` for the agent's own tables.
  */
 
 import {
@@ -42,8 +48,30 @@ type Result<T> = { ok: true; data: T } | { ok: false; error: string; code: strin
 const ok = <T>(data: T): Result<T> => ({ ok: true, data })
 const err = (error: string, code = 'error'): Result<never> => ({ ok: false, error, code })
 
-function scope(ctx: ToolContext): { teamId: number; applicationId: string } {
-    return { teamId: ctx.teamId, applicationId: ctx.applicationId }
+type Scope = { teamId: number; applicationId: string; space?: string }
+// Resolve the storage scope. `space` targets a shared memory space (see
+// MemoryStore); it's honoured only when the agent's spec grants access — reads
+// need any grant, writes need `read_write`. Omitting `space` = the agent's own
+// private tables (always allowed). `teamId` is NEVER taken from an arg, so a
+// grant can only reach spaces in the agent's own team. null = access denied.
+function resolveScope(ctx: ToolContext, space: string | undefined, needWrite: boolean): Scope | null {
+    if (space === undefined) {
+        return { teamId: ctx.teamId, applicationId: ctx.applicationId }
+    }
+    const grant = ctx.memorySpaceGrants?.get(space)
+    if (!grant || (needWrite && grant.access !== 'read_write')) {
+        return null
+    }
+    return { teamId: ctx.teamId, applicationId: ctx.applicationId, space }
+}
+const SPACE = Type.Optional(
+    Type.String({
+        description:
+            'Use a shared memory space instead of your own private tables: the space slug. Works only when your agent is granted access to that space (same team). Reads need a read grant; writes need read_write. Omit to use your own private tables.',
+    })
+)
+function denied(space: string | undefined): Result<never> {
+    return err(`no memory access to space '${space}'`, 'access_denied')
 }
 function storeOrError(ctx: ToolContext): TabularStore | { error: string } {
     if (!ctx.tabularStore) {
@@ -75,6 +103,7 @@ export const tableMembershipV1 = defineNativeTool({
         table: TABLE,
         key_column: Type.String({ description: 'The column holding the identifier to test membership against.' }),
         values: Type.Array(SCALAR, { description: 'Candidate values to test.' }),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -83,8 +112,12 @@ export const tableMembershipV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
+        const sc = resolveScope(ctx, args.space, false)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            const res = await s.membership(scope(ctx), args.table, args.key_column, args.values)
+            const res = await s.membership(sc, args.table, args.key_column, args.values)
             return ok(res)
         } catch (e) {
             return err(asError(e), asCode(e))
@@ -103,6 +136,7 @@ export const tableAppendV1 = defineNativeTool({
         dedupe_on: Type.Optional(
             Type.String({ description: 'Column to dedupe on; skip rows whose key already exists.' })
         ),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -111,8 +145,12 @@ export const tableAppendV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
+        const sc = resolveScope(ctx, args.space, true)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            const res = await s.append(scope(ctx), args.table, args.rows, { dedupeOn: args.dedupe_on })
+            const res = await s.append(sc, args.table, args.rows, { dedupeOn: args.dedupe_on })
             return ok(res)
         } catch (e) {
             return err(asError(e), asCode(e))
@@ -132,6 +170,7 @@ export const tableQueryV1 = defineNativeTool({
         order_by: Type.Optional(Type.String({ description: 'Sort by this column.' })),
         desc: Type.Optional(Type.Boolean({ description: 'Descending order.' })),
         limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+        space: SPACE,
     }),
     returns: RESULT,
     cost_hint: 'cheap',
@@ -140,8 +179,12 @@ export const tableQueryV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
+        const sc = resolveScope(ctx, args.space, false)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            const rows = await s.query(scope(ctx), args.table, {
+            const rows = await s.query(sc, args.table, {
                 where: args.where as Where,
                 columns: args.columns,
                 order_by: args.order_by,
@@ -159,7 +202,7 @@ export const tableCountV1 = defineNativeTool({
     id: '@posthog/table-count',
     approval: 'allow',
     description: 'Count rows in a table matching `where` (or all rows if omitted).',
-    args: Type.Object({ table: TABLE, where: Type.Optional(WHERE) }),
+    args: Type.Object({ table: TABLE, where: Type.Optional(WHERE), space: SPACE }),
     returns: RESULT,
     cost_hint: 'cheap',
     async run(args, ctx) {
@@ -167,8 +210,12 @@ export const tableCountV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
+        const sc = resolveScope(ctx, args.space, false)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            return ok({ count: await s.count(scope(ctx), args.table, args.where as Where) })
+            return ok({ count: await s.count(sc, args.table, args.where as Where) })
         } catch (e) {
             return err(asError(e), asCode(e))
         }
@@ -179,7 +226,7 @@ export const tableDeleteV1 = defineNativeTool({
     id: '@posthog/table-delete',
     approval: 'allow',
     description: 'Delete rows from a table matching `where` (required). Returns how many were removed.',
-    args: Type.Object({ table: TABLE, where: WHERE }),
+    args: Type.Object({ table: TABLE, where: WHERE, space: SPACE }),
     returns: RESULT,
     cost_hint: 'cheap',
     async run(args, ctx) {
@@ -187,8 +234,12 @@ export const tableDeleteV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
+        const sc = resolveScope(ctx, args.space, true)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            return ok(await s.delete(scope(ctx), args.table, args.where as Where))
+            return ok(await s.delete(sc, args.table, args.where as Where))
         } catch (e) {
             return err(asError(e), asCode(e))
         }
@@ -199,7 +250,7 @@ export const tableTruncateV1 = defineNativeTool({
     id: '@posthog/table-truncate',
     approval: 'allow',
     description: 'Remove an entire table (all rows). Use to reset state.',
-    args: Type.Object({ table: TABLE }),
+    args: Type.Object({ table: TABLE, space: SPACE }),
     returns: RESULT,
     cost_hint: 'cheap',
     async run(args, ctx) {
@@ -207,8 +258,12 @@ export const tableTruncateV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
+        const sc = resolveScope(ctx, args.space, true)
+        if (!sc) {
+            return denied(args.space)
+        }
         try {
-            await s.truncate(scope(ctx), args.table)
+            await s.truncate(sc, args.table)
             return ok({ truncated: args.table })
         } catch (e) {
             return err(asError(e), asCode(e))

--- a/products/agent_platform/services/agent-tools/src/tools/table.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/table.ts
@@ -30,6 +30,8 @@ import {
     Type,
 } from '@posthog/agent-shared'
 
+import { resolveMemoryScope, SPACE } from './memory-scope'
+
 // The TypeBox `where` schema infers as Record<string, unknown>; the store
 // evaluates each condition structurally at runtime (scalar or predicate), so we
 // cast at the tool boundary.
@@ -48,28 +50,6 @@ type Result<T> = { ok: true; data: T } | { ok: false; error: string; code: strin
 const ok = <T>(data: T): Result<T> => ({ ok: true, data })
 const err = (error: string, code = 'error'): Result<never> => ({ ok: false, error, code })
 
-type Scope = { teamId: number; applicationId: string; space?: string }
-// Resolve the storage scope. `space` targets a shared memory space (see
-// MemoryStore); it's honoured only when the agent's spec grants access — reads
-// need any grant, writes need `read_write`. Omitting `space` = the agent's own
-// private tables (always allowed). `teamId` is NEVER taken from an arg, so a
-// grant can only reach spaces in the agent's own team. null = access denied.
-function resolveScope(ctx: ToolContext, space: string | undefined, needWrite: boolean): Scope | null {
-    if (space === undefined) {
-        return { teamId: ctx.teamId, applicationId: ctx.applicationId }
-    }
-    const grant = ctx.memorySpaceGrants?.get(space)
-    if (!grant || (needWrite && grant.access !== 'read_write')) {
-        return null
-    }
-    return { teamId: ctx.teamId, applicationId: ctx.applicationId, space }
-}
-const SPACE = Type.Optional(
-    Type.String({
-        description:
-            'Use a shared memory space instead of your own private tables: the space slug. Works only when your agent is granted access to that space (same team). Reads need a read grant; writes need read_write. Omit to use your own private tables.',
-    })
-)
 function denied(space: string | undefined): Result<never> {
     return err(`no memory access to space '${space}'`, 'access_denied')
 }
@@ -112,7 +92,7 @@ export const tableMembershipV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
-        const sc = resolveScope(ctx, args.space, false)
+        const sc = resolveMemoryScope(ctx, args.space, false)
         if (!sc) {
             return denied(args.space)
         }
@@ -145,7 +125,7 @@ export const tableAppendV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
-        const sc = resolveScope(ctx, args.space, true)
+        const sc = resolveMemoryScope(ctx, args.space, true)
         if (!sc) {
             return denied(args.space)
         }
@@ -179,7 +159,7 @@ export const tableQueryV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
-        const sc = resolveScope(ctx, args.space, false)
+        const sc = resolveMemoryScope(ctx, args.space, false)
         if (!sc) {
             return denied(args.space)
         }
@@ -210,7 +190,7 @@ export const tableCountV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
-        const sc = resolveScope(ctx, args.space, false)
+        const sc = resolveMemoryScope(ctx, args.space, false)
         if (!sc) {
             return denied(args.space)
         }
@@ -234,7 +214,7 @@ export const tableDeleteV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
-        const sc = resolveScope(ctx, args.space, true)
+        const sc = resolveMemoryScope(ctx, args.space, true)
         if (!sc) {
             return denied(args.space)
         }
@@ -258,7 +238,7 @@ export const tableTruncateV1 = defineNativeTool({
         if ('error' in s) {
             return err(s.error, 'unavailable')
         }
-        const sc = resolveScope(ctx, args.space, true)
+        const sc = resolveMemoryScope(ctx, args.space, true)
         if (!sc) {
             return denied(args.space)
         }


### PR DESCRIPTION
## Problem

The cross-agent memory-read approach in #71696 couples agents to each other's
identities: it makes one agent's *private* per-`(team, application)` memory
readable by flipping a team-wide flag on that agent, and a reader reaches it by
passing **another agent's application id** (`owner`). That blends "an agent's
private notebook" with "shared team knowledge," is read-only, and forces the
runner to enumerate every sharing agent in the team each session.

This PR is an **alternative design for that memory-sharing half only**, opened
to compare against #71696. It does **not** touch #71696 and deliberately leaves
out the `authenticated` audience / envelope work.

## Changes

Introduce a first-class **memory space** — a team-local slug that owns memory +
tabular data independently of any agent. Several agents can be granted access to
the same space, decoupling the data from any single agent.

- **Spec grant.** A new top-level `memory_spaces: [{ space, access }]` on the
  agent spec (`access` = `read` or `read_write`). Validated at freeze and
  session start like every other capability.
- **Tool arg.** The `@posthog/memory-*` and `@posthog/table-*` tools take an
  optional `space` arg, resolved against the agent's grants (reads need any
  grant, writes need `read_write`). Omit it for the agent's own private memory.
- **Storage.** `MemoryScope` gains an optional `space`; keys land under
  `team/<id>/space/<slug>/…`. Private memory keeps its existing
  `team/<id>/agent/<app>/…` layout, so there is **no data migration**.
- **No team-wide scan.** The runner builds the grant map straight off the frozen
  spec — reaching shared data no longer means pointing at another agent's id, and
  there's no per-session "which agents share" lookup.

`teamId` is always the session's team (never taken from a tool arg), so
cross-team access stays impossible by construction; an ungranted space returns
`access_denied`; writes require `read_write`.

**Deliberately out of scope:** gating shared-space grants on agents reachable by
untrusted callers (a posthog `authenticated` audience or `public` auth). That
belongs with the untrusted-caller envelope in the authentication work — see
Refs #71714. This PR is purely the memory mechanism. Prefix/"folder"-scoped
grants are a noted follow-up.

## How did you test this code?

The agent could **not** run the build or test suites in its environment (no
installed dependencies, no local Postgres/Redis/Kafka/SeaweedFS), so this needs
a local/CI run to confirm — no manual testing is claimed. Automated coverage
added with the change:

- **Unit (zod, `spec.test.ts`):** grants parse and default `access` to `read`;
  `read_write` accepted; invalid slug and duplicate-slug grants rejected.
- **Unit (tools, `memory.test.ts`):** a `read_write` grantee writes to a space
  and a different agent with a `read` grant reads it back; an ungranted space is
  denied though the file exists; a `read`-only grantee is denied a write; a
  space file is separate from private memory (no `space` arg → not found).
- **E2E (`agent-tests/cases/memory.test.ts`):** writer agent A (read_write)
  writes into a space; reader agent B (read) reads it via `space`; an ungranted
  space returns `access_denied`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated the memory node in `docs/overview.md` and the memory-tool docstrings to
describe spaces; no separate docs page.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed the work, including
the key design choices (grants declared in the spec, lightweight named-slug
spaces rather than a first-class DB model, and keeping this PR to the memory
mechanism only).

- Tool: Claude Code (this session). No repo skills were invoked.
- Design decisions: started from a broader redesign that also refactored the
  authentication envelope, then narrowed — per direction — to just the shared
  memory mechanism, based on `master` (not on #71696). A public-agent guard on
  shared-space grants was written and then removed to keep this PR free of
  authentication concerns; that gating is left to the untrusted-caller envelope
  (#71714).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
