### PR TITLE
fix(experiments): read metric-events preagg parts from the aux cluster in cache_health

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/CacheHealth.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/CacheHealth.tsx
@@ -41,6 +41,15 @@ function tableLabel(table: string): string {
 }
 
 function TableCard({ table }: { table: CacheTableStats }): JSX.Element {
+    if (table.unavailable) {
+        return (
+            <LemonCard hoverEffect={false} className="flex-1 min-w-72">
+                <div className="font-mono text-xs text-muted">{table.table}</div>
+                <div className="text-xl font-semibold mt-1">Unavailable</div>
+                <div className="text-xs text-muted mt-1">Couldn't read system.parts from this table's cluster</div>
+            </LemonCard>
+        )
+    }
     return (
         <LemonCard hoverEffect={false} className="flex-1 min-w-72">
             <div className="font-mono text-xs text-muted">{table.table}</div>

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -103,6 +103,9 @@ export interface CacheTableStats {
     oldest_partition: string | null
     newest_partition: string | null
     partitions: CachePartitionStats[]
+    // Set when system.parts couldn't be read from the cluster this table lives on — the zeros
+    // above are then "unknown", not "empty".
+    unavailable?: boolean
 }
 
 export interface CacheHealthResponse {

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -34,7 +34,7 @@ from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.team.team import Team
 from posthog.permissions import APIScopePermission
 from posthog.settings.base_variables import DEBUG
-from posthog.settings.data_stores import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
+from posthog.settings.data_stores import CLICKHOUSE_AUX_CLUSTER, CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
 
 from products.analytics_platform.backend.models import PreaggregationJob
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
@@ -85,36 +85,15 @@ def _cache_table_stats() -> list[dict]:
     ttl_only_drop_parts=1, so each partition id is the day the partition drops — the
     per-partition breakdown doubles as a TTL/growth timeline.
     """
+    # Each sharded table's parts live on the cluster its Distributed table targets: exposures on
+    # the main cluster, metric_events on the aux cluster — so system.parts must be read per cluster.
     tables = {
-        SHARDED_EXPERIMENT_EXPOSURES_TABLE(): DISTRIBUTED_EXPERIMENT_EXPOSURES_TABLE(),
-        SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE(): DISTRIBUTED_EXPERIMENT_METRIC_EVENTS_TABLE(),
+        SHARDED_EXPERIMENT_EXPOSURES_TABLE(): (DISTRIBUTED_EXPERIMENT_EXPOSURES_TABLE(), CLICKHOUSE_CLUSTER),
+        SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE(): (
+            DISTRIBUTED_EXPERIMENT_METRIC_EVENTS_TABLE(),
+            CLICKHOUSE_AUX_CLUSTER,
+        ),
     }
-    # cluster() reads one replica per shard. clusterAllReplicas would visit every replica and,
-    # unlike query_log (deduped via is_initial_query), each replica of a shard reports the same
-    # parts — rows/bytes would be multiplied by the replica count.
-    response = sync_execute(
-        """
-        SELECT
-            table,
-            partition,
-            sum(rows) AS rows,
-            sum(bytes_on_disk) AS bytes_on_disk,
-            count() AS parts
-        FROM cluster(%(cluster)s, system, parts)
-        WHERE
-            database = %(database)s
-            AND table IN %(tables)s
-            AND active
-        GROUP BY table, partition
-        ORDER BY table, partition
-        SETTINGS skip_unavailable_shards=1
-        """,
-        {
-            "cluster": CLICKHOUSE_CLUSTER,
-            "database": CLICKHOUSE_DATABASE,
-            "tables": list(tables.keys()),
-        },
-    )
 
     stats: dict[str, dict[str, Any]] = {
         sharded: {
@@ -127,19 +106,47 @@ def _cache_table_stats() -> list[dict]:
             "newest_partition": None,
             "partitions": [],
         }
-        for sharded, base in tables.items()
+        for sharded, (base, _) in tables.items()
     }
-    for table, partition, rows, bytes_on_disk, parts in response:
-        entry = stats.get(table)
-        if entry is None:
-            continue
-        entry["total_rows"] += rows
-        entry["bytes_on_disk"] += bytes_on_disk
-        entry["active_parts"] += parts
-        entry["partition_count"] += 1
-        entry["partitions"].append(
-            {"partition": partition, "rows": rows, "bytes_on_disk": bytes_on_disk, "parts": parts}
+
+    for cluster in dict.fromkeys(cluster for _, cluster in tables.values()):
+        # cluster() reads one replica per shard. clusterAllReplicas would visit every replica and,
+        # unlike query_log (deduped via is_initial_query), each replica of a shard reports the same
+        # parts — rows/bytes would be multiplied by the replica count.
+        response = sync_execute(
+            """
+            SELECT
+                table,
+                partition,
+                sum(rows) AS rows,
+                sum(bytes_on_disk) AS bytes_on_disk,
+                count() AS parts
+            FROM cluster(%(cluster)s, system, parts)
+            WHERE
+                database = %(database)s
+                AND table IN %(tables)s
+                AND active
+            GROUP BY table, partition
+            ORDER BY table, partition
+            SETTINGS skip_unavailable_shards=1
+            """,
+            {
+                "cluster": cluster,
+                "database": CLICKHOUSE_DATABASE,
+                "tables": [sharded for sharded, (_, c) in tables.items() if c == cluster],
+            },
         )
+        for table, partition, rows, bytes_on_disk, parts in response:
+            entry = stats.get(table)
+            if entry is None:
+                continue
+            entry["total_rows"] += rows
+            entry["bytes_on_disk"] += bytes_on_disk
+            entry["active_parts"] += parts
+            entry["partition_count"] += 1
+            entry["partitions"].append(
+                {"partition": partition, "rows": rows, "bytes_on_disk": bytes_on_disk, "parts": parts}
+            )
     for entry in stats.values():
         if entry["partitions"]:
             entry["oldest_partition"] = entry["partitions"][0]["partition"]

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -110,32 +110,41 @@ def _cache_table_stats() -> list[dict]:
     }
 
     for cluster in dict.fromkeys(cluster for _, cluster in tables.values()):
+        cluster_tables = [sharded for sharded, (_, c) in tables.items() if c == cluster]
         # cluster() reads one replica per shard. clusterAllReplicas would visit every replica and,
         # unlike query_log (deduped via is_initial_query), each replica of a shard reports the same
         # parts — rows/bytes would be multiplied by the replica count.
-        response = sync_execute(
-            """
-            SELECT
-                table,
-                partition,
-                sum(rows) AS rows,
-                sum(bytes_on_disk) AS bytes_on_disk,
-                count() AS parts
-            FROM cluster(%(cluster)s, system, parts)
-            WHERE
-                database = %(database)s
-                AND table IN %(tables)s
-                AND active
-            GROUP BY table, partition
-            ORDER BY table, partition
-            SETTINGS skip_unavailable_shards=1
-            """,
-            {
-                "cluster": cluster,
-                "database": CLICKHOUSE_DATABASE,
-                "tables": [sharded for sharded, (_, c) in tables.items() if c == cluster],
-            },
-        )
+        try:
+            response = sync_execute(
+                """
+                SELECT
+                    table,
+                    partition,
+                    sum(rows) AS rows,
+                    sum(bytes_on_disk) AS bytes_on_disk,
+                    count() AS parts
+                FROM cluster(%(cluster)s, system, parts)
+                WHERE
+                    database = %(database)s
+                    AND table IN %(tables)s
+                    AND active
+                GROUP BY table, partition
+                ORDER BY table, partition
+                SETTINGS skip_unavailable_shards=1
+                """,
+                {
+                    "cluster": cluster,
+                    "database": CLICKHOUSE_DATABASE,
+                    "tables": cluster_tables,
+                },
+            )
+        except Exception:
+            # One cluster being unreachable (or absent in a single-cluster deployment) must not
+            # take down the stats read from the healthy cluster.
+            logger.exception("cache_health: failed to read system.parts from cluster %s", cluster)
+            for sharded in cluster_tables:
+                stats[sharded]["unavailable"] = True
+            continue
         for table, partition, rows, bytes_on_disk, parts in response:
             entry = stats.get(table)
             if entry is None:

--- a/posthog/api/test/test_debug_ch_queries.py
+++ b/posthog/api/test/test_debug_ch_queries.py
@@ -124,3 +124,21 @@ class TestCacheTableStats(SimpleTestCase):
         self.assertEqual(
             metric_events["partitions"], [{"partition": "20260802", "rows": 20, "bytes_on_disk": 200, "parts": 2}]
         )
+
+    def test_unreachable_cluster_degrades_instead_of_raising(self):
+        # A deployment without the aux cluster (or an aux outage) must not 500 the whole
+        # endpoint and lose the stats already readable from the main cluster.
+        def fake_sync_execute(_query, params):
+            if params["cluster"] == CLICKHOUSE_AUX_CLUSTER:
+                raise Exception("Requested cluster 'aux' not found")
+            return [(SHARDED_EXPERIMENT_EXPOSURES_TABLE(), "20260801", 10, 100, 1)]
+
+        with patch("posthog.api.debug_ch_queries.sync_execute", side_effect=fake_sync_execute):
+            stats = {entry["table"]: entry for entry in _cache_table_stats()}
+
+        exposures = stats["experiment_exposures_preaggregated"]
+        metric_events = stats["experiment_metric_events_preaggregated"]
+        self.assertEqual(exposures["total_rows"], 10)
+        self.assertNotIn("unavailable", exposures)
+        self.assertTrue(metric_events["unavailable"])
+        self.assertEqual(metric_events["total_rows"], 0)

--- a/posthog/api/test/test_debug_ch_queries.py
+++ b/posthog/api/test/test_debug_ch_queries.py
@@ -1,10 +1,16 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.test import SimpleTestCase
+
 from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
 
+from posthog.api.debug_ch_queries import _cache_table_stats
+from posthog.clickhouse.preaggregation.experiment_exposures_sql import SHARDED_EXPERIMENT_EXPOSURES_TABLE
+from posthog.clickhouse.preaggregation.experiment_metric_events_sql import SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
+from posthog.settings.data_stores import CLICKHOUSE_AUX_CLUSTER, CLICKHOUSE_CLUSTER
 
 
 class TestDebugCHQuery(APIBaseTest):
@@ -92,3 +98,29 @@ class TestDebugCHQuery(APIBaseTest):
             headers={"authorization": f"Bearer {token}"},
         )
         self.assertEqual(resp.status_code, HTTP_200_OK, resp.content)
+
+
+class TestCacheTableStats(SimpleTestCase):
+    def test_reads_each_table_from_its_own_cluster(self):
+        # The metric-events sharded table lives on the aux cluster; reading system.parts only on
+        # the main cluster silently reported it as empty in prod. This fails if the per-cluster
+        # dispatch is reverted to a single main-cluster query.
+        def fake_sync_execute(_query, params):
+            parts_by_cluster = {
+                CLICKHOUSE_CLUSTER: [(SHARDED_EXPERIMENT_EXPOSURES_TABLE(), "20260801", 10, 100, 1)],
+                CLICKHOUSE_AUX_CLUSTER: [(SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE(), "20260802", 20, 200, 2)],
+            }
+            return [row for row in parts_by_cluster[params["cluster"]] if row[0] in params["tables"]]
+
+        with patch("posthog.api.debug_ch_queries.sync_execute", side_effect=fake_sync_execute):
+            stats = {entry["table"]: entry for entry in _cache_table_stats()}
+
+        exposures = stats["experiment_exposures_preaggregated"]
+        metric_events = stats["experiment_metric_events_preaggregated"]
+        self.assertEqual(exposures["total_rows"], 10)
+        self.assertEqual(exposures["newest_partition"], "20260801")
+        self.assertEqual(metric_events["total_rows"], 20)
+        self.assertEqual(metric_events["active_parts"], 2)
+        self.assertEqual(
+            metric_events["partitions"], [{"partition": "20260802", "rows": 20, "bytes_on_disk": 200, "parts": 2}]
+        )


### PR DESCRIPTION
## Problem

The `cache_health` endpoint on `/instance/query_performance` reports `experiment_metric_events_preaggregated` as empty (0 rows, 0 parts) in both prod regions, despite ~10k successful metric-events builds per week.
`_cache_table_stats()` reads `system.parts` via `cluster(CLICKHOUSE_CLUSTER, ...)` for both preaggregation tables, but the metric-events sharded table lives on the aux cluster (its Distributed engine targets `CLICKHOUSE_AUX_CLUSTER`), so its parts are never visible from the main cluster.

## Changes

`_cache_table_stats()` now maps each sharded table to the cluster its Distributed table targets (exposures → main, metric_events → aux) and runs the `system.parts` aggregation once per distinct cluster, merging the results.

If a cluster is unreachable (or absent in a single-cluster deployment), its tables are marked `unavailable: true` and the other cluster's stats are still returned; the scene renders those cards as "Unavailable" instead of zeros.

## How did you test this code?

`hogli test posthog/api/test/test_debug_ch_queries.py` (7 passed).
Added two unit tests with a fake `sync_execute`: one returns metric-events parts only for the aux cluster (fails under the previous single-cluster query, which silently reported the table as empty in prod), one raises for the aux cluster (guards the endpoint 500ing and losing main-cluster stats when aux is unreachable). mypy clean on both changed backend files; oxlint/oxfmt clean and no tsgo errors in the touched frontend files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Staff-only debug endpoint, no user-facing docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code while running the `analyzing-experiment-query-performance` skill against prod: both regions returned zero rows for the metric-events table while the same week's overview showed thousands of successful builds into it, and the build INSERT SQL confirmed writes target that table. Skills invoked: `analyzing-experiment-query-performance`, `improving-drf-endpoints`, `writing-tests`.

The per-cluster degradation (rather than letting one cluster's failure 500 the endpoint) was added in response to Greptile's P1 review comment.