### PR TITLE
refactor(data-warehouse): migrate hetzner, hugging_face, instatus, invoiceninja, jobnimbus, jotform (batch 23)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hetzner/hetzner.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hetzner/hetzner.py
@@ -1,22 +1,18 @@
-import random
 import dataclasses
-from collections.abc import Iterator
-from email.utils import parsedate_to_datetime
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.settings import (
-    HETZNER_ENDPOINTS,
-    HetznerEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.settings import HETZNER_ENDPOINTS
 
 # Single global base URL — Hetzner Cloud has no regional hosts.
 HETZNER_BASE_URL = "https://api.hetzner.cloud/v1"
@@ -25,213 +21,124 @@ HETZNER_BASE_URL = "https://api.hetzner.cloud/v1"
 # round trips against the 3600 req/hour budget.
 PAGE_SIZE = 50
 
-# Cap on how long we honor a rate-limit reset before retrying anyway, so a misreported reset header
-# can't stall a worker past the activity heartbeat window.
-MAX_RETRY_AFTER_SECONDS = 300.0
-
-
-class HetznerRetryableError(Exception):
-    """Raised for transient responses (429 / 5xx). Carries the server-advertised retry delay when
-    the response provided one so the retry can wait exactly that long instead of guessing."""
-
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
+# Hetzner list endpoints are 1-indexed.
+FIRST_PAGE = 1
 
 
 @dataclasses.dataclass
 class HetznerResumeConfig:
-    # Page number to fetch first on resume. In-flight we checkpoint the CURRENT page after yielding a
-    # batch: a crash re-fetches that one page rather than skipping its un-yielded tail (dropping rows
-    # is worse than re-reading a page). On clean completion we advance the checkpoint PAST the last
-    # page so a spurious retry resumes onto an empty page instead of replaying. These tables are full
-    # refresh, so any rows a re-fetched page duplicates are bounded to that single page and are wiped
-    # by the next non-resumed run, which overwrites the table from scratch.
-    page: int = 1
+    # Page number to fetch first on resume. The framework checkpoints the NEXT page after a page has
+    # been yielded, so a crash mid-page resumes onto that in-flight page and re-reads it rather than
+    # skipping its un-yielded tail (dropping rows is worse than re-reading a page). These tables are
+    # full refresh with an `id` primary key, so any rows a re-fetched page duplicates are wiped by the
+    # next non-resumed run (which overwrites the table from scratch) or deduped on merge.
+    page: int = FIRST_PAGE
 
 
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_token}",
-        "Accept": "application/json",
+def _non_secret_headers() -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs and
+    # raised error messages; only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
+
+
+def hetzner_source(
+    api_token: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[HetznerResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = HETZNER_ENDPOINTS[endpoint]
+
+    params: dict[str, Any] = {"per_page": PAGE_SIZE}
+    if config.sort is not None:
+        params["sort"] = config.sort
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": HETZNER_BASE_URL,
+            "headers": _non_secret_headers(),
+            "auth": {"type": "bearer", "token": api_token},
+            # Page-number pagination; `meta.pagination.last_page` is the TOTAL number of pages, so the
+            # paginator stops after the last page instead of paying one extra empty-page request.
+            # stop_after_empty_page (default) is the fallback when a response omits the total.
+            "paginator": PageNumberPaginator(
+                base_page=FIRST_PAGE,
+                page_param="page",
+                total_path="meta.pagination.last_page",
+            ),
+            # Disable redirect following so a 3xx can never replay the Authorization header to another
+            # host — the SSRF guard the hand-rolled transport used.
+            "allow_redirects": False,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # The list lives under the endpoint's envelope key, e.g. {"servers": [...]}. A
+                    # missing key means an empty page (Hetzner never returns 200 without it), so a
+                    # non-required selector lets the paginator stop rather than failing loud.
+                    "data_selector": config.response_key,
+                },
+            }
+        ],
     }
 
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
 
-def _parse_retry_after(response: requests.Response) -> float | None:
-    """Prefer the standard `Retry-After` (seconds); fall back to `RateLimit-Reset` (unix epoch
-    seconds), which Hetzner returns on a throttled request. Returns None when neither is usable."""
-    retry_after = response.headers.get("Retry-After")
-    if retry_after:
-        try:
-            return float(retry_after)
-        except ValueError:
-            pass
-    reset = response.headers.get("RateLimit-Reset")
-    if reset:
-        try:
-            # Reset is an absolute epoch second; Date gives the server's "now" so we don't depend on
-            # local clock skew. Fall back to a small delay if the delta is nonsensical.
-            server_now = response.headers.get("Date")
-            if server_now:
-                now_ts = parsedate_to_datetime(server_now).timestamp()
-                delta = float(reset) - now_ts
-                return delta if delta > 0 else None
-        except (ValueError, TypeError):
-            pass
-    return None
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the framework calls this AFTER a page is yielded with
+        # the NEXT page to fetch, so a crash re-reads the in-flight page (bounded, deduped) rather than
+        # skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(HetznerResumeConfig(page=int(state["page"])))
 
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
-_backoff_wait = wait_exponential_jitter(initial=1, max=30)
-
-
-def _retry_wait(state: RetryCallState) -> float:
-    """Wait the server-advertised reset (capped, plus jitter) when we got one; otherwise exponential
-    backoff. Jitter keeps sources sharing one project token from all waking at the same reset instant."""
-    if state.outcome is not None and state.outcome.failed:
-        exc = state.outcome.exception()
-        if isinstance(exc, HetznerRetryableError) and exc.retry_after is not None:
-            return min(exc.retry_after, MAX_RETRY_AFTER_SECONDS) + random.uniform(0, 1)
-    return _backoff_wait(state)
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            HetznerRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            # A mid-stream break on a chunked body; transient, so a fresh GET re-fetches the page.
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=_retry_wait,
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=60)
-
-    # 429 (rate limited) and 5xx are transient — retry, honoring the reset header on a 429.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise HetznerRetryableError(
-            f"Hetzner API error (retryable): status={response.status_code}, url={url}",
-            retry_after=_parse_retry_after(response) if response.status_code == 429 else None,
-        )
-
-    if not response.ok:
-        logger.error(f"Hetzner API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _build_url(config: HetznerEndpointConfig, page: int) -> str:
-    params: dict[str, Any] = {"page": page, "per_page": PAGE_SIZE}
-    if config.sort:
-        params["sort"] = config.sort
-    return f"{HETZNER_BASE_URL}{config.path}?{urlencode(params)}"
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        # id:asc (or default order for the catalog endpoints) — rows arrive oldest-id first.
+        sort_mode="asc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="week" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
+    )
 
 
 def validate_credentials(api_token: str) -> tuple[bool, str | None]:
     """One cheap authenticated probe to confirm the token is genuine. Hetzner project tokens grant
     read access to every resource in the project (a read-only token still reads all of them), so
     there is no per-endpoint scope to check — a valid token can sync any table."""
-    url = f"{HETZNER_BASE_URL}/ssh_keys?per_page=1"
-    try:
-        # redact_values masks the token in logged URLs / captured samples; allow_redirects=False keeps
-        # a redirect from ever replaying the Authorization header (or the token in a query param) to
-        # another host. Mirrors the hardened transport other warehouse sources use.
-        session = make_tracked_session(redact_values=(api_token,), allow_redirects=False)
-        response = session.get(url, headers=_get_headers(api_token), timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
-
-    if response.status_code == 200:
-        return True, None
-    if response.status_code in (401, 403):
-        return False, "Invalid Hetzner Cloud API token"
-    try:
-        message = response.json().get("error", {}).get("message", response.text)
-    except (ValueError, AttributeError):
-        message = response.text
-    return False, message
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[HetznerResumeConfig],
-) -> Iterator[Any]:
-    config = HETZNER_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    # redact_values keeps the token out of tracked telemetry/samples; allow_redirects=False stops a
-    # redirect from ever forwarding the Authorization header to another host.
-    session = make_tracked_session(redact_values=(api_token,), allow_redirects=False)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume is not None else 1
-    if resume is not None:
-        logger.debug(f"Hetzner: resuming {endpoint} from page {page}")
-
-    last_page = page
-    while True:
-        data = _fetch_page(session, _build_url(config, page), headers, logger)
-        items = data.get(config.response_key) or []
-        if not items:
-            break
-
-        last_page = page
-        next_page = data.get("meta", {}).get("pagination", {}).get("next_page")
-        # Checkpoint the CURRENT page: on resume we re-fetch it rather than jumping to next_page and
-        # dropping this page's un-yielded tail. A re-fetch can re-yield rows already written, but that
-        # is bounded to one page and self-heals on the next full-refresh run.
-        checkpoint_page = page
-
-        for item in items:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-                resumable_source_manager.save_state(HetznerResumeConfig(page=checkpoint_page))
-
-        if not next_page:
-            break
-        page = next_page
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
-    # Every page is now written. Advance the checkpoint past the last page so a crash between this
-    # final write and the activity completing resumes onto an empty page (a no-op) instead of
-    # replaying already-written pages from the last in-flight checkpoint and appending duplicates.
-    resumable_source_manager.save_state(HetznerResumeConfig(page=last_page + 1))
-
-
-def hetzner_source(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[HetznerResumeConfig],
-) -> SourceResponse:
-    endpoint_config = HETZNER_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=endpoint_config.primary_keys,
-        # id:asc (or default order for the catalog endpoints) — rows arrive oldest-id first.
-        sort_mode="asc",
-        partition_count=1,
-        partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="week" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+    # redact_values masks the token in logged URLs / captured samples; allow_redirects=False keeps a
+    # redirect from ever replaying the Authorization header to another host.
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,), allow_redirects=False),
+        f"{HETZNER_BASE_URL}/ssh_keys?per_page=1",
+        headers={"Authorization": f"Bearer {api_token}", **_non_secret_headers()},
     )
+    if ok:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid Hetzner Cloud API token"
+    if status is None:
+        return False, "Could not reach the Hetzner Cloud API"
+    return False, f"Hetzner Cloud API returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hetzner/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hetzner/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import HetznerSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.hetzner import (
     HetznerResumeConfig,
