### PR TITLE
refactor(data-warehouse): migrate hibob, hubplanner, humanitix, incident_io, insightly, invoiced, iterable (batch 22)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/hibob.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/hibob.py
@@ -1,30 +1,17 @@
-from collections.abc import Iterator
 from typing import Any
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.settings import HIBOB_ENDPOINTS
 
 HIBOB_BASE_URL = "https://api.hibob.com"
-REQUEST_TIMEOUT_SECONDS = 120
-# Rate limits are per endpoint (people/search is 50 req/min); 429s carry
-# X-RateLimit headers but exponential backoff is sufficient. Repeated 401/403s
-# trigger a 5-minute WAF block, so auth errors must never be retried.
-MAX_RETRY_ATTEMPTS = 5
-
-
-class HiBobRetryableError(Exception):
-    pass
-
-
-def _get_session(service_user_id: str, service_user_token: str) -> requests.Session:
-    session = make_tracked_session(redact_values=(service_user_token,))
-    session.auth = (service_user_id, service_user_token)
-    return session
 
 
 def validate_credentials(service_user_id: str, service_user_token: str) -> tuple[bool, str | None]:
@@ -33,7 +20,8 @@ def validate_credentials(service_user_id: str, service_user_token: str) -> tuple
     Service users need explicit per-category permission grants (403); only 401
     means the credentials themselves are bad. Transport failures surface their
     real reason rather than masquerading as an auth error."""
-    session = _get_session(service_user_id, service_user_token)
+    session = make_tracked_session(redact_values=(service_user_token,))
+    session.auth = (service_user_id, service_user_token)
     try:
         response = session.get(f"{HIBOB_BASE_URL}/v1/tasks", timeout=10)
         if response.status_code == 401:
@@ -45,63 +33,48 @@ def validate_credentials(service_user_id: str, service_user_token: str) -> tuple
         session.close()
 
 
-def get_rows(
-    service_user_id: str,
-    service_user_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = HIBOB_ENDPOINTS[endpoint]
-    session = _get_session(service_user_id, service_user_token)
-    url = f"{HIBOB_BASE_URL}{config.path}"
-
-    @retry(
-        retry=retry_if_exception_type((HiBobRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=2, max=90),
-        reraise=True,
-    )
-    def fetch() -> dict[str, Any]:
-        if config.method == "POST":
-            response = session.post(url, json=config.body or {}, timeout=REQUEST_TIMEOUT_SECONDS)
-        else:
-            response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise HiBobRetryableError(f"HiBob API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"HiBob API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    # Both shipped endpoints return their full result set in one response.
-    try:
-        data = fetch()
-        items = data.get(config.data_key, []) or []
-        if items:
-            yield items
-    finally:
-        session.close()
-
-
 def hibob_source(
     service_user_id: str,
     service_user_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     config = HIBOB_ENDPOINTS[endpoint]
 
+    # Basic auth carries the token; supplying it via the framework auth config redacts the
+    # token from any raised error. Repeated 401/403s trip HiBob's WAF, so auth errors must
+    # fail loud (raise_for_status) rather than retry — the client only retries 429/5xx.
+    api_endpoint: dict[str, Any] = {
+        "path": config.path,
+        "method": config.method,
+        # A missing data key is a legit "no rows" answer (not a shape error), so the selector
+        # stays optional — an absent key yields an empty page, matching the old behaviour.
+        "data_selector": config.data_key,
+    }
+    if config.body is not None:
+        api_endpoint["json"] = config.body
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": HIBOB_BASE_URL,
+            "auth": {"type": "http_basic", "username": service_user_id, "password": service_user_token},
+            # Both shipped endpoints return their full result set in one response.
+            "paginator": SinglePagePaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": api_endpoint,
+            }
+        ],
+    }
+
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            service_user_id=service_user_id,
-            service_user_token=service_user_token,
-            endpoint=endpoint,
-            logger=logger,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/settings.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Literal, Optional
 
+from products.warehouse_sources.backend.types import IncrementalField
+
 
 @dataclass
 class HiBobEndpointConfig:
@@ -36,3 +38,6 @@ HIBOB_ENDPOINTS: dict[str, HiBobEndpointConfig] = {
 }
 
 ENDPOINTS = tuple(HIBOB_ENDPOINTS.keys())
+
+# No endpoint carries a usable updated-at watermark, so every stream is full refresh.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/source.py
@@ -18,13 +18,19 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import HiBobSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob import (
     hibob_source,
     validate_credentials as validate_hibob_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
@@ -100,21 +106,7 @@ Create a Service User in Bob under Settings > Integrations > Automation > Servic
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # HiBob has no updated-at filters; every stream is full refresh.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: HiBobSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -126,5 +118,6 @@ Create a Service User in Bob under Settings > Integrations > Automation > Servic
             service_user_id=config.service_user_id,
             service_user_token=config.service_user_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/tests/test_hibob.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/tests/test_hibob.py
@@ -1,22 +1,156 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob import (
-    get_rows,
     hibob_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.settings import ENDPOINTS, HIBOB_ENDPOINTS
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the hibob module.
+HIBOB_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session"
+)
 
-def _response(body: dict[str, Any]) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = body
-    resp.status_code = 200
-    resp.ok = True
+
+def _response(body: Any, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://api.hibob.com/probe"
     return resp
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session, snapshotting each request (method/url/json/auth) AT SEND TIME."""
+    session.headers = {}
+    captured: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        captured.append(
+            {
+                "method": request.method,
+                "url": request.url,
+                "params": dict(request.params or {}),
+                "json": request.json,
+                "auth": request.auth,
+            }
+        )
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return captured
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestGetRows:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_employees_uses_post_for_read_with_body(self, MockSession) -> None:
+        session = MockSession.return_value
+        captured = _wire(session, [_response({"employees": [{"id": "1"}]})])
+
+        rows = _rows(hibob_source("service-id", "token", "employees", team_id=1, job_id="j"))
+
+        assert rows == [{"id": "1"}]
+        assert session.send.call_count == 1
+        assert captured[0]["method"] == "POST"
+        assert captured[0]["url"] == "https://api.hibob.com/v1/people/search"
+        assert captured[0]["json"] == {"showInactive": True, "humanReadable": "REPLACE"}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tasks_uses_get_with_no_body(self, MockSession) -> None:
+        session = MockSession.return_value
+        captured = _wire(session, [_response({"tasks": [{"id": 1}, {"id": 2}]})])
+
+        rows = _rows(hibob_source("service-id", "token", "tasks", team_id=1, job_id="j"))
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert captured[0]["method"] == "GET"
+        assert captured[0]["url"] == "https://api.hibob.com/v1/tasks"
+        assert captured[0]["json"] is None
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_basic_auth_carries_service_user_credentials(self, MockSession) -> None:
+        session = MockSession.return_value
+        captured = _wire(session, [_response({"tasks": []})])
+
+        _rows(hibob_source("service-id", "token", "tasks", team_id=1, job_id="j"))
+
+        auth = captured[0]["auth"]
+        assert (auth.username, auth.password) == ("service-id", "token")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_request_no_pagination(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"employees": [{"id": "1"}]})])
+
+        _rows(hibob_source("service-id", "token", "employees", team_id=1, job_id="j"))
+
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"employees": []})])
+
+        assert _rows(hibob_source("service-id", "token", "employees", team_id=1, job_id="j")) == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"unexpected": "shape"})])
+
+        # A missing data key is a valid "no rows" answer here (not fail-loud), matching the old source.
+        assert _rows(hibob_source("service-id", "token", "employees", team_id=1, job_id="j")) == []
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_then_succeeds_on_rate_limit(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        # 429 is retryable; the client re-issues and eventually returns the rows.
+        _wire(session, [_response({}, status=429), _response({"tasks": [{"id": 1}]})])
+
+        rows = _rows(hibob_source("service-id", "token", "tasks", team_id=1, job_id="j"))
+
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 2
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_error_is_not_retried_and_raises(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        # 401 trips HiBob's WAF on repeat, so it must fail loud without retrying.
+        _wire(session, [_response({"error": "unauthorized"}, status=401)])
+
+        with pytest.raises(Exception):
+            _rows(hibob_source("service-id", "token", "tasks", team_id=1, job_id="j"))
+
+        assert session.send.call_count == 1
+
+
+class TestHiBobSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata_per_endpoint(self, MockSession, endpoint) -> None:
+        config = HIBOB_ENDPOINTS[endpoint]
+        response = hibob_source("service-id", "token", endpoint, team_id=1, job_id="j")
+
+        assert response.name == endpoint
+        assert response.primary_keys == [config.primary_key]
+        assert response.sort_mode == "asc"
+        assert response.partition_mode is None
+        assert response.partition_keys is None
 
 
 class TestValidateCredentials:
@@ -29,7 +163,7 @@ class TestValidateCredentials:
             (401, False, "Invalid HiBob Service User credentials"),
         ],
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    @mock.patch(HIBOB_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected_valid, expected_error):
         response = mock.MagicMock()
         response.status_code = status_code
@@ -37,65 +171,15 @@ class TestValidateCredentials:
 
         assert validate_credentials("service-id", "token") == (expected_valid, expected_error)
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_validate_credentials_surfaces_transport_errors(self, mock_session):
-        mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("service-id", "token") == (False, "boom")
+    @mock.patch(HIBOB_SESSION_PATCH)
+    def test_validate_credentials_uses_basic_auth(self, mock_session):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
-
-class TestGetRows:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_employees_uses_post_for_read_with_body(self, mock_session):
-        mock_session.return_value.post.return_value = _response({"employees": [{"id": "1"}]})
-
-        batches = list(get_rows("service-id", "token", "employees", mock.MagicMock()))
-
-        assert batches == [[{"id": "1"}]]
-        mock_session.return_value.post.assert_called_once()
-        call = mock_session.return_value.post.call_args
-        assert call.args[0] == "https://api.hibob.com/v1/people/search"
-        assert call.kwargs["json"] == {"showInactive": True, "humanReadable": "REPLACE"}
-        mock_session.return_value.get.assert_not_called()
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_tasks_uses_get(self, mock_session):
-        mock_session.return_value.get.return_value = _response({"tasks": [{"id": 1}, {"id": 2}]})
-
-        batches = list(get_rows("service-id", "token", "tasks", mock.MagicMock()))
-
-        assert batches == [[{"id": 1}, {"id": 2}]]
-        mock_session.return_value.get.assert_called_once_with("https://api.hibob.com/v1/tasks", timeout=mock.ANY)
-        mock_session.return_value.post.assert_not_called()
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_session_uses_basic_auth(self, mock_session):
-        mock_session.return_value.get.return_value = _response({"tasks": []})
-
-        list(get_rows("service-id", "token", "tasks", mock.MagicMock()))
+        validate_credentials("service-id", "token")
 
         assert mock_session.return_value.auth == ("service-id", "token")
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_empty_response_yields_nothing(self, mock_session):
-        mock_session.return_value.post.return_value = _response({"employees": []})
-
-        assert list(get_rows("service-id", "token", "employees", mock.MagicMock())) == []
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_missing_data_key_yields_nothing(self, mock_session):
-        mock_session.return_value.post.return_value = _response({"unexpected": "shape"})
-
-        assert list(get_rows("service-id", "token", "employees", mock.MagicMock())) == []
-
-
-class TestHiBobSourceResponse:
-    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
-        config = HIBOB_ENDPOINTS[endpoint]
-        response = hibob_source("service-id", "token", endpoint, mock.MagicMock())
-
-        assert response.name == endpoint
-        assert response.primary_keys == [config.primary_key]
-        assert response.sort_mode == "asc"
-        assert response.partition_mode is None
-        assert response.partition_keys is None
+    @mock.patch(HIBOB_SESSION_PATCH)
+    def test_validate_credentials_surfaces_transport_errors(self, mock_session):
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("service-id", "token") == (False, "boom")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubplanner/hubplanner.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubplanner/hubplanner.py
@@ -1,17 +1,19 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
-import orjson
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner.settings import (
     HUBPLANNER_ENDPOINTS,
     HubPlannerEndpointConfig,
@@ -24,15 +26,59 @@ HUBPLANNER_BASE_URL = "https://api.hubplanner.com/v1"
 PAGE_SIZE = 1000
 
 
-class HubPlannerRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class HubPlannerResumeConfig:
     # Next 0-indexed page to fetch. Pagination is page-number based, so the page index is the
     # only cursor we need to persist to resume mid-endpoint after a heartbeat timeout.
     page: int = 0
+
+
+class HubPlannerPagePaginator(BasePaginator):
+    """Page-number paginator that terminates on a short page.
+
+    Hub Planner's list/search endpoints have no next-page token; the last page is the one
+    returning fewer rows than the requested limit. The built-in ``PageNumberPaginator`` only
+    stops on a fully empty page (costing one extra request), so we keep the exact short-page
+    stop here.
+    """
+
+    def __init__(self, page_size: int, page_param: str = "page", base_page: int = 0) -> None:
+        super().__init__()
+        self.page_size = page_size
+        self.page_param = page_param
+        self.page = base_page
+
+    def _inject_page(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params[self.page_param] = self.page
+
+    def init_request(self, request: Request) -> None:
+        self._inject_page(request)
+
+    def update_state(self, response: Any, data: Optional[list[Any]] = None) -> None:
+        # A short page (fewer rows than the limit) — including an empty page — is the last page.
+        if data is None or len(data) < self.page_size:
+            self._has_next_page = False
+            return
+        self.page += 1
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        self._inject_page(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page points at the next page to fetch once update_state has advanced it.
+        return {"page": self.page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"HubPlannerPagePaginator(page={self.page})"
 
 
 def _format_value(value: Any) -> str:
@@ -49,75 +95,34 @@ def _format_value(value: Any) -> str:
     return str(value)
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    # Despite Hub Planner's docs calling this an "OAuth 2.0 Bearer Token", the API key is placed
-    # raw in the Authorization header with no `Bearer ` prefix (verified against the live API).
-    return {
-        "Authorization": api_key,
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-    }
-
-
 def _build_url(base_url: str, params: dict[str, Any]) -> str:
     if not params:
         return base_url
     return f"{base_url}?{urlencode(params)}"
 
 
+def _probe_headers(api_key: str) -> dict[str, str]:
+    # Despite Hub Planner's docs calling this an "OAuth 2.0 Bearer Token", the API key is placed
+    # raw in the Authorization header with no `Bearer ` prefix (verified against the live API).
+    return {"Authorization": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+
+
+def _non_secret_headers() -> dict[str, str]:
+    # Auth (the raw API key on the Authorization header) is supplied via the framework auth config
+    # so its value is redacted from logs and error messages; only these non-secret headers are set.
+    return {"Content-Type": "application/json", "Accept": "application/json"}
+
+
 def validate_credentials(api_key: str) -> bool:
     # One cheap probe: list a single project. A valid key returns 200; an invalid or
     # insufficiently-permissioned key returns 403 (Hub Planner keys are account-wide, not
     # per-resource scoped, so a reachable /project confirms the whole token).
-    url = _build_url(f"{HUBPLANNER_BASE_URL}/project", {"page": 0, "limit": 1})
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            HubPlannerRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    # Hub Planner returns 429 with a Retry-After header on burst (50 req / 5s) or daily
-    # (6000/day) limits; exponential jitter keeps us comfortably under both without parsing it.
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    method: str,
-    url: str,
-    headers: dict[str, str],
-    body: Optional[dict[str, Any]],
-    logger: FilteringBoundLogger,
-) -> list[dict[str, Any]]:
-    data = orjson.dumps(body) if body is not None else None
-    response = session.request(method, url, headers=headers, data=data, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise HubPlannerRetryableError(f"Hub Planner API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        # Never log the response body: Hub Planner echoes the supplied API key back in auth-error
-        # bodies, so logging it would leak the credential.
-        logger.error(f"Hub Planner API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
-
-    payload = response.json()
-    # Every list/search endpoint returns a bare JSON array; guard against an unexpected object.
-    if not isinstance(payload, list):
-        logger.warning(f"Hub Planner: expected a list response, got {type(payload).__name__} from url={url}")
-        return []
-    return payload
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        _build_url(f"{HUBPLANNER_BASE_URL}/project", {"page": 0, "limit": 1}),
+        headers=_probe_headers(api_key),
+    )
+    return ok
 
 
 def _build_request_plan(
@@ -151,68 +156,82 @@ def _build_request_plan(
     return "GET", config.path, None, None
 
 
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[HubPlannerResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = HUBPLANNER_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    method, path, body, sort_field = _build_request_plan(
-        config, should_use_incremental_field, db_incremental_field_last_value
-    )
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume else 0
-
-    while True:
-        params: dict[str, Any] = {"page": page, "limit": PAGE_SIZE}
-        if sort_field:
-            params["sort"] = sort_field
-        url = _build_url(f"{HUBPLANNER_BASE_URL}{path}", params)
-
-        items = _fetch_page(session, method, url, headers, body, logger)
-
-        if items:
-            yield items
-
-        # A short page (fewer rows than requested) is the last page — the API has no next-page
-        # token, so we page until the server returns less than the limit.
-        if len(items) < PAGE_SIZE:
-            break
-
-        page += 1
-        # Save AFTER yielding so a crash re-yields the last page rather than skipping it; the
-        # delta merge dedupes the re-pulled rows on the primary key.
-        resumable_source_manager.save_state(HubPlannerResumeConfig(page=page))
-
-
 def hubplanner_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[HubPlannerResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = HUBPLANNER_ENDPOINTS[endpoint]
 
+    method, path, body, sort_field = _build_request_plan(
+        config, should_use_incremental_field, db_incremental_field_last_value
+    )
+
+    # `page` is injected per request by the paginator; `limit` and `sort` are static query params.
+    params: dict[str, Any] = {"limit": PAGE_SIZE}
+    if sort_field:
+        params["sort"] = sort_field
+
+    endpoint_config: dict[str, Any] = {
+        "path": path,
+        "method": method,
+        "params": params,
+        "paginator": HubPlannerPagePaginator(page_size=PAGE_SIZE),
+        # Every list/search endpoint returns a bare JSON array; a non-list body means the
+        # response shape changed — fail loud rather than syncing a stray object as a row.
+        "data_selector_required": True,
+    }
+    # Only search (POST) requests carry a JSON body — an empty {} for a full search, or the
+    # incremental `$gte` filter. Full-refresh GETs send no body at all.
+    if body is not None:
+        endpoint_config["json"] = body
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": HUBPLANNER_BASE_URL,
+            "headers": _non_secret_headers(),
+            # Raw API key on the Authorization header (no Bearer prefix); redacted from logs/errors.
+            "auth": {"type": "api_key", "api_key": api_key, "name": "Authorization", "location": "header"},
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": endpoint_config,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(HubPlannerResumeConfig(page=int(state["page"])))
+
+    # We inject the incremental filter into the POST body ourselves (Hub Planner uses a Mongo-style
+    # `$gte` operator, not a flat query param), so the framework's server-side param injection is
+    # unused here — pass None for its incremental value.
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -220,4 +239,5 @@ def hubplanner_source(
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubplanner/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubplanner/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import HubplannerSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner.hubplanner import (
     HubPlannerResumeConfig,
@@ -28,7 +31,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner.settings import (
     ENDPOINTS,
-    HUBPLANNER_ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -92,22 +94,10 @@ Generate a **Read Only** API key in Hub Planner under **Settings → API** (admi
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = HUBPLANNER_ENDPOINTS[endpoint]
-            has_incremental = endpoint_config.incremental_search_field is not None
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=has_incremental,
-                supports_append=has_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Only bookings and time_entries carry a searchable `updatedDate`, so they're the only
+        # endpoints with incremental fields — build_endpoint_schemas derives incremental/append
+        # support from that (has_incremental == incremental_search_field is not None).
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: HubplannerSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -129,7 +119,8 @@ Generate a **Read Only** API key in Hub Planner under **Settings → API** (admi
         return hubplanner_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubplanner/tests/test_hubplanner.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubplanner/tests/test_hubplanner.py
@@ -1,24 +1,76 @@
+import json
 from datetime import UTC, date, datetime
-from typing import Any, Optional
+from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import HTTPError, PreparedRequest, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner import hubplanner
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner.hubplanner import (
     PAGE_SIZE,
     HubPlannerResumeConfig,
     _build_request_plan,
     _format_value,
-    _get_headers,
-    get_rows,
     hubplanner_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner.settings import HUBPLANNER_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the hubplanner module.
+HUBPLANNER_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.hubplanner.hubplanner.make_tracked_session"
+)
+
+
+def _response(items: list[dict[str, Any]] | Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(items).encode()
+    return resp
+
+
+def _make_manager(resume_state: HubPlannerResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's method/url/params/json/auth AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so a copy is snapshotted
+    when each request is prepared rather than inspected after the run.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append(
+            {
+                "method": request.method,
+                "url": request.url,
+                "params": dict(request.params or {}),
+                "json": request.json,
+                "auth": request.auth,
+            }
+        )
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatValue:
@@ -41,15 +93,6 @@ class TestFormatValue:
     def test_datetime_has_no_plus_zero_offset(self) -> None:
         # Hub Planner expects a Z suffix, not the +00:00 offset isoformat() produces.
         assert "+00:00" not in _format_value(datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC))
-
-
-class TestHeaders:
-    def test_authorization_header_is_raw_key_without_bearer_prefix(self) -> None:
-        headers = _get_headers("my-secret-key")
-        assert headers["Authorization"] == "my-secret-key"
-        assert "Bearer" not in headers["Authorization"]
-        assert headers["Content-Type"] == "application/json"
-        assert headers["Accept"] == "application/json"
 
 
 class TestBuildRequestPlan:
@@ -95,204 +138,193 @@ class TestBuildRequestPlan:
         assert (method, path, body, sort_field) == ("POST", "/milestone/search", {}, None)
 
 
-class _FakeResumableManager:
-    def __init__(self, state: Optional[HubPlannerResumeConfig] = None) -> None:
-        self._state = state
-        self.saved: list[HubPlannerResumeConfig] = []
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_terminates_without_saving_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"_id": "1"}, {"_id": "2"}])])
 
-    def can_resume(self) -> bool:
-        return self._state is not None
+        manager = _make_manager()
+        rows = _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=manager))
 
-    def load_state(self) -> Optional[HubPlannerResumeConfig]:
-        return self._state
-
-    def save_state(self, data: HubPlannerResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class TestGetRows:
-    @staticmethod
-    def _run(manager: _FakeResumableManager, pages: list[list[dict]], **kwargs: Any) -> tuple[list[list[dict]], list]:
-        calls: list[dict[str, Any]] = []
-
-        def fake_fetch(session: Any, method: str, url: str, headers: dict, body: Any, logger: Any) -> list[dict]:
-            calls.append({"method": method, "url": url, "body": body})
-            return pages[len(calls) - 1]
-
-        with (
-            patch.object(hubplanner, "_fetch_page", fake_fetch),
-            patch.object(hubplanner, "make_tracked_session", return_value=MagicMock()),
-        ):
-            batches = list(
-                get_rows(
-                    api_key="k",
-                    endpoint=kwargs.pop("endpoint", "projects"),
-                    logger=MagicMock(),
-                    resumable_source_manager=manager,  # type: ignore[arg-type]
-                    **kwargs,
-                )
-            )
-        return batches, calls
-
-    def test_single_short_page_terminates_without_saving_state(self) -> None:
-        manager = _FakeResumableManager()
-        batches, calls = self._run(manager, pages=[[{"_id": "1"}, {"_id": "2"}]])
-
-        assert batches == [[{"_id": "1"}, {"_id": "2"}]]
-        assert len(calls) == 1
+        assert [r["_id"] for r in rows] == ["1", "2"]
+        assert session.send.call_count == 1
         # A short first page is the last page, so there's no next page to checkpoint.
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_paginates_until_short_page_and_saves_state_after_each_full_page(self) -> None:
-        manager = _FakeResumableManager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page_and_saves_state_after_each_full_page(self, MockSession) -> None:
+        session = MockSession.return_value
         full_page = [{"_id": str(i)} for i in range(PAGE_SIZE)]
         short_page = [{"_id": "last"}]
-        batches, calls = self._run(manager, pages=[full_page, short_page])
+        snaps = _wire(session, [_response(full_page), _response(short_page)])
 
-        assert batches == [full_page, short_page]
-        assert [c["url"].split("page=")[1].split("&")[0] for c in calls] == ["0", "1"]
+        manager = _make_manager()
+        rows = _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert len(rows) == PAGE_SIZE + 1
+        assert [s["params"]["page"] for s in snaps] == [0, 1]
+        assert [s["params"]["limit"] for s in snaps] == [PAGE_SIZE, PAGE_SIZE]
         # State saved once after the first (full) page points at page 1; the short page ends the loop.
-        assert manager.saved == [HubPlannerResumeConfig(page=1)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == HubPlannerResumeConfig(page=1)
 
-    def test_resumes_from_saved_page(self) -> None:
-        manager = _FakeResumableManager(state=HubPlannerResumeConfig(page=3))
-        _batches, calls = self._run(manager, pages=[[{"_id": "x"}]])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response([{"_id": "x"}])])
 
-        assert calls[0]["url"].split("page=")[1].split("&")[0] == "3"
+        manager = _make_manager(HubPlannerResumeConfig(page=3))
+        _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=manager))
 
-    def test_empty_first_page_yields_nothing(self) -> None:
-        manager = _FakeResumableManager()
-        batches, calls = self._run(manager, pages=[[]])
-        assert batches == []
-        assert len(calls) == 1
+        assert snaps[0]["params"]["page"] == 3
 
-    def test_incremental_sync_posts_search_body(self) -> None:
-        manager = _FakeResumableManager()
-        _batches, calls = self._run(
-            manager,
-            pages=[[{"_id": "1"}]],
-            endpoint="bookings",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_sync_posts_search_body(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response([{"_id": "1"}])])
+
+        manager = _make_manager()
+        _rows(
+            hubplanner_source(
+                "k",
+                "bookings",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
         )
-        assert calls[0]["method"] == "POST"
-        assert "/booking/search" in calls[0]["url"]
-        assert calls[0]["body"] == {"updatedDate": {"$gte": "2026-03-04T00:00:00.000Z"}}
+
+        assert snaps[0]["method"] == "POST"
+        assert snaps[0]["url"].endswith("/booking/search")
+        assert snaps[0]["json"] == {"updatedDate": {"$gte": "2026-03-04T00:00:00.000Z"}}
+        assert snaps[0]["params"]["sort"] == "updatedDate"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_get_sends_no_body_and_no_sort(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response([{"_id": "1"}])])
+
+        _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+
+        assert snaps[0]["method"] == "GET"
+        assert snaps[0]["json"] is None
+        assert "sort" not in snaps[0]["params"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_response_fails_loud(self, MockSession) -> None:
+        # Every list/search endpoint returns a bare JSON array; a stray object means the response
+        # shape changed, so fail loud rather than syncing a garbage row.
+        session = MockSession.return_value
+        _wire(session, [_response({"message": "unexpected"})])
+
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
 
-class TestFetchPage:
+class TestAuth:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_authorization_header_is_raw_key_without_bearer_prefix(self, MockSession) -> None:
+        # The API key rides raw on the Authorization header (Hub Planner uses no Bearer prefix).
+        session = MockSession.return_value
+        snaps = _wire(session, [_response([{"_id": "1"}])])
+
+        _rows(
+            hubplanner_source(
+                "my-secret-key", "projects", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+            )
+        )
+
+        prepared = PreparedRequest()
+        prepared.headers = {}
+        snaps[0]["auth"](prepared)
+        assert prepared.headers["Authorization"] == "my-secret-key"
+        assert "Bearer" not in prepared.headers["Authorization"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_session_built_with_api_key_redacted(self, MockSession) -> None:
+        # The tracked session must be given the key as a redact value — Hub Planner echoes it back
+        # in auth-error bodies, so it could otherwise leak into captured samples.
+        _wire(MockSession.return_value, [_response([{"_id": "1"}])])
+
+        _rows(
+            hubplanner_source(
+                "my-secret-key", "projects", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+            )
+        )
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("my-secret-key",)
+
+
+class TestErrorHandling:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_status_raises_retryable_error(self, _name: str, status_code: int) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        session = MagicMock()
-        session.request.return_value = response
+    @mock.patch("tenacity.nap.time.sleep", lambda *_: None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_raises_retryable_error(self, _name: str, status_code: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], status_code=status_code) for _ in range(5)])
 
-        with patch.object(hubplanner._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(hubplanner.HubPlannerRetryableError):
-                hubplanner._fetch_page(session, "GET", "https://api.hubplanner.com/v1/project", {}, None, MagicMock())
+        with pytest.raises(RESTClientRetryableError):
+            _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
-        assert session.request.call_count == 5
+        assert session.send.call_count == 5
 
-    def test_bare_list_response_returned_as_is(self) -> None:
-        response = MagicMock()
-        response.status_code = 200
-        response.ok = True
-        response.json.return_value = [{"_id": "1"}, {"_id": "2"}]
-        session = MagicMock()
-        session.request.return_value = response
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_error_raises_http_error(self, MockSession) -> None:
+        # A 403 is non-retryable (get_non_retryable_errors maps it) and surfaces as an HTTPError.
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "OAUTH_ERROR_TOKEN_NOT_VALID"}, status_code=403)])
 
-        result = hubplanner._fetch_page(session, "GET", "https://api.hubplanner.com/v1/project", {}, None, MagicMock())
-        assert result == [{"_id": "1"}, {"_id": "2"}]
-
-    def test_non_list_response_returns_empty(self) -> None:
-        response = MagicMock()
-        response.status_code = 200
-        response.ok = True
-        response.json.return_value = {"message": "unexpected"}
-        session = MagicMock()
-        session.request.return_value = response
-
-        result = hubplanner._fetch_page(session, "GET", "https://api.hubplanner.com/v1/project", {}, None, MagicMock())
-        assert result == []
-
-    def test_auth_error_does_not_log_response_body(self) -> None:
-        # Hub Planner echoes the API key back in auth-error bodies; logging it would leak the secret.
-        response = requests.Response()
-        response.status_code = 403
-        response._content = b'{"error":"OAUTH_ERROR_TOKEN_NOT_VALID","authHeaders":"my-secret-key"}'
-        session = MagicMock()
-        session.request.return_value = response
-        logger = MagicMock()
-
-        with pytest.raises(requests.HTTPError):
-            hubplanner._fetch_page(session, "GET", "https://api.hubplanner.com/v1/project", {}, None, logger)
-
-        logged = " ".join(str(call) for call in logger.error.call_args_list)
-        assert "my-secret-key" not in logged
-        assert "OAUTH_ERROR_TOKEN_NOT_VALID" not in logged
+        with pytest.raises(HTTPError):
+            _rows(hubplanner_source("k", "projects", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
 
 class TestSourceResponse:
-    def test_partitioned_endpoint_sets_datetime_partitioning(self) -> None:
-        response = hubplanner_source(
-            api_key="k", endpoint="bookings", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_partitioned_endpoint_sets_datetime_partitioning(self, MockSession) -> None:
+        response = hubplanner_source("k", "bookings", team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.name == "bookings"
         assert response.primary_keys == ["_id"]
         assert response.partition_mode == "datetime"
         assert response.partition_keys == ["createdDate"]
         assert response.sort_mode == "asc"
 
-    def test_endpoint_without_partition_key_has_no_partitioning(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_endpoint_without_partition_key_has_no_partitioning(self, MockSession) -> None:
         # Vacations carry no creation timestamp, so they aren't partitioned.
-        response = hubplanner_source(
-            api_key="k", endpoint="vacations", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = hubplanner_source("k", "vacations", team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.partition_mode is None
         assert response.partition_keys is None
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("forbidden", 403, False), ("unauthorized", 401, False)])
-    def test_status_maps_to_validity(self, _name: str, status_code: int, expected: bool) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
+    @mock.patch(HUBPLANNER_SESSION_PATCH)
+    def test_status_maps_to_validity(self, _name: str, status_code: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("some-key") is expected
 
-        with patch.object(hubplanner, "make_tracked_session", return_value=session):
-            assert validate_credentials("some-key") is expected
+    @mock.patch(HUBPLANNER_SESSION_PATCH)
+    def test_network_error_is_invalid(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("some-key") is False
 
-    def test_network_error_is_invalid(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(hubplanner, "make_tracked_session", return_value=session):
-            assert validate_credentials("some-key") is False
-
-
-class TestApiKeyRedaction:
-    # Hub Planner echoes the API key back in auth-error bodies, so the tracked transport must be
-    # given the key as a redact value on every path — otherwise it can leak into captured samples.
-    def test_validate_credentials_redacts_api_key(self) -> None:
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=200)
-        with patch.object(hubplanner, "make_tracked_session", return_value=session) as factory:
-            validate_credentials("my-secret-key")
-        assert factory.call_args.kwargs["redact_values"] == ("my-secret-key",)
-
-    def test_get_rows_redacts_api_key(self) -> None:
-        with (
-            patch.object(hubplanner, "_fetch_page", return_value=[]),
-            patch.object(hubplanner, "make_tracked_session", return_value=MagicMock()) as factory,
-        ):
-            list(
-                get_rows(
-                    api_key="my-secret-key",
-                    endpoint="projects",
-                    logger=MagicMock(),
-                    resumable_source_manager=MagicMock(),
-                )
-            )
-        assert factory.call_args.kwargs["redact_values"] == ("my-secret-key",)
+    @mock.patch(HUBPLANNER_SESSION_PATCH)
+    def test_validate_credentials_redacts_api_key(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("my-secret-key")
+        assert mock_session.call_args.kwargs["redact_values"] == ("my-secret-key",)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/humanitix.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/humanitix.py
@@ -1,27 +1,25 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.settings import HUMANITIX_ENDPOINTS
 
 HUMANITIX_BASE_URL = "https://api.humanitix.com/v1"
 # The list endpoints accept pageSize 1..100; 100 minimises round trips.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm the API key is genuine. The key is account-wide, so one probe
 # validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/events"
-
-
-class HumanitixRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -31,119 +29,150 @@ class HumanitixResumeConfig:
     next_page: int = 1
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    return {"x-api-key": api_key, "Accept": "application/json"}
+class HumanitixPaginator(BasePaginator):
+    """Page-number pagination over the Humanitix `{total, page, pageSize, <list_key>[]}` envelope.
+
+    Terminates on a short/empty page, or once the pages fetched cover the reported item ``total`` —
+    the latter saving the extra empty-page request the built-in `PageNumberPaginator` would pay when
+    the total is an exact multiple of the page size. Resumable: the saved page seeds the first request.
+    """
+
+    def __init__(self, page_size: int, page: int = 1) -> None:
+        super().__init__()
+        self.page_size = page_size
+        self.page = page
+
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        items = data or []
+        # A short/empty page is the last page — no further rows to fetch.
+        if len(items) < self.page_size:
+            self._has_next_page = False
+            return
+
+        # A full page whose running count already covers the reported total ends the sync without
+        # paying for an extra empty page. `self.page` is still the page just fetched here.
+        try:
+            total = response.json().get("total")
+        except Exception:
+            total = None
+        if isinstance(total, int) and self.page * self.page_size >= total:
+            self._has_next_page = False
+            return
+
+        self.page += 1
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["page"] = self.page
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page already points at the next page to fetch (update_state incremented it).
+        return {"next_page": self.page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_page = state.get("next_page")
+        if next_page is not None:
+            self.page = int(next_page)
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"HumanitixPaginator(page={self.page})"
 
 
-@retry(
-    retry=retry_if_exception_type((HumanitixRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    page: int,
-    page_size: int,
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    # `page` is required (1-indexed); the API returns the paginated envelope
-    # ({total, page, pageSize, <list_key>[]}).
-    response = session.get(
-        f"{HUMANITIX_BASE_URL}{path}",
-        params={"page": page, "pageSize": page_size},
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise HumanitixRetryableError(f"Humanitix API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        logger.error(f"Humanitix API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[HumanitixResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = HUMANITIX_ENDPOINTS[endpoint]
-    # `redact_values` masks the API key in logged URLs and captured samples.
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume else 1
-    if resume and resume.next_page > 1:
-        logger.debug(f"Humanitix: resuming {endpoint} from page {page}")
-
-    while True:
-        data = _fetch_page(session, config.path, page, PAGE_SIZE, logger)
-
-        # The row array is always present in the envelope; missing it means a malformed response, so
-        # fail loudly rather than silently advancing the cursor past lost rows.
-        items = data[config.list_key]
-        if items:
-            yield items
-
-        # Terminate on a short/empty page, or once the pages fetched cover the reported total.
-        if len(items) < PAGE_SIZE:
-            break
-        total = data.get("total")
-        if total is not None and page * PAGE_SIZE >= total:
-            break
-
-        page += 1
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(HumanitixResumeConfig(next_page=page))
+def _headers() -> dict[str, str]:
+    # Auth (the `x-api-key` header) is supplied via the framework auth config so its value is redacted
+    # from logs and raised error messages; only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def humanitix_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[HumanitixResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = HUMANITIX_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": HUMANITIX_BASE_URL,
+            "headers": _headers(),
+            "auth": {"type": "api_key", "api_key": api_key, "name": "x-api-key", "location": "header"},
+            "paginator": HumanitixPaginator(page_size=PAGE_SIZE),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"pageSize": PAGE_SIZE},
+                    "data_selector": config.list_key,
+                    # The row array is always present in the envelope; missing it means a malformed
+                    # response, so fail loud rather than silently syncing 0 rows.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_page > 1:
+            initial_paginator_state = {"next_page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on `_id`) rather than skipping it.
+        if state and state.get("next_page") is not None:
+            resumable_source_manager.save_state(HumanitixResumeConfig(next_page=int(state["next_page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single list endpoint to validate the API key.
+def validate_credentials(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[bool, str | None]:
+    """Probe a single list endpoint to validate the account-wide API key.
 
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
+    The key is account-wide, so one probe validates access to every list endpoint. Maps 401/403 to a
+    bad-key message, any other non-200 to its status, and an unreachable probe to a generic message.
     """
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-    try:
-        response = session.get(f"{HUMANITIX_BASE_URL}{path}", params={"page": 1, "pageSize": 1}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Humanitix: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Humanitix returned HTTP {response.status_code}"
-
-    return 200, None
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{HUMANITIX_BASE_URL}{path}?page=1&pageSize=1",
+        headers={"x-api-key": api_key, **_headers()},
+    )
+    if ok:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid Humanitix API key"
+    if status is None:
+        return False, "Could not validate Humanitix API key"
+    return False, f"Humanitix returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/source.py
@@ -19,16 +19,20 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import HumanitixSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.humanitix import (
     HumanitixResumeConfig,
-    check_access,
     humanitix_source,
+    validate_credentials as validate_humanitix_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.settings import (
     ENDPOINTS,
     HUMANITIX_ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -98,32 +102,15 @@ You can generate an API key under **Account → Advanced → Public API key** in
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Every endpoint is full refresh only — Humanitix's list endpoints expose no server-side
-        # timestamp filter, so there is no incremental cursor to advance.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # timestamp filter, so there is no incremental cursor to advance (INCREMENTAL_FIELDS is empty).
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: HumanitixSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
         # The API key is account-wide, so a single probe validates access to every schema; there is
         # no per-endpoint scope to check.
-        status, message = check_access(config.api_key)
-        if status == 200:
-            return True, None
-        if status in (401, 403):
-            return False, "Invalid Humanitix API key"
-        return False, message or "Could not validate Humanitix API key"
+        return validate_humanitix_credentials(config.api_key)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[HumanitixResumeConfig]:
         return ResumableSourceManager[HumanitixResumeConfig](inputs, HumanitixResumeConfig)
@@ -140,6 +127,8 @@ You can generate an API key under **Account → Advanced → Public API key** in
         return humanitix_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Humanitix endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/tests/test_humanitix.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/tests/test_humanitix.py
@@ -1,214 +1,275 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
+from requests.exceptions import HTTPError
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.humanitix import humanitix
 from products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.humanitix import (
     PAGE_SIZE,
     HumanitixResumeConfig,
-    HumanitixRetryableError,
-    check_access,
-    get_rows,
     humanitix_source,
+    validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.settings import (
     ENDPOINTS,
     HUMANITIX_ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = humanitix._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the humanitix module.
+HUMANITIX_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.humanitix.make_tracked_session"
+)
+# The client retries 429/5xx behind a real tenacity wait; patch the sleep so the retry path is instant.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResumableManager:
-    def __init__(self, state: HumanitixResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[HumanitixResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> HumanitixResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: HumanitixResumeConfig) -> None:
-        self.saved.append(data)
+def _rows(_id_prefix: str, count: int) -> list[dict[str, Any]]:
+    return [{"_id": f"{_id_prefix}-{i}"} for i in range(count)]
 
 
-def _page(items: list[dict], total: int, page: int = 1, list_key: str = "events") -> dict[str, Any]:
-    return {"total": total, "page": page, "pageSize": PAGE_SIZE, list_key: items}
+def _response(
+    items: list[dict[str, Any]] | None,
+    *,
+    total: int | None = None,
+    list_key: str = "events",
+    drop_key: bool = False,
+) -> Response:
+    body: dict[str, Any] = {"page": 1, "pageSize": PAGE_SIZE}
+    if total is not None:
+        body["total"] = total
+    if not drop_key:
+        body[list_key] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://api.humanitix.com/v1/events"
+    return resp
 
 
-def _rows(count: int) -> list[dict]:
-    return [{"_id": f"id-{i}"} for i in range(count)]
+def _error_response(status: int, reason: str) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.reason = reason
+    resp._content = b"{}"
+    resp.url = "https://api.humanitix.com/v1/events?page=1&pageSize=100"
+    return resp
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager, monkeypatch: Any, pages: dict[int, dict], endpoint: str = "events"
-    ) -> list[dict]:
-        def fake_fetch(session: Any, path: str, page: int, page_size: int, logger: Any) -> dict:
-            return pages[page]
+def _make_manager(resume_state: HumanitixResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-        monkeypatch.setattr(humanitix, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(humanitix, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="hmtx-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session; return a list capturing each request's params AT SEND TIME.
 
-    def test_single_short_page_yields_items_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {1: _page(_rows(2), total=2)})
-        assert rows == _rows(2)
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared rather than reading the final state after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _collect(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return humanitix_source(
+        api_key="hmtx-key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager,
+    )
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_yields_items_and_stops(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_rows("id", 2), total=2)])
+
+        manager = _make_manager()
+        rows = _collect(_source("events", manager))
+
+        assert rows == _rows("id", 2)
+        assert params[0] == {"page": 1, "pageSize": PAGE_SIZE}
+        assert session.send.call_count == 1
         # A short final page means no further pages, so no resume state is persisted.
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_follows_pagination_until_total_reached(self, monkeypatch: Any) -> None:
-        # Two full pages exactly cover the total; a full page whose running count hits total ends it.
-        pages = {
-            1: _page(_rows(PAGE_SIZE), total=PAGE_SIZE + 1, page=1),
-            2: _page(_rows(1), total=PAGE_SIZE + 1, page=2),
-        }
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, pages)
-        assert len(rows) == PAGE_SIZE + 1
-
-    def test_stops_on_full_page_that_reaches_total(self, monkeypatch: Any) -> None:
-        # A single full page whose length equals total must terminate without fetching page 2.
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {1: _page(_rows(PAGE_SIZE), total=PAGE_SIZE)})
-        assert len(rows) == PAGE_SIZE
-        assert manager.saved == []
-
-    def test_saves_next_page_after_yielding_each_batch(self, monkeypatch: Any) -> None:
-        pages = {
-            1: _page(_rows(PAGE_SIZE), total=PAGE_SIZE + 1, page=1),
-            2: _page(_rows(1), total=PAGE_SIZE + 1, page=2),
-        }
-        manager = _FakeResumableManager()
-        self._collect(manager, monkeypatch, pages)
-        # State is saved AFTER page 1 is yielded (pointing at page 2), and never for the final page.
-        assert [s.next_page for s in manager.saved] == [2]
-
-    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(HumanitixResumeConfig(next_page=2))
-        pages = {
-            # Page 1 must never be fetched on resume. Total spans 3 pages so page 2 (a full page)
-            # doesn't hit the total-based stop, and page 3 (a short page) ends the sync.
-            2: _page(_rows(PAGE_SIZE), total=2 * PAGE_SIZE + 1, page=2),
-            3: _page(_rows(1), total=2 * PAGE_SIZE + 1, page=3),
-        }
-        rows = self._collect(manager, monkeypatch, pages)
-        assert len(rows) == PAGE_SIZE + 1
-
-    def test_empty_page_does_not_yield(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {1: _page([], total=0)})
-        assert rows == []
-
-    def test_uses_endpoint_specific_list_key(self, monkeypatch: Any) -> None:
-        # The `tags` endpoint returns its rows under a `tags` key, not `events`.
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {1: _page(_rows(1), total=1, list_key="tags")}, endpoint="tags")
-        assert rows == _rows(1)
-
-
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: dict | None = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body or {}
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_pagination_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(_rows("a", PAGE_SIZE), total=PAGE_SIZE + 1),
+                _response(_rows("b", 1), total=PAGE_SIZE + 1),
+            ],
         )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
 
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(HumanitixRetryableError):
-            _fetch_page_unwrapped(session, "/events", 1, PAGE_SIZE, MagicMock())
+        manager = _make_manager()
+        rows = _collect(_source("events", manager))
 
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "/events", 1, PAGE_SIZE, MagicMock())
+        assert len(rows) == PAGE_SIZE + 1
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
+        # State is saved AFTER page 1 is yielded (pointing at page 2), and never for the final page.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == HumanitixResumeConfig(next_page=2)
 
-    def test_success_returns_json_body(self) -> None:
-        body = _page(_rows(1), total=1)
-        session = self._session_returning(200, body)
-        result = _fetch_page_unwrapped(session, "/events", 1, PAGE_SIZE, MagicMock())
-        assert result == body
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_on_full_page_that_reaches_total(self, MockSession) -> None:
+        # A single full page whose length equals total must terminate without fetching page 2.
+        session = MockSession.return_value
+        _wire(session, [_response(_rows("id", PAGE_SIZE), total=PAGE_SIZE)])
 
-    def test_request_uses_page_and_page_size_params(self) -> None:
-        session = self._session_returning(200, _page([], total=0))
-        _fetch_page_unwrapped(session, "/tags", 3, PAGE_SIZE, MagicMock())
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"page": 3, "pageSize": PAGE_SIZE}
+        manager = _make_manager()
+        rows = _collect(_source("events", manager))
+
+        assert len(rows) == PAGE_SIZE
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Page 1 must never be fetched on resume. Total spans 3 pages so page 2 (full) doesn't hit the
+        # total-based stop, and page 3 (short) ends the sync.
+        params = _wire(
+            session,
+            [
+                _response(_rows("p2", PAGE_SIZE), total=2 * PAGE_SIZE + 1),
+                _response(_rows("p3", 1), total=2 * PAGE_SIZE + 1),
+            ],
+        )
+
+        manager = _make_manager(HumanitixResumeConfig(next_page=2))
+        rows = _collect(_source("events", manager))
+
+        assert len(rows) == PAGE_SIZE + 1
+        assert params[0]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], total=0)])
+
+        manager = _make_manager()
+        rows = _collect(_source("events", manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_uses_endpoint_specific_list_key(self, MockSession) -> None:
+        # The `tags` endpoint returns its rows under a `tags` key, not `events`.
+        session = MockSession.return_value
+        _wire(session, [_response(_rows("t", 1), total=1, list_key="tags")])
+
+        manager = _make_manager()
+        rows = _collect(_source("tags", manager))
+
+        assert rows == _rows("t", 1)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_list_key_raises_loudly(self, MockSession) -> None:
+        # A 200 body without the list key means the response shape changed — fail loud, not 0 rows.
+        session = MockSession.return_value
+        _wire(session, [_response(None, total=0, drop_key=True)])
+
+        manager = _make_manager()
+        with pytest.raises(ValueError, match="matched nothing"):
+            _collect(_source("events", manager))
 
 
-class TestCheckAccess:
-    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        monkeypatch.setattr(humanitix, "make_tracked_session", lambda **kwargs: session)
-        return session
+class TestRetryAndErrors:
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        # A 429 raises a retryable error; the retry re-issues the request and the 200 completes it.
+        _wire(session, [_error_response(429, "Too Many Requests"), _response(_rows("id", 1), total=1)])
 
+        manager = _make_manager()
+        rows = _collect(_source("events", manager))
+
+        assert rows == _rows("id", 1)
+        assert session.send.call_count == 2
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_server_error_is_retried(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_error_response(500, "Internal Server Error"), _response(_rows("id", 1), total=1)])
+
+        manager = _make_manager()
+        rows = _collect(_source("events", manager))
+
+        assert rows == _rows("id", 1)
+        assert session.send.call_count == 2
+
+    @parameterized.expand([("unauthorized", 401, "Unauthorized"), ("forbidden", 403, "Forbidden")])
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_auth_errors_raise_without_retry(self, _name, status, reason, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        # A 4xx auth failure is permanent: raise_for_status surfaces an HTTPError and it is not retried.
+        _wire(session, [_error_response(status, reason)])
+
+        manager = _make_manager()
+        with pytest.raises(HTTPError):
+            _collect(_source("events", manager))
+        assert session.send.call_count == 1
+
+
+class TestValidateCredentials:
     @parameterized.expand(
         [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "Humanitix returned HTTP 500"),
+            ("ok", 200, True, None),
+            ("unauthorized", 401, False, "Invalid Humanitix API key"),
+            ("forbidden", 403, False, "Invalid Humanitix API key"),
+            ("server_error", 500, False, "Humanitix returned HTTP 500"),
         ]
     )
-    def test_status_mapping(
-        self, _name: str, status: int, ok: bool, expected_status: int, expected_message: str | None
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(humanitix, "make_tracked_session", return_value=session):
-            assert check_access("hmtx-key") == (expected_status, expected_message)
+    @mock.patch(HUMANITIX_SESSION_PATCH)
+    def test_status_mapping(self, _name, status, expected_valid, expected_message, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("hmtx-key") == (expected_valid, expected_message)
 
-    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
-        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
-        status, message = check_access("hmtx-key")
-        assert status == 0
-        assert message is not None and "boom" in message
+    @mock.patch(HUMANITIX_SESSION_PATCH)
+    def test_unreachable_probe_maps_to_generic_message(self, mock_session) -> None:
+        # validate_via_probe swallows transport errors and reports no status; surface a generic message.
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("hmtx-key") == (False, "Could not validate Humanitix API key")
 
 
-class TestHumanitixSourceResponse:
+class TestSourceResponse:
     @parameterized.expand([("events",), ("tags",)])
-    def test_source_response_uses_id_primary_key(self, endpoint: str) -> None:
-        response = humanitix_source(
-            api_key="hmtx-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_uses_id_primary_key(self, endpoint, MockSession) -> None:
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ["_id"]
         # Every endpoint is full refresh only, so there is no datetime partitioning.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/tests/test_humanitix_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/humanitix/tests/test_humanitix_source.py
@@ -98,38 +98,35 @@ class TestHumanitixSource:
 
     @parameterized.expand(
         [
-            ("ok", 200, True, None),
-            ("unauthorized", 401, False, "Invalid Humanitix API key"),
-            ("forbidden", 403, False, "Invalid Humanitix API key"),
-            ("server_error", 500, False, "Humanitix returned HTTP 500"),
-            ("connection_error", 0, False, "Could not connect to Humanitix: boom"),
+            ("ok", (True, None), True, None),
+            ("unauthorized", (False, "Invalid Humanitix API key"), False, "Invalid Humanitix API key"),
+            ("server_error", (False, "Humanitix returned HTTP 500"), False, "Humanitix returned HTTP 500"),
         ]
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.source.check_access")
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.source.validate_humanitix_credentials"
+    )
     def test_validate_credentials(
         self,
         _name: str,
-        status: int,
+        probe_result: tuple[bool, str | None],
         expected_valid: bool,
         expected_message: str | None,
-        mock_check: mock.MagicMock,
+        mock_validate: mock.MagicMock,
     ) -> None:
-        message = (
-            "Humanitix returned HTTP 500"
-            if status == 500
-            else ("Could not connect to Humanitix: boom" if status == 0 else None)
-        )
-        mock_check.return_value = (status, message)
+        mock_validate.return_value = probe_result
         is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
         assert is_valid is expected_valid
         assert returned == expected_message
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.source.check_access")
-    def test_validate_credentials_probes_the_account_key(self, mock_check: mock.MagicMock) -> None:
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.humanitix.source.validate_humanitix_credentials"
+    )
+    def test_validate_credentials_probes_the_account_key(self, mock_validate: mock.MagicMock) -> None:
         # The API key is account-wide, so validation probes the key, not a per-schema scope.
-        mock_check.return_value = (200, None)
+        mock_validate.return_value = (200, None)
         self.source.validate_credentials(self.config, self.team_id, schema_name="tags")
-        mock_check.assert_called_once_with("hmtx-key")
+        mock_validate.assert_called_once_with("hmtx-key")
 
     def test_get_resumable_source_manager_binds_resume_config(self) -> None:
         manager = self.source.get_resumable_source_manager(mock.MagicMock())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/incident_io/incident_io.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/incident_io/incident_io.py
@@ -1,16 +1,21 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import date, datetime
 from typing import Any, Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    JSONResponseCursorPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.settings import (
     INCIDENT_IO_ENDPOINTS,
     IncidentIoEndpointConfig,
@@ -18,28 +23,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.incident_i
 
 # Single global host — incident.io has no regions or per-account base paths.
 INCIDENT_IO_BASE_URL = "https://api.incident.io"
-REQUEST_TIMEOUT_SECONDS = 60
 VALIDATION_TIMEOUT_SECONDS = 10
-MAX_RETRIES = 5
-MAX_RETRY_AFTER_SECONDS = 120
-
-
-class IncidentIoRetryableError(Exception):
-    def __init__(self, message: str, retry_after: Optional[float] = None):
-        super().__init__(message)
-        self.retry_after = retry_after
 
 
 @dataclasses.dataclass
 class IncidentIoResumeConfig:
     next_url: str
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-    }
 
 
 def _build_url(path: str, params: dict[str, Any]) -> str:
@@ -59,6 +48,10 @@ def _params_from_url(url: str) -> dict[str, str]:
     params = dict(parse_qsl(urlsplit(url).query))
     params.pop("after", None)
     return params
+
+
+def _after_from_url(url: str) -> Optional[str]:
+    return dict(parse_qsl(urlsplit(url).query)).get("after")
 
 
 def _format_filter_value(value: Any) -> Optional[str]:
@@ -97,24 +90,14 @@ def _build_params(
     return params
 
 
-def _parse_retry_after(header_value: Optional[str]) -> Optional[float]:
-    if not header_value:
-        return None
-    try:
-        return max(0.0, float(header_value))
-    except ValueError:
-        # Retry-After can also be an HTTP date; fall back to exponential backoff.
-        return None
-
-
-_fallback_wait = wait_exponential_jitter(initial=1, max=60)
-
-
-def _wait_with_retry_after(retry_state: RetryCallState) -> float:
-    exception = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exception, IncidentIoRetryableError) and exception.retry_after is not None:
-        return min(exception.retry_after, MAX_RETRY_AFTER_SECONDS)
-    return _fallback_wait(retry_state)
+def _client_config(api_key: str) -> dict[str, Any]:
+    # Bearer token goes through the framework auth config so it's redacted from logs and raised
+    # errors; only the non-secret Accept header rides in the client headers.
+    return {
+        "base_url": INCIDENT_IO_BASE_URL,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_key},
+    }
 
 
 def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tuple[bool, str | None]:
@@ -128,19 +111,20 @@ def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tup
     config = INCIDENT_IO_ENDPOINTS.get(schema_name or "", INCIDENT_IO_ENDPOINTS["incidents"])
     params: dict[str, Any] = {"page_size": 1} if config.paginated else {}
 
-    try:
-        response = make_tracked_session().get(
-            _build_url(config.path, params),
-            headers=_get_headers(api_key),
-            timeout=VALIDATION_TIMEOUT_SECONDS,
-        )
-    except Exception:
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        _build_url(config.path, params),
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+        timeout=VALIDATION_TIMEOUT_SECONDS,
+    )
+
+    if status is None:
         return False, "Unable to reach the incident.io API. Please try again."
 
-    if response.status_code == 401:
+    if status == 401:
         return False, "incident.io authentication failed. Please check that your API key is valid."
 
-    if response.status_code == 403:
+    if status == 403:
         if schema_name is None:
             return True, None
         return (
@@ -148,85 +132,17 @@ def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tup
             f"Your incident.io API key can't list {schema_name}. incident.io API keys have per-resource permissions — grant the key the 'view' scope for this resource and try again.",
         )
 
-    if response.ok:
+    if status < 400:
         return True, None
 
-    return False, f"incident.io API returned an unexpected response (status {response.status_code})."
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[IncidentIoResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = INCIDENT_IO_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-
-    incremental_value = _format_filter_value(db_incremental_field_last_value) if should_use_incremental_field else None
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url: str = resume_config.next_url
-        params: dict[str, Any] = _params_from_url(url)
-        logger.debug(f"incident.io: resuming from URL: {url}")
-    else:
-        params = _build_params(config, incremental_field if should_use_incremental_field else None, incremental_value)
-        url = _build_url(config.path, params)
-
-    @retry(
-        retry=retry_if_exception_type((IncidentIoRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_wait_with_retry_after,
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # incident.io rate-limits at 1,200 req/min; honor Retry-After when present and
-        # fall back to exponential backoff otherwise.
-        if response.status_code == 429:
-            raise IncidentIoRetryableError(
-                f"incident.io rate limit hit: url={page_url}",
-                retry_after=_parse_retry_after(response.headers.get("Retry-After")),
-            )
-
-        if response.status_code >= 500:
-            raise IncidentIoRetryableError(
-                f"incident.io API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"incident.io API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-        items = data.get(config.data_key) or []
-
-        if items:
-            yield items
-
-        # `pagination_meta.after` is a record ID tied to this run's ordering — it's only
-        # valid as a within-run page cursor, never persisted as the incremental watermark
-        # (the pipeline persists the max incremental field value instead).
-        after = (data.get("pagination_meta") or {}).get("after")
-        if not config.paginated or not after:
-            break
-
-        url = _build_url(config.path, {**params, "after": after})
-        resumable_source_manager.save_state(IncidentIoResumeConfig(next_url=url))
+    return False, f"incident.io API returned an unexpected response (status {status})."
 
 
 def incident_io_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[IncidentIoResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -234,17 +150,64 @@ def incident_io_source(
 ) -> SourceResponse:
     config = INCIDENT_IO_ENDPOINTS[endpoint]
 
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume is not None:
+        # Preserve the interrupted chain's filters and cursor verbatim — never recompute the
+        # `gte` filter from a possibly-advanced watermark against an old `after` cursor.
+        params: dict[str, Any] = _params_from_url(resume.next_url)
+        after = _after_from_url(resume.next_url)
+        if after is not None:
+            initial_paginator_state = {"cursor": after}
+    else:
+        incremental_value = (
+            _format_filter_value(db_incremental_field_last_value) if should_use_incremental_field else None
+        )
+        params = _build_params(config, incremental_field if should_use_incremental_field else None, incremental_value)
+
+    # incident.io paginates via a record-ID cursor in `pagination_meta.after`, replayed as the
+    # `after` query param. Config-style endpoints return the full list in one unpaginated response.
+    paginator: BasePaginator = (
+        JSONResponseCursorPaginator(cursor_path="pagination_meta.after", cursor_param="after")
+        if config.paginated
+        else SinglePagePaginator()
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    "data_selector": config.data_key,
+                    "paginator": paginator,
+                },
+            }
+        ],
+    }
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on id) rather than skipping it. The saved URL keeps the
+        # run's filters so resume replays the exact same chain with the next cursor.
+        if state and state.get("cursor"):
+            url = _build_url(config.path, {**params, "after": state["cursor"]})
+            resumable_source_manager.save_state(IncidentIoResumeConfig(next_url=url))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         # Incidents are requested with `sort_by=created_at_oldest_first` (the only sortable
         # endpoint). When syncing incrementally on `updated_at`, values within a run aren't

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/incident_io/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/incident_io/source.py
@@ -125,7 +125,8 @@ You can create an API key in your [incident.io dashboard](https://app.incident.i
         return incident_io_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/incident_io/tests/test_incident_io.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/incident_io/tests/test_incident_io.py
@@ -1,19 +1,18 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io import (
     IncidentIoResumeConfig,
-    IncidentIoRetryableError,
     _build_params,
     _build_url,
     _format_filter_value,
     _params_from_url,
-    _parse_retry_after,
-    _wait_with_retry_after,
-    get_rows,
     incident_io_source,
     validate_credentials,
 )
@@ -21,6 +20,26 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.incident_i
     ENDPOINTS,
     INCIDENT_IO_ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the incident_io module.
+INCIDENT_IO_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
+)
+
+
+def _page_body(data_key: str, items: list[dict[str, Any]], after: str | None) -> dict[str, Any]:
+    return {data_key: items, "pagination_meta": {"after": after, "page_size": 250}}
+
+
+def _response(body: dict[str, Any], status_code: int = 200, retry_after: str | None = None) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    if retry_after is not None:
+        resp.headers["Retry-After"] = retry_after
+    return resp
 
 
 def _make_manager(resume_state: IncidentIoResumeConfig | None = None) -> mock.MagicMock:
@@ -30,17 +49,29 @@ def _make_manager(resume_state: IncidentIoResumeConfig | None = None) -> mock.Ma
     return manager
 
 
-def _page(data_key: str, items: list[dict[str, Any]], after: str | None) -> dict[str, Any]:
-    return {data_key: items, "pagination_meta": {"after": after, "page_size": 250}}
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-def _response(body: dict[str, Any], status_code: int = 200) -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.json.return_value = body
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.headers = {}
-    return response
+def _source(session: mock.MagicMock, responses: list[Response], endpoint: str, manager: mock.MagicMock, **kwargs):
+    params = _wire(session, responses)
+    response = incident_io_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
+    rows = [row for page in response.items() for row in page]
+    return rows, params
 
 
 class TestFormatFilterValue:
@@ -111,48 +142,6 @@ class TestParamsFromUrl:
         assert _params_from_url("https://api.incident.io/v1/severities") == {}
 
 
-class TestRetryAfter:
-    @pytest.mark.parametrize(
-        "header_value, expected",
-        [
-            (None, None),
-            ("", None),
-            ("30", 30.0),
-            ("0", 0.0),
-            ("-5", 0.0),
-            ("1.5", 1.5),
-            ("Wed, 21 Oct 2026 07:28:00 GMT", None),
-        ],
-    )
-    def test_parse_retry_after(self, header_value, expected):
-        assert _parse_retry_after(header_value) == expected
-
-    def test_wait_honors_retry_after(self):
-        retry_state = mock.MagicMock()
-        retry_state.outcome.exception.return_value = IncidentIoRetryableError("rate limited", retry_after=30.0)
-        assert _wait_with_retry_after(retry_state) == 30.0
-
-    def test_wait_caps_retry_after(self):
-        retry_state = mock.MagicMock()
-        retry_state.outcome.exception.return_value = IncidentIoRetryableError("rate limited", retry_after=9999.0)
-        assert _wait_with_retry_after(retry_state) == 120.0
-
-    @pytest.mark.parametrize(
-        "exception",
-        [
-            IncidentIoRetryableError("server error"),
-            ValueError("boom"),
-        ],
-    )
-    def test_wait_falls_back_to_exponential_backoff(self, exception):
-        retry_state = mock.MagicMock()
-        retry_state.outcome.exception.return_value = exception
-        retry_state.attempt_number = 1
-        wait = _wait_with_retry_after(retry_state)
-        assert isinstance(wait, float)
-        assert wait >= 0
-
-
 class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected_valid",
@@ -163,11 +152,9 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
+    @mock.patch(INCIDENT_IO_SESSION_PATCH)
     def test_status_mapping_at_source_create(self, mock_session, status_code, expected_valid):
-        mock_session.return_value.get.return_value = _response({}, status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         is_valid, _ = validate_credentials("key")
 
@@ -182,11 +169,9 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
+    @mock.patch(INCIDENT_IO_SESSION_PATCH)
     def test_status_mapping_with_schema_name(self, mock_session, status_code, expected_valid):
-        mock_session.return_value.get.return_value = _response({}, status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         is_valid, error = validate_credentials("key", schema_name="alerts")
 
@@ -194,42 +179,34 @@ class TestValidateCredentials:
         if status_code == 403:
             assert error is not None and "alerts" in error
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
+    @mock.patch(INCIDENT_IO_SESSION_PATCH)
     def test_probes_incidents_with_minimal_page_at_source_create(self, mock_session):
-        mock_session.return_value.get.return_value = _response({})
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
         validate_credentials("key")
 
         url = mock_session.return_value.get.call_args.args[0]
         assert url == "https://api.incident.io/v2/incidents?page_size=1"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
+    @mock.patch(INCIDENT_IO_SESSION_PATCH)
     def test_probes_non_paginated_endpoint_without_page_size(self, mock_session):
-        mock_session.return_value.get.return_value = _response({})
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
         validate_credentials("key", schema_name="severities")
 
         url = mock_session.return_value.get.call_args.args[0]
         assert url == "https://api.incident.io/v1/severities"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
+    @mock.patch(INCIDENT_IO_SESSION_PATCH)
     def test_sends_bearer_auth_header(self, mock_session):
-        mock_session.return_value.get.return_value = _response({})
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
         validate_credentials("secret-key")
 
         headers = mock_session.return_value.get.call_args.kwargs["headers"]
         assert headers["Authorization"] == "Bearer secret-key"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
+    @mock.patch(INCIDENT_IO_SESSION_PATCH)
     def test_swallows_network_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
 
@@ -240,183 +217,165 @@ class TestValidateCredentials:
 
 
 class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_paginates_via_pagination_meta_after(self, mock_session):
-        pages = [
-            _page("incidents", [{"id": "01A"}, {"id": "01B"}], "01B"),
-            _page("incidents", [{"id": "01C"}], None),
-        ]
-        mock_session.return_value.get.side_effect = [_response(page) for page in pages]
-
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_pagination_meta_after(self, MockSession):
+        session = MockSession.return_value
         manager = _make_manager()
-        batches = list(get_rows("key", "incidents", mock.MagicMock(), manager))
+        rows, params = _source(
+            session,
+            [
+                _response(_page_body("incidents", [{"id": "01A"}, {"id": "01B"}], "01B")),
+                _response(_page_body("incidents", [{"id": "01C"}], None)),
+            ],
+            "incidents",
+            manager,
+        )
 
-        assert [item["id"] for batch in batches for item in batch] == ["01A", "01B", "01C"]
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert "after=01B" in second_url
+        assert [r["id"] for r in rows] == ["01A", "01B", "01C"]
+        assert "after" not in params[0]
+        assert params[1]["after"] == "01B"
         # State is saved only while a next page exists, after the batch was yielded.
         manager.save_state.assert_called_once()
         assert "after=01B" in manager.save_state.call_args.args[0].next_url
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_incremental_request_includes_filter_and_sort(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_page("incidents", [], None))
-
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                "incidents",
-                mock.MagicMock(),
-                manager,
-                should_use_incremental_field=True,
-                db_incremental_field_last_value=datetime(2024, 5, 1, 12, 30, tzinfo=UTC),
-                incremental_field="updated_at",
-            )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_includes_filter_and_sort(self, MockSession):
+        session = MockSession.return_value
+        _, params = _source(
+            session,
+            [_response(_page_body("incidents", [], None))],
+            "incidents",
+            _make_manager(),
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2024, 5, 1, 12, 30, tzinfo=UTC),
+            incremental_field="updated_at",
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert "updated_at%5Bgte%5D=2024-05-01" in url
-        assert "sort_by=created_at_oldest_first" in url
-        assert "page_size=250" in url
+        assert params[0]["updated_at[gte]"] == "2024-05-01"
+        assert params[0]["sort_by"] == "created_at_oldest_first"
+        assert params[0]["page_size"] == 250
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_full_refresh_ignores_incremental_value(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_page("incidents", [], None))
-
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                "incidents",
-                mock.MagicMock(),
-                manager,
-                should_use_incremental_field=False,
-                db_incremental_field_last_value=datetime(2024, 5, 1, tzinfo=UTC),
-                incremental_field="updated_at",
-            )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_ignores_incremental_value(self, MockSession):
+        session = MockSession.return_value
+        _, params = _source(
+            session,
+            [_response(_page_body("incidents", [], None))],
+            "incidents",
+            _make_manager(),
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=datetime(2024, 5, 1, tzinfo=UTC),
+            incremental_field="updated_at",
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert "gte" not in url
+        assert not any("gte" in key for key in params[0])
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_resumes_from_saved_state_and_preserves_filters(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state_and_preserves_filters(self, MockSession):
+        session = MockSession.return_value
         resume_url = _build_url(
             "/v2/incidents",
             {"page_size": 250, "sort_by": "created_at_oldest_first", "updated_at[gte]": "2024-05-01", "after": "01B"},
         )
-        pages = [
-            _page("incidents", [{"id": "01C"}], "01C"),
-            _page("incidents", [], None),
-        ]
-        mock_session.return_value.get.side_effect = [_response(page) for page in pages]
-
         manager = _make_manager(IncidentIoResumeConfig(next_url=resume_url))
-        list(get_rows("key", "incidents", mock.MagicMock(), manager))
+        _, params = _source(
+            session,
+            [
+                _response(_page_body("incidents", [{"id": "01C"}], "01C")),
+                _response(_page_body("incidents", [], None)),
+            ],
+            "incidents",
+            manager,
+        )
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert first_url == resume_url
-        # The next page keeps the original chain's filter and swaps in the new cursor.
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert "updated_at%5Bgte%5D=2024-05-01" in second_url
-        assert "after=01C" in second_url
-        assert "after=01B" not in second_url
+        # First request replays the saved cursor and keeps the original chain's filter.
+        assert params[0]["after"] == "01B"
+        assert params[0]["updated_at[gte]"] == "2024-05-01"
+        # The next page swaps in the new cursor but keeps the filter.
+        assert params[1]["after"] == "01C"
+        assert params[1]["updated_at[gte]"] == "2024-05-01"
+        assert "after=01C" in manager.save_state.call_args.args[0].next_url
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_non_paginated_endpoint_fetches_once(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_endpoint_fetches_once(self, MockSession):
+        session = MockSession.return_value
+        # Body carries an `after`, but a non-paginated endpoint must still fetch exactly once.
         body = {"severities": [{"id": "01A"}], "pagination_meta": {"after": "01A"}}
-        mock_session.return_value.get.return_value = _response(body)
-
         manager = _make_manager()
-        batches = list(get_rows("key", "severities", mock.MagicMock(), manager))
+        rows, _ = _source(session, [_response(body)], "severities", manager)
 
-        assert mock_session.return_value.get.call_count == 1
-        assert [item["id"] for batch in batches for item in batch] == ["01A"]
+        assert session.send.call_count == 1
+        assert [r["id"] for r in rows] == ["01A"]
         manager.save_state.assert_not_called()
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_empty_response_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_page("alerts", [], None))
-
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_no_rows(self, MockSession):
+        session = MockSession.return_value
         manager = _make_manager()
-        batches = list(get_rows("key", "alerts", mock.MagicMock(), manager))
+        rows, _ = _source(session, [_response(_page_body("alerts", [], None))], "alerts", manager)
 
-        assert batches == []
+        assert rows == []
         manager.save_state.assert_not_called()
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_missing_data_key_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _response({"pagination_meta": {"after": None}})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows(self, MockSession):
+        session = MockSession.return_value
+        rows, _ = _source(session, [_response({"pagination_meta": {"after": None}})], "incidents", _make_manager())
 
+        assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_on_429_honoring_retry_after(self, MockSession):
+        session = MockSession.return_value
         manager = _make_manager()
-        assert list(get_rows("key", "incidents", mock.MagicMock(), manager)) == []
+        rows, _ = _source(
+            session,
+            [
+                _response({}, status_code=429, retry_after="0"),
+                _response(_page_body("incidents", [{"id": "01A"}], None)),
+            ],
+            "incidents",
+            manager,
+        )
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_retries_on_429_honoring_retry_after(self, mock_session):
-        rate_limited = _response({}, 429)
-        rate_limited.headers = {"Retry-After": "0"}
-        ok = _response(_page("incidents", [{"id": "01A"}], None))
-        mock_session.return_value.get.side_effect = [rate_limited, ok]
+        assert session.send.call_count == 2
+        assert [r["id"] for r in rows] == ["01A"]
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_on_5xx(self, MockSession):
+        session = MockSession.return_value
         manager = _make_manager()
-        batches = list(get_rows("key", "incidents", mock.MagicMock(), manager))
+        rows, _ = _source(
+            session,
+            [
+                _response({}, status_code=500, retry_after="0"),
+                _response(_page_body("incidents", [{"id": "01A"}], None)),
+            ],
+            "incidents",
+            manager,
+        )
 
-        assert mock_session.return_value.get.call_count == 2
-        assert [item["id"] for batch in batches for item in batch] == ["01A"]
+        assert session.send.call_count == 2
+        assert [r["id"] for r in rows] == ["01A"]
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_retries_on_5xx(self, mock_session):
-        server_error = _response({}, 500)
-        ok = _response(_page("incidents", [{"id": "01A"}], None))
-        mock_session.return_value.get.side_effect = [server_error, ok]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_on_client_error(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({}, status_code=404)])
 
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io._fallback_wait",
-            return_value=0,
-        ):
-            manager = _make_manager()
-            batches = list(get_rows("key", "incidents", mock.MagicMock(), manager))
-
-        assert mock_session.return_value.get.call_count == 2
-        assert [item["id"] for batch in batches for item in batch] == ["01A"]
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.incident_io.incident_io.make_tracked_session"
-    )
-    def test_raises_on_client_error(self, mock_session):
-        not_found = _response({}, 404)
-        not_found.raise_for_status.side_effect = Exception("404 Client Error")
-        mock_session.return_value.get.return_value = not_found
-
-        manager = _make_manager()
-        with pytest.raises(Exception, match="404 Client Error"):
-            list(get_rows("key", "incidents", mock.MagicMock(), manager))
+        response = incident_io_source(
+            "key", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
+        with pytest.raises(Exception):
+            [row for page in response.items() for row in page]
 
 
 class TestIncidentIoSourceResponse:
+    @mock.patch(CLIENT_SESSION_PATCH)
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    def test_response_metadata_per_endpoint(self, MockSession, endpoint):
         config = INCIDENT_IO_ENDPOINTS[endpoint]
-        response = incident_io_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = incident_io_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/insightly/insightly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/insightly/insightly.py
@@ -1,36 +1,33 @@
 import re
-import base64
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.insightly.settings import (
-    INSIGHTLY_ENDPOINTS,
-    InsightlyEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.insightly.settings import INSIGHTLY_ENDPOINTS
 
 API_VERSION = "v3.1"
 # Insightly caps list pages at 500 items (default is 100).
 PAGE_SIZE = 500
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
+# Insightly exposes this server-side filter on incremental endpoints; the last synced cursor is
+# injected here so an incremental sync never walks unbounded history.
+UPDATED_AFTER_PARAM = "updated_after_utc"
 
 # A pod/instance is a short region token such as `na1`, `eu1`, `aps1`.
 _POD_RE = re.compile(r"^[a-z0-9]+$")
 _POD_FROM_URL_RE = re.compile(r"api\.([a-z0-9]+)\.insightly\.com")
-
-
-class InsightlyRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -60,12 +57,6 @@ def base_url(pod: str) -> str:
     return f"https://api.{normalize_pod(pod)}.insightly.com/{API_VERSION}"
 
 
-def _auth_headers(api_key: str) -> dict[str, str]:
-    # Insightly uses HTTP Basic auth with the API key as the username and a blank password.
-    token = base64.b64encode(f"{api_key}:".encode()).decode()
-    return {"Authorization": f"Basic {token}", "Accept": "application/json"}
-
-
 def _format_updated_after(value: Any) -> str:
     """Format the incremental cursor as ISO 8601 with a trailing Z, which `updated_after_utc` expects
     (e.g. ``2018-04-09T16:58:14Z``)."""
@@ -79,128 +70,85 @@ def _format_updated_after(value: Any) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _build_params(
-    config: InsightlyEndpointConfig,
-    skip: int,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"top": PAGE_SIZE, "skip": skip}
-    if config.supports_incremental and should_use_incremental_field and db_incremental_field_last_value:
-        params["updated_after_utc"] = _format_updated_after(db_incremental_field_last_value)
-    return params
-
-
-def _build_url(pod: str, path: str, params: dict[str, Any]) -> str:
-    return f"{base_url(pod)}{path}?{urlencode(params)}"
-
-
-def validate_credentials(pod: str, api_key: str, path: str = "/Contacts") -> Optional[int]:
-    """Return the status code of a cheap authenticated probe, or ``None`` on transport error.
-
-    Requests a single row from ``path`` so a genuine key returns 200, a bad key 401, and a key
-    without scope for that resource 403. Built outside the ``try`` so an invalid-pod ``ValueError``
-    propagates rather than being flattened to ``None`` by the transport-error handler.
-    """
-    url = _build_url(pod, path, {"top": 1})
-    try:
-        session = make_tracked_session(headers=_auth_headers(api_key), redact_values=(api_key,))
-        response = session.get(url, timeout=10)
-        return response.status_code
-    except Exception:
-        return None
-
-
-def get_rows(
-    pod: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[InsightlyResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = INSIGHTLY_ENDPOINTS[endpoint]
-    # `redact_values` masks the key inside the base64 Authorization header in logged URLs / captured
-    # samples, on top of the name-based denylist that already scrubs the header itself.
-    session = make_tracked_session(headers=_auth_headers(api_key), redact_values=(api_key,))
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        skip = resume_config.skip
-        logger.debug(f"Insightly: resuming {endpoint} from skip={skip}")
-    else:
-        skip = 0
-
-    @retry(
-        retry=retry_if_exception_type((InsightlyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> Any:
-        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # Insightly rate-limits at 10 req/s plus daily caps, returning 429; retry those and
-        # transient 5xx with exponential backoff.
-        if response.status_code == 429 or response.status_code >= 500:
-            raise InsightlyRetryableError(
-                f"Insightly API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Insightly API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        url = _build_url(
-            pod, config.path, _build_params(config, skip, should_use_incremental_field, db_incremental_field_last_value)
-        )
-        data = fetch_page(url)
-        # Insightly list endpoints return a bare JSON array. Anything else (a 2xx error envelope,
-        # an HTML gateway page) would otherwise make `items` empty and silently end the sync with
-        # no rows and no error — so fail loudly instead of masking it as an empty table.
-        if not isinstance(data, list):
-            raise ValueError(f"Insightly API returned an unexpected {type(data).__name__} response for {url}")
-        items = data
-
-        if items:
-            yield items
-
-        # A short page (fewer than a full `top`) is the last page — offset pagination is done.
-        if len(items) < PAGE_SIZE:
-            break
-
-        skip += PAGE_SIZE
-        # Save the next offset only after the current page has been yielded, so a crash resumes at
-        # this page rather than past it. Merge dedupes any rows re-yielded on resume by primary key.
-        resumable_source_manager.save_state(InsightlyResumeConfig(skip=skip))
-
-
 def insightly_source(
     pod: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[InsightlyResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = INSIGHTLY_ENDPOINTS[endpoint]
 
+    endpoint_config: dict[str, Any] = {
+        "path": config.path,
+        # Offset pagination with Insightly's `top`/`skip`; a short (< top) page is the last one.
+        "paginator": OffsetPaginator(
+            limit=PAGE_SIZE,
+            offset_param="skip",
+            limit_param="top",
+            total_path=None,
+        ),
+        # Insightly list endpoints return a bare JSON array. A non-list 200 body (a 2xx error
+        # envelope, an HTML gateway page) must fail loud instead of silently syncing 0 rows.
+        "data_selector_required": True,
+    }
+
+    # Only incremental endpoints expose `updated_after_utc`, and only when the job supplies a cursor.
+    use_incremental = bool(
+        config.supports_incremental and should_use_incremental_field and db_incremental_field_last_value
+    )
+    if use_incremental:
+        endpoint_config["incremental"] = {
+            "start_param": UPDATED_AFTER_PARAM,
+            "convert": _format_updated_after,
+        }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url(pod),
+            "headers": {"Accept": "application/json"},
+            # HTTP Basic auth with the API key as the username and a blank password. Using the
+            # framework auth keeps the key out of raised error messages / logged URLs.
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            # Pin every request (including resume URLs) to api.<pod>.insightly.com — reinforces the
+            # pod normalization guard so credentials can never be sent off-host.
+            "allowed_hosts": [],
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": endpoint_config,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.skip}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(InsightlyResumeConfig(skip=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if use_incremental else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            pod=pod,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         # Insightly paginates in record-id (creation) order, so rows for a given sync arrive roughly
         # oldest-first; DATE_UPDATED_UTC is not strictly monotonic across pages. We keep the same
@@ -214,3 +162,19 @@ def insightly_source(
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(pod: str, api_key: str, path: str = "/Contacts") -> Optional[int]:
+    """Return the status code of a cheap authenticated probe, or ``None`` on transport error.
+
+    Requests a single row from ``path`` so a genuine key returns 200, a bad key 401, and a key
+    without scope for that resource 403. The URL is built outside the probe so an invalid-pod
+    ``ValueError`` propagates rather than being flattened to ``None`` by the transport-error handler.
+    """
+    url = f"{base_url(pod)}{path}?{urlencode({'top': 1})}"
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        url,
+        auth=HttpBasicAuth(username=api_key, password=""),
+    )
+    return status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/insightly/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/insightly/source.py
@@ -160,7 +160,8 @@ The API key inherits your Insightly user's permissions, so make sure your user c
             pod=normalize_pod(config.pod),
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/insightly/tests/test_insightly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/insightly/tests/test_insightly.py
@@ -1,21 +1,80 @@
-from typing import Any
+import json
+from typing import Any, Optional
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly import (
     PAGE_SIZE,
     InsightlyResumeConfig,
-    _build_params,
-    _build_url,
     _format_updated_after,
     base_url,
-    get_rows,
     insightly_source,
     normalize_pod,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.insightly.settings import INSIGHTLY_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the insightly module.
+INSIGHTLY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
+)
+
+# A prepared-request URL on the pinned host, so the client's allowed_hosts guard passes with mocks.
+_PINNED_URL = "https://api.na1.insightly.com/v3.1/Contacts"
+
+
+def _response(items: list[dict[str, Any]] | None, *, status: int = 200, raw: Optional[bytes] = None) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = _PINNED_URL
+    resp.reason = "OK" if status < 400 else "Unauthorized"
+    resp._content = raw if raw is not None else json.dumps(items or []).encode()
+    return resp
+
+
+def _make_manager(resume_state: InsightlyResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared. The prepared request carries the pinned URL so the allowed_hosts check passes.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock(url=_PINNED_URL)
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(manager: mock.MagicMock, **kwargs: Any):
+    return insightly_source(
+        "na1",
+        "key",
+        kwargs.pop("endpoint", "Contacts"),
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
 
 
 class TestNormalizePod:
@@ -73,45 +132,114 @@ class TestFormatUpdatedAfter:
         assert _format_updated_after("2022-03-04T05:06:07Z") == "2022-03-04T05:06:07Z"
 
 
-class TestBuildParams:
-    def test_adds_updated_after_only_for_incremental_endpoint_with_value(self) -> None:
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_offset_and_saves_state_after_full_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"CONTACT_ID": i} for i in range(PAGE_SIZE)]
+        params = _wire(session, [_response(full_page), _response([{"CONTACT_ID": 9999}])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        # Both pages are yielded; the short second page ends pagination.
+        assert rows[-1] == {"CONTACT_ID": 9999}
+        assert len(rows) == PAGE_SIZE + 1
+        # `top`/`skip` progress from 0 to PAGE_SIZE.
+        assert params[0]["skip"] == 0
+        assert params[0]["top"] == PAGE_SIZE
+        assert params[1]["skip"] == PAGE_SIZE
+        # State saved once after the first full page, pointing at the next offset.
+        manager.save_state.assert_called_once_with(InsightlyResumeConfig(skip=PAGE_SIZE))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"CONTACT_ID": 1}, {"CONTACT_ID": 2}])])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == [{"CONTACT_ID": 1}, {"CONTACT_ID": 2}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"CONTACT_ID": 7}])])
+
+        rows = _rows(_source(_make_manager(InsightlyResumeConfig(skip=1000))))
+
+        assert rows == [{"CONTACT_ID": 7}]
+        assert params[0]["skip"] == 1000
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_filter_applied_on_every_page(self, MockSession) -> None:
         from datetime import UTC, datetime
 
-        params = _build_params(
-            INSIGHTLY_ENDPOINTS["Contacts"],
-            skip=0,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2020, 1, 1, tzinfo=UTC),
-        )
-        assert params == {"top": PAGE_SIZE, "skip": 0, "updated_after_utc": "2020-01-01T00:00:00Z"}
+        session = MockSession.return_value
+        full_page = [{"CONTACT_ID": i} for i in range(PAGE_SIZE)]
+        params = _wire(session, [_response(full_page), _response([])])
 
-    def test_no_updated_after_without_value(self) -> None:
-        params = _build_params(
-            INSIGHTLY_ENDPOINTS["Contacts"],
-            skip=500,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=None,
+        _rows(
+            _source(
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2020, 1, 1, tzinfo=UTC),
+            )
         )
-        assert params == {"top": PAGE_SIZE, "skip": 500}
+        # The `updated_after_utc` server-side filter is present on both the first and second page.
+        assert all(p.get("updated_after_utc") == "2020-01-01T00:00:00Z" for p in params)
+        assert len(params) == 2
 
-    def test_full_refresh_endpoint_never_filters(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_incremental_filter_without_value(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"CONTACT_ID": 1}])])
+
+        _rows(_source(_make_manager(), should_use_incremental_field=True, db_incremental_field_last_value=None))
+        assert "updated_after_utc" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_never_filters(self, MockSession) -> None:
         from datetime import UTC, datetime
+
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"USER_ID": 1}])])
 
         # Users is full-refresh only; even with an incremental value it must not send updated_after_utc.
-        params = _build_params(
-            INSIGHTLY_ENDPOINTS["Users"],
-            skip=0,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2020, 1, 1, tzinfo=UTC),
+        _rows(
+            _source(
+                _make_manager(),
+                endpoint="Users",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2020, 1, 1, tzinfo=UTC),
+            )
         )
-        assert params == {"top": PAGE_SIZE, "skip": 0}
+        assert "updated_after_utc" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_on_non_retryable_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], status=401)])
+
+        with pytest.raises(Exception, match="401 Client Error"):
+            _rows(_source(_make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_on_non_list_response(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A 200 with an unexpected (non-array) body must fail loudly, not sync zero rows silently.
+        _wire(session, [_response(None, raw=json.dumps({"error": "something went wrong"}).encode())])
+
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(_source(_make_manager()))
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code", [200, 401, 403, 500])
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
+    @mock.patch(INSIGHTLY_SESSION_PATCH)
     def test_returns_status_code(self, mock_session: mock.MagicMock, status_code: int) -> None:
         mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("na1", "key", "/Contacts") == status_code
@@ -120,9 +248,7 @@ class TestValidateCredentials:
         # The key is masked in logged URLs and captured samples.
         assert mock_session.call_args.kwargs["redact_values"] == ("key",)
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
+    @mock.patch(INSIGHTLY_SESSION_PATCH)
     def test_returns_none_on_transport_error(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("na1", "key") is None
@@ -130,115 +256,6 @@ class TestValidateCredentials:
     def test_propagates_invalid_pod(self) -> None:
         with pytest.raises(ValueError):
             validate_credentials("evil.com", "key")
-
-
-class TestGetRows:
-    def _manager(self, resume_state: InsightlyResumeConfig | None = None) -> mock.MagicMock:
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = resume_state is not None
-        manager.load_state.return_value = resume_state
-        return manager
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
-    def test_paginates_offset_and_saves_state_after_yield(self, mock_session: mock.MagicMock) -> None:
-        # A full page forces a second request; the short second page ends pagination.
-        full_page = mock.MagicMock(status_code=200, ok=True)
-        full_page.json.return_value = [{"CONTACT_ID": i} for i in range(PAGE_SIZE)]
-        last_page = mock.MagicMock(status_code=200, ok=True)
-        last_page.json.return_value = [{"CONTACT_ID": 9999}]
-        mock_session.return_value.get.side_effect = [full_page, last_page]
-
-        manager = self._manager()
-        batches = list(get_rows("na1", "key", "Contacts", mock.MagicMock(), manager))
-
-        assert len(batches) == 2
-        assert batches[1] == [{"CONTACT_ID": 9999}]
-        # Two page fetches at skip=0 then skip=PAGE_SIZE.
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert urls[0].endswith(f"top={PAGE_SIZE}&skip=0")
-        assert urls[1].endswith(f"top={PAGE_SIZE}&skip={PAGE_SIZE}")
-        # State saved once, after the first (full) page, pointing at the next offset.
-        manager.save_state.assert_called_once_with(InsightlyResumeConfig(skip=PAGE_SIZE))
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
-    def test_single_short_page_does_not_save_state(self, mock_session: mock.MagicMock) -> None:
-        page = mock.MagicMock(status_code=200, ok=True)
-        page.json.return_value = [{"CONTACT_ID": 1}, {"CONTACT_ID": 2}]
-        mock_session.return_value.get.return_value = page
-
-        manager = self._manager()
-        batches = list(get_rows("na1", "key", "Contacts", mock.MagicMock(), manager))
-
-        assert batches == [[{"CONTACT_ID": 1}, {"CONTACT_ID": 2}]]
-        manager.save_state.assert_not_called()
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
-    def test_resumes_from_saved_offset(self, mock_session: mock.MagicMock) -> None:
-        page = mock.MagicMock(status_code=200, ok=True)
-        page.json.return_value = [{"CONTACT_ID": 7}]
-        mock_session.return_value.get.return_value = page
-
-        manager = self._manager(InsightlyResumeConfig(skip=1000))
-        batches = list(get_rows("na1", "key", "Contacts", mock.MagicMock(), manager))
-
-        assert batches == [[{"CONTACT_ID": 7}]]
-        assert mock_session.return_value.get.call_args.args[0].endswith(f"top={PAGE_SIZE}&skip=1000")
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
-    def test_incremental_filter_applied_on_every_page(self, mock_session: mock.MagicMock) -> None:
-        from datetime import UTC, datetime
-
-        full_page = mock.MagicMock(status_code=200, ok=True)
-        full_page.json.return_value = [{"CONTACT_ID": i} for i in range(PAGE_SIZE)]
-        last_page = mock.MagicMock(status_code=200, ok=True)
-        last_page.json.return_value = []
-        mock_session.return_value.get.side_effect = [full_page, last_page]
-
-        list(
-            get_rows(
-                "na1",
-                "key",
-                "Contacts",
-                mock.MagicMock(),
-                self._manager(),
-                should_use_incremental_field=True,
-                db_incremental_field_last_value=datetime(2020, 1, 1, tzinfo=UTC),
-            )
-        )
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        # The `updated_after_utc` filter is present on both the first and the second page.
-        assert all("updated_after_utc=2020-01-01T00%3A00%3A00Z" in url for url in urls)
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
-    def test_raises_on_non_retryable_error(self, mock_session: mock.MagicMock) -> None:
-        page = mock.MagicMock(status_code=401, ok=False, text="unauthorized")
-        page.raise_for_status.side_effect = Exception("401 Client Error")
-        mock_session.return_value.get.return_value = page
-
-        with pytest.raises(Exception, match="401 Client Error"):
-            list(get_rows("na1", "key", "Contacts", mock.MagicMock(), self._manager()))
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.insightly.insightly.make_tracked_session"
-    )
-    def test_raises_on_non_list_response(self, mock_session: mock.MagicMock) -> None:
-        # A 2xx with an unexpected (non-array) body must fail loudly, not sync zero rows silently.
-        page = mock.MagicMock(status_code=200, ok=True)
-        page.json.return_value = {"error": "something went wrong"}
-        mock_session.return_value.get.return_value = page
-
-        with pytest.raises(ValueError, match="unexpected"):
-            list(get_rows("na1", "key", "Contacts", mock.MagicMock(), self._manager()))
 
 
 class TestInsightlySourceResponse:
@@ -251,25 +268,18 @@ class TestInsightlySourceResponse:
             ("Pipelines", "PIPELINE_ID", None, None),
         ],
     )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_source_response_shape(
         self,
+        MockSession,
         endpoint: str,
         expected_pk: str,
         expected_partition_keys: list[str] | None,
         expected_mode: str | None,
     ) -> None:
-        response = insightly_source("na1", "key", endpoint, mock.MagicMock(), mock.MagicMock())
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == [expected_pk]
         assert response.partition_keys == expected_partition_keys
         assert response.partition_mode == expected_mode
         assert response.sort_mode == "asc"
-
-
-class TestBuildUrl:
-    def test_build_url_encodes_params(self) -> None:
-        params: dict[str, Any] = {"top": 500, "skip": 0, "updated_after_utc": "2020-01-01T00:00:00Z"}
-        url = _build_url("na1", "/Contacts", params)
-        assert url == (
-            "https://api.na1.insightly.com/v3.1/Contacts?top=500&skip=0&updated_after_utc=2020-01-01T00%3A00%3A00Z"
-        )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/invoiced/invoiced.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/invoiced/invoiced.py
@@ -1,32 +1,30 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import quote, urlencode, urlsplit
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-from urllib3.util.retry import Retry
+from urllib.parse import urlsplit
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import Endpoint
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.invoiced.settings import INVOICED_ENDPOINTS
 
 INVOICED_BASE_URL = "https://api.invoiced.com"
 INVOICED_HOST = "api.invoiced.com"
 # List endpoints paginate GitHub-style (page/per_page + Link header) in pages of up to 100.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
 # Cheap list endpoint used to confirm an API key is genuine. Invoiced API keys are
 # account-wide, so one probe validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/customers"
-
-
-class InvoicedRetryableError(Exception):
-    pass
 
 
 class InvoicedUntrustedURLError(Exception):
@@ -55,21 +53,6 @@ class InvoicedResumeConfig:
     next_url: str | None = None
 
 
-def _get_session(api_key: str) -> requests.Session:
-    # Invoiced authenticates via HTTP Basic with the API key as the username and a blank password.
-    # `allow_redirects=False` stops a redirect response from sending the API key to another host, and
-    # `retry=Retry(total=0)` disables the adapter's built-in retries — `_fetch_page` already retries
-    # 429/5xx via tenacity, so the adapter default would stack a second retry layer.
-    session = make_tracked_session(
-        headers={"Accept": "application/json"},
-        redact_values=(api_key,),
-        allow_redirects=False,
-        retry=Retry(total=0),
-    )
-    session.auth = (api_key, "")
-    return session
-
-
 def _to_unix_timestamp(value: Any) -> int:
     """Convert an incremental cursor to the UNIX epoch integer `updated_after` expects."""
     if isinstance(value, datetime):
@@ -80,141 +63,115 @@ def _to_unix_timestamp(value: Any) -> int:
     return int(value)
 
 
-def _build_initial_url(
-    path: str,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> str:
-    # An explicit ascending updated_at sort keeps page traversal deterministic and lets the
-    # pipeline checkpoint the incremental watermark per batch (sort_mode="asc"). `sort` is
-    # documented on every list endpoint we sync ("Column to sort by, i.e. name asc").
-    params: dict[str, Any] = {"per_page": PAGE_SIZE, "sort": "updated_at asc"}
-    if should_use_incremental_field and db_incremental_field_last_value is not None:
-        params["updated_after"] = _to_unix_timestamp(db_incremental_field_last_value)
-    return f"{INVOICED_BASE_URL}{path}?{urlencode(params, quote_via=quote)}"
-
-
-@retry(
-    retry=retry_if_exception_type((InvoicedRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    logger: FilteringBoundLogger,
-) -> tuple[list[dict[str, Any]], Optional[str]]:
-    # `url` is already absolute — either the initial endpoint URL or a verbatim Link rel="next",
-    # so we never re-send query params (they're baked into the pagination URL).
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Invoiced enforces rate limits via 429 with no published numeric limits; back off and retry.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise InvoicedRetryableError(f"Invoiced API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Invoiced API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    # List endpoints return a top-level JSON array; pagination lives in the Link header.
-    if not isinstance(data, list):
-        raise InvoicedRetryableError(f"Invoiced returned an unexpected payload for {url}: {type(data).__name__}")
-
-    next_url = response.links.get("next", {}).get("url")
-    return data, next_url
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[InvoicedResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = INVOICED_ENDPOINTS[endpoint]
-    session = _get_session(api_key)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume and resume.next_url:
-        # Resume state comes from Redis — validate before sending the API key to it.
-        url: Optional[str] = _validate_pagination_url(resume.next_url)
-        logger.debug(f"Invoiced: resuming {endpoint} from {url}")
-    else:
-        url = _build_initial_url(config.path, should_use_incremental_field, db_incremental_field_last_value)
-
-    while url:
-        items, next_url = _fetch_page(session, url, logger)
-        if items:
-            yield items
-
-        # No Link rel="next" means we've reached the last page.
-        if not next_url:
-            break
-
-        # The upstream-supplied next-page URL is followed verbatim with the API key — pin it to the
-        # Invoiced API so a hostile response can't retarget the authenticated request.
-        url = _validate_pagination_url(next_url)
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(InvoicedResumeConfig(next_url=url))
-
-
 def invoiced_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[InvoicedResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = INVOICED_ENDPOINTS[endpoint]
 
+    # An explicit ascending updated_at sort keeps page traversal deterministic and lets the
+    # pipeline checkpoint the incremental watermark per batch (sort_mode="asc"). `sort` is
+    # documented on every list endpoint we sync ("Column to sort by, i.e. name asc").
+    params: dict[str, Any] = {"per_page": PAGE_SIZE, "sort": "updated_at asc"}
+
+    endpoint_config: Endpoint = {
+        "path": config.path,
+        "params": params,
+        # List endpoints return a top-level JSON array; a non-list body means the response shape
+        # changed — fail loud rather than wrapping a stray object as a single row.
+        "data_selector_required": True,
+        # GitHub-style pagination: the next page lives in the Link header's rel="next".
+        "paginator": HeaderLinkPaginator(),
+    }
+
+    use_incremental = should_use_incremental_field and db_incremental_field_last_value is not None
+    if use_incremental:
+        # Every list endpoint documents a server-side `updated_after` UNIX-timestamp filter; inject
+        # the last synced value as that filter so the sync only pulls rows touched since.
+        endpoint_config["incremental"] = {
+            "start_param": "updated_after",
+            "cursor_path": "updated_at",
+            "convert": _to_unix_timestamp,
+        }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": INVOICED_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Invoiced authenticates via HTTP Basic with the API key as the username and a blank
+            # password. The framework applies (and redacts) it, so no hand-built Authorization header.
+            "auth": HttpBasicAuth(username=api_key, password=""),
+            # Pin every request — including paginator next-page links and seeded resume URLs — to the
+            # Invoiced API host, and reject any 3xx, so a spoofed link or redirect can't retarget the
+            # authenticated request at another origin (SSRF). The scheme/host guard in the resume hook
+            # below adds the https-downgrade rejection host-pinning alone would miss.
+            "allowed_hosts": [],
+            "allow_redirects": False,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": endpoint_config,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_url:
+            # Resume state comes from Redis — validate before sending the API key to it.
+            initial_paginator_state = {"next_url": _validate_pagination_url(resume.next_url)}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # from the next page (already-yielded pages are persisted) and merge dedupes the re-pulled
+        # page on the primary key. The upstream-supplied next URL is validated before it's stored so
+        # a hostile Link header aborts the sync instead of poisoning the saved resume state.
+        next_url = state.get("next_url") if state else None
+        if next_url:
+            resumable_source_manager.save_state(InvoicedResumeConfig(next_url=_validate_pagination_url(next_url)))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if use_incremental else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
-        # Rows are requested with an explicit `sort=updated_at asc` (see _build_initial_url).
+        # Rows are requested with an explicit `sort=updated_at asc`.
         sort_mode="asc",
     )
 
 
-def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
     """Probe a single endpoint to validate the API key.
 
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
+    Invoiced API keys are account-wide, so one probe validates access to every list endpoint.
     """
-    session = _get_session(api_key)
-    try:
-        response = session.get(f"{INVOICED_BASE_URL}{path}", params={"per_page": 1}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Invoiced: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Invoiced returned HTTP {response.status_code}"
-
-    return 200, None
-
-
-def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_key)
-    if status == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{INVOICED_BASE_URL}{DEFAULT_PROBE_PATH}?per_page=1",
+        auth=HttpBasicAuth(username=api_key, password=""),
+        timeout=15,
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid Invoiced API key"
-    return False, message or "Could not validate Invoiced API key"
+    if status is None:
+        return False, "Could not connect to Invoiced"
+    return False, f"Invoiced returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/invoiced/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/invoiced/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import InvoicedSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.invoiced.invoiced import (
     InvoicedResumeConfig,
@@ -94,19 +97,7 @@ You can create an API key under **Settings → Developers → API Keys** in [Inv
     ) -> list[SourceSchema]:
         # Every list endpoint documents a server-side `updated_after` UNIX-timestamp filter, so
         # each schema advertises `updated_at` as a genuine incremental cursor.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=True,
-                supports_append=True,
-                incremental_fields=INCREMENTAL_FIELDS[endpoint],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: InvoicedSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -129,7 +120,8 @@ You can create an API key under **Settings → Developers → API Keys** in [Inv
         return invoiced_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/invoiced/tests/test_invoiced.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/invoiced/tests/test_invoiced.py
@@ -1,11 +1,13 @@
+import json
+from base64 import b64encode
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
 from parameterized import parameterized
+from requests import PreparedRequest, Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.invoiced.invoiced import (
     INVOICED_BASE_URL,
@@ -14,12 +16,26 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.invoiced.i
     InvoicedUntrustedURLError,
     _to_unix_timestamp,
     _validate_pagination_url,
-    get_rows,
     invoiced_source,
     validate_credentials,
 )
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.invoiced.invoiced"
+# The framework's RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the invoiced module.
+INVOICED_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.invoiced.invoiced.make_tracked_session"
+)
+
+
+def _response(items: Any, next_url: str | None = None, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(items).encode()
+    if next_url:
+        # requests parses `response.links` from the Link header; HeaderLinkPaginator reads rel="next".
+        resp.headers["Link"] = f'<{next_url}>; rel="next"'
+    return resp
 
 
 def _make_manager(resume_state: InvoicedResumeConfig | None = None) -> mock.MagicMock:
@@ -29,13 +45,29 @@ def _make_manager(resume_state: InvoicedResumeConfig | None = None) -> mock.Magi
     return manager
 
 
-def _response(items: Any, next_url: str | None = None, status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = items
-    resp.status_code = status_code
-    resp.ok = status_code < 400
-    resp.links = {"next": {"url": next_url}} if next_url else {}
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so inspecting it after the run shows
+    only the final state — snapshot it when each request is prepared. Preparing the request for real
+    also applies the framework auth (so the Authorization header can be asserted) and builds a real
+    ``prepared.url`` for the client's SSRF host check.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Request) -> PreparedRequest:
+        prepared = request.prepare()
+        snapshots.append({"url": request.url, "params": dict(request.params or {}), "prepared": prepared})
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[list[dict[str, Any]]]:
+    return list(source_response.items())
 
 
 class TestToUnixTimestamp:
@@ -52,105 +84,129 @@ class TestToUnixTimestamp:
         assert _to_unix_timestamp(value) == expected
 
 
-class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_paginates_via_link_header_and_saves_state_after_yield(self, mock_session: mock.MagicMock) -> None:
+class TestSourcePagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_link_header_and_saves_state_after_yield(self, MockSession) -> None:
+        session = MockSession.return_value
         page_two_url = f"{INVOICED_BASE_URL}/customers?page=2&per_page={PAGE_SIZE}"
-        mock_session.return_value.get.side_effect = [
-            _response([{"id": 1}, {"id": 2}], next_url=page_two_url),
-            _response([{"id": 3}]),
-        ]
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": 1}, {"id": 2}], next_url=page_two_url),
+                _response([{"id": 3}]),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("api-key", "customers", mock.MagicMock(), manager))
+        batches = _rows(
+            invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
 
         assert batches == [[{"id": 1}, {"id": 2}], [{"id": 3}]]
         manager.save_state.assert_called_once()
         assert manager.save_state.call_args.args[0].next_url == page_two_url
         # The second request follows the Link rel="next" URL verbatim.
-        assert mock_session.return_value.get.call_args_list[1].args[0] == page_two_url
+        assert snapshots[1]["url"] == page_two_url
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_incremental_request_includes_updated_after_and_sort(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_includes_updated_after_and_sort(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([])])
 
-        manager = _make_manager()
-        list(
-            get_rows(
+        _rows(
+            invoiced_source(
                 "api-key",
                 "invoices",
-                mock.MagicMock(),
-                manager,
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=1700000000,
             )
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        query = parse_qs(urlparse(url).query)
-        assert urlparse(url).path == "/invoices"
-        assert query["updated_after"] == ["1700000000"]
-        assert query["sort"] == ["updated_at asc"]
-        assert query["per_page"] == [str(PAGE_SIZE)]
+        params = snapshots[0]["params"]
+        assert params["updated_after"] == 1700000000
+        assert params["sort"] == "updated_at asc"
+        assert params["per_page"] == PAGE_SIZE
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_full_refresh_omits_updated_after(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_omits_updated_after(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([])])
 
-        manager = _make_manager()
-        list(get_rows("api-key", "customers", mock.MagicMock(), manager))
+        _rows(invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert "updated_after" not in parse_qs(urlparse(url).query)
+        assert "updated_after" not in snapshots[0]["params"]
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resumes_from_saved_next_url(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_next_url(self, MockSession) -> None:
+        session = MockSession.return_value
         saved_url = f"{INVOICED_BASE_URL}/customers?page=7&per_page={PAGE_SIZE}"
-        mock_session.return_value.get.return_value = _response([])
+        snapshots = _wire(session, [_response([])])
 
         manager = _make_manager(InvoicedResumeConfig(next_url=saved_url))
-        list(get_rows("api-key", "customers", mock.MagicMock(), manager))
+        _rows(invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert mock_session.return_value.get.call_args.args[0] == saved_url
+        assert snapshots[0]["url"] == saved_url
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_response_stops_without_saving_state(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops_without_saving_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
 
         manager = _make_manager()
-        batches = list(get_rows("api-key", "customers", mock.MagicMock(), manager))
+        batches = _rows(
+            invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
 
         assert batches == []
         manager.save_state.assert_not_called()
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_authenticates_with_api_key_as_basic_auth_username(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_authenticates_with_api_key_as_basic_auth_username(self, MockSession) -> None:
+        session = MockSession.return_value
+        snapshots = _wire(session, [_response([])])
 
-        list(get_rows("api-key", "customers", mock.MagicMock(), _make_manager()))
+        _rows(invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
-        assert mock_session.return_value.auth == ("api-key", "")
+        # HTTP Basic with the API key as username and a blank password: base64("api-key:").
+        expected = "Basic " + b64encode(b"api-key:").decode()
+        assert snapshots[0]["prepared"].headers["Authorization"] == expected
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_hostile_upstream_next_url_is_rejected(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_fails_loud(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "boom"})])
+
+        # List endpoints return a top-level array; a non-list body means the shape changed.
+        with pytest.raises(ValueError, match="list response body"):
+            _rows(
+                invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+            )
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_hostile_upstream_next_url_is_rejected(self, MockSession) -> None:
         # An upstream Link header pointing at another host must abort before the API key is sent
         # there, and the poisoned URL must not be persisted as resume state.
-        mock_session.return_value.get.return_value = _response(
-            [{"id": 1}], next_url="https://evil.example.com/customers"
-        )
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}], next_url="https://evil.example.com/customers")])
 
         manager = _make_manager()
         with pytest.raises(InvoicedUntrustedURLError):
-            list(get_rows("api-key", "customers", mock.MagicMock(), manager))
+            _rows(invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=manager))
         manager.save_state.assert_not_called()
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_hostile_resumed_next_url_is_rejected(self, mock_session: mock.MagicMock) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_hostile_resumed_next_url_is_rejected(self, MockSession) -> None:
         # A poisoned resume state from Redis must never be requested with the API key.
+        session = MockSession.return_value
+        _wire(session, [])
+
         manager = _make_manager(InvoicedResumeConfig(next_url="https://evil.example.com/customers"))
         with pytest.raises(InvoicedUntrustedURLError):
-            list(get_rows("api-key", "customers", mock.MagicMock(), manager))
-        mock_session.return_value.get.assert_not_called()
+            _rows(invoiced_source("api-key", "customers", team_id=1, job_id="j", resumable_source_manager=manager))
+        session.send.assert_not_called()
 
 
 class TestValidatePaginationUrl:
@@ -184,24 +240,24 @@ class TestValidateCredentials:
             ("forbidden", 403),
         ]
     )
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(INVOICED_SESSION_PATCH)
     def test_auth_failure_maps_to_invalid_key(self, _name: str, status_code: int, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response({}, status_code=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("bad-key") == (False, "Invalid Invoiced API key")
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(INVOICED_SESSION_PATCH)
     def test_valid_key(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response([])
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         assert validate_credentials("good-key") == (True, None)
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(INVOICED_SESSION_PATCH)
     def test_unexpected_status_returns_message(self, mock_session: mock.MagicMock) -> None:
-        mock_session.return_value.get.return_value = _response({}, status_code=500)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=500)
         ok, message = validate_credentials("key")
         assert ok is False
         assert message == "Invoiced returned HTTP 500"
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(INVOICED_SESSION_PATCH)
     def test_connection_error_returns_message(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         ok, message = validate_credentials("key")
@@ -211,7 +267,9 @@ class TestValidateCredentials:
 
 class TestInvoicedSourceResponse:
     def test_response_metadata(self) -> None:
-        response = invoiced_source("api-key", "invoices", mock.MagicMock(), _make_manager())
+        response = invoiced_source(
+            "api-key", "invoices", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
 
         assert response.name == "invoices"
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/iterable/iterable.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/iterable/iterable.py
@@ -1,15 +1,20 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import urlparse
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BaseNextUrlPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.iterable.settings import ITERABLE_ENDPOINTS
 
 # Iterable is region-locked: a key issued in one data center only works against that data center.
@@ -18,14 +23,9 @@ ITERABLE_BASE_URLS: dict[str, str] = {
     "eu": "https://api.eu.iterable.com",
 }
 
-REQUEST_TIMEOUT_SECONDS = 60
 # Safety bound on the pagination loop. Iterable's list endpoints normally return everything in a
 # single response, but if one ever starts returning `nextPageUrl` we don't want an unbounded scan.
 MAX_PAGES = 10_000
-
-
-class IterableRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -37,24 +37,21 @@ def base_url_for_region(region: str | None) -> str:
     return ITERABLE_BASE_URLS.get((region or "us").lower(), ITERABLE_BASE_URLS["us"])
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Api-Key": api_key,
-        "Accept": "application/json",
-    }
+def _probe_headers(api_key: str) -> dict[str, str]:
+    # The Api-Key credential rides in a header the tracked session's name-based scrubber doesn't
+    # know, so the probe session masks it by value via `redact_values`.
+    return {"Api-Key": api_key, "Accept": "application/json"}
 
 
 def validate_credentials(api_key: str, region: str | None) -> bool:
     # `/api/channels` is a cheap, low-cardinality endpoint that requires a valid server-side key.
     url = f"{base_url_for_region(region)}/api/channels"
-    # `redact_values` masks the key in logs and sample capture: the sampler's name-based scrubber
-    # doesn't recognise Iterable's `Api-Key` header, so the value would otherwise be captured raw.
-    session = make_tracked_session(headers=_get_headers(api_key), redact_values=(api_key,))
-    try:
-        response = session.get(url, timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        url,
+        headers=_probe_headers(api_key),
+    )
+    return ok
 
 
 def _is_same_origin(base_url: str, url: str) -> bool:
@@ -78,87 +75,96 @@ def _resolve_next_url(base_url: str, next_page: Any) -> str | None:
     return f"{base_url}{next_page}" if next_page.startswith("/") else f"{base_url}/{next_page}"
 
 
-def get_rows(
-    api_key: str,
-    region: str | None,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[IterableResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = ITERABLE_ENDPOINTS[endpoint]
-    base_url = base_url_for_region(region)
-    # `redact_values` masks the key in logs and sample capture: the sampler's name-based scrubber
-    # doesn't recognise Iterable's `Api-Key` header, so the value would otherwise be captured raw.
-    session = make_tracked_session(headers=_get_headers(api_key), redact_values=(api_key,))
+class IterableNextPagePaginator(BaseNextUrlPaginator):
+    """Follows Iterable's body-level ``nextPageUrl``.
 
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None and _is_same_origin(base_url, resume_config.next_url):
-        url: str | None = resume_config.next_url
-        logger.debug(f"Iterable: resuming {endpoint} from URL: {url}")
-    else:
-        # Either no resume state, or it points off-host (corrupted/poisoned) — start from the top.
-        # The session carries the `Api-Key` header, so we never follow a resumed off-host URL.
-        url = f"{base_url}{config.path}"
+    Iterable list endpoints normally return their whole result set in one response, but if one ever
+    starts paging we resolve a relative ``nextPageUrl`` against the region base URL and refuse to
+    follow an off-host absolute link. The session carries the ``Api-Key`` header, so an
+    attacker-echoed off-host ``nextPageUrl`` would otherwise leak the key — such links stop
+    pagination (the clean completion the hand-rolled source produced) rather than being followed.
+    ``max_pages`` bounds the loop so a self-referential ``nextPageUrl`` can't scan unbounded.
+    """
 
-    @retry(
-        retry=retry_if_exception_type((IterableRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
+    def __init__(self, base_url: str, max_pages: int = MAX_PAGES) -> None:
+        super().__init__()
+        self.base_url = base_url
+        self.max_pages = max_pages
+        self._pages = 0
 
-        if response.status_code == 429 or response.status_code >= 500:
-            raise IterableRetryableError(
-                f"Iterable API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Iterable API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    pages = 0
-    while url is not None:
-        data = fetch_page(url)
-        items = data.get(config.data_key, [])
-
-        next_url = _resolve_next_url(base_url, data.get("nextPageUrl"))
-
-        if items:
-            yield items
-            # Save state AFTER yielding so a crash re-yields the last batch (merge dedupes on the
-            # primary key) rather than skipping it.
-            if next_url is not None:
-                resumable_source_manager.save_state(IterableResumeConfig(next_url=next_url))
-
-        pages += 1
-        if pages >= MAX_PAGES:
-            logger.warning(f"Iterable: hit MAX_PAGES={MAX_PAGES} cap for endpoint={endpoint}; stopping pagination")
-            break
-
-        url = next_url
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        self._pages += 1
+        try:
+            next_page = response.json().get("nextPageUrl")
+        except Exception:
+            next_page = None
+        next_url = _resolve_next_url(self.base_url, next_page)
+        if next_url is not None and self._pages < self.max_pages:
+            self._next_url = next_url
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
 
 
 def iterable_source(
     api_key: str,
     region: str | None,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[IterableResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = ITERABLE_ENDPOINTS[endpoint]
+    base_url = base_url_for_region(region)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            # Only the non-secret Accept header goes here; the Api-Key credential is supplied via the
+            # framework auth config so its value is redacted from logs and sampled request captures.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "Api-Key", "location": "header"},
+            "paginator": IterableNextPagePaginator(base_url),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # `.get(data_key, [])` in the hand-rolled source treated a missing key as zero
+                    # rows, not an error — so the selector is NOT required (no fail-loud here).
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        # Only resume from a same-origin URL. A resume URL pointing off-host (corrupted/poisoned
+        # state) must not be requested with the Api-Key header — start from the top instead.
+        if resume is not None and _is_same_origin(base_url, resume.next_url):
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(IterableResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            region=region,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/iterable/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/iterable/source.py
@@ -21,7 +21,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import IterableSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.iterable.iterable import (
     IterableResumeConfig,
@@ -71,21 +74,7 @@ class IterableSource(ResumableSource[IterableSourceConfig, IterableResumeConfig]
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: IterableSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -108,8 +97,10 @@ class IterableSource(ResumableSource[IterableSourceConfig, IterableResumeConfig]
             api_key=config.api_key,
             region=config.region,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Iterable endpoint is full refresh
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/iterable/tests/test_iterable.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/iterable/tests/test_iterable.py
@@ -1,29 +1,31 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.iterable.iterable import (
     IterableResumeConfig,
-    _get_headers,
     _resolve_next_url,
     base_url_for_region,
-    get_rows,
     iterable_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.iterable.settings import ITERABLE_ENDPOINTS
 
 MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.iterable.iterable"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
 
 
-def _make_response(status_code: int = 200, body: dict[str, Any] | None = None) -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    response.json.return_value = body or {}
-    response.text = ""
-    return response
+def _response(body: dict[str, Any]) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: IterableResumeConfig | None = None) -> mock.MagicMock:
@@ -31,6 +33,36 @@ def _make_manager(resume_state: IterableResumeConfig | None = None) -> mock.Magi
     manager.can_resume.return_value = resume_state is not None
     manager.load_state.return_value = resume_state
     return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[str], list[Any]]:
+    """Wire a mock session; capture each request's URL and auth AT PREPARE TIME.
+
+    The paginator retargets a single ``Request`` object in place across pages, so inspecting it after
+    the run shows only the final URL — snapshot each request as it is prepared instead.
+    """
+    session.headers = {}
+    url_snapshots: list[str] = []
+    auth_snapshots: list[Any] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        url_snapshots.append(request.url)
+        auth_snapshots.append(request.auth)
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return url_snapshots, auth_snapshots
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(session: mock.MagicMock, api_key: str, region: str, endpoint: str, manager: mock.MagicMock) -> list[dict]:
+    return _rows(iterable_source(api_key, region, endpoint, team_id=1, job_id="j", resumable_source_manager=manager))
 
 
 class TestBaseUrlForRegion:
@@ -47,15 +79,6 @@ class TestBaseUrlForRegion:
     )
     def test_base_url_for_region(self, region: str | None, expected: str) -> None:
         assert base_url_for_region(region) == expected
-
-
-class TestHeaders:
-    def test_uses_api_key_header(self) -> None:
-        headers = _get_headers("secret-key")
-        assert headers["Api-Key"] == "secret-key"
-        assert headers["Accept"] == "application/json"
-        # Iterable uses the `Api-Key` header, not `Authorization`.
-        assert "Authorization" not in headers
 
 
 class TestResolveNextUrl:
@@ -90,7 +113,7 @@ class TestValidateCredentials:
     )
     @mock.patch(f"{MODULE}.make_tracked_session")
     def test_status_code_mapping(self, mock_session, status_code: int, expected: bool) -> None:
-        mock_session.return_value.get.return_value = _make_response(status_code=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("key", "us") is expected
 
     @mock.patch(f"{MODULE}.make_tracked_session")
@@ -100,83 +123,129 @@ class TestValidateCredentials:
 
     @mock.patch(f"{MODULE}.make_tracked_session")
     def test_uses_region_base_url(self, mock_session) -> None:
-        mock_session.return_value.get.return_value = _make_response(status_code=200)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("key", "eu")
         called_url = mock_session.return_value.get.call_args.args[0]
         assert called_url == "https://api.eu.iterable.com/api/channels"
 
-
-class TestGetRows:
     @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_single_page_yields_items_without_saving_state(self, mock_session) -> None:
-        mock_session.return_value.get.return_value = _make_response(body={"campaigns": [{"id": 1}, {"id": 2}]})
+    def test_sends_api_key_header(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("secret-key", "us")
+        headers = mock_session.return_value.get.call_args.kwargs["headers"]
+        # Iterable authenticates with the `Api-Key` header, not `Authorization`.
+        assert headers["Api-Key"] == "secret-key"
+        assert "Authorization" not in headers
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_uses_api_key_header_auth(self, MockSession) -> None:
+        session = MockSession.return_value
+        _, auth_snapshots = _wire(session, [_response({"campaigns": [{"id": 1}]})])
+
+        _run(session, "secret-key", "us", "campaigns", _make_manager())
+
+        auth = auth_snapshots[0]
+        assert isinstance(auth, APIKeyAuth)
+        assert auth.name == "Api-Key"
+        assert auth.location == "header"
+        assert auth.api_key == "secret-key"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_yields_items_without_saving_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"campaigns": [{"id": 1}, {"id": 2}]})])
         manager = _make_manager()
 
-        batches = list(get_rows("key", "us", "campaigns", mock.MagicMock(), manager))
+        rows = _run(session, "key", "us", "campaigns", manager)
 
-        assert batches == [[{"id": 1}, {"id": 2}]]
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_empty_response_yields_nothing(self, mock_session) -> None:
-        mock_session.return_value.get.return_value = _make_response(body={"campaigns": []})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"campaigns": []})])
         manager = _make_manager()
 
-        batches = list(get_rows("key", "us", "campaigns", mock.MagicMock(), manager))
+        rows = _run(session, "key", "us", "campaigns", manager)
 
-        assert batches == []
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_follows_next_page_url_and_saves_state_after_yield(self, mock_session) -> None:
-        first = _make_response(body={"campaigns": [{"id": 1}], "nextPageUrl": "/api/campaigns?page=2"})
-        second = _make_response(body={"campaigns": [{"id": 2}]})
-        mock_session.return_value.get.side_effect = [first, second]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_next_page_url_and_saves_state_after_yield(self, MockSession) -> None:
+        session = MockSession.return_value
+        urls, _ = _wire(
+            session,
+            [
+                _response({"campaigns": [{"id": 1}], "nextPageUrl": "/api/campaigns?page=2"}),
+                _response({"campaigns": [{"id": 2}]}),
+            ],
+        )
         manager = _make_manager()
 
-        batches = list(get_rows("key", "us", "campaigns", mock.MagicMock(), manager))
+        rows = _run(session, "key", "us", "campaigns", manager)
 
-        assert batches == [[{"id": 1}], [{"id": 2}]]
+        assert rows == [{"id": 1}, {"id": 2}]
+        # Second request follows the resolved (relative -> absolute) next URL.
+        assert urls == ["https://api.iterable.com/api/campaigns", "https://api.iterable.com/api/campaigns?page=2"]
         # State is saved once — after the first page yields, pointing at the resolved next URL.
         manager.save_state.assert_called_once_with(
             IterableResumeConfig(next_url="https://api.iterable.com/api/campaigns?page=2")
         )
-        # Second request follows the resolved next URL.
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert urls == ["https://api.iterable.com/api/campaigns", "https://api.iterable.com/api/campaigns?page=2"]
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_resumes_from_saved_state(self, mock_session) -> None:
-        mock_session.return_value.get.return_value = _make_response(body={"campaigns": [{"id": 9}]})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        urls, _ = _wire(session, [_response({"campaigns": [{"id": 9}]})])
         manager = _make_manager(
             resume_state=IterableResumeConfig(next_url="https://api.iterable.com/api/campaigns?page=5")
         )
 
-        list(get_rows("key", "us", "campaigns", mock.MagicMock(), manager))
+        _run(session, "key", "us", "campaigns", manager)
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert first_url == "https://api.iterable.com/api/campaigns?page=5"
+        assert urls[0] == "https://api.iterable.com/api/campaigns?page=5"
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_off_host_resume_state_restarts_from_top(self, mock_session) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_off_host_resume_state_restarts_from_top(self, MockSession) -> None:
         # A resume URL pointing at another host (corrupted/poisoned state) must not be requested
         # with the Api-Key header — pagination restarts from the endpoint's base URL instead.
-        mock_session.return_value.get.return_value = _make_response(body={"campaigns": [{"id": 9}]})
+        session = MockSession.return_value
+        urls, _ = _wire(session, [_response({"campaigns": [{"id": 9}]})])
         manager = _make_manager(resume_state=IterableResumeConfig(next_url="https://evil.com/api/campaigns?page=5"))
 
-        list(get_rows("key", "us", "campaigns", mock.MagicMock(), manager))
+        _run(session, "key", "us", "campaigns", manager)
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert first_url == "https://api.iterable.com/api/campaigns"
+        assert urls[0] == "https://api.iterable.com/api/campaigns"
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_uses_endpoint_data_key(self, mock_session) -> None:
-        mock_session.return_value.get.return_value = _make_response(body={"templates": [{"templateId": 7}]})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_off_host_next_page_url_stops_pagination(self, MockSession) -> None:
+        # An off-host absolute `nextPageUrl` (attacker-echoed) is not followed — pagination stops
+        # cleanly after the first page rather than sending the Api-Key header off-host.
+        session = MockSession.return_value
+        _wire(session, [_response({"campaigns": [{"id": 1}], "nextPageUrl": "https://evil.com/api/campaigns?page=2"})])
         manager = _make_manager()
 
-        batches = list(get_rows("key", "us", "templates", mock.MagicMock(), manager))
+        rows = _run(session, "key", "us", "campaigns", manager)
 
-        assert batches == [[{"templateId": 7}]]
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_uses_endpoint_data_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        urls, _ = _wire(session, [_response({"templates": [{"templateId": 7}]})])
+        manager = _make_manager()
+
+        rows = _run(session, "key", "us", "templates", manager)
+
+        assert rows == [{"templateId": 7}]
+        assert urls[0] == "https://api.iterable.com/api/templates"
 
 
 class TestIterableSource:
@@ -191,7 +260,9 @@ class TestIterableSource:
         ],
     )
     def test_source_response_primary_keys(self, endpoint: str, expected_pk: str) -> None:
-        response = iterable_source("key", "us", endpoint, mock.MagicMock(), _make_manager())
+        response = iterable_source(
+            "key", "us", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
         assert response.name == endpoint
         assert response.primary_keys == [expected_pk]
         assert response.primary_keys == [ITERABLE_ENDPOINTS[endpoint].primary_key]


### PR DESCRIPTION
## Problem

Batch 22 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **hibob**
- **hubplanner**
- **humanitix**
- **incident_io**
- **insightly**
- **invoiced** — key-as-username Basic auth, header-link pagination, SSRF host/scheme pinning
- **iterable**

Not migrated this batch (left hand-rolled, valid blocker):
- **harvey** — mixes framework-inexpressible transport modes: a watermark-branched seed request to a separate endpoint whose single-row body is yielded before cursor-paginating a different endpoint, plus client-side date-window chunking with client-side watermark clamping and early termination.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 7 migrated dirs + `common/rest_source/tests/` — 549 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-21 PR (#71891); merge in order.
