### PR TITLE
chore(data-warehouse): narrow warehouse_sources contract-check inputs

### DIFF
--- a/products/warehouse_sources/turbo.json
+++ b/products/warehouse_sources/turbo.json
@@ -13,7 +13,18 @@
                 "backend/temporal/data_imports/sources/redshift/**",
                 "backend/temporal/data_imports/sources/salesforce/**",
                 "backend/temporal/data_imports/sources/snowflake/**",
-                "backend/temporal/data_imports/sources/stripe/**"
+                "backend/temporal/data_imports/sources/stripe/**",
+                "!backend/temporal/data_imports/sources/common/rest_source/**",
+                "!backend/temporal/data_imports/sources/common/test/**",
+                "!backend/temporal/data_imports/sources/common/sql/tests/**",
+                "!backend/temporal/data_imports/sources/google_search_console/tests/**",
+                "!backend/temporal/data_imports/sources/mysql/tests/**",
+                "!backend/temporal/data_imports/sources/postgres/cdc/tests/**",
+                "!backend/temporal/data_imports/sources/postgres/test_postgres.py",
+                "!backend/temporal/data_imports/sources/redshift/tests/**",
+                "!backend/temporal/data_imports/sources/salesforce/test/**",
+                "!backend/temporal/data_imports/sources/snowflake/tests/**",
+                "!backend/temporal/data_imports/sources/stripe/tests/**"
             ],
             "outputs": [],
             "cache": true


### PR DESCRIPTION
## Problem

PRs that only touch internal warehouse_sources code — the `rest_source` framework or test files that happen to live inside contract-input globs — trigger the full Django CI matrix (~38 sharded jobs) plus the tach.toml dependent-product cascade, because `products/warehouse_sources/turbo.json` counts them as contract-surface changes. Example: #71481 changed only `sources/common/rest_source/**` and test files, yet ran the entire backend suite.

An audit of the actual cross-product import surface shows:

- `common/rest_source/**` is never imported by production code outside warehouse_sources, and the facade re-exports nothing from it. The only external reference is a set of `mock.patch` target strings in data_warehouse's `test_external_data_source.py` — the same accepted exposure class as `sources/custom` (which has never been a contract input, with the same patch-string coupling).
- The test directories inside contract globs (`common/test/`, `common/sql/tests/`, per-vendor `tests/` dirs, `postgres/test_postgres.py`) exercise no external contract; they already run in the product's own `backend:test` job on every warehouse_sources change.

## Changes

Adds negated globs to `backend:contract-check` inputs in `products/warehouse_sources/turbo.json`, excluding `common/rest_source/**` and the test dirs/files inside the remaining contract globs. All positive globs are unchanged, so the genuinely core-coupled surface (facade, models, `generated_configs.py`, the permanent-interface vendor sources) still re-runs the full suite.

Deliberately kept in the contract: `common/test_mixins.py` and `common/test_source_schema.py` (shared test helpers re-exported via `facade/testing.py` to other products' tests) and `common/http/**` (prod consumer in conversations' Zendesk import). `common/grpc/**` has no external consumers today and is a candidate for a future exclusion.

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_ci_core_coupled_sources.py` — the guard that maps Core-consumed facade re-exports to covered vendors passes; its parser ignores negated inputs, so the covered vendor set is unchanged.
- `bin/hogli product:lint warehouse_sources` — all checks pass, including IsolationChainCheck (permanent-interface module coverage is computed from non-negated inputs only).
- Affectedness proofs, running `.github/scripts/turbo-discover.js` exactly as CI does against scratch commits:
  - change only `common/rest_source/rest_client.py` → `backend:contract-check` not affected, `run_legacy: false`, matrix = warehouse-sources shards only
  - change only `stripe/tests/test_stripe.py` → same skip
  - control: change `postgres/source.py` → `run_legacy: true` with the full dependent cascade, unchanged from today

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior changes; CI-internal configuration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session auditing why warehouse_sources PRs fan out to full CI. The audit mapped every external import of the contract globs (facade re-export targets, direct prod imports, test-only references) before deciding what to exclude; the alternative of physically moving test files out of the globs was rejected in favor of turbo input negations since both CI guards (`test_ci_core_coupled_sources.py`, IsolationChainCheck) explicitly ignore negated globs and file moves would risk pytest namespace issues. JSONC comments in the product turbo.json were tried and reverted — the guard test parses it with strict `json.loads`.

A follow-up PR splits `generated_configs.py` into a per-source package so new-source implementation PRs (which regenerate that file) also stop triggering the full matrix.