@@ -28,7 +31,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.he
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.settings import (
     ENDPOINTS,
-    HETZNER_ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -81,7 +83,7 @@ Create a token under **Security > API tokens** in the [Hetzner Cloud Console](ht
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # A revoked or invalid token surfaces as an HTTPError when `_fetch_page` calls
+            # A revoked or invalid token surfaces as an HTTPError when the client calls
             # `raise_for_status()`. Retrying can never fix a credential problem, so stop the sync.
             # Match the stable status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://api.hetzner.cloud": "Your Hetzner Cloud API token is invalid or has been revoked. Create a new token in the Hetzner Cloud Console, then reconnect.",
@@ -98,22 +100,9 @@ Create a token under **Security > API tokens** in the [Hetzner Cloud Console](ht
     ) -> list[SourceSchema]:
         # The Hetzner Cloud API has no server-side timestamp filter on any list endpoint, so every
         # table is full refresh only — no incremental, no append (append would re-append the whole
-        # list every run and materialize duplicates).
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = HETZNER_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # list every run and materialize duplicates). INCREMENTAL_FIELDS is empty for every endpoint,
+        # so build_endpoint_schemas yields supports_incremental/supports_append=False for all.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: HetznerSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -132,6 +121,8 @@ Create a token under **Security > API tokens** in the [Hetzner Cloud Console](ht
         return hetzner_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Hetzner endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hetzner/tests/test_hetzner.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hetzner/tests/test_hetzner.py
@@ -1,209 +1,256 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
-from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner import hetzner
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.hetzner import (
     HETZNER_BASE_URL,
     HetznerResumeConfig,
-    HetznerRetryableError,
-    _build_url,
-    _parse_retry_after,
-    get_rows,
     hetzner_source,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.settings import HETZNER_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the hetzner module.
+HETZNER_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.hetzner.hetzner.make_tracked_session"
+)
+# Retryable tests: silence tenacity's backoff so retries don't actually sleep.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResumableManager:
-    def __init__(self, state: HetznerResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[HetznerResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> HetznerResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: HetznerResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class _OneRowBatcher(Batcher):
-    """Force a yield after every row so pagination/resume checkpoints are observable without
-    materializing the 2000-row default chunk."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs["chunk_size"] = 1
-        super().__init__(*args, **kwargs)
+def _page(
+    items: list[dict[str, Any]] | None,
+    *,
+    endpoint: str = "servers",
+    last_page: int = 1,
+    status: int = 200,
+    drop_key: bool = False,
+    reason: str = "",
+) -> Response:
+    body: dict[str, Any] = {"meta": {"pagination": {"last_page": last_page}}}
+    if not drop_key:
+        body[endpoint] = items or []
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = f"{HETZNER_BASE_URL}/{endpoint}"
+    resp.reason = reason
+    return resp
 
 
-def _mock_response(status_code: int, headers: dict[str, str] | None = None, body: Any = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    response.headers = headers or {}
-    response.json.return_value = body if body is not None else {}
-    response.text = "" if body is None else str(body)
-    if not response.ok:
-        response.raise_for_status.side_effect = requests.HTTPError(
-            f"{status_code} Client Error for url: {HETZNER_BASE_URL}/servers", response=response
+def _make_manager(resume_state: HetznerResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's query params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared rather than inspecting the shared dict after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return hetzner_source(
+        api_token="token",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_last_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _page([{"id": 1}, {"id": 2}], last_page=2),
+                _page([{"id": 3}], last_page=2),
+            ],
         )
-    return response
+        manager = _make_manager()
 
+        rows = _rows(_source("servers", manager))
 
-def _servers_page(items: list[dict], next_page: int | None) -> dict:
-    return {"servers": items, "meta": {"pagination": {"next_page": next_page}}}
+        assert [r["id"] for r in rows] == [1, 2, 3]
+        # last_page=2 stops after page 2 — no extra empty-page request.
+        assert session.send.call_count == 2
+        assert params[0]["page"] == 1
+        assert params[0]["per_page"] == 50
+        assert params[1]["page"] == 2
+        # Checkpoint saved after the first page, pointing at the next page.
+        manager.save_state.assert_called_once_with(HetznerResumeConfig(page=2))
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": 1}, {"id": 2}], last_page=1)])
+        manager = _make_manager()
 
-class TestBuildUrl:
-    def test_includes_pagination_and_sort(self) -> None:
-        url = _build_url(HETZNER_ENDPOINTS["servers"], page=3)
-        query = parse_qs(urlparse(url).query)
-        assert url.startswith(f"{HETZNER_BASE_URL}/servers?")
-        assert query["page"] == ["3"]
-        assert query["per_page"] == ["50"]
-        assert query["sort"] == ["id:asc"]
+        rows = _rows(_source("servers", manager))
 
-    def test_catalog_endpoint_omits_sort(self) -> None:
+        assert [r["id"] for r in rows] == [1, 2]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_response_key_empty(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([], last_page=1)])
+        manager = _make_manager()
+
+        rows = _rows(_source("servers", manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_response_key_stops_without_raising(self, MockSession) -> None:
+        # The hand-rolled source treated a missing envelope key as an empty page (stop), not an error;
+        # a non-required data_selector preserves that — the paginator stops rather than failing loud.
+        session = MockSession.return_value
+        _wire(session, [_page(None, drop_key=True, last_page=1)])
+        manager = _make_manager()
+
+        rows = _rows(_source("servers", manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        # A saved page must skip already-synced pages instead of restarting at page 1.
+        session = MockSession.return_value
+        params = _wire(session, [_page([{"id": 99}], last_page=2)])
+        manager = _make_manager(HetznerResumeConfig(page=2))
+
+        rows = _rows(_source("servers", manager))
+
+        assert [r["id"] for r in rows] == [99]
+        assert params[0]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sort_param_present_for_resource_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_page([{"id": 1}], last_page=1)])
+
+        _rows(_source("servers", _make_manager()))
+
+        assert params[0]["sort"] == "id:asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_catalog_endpoint_omits_sort(self, MockSession) -> None:
         # server_types has no verified sort support, so we must not send a sort param that could 400.
-        url = _build_url(HETZNER_ENDPOINTS["server_types"], page=1)
-        assert "sort" not in parse_qs(urlparse(url).query)
+        session = MockSession.return_value
+        params = _wire(session, [_page([{"id": 1}], endpoint="server_types", last_page=1)])
+
+        _rows(_source("server_types", _make_manager()))
+
+        assert "sort" not in params[0]
 
 
-class TestParseRetryAfter:
-    def test_prefers_retry_after_header(self) -> None:
-        response = _mock_response(429, headers={"Retry-After": "12"})
-        assert _parse_retry_after(response) == 12.0
+class TestRetries:
+    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
+    @mock.patch(SLEEP_PATCH, lambda *_: None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_transient_status_is_retried_then_reraised(self, _name: str, status: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_page([], status=status, reason="err") for _ in range(5)])
 
-    def test_falls_back_to_ratelimit_reset_minus_server_now(self) -> None:
-        # Date parses to 1445412480 (server's "now"); reset is 60s later, so we wait ~60s using the
-        # server clock rather than the local one (which may be skewed).
-        response = _mock_response(
-            429,
-            headers={"RateLimit-Reset": "1445412540", "Date": "Wed, 21 Oct 2015 07:28:00 GMT"},
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source("servers", _make_manager()))
+        # 5 attempts (DEFAULT_RETRY_ATTEMPTS) before giving up.
+        assert session.send.call_count == 5
+
+    @mock.patch(SLEEP_PATCH, lambda *_: None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_then_succeeds(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page([], status=503, reason="err"),
+                _page([{"id": 7}], last_page=1),
+            ],
         )
-        assert _parse_retry_after(response) == 60.0
 
-    def test_returns_none_without_usable_headers(self) -> None:
-        assert _parse_retry_after(_mock_response(429)) is None
+        rows = _rows(_source("servers", _make_manager()))
+
+        assert [r["id"] for r in rows] == [7]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_is_not_retried(self, MockSession) -> None:
+        # A 401 is fatal; raising HTTPError immediately (not retrying) lets get_non_retryable_errors act.
+        session = MockSession.return_value
+        _wire(session, [_page([], status=401, reason="Unauthorized")])
+
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("servers", _make_manager()))
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
     @parameterized.expand(
         [
-            ("valid", 200, None, True),
-            ("unauthorized", 401, None, False),
-            ("forbidden", 403, None, False),
+            ("valid", 200, True, None),
+            ("unauthorized", 401, False, "Invalid Hetzner Cloud API token"),
+            ("forbidden", 403, False, "Invalid Hetzner Cloud API token"),
         ]
     )
-    def test_status_maps_to_validity(self, _name: str, status: int, body: Any, expected: bool) -> None:
-        session = MagicMock()
-        session.get.return_value = _mock_response(status, body=body)
-        with patch.object(hetzner, "make_tracked_session", return_value=session):
-            valid, _message = validate_credentials("token")
-        assert valid is expected
+    @mock.patch(HETZNER_SESSION_PATCH)
+    def test_status_maps_to_validity(
+        self, _name: str, status: int, expected_valid: bool, expected_message: str | None, mock_session
+    ) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        valid, message = validate_credentials("token")
+        assert valid is expected_valid
+        assert message == expected_message
 
-    def test_network_error_is_invalid_not_raised(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(hetzner, "make_tracked_session", return_value=session):
-            valid, message = validate_credentials("token")
+    @mock.patch(HETZNER_SESSION_PATCH)
+    def test_network_error_is_invalid_not_raised(self, mock_session) -> None:
+        # A probe transport failure must return "not validated", never raise out of source creation.
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        valid, message = validate_credentials("token")
         assert valid is False
-        assert message == "boom"
+        assert message == "Could not reach the Hetzner Cloud API"
 
 
-class TestFetchPageRetries:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_transient_status_raises_retryable(self, _name: str, status: int) -> None:
-        session = MagicMock()
-        session.get.return_value = _mock_response(status, headers={"Retry-After": "1"} if status == 429 else {})
-        with patch.object(hetzner._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(HetznerRetryableError):
-                hetzner._fetch_page(session, f"{HETZNER_BASE_URL}/servers", {}, MagicMock())
-        # 5 attempts (stop_after_attempt(5)) before giving up.
-        assert session.get.call_count == 5
-
-    def test_retries_then_succeeds(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = [
-            requests.ReadTimeout("slow"),
-            _mock_response(200, body=_servers_page([], None)),
-        ]
-        with patch.object(hetzner._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = hetzner._fetch_page(session, f"{HETZNER_BASE_URL}/servers", {}, MagicMock())
-        assert result == _servers_page([], None)
-        assert session.get.call_count == 2
-
-    def test_client_error_is_not_retried(self) -> None:
-        # A 404/401 is fatal; raising HTTPError immediately (not retrying) lets get_non_retryable_errors act.
-        session = MagicMock()
-        session.get.return_value = _mock_response(401)
-        with pytest.raises(requests.HTTPError):
-            hetzner._fetch_page(session, f"{HETZNER_BASE_URL}/servers", {}, MagicMock())
-        assert session.get.call_count == 1
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(manager: _FakeResumableManager, responses: dict[int, dict], endpoint: str = "servers") -> list[dict]:
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            page = int(parse_qs(urlparse(url).query)["page"][0])
-            return responses[page]
-
-        rows: list[dict] = []
-        with patch.object(hetzner, "_fetch_page", fake_fetch):
-            for table in get_rows("token", endpoint, MagicMock(), manager):  # type: ignore[arg-type]
-                rows.extend(table.to_pylist())
-        return rows
-
-    def test_paginates_until_next_page_is_null(self) -> None:
-        responses = {
-            1: _servers_page([{"id": 1}, {"id": 2}], next_page=2),
-            2: _servers_page([{"id": 3}], next_page=None),
-        }
-        rows = self._collect(_FakeResumableManager(), responses)
-        assert [r["id"] for r in rows] == [1, 2, 3]
-
-    def test_stops_when_response_key_empty(self) -> None:
-        rows = self._collect(_FakeResumableManager(), {1: _servers_page([], next_page=2)})
-        assert rows == []
-
-    def test_resumes_from_saved_page(self) -> None:
-        # A saved page must skip already-synced pages instead of restarting at page 1.
-        responses = {2: _servers_page([{"id": 99}], next_page=None)}
-        rows = self._collect(_FakeResumableManager(HetznerResumeConfig(page=2)), responses)
-        assert [r["id"] for r in rows] == [99]
-
-    def test_checkpoints_current_page_then_advances_past_end(self) -> None:
-        # In-flight we checkpoint the CURRENT page (not next_page) so a crash re-fetches that page
-        # instead of skipping its un-yielded tail and dropping rows. On completion we advance the
-        # checkpoint past the last page so a post-final-write crash resumes onto an empty page rather
-        # than replaying already-written pages into the full-refresh table.
-        responses = {
-            1: _servers_page([{"id": 1}, {"id": 2}], next_page=2),
-            2: _servers_page([{"id": 3}], next_page=None),
-        }
-        manager = _FakeResumableManager()
-        with patch.object(hetzner, "Batcher", _OneRowBatcher):
-            self._collect(manager, responses)
-        saved_pages = [state.page for state in manager.saved]
-        # Page 1 yields twice (checkpoint 1), page 2 yields once (checkpoint 2), then the completion
-        # sentinel advances to page 3 (the empty page past the end).
-        assert saved_pages == [1, 1, 2, 3]
-
-
-class TestHetznerSourceResponse:
+class TestSourceResponse:
     def test_datetime_partition_for_resource_endpoint(self) -> None:
-        response = hetzner_source("token", "servers", MagicMock(), MagicMock())
+        with mock.patch(CLIENT_SESSION_PATCH):
+            response = _source("servers", _make_manager())
         assert response.name == "servers"
         assert response.primary_keys == ["id"]
         assert response.sort_mode == "asc"
@@ -214,6 +261,7 @@ class TestHetznerSourceResponse:
     def test_no_partition_for_timestampless_endpoints(self, endpoint: str) -> None:
         # actions has no `created`; catalog endpoints carry no timestamps — partitioning on a null or
         # absent field would rewrite partitions every sync, so these must stay unpartitioned.
-        response = hetzner_source("token", endpoint, MagicMock(), MagicMock())
+        with mock.patch(CLIENT_SESSION_PATCH):
+            response = _source(endpoint, _make_manager())
         assert response.partition_mode is None
         assert response.partition_keys is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/hugging_face.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/hugging_face.py
@@ -1,16 +1,19 @@
-import re
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    HeaderLinkPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.hugging_face.settings import (
     HUGGING_FACE_ENDPOINTS,
     HuggingFaceEndpointConfig,
@@ -22,150 +25,109 @@ HUGGING_FACE_BASE_URL = "https://huggingface.co"
 PAGE_SIZE = 1000
 
 
-class HuggingFaceRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class HuggingFaceResumeConfig:
-    # URL of the page to resume from. We checkpoint the *current* page (not the next one) after
-    # yielding it, so a crash re-fetches and re-yields that page rather than skipping it — the delta
-    # merge dedupes the re-pulled rows on the primary key.
+    # URL of the page to resume from. We checkpoint the *next* page's self-contained Link-header URL
+    # after a page is yielded, so a resumed run continues from where it left off (already-yielded
+    # pages are persisted before the checkpoint; the delta merge dedupes on the primary key).
     resume_url: str
 
 
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_token}",
-        "Accept": "application/json",
-    }
+class HuggingFaceLinkPaginator(HeaderLinkPaginator):
+    """Follows the Hub's ``Link: <…>; rel="next"`` cursor, but also stops on an empty page.
 
+    The Hub omits the next link once it runs out of rows, but we terminate on an empty page even if a
+    stray next link is present — matching the original source's "empty page ends the stream" guard and
+    avoiding an unbounded loop.
+    """
 
-def _parse_next_url(link_header: str) -> str | None:
-    """Return the URL with rel="next" from the Hub's Link header, if any."""
-    if not link_header:
-        return None
-    for part in link_header.split(","):
-        part = part.strip()
-        match = re.match(r'<([^>]+)>;\s*rel="next"', part)
-        if match:
-            return match.group(1)
-    return None
-
-
-def validate_credentials(api_token: str) -> bool:
-    url = f"{HUGGING_FACE_BASE_URL}/api/whoami-v2"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_token), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            HuggingFaceRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> requests.Response:
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise HuggingFaceRetryableError(f"Hugging Face API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Hugging Face API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response
-
-
-def _build_initial_url(config: HuggingFaceEndpointConfig, author: str) -> str:
-    # Sort ascending by createdAt (immutable), so new repos append to the end and don't shift pages
-    # we've already walked mid-sync. The Hub has no server-side timestamp range filter, so these
-    # endpoints are full refresh only.
-    params: dict[str, Any] = {
-        "author": author,
-        "sort": "createdAt",
-        "direction": 1,
-        "limit": PAGE_SIZE,
-    }
-    if config.full:
-        params["full"] = "true"
-    return f"{HUGGING_FACE_BASE_URL}{config.path}?{urlencode(params)}"
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    author: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[HuggingFaceResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = HUGGING_FACE_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = make_tracked_session()
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None:
-        url = resume.resume_url
-        logger.debug(f"Hugging Face: resuming from URL: {url}")
-    else:
-        url = _build_initial_url(config, author)
-
-    while True:
-        response = _fetch_page(session, url, headers, logger)
-        items = response.json()
-        if not isinstance(items, list) or not items:
-            break
-
-        next_url = _parse_next_url(response.headers.get("Link", ""))
-
-        yield items
-
-        # Checkpoint AFTER yielding, and checkpoint the current page URL so a crash re-fetches this
-        # page (merge dedupes on the primary key) rather than skipping it.
-        if next_url:
-            resumable_source_manager.save_state(HuggingFaceResumeConfig(resume_url=url))
-        else:
-            break
-
-        url = next_url
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+        super().update_state(response, data)
 
 
 def hugging_face_source(
     api_token: str,
     endpoint: str,
     author: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[HuggingFaceResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = HUGGING_FACE_ENDPOINTS[endpoint]
+    params = _build_initial_params(config, author)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": HUGGING_FACE_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted from
+            # logs and raised errors; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_token},
+            "paginator": HuggingFaceLinkPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.resume_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a resumed run picks
+        # up at the next self-contained Link-header URL.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(HuggingFaceResumeConfig(resume_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            author=author,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime",
         partition_format="month",
         partition_keys=[config.partition_key],
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_token: str) -> bool:
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{HUGGING_FACE_BASE_URL}/api/whoami-v2",
+        headers={"Authorization": f"Bearer {api_token}", "Accept": "application/json"},
+    )
+    return ok
+
+
+def _build_initial_params(config: HuggingFaceEndpointConfig, author: str) -> dict[str, Any]:
+    # Sort ascending by createdAt (immutable), so new repos append to the end and don't shift pages
+    # we've already walked mid-sync. The Hub has no server-side timestamp range filter, so these
+    # endpoints are full refresh only.
+    params: dict[str, Any] = {"author": author, "sort": "createdAt", "direction": 1, "limit": PAGE_SIZE}
+    if config.full:
+        params["full"] = "true"
+    return params

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/settings.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 
+from products.warehouse_sources.backend.types import IncrementalField
+
 
 @dataclass
 class HuggingFaceEndpointConfig:
@@ -24,3 +26,8 @@ HUGGING_FACE_ENDPOINTS: dict[str, HuggingFaceEndpointConfig] = {
 }
 
 ENDPOINTS = tuple(HUGGING_FACE_ENDPOINTS.keys())
+
+# The Hub has no server-side timestamp range filter (it silently ignores `since`), so every endpoint
+# is full refresh only. Repo metadata (likes, downloads, lastModified) mutates in place, so
+# append-only would drop updates — hence no incremental/append fields for any endpoint.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/source.py
@@ -19,14 +19,20 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import HuggingFaceSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.hugging_face.hugging_face import (
     HuggingFaceResumeConfig,
     hugging_face_source,
     validate_credentials as validate_hugging_face_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.hugging_face.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.hugging_face.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
@@ -107,21 +113,9 @@ Set **Username or organization** to the namespace whose models, datasets, and Sp
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # The Hub has no server-side timestamp range filter (it silently ignores `since`), so every
-        # endpoint is full refresh only. Repo metadata (likes, downloads, lastModified) mutates in
-        # place, so append-only would drop updates — hence no incremental/append.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # endpoint is full refresh only (INCREMENTAL_FIELDS is empty). Repo metadata (likes,
+        # downloads, lastModified) mutates in place, so append-only would drop updates.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: HuggingFaceSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -144,6 +138,8 @@ Set **Username or organization** to the namespace whose models, datasets, and Sp
             api_token=config.api_token,
             endpoint=inputs.schema_name,
             author=config.author,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Hugging Face endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/tests/test_hugging_face.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/tests/test_hugging_face.py
@@ -1,18 +1,16 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import HTTPError, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.hugging_face import hugging_face
 from products.warehouse_sources.backend.temporal.data_imports.sources.hugging_face.hugging_face import (
+    HUGGING_FACE_BASE_URL,
     HuggingFaceResumeConfig,
-    HuggingFaceRetryableError,
-    _build_initial_url,
-    _parse_next_url,
-    get_rows,
+    _build_initial_params,
     hugging_face_source,
     validate_credentials,
 )
@@ -20,195 +18,207 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.hugging_fa
     HUGGING_FACE_ENDPOINTS,
 )
 
-
-class _FakeResumableManager:
-    def __init__(self, state: HuggingFaceResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[HuggingFaceResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> HuggingFaceResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: HuggingFaceResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the hugging_face module.
+HF_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.hugging_face.hugging_face.make_tracked_session"
+)
+# tenacity sleeps between retries; silence it so retry tests don't wait.
+TENACITY_SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResponse:
-    def __init__(self, items: Any, next_url: str | None) -> None:
-        self._items = items
-        link = f'<{next_url}>; rel="next"' if next_url else ""
-        self.headers = {"Link": link}
-
-    def json(self) -> Any:
-        return self._items
-
-
-class TestParseNextUrl:
-    @parameterized.expand(
-        [
-            (
-                "next_only",
-                '<https://huggingface.co/api/models?cursor=abc>; rel="next"',
-                "https://huggingface.co/api/models?cursor=abc",
-            ),
-            (
-                "prev_and_next",
-                '<https://huggingface.co/api/models?cursor=p>; rel="prev", '
-                '<https://huggingface.co/api/models?cursor=n>; rel="next"',
-                "https://huggingface.co/api/models?cursor=n",
-            ),
-            ("no_next", '<https://huggingface.co/api/models?cursor=p>; rel="prev"', None),
-            ("empty", "", None),
-        ]
-    )
-    def test_parse_next_url(self, _name: str, header: str, expected: str | None) -> None:
-        assert _parse_next_url(header) == expected
+def _response(items: Any, *, next_url: str | None = None, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(items).encode()
+    if next_url:
+        resp.headers["Link"] = f'<{next_url}>; rel="next"'
+    return resp
 
 
-class TestBuildInitialUrl:
-    def test_models_url_is_scoped_sorted_and_full(self) -> None:
-        url = _build_initial_url(HUGGING_FACE_ENDPOINTS["models"], author="huggingface")
-        assert url.startswith("https://huggingface.co/api/models?")
-        assert "author=huggingface" in url
+def _make_manager(resume_state: HuggingFaceResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session; return a list capturing each request's url+params AT SEND TIME.
+
+    The paginator mutates the single ``Request`` in place across pages (setting ``request.url`` and
+    clearing ``request.params`` for the next-page link), so inspect a snapshot at prepare time.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestBuildInitialParams:
+    def test_models_params_are_scoped_sorted_and_full(self) -> None:
+        params = _build_initial_params(HUGGING_FACE_ENDPOINTS["models"], author="huggingface")
+        assert params["author"] == "huggingface"
         # createdAt is immutable, so ascending pages don't shift mid-sync.
-        assert "sort=createdAt" in url
-        assert "direction=1" in url
-        assert "limit=1000" in url
-        assert "full=true" in url
+        assert params["sort"] == "createdAt"
+        assert params["direction"] == 1
+        assert params["limit"] == 1000
+        assert params["full"] == "true"
 
     @parameterized.expand([("models",), ("datasets",), ("spaces",)])
-    def test_every_endpoint_builds_a_scoped_url(self, endpoint: str) -> None:
-        url = _build_initial_url(HUGGING_FACE_ENDPOINTS[endpoint], author="acme")
-        assert f"/api/{endpoint}?" in url
-        assert "author=acme" in url
+    def test_every_endpoint_is_scoped_to_author(self, endpoint: str) -> None:
+        params = _build_initial_params(HUGGING_FACE_ENDPOINTS[endpoint], author="acme")
+        assert params["author"] == "acme"
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_link_header_pagination(self, MockSession) -> None:
+        session = MockSession.return_value
+        page2 = "https://huggingface.co/api/models?cursor=2"
+        snapshots = _wire(
+            session,
+            [
+                _response([{"id": "acme/a"}, {"id": "acme/b"}], next_url=page2),
+                _response([{"id": "acme/c"}], next_url=None),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(
+            hugging_face_source("hf_token", "models", "acme", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        assert [r["id"] for r in rows] == ["acme/a", "acme/b", "acme/c"]
+        # First request is the scoped list endpoint; the second follows the self-contained next link.
+        assert snapshots[0]["url"] == f"{HUGGING_FACE_BASE_URL}/api/models"
+        assert snapshots[0]["params"]["author"] == "acme"
+        assert snapshots[0]["params"]["limit"] == 1000
+        assert snapshots[1]["url"] == page2
+        assert snapshots[1]["params"] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_next_page_after_yield(self, MockSession) -> None:
+        # Save the next page's self-contained link after yielding, so a resumed run continues there.
+        session = MockSession.return_value
+        page2 = "https://huggingface.co/api/models?cursor=2"
+        _wire(session, [_response([{"id": "acme/a"}], next_url=page2), _response([{"id": "acme/b"}], next_url=None)])
+
+        manager = _make_manager()
+        _rows(
+            hugging_face_source("hf_token", "models", "acme", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        # Only the first page has a next link, so exactly one checkpoint — pointing at the next page.
+        assert manager.save_state.call_count == 1
+        assert manager.save_state.call_args.args[0] == HuggingFaceResumeConfig(resume_url=page2)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "acme/a"}, {"id": "acme/b"}], next_url=None)])
+
+        manager = _make_manager()
+        rows = _rows(
+            hugging_face_source("hf_token", "models", "acme", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        assert [r["id"] for r in rows] == ["acme/a", "acme/b"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession) -> None:
+        session = MockSession.return_value
+        page2 = "https://huggingface.co/api/models?cursor=2"
+        snapshots = _wire(session, [_response([{"id": "acme/b"}], next_url=None)])
+
+        manager = _make_manager(HuggingFaceResumeConfig(resume_url=page2))
+        rows = _rows(
+            hugging_face_source("hf_token", "models", "acme", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        # Resuming starts at the saved page and skips the already-synced first page.
+        assert [r["id"] for r in rows] == ["acme/b"]
+        assert snapshots[0]["url"] == page2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_terminates_even_with_next_link(self, MockSession) -> None:
+        # An empty page ends the stream even if a stray next link is present (no unbounded loop).
+        session = MockSession.return_value
+        _wire(session, [_response([], next_url="https://huggingface.co/api/datasets?cursor=2")])
+
+        manager = _make_manager()
+        rows = _rows(
+            hugging_face_source("hf_token", "datasets", "acme", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        assert rows == []
+        assert session.send.call_count == 1
+
+
+class TestRetries:
+    @mock.patch(TENACITY_SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], status=429), _response([{"id": "acme/a"}], next_url=None)])
+
+        manager = _make_manager()
+        rows = _rows(
+            hugging_face_source("hf_token", "models", "acme", team_id=1, job_id="j", resumable_source_manager=manager)
+        )
+
+        assert [r["id"] for r in rows] == ["acme/a"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unauthorized_raises_http_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unauthorized"}, status=401)])
+
+        manager = _make_manager()
+        with pytest.raises(HTTPError):
+            _rows(
+                hugging_face_source(
+                    "hf_token", "models", "acme", team_id=1, job_id="j", resumable_source_manager=manager
+                )
+            )
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
-    def test_status_maps_to_bool(self, _name: str, status_code: int, expected: bool) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(hugging_face, "make_tracked_session", return_value=session):
-            assert validate_credentials("hf_token") is expected
+    @mock.patch(HF_SESSION_PATCH)
+    def test_status_maps_to_bool(self, _name: str, status_code: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
+        assert validate_credentials("hf_token") is expected
 
-    def test_network_error_is_false(self) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(hugging_face, "make_tracked_session", return_value=session):
-            assert validate_credentials("hf_token") is False
+    @mock.patch(HF_SESSION_PATCH)
+    def test_network_error_is_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("hf_token") is False
 
 
-class TestFetchPage:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_status_raises_retryable_error(self, _name: str, status_code: int) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(hugging_face._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(HuggingFaceRetryableError):
-                hugging_face._fetch_page(session, "https://huggingface.co/api/models", {}, MagicMock())
-
-    @parameterized.expand([("read_timeout", requests.ReadTimeout()), ("connection", requests.ConnectionError())])
-    def test_transient_errors_are_retried_then_succeed(self, _name: str, transient: Exception) -> None:
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        session = MagicMock()
-        session.get.side_effect = [transient, good]
-        with patch.object(hugging_face._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = hugging_face._fetch_page(session, "https://huggingface.co/api/models", {}, MagicMock())
-        assert result is good
-
-    def test_unauthorized_raises_for_status(self) -> None:
-        response = MagicMock()
-        response.status_code = 401
-        response.ok = False
-        response.raise_for_status.side_effect = requests.HTTPError(
-            "401 Client Error: Unauthorized", response=requests.Response()
-        )
-        session = MagicMock()
-        session.get.return_value = response
-        with pytest.raises(requests.HTTPError):
-            hugging_face._fetch_page(session, "https://huggingface.co/api/models", {}, MagicMock())
-
-
-def _collect(manager: _FakeResumableManager, monkeypatch: Any, pages: dict[str, _FakeResponse], endpoint: str) -> list:
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> _FakeResponse:
-        return pages[url]
-
-    monkeypatch.setattr(hugging_face, "_fetch_page", fake_fetch)
-    monkeypatch.setattr(hugging_face, "make_tracked_session", lambda *a, **k: MagicMock())
-
-    rows: list = []
-    for page in get_rows(
-        api_token="hf_token",
-        endpoint=endpoint,
-        author="acme",
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-    ):
-        rows.extend(page)
-    return rows
-
-
-class TestGetRows:
-    def test_follows_link_header_pagination(self, monkeypatch: Any) -> None:
-        start = _build_initial_url(HUGGING_FACE_ENDPOINTS["models"], author="acme")
-        page2 = "https://huggingface.co/api/models?cursor=2"
-        pages = {
-            start: _FakeResponse([{"id": "acme/a"}, {"id": "acme/b"}], next_url=page2),
-            page2: _FakeResponse([{"id": "acme/c"}], next_url=None),
-        }
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, "models")
-        assert [r["id"] for r in rows] == ["acme/a", "acme/b", "acme/c"]
-
-    def test_checkpoints_current_page_after_yield(self, monkeypatch: Any) -> None:
-        # Saving the current (not next) page URL means a crash re-fetches it; merge dedupes on id.
-        start = _build_initial_url(HUGGING_FACE_ENDPOINTS["models"], author="acme")
-        page2 = "https://huggingface.co/api/models?cursor=2"
-        pages = {
-            start: _FakeResponse([{"id": "acme/a"}], next_url=page2),
-            page2: _FakeResponse([{"id": "acme/b"}], next_url=None),
-        }
-        manager = _FakeResumableManager()
-        _collect(manager, monkeypatch, pages, "models")
-        # Only the first page has a next page, so exactly one checkpoint — pointing at the first page.
-        assert [s.resume_url for s in manager.saved] == [start]
-
-    def test_resumes_from_saved_state(self, monkeypatch: Any) -> None:
-        start = _build_initial_url(HUGGING_FACE_ENDPOINTS["models"], author="acme")
-        page2 = "https://huggingface.co/api/models?cursor=2"
-        pages = {
-            start: _FakeResponse([{"id": "acme/a"}], next_url=page2),
-            page2: _FakeResponse([{"id": "acme/b"}], next_url=None),
-        }
-        manager = _FakeResumableManager(state=HuggingFaceResumeConfig(resume_url=page2))
-        rows = _collect(manager, monkeypatch, pages, "models")
-        # Resuming at page2 skips the already-synced first page.
-        assert [r["id"] for r in rows] == ["acme/b"]
-
-    def test_empty_response_terminates(self, monkeypatch: Any) -> None:
-        start = _build_initial_url(HUGGING_FACE_ENDPOINTS["datasets"], author="acme")
-        pages = {start: _FakeResponse([], next_url="https://huggingface.co/api/datasets?cursor=2")}
-        rows = _collect(_FakeResumableManager(), monkeypatch, pages, "datasets")
-        assert rows == []
-
-
-class TestHuggingFaceSource:
+class TestHuggingFaceSourceResponse:
     @parameterized.expand([("models",), ("datasets",), ("spaces",)])
-    def test_source_response_shape(self, endpoint: str) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], next_url=None)])
+
         response = hugging_face_source(
-            api_token="hf_token",
-            endpoint=endpoint,
-            author="acme",
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
+            "hf_token", endpoint, "acme", team_id=1, job_id="j", resumable_source_manager=_make_manager()
         )
         assert response.name == endpoint
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/tests/test_hugging_face_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/tests/test_hugging_face_source.py
@@ -87,6 +87,8 @@ class TestHuggingFaceSourceClass:
     def test_source_for_pipeline_plumbs_arguments(self) -> None:
         inputs = MagicMock()
         inputs.schema_name = "datasets"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         manager = MagicMock()
         with patch.object(source_module, "hugging_face_source") as mock_source:
             self.source.source_for_pipeline(_config(), manager, inputs)
@@ -94,8 +96,10 @@ class TestHuggingFaceSourceClass:
             api_token="hf_token",
             endpoint="datasets",
             author="acme",
-            logger=inputs.logger,
+            team_id=123,
+            job_id="job-1",
             resumable_source_manager=manager,
+            db_incremental_field_last_value=None,
         )
 
     def test_canonical_descriptions_cover_every_endpoint(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/instatus.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/instatus.py
@@ -1,203 +1,231 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.instatus.settings import INSTATUS_ENDPOINTS
 
 # Single global host — Instatus has no per-account subdomains (unlike Statuspage).
 INSTATUS_BASE_URL = "https://api.instatus.com"
+PAGES_ENDPOINT_PATH = "/v2/pages"
 
 # per_page defaults to 50 and is capped at 100; we always request the maximum to minimise round-trips.
-_PAGE_SIZE = 100
-# The Instatus OpenAPI spec documents no rate limits, but we still retry transient 5xx and 429 with
-# bounded exponential backoff so a blip or an undocumented throttle doesn't fail the whole sync.
-_MAX_ATTEMPTS = 8
-_REQUEST_TIMEOUT_SECONDS = 60
+PAGE_SIZE = 100
 
-
-class InstatusRetryableError(Exception):
-    """Raised for rate-limit (429) and transient 5xx responses so tenacity retries them."""
-
-    pass
+# The framework binds the resolved parent id into the child path via `str.format`, so the parent
+# status page id rides in the URL path (`/v1/{page_id}/...`) rather than the query string.
+_PARENT_PAGE_ID_KEY = "_pages_id"
 
 
 @dataclasses.dataclass
 class InstatusResumeConfig:
-    # The page number most recently yielded for the resource currently being read. On resume we
-    # re-fetch this page and re-yield it (merge dedupes on the primary key) rather than risk
-    # skipping rows that were batched but not yet persisted when the worker stopped.
-    page: int
-    # For page-scoped (fan-out) endpoints, the id of the status page we were reading children for.
-    # None for the top-level /v2/pages listing.
+    # Next page to fetch for a non-fan-out resource (1-based page-number pagination). Kept with a
+    # default so previously saved fan-out state (which never set it) still parses.
+    page: int = 1
+    # Pre-framework fan-out bookkeeping: the parent status page whose children were being read.
+    # Retained (with a default) so old saved state still parses; translated into fanout_state on load.
     parent_page_id: Optional[str] = None
+    # Framework fan-out resume state for page-scoped endpoints:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: Optional[dict] = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
+def _headers() -> dict[str, str]:
+    # Instatus requires the JSON content type on every request, including GETs. The credential
+    # travels via framework bearer auth (not a hand-built header) so its value is registered for
+    # redaction wherever it surfaces in logs and raised errors.
+    return {"Content-Type": "application/json"}
+
+
+def _client_config(api_key: str) -> ClientConfig:
     return {
-        "Authorization": f"Bearer {api_key}",
-        # Instatus requires the JSON content type on every request, including GETs.
-        "Content-Type": "application/json",
+        "base_url": INSTATUS_BASE_URL,
+        "headers": _headers(),
+        "auth": {"type": "bearer", "token": api_key},
+        # A credentialed request stays pinned to the validated Instatus host — a 3xx can't replay
+        # it (and its Authorization header) to another origin.
+        "allow_redirects": False,
     }
 
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    return f"{INSTATUS_BASE_URL}{path}?{urlencode(params)}"
+def _paginator() -> PageNumberPaginator:
+    # 1-based `page` with `per_page` (capped at 100). Termination is on an empty array only: we
+    # deliberately do NOT stop on a short page, because if the API ignores the size param and
+    # defaults below 100, a short-but-non-empty page is still not the last one.
+    return PageNumberPaginator(base_page=1, page_param="page", stop_after_empty_page=True)
 
 
-def _get_session(api_key: str) -> requests.Session:
-    # One session per sync so keep-alive is preserved across pages and retries. `redact_values`
-    # masks the key from request telemetry/log samples, and `allow_redirects=False` keeps a
-    # credentialed request pinned to the validated Instatus host (it can't be replayed elsewhere).
-    return make_tracked_session(
-        headers=_get_headers(api_key),
-        redact_values=(api_key,),
-        allow_redirects=False,
+def _stamp_page_id(row: dict[str, Any]) -> dict[str, Any]:
+    # include_from_parent lands the parent status page id as `_pages_id`; rename it to the plain
+    # `page_id` column child rows carry (part of the composite primary key — see settings.py) so a
+    # sync that aggregates rows from every page keeps the key unique table-wide.
+    value = row.pop(_PARENT_PAGE_ID_KEY, None)
+    if value is not None:
+        row["page_id"] = value
+    return row
+
+
+def _standard_resource(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[InstatusResumeConfig],
+) -> Resource:
+    config = INSTATUS_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"per_page": PAGE_SIZE},
+                    "paginator": _paginator(),
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
+        if resume is not None and resume.page and resume.page > 1:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the checkpoint is saved AFTER a page is yielded so
+        # a crash re-fetches the in-flight page (merge dedupes re-pulled rows) rather than skipping it.
+        if state and state.get("page") is not None:
+            manager.save_state(InstatusResumeConfig(page=int(state["page"])))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
     )
 
 
-@retry(
-    retry=retry_if_exception_type((InstatusRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(_MAX_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=2, max=60),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> requests.Response:
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise InstatusRetryableError(f"Instatus API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Instatus API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response
+def _child_path(endpoint: str, page_id: str) -> str:
+    return INSTATUS_ENDPOINTS[endpoint].path.format(page_id=page_id)
 
 
-def _iter_resource(
-    session: requests.Session,
-    path: str,
-    logger: FilteringBoundLogger,
-    start_page: int = 1,
-) -> Iterator[tuple[list[dict[str, Any]], int]]:
-    """Yield (rows, page_number) for each non-empty page, incrementing `page` from start_page.
+def _translate_legacy_fanout_state(resume: InstatusResumeConfig, endpoint: str) -> Optional[dict[str, Any]]:
+    """Translate a pre-framework fan-out bookmark into the framework's resume shape.
 
-    Every Instatus list endpoint we sync returns a bare JSON array and pages with a 1-based `page`
-    number plus `per_page` (capped at 100). Termination is on an empty array: we deliberately do
-    NOT stop on a short page, because if the API ignores the size param and defaults below 100, a
-    short-but-non-empty page is still not the last one.
+    The old bookkeeping only recorded the parent page currently being read plus its next page; it
+    relied on parent-listing order to skip already-finished parents. The framework keys resume by
+    resolved child path, so we resume the in-progress parent precisely and let already-finished
+    parents be re-fetched (merge dedupes on the composite primary key) rather than skipping them.
     """
-    page = start_page
-    while True:
-        params = {"per_page": _PAGE_SIZE, "page": page}
-        response = _fetch_page(session, _build_url(path, params), logger)
-        data = response.json()
-        if not isinstance(data, list) or not data:
-            return
-        yield data, page
-        page += 1
+    if resume.parent_page_id is None:
+        return None
+    return {
+        "completed": [],
+        "current": _child_path(endpoint, resume.parent_page_id),
+        "child_state": {"page": resume.page},
+    }
 
 
-def _list_page_ids(session: requests.Session, logger: FilteringBoundLogger) -> list[str]:
-    """List every status page id the token can see — the parents that page-scoped endpoints fan out over."""
-    pages_config = INSTATUS_ENDPOINTS["pages"]
-    page_ids: list[str] = []
-    for rows, _page in _iter_resource(session, pages_config.path, logger):
-        for row in rows:
-            # Direct access: page_id drives the entire child fan-out, so a page without an id is a
-            # malformed response we want to surface loudly rather than silently drop its children.
-            page_ids.append(row["id"])
-    return page_ids
-
-
-def get_rows(
+def _fanout_resource(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[InstatusResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = INSTATUS_ENDPOINTS[endpoint]
-    session = _get_session(api_key)
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    team_id: int,
+    job_id: str,
+    manager: ResumableSourceManager[InstatusResumeConfig],
+) -> Resource:
+    """Fan out over every status page, listing the page-scoped resource and stamping the parent id.
 
-    if not config.page_scoped:
-        start_page = resume.page if resume is not None else 1
+    Page-scoped resources live under `/v1/{page_id}/...`, so they can only be pulled per status
+    page. Full refresh — re-pulled rows on resume are deduped by the (page_id, id) primary key.
+    """
+    pages_config = INSTATUS_ENDPOINTS["pages"]
+    child_config = INSTATUS_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": "pages",
+                "endpoint": {
+                    "path": pages_config.path,
+                    "params": {"per_page": PAGE_SIZE},
+                    "paginator": _paginator(),
+                },
+            },
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": child_config.path,
+                    "params": {
+                        "page_id": {"type": "resolve", "resource": "pages", "field": "id"},
+                        "per_page": PAGE_SIZE,
+                    },
+                    "paginator": _paginator(),
+                },
+                "include_from_parent": ["id"],
+                "data_map": _stamp_page_id,
+            },
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if manager.can_resume():
+        resume = manager.load_state()
         if resume is not None:
-            logger.debug(f"Instatus: resuming {endpoint} from page {start_page}")
-        for rows, page in _iter_resource(session, config.path, logger, start_page=start_page):
-            yield rows
-            resumable_source_manager.save_state(InstatusResumeConfig(page=page, parent_page_id=None))
-        return
+            if resume.fanout_state is not None:
+                initial_paginator_state = resume.fanout_state
+            else:
+                initial_paginator_state = _translate_legacy_fanout_state(resume, endpoint)
 
-    page_ids = _list_page_ids(session, logger)
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state:
+            manager.save_state(InstatusResumeConfig(fanout_state=state))
 
-    start_index = 0
-    resume_start_page = 1
-    if resume is not None and resume.parent_page_id is not None and resume.parent_page_id in page_ids:
-        start_index = page_ids.index(resume.parent_page_id)
-        resume_start_page = resume.page
-        logger.debug(
-            f"Instatus: resuming {endpoint} fan-out at page_id={resume.parent_page_id}, page={resume_start_page}"
-        )
-
-    for idx in range(start_index, len(page_ids)):
-        page_id = page_ids[idx]
-        path = config.path.format(page_id=page_id)
-        start_page = resume_start_page if idx == start_index else 1
-        for rows, page in _iter_resource(session, path, logger, start_page=start_page):
-            # Inject the parent page id so the composite primary key is unique table-wide — a sync
-            # aggregates rows from every page, and the bare resource id is only unique within a page.
-            for row in rows:
-                row["page_id"] = page_id
-            yield rows
-            resumable_source_manager.save_state(InstatusResumeConfig(page=page, parent_page_id=page_id))
-
-
-def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    """Confirm the API key is genuine with one cheap probe against the status-page listing."""
-    url = _build_url("/v2/pages", {"per_page": 1, "page": 1})
-    try:
-        response = _get_session(api_key).get(url, timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
-
-    if response.status_code == 200:
-        return True, None
-    if response.status_code == 401:
-        return False, "Invalid Instatus API key. Please check your API key and try again."
-    if response.status_code == 403:
-        return False, "Your Instatus API key does not have permission to list status pages."
-
-    try:
-        body = response.json()
-        message = (body.get("error", {}) or {}).get("message") if isinstance(body, dict) else response.text
-    except Exception:
-        message = response.text
-    return False, message or response.text
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(r for r in resources if r.name == endpoint)
 
 
 def instatus_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[InstatusResumeConfig],
 ) -> SourceResponse:
     config = INSTATUS_ENDPOINTS[endpoint]
 
-    def items() -> Iterator[list[dict[str, Any]]]:
-        return get_rows(api_key, endpoint, logger, resumable_source_manager)
+    if config.page_scoped:
+        resource = _fanout_resource(api_key, endpoint, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _standard_resource(api_key, endpoint, team_id, job_id, resumable_source_manager)
 
     return SourceResponse(
         name=endpoint,
-        items=items,
+        items=lambda: resource,
         primary_keys=config.primary_key,
         # Full refresh only — Instatus exposes no server-side timestamp filter — but rows still
         # arrive in a stable page order, so asc is correct.
@@ -208,3 +236,22 @@ def instatus_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    """Confirm the API key is genuine with one cheap probe against the status-page listing."""
+    url = f"{INSTATUS_BASE_URL}{PAGES_ENDPOINT_PATH}?per_page=1&page=1"
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,), allow_redirects=False),
+        url,
+        headers={"Authorization": f"Bearer {api_key}", **_headers()},
+    )
+    if ok:
+        return True, None
+    if status == 401:
+        return False, "Invalid Instatus API key. Please check your API key and try again."
+    if status == 403:
+        return False, "Your Instatus API key does not have permission to list status pages."
+    if status is None:
+        return False, "Could not connect to Instatus. Please try again."
+    return False, f"Instatus returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/source.py
@@ -126,6 +126,7 @@ class InstatusSource(ResumableSource[InstatusSourceConfig, InstatusResumeConfig]
         return instatus_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/tests/test_instatus.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/tests/test_instatus.py
@@ -1,24 +1,34 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.instatus.instatus import (
     InstatusResumeConfig,
-    InstatusRetryableError,
-    _build_url,
-    _fetch_page,
-    _get_headers,
-    _list_page_ids,
-    get_rows,
+    _child_path,
+    _client_config,
     instatus_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.instatus.settings import INSTATUS_ENDPOINTS
 
-_TRANSPORT = "products.warehouse_sources.backend.temporal.data_imports.sources.instatus.instatus.make_tracked_session"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the instatus module.
+INSTATUS_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.instatus.instatus.make_tracked_session"
+)
+
+
+def _response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: InstatusResumeConfig | None = None) -> mock.MagicMock:
@@ -28,60 +38,169 @@ def _make_manager(resume_state: InstatusResumeConfig | None = None) -> mock.Magi
     return manager
 
 
-def _response(body: Any, status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = body
-    resp.status_code = status_code
-    resp.ok = 200 <= status_code < 300
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[str], list[dict[str, Any]]]:
+    """Wire a mock session, capturing each request's url and params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    url_snapshots: list[str] = []
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        url_snapshots.append(request.url)
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return url_snapshots, param_snapshots
 
 
-def _session_returning(*bodies: Any) -> mock.MagicMock:
-    """Build a session whose successive .get() calls return the given JSON bodies."""
-    session = mock.MagicMock()
-    session.get.side_effect = [_response(b) for b in bodies]
-    return session
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
-class TestInstatus:
-    def test_headers_use_bearer_and_json_content_type(self):
-        headers = _get_headers("abc123")
-        assert headers["Authorization"] == "Bearer abc123"
+def _source(endpoint: str, manager: mock.MagicMock):
+    return instatus_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+class TestClientConfig:
+    def test_uses_bearer_auth_and_json_content_type(self):
+        config = _client_config("abc123")
+        assert config["auth"] == {"type": "bearer", "token": "abc123"}
         # Instatus requires the JSON content type on every request, including GETs.
-        assert headers["Content-Type"] == "application/json"
+        assert config["headers"]["Content-Type"] == "application/json"
+        # A credentialed request stays pinned to the validated host — a 3xx can't replay it elsewhere.
+        assert config["allow_redirects"] is False
 
-    @pytest.mark.parametrize(
-        "path, expected",
-        [
-            ("/v2/pages", "https://api.instatus.com/v2/pages?per_page=100&page=1"),
-            ("/v1/p1/components", "https://api.instatus.com/v1/p1/components?per_page=100&page=1"),
-        ],
-    )
-    def test_build_url(self, path, expected):
-        assert _build_url(path, {"per_page": 100, "page": 1}) == expected
 
-    @pytest.mark.parametrize("status_code", [429, 500, 502, 503])
-    @mock.patch("time.sleep")  # neutralize tenacity's exponential backoff so retries are instant
-    def test_fetch_page_retryable_statuses_raise(self, _mock_sleep, status_code):
-        session = mock.MagicMock()
-        session.get.return_value = _response([], status_code=status_code)
-        # reraise=True surfaces the final InstatusRetryableError after retries are exhausted.
-        with pytest.raises(InstatusRetryableError):
-            _fetch_page(session, "https://api.instatus.com/v2/pages", mock.MagicMock())
+class TestPagesEndpoint:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_empty_including_short_pages(self, MockSession):
+        session = MockSession.return_value
+        # Pages of 2 then 1 rows are both short (< per_page) yet pagination must continue: a
+        # short-but-non-empty page is not the last one. Only the empty array terminates.
+        _, params = _wire(
+            session,
+            [_response([{"id": "p1"}, {"id": "p2"}]), _response([{"id": "p3"}]), _response([])],
+        )
 
-    def test_fetch_page_client_error_raises_for_status(self):
-        resp = _response({"error": {"message": "Could not authenticate"}}, status_code=401)
-        resp.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=resp)
-        session = mock.MagicMock()
-        session.get.return_value = resp
+        rows = _rows(_source("pages", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["p1", "p2", "p3"]
+        assert params[0]["per_page"] == 100
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_next_page_after_each_non_empty_page(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "p1"}]), _response([{"id": "p2"}]), _response([])])
+        manager = _make_manager()
+
+        _rows(_source("pages", manager))
+
+        saved = [c.args[0] for c in manager.save_state.call_args_list]
+        # State saved once per non-empty yielded page, each pointing at the next page.
+        assert [(s.page, s.parent_page_id, s.fanout_state) for s in saved] == [(2, None, None), (3, None, None)]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession):
+        session = MockSession.return_value
+        _, params = _wire(session, [_response([{"id": "p9"}]), _response([])])
+        manager = _make_manager(InstatusResumeConfig(page=3, parent_page_id=None))
+
+        _rows(_source("pages", manager))
+
+        assert params[0]["page"] == 3
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"error": {"message": "Could not authenticate"}}, status_code=401)])
+
         with pytest.raises(requests.HTTPError):
-            _fetch_page(session, "https://api.instatus.com/v2/pages", mock.MagicMock())
+            _rows(_source("pages", _make_manager()))
 
-    def test_fetch_page_ok_response_returned(self):
-        session = mock.MagicMock()
-        session.get.return_value = _response([{"id": "p1"}])
-        resp = _fetch_page(session, "https://api.instatus.com/v2/pages", mock.MagicMock())
-        assert resp.json() == [{"id": "p1"}]
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_rate_limit_then_succeeds(self, MockSession, _mock_sleep):
+        session = MockSession.return_value
+        # A 429 is retried by the shared client; the retried attempt returns the page.
+        _wire(session, [_response([], status_code=429), _response([{"id": "p1"}]), _response([])])
+
+        rows = _rows(_source("pages", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["p1"]
+        # First send 429, retried, then page 1, then empty terminator = 3 sends.
+        assert session.send.call_count == 3
+
+
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_over_pages_and_injects_page_id(self, MockSession):
+        session = MockSession.return_value
+        urls, _ = _wire(
+            session,
+            [
+                _response([{"id": "p1"}, {"id": "p2"}]),  # /v2/pages page 1
+                _response([{"id": "c1"}]),  # /v1/p1/components page 1
+                _response([]),  # /v1/p1/components page 2 (stop)
+                _response([{"id": "c2"}]),  # /v1/p2/components page 1
+                _response([]),  # /v1/p2/components page 2 (stop)
+                _response([]),  # /v2/pages page 2 (stop)
+            ],
+        )
+
+        rows = _rows(_source("components", _make_manager()))
+
+        # page_id injected so the composite [page_id, id] key stays unique table-wide.
+        assert rows == [{"id": "c1", "page_id": "p1"}, {"id": "c2", "page_id": "p2"}]
+        assert "https://api.instatus.com/v1/p1/components" in urls
+        assert "https://api.instatus.com/v1/p2/components" in urls
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_fan_out_at_saved_parent_and_page(self, MockSession):
+        session = MockSession.return_value
+        urls, params = _wire(
+            session,
+            [
+                _response([{"id": "p1"}, {"id": "p2"}]),  # pages relisted on resume
+                _response([{"id": "c2b"}]),  # resume p2 at page 2
+                _response([]),  # p2 components page 3 (stop)
+                _response([]),  # pages page 2 (stop)
+            ],
+        )
+        # p1 already completed, p2 in progress at its next page (2) — p1 must not be re-requested.
+        manager = _make_manager(
+            InstatusResumeConfig(
+                fanout_state={
+                    "completed": [_child_path("components", "p1")],
+                    "current": _child_path("components", "p2"),
+                    "child_state": {"page": 2},
+                }
+            )
+        )
+
+        rows = _rows(_source("components", manager))
+
+        assert rows == [{"id": "c2b", "page_id": "p2"}]
+        assert not any("/v1/p1/components" in url for url in urls)
+        component_requests = [
+            (url, p) for url, p in zip(urls, params) if url == "https://api.instatus.com/v1/p2/components"
+        ]
+        assert component_requests[0][1]["page"] == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_parent_id_raises_loudly(self, MockSession):
+        session = MockSession.return_value
+        # A status page without an id can't drive the child fan-out — surface it loudly.
+        _wire(session, [_response([{"name": "no-id"}]), _response([])])
+
+        with pytest.raises(ValueError, match="id"):
+            _rows(_source("components", _make_manager()))
 
 
 class TestValidateCredentials:
@@ -89,121 +208,34 @@ class TestValidateCredentials:
         "status_code, expected_ok",
         [(200, True), (401, False), (403, False), (500, False)],
     )
-    @mock.patch(_TRANSPORT)
+    @mock.patch(INSTATUS_SESSION_PATCH)
     def test_status_mapping(self, mock_session, status_code, expected_ok):
-        body = [] if status_code == 200 else {"error": {"message": "nope"}}
-        mock_session.return_value.get.return_value = _response(body, status_code=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         ok, error = validate_credentials("key")
         assert ok is expected_ok
         if not ok:
             assert error
 
-    @mock.patch(_TRANSPORT)
+    @mock.patch(INSTATUS_SESSION_PATCH)
     def test_probes_pages_endpoint(self, mock_session):
-        mock_session.return_value.get.return_value = _response([], status_code=200)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("key")
         url = mock_session.return_value.get.call_args.args[0]
         assert url.startswith("https://api.instatus.com/v2/pages")
 
-    @mock.patch(_TRANSPORT)
+    @mock.patch(INSTATUS_SESSION_PATCH)
     def test_request_exception_is_failure(self, mock_session):
         mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
         ok, error = validate_credentials("key")
         assert ok is False
-        assert "boom" in (error or "")
-
-
-class TestGetRowsTopLevel:
-    @mock.patch(_TRANSPORT)
-    def test_paginates_pages_until_empty(self, mock_session):
-        mock_session.return_value = _session_returning(
-            [{"id": "p1"}, {"id": "p2"}],
-            [{"id": "p3"}],
-            [],  # empty page terminates
-        )
-        manager = _make_manager()
-
-        batches = list(get_rows("key", "pages", mock.MagicMock(), manager))
-
-        assert [row["id"] for batch in batches for row in batch] == ["p1", "p2", "p3"]
-        # State saved once per non-empty yielded page.
-        assert manager.save_state.call_count == 2
-        saved = [c.args[0] for c in manager.save_state.call_args_list]
-        assert [(s.page, s.parent_page_id) for s in saved] == [(1, None), (2, None)]
-
-    @mock.patch(_TRANSPORT)
-    def test_resumes_from_saved_page(self, mock_session):
-        mock_session.return_value = _session_returning(
-            [{"id": "p9"}],  # page 3 (resumed)
-            [],
-        )
-        manager = _make_manager(InstatusResumeConfig(page=3, parent_page_id=None))
-
-        list(get_rows("key", "pages", mock.MagicMock(), manager))
-
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "page=3" in first_url
-
-
-class TestGetRowsFanOut:
-    @mock.patch(_TRANSPORT)
-    def test_fans_out_over_pages_and_injects_page_id(self, mock_session):
-        mock_session.return_value = _session_returning(
-            # _list_page_ids walks /v2/pages first
-            [{"id": "p1"}, {"id": "p2"}],
-            [],
-            # components for p1
-            [{"id": "c1"}],
-            [],
-            # components for p2
-            [{"id": "c2"}],
-            [],
-        )
-        manager = _make_manager()
-
-        batches = list(get_rows("key", "components", mock.MagicMock(), manager))
-        rows = [row for batch in batches for row in batch]
-
-        # page_id injected so the composite [page_id, id] key stays unique table-wide.
-        assert rows == [{"id": "c1", "page_id": "p1"}, {"id": "c2", "page_id": "p2"}]
-        saved = [c.args[0] for c in manager.save_state.call_args_list]
-        assert [(s.page, s.parent_page_id) for s in saved] == [(1, "p1"), (1, "p2")]
-
-    @mock.patch(_TRANSPORT)
-    def test_resumes_fan_out_at_saved_parent_and_page(self, mock_session):
-        mock_session.return_value = _session_returning(
-            # pages relisted on resume
-            [{"id": "p1"}, {"id": "p2"}],
-            [],
-            # resume at p2, page 2 — p1 is skipped entirely
-            [{"id": "c2b"}],
-            [],
-        )
-        manager = _make_manager(InstatusResumeConfig(page=2, parent_page_id="p2"))
-
-        batches = list(get_rows("key", "components", mock.MagicMock(), manager))
-        rows = [row for batch in batches for row in batch]
-
-        assert rows == [{"id": "c2b", "page_id": "p2"}]
-        child_urls = [c.args[0] for c in mock_session.return_value.get.call_args_list if "/components" in c.args[0]]
-        assert child_urls[0] == "https://api.instatus.com/v1/p2/components?per_page=100&page=2"
-
-
-class TestListPageIds:
-    def test_collects_ids_across_pages(self):
-        session = _session_returning(
-            [{"id": "p1"}, {"id": "p2"}],
-            [{"id": "p3"}],
-            [],
-        )
-        assert _list_page_ids(session, mock.MagicMock()) == ["p1", "p2", "p3"]
+        assert error
 
 
 class TestInstatusSourceResponse:
     @pytest.mark.parametrize("endpoint", list(INSTATUS_ENDPOINTS.keys()))
     def test_source_response_shape(self, endpoint):
         config = INSTATUS_ENDPOINTS[endpoint]
-        response = instatus_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_key

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/tests/test_instatus_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instatus/tests/test_instatus_source.py
@@ -89,13 +89,15 @@ class TestInstatusSource:
         manager = mock.MagicMock()
         inputs = mock.MagicMock()
         inputs.schema_name = "incidents"
-        inputs.logger = mock.MagicMock()
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
 
         self.source.source_for_pipeline(config, manager, inputs)
 
         mock_instatus_source.assert_called_once_with(
             api_key="key",
             endpoint="incidents",
-            logger=inputs.logger,
+            team_id=123,
+            job_id="job-1",
             resumable_source_manager=manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/invoiceninja/invoiceninja.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/invoiceninja/invoiceninja.py
@@ -7,7 +7,7 @@ configurable. Auth is a single ``X-API-TOKEN`` header; every request must also c
 
 List endpoints are page-number paginated (``page`` / ``per_page``) and wrap their records under a
 top-level ``data`` key alongside a ``meta.pagination`` object that reports ``current_page`` and
-``total_pages``.
+``total_pages`` (and a ``links.next`` URL that is null on the last page).
 
 Every stream is full-refresh. Invoice Ninja documents ``created_at`` / ``updated_at`` filters on its
 index endpoints, but the timestamps are integer unix seconds and the ordering the API applies under
@@ -18,38 +18,30 @@ per endpoint once its server-side filter and sort behaviour are verified with re
 
 import re
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 from urllib.parse import urlencode, urlparse
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _is_host_safe
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.invoiceninja.settings import (
     INVOICENINJA_ENDPOINTS,
-    InvoiceNinjaEndpointConfig,
 )
 
 DEFAULT_API_HOST = "https://invoicing.co"
 API_VERSION_PATH = "/api/v1"
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-MAX_RETRY_AFTER_SECONDS = 60
-
 HOST_NOT_ALLOWED_ERROR = "Invoice Ninja API URL is not allowed"
 HTTP_NOT_ALLOWED_ERROR = "Invoice Ninja API URL must use HTTPS"
-
-
-class InvoiceNinjaRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
 
 
 class InvoiceNinjaHostNotAllowedError(Exception):
@@ -61,6 +53,65 @@ class InvoiceNinjaResumeConfig:
     # The next page to fetch on resume. Persisted after each page is yielded, so a crash before this
     # write leaves the previous value in place and the last page is re-yielded (merge dedupes on `id`).
     next_page: int
+
+
+class InvoiceNinjaPaginator(BasePaginator):
+    """Page-number paginator matching Invoice Ninja's Laravel/Fractal envelope.
+
+    A page has more after it when ``meta.pagination`` reports ``current_page < total_pages`` OR
+    carries a non-null ``links.next`` (some deployments expose only one of the two signals). An empty
+    ``data`` list, or a response with no pagination block at all, terminates — the latter guards
+    against an unbounded loop on a malformed index response.
+    """
+
+    def __init__(self, page: int = 1, page_param: str = "page") -> None:
+        super().__init__()
+        self.page = page
+        self.page_param = page_param
+
+    def _set_page(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params[self.page_param] = self.page
+
+    def init_request(self, request: Request) -> None:
+        self._set_page(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        pagination = (body.get("meta") or {}).get("pagination") or {}
+        current_page = pagination.get("current_page")
+        total_pages = pagination.get("total_pages")
+        has_next_link = bool((pagination.get("links") or {}).get("next"))
+        more_by_count = bool(current_page and total_pages and int(current_page) < int(total_pages))
+
+        if not (more_by_count or has_next_link):
+            self._has_next_page = False
+            return
+
+        # Prefer the server's reported page number; fall back to incrementing our own when the API
+        # exposes only the `links.next` signal without a current-page count.
+        self.page = (int(current_page) + 1) if current_page else self.page + 1
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        self._set_page(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"page": self.page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._has_next_page = True
 
 
 def normalize_base_url(base_url: Optional[str]) -> str:
@@ -99,6 +150,15 @@ def _get_headers(api_token: str) -> dict[str, str]:
     return {
         "X-API-TOKEN": api_token,
         # Invoice Ninja rejects API requests that omit this header.
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept": "application/json",
+    }
+
+
+def _request_headers() -> dict[str, str]:
+    # Auth (the X-API-TOKEN key) is supplied via the framework auth config so its value is redacted
+    # from logs and raised errors; only the non-secret required headers are set here.
+    return {
         "X-Requested-With": "XMLHttpRequest",
         "Accept": "application/json",
     }
@@ -179,141 +239,77 @@ def validate_credentials(
         return False, response.text
 
 
-def _parse_retry_after(response: requests.Response) -> float | None:
-    """Honor a whole-second ``Retry-After`` on 429. HTTP-date forms are ignored."""
-    raw = response.headers.get("Retry-After")
-    if raw and raw.strip().isdigit():
-        return min(float(raw.strip()), MAX_RETRY_AFTER_SECONDS)
-    return None
-
-
-def _retry_wait(retry_state: RetryCallState) -> float:
-    """Use a server-provided Retry-After when present, else exponential backoff."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, InvoiceNinjaRetryableError) and exc.retry_after is not None:
-        return exc.retry_after
-    return wait_exponential_jitter(initial=1, max=30)(retry_state)
-
-
-def get_rows(
-    base_url: Optional[str],
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[InvoiceNinjaResumeConfig],
-    team_id: int,
-) -> Iterator[list[dict[str, Any]]]:
-    config: InvoiceNinjaEndpointConfig = INVOICENINJA_ENDPOINTS[endpoint]
-    resolved_base_url = normalize_base_url(base_url)
-    host = _host_of(resolved_base_url)
-
-    # Re-check at run time (not just at source-create) in case the URL was edited or now resolves to an
-    # internal address (SSRF / DNS rebinding). Only enforced on cloud.
-    host_ok, host_err = _is_host_safe(host, team_id)
-    if not host_ok:
-        raise InvoiceNinjaHostNotAllowedError(host_err or HOST_NOT_ALLOWED_ERROR)
-
-    # Refuse plaintext HTTP before the token is used, so the token is never sent in the clear.
-    if not _is_https(resolved_base_url):
-        raise InvoiceNinjaHostNotAllowedError(HTTP_NOT_ALLOWED_ERROR)
-
-    headers = _get_headers(api_token)
-    request_url = f"{resolved_base_url}{config.path}"
-
-    # One session reused across every page (and retry) so urllib3 keeps the connection alive. It
-    # redacts the token from captured HTTP samples — the token rides in the `X-API-TOKEN` header, which
-    # the transport's name-based denylist doesn't recognise, so value-based masking is what covers it.
-    session = make_tracked_session(redact_values=(api_token,))
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume_config.next_page if resume_config is not None else 1
-    if resume_config is not None:
-        logger.debug(f"Invoice Ninja: resuming {endpoint} from page {page}")
-
-    @retry(
-        retry=retry_if_exception_type((InvoiceNinjaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_retry_wait,
-        reraise=True,
-    )
-    def fetch_page(page_number: int) -> requests.Response:
-        query = urlencode({"page": page_number, "per_page": config.page_size})
-        # Don't follow redirects: an attacker-controlled host could 3xx to an internal address,
-        # bypassing the host validation done before the request (SSRF).
-        response = session.get(
-            f"{request_url}?{query}", headers=headers, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False
-        )
-
-        if response.status_code == 429 or response.status_code >= 500:
-            retry_after = _parse_retry_after(response) if response.status_code == 429 else None
-            raise InvoiceNinjaRetryableError(
-                f"Invoice Ninja API error (retryable): status={response.status_code}, url={request_url}",
-                retry_after=retry_after,
-            )
-
-        # A 3xx isn't an error status (`response.ok` is True), so reject it explicitly rather than
-        # silently parsing the redirect body as data.
-        if response.is_redirect or response.is_permanent_redirect:
-            raise InvoiceNinjaHostNotAllowedError(
-                f"Invoice Ninja API returned an unexpected redirect (status={response.status_code}); "
-                "refusing to follow it"
-            )
-
-        if not response.ok:
-            logger.error(
-                f"Invoice Ninja API error: status={response.status_code}, body={response.text}, url={request_url}"
-            )
-            response.raise_for_status()
-
-        return response
-
-    while True:
-        response = fetch_page(page)
-        body = response.json()
-        rows = body.get("data") or []
-        if not isinstance(rows, list) or not rows:
-            break
-
-        yield rows
-
-        # Invoice Ninja wraps its Laravel/Fractal paginator under `meta.pagination`, reporting the
-        # current/total page count and a `links.next` URL that is null on the last page. Treat either
-        # signal as "more pages remain". If the pagination block is missing entirely (never the case
-        # for a healthy index endpoint), stop rather than risk an unbounded loop.
-        pagination = (body.get("meta") or {}).get("pagination") or {}
-        current_page = pagination.get("current_page")
-        total_pages = pagination.get("total_pages")
-        has_next_link = bool((pagination.get("links") or {}).get("next"))
-        more_by_count = bool(current_page and total_pages and int(current_page) < int(total_pages))
-        if not (more_by_count or has_next_link):
-            break
-        page = (int(current_page) + 1) if current_page else page + 1
-
-        # Checkpoint AFTER yielding the page: a crash before this write re-yields the page on resume
-        # (dedupes on the primary key), while a crash after it resumes at the next page.
-        resumable_source_manager.save_state(InvoiceNinjaResumeConfig(next_page=page))
-
-
 def invoiceninja_source(
     base_url: Optional[str],
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[InvoiceNinjaResumeConfig],
     team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[InvoiceNinjaResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = INVOICENINJA_ENDPOINTS[endpoint]
+    resolved_base_url = normalize_base_url(base_url)
+    host = _host_of(resolved_base_url)
+
+    # Seed the paginator from any saved resume state; map back into the persisted dataclass on save.
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes on the primary key) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(InvoiceNinjaResumeConfig(next_page=int(state["page"])))
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": resolved_base_url,
+            "headers": _request_headers(),
+            "auth": {"type": "api_key", "api_key": api_token, "name": "X-API-TOKEN", "location": "header"},
+            # Don't follow redirects: an attacker-controlled host could 3xx to an internal address,
+            # bypassing the host validation done before the request (SSRF).
+            "allow_redirects": False,
+            "paginator": InvoiceNinjaPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"per_page": config.page_size},
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    def items() -> Any:
+        # Re-check at run time (not just at source-create) in case the URL was edited or now resolves
+        # to an internal address (SSRF / DNS rebinding). Only enforced on cloud. Refuse plaintext HTTP
+        # before the token is used, so the token is never sent in the clear. Both raise before any
+        # request leaves the process.
+        host_ok, host_err = _is_host_safe(host, team_id)
+        if not host_ok:
+            raise InvoiceNinjaHostNotAllowedError(host_err or HOST_NOT_ALLOWED_ERROR)
+        if not _is_https(resolved_base_url):
+            raise InvoiceNinjaHostNotAllowedError(HTTP_NOT_ALLOWED_ERROR)
+
+        yield from rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            base_url=base_url,
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            team_id=team_id,
-        ),
+        items=items,
         primary_keys=[config.primary_key],
         # Full-refresh replace: no incremental cursor is enabled, so there is no watermark to
         # checkpoint. Invoice Ninja returns `created_at` / `updated_at` as integer unix seconds rather

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/invoiceninja/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/invoiceninja/source.py
@@ -105,9 +105,10 @@ class InvoiceninjaSource(ResumableSource[InvoiceninjaSourceConfig, InvoiceNinjaR
             base_url=config.base_url,
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
-            resumable_source_manager=resumable_source_manager,
             team_id=inputs.team_id,
+            job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Invoice Ninja endpoint is full refresh
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/invoiceninja/tests/test_invoiceninja.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/invoiceninja/tests/test_invoiceninja.py
@@ -1,8 +1,12 @@
+import json
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
+
+import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.invoiceninja import (
     invoiceninja as invoiceninja_module,
@@ -10,7 +14,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.invoicenin
 from products.warehouse_sources.backend.temporal.data_imports.sources.invoiceninja.invoiceninja import (
     InvoiceNinjaHostNotAllowedError,
     InvoiceNinjaResumeConfig,
-    get_rows,
     invoiceninja_source,
     normalize_base_url,
     validate_credentials,
@@ -19,23 +22,87 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.invoicenin
     INVOICENINJA_ENDPOINTS,
 )
 
-
-def _response(*, status_code: int = 200, json_data: Any = None, text: str = "") -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 400
-    response.is_redirect = status_code in (301, 302, 303, 307, 308)
-    response.is_permanent_redirect = status_code in (301, 308)
-    response.text = text
-    response.json.return_value = json_data
-    response.headers = {}
-    return response
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
 
 
-def _page(rows: list[dict[str, Any]], *, current_page: int, total_pages: int) -> mock.MagicMock:
-    return _response(
-        json_data={"data": rows, "meta": {"pagination": {"current_page": current_page, "total_pages": total_pages}}}
+def _response(*, status_code: int = 200, body: Any = None, location: str | None = None) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode() if body is not None else b""
+    if location is not None:
+        resp.headers["Location"] = location
+    return resp
+
+
+def _page(
+    rows: list[dict[str, Any]],
+    *,
+    current_page: int | None = None,
+    total_pages: int | None = None,
+    links_next: Any = "__omit__",
+    with_meta: bool = True,
+) -> Response:
+    pagination: dict[str, Any] = {}
+    if current_page is not None:
+        pagination["current_page"] = current_page
+    if total_pages is not None:
+        pagination["total_pages"] = total_pages
+    if links_next != "__omit__":
+        pagination["links"] = {"next": links_next}
+    body: dict[str, Any] = {"data": rows}
+    if with_meta:
+        body["meta"] = {"pagination": pagination}
+    return _response(body=body)
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[requests.PreparedRequest]:
+    """Wire a mock session; delegate prepare_request to a real session so auth + params are applied.
+
+    The framework mutates a single request/params dict in place across pages, so we snapshot each
+    prepared request (its URL carries the page/per_page query and its headers carry the auth) as the
+    client prepares it, then return canned responses from ``send``.
+    """
+    session.headers = {}
+    real = requests.Session()
+    prepared: list[requests.PreparedRequest] = []
+
+    def _prepare(request: Any) -> requests.PreparedRequest:
+        real.headers.clear()
+        real.headers.update(session.headers)
+        p = real.prepare_request(request)
+        prepared.append(p)
+        return p
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return prepared
+
+
+def _make_manager(resume_state: InvoiceNinjaResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _source(manager: mock.MagicMock, *, base_url: str | None = None, endpoint: str = "clients") -> Any:
+    return invoiceninja_source(
+        base_url=base_url,
+        api_token="tok",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
     )
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _page_qs(prepared: requests.PreparedRequest) -> list[str]:
+    return parse_qs(urlparse(prepared.url).query)["page"]
 
 
 class TestNormalizeBaseUrl:
@@ -83,19 +150,28 @@ class TestValidateCredentials:
             session.get.return_value = response
         return mock.patch.object(invoiceninja_module, "make_tracked_session", return_value=session)
 
+    def _resp(self, *, status_code=200, json_data=None, text=""):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        response.is_redirect = status_code in (301, 302, 303, 307, 308)
+        response.is_permanent_redirect = status_code in (301, 308)
+        response.text = text
+        response.json.return_value = json_data
+        return response
+
     def test_success(self):
-        with self._patch_session(_response(status_code=200)):
+        with self._patch_session(self._resp(status_code=200)):
             assert validate_credentials(None, "tok") == (True, None)
 
     def test_invalid_token_401(self):
-        with self._patch_session(_response(status_code=401)):
+        with self._patch_session(self._resp(status_code=401)):
             valid, msg = validate_credentials(None, "tok")
             assert valid is False
             assert msg == "Invalid Invoice Ninja API token"
 
     def test_invalid_token_403_message_always_fails(self):
         # A bad Invoice Ninja token returns 403 {"message": "Invalid token"} — reject it even at create.
-        response = _response(status_code=403, json_data={"message": "Invalid token"})
+        response = self._resp(status_code=403, json_data={"message": "Invalid token"})
         with self._patch_session(response):
             valid, msg = validate_credentials(None, "tok", schema_name=None)
             assert valid is False
@@ -103,27 +179,25 @@ class TestValidateCredentials:
 
     def test_permission_403_at_source_create_is_accepted(self):
         # A 403 without the "Invalid token" message is a restricted (enterprise) token, not a bad one.
-        response = _response(status_code=403, json_data={"message": "This action is unauthorized."})
+        response = self._resp(status_code=403, json_data={"message": "This action is unauthorized."})
         with self._patch_session(response):
             assert validate_credentials(None, "tok", schema_name=None) == (True, None)
 
     def test_permission_403_for_scoped_probe_fails(self):
-        response = _response(status_code=403, json_data={"message": "This action is unauthorized."})
+        response = self._resp(status_code=403, json_data={"message": "This action is unauthorized."})
         with self._patch_session(response):
             valid, msg = validate_credentials(None, "tok", schema_name="invoices")
             assert valid is False
             assert msg is not None
 
     def test_request_exception_returns_failure(self):
-        import requests
-
         with self._patch_session(raises=requests.exceptions.ConnectionError("boom")):
             valid, msg = validate_credentials(None, "tok")
             assert valid is False
             assert "boom" in (msg or "")
 
     def test_rejects_redirect_response(self):
-        with self._patch_session(_response(status_code=302)) as patched:
+        with self._patch_session(self._resp(status_code=302)) as patched:
             valid, msg = validate_credentials(None, "tok")
             assert valid is False
             assert msg == invoiceninja_module.HOST_NOT_ALLOWED_ERROR
@@ -132,7 +206,7 @@ class TestValidateCredentials:
     def test_blocks_unsafe_host(self):
         with (
             mock.patch.object(invoiceninja_module, "_is_host_safe", return_value=(False, "internal address")),
-            self._patch_session(_response(status_code=200)) as patched,
+            self._patch_session(self._resp(status_code=200)) as patched,
         ):
             valid, msg = validate_credentials("http://10.0.0.1", "tok", team_id=99)
             assert valid is False
@@ -140,7 +214,7 @@ class TestValidateCredentials:
             patched.return_value.get.assert_not_called()
 
     def test_probe_hits_configured_host_with_required_headers(self):
-        with self._patch_session(_response(status_code=200)) as patched:
+        with self._patch_session(self._resp(status_code=200)) as patched:
             validate_credentials("https://invoices.example.com", "tok")
             call = patched.return_value.get.call_args
             assert call.args[0].startswith("https://invoices.example.com/api/v1/clients")
@@ -151,14 +225,14 @@ class TestValidateCredentials:
     def test_redacts_token_in_telemetry(self):
         # The token rides in X-API-TOKEN, which the transport's name-based scrubber doesn't cover, so
         # it must be passed as a redact value to keep it out of captured HTTP samples.
-        with self._patch_session(_response(status_code=200)) as patched:
+        with self._patch_session(self._resp(status_code=200)) as patched:
             validate_credentials(None, "tok")
             assert patched.call_args.kwargs["redact_values"] == ("tok",)
 
     def test_rejects_plaintext_http_before_sending_token(self):
         # A plaintext http:// URL would expose the X-API-TOKEN on the wire, so reject it without
         # ever issuing the token-bearing request.
-        with self._patch_session(_response(status_code=200)) as patched:
+        with self._patch_session(self._resp(status_code=200)) as patched:
             valid, msg = validate_credentials("http://invoices.example.com", "tok")
             assert valid is False
             assert msg == invoiceninja_module.HTTP_NOT_ALLOWED_ERROR
@@ -168,14 +242,7 @@ class TestValidateCredentials:
 class TestInvoiceNinjaSourceResponse:
     @pytest.mark.parametrize("endpoint", list(INVOICENINJA_ENDPOINTS.keys()))
     def test_response_shape(self, endpoint):
-        response = invoiceninja_source(
-            base_url=None,
-            api_token="tok",
-            endpoint=endpoint,
-            logger=mock.MagicMock(),
-            resumable_source_manager=mock.MagicMock(),
-            team_id=1,
-        )
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         assert response.sort_mode == "asc"
@@ -184,42 +251,37 @@ class TestInvoiceNinjaSourceResponse:
         assert response.partition_mode is None
 
 
-class TestGetRows:
-    def _run(self, manager, responses, team_id=1, base_url=None):
-        session = mock.MagicMock()
-        session.get.side_effect = responses
-        with mock.patch.object(invoiceninja_module, "make_tracked_session", return_value=session):
-            rows: list[dict[str, Any]] = []
-            for batch in get_rows(
-                base_url=base_url,
-                api_token="tok",
-                endpoint="clients",
-                logger=mock.MagicMock(),
-                resumable_source_manager=manager,
-                team_id=team_id,
-            ):
-                rows.extend(batch)
-        return rows, session
-
-    def test_paginates_via_meta_pagination(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        page1 = _page([{"id": "1"}, {"id": "2"}], current_page=1, total_pages=2)
-        page2 = _page([{"id": "3"}], current_page=2, total_pages=2)
-        rows, session = self._run(manager, [page1, page2])
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_meta_pagination(self, MockSession):
+        session = MockSession.return_value
+        prepared = _wire(
+            session,
+            [
+                _page([{"id": "1"}, {"id": "2"}], current_page=1, total_pages=2),
+                _page([{"id": "3"}], current_page=2, total_pages=2),
+            ],
+        )
+        rows = _rows(_source(_make_manager()))
 
         assert [r["id"] for r in rows] == ["1", "2", "3"]
-        first_qs = parse_qs(urlparse(session.get.call_args_list[0].args[0]).query)
-        second_qs = parse_qs(urlparse(session.get.call_args_list[1].args[0]).query)
-        assert first_qs["page"] == ["1"]
-        assert second_qs["page"] == ["2"]
+        assert _page_qs(prepared[0]) == ["1"]
+        assert _page_qs(prepared[1]) == ["2"]
+        # per_page rides alongside the page param on every request.
+        assert parse_qs(urlparse(prepared[0].url).query)["per_page"] == ["100"]
 
-    def test_saves_next_page_after_yielding(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        page1 = _page([{"id": "1"}], current_page=1, total_pages=2)
-        page2 = _page([{"id": "2"}], current_page=2, total_pages=2)
-        self._run(manager, [page1, page2])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_page_after_yielding(self, MockSession):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page([{"id": "1"}], current_page=1, total_pages=2),
+                _page([{"id": "2"}], current_page=2, total_pages=2),
+            ],
+        )
+        manager = _make_manager()
+        _rows(_source(manager))
 
         # State is saved once (after page 1, pointing at page 2); the last page is terminal.
         assert manager.save_state.call_count == 1
@@ -227,141 +289,118 @@ class TestGetRows:
         assert isinstance(saved, InvoiceNinjaResumeConfig)
         assert saved.next_page == 2
 
-    def test_resumes_from_saved_state(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = InvoiceNinjaResumeConfig(next_page=3)
-        rows, session = self._run(manager, [_page([{"id": "9"}], current_page=3, total_pages=3)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession):
+        session = MockSession.return_value
+        prepared = _wire(session, [_page([{"id": "9"}], current_page=3, total_pages=3)])
+        manager = _make_manager(InvoiceNinjaResumeConfig(next_page=3))
+        rows = _rows(_source(manager))
 
-        first_qs = parse_qs(urlparse(session.get.call_args_list[0].args[0]).query)
-        assert first_qs["page"] == ["3"]
+        assert _page_qs(prepared[0]) == ["3"]
         assert [r["id"] for r in rows] == ["9"]
 
-    def test_paginates_via_links_next_when_page_counts_absent(self):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_links_next_when_page_counts_absent(self, MockSession):
         # Some deployments only expose `links.next` without current/total page counts.
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        page1 = _response(
-            json_data={"data": [{"id": "1"}], "meta": {"pagination": {"links": {"next": "https://next"}}}}
+        session = MockSession.return_value
+        prepared = _wire(
+            session,
+            [
+                _page([{"id": "1"}], links_next="https://next"),
+                _page([{"id": "2"}], links_next=None),
+            ],
         )
-        page2 = _response(json_data={"data": [{"id": "2"}], "meta": {"pagination": {"links": {"next": None}}}})
-        rows, session = self._run(manager, [page1, page2])
+        rows = _rows(_source(_make_manager()))
+
         assert [r["id"] for r in rows] == ["1", "2"]
-        assert session.get.call_count == 2
-        second_qs = parse_qs(urlparse(session.get.call_args_list[1].args[0]).query)
-        assert second_qs["page"] == ["2"]
+        assert session.send.call_count == 2
+        assert _page_qs(prepared[1]) == ["2"]
 
-    def test_empty_page_terminates(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        rows, session = self._run(manager, [_page([], current_page=1, total_pages=5)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_terminates(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([], current_page=1, total_pages=5)])
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == []
-        assert session.get.call_count == 1
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_missing_pagination_terminates_after_first_page(self):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_pagination_terminates_after_first_page(self, MockSession):
         # A response with no pagination block must not loop forever.
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        rows, session = self._run(manager, [_response(json_data={"data": [{"id": "1"}]})])
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "1"}], with_meta=False)])
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert [r["id"] for r in rows] == ["1"]
-        assert session.get.call_count == 1
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_does_not_follow_redirects(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        with pytest.raises(InvoiceNinjaHostNotAllowedError):
-            self._run(manager, [_response(status_code=302)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_does_not_follow_redirects(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response(status_code=302, location="https://internal")])
+        # With redirects disabled the framework rejects a 3xx before following it.
+        with pytest.raises(ValueError):
+            _rows(_source(_make_manager()))
 
-    def test_passes_allow_redirects_false(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        _rows, session = self._run(manager, [_page([{"id": "1"}], current_page=1, total_pages=1)])
-        assert session.get.call_args.kwargs["allow_redirects"] is False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_passes_allow_redirects_false(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "1"}], current_page=1, total_pages=1)])
+        _rows(_source(_make_manager()))
+        assert session.send.call_args.kwargs["allow_redirects"] is False
 
-    def test_sends_required_headers(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        _rows, session = self._run(manager, [_page([{"id": "1"}], current_page=1, total_pages=1)])
-        headers = session.get.call_args.kwargs["headers"]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sends_required_headers_and_token(self, MockSession):
+        session = MockSession.return_value
+        prepared = _wire(session, [_page([{"id": "1"}], current_page=1, total_pages=1)])
+        _rows(_source(_make_manager()))
+        headers = prepared[0].headers
         assert headers["X-API-TOKEN"] == "tok"
         assert headers["X-Requested-With"] == "XMLHttpRequest"
 
-    def test_redacts_token_in_telemetry(self):
-        # The token rides in X-API-TOKEN, which the transport's name-based scrubber doesn't cover, so
-        # it must be passed as a redact value to keep it out of captured HTTP samples.
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        session = mock.MagicMock()
-        session.get.side_effect = [_page([{"id": "1"}], current_page=1, total_pages=1)]
-        with mock.patch.object(invoiceninja_module, "make_tracked_session", return_value=session) as mts:
-            list(
-                get_rows(
-                    base_url=None,
-                    api_token="tok",
-                    endpoint="clients",
-                    logger=mock.MagicMock(),
-                    resumable_source_manager=manager,
-                    team_id=1,
-                )
-            )
-        assert mts.call_args.kwargs["redact_values"] == ("tok",)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_redacts_token_in_telemetry(self, MockSession):
+        # The api_key auth carries the token, so the framework masks it in logs / raised errors by
+        # passing it to the tracked session as a redact value.
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "1"}], current_page=1, total_pages=1)])
+        _rows(_source(_make_manager()))
+        assert MockSession.call_args.kwargs["redact_values"] == ("tok",)
 
-    def test_raises_when_host_not_allowed(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_when_host_not_allowed(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "1"}], current_page=1, total_pages=1)])
         with mock.patch.object(invoiceninja_module, "_is_host_safe", return_value=(False, "internal address")):
             with pytest.raises(InvoiceNinjaHostNotAllowedError):
-                self._run(manager, [_page([{"id": "1"}], current_page=1, total_pages=1)])
+                _rows(_source(_make_manager()))
 
-    def test_raises_on_plaintext_http(self):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_on_plaintext_http(self, MockSession):
         # A plaintext http:// URL must fail before the token-bearing request goes out.
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
+        session = MockSession.return_value
+        _wire(session, [_page([{"id": "1"}], current_page=1, total_pages=1)])
         with pytest.raises(InvoiceNinjaHostNotAllowedError):
-            self._run(
-                manager, [_page([{"id": "1"}], current_page=1, total_pages=1)], base_url="http://invoices.example.com"
-            )
+            _rows(_source(_make_manager(), base_url="http://invoices.example.com"))
 
     @pytest.mark.parametrize("status_code", [429, 503])
-    def test_retries_retryable_status_then_succeeds(self, status_code):
-        # End-to-end: a retryable status raises, tenacity retries, and the subsequent 200 yields rows.
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        responses = [_response(status_code=status_code), _page([{"id": "r1"}], current_page=1, total_pages=1)]
-        with mock.patch.object(invoiceninja_module, "_retry_wait", return_value=0):
-            rows, session = self._run(manager, responses)
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_retryable_status_then_succeeds(self, MockSession, _sleep, status_code):
+        # End-to-end: a retryable status raises, the framework retries, and the next 200 yields rows.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(status_code=status_code),
+                _page([{"id": "r1"}], current_page=1, total_pages=1),
+            ],
+        )
+        rows = _rows(_source(_make_manager()))
         assert [r["id"] for r in rows] == ["r1"]
-        assert session.get.call_count == 2
-
-
-class TestRetryAfter:
-    @pytest.mark.parametrize(
-        "header, expected",
-        [
-            ({"Retry-After": "5"}, 5.0),
-            ({"Retry-After": "  9 "}, 9.0),
-            ({"Retry-After": "100000"}, 60.0),
-            ({"Retry-After": "Wed, 21 Oct 2025 07:28:00 GMT"}, None),
-            ({}, None),
-        ],
-    )
-    def test_parse_retry_after(self, header, expected):
-        from products.warehouse_sources.backend.temporal.data_imports.sources.invoiceninja.invoiceninja import (
-            _parse_retry_after,
-        )
-
-        response = mock.MagicMock()
-        response.headers = header
-        assert _parse_retry_after(response) == expected
-
-    def test_retry_wait_prefers_retry_after(self):
-        from products.warehouse_sources.backend.temporal.data_imports.sources.invoiceninja.invoiceninja import (
-            InvoiceNinjaRetryableError,
-            _retry_wait,
-        )
-
-        state = mock.MagicMock()
-        state.outcome.exception.return_value = InvoiceNinjaRetryableError("rate limited", retry_after=7.0)
-        assert _retry_wait(state) == 7.0
+        assert session.send.call_count == 2

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/jobnimbus.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/jobnimbus.py
@@ -1,28 +1,26 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.settings import JOBNIMBUS_ENDPOINTS
 
 JOBNIMBUS_BASE_URL = "https://app.jobnimbus.com/api1"
 # The Elasticsearch-backed list endpoints accept a `size` of up to 100; the largest page minimises
 # round trips.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm an API key is genuine. The key is account-wide, so one probe
 # validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/contacts"
-
-
-class JobNimbusRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -32,127 +30,91 @@ class JobNimbusResumeConfig:
     offset: int = 0
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
-
-
-@retry(
-    retry=retry_if_exception_type((JobNimbusRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    offset: int,
-    limit: int,
-    logger: FilteringBoundLogger,
-) -> tuple[list[dict[str, Any]], int]:
-    response = session.get(
-        f"{JOBNIMBUS_BASE_URL}{path}",
-        params={"size": limit, "from": offset},
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise JobNimbusRetryableError(f"JobNimbus API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        logger.error(f"JobNimbus API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
-
-    data = response.json()
-    # JobNimbus list endpoints wrap rows in `{"count": N, "results": [...]}`.
-    if not isinstance(data, dict):
-        raise JobNimbusRetryableError(f"JobNimbus returned an unexpected payload for {path}: {type(data).__name__}")
-    results = data.get("results")
-    if not isinstance(results, list):
-        raise JobNimbusRetryableError(f"JobNimbus returned no results list for {path}: {type(results).__name__}")
-    count = data.get("count")
-    # `count` is the total matching row count; if it's ever missing the short-page check still
-    # terminates the scan safely.
-    if not isinstance(count, int):
-        count = offset + len(results)
-    return results, count
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[JobNimbusResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = JOBNIMBUS_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume else 0
-    if resume and resume.offset > 0:
-        logger.debug(f"JobNimbus: resuming {endpoint} from offset {offset}")
-
-    while True:
-        items, count = _fetch_page(session, config.path, offset, PAGE_SIZE, logger)
-        if items:
-            yield items
-
-        # Stop on a short/empty page or once the offset has caught up to the reported total.
-        if len(items) < PAGE_SIZE or offset + len(items) >= count:
-            break
-
-        offset += PAGE_SIZE
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(JobNimbusResumeConfig(offset=offset))
+def _headers() -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs and
+    # raised errors; only the non-secret accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def jobnimbus_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[JobNimbusResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = JOBNIMBUS_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": JOBNIMBUS_BASE_URL,
+            "headers": _headers(),
+            "auth": {"type": "bearer", "token": api_key},
+            # JobNimbus list endpoints paginate with size/from and report the grand total as `count`;
+            # pagination stops once the offset reaches that total or a short/empty page arrives.
+            "paginator": OffsetPaginator(
+                limit=PAGE_SIZE,
+                offset_param="from",
+                limit_param="size",
+                total_path="count",
+            ),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "data_selector": "results",
+                    # A 200 body without a `results` list means the response shape changed — fail
+                    # loud instead of silently syncing 0 rows (or wrapping a stray object as a row).
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on `jnid`) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(JobNimbusResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
     )
 
 
-def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the API key.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-    try:
-        response = session.get(f"{JOBNIMBUS_BASE_URL}{path}", params={"size": 1, "from": 0}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to JobNimbus: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"JobNimbus returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_key)
-    if status == 200:
+    # The API key is account-wide, so a single probe validates access to every list endpoint.
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{JOBNIMBUS_BASE_URL}{DEFAULT_PROBE_PATH}?size=1&from=0",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid JobNimbus API key"
-    return False, message or "Could not validate JobNimbus API key"
+    if status is None:
+        return False, "Could not validate JobNimbus API key"
+    return False, f"JobNimbus returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import JobNimbusSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus import (
     JobNimbusResumeConfig,
@@ -28,6 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.settings import (
     ENDPOINTS,
+    INCREMENTAL_FIELDS,
     JOBNIMBUS_ENDPOINTS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -92,20 +96,9 @@ You can create an API key under **Settings → API** in [JobNimbus](https://app.
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
         # Every endpoint is full refresh only — JobNimbus's list endpoints expose no reliably
-        # documented server-side timestamp filter, so there is no incremental cursor to advance.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # documented server-side timestamp filter, so there is no incremental cursor to advance
+        # (INCREMENTAL_FIELDS is empty, so build_endpoint_schemas marks each schema full-refresh).
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: JobNimbusSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -128,6 +121,8 @@ You can create an API key under **Settings → API** in [JobNimbus](https://app.
         return jobnimbus_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every JobNimbus endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus.py
@@ -1,18 +1,15 @@
-from typing import Any
+import json
+from typing import Any, Optional
 
 import pytest
-from unittest.mock import MagicMock
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import HTTPError, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus import jobnimbus
 from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus import (
     PAGE_SIZE,
     JobNimbusResumeConfig,
-    JobNimbusRetryableError,
-    check_access,
-    get_rows,
     jobnimbus_source,
     validate_credentials,
 )
@@ -21,205 +18,209 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.
     JOBNIMBUS_ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = jobnimbus._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the jobnimbus module.
+JOBNIMBUS_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus.make_tracked_session"
+)
+# tenacity sleeps between retries; patch it so the retry-path tests don't actually wait.
+TENACITY_SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResumableManager:
-    def __init__(self, state: JobNimbusResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[JobNimbusResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> JobNimbusResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: JobNimbusResumeConfig) -> None:
-        self.saved.append(data)
+def _raw_response(body: Any, *, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = "https://app.jobnimbus.com/api1/contacts"
+    resp._content = b"" if body is None else json.dumps(body).encode()
+    return resp
 
 
-def _full_page(start_id: int) -> list[dict]:
-    return [{"jnid": str(start_id + i)} for i in range(PAGE_SIZE)]
+def _response(results: list[dict[str, Any]], count: int, *, status: int = 200) -> Response:
+    return _raw_response({"count": count, "results": results}, status=status)
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        pages: dict[int, tuple[list[dict], int]],
-        endpoint: str = "contacts",
-    ) -> list[dict]:
-        def fake_fetch(session: Any, path: str, offset: int, limit: int, logger: Any) -> tuple[list[dict], int]:
-            return pages[offset]
+def _make_manager(resume_state: Optional[JobNimbusResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-        monkeypatch.setattr(jobnimbus, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(jobnimbus, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="jn-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
 
-    def test_single_short_page_yields_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {0: ([{"jnid": "1"}, {"jnid": "2"}], 2)})
-        assert rows == [{"jnid": "1"}, {"jnid": "2"}]
-        # The page is short (< PAGE_SIZE), so we stop without persisting resume state.
-        assert manager.saved == []
+    ``request.params`` is one dict mutated in place across pages, so inspecting it after the run shows
+    only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
 
-    def test_follows_offset_pagination_until_short_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {0: (_full_page(0), PAGE_SIZE + 1), PAGE_SIZE: ([{"jnid": "999"}], PAGE_SIZE + 1)}
-        rows = self._collect(manager, monkeypatch, pages)
-        assert len(rows) == PAGE_SIZE + 1
-        # State is saved after the first full page (offset advances to PAGE_SIZE), then we stop.
-        assert [s.offset for s in manager.saved] == [PAGE_SIZE]
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
 
-    def test_stops_when_offset_reaches_reported_count(self, monkeypatch: Any) -> None:
-        # A full page whose length exactly equals the reported total must terminate without a
-        # second request, even though the page isn't short.
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {0: (_full_page(0), PAGE_SIZE)})
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(manager: mock.MagicMock, endpoint: str = "contacts") -> Any:
+    return jobnimbus_source(
+        api_key="jn-key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager,
+    )
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_progresses_offset(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        full = [{"jnid": str(i)} for i in range(PAGE_SIZE)]
+        params = _wire(session, [_response(full, PAGE_SIZE + 1), _response([{"jnid": "last"}], PAGE_SIZE + 1)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert [r["jnid"] for r in rows] == [*(str(i) for i in range(PAGE_SIZE)), "last"]
+        # size/from map onto the offset paginator's limit/offset params.
+        assert params[0] == {"from": 0, "size": PAGE_SIZE}
+        assert params[1]["from"] == PAGE_SIZE
+        # Checkpoint saved once after the first full page (points at the next page); short page ends it.
+        manager.save_state.assert_called_once_with(JobNimbusResumeConfig(offset=PAGE_SIZE))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_one_request_and_no_checkpoint(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"jnid": "a"}, {"jnid": "b"}], 2)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert [r["jnid"] for r in rows] == ["a", "b"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_offset_reaches_reported_count(self, MockSession: mock.MagicMock) -> None:
+        # A full page whose length exactly equals the reported total must terminate without a second
+        # request, even though the page isn't short — the `count` total drives the stop.
+        session = MockSession.return_value
+        full = [{"jnid": str(i)} for i in range(PAGE_SIZE)]
+        _wire(session, [_response(full, PAGE_SIZE)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert len(rows) == PAGE_SIZE
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(JobNimbusResumeConfig(offset=PAGE_SIZE))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"jnid": "x"}], PAGE_SIZE + 1)])
+
         # Offset 0 must never be fetched on resume.
-        pages = {PAGE_SIZE: ([{"jnid": "5"}], PAGE_SIZE + 1)}
-        rows = self._collect(manager, monkeypatch, pages)
-        assert rows == [{"jnid": "5"}]
+        manager = _make_manager(JobNimbusResumeConfig(offset=PAGE_SIZE))
+        _rows(_source(manager))
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {0: ([], 0)})
+        assert params[0]["from"] == PAGE_SIZE
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], 0)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == []
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
 
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else {"count": 0, "results": []}
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
-        )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
+class TestErrorHandling:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(JobNimbusRetryableError):
-            _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
+    @mock.patch(TENACITY_SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(
+        self, _name: str, status: int, MockSession: mock.MagicMock, _sleep: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_raw_response(None, status=status), _response([{"jnid": "ok"}], 1)])
+
+        rows = _rows(_source(_make_manager()))
+
+        assert [r["jnid"] for r in rows] == ["ok"]
+        # The first (retryable) response is reissued, so the successful page needs a second send.
+        assert session.send.call_count == 2
 
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_status_raises(self, _name: str, status: int, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_raw_response(None, status=status)])
 
-    def test_success_returns_results_and_count(self) -> None:
-        body = {"count": 3, "results": [{"jnid": "1"}]}
-        session = self._session_returning(200, body)
-        results, count = _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
-        assert results == [{"jnid": "1"}]
-        assert count == 3
+        with pytest.raises(HTTPError):
+            _rows(_source(_make_manager()))
 
-    def test_missing_count_falls_back_to_offset_plus_len(self) -> None:
-        body = {"results": [{"jnid": "1"}, {"jnid": "2"}]}
-        session = self._session_returning(200, body)
-        results, count = _fetch_page_unwrapped(session, "/contacts", 50, PAGE_SIZE, MagicMock())
-        assert results == body["results"]
-        assert count == 52
-
-    @parameterized.expand([("bare_list", [{"jnid": "1"}]), ("results_not_a_list", {"results": "nope"})])
-    def test_unexpected_payload_is_retryable(self, _name: str, body: Any) -> None:
-        session = self._session_returning(200, body)
-        with pytest.raises(JobNimbusRetryableError):
-            _fetch_page_unwrapped(session, "/contacts", 0, PAGE_SIZE, MagicMock())
-
-    def test_request_uses_size_and_from_params(self) -> None:
-        session = self._session_returning(200, {"count": 0, "results": []})
-        _fetch_page_unwrapped(session, "/jobs", 200, PAGE_SIZE, MagicMock())
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"size": PAGE_SIZE, "from": 200}
-
-
-class TestCheckAccess:
-    def _patch_session(self, monkeypatch: Any, response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        monkeypatch.setattr(jobnimbus, "make_tracked_session", lambda **kwargs: session)
-        return session
-
-    @pytest.mark.parametrize(
-        "status, ok, expected_status, expected_message",
+    @parameterized.expand(
         [
-            (200, True, 200, None),
-            (401, False, 401, None),
-            (403, False, 403, None),
-            (500, False, 500, "JobNimbus returned HTTP 500"),
-        ],
+            ("missing_results_key", {"count": 0}),
+            ("bare_list_body", [{"jnid": "1"}]),
+        ]
     )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_shape_change_fails_loud(self, _name: str, body: Any, MockSession: mock.MagicMock) -> None:
+        # A 200 body without a `results` list means the response shape changed — fail loud instead of
+        # silently syncing 0 rows or wrapping a stray object as a row.
+        session = MockSession.return_value
+        _wire(session, [_raw_response(body)])
+
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(_make_manager()))
+
+
+class TestValidateCredentials:
+    @parameterized.expand(
+        [
+            ("ok", 200, True, None),
+            ("unauthorized", 401, False, "Invalid JobNimbus API key"),
+            ("forbidden", 403, False, "Invalid JobNimbus API key"),
+            ("server_error", 500, False, "JobNimbus returned HTTP 500"),
+        ]
+    )
+    @mock.patch(JOBNIMBUS_SESSION_PATCH)
     def test_status_mapping(
-        self, status: int, ok: bool, expected_status: int, expected_message: str | None, monkeypatch: Any
+        self,
+        _name: str,
+        status: int,
+        expected_valid: bool,
+        expected_message: str | None,
+        mock_session: mock.MagicMock,
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        self._patch_session(monkeypatch, response)
-        assert check_access("jn-key") == (expected_status, expected_message)
-
-    def test_connection_error_maps_to_zero(self, monkeypatch: Any) -> None:
-        self._patch_session(monkeypatch, requests.ConnectionError("boom"))
-        status, message = check_access("jn-key")
-        assert status == 0
-        assert message is not None and "boom" in message
-
-    @pytest.mark.parametrize(
-        "status, expected_valid, expected_message",
-        [
-            (200, True, None),
-            (401, False, "Invalid JobNimbus API key"),
-            (403, False, "Invalid JobNimbus API key"),
-            (500, False, "JobNimbus returned HTTP 500"),
-        ],
-    )
-    def test_validate_credentials(
-        self, status: int, expected_valid: bool, expected_message: str | None, monkeypatch: Any
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        self._patch_session(monkeypatch, response)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
         assert validate_credentials("jn-key") == (expected_valid, expected_message)
 
+    @mock.patch(JOBNIMBUS_SESSION_PATCH)
+    def test_probe_failure_is_not_validated(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("jn-key") == (False, "Could not validate JobNimbus API key")
 
-class TestJobNimbusSourceResponse:
+
+class TestSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        response = jobnimbus_source(
-            api_key="jn-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, _MockSession: mock.MagicMock) -> None:
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["jnid"]
         # No stable creation timestamp is guaranteed across every object, so we don't partition.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jobnimbus/tests/test_jobnimbus_source.py
@@ -91,30 +91,27 @@ class TestJobNimbusSource:
 
     @parameterized.expand(
         [
-            (200, True, None),
-            (401, False, "Invalid JobNimbus API key"),
-            (403, False, "Invalid JobNimbus API key"),
-            (500, False, "JobNimbus returned HTTP 500"),
-            (0, False, "Could not connect to JobNimbus: boom"),
+            (True, None),
+            (False, "Invalid JobNimbus API key"),
+            (False, "Could not validate JobNimbus API key"),
         ]
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.jobnimbus.check_access")
-    def test_validate_credentials(
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.jobnimbus.source._validate_credentials"
+    )
+    def test_validate_credentials_delegates(
         self,
-        status: int,
         expected_valid: bool,
         expected_message: str | None,
-        mock_check: mock.MagicMock,
+        mock_validate: mock.MagicMock,
     ) -> None:
-        message = (
-            "JobNimbus returned HTTP 500"
-            if status == 500
-            else ("Could not connect to JobNimbus: boom" if status == 0 else None)
-        )
-        mock_check.return_value = (status, message)
+        # The status→message mapping is exercised against the real function in test_jobnimbus.py;
+        # here we only prove the source forwards the account-wide api_key and returns the verdict.
+        mock_validate.return_value = (expected_valid, expected_message)
         is_valid, returned = self.source.validate_credentials(self.config, self.team_id)
         assert is_valid is expected_valid
         assert returned == expected_message
+        mock_validate.assert_called_once_with("jn-key")
 
     def test_get_resumable_source_manager_binds_resume_config(self) -> None:
         manager = self.source.get_resumable_source_manager(mock.MagicMock())
@@ -125,6 +122,8 @@ class TestJobNimbusSource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
         inputs = mock.MagicMock()
         inputs.schema_name = "contacts"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         manager = mock.MagicMock()
 
         self.source.source_for_pipeline(self.config, manager, inputs)
@@ -133,6 +132,8 @@ class TestJobNimbusSource:
         kwargs = mock_source.call_args.kwargs
         assert kwargs["api_key"] == "jn-key"
         assert kwargs["endpoint"] == "contacts"
+        assert kwargs["team_id"] == 123
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
 
     def test_source_for_pipeline_rejects_unknown_schema(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jotform/jotform.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jotform/jotform.py
@@ -1,17 +1,23 @@
 import json
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import quote
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.jotform.settings import (
     JOTFORM_ENDPOINTS,
     JotformEndpointConfig,
@@ -24,25 +30,21 @@ JOTFORM_REGION_BASE_URLS = {
     "hipaa": "https://hipaa-api.jotform.com",
 }
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
 # Jotform's `filter` operator for "created/updated after" is `:gt` (strictly greater than).
 FILTER_GT_SUFFIX = ":gt"
 
 
-class JotformRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class JotformResumeConfig:
-    # Offset of the page to (re)fetch when resuming a list endpoint. Saved as the offset of the page
-    # just yielded so a crash re-yields that page (merge dedupes on the primary key) instead of
-    # skipping it.
+    # Offset of the page to (re)fetch when resuming a list endpoint. The framework saves the offset
+    # of the NEXT page here after each page is committed (merge dedupes on the primary key).
     offset: int = 0
-    # Form currently being processed by the questions fan-out. A stable form-id bookmark so a crash
-    # resumes that form rather than a positional index that shifts as forms are added/removed.
+    # Retained for backward-compatible parsing of resume state saved by the pre-rest_source
+    # implementation (`dataclass(**saved)` must still load). No longer written.
     form_id: Optional[str] = None
+    # Opaque fan-out checkpoint for the questions resource: the rest_source dependent-resource
+    # resume state (`{"completed": [...], "current": ..., "child_state": ...}`).
+    fanout_state: Optional[dict[str, Any]] = None
 
 
 def normalize_enterprise_host(enterprise_domain: Optional[str]) -> Optional[str]:
@@ -99,187 +101,191 @@ def _format_filter_value(value: Any) -> Optional[str]:
     return capped.strftime("%Y-%m-%d %H:%M:%S")
 
 
-def _build_list_params(
+def _filter_convert(field_name: str) -> Callable[[Any], Optional[str]]:
+    """Build the incremental `convert` that turns a watermark into Jotform's JSON `filter` value.
+
+    Returns ``None`` for an unparseable/absent watermark so the framework drops the `filter` param
+    (a `None` param is not sent), matching the hand-rolled "omit filter when it can't be formatted".
+    """
+
+    def convert(value: Any) -> Optional[str]:
+        formatted = _format_filter_value(value)
+        if formatted is None:
+            return None
+        return json.dumps({f"{field_name}{FILTER_GT_SUFFIX}": formatted}, separators=(",", ":"))
+
+    return convert
+
+
+def _client_config(api_key: str, base_url: str) -> dict[str, Any]:
+    # The key rides in the `APIKEY` header via framework auth so it is redacted from every raised
+    # error message; only the non-secret Accept header is set on the client. `enterprise_domain` is
+    # user-supplied, so pin redirects off (defense-in-depth on top of the Smokescreen egress proxy)
+    # to keep the key-bearing request on the validated host.
+    return {
+        "base_url": base_url,
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "api_key", "api_key": api_key, "name": "APIKEY", "location": "header"},
+        "allow_redirects": False,
+    }
+
+
+def _list_params(
     config: JotformEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
+    last_value: Optional[Any],
     incremental_field: Optional[str],
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
     if not config.incremental_fields:
-        # Full-refresh endpoints (reports): no orderby/filter. Jotform doesn't document an orderby
-        # enum for these, and they're small enough that offset stability isn't a concern.
+        # Full-refresh endpoints (reports): no orderby/filter.
         return params
 
     field_name = incremental_field or config.default_incremental_field
-    # Order by the cursor field so pages arrive oldest-first and the asc watermark advances
-    # correctly. Jotform's `orderby` sorts ascending by the given field (per the API docs; couldn't
-    # be curl-verified without an API key).
-    if field_name:
-        params["orderby"] = field_name
-        if should_use_incremental_field and db_incremental_field_last_value is not None:
-            formatted = _format_filter_value(db_incremental_field_last_value)
-            if formatted is not None:
-                params["filter"] = json.dumps({f"{field_name}{FILTER_GT_SUFFIX}": formatted}, separators=(",", ":"))
+    if not field_name:
+        return params
+
+    # Order by the cursor field so pages arrive oldest-first and the asc watermark advances.
+    params["orderby"] = field_name
+    if last_value is not None:
+        params["filter"] = {
+            "type": "incremental",
+            "cursor_path": field_name,
+            "convert": _filter_convert(field_name),
+        }
     return params
 
 
-@retry(
-    retry=retry_if_exception_type((JotformRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch_page(url: str, params: dict[str, Any], headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    # `enterprise_domain` is user-supplied, so pin redirects off (defense-in-depth on top of the
-    # Smokescreen egress proxy, which is the load-bearing SSRF control) to keep the API-key-bearing
-    # request on the validated host, and value-redact the key carried in the `APIKEY` header.
-    api_key = headers.get("APIKEY")
-    session = make_tracked_session(redact_values=(api_key,) if api_key else (), allow_redirects=False)
-    response = session.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+def _question_row(row: dict[str, Any]) -> dict[str, Any]:
+    # `include_from_parent=["id"]` injects the parent form's id under `_forms_id`; expose it as
+    # `form_id` (stringified) so the row shape matches the hand-rolled source. `qid` is unique only
+    # within a form, so every row carries the form id for a table-wide key.
+    form_id = row.pop("_forms_id")
+    row["form_id"] = str(form_id)
+    return row
 
-    # Jotform enforces daily call quotas rather than per-second rate limits; an exhausted quota or a
-    # transient server error is worth retrying. Auth failures (401/403) are not — they surface to
-    # `get_non_retryable_errors` and stop the sync.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise JotformRetryableError(f"Jotform API error (retryable): status={response.status_code}, url={url}")
 
-    if not response.ok:
-        logger.error(f"Jotform API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
+def _list_source(
+    api_key: str,
+    base_url: str,
+    endpoint: str,
+    config: JotformEndpointConfig,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[JotformResumeConfig],
+    last_value: Optional[Any],
+    incremental_field: Optional[str],
+) -> Resource:
+    rest_config: RESTAPIConfig = {
+        "client": {
+            **_client_config(api_key, base_url),
+            # Jotform reports no reliable top-level total; termination is the short/empty page.
+            "paginator": OffsetPaginator(limit=config.page_size, total_path=None),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": _list_params(config, last_value, incremental_field),
+                    "data_selector": "content",
+                },
+            }
+        ],
+    }
 
-    return response.json()
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is committed so a crash re-yields the last page (merge dedupes) rather
+        # than skipping it; the paginator only reports state while a next page remains.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(JotformResumeConfig(offset=int(state["offset"])))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _questions_source(
+    api_key: str,
+    base_url: str,
+    config: JotformEndpointConfig,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[JotformResumeConfig],
+) -> Resource:
+    forms_config = JOTFORM_ENDPOINTS["forms"]
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key, base_url),
+        "resources": [
+            {
+                "name": "forms",
+                "endpoint": {
+                    "path": forms_config.path,
+                    "params": {"orderby": "created_at"},
+                    "data_selector": "content",
+                    "paginator": OffsetPaginator(limit=forms_config.page_size, total_path=None),
+                },
+            },
+            {
+                "name": "questions",
+                "include_from_parent": ["id"],
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"form_id": {"type": "resolve", "resource": "forms", "field": "id"}},
+                    # `/form/{id}/questions` returns an object keyed by question id; `.*` yields the
+                    # question objects as rows.
+                    "data_selector": "content.*",
+                    "paginator": SinglePagePaginator(),
+                },
+                "data_map": _question_row,
+            },
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        resumable_source_manager.save_state(JotformResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    forms_resource = next(r for r in resources if r.name == "forms")
+    # Skip forms without an id so the fan-out never tries to resolve a form-less path (the
+    # hand-rolled source skipped id-less form rows too).
+    forms_resource.add_filter(lambda form: form.get("id") is not None)
+    return next(r for r in resources if r.name == "questions")
 
 
 def validate_credentials(api_key: str, region: Optional[str], enterprise_domain: Optional[str] = None) -> bool:
     """Confirm the API key is valid for the target host. ``/user`` is the cheapest authenticated probe."""
-    try:
-        # Same SSRF posture as `_fetch_page`: no redirects off the validated host, redact the key.
-        response = make_tracked_session(redact_values=(api_key,), allow_redirects=False).get(
-            f"{resolve_base_url(region, enterprise_domain)}/user",
-            headers=_headers(api_key),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_form_ids(base_url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> list[str]:
-    config = JOTFORM_ENDPOINTS["forms"]
-    ids: list[str] = []
-    offset = 0
-
-    while True:
-        params = {"limit": config.page_size, "offset": offset, "orderby": "created_at"}
-        data = _fetch_page(f"{base_url}{config.path}", params, headers, logger)
-        content = data.get("content")
-        if not isinstance(content, list) or not content:
-            break
-
-        ids.extend(str(item["id"]) for item in content if isinstance(item, dict) and item.get("id") is not None)
-
-        if len(content) < config.page_size:
-            break
-        offset += config.page_size
-
-    return ids
-
-
-def _question_row(form_id: str, question: dict[str, Any]) -> dict[str, Any]:
-    row = dict(question)
-    # `qid` is unique only within a form, so every row carries the form id for a table-wide key.
-    row["form_id"] = form_id
-    return row
-
-
-def _iter_list_pages(
-    base_url: str,
-    config: JotformEndpointConfig,
-    headers: dict[str, str],
-    base_params: dict[str, Any],
-    manager: ResumableSourceManager[JotformResumeConfig],
-    start_offset: int,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    offset = start_offset
-
-    while True:
-        params = {**base_params, "limit": config.page_size, "offset": offset}
-        data = _fetch_page(f"{base_url}{config.path}", params, headers, logger)
-        content = data.get("content")
-        if not isinstance(content, list) or not content:
-            break
-
-        yield content
-
-        # Save the offset of the page just yielded so a crash re-fetches and re-yields it (merge
-        # dedupes on the primary key) rather than skipping it.
-        manager.save_state(JotformResumeConfig(offset=offset))
-
-        if len(content) < config.page_size:
-            break
-        offset += config.page_size
-
-
-def _iter_questions(
-    base_url: str,
-    config: JotformEndpointConfig,
-    headers: dict[str, str],
-    manager: ResumableSourceManager[JotformResumeConfig],
-    resume: Optional[JotformResumeConfig],
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    form_ids = get_form_ids(base_url, headers, logger)
-
-    remaining = form_ids
-    if resume is not None and resume.form_id is not None and resume.form_id in form_ids:
-        # Resume from the bookmarked form (re-fetched and re-yielded; merge dedupes). If the form was
-        # deleted between runs, fall through and start over from the first form.
-        remaining = form_ids[form_ids.index(resume.form_id) :]
-        logger.debug(f"Jotform: resuming questions from form_id={resume.form_id}")
-
-    for form_id in remaining:
-        path = config.path.format(form_id=quote(str(form_id), safe=""))
-        data = _fetch_page(f"{base_url}{path}", {}, headers, logger)
-        content = data.get("content")
-
-        # `/form/{id}/questions` returns an object keyed by question id, not a list.
-        if isinstance(content, dict):
-            rows = [_question_row(form_id, question) for question in content.values() if isinstance(question, dict)]
-            if rows:
-                yield rows
-
-        # Bookmark the form just processed so a crash resumes here rather than skipping ahead.
-        manager.save_state(JotformResumeConfig(form_id=form_id))
-
-
-def get_rows(
-    api_key: str,
-    region: Optional[str],
-    enterprise_domain: Optional[str],
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[JotformResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = JOTFORM_ENDPOINTS[endpoint]
-    base_url = resolve_base_url(region, enterprise_domain)
-    headers = _headers(api_key)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if config.fan_out_over_forms:
-        yield from _iter_questions(base_url, config, headers, resumable_source_manager, resume, logger)
-        return
-
-    base_params = _build_list_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    # Same SSRF posture as the sync client: no redirects off the validated host, redact the key.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,), allow_redirects=False),
+        f"{resolve_base_url(region, enterprise_domain)}/user",
+        headers=_headers(api_key),
     )
-    start_offset = resume.offset if resume is not None else 0
-    yield from _iter_list_pages(base_url, config, headers, base_params, resumable_source_manager, start_offset, logger)
+    return ok
 
 
 def jotform_source(
@@ -287,27 +293,35 @@ def jotform_source(
     region: Optional[str],
     enterprise_domain: Optional[str],
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[JotformResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
 ) -> SourceResponse:
     config = JOTFORM_ENDPOINTS[endpoint]
+    base_url = resolve_base_url(region, enterprise_domain)
+    last_value = db_incremental_field_last_value if should_use_incremental_field else None
+
+    if config.fan_out_over_forms:
+        resource = _questions_source(api_key, base_url, config, team_id, job_id, resumable_source_manager)
+    else:
+        resource = _list_source(
+            api_key,
+            base_url,
+            endpoint,
+            config,
+            team_id,
+            job_id,
+            resumable_source_manager,
+            last_value,
+            incremental_field,
+        )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            region=region,
-            enterprise_domain=enterprise_domain,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=list(config.primary_keys),
         sort_mode="asc",
         partition_count=1,
@@ -315,4 +329,5 @@ def jotform_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format=config.partition_format if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jotform/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jotform/source.py
@@ -185,7 +185,8 @@ Supported tables:
             region=config.region,
             enterprise_domain=config.enterprise_domain,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/jotform/tests/test_jotform.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/jotform/tests/test_jotform.py
@@ -1,19 +1,19 @@
+import json
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import pytest
 from unittest import mock
 
-import requests
+from requests import Response
+from requests.exceptions import HTTPError
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform import (
     JotformResumeConfig,
-    JotformRetryableError,
-    _build_list_params,
     _format_filter_value,
-    _question_row,
-    get_form_ids,
-    get_rows,
     jotform_source,
     normalize_enterprise_host,
     resolve_base_url,
@@ -26,6 +26,20 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.jotform.se
 
 US_BASE = "https://api.jotform.com"
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the jotform module.
+JOTFORM_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session"
+)
+
+
+def _response(content: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps({"content": content, "responseCode": status_code}).encode()
+    return resp
+
 
 def _make_manager(resume_state: JotformResumeConfig | None = None) -> mock.MagicMock:
     manager = mock.MagicMock()
@@ -34,17 +48,36 @@ def _make_manager(resume_state: JotformResumeConfig | None = None) -> mock.Magic
     return manager
 
 
-def _response(content: Any, status_code: int = 200) -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.json.return_value = {"content": content, "responseCode": status_code}
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.text = ""
-    return response
+class _Capture:
+    """Snapshot each request's URL + params at prepare time (params dict is mutated in place)."""
+
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+        self.params: list[dict[str, Any]] = []
 
 
-def _params(call: mock.Mock) -> dict[str, Any]:
-    return call.kwargs["params"]
+def _wire(session: mock.MagicMock, responses: list[Response]) -> _Capture:
+    session.headers = {}
+    capture = _Capture()
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        capture.urls.append(request.url)
+        capture.params.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return capture
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return jotform_source(
+        "key", "us", None, endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs
+    )
 
 
 class TestResolveBaseUrl:
@@ -72,7 +105,6 @@ class TestResolveBaseUrl:
         ],
     )
     def test_enterprise_domain_overrides_region(self, domain, expected):
-        # Enterprise domain wins over the region selection and is served under /API.
         assert resolve_base_url("eu", domain) == expected
 
     @pytest.mark.parametrize("domain", ["", "   ", None])
@@ -113,57 +145,133 @@ class TestFormatFilterValue:
         )
 
 
-class TestBuildListParams:
-    def test_full_refresh_endpoint_has_no_params(self):
-        # reports has no incremental fields, so no orderby/filter is sent.
-        assert _build_list_params(JOTFORM_ENDPOINTS["reports"], False, None, None) == {}
+class TestListEndpoints:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_partial_page_yields_once_and_no_checkpoint(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "1"}, {"id": "2"}])])
 
-    def test_incremental_off_still_orders_by_default_field(self):
-        params = _build_list_params(JOTFORM_ENDPOINTS["submissions"], False, None, None)
-        assert params == {"orderby": "created_at"}
-        assert "filter" not in params
+        manager = _make_manager()
+        rows = _rows(_source("submissions", manager))
 
-    def test_incremental_on_adds_gt_filter_on_chosen_field(self):
-        params = _build_list_params(
-            JOTFORM_ENDPOINTS["submissions"], True, datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC), "updated_at"
+        assert [r["id"] for r in rows] == ["1", "2"]
+        # A short first page ends pagination; no next page means no checkpoint.
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_partial_page_and_checkpoints_next_offset(self, MockSession):
+        session = MockSession.return_value
+        with mock.patch.object(JOTFORM_ENDPOINTS["submissions"], "page_size", 2):
+            capture = _wire(session, [_response([{"id": "1"}, {"id": "2"}]), _response([{"id": "3"}])])
+            manager = _make_manager()
+            rows = _rows(_source("submissions", manager))
+
+        assert [r["id"] for r in rows] == ["1", "2", "3"]
+        assert capture.params[0]["offset"] == 0
+        assert capture.params[0]["limit"] == 2
+        assert capture.params[1]["offset"] == 2
+        # Checkpoint saved after the first full page (points at the next page); short page ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == JotformResumeConfig(offset=2)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession):
+        session = MockSession.return_value
+        capture = _wire(session, [_response([{"id": "9"}])])
+
+        manager = _make_manager(JotformResumeConfig(offset=200))
+        _rows(_source("submissions", manager))
+
+        assert capture.params[0]["offset"] == 200
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_off_still_orders_by_default_field(self, MockSession):
+        session = MockSession.return_value
+        capture = _wire(session, [_response([{"id": "1"}])])
+
+        _rows(_source("submissions", _make_manager()))
+
+        assert capture.params[0]["orderby"] == "created_at"
+        assert "filter" not in capture.params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_run_sends_gt_filter_on_chosen_field(self, MockSession):
+        session = MockSession.return_value
+        capture = _wire(session, [_response([])])
+
+        _rows(
+            _source(
+                "submissions",
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC),
+                incremental_field="updated_at",
+            )
         )
-        assert params["orderby"] == "updated_at"
-        assert params["filter"] == '{"updated_at:gt":"2024-01-15 10:30:45"}'
 
-    def test_incremental_on_without_watermark_omits_filter(self):
-        params = _build_list_params(JOTFORM_ENDPOINTS["forms"], True, None, None)
-        assert params == {"orderby": "created_at"}
+        assert capture.params[0]["orderby"] == "updated_at"
+        assert capture.params[0]["filter"] == '{"updated_at:gt":"2024-01-15 10:30:45"}'
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_on_without_watermark_omits_filter(self, MockSession):
+        session = MockSession.return_value
+        capture = _wire(session, [_response([{"id": "1"}])])
+
+        _rows(_source("forms", _make_manager(), should_use_incremental_field=True))
+
+        assert capture.params[0]["orderby"] == "created_at"
+        assert "filter" not in capture.params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_has_no_orderby_or_filter(self, MockSession):
+        session = MockSession.return_value
+        capture = _wire(session, [_response([{"id": "1"}])])
+
+        _rows(_source("reports", _make_manager()))
+
+        assert "orderby" not in capture.params[0]
+        assert "filter" not in capture.params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_content_yields_nothing(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        assert _rows(_source("reports", _make_manager())) == []
 
 
-class TestFetchPageRetries:
+class TestRetries:
     @pytest.mark.parametrize("status_code", [429, 500, 503])
     @mock.patch("tenacity.nap.time.sleep", return_value=None)
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_retryable_statuses_eventually_raise(self, mock_session, _sleep, status_code):
-        mock_session.return_value.get.return_value = _response([], status_code)
-        manager = _make_manager()
-        with pytest.raises(JotformRetryableError):
-            list(get_rows("key", "us", None, "forms", mock.MagicMock(), manager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_eventually_raise(self, MockSession, _sleep, status_code):
+        session = MockSession.return_value
+        # The client re-issues on 429/5xx; exhaust the attempts with the same status.
+        _wire(session, [_response([], status_code) for _ in range(10)])
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source("forms", _make_manager()))
 
     @pytest.mark.parametrize("status_code", [401, 403, 404])
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_client_errors_raise_immediately(self, mock_session, status_code):
-        response = _response([], status_code)
-        response.raise_for_status.side_effect = requests.HTTPError(f"{status_code} Client Error", response=response)
-        mock_session.return_value.get.return_value = response
-        manager = _make_manager()
-        with pytest.raises(requests.HTTPError):
-            list(get_rows("key", "us", None, "forms", mock.MagicMock(), manager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_immediately(self, MockSession, status_code):
+        session = MockSession.return_value
+        _wire(session, [_response([], status_code)])
+
+        with pytest.raises(HTTPError):
+            _rows(_source("forms", _make_manager()))
+        # No retry on a 4xx: exactly one request was sent.
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
+    @mock.patch(JOTFORM_SESSION_PATCH)
     def test_status_mapping(self, mock_session, status_code, expected):
-        mock_session.return_value.get.return_value = _response("", status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("key", "us") is expected
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
+    @mock.patch(JOTFORM_SESSION_PATCH)
     def test_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("key", "us") is False
@@ -176,188 +284,117 @@ class TestValidateCredentials:
             ("us", "forms.acme.com", "https://forms.acme.com/API/user"),
         ],
     )
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
+    @mock.patch(JOTFORM_SESSION_PATCH)
     def test_targets_correct_host(self, mock_session, region, enterprise_domain, expected_url):
-        mock_session.return_value.get.return_value = _response("", 200)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("key", region, enterprise_domain)
         assert mock_session.return_value.get.call_args.args[0] == expected_url
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
+    @mock.patch(JOTFORM_SESSION_PATCH)
     def test_sends_api_key_header(self, mock_session):
-        mock_session.return_value.get.return_value = _response("", 200)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("key-123", "us")
         assert mock_session.return_value.get.call_args.kwargs["headers"]["APIKEY"] == "key-123"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
+    @mock.patch(JOTFORM_SESSION_PATCH)
     def test_pins_redirects_off_and_redacts_key(self, mock_session):
-        mock_session.return_value.get.return_value = _response("", 200)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("key-123", "us", "forms.acme.com")
         # User-controlled host: no redirects off the validated host, and the key is value-redacted.
         assert mock_session.call_args.kwargs["allow_redirects"] is False
         assert mock_session.call_args.kwargs["redact_values"] == ("key-123",)
 
 
-class TestGetFormIds:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_paginates_across_offset_pages(self, mock_session):
-        page_size = JOTFORM_ENDPOINTS["forms"].page_size
-        full = [{"id": f"f{i}"} for i in range(page_size)]
-        partial = [{"id": "last"}]
-        mock_session.return_value.get.side_effect = [_response(full), _response(partial)]
-
-        ids = get_form_ids(US_BASE, {"APIKEY": "key"}, mock.MagicMock())
-
-        assert len(ids) == page_size + 1
-        assert ids[-1] == "last"
-        assert _params(mock_session.return_value.get.call_args_list[1])["offset"] == page_size
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_skips_items_without_id_and_stringifies(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": 42}, {"title": "no id"}])
-        assert get_form_ids(US_BASE, {}, mock.MagicMock()) == ["42"]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_pins_redirects_off_and_redacts_key(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "1"}])
-        get_form_ids(US_BASE, {"APIKEY": "secret-key"}, mock.MagicMock())
-        # Page fetches against a potentially user-controlled host must not follow redirects, and the
-        # key carried in the APIKEY header is value-redacted from logs.
-        assert mock_session.call_args.kwargs["allow_redirects"] is False
-        assert mock_session.call_args.kwargs["redact_values"] == ("secret-key",)
-
-
-class TestGetRowsListEndpoints:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_single_partial_page_yields_once_and_saves_offset(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "1"}, {"id": "2"}])
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "us", None, "submissions", mock.MagicMock(), manager))
-
-        assert [row["id"] for batch in batches for row in batch] == ["1", "2"]
-        saved = [c.args[0].offset for c in manager.save_state.call_args_list]
-        assert saved == [0]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_paginates_until_partial_page(self, mock_session):
-        with mock.patch.object(JOTFORM_ENDPOINTS["submissions"], "page_size", 2):
-            mock_session.return_value.get.side_effect = [
-                _response([{"id": "1"}, {"id": "2"}]),
-                _response([{"id": "3"}]),
-            ]
-
-            manager = _make_manager()
-            batches = list(get_rows("key", "us", None, "submissions", mock.MagicMock(), manager))
-
-        assert [row["id"] for batch in batches for row in batch] == ["1", "2", "3"]
-        # Offset advances by page_size between pages; state saved after each yielded page.
-        assert _params(mock_session.return_value.get.call_args_list[1])["offset"] == 2
-        assert [c.args[0].offset for c in manager.save_state.call_args_list] == [0, 2]
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_resumes_from_saved_offset(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "9"}])
-
-        manager = _make_manager(JotformResumeConfig(offset=200))
-        list(get_rows("key", "us", None, "submissions", mock.MagicMock(), manager))
-
-        assert _params(mock_session.return_value.get.call_args_list[0])["offset"] == 200
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_incremental_run_sends_gt_filter(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
-
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                "us",
-                None,
-                "submissions",
-                mock.MagicMock(),
-                manager,
-                should_use_incremental_field=True,
-                db_incremental_field_last_value=datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC),
-                incremental_field="created_at",
-            )
-        )
-
-        params = _params(mock_session.return_value.get.call_args_list[0])
-        assert params["orderby"] == "created_at"
-        assert params["filter"] == '{"created_at:gt":"2024-01-15 10:30:45"}'
-
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_empty_content_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
-
-        manager = _make_manager()
-        assert list(get_rows("key", "us", None, "reports", mock.MagicMock(), manager)) == []
-
-
-class TestGetRowsQuestionsFanOut:
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_fans_out_over_forms_and_injects_form_id(self, mock_session):
+class TestQuestionsFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_over_forms_and_injects_form_id(self, MockSession):
+        session = MockSession.return_value
         forms_page = [{"id": "f1"}, {"id": "f2"}]
         f1_questions = {"1": {"qid": "1", "text": "Name"}, "2": {"qid": "2", "text": "Email"}}
         f2_questions = {"1": {"qid": "1", "text": "Age"}}
