### PR TITLE
fix(data-warehouse): detect self-driving marker in proxied MCP header

### DIFF
--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -355,11 +355,16 @@ def is_wizard_self_driving_program(request) -> bool:
     can only tell they're "the wizard". The self-driving program additionally tags its
     UA with a `program: self-driving` marker, letting callers attribute its work apart
     from other wizard runs.
+
+    When the request is proxied through the PostHog MCP server, that server overwrites
+    `User-Agent` with its own token and forwards the wizard's original UA — marker
+    included — in `X-Posthog-Mcp-User-Agent`. Inspect both so the marker is found whether
+    the wizard called us directly or via the MCP server.
     """
     user_agent = request.headers.get("user-agent", "") or ""
-    if not isinstance(user_agent, str):
-        return False
-    return "posthog/wizard" in user_agent and bool(_WIZARD_SELF_DRIVING_PROGRAM_RE.search(user_agent))
+    mcp_user_agent = request.headers.get("X-Posthog-Mcp-User-Agent", "") or ""
+    combined = "\n".join(part for part in (user_agent, mcp_user_agent) if isinstance(part, str))
+    return "posthog/wizard" in combined and bool(_WIZARD_SELF_DRIVING_PROGRAM_RE.search(combined))
 
 
 MAX_HEADER_VALUE_LENGTH = 1000

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -12,6 +12,7 @@ from posthog.event_usage import (
     EventSource,
     get_event_source,
     get_mcp_properties,
+    is_wizard_self_driving_program,
     report_user_action,
     sanitize_header_value,
 )
@@ -350,6 +351,48 @@ class TestGetEventSource(BaseTest):
             kwargs["HTTP_X_POSTHOG_CLIENT"] = x_posthog_client
         request = factory.get("/fake", **kwargs)
         assert get_event_source(request) == expected
+
+
+class TestIsWizardSelfDrivingProgram(BaseTest):
+    @parameterized.expand(
+        [
+            # Direct wizard → Django: the marker rides on the User-Agent itself.
+            ("direct_with_marker", "posthog/wizard; version: 2.44.0; program: self-driving-setup", None, True),
+            ("direct_without_marker", "posthog/wizard; version: 2.44.0", None, False),
+            ("direct_other_program", "posthog/wizard; version: 2.44.0; program: revenue-analytics", None, False),
+            # Proxied via the MCP server: it overwrites User-Agent with its own token and forwards
+            # the wizard's real UA (marker included) in X-Posthog-Mcp-User-Agent. The marker must
+            # still be found there — this is the case that previously went undetected.
+            (
+                "proxied_with_marker",
+                "posthog/mcp-server; version: 1.0.0; for posthog/wizard",
+                "posthog/wizard; version: 2.45.0; program: self-driving-setup",
+                True,
+            ),
+            (
+                "proxied_without_marker",
+                "posthog/mcp-server; version: 1.0.0; for posthog/wizard",
+                "posthog/wizard; version: 2.45.0",
+                False,
+            ),
+            (
+                "proxied_other_program",
+                "posthog/mcp-server; version: 1.0.0; for posthog/wizard",
+                "posthog/wizard; version: 2.45.0; program: web-analytics-doctor",
+                False,
+            ),
+            # A stray marker with no wizard token anywhere must not qualify.
+            ("marker_without_wizard", "some-agent/1.0; program: self-driving", None, False),
+            ("no_signals", "some-random-agent/1.0", None, False),
+        ]
+    )
+    def test_is_wizard_self_driving_program(self, _name, user_agent, mcp_user_agent, expected):
+        factory = APIRequestFactory()
+        kwargs = {"HTTP_USER_AGENT": user_agent}
+        if mcp_user_agent is not None:
+            kwargs["HTTP_X_POSTHOG_MCP_USER_AGENT"] = mcp_user_agent
+        request = factory.get("/fake", **kwargs)
+        assert is_wizard_self_driving_program(request) is expected
 
 
 class TestGetMcpProperties(BaseTest):

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -510,6 +510,52 @@ class TestExternalDataSource(APIBaseTest):
         source = ExternalDataSource.objects.get(id=response.json()["id"])
         assert source.created_via == expected_created_via
 
+    @parameterized.expand(
+        [
+            # The MCP server overwrites User-Agent with its own token and forwards the wizard's real
+            # UA in X-Posthog-Mcp-User-Agent. The self-driving marker lives there, not on User-Agent.
+            (
+                "self_driving_marker_in_mcp_header",
+                "posthog/wizard; version: 2.45.0; program: self-driving-setup",
+                ExternalDataSource.CreatedVia.SELF_DRIVING,
+            ),
+            # Same proxy shape, plain wizard run: stays wizard, not self_driving.
+            (
+                "plain_wizard_no_marker",
+                "posthog/wizard; version: 2.45.0",
+                ExternalDataSource.CreatedVia.WIZARD,
+            ),
+        ]
+    )
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_self_driving_via_proxied_mcp_user_agent(
+        self, _name, mcp_user_agent, expected_created_via, _mock_validate
+    ):
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/",
+            data={
+                "source_type": "Stripe",
+                "created_via": ExternalDataSource.CreatedVia.MCP,
+                "payload": {
+                    "auth_method": {"selection": "api_key", "stripe_secret_key": "sk_test_123"},
+                    "schemas": [
+                        {"name": STRIPE_CUSTOMER_RESOURCE_NAME, "should_sync": True, "sync_type": "full_refresh"},
+                    ],
+                },
+            },
+            headers={
+                "user-agent": "posthog/mcp-server; version: 1.0.0; for posthog/wizard",
+                "x-posthog-mcp-user-agent": mcp_user_agent,
+            },
+        )
+
+        assert response.status_code == 201, response.json()
+        source = ExternalDataSource.objects.get(id=response.json()["id"])
+        assert source.created_via == expected_created_via
+
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
         return_value=(True, None),


### PR DESCRIPTION
## Problem

The dashboard tracking data warehouse sources by `created_via` shows zero `self_driving` sources, even though the wizard's self-driving onboarding program has been connecting sources since v2.44.0.

`self_driving` is derived server-side: the wizard tags its user-agent with a `program: self-driving` marker, and `is_wizard_self_driving_program` looks for it to distinguish self-driving runs from plain wizard setups. The problem is that only inspects the `User-Agent` header.

When a self-driving run connects a source, it goes wizard → PostHog MCP server → our API. The MCP server overwrites `User-Agent` with its own token (`posthog/mcp-server; ...; for posthog/wizard`) and forwards the wizard's real UA — marker included — in the separate `X-Posthog-Mcp-User-Agent` header. So the marker never appeared in the header we were checking, the function always returned `False`, and every self-driving source landed as plain `wizard`.

I confirmed this against production logs: real traffic (wizard v2.45.0) arrives as `http_user_agent: "posthog/mcp-server; version: 1.0.0; for posthog/wizard"` with `mcp_user_agent: "posthog/wizard; version: 2.45.0; program: self-driving-setup"`. The marker is there, just in the header the detection ignored.

For contrast, the PostHog Code path already works because its signal (`for posthog/code`) rides on the `User-Agent` the MCP server does forward — `get_event_source` picks it up directly. The wizard path is the only one that depends on the `program:` marker, which the proxy moves to a different header.

## Changes

`is_wizard_self_driving_program` now inspects both `User-Agent` and `X-Posthog-Mcp-User-Agent`, so the marker is found whether the wizard calls the API directly or via the MCP server.

> [!NOTE]
> This only changes attribution (`created_via`). No behavior or access changes. Even with the fix, expect data to trickle in until self-driving adoption grows — only a handful of runs appear in the logs so far.

## How did you test this code?

Automated tests I (Claude, agent-assisted) added and ran:

- `posthog/test/test_event_usage.py::TestIsWizardSelfDrivingProgram` — 8 parameterized cases. The key regression: the proxied case where the marker is only in `X-Posthog-Mcp-User-Agent` while `User-Agent` is the MCP server's own token. Also covers direct-with/without-marker, a wrong-program value, and guards (a stray marker with no wizard token, and no signals at all). **Ran locally: 8 passed.**
- `test_external_data_source.py::...self_driving_via_proxied_mcp_user_agent` — end-to-end at the DRF layer: a `created_via=mcp` POST with the proxied `mcp-server` User-Agent plus `program: self-driving-setup` in `X-Posthog-Mcp-User-Agent` resolves to `self_driving`, and a plain proxied wizard run stays `wizard`.

I could not run the DRF endpoint test locally — this checkout's venv is Python 3.12 and master needs 3.13, which fails collection in an unrelated temporal conftest (`typing.AsyncGenerator`). It mirrors the existing passing `..._transport_user_agent_upgrades_mcp_created_via` test and runs in CI on 3.13.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom noticed the empty `self_driving` column on the sources dashboard and asked me (Claude) to find out why. I traced it from the insight query → the backend attribution logic → the wizard repo (confirming it does emit `program: self-driving-setup` since v2.44.0) → production Loki logs, which showed the marker arriving in `X-Posthog-Mcp-User-Agent` rather than `User-Agent`. That pinned the bug to the header the detection function reads.

I considered widening `get_event_source` instead, but the wizard-vs-self-driving distinction is specifically the `program:` marker, so the fix belongs in `is_wizard_self_driving_program`. Kept the existing `posthog/wizard` guard by checking it across the combined header text.

No skills were needed for the fix itself.