-        mock_session.return_value.get.side_effect = [
-            _response(forms_page),
-            _response(f1_questions),
-            _response(f2_questions),
-        ]
+        capture = _wire(session, [_response(forms_page), _response(f1_questions), _response(f2_questions)])
 
-        manager = _make_manager()
-        batches = list(get_rows("key", "us", None, "questions", mock.MagicMock(), manager))
+        rows = _rows(_source("questions", _make_manager()))
 
-        rows = [row for batch in batches for row in batch]
         assert [(row["form_id"], row["qid"]) for row in rows] == [("f1", "1"), ("f1", "2"), ("f2", "1")]
-        # The form id is fetched then each form's questions endpoint is hit.
-        assert mock_session.return_value.get.call_args_list[1].args[0] == f"{US_BASE}/form/f1/questions"
-        assert [c.args[0].form_id for c in manager.save_state.call_args_list] == ["f1", "f2"]
+        # Forms are listed once, then each form's questions endpoint is hit in turn.
+        assert capture.urls[0] == f"{US_BASE}/user/forms"
+        assert capture.urls[1] == f"{US_BASE}/form/f1/questions"
+        assert capture.urls[2] == f"{US_BASE}/form/f2/questions"
+        assert capture.params[0]["orderby"] == "created_at"
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_resumes_from_bookmarked_form(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_form_id_is_stringified(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 42}]), _response({"1": {"qid": "1"}})])
+
+        rows = _rows(_source("questions", _make_manager()))
+        assert rows == [{"qid": "1", "form_id": "42"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_skips_forms_without_id(self, MockSession):
+        session = MockSession.return_value
+        # The id-less form must not trigger a questions request.
+        _wire(session, [_response([{"id": "f1"}, {"title": "no id"}]), _response({"1": {"qid": "1"}})])
+
+        rows = _rows(_source("questions", _make_manager()))
+        assert [r["form_id"] for r in rows] == ["f1"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_questions_form_yields_no_rows(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "f1"}]), _response({})])
+
+        assert _rows(_source("questions", _make_manager())) == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_and_skips_completed_forms(self, MockSession):
+        session = MockSession.return_value
         forms_page = [{"id": "f1"}, {"id": "f2"}]
         f2_questions = {"1": {"qid": "1", "text": "Age"}}
-        mock_session.return_value.get.side_effect = [_response(forms_page), _response(f2_questions)]
+        capture = _wire(session, [_response(forms_page), _response(f2_questions)])
 
-        manager = _make_manager(JotformResumeConfig(form_id="f2"))
-        batches = list(get_rows("key", "us", None, "questions", mock.MagicMock(), manager))
+        # f1's questions completed in the prior run; only f2 is re-fetched.
+        resume = JotformResumeConfig(
+            fanout_state={"completed": ["/form/f1/questions"], "current": None, "child_state": None}
+        )
+        rows = _rows(_source("questions", _make_manager(resume)))
 
-        rows = [row for batch in batches for row in batch]
-        # f1 was completed in the prior run; only f2 is re-fetched.
         assert [(row["form_id"], row["qid"]) for row in rows] == [("f2", "1")]
-        assert mock_session.return_value.get.call_args_list[1].args[0] == f"{US_BASE}/form/f2/questions"
+        # Forms are re-listed, but f1's questions endpoint is not hit again.
+        assert capture.urls == [f"{US_BASE}/user/forms", f"{US_BASE}/form/f2/questions"]
 
-    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.jotform.jotform.make_tracked_session")
-    def test_deleted_bookmark_form_restarts_from_first(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_deleted_bookmark_form_restarts_from_first(self, MockSession):
+        session = MockSession.return_value
         forms_page = [{"id": "f1"}, {"id": "f2"}]
-        mock_session.return_value.get.side_effect = [
-            _response(forms_page),
-            _response({"1": {"qid": "1"}}),
-            _response({"1": {"qid": "1"}}),
-        ]
+        _wire(session, [_response(forms_page), _response({"1": {"qid": "1"}}), _response({"1": {"qid": "1"}})])
 
-        manager = _make_manager(JotformResumeConfig(form_id="deleted-form"))
-        batches = list(get_rows("key", "us", None, "questions", mock.MagicMock(), manager))
-
-        rows = [row for batch in batches for row in batch]
+        resume = JotformResumeConfig(
+            fanout_state={"completed": ["/form/deleted/questions"], "current": None, "child_state": None}
+        )
+        rows = _rows(_source("questions", _make_manager(resume)))
         assert [row["form_id"] for row in rows] == ["f1", "f2"]
 
-    def test_question_row_injects_form_id(self):
-        assert _question_row("f9", {"qid": "3", "text": "Q"}) == {"qid": "3", "text": "Q", "form_id": "f9"}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_completed_forms(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "f1"}]), _response({"1": {"qid": "1"}})])
 
-    def test_question_row_does_not_mutate_input(self):
-        question = {"qid": "3"}
-        _question_row("f9", question)
-        assert question == {"qid": "3"}
+        manager = _make_manager()
+        _rows(_source("questions", manager))
+
+        # The final checkpoint records f1's questions path as completed.
+        saved_states = [c.args[0].fanout_state for c in manager.save_state.call_args_list]
+        assert any(state and "/form/f1/questions" in (state.get("completed") or []) for state in saved_states)
 
 
 class TestJotformSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = JOTFORM_ENDPOINTS[endpoint]
-        response = jotform_source("key", "us", None, endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -372,10 +409,8 @@ class TestJotformSourceResponse:
 
     @pytest.mark.parametrize("config", list(JOTFORM_ENDPOINTS.values()))
     def test_partition_keys_are_stable_creation_fields(self, config):
-        # Partitioning must never key off an updated_at-style field that rewrites on every sync.
         if config.partition_key:
             assert config.partition_key == "created_at"
 
     def test_questions_primary_key_includes_form_id(self):
-        # qid is unique only within a form, so the table-wide key needs form_id.
         assert JOTFORM_ENDPOINTS["questions"].primary_keys == ["form_id", "qid"]


### PR DESCRIPTION
## Problem

Batch 23 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **hetzner**
- **hugging_face**
- **instatus**
- **invoiceninja**
- **jobnimbus**
- **jotform**

Not migrated this batch (left hand-rolled, valid blocker):
- **inngest** — client-side incremental watermark clamping, cursor-event row dropping, and cross-sync run dedup inside an internal-parent fan-out; none framework-expressible without weakening pinned tests.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 6 migrated dirs + `common/rest_source/tests/` — 475 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-22 PR (#71911); merge in order.
