### PR TITLE
chore(clickhouse): bump hclexp pin to sha-5eadb87

### DIFF
--- a/posthog/clickhouse/hcl/bin/hclexp
+++ b/posthog/clickhouse/hcl/bin/hclexp
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # Wrapper for the `hclexp` declarative ClickHouse schema tool (../python-clickhouse-schema).
 #
-# Resolution order:
-#   1. $HCLEXP_BIN            — explicit path to a local hclexp binary
-#   2. `hclexp` on $PATH
-#   3. the pinned container image (CI default)
+# Resolution order, most explicit first:
+#   1. $HCLEXP_BIN    — that binary (explicit: a local build, for fast iteration)
+#   2. $HCLEXP_IMAGE  — that image  (explicit: trying another pin)
+#   3. bin/image.txt  — the pin. The default, and what CI runs.
 #
-# CI uses the container image; locals can point HCLEXP_BIN at a built binary
-# (`go build -o hclexp ./cmd/hclexp` in the sibling repo) for faster iteration.
+# An `hclexp` on $PATH is deliberately NOT consulted. It used to win over both the
+# pin and an explicit $HCLEXP_IMAGE, which meant `HCLEXP_IMAGE=<new> bin/hclexp ...`
+# silently ran whatever stale binary happened to be installed. That is not a loud
+# failure — it is a wrong answer, and it cost real time: a released hclexp feature
+# looked missing because an ambient build shadowed the image being tested. Goldens
+# are canonicalization-sensitive, so "whatever is on PATH" is exactly what a pin
+# exists to prevent. Use $HCLEXP_BIN to say so on purpose.
 set -euo pipefail
 
 # Pinned to a concrete build (not :latest) for reproducibility, in bin/image.txt
@@ -17,10 +22,6 @@ HCLEXP_IMAGE="${HCLEXP_IMAGE:-$(cat "$HERE/image.txt")}"
 
 if [[ -n "${HCLEXP_BIN:-}" ]]; then
   exec "$HCLEXP_BIN" "$@"
-fi
-
-if command -v hclexp >/dev/null 2>&1; then
-  exec hclexp "$@"
 fi
 
 # Mount the repo (relative layer/golden paths resolve under -w /work) and the temp

--- a/posthog/clickhouse/hcl/bin/image.txt
+++ b/posthog/clickhouse/hcl/bin/image.txt
@@ -1,1 +1,1 @@
-ghcr.io/posthog/chschema:sha-de64883
+ghcr.io/posthog/chschema:sha-5eadb87

--- a/posthog/clickhouse/hcl/golden/local-multi/data.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/data.hcl
@@ -1715,7 +1715,7 @@ database "posthog" {
       type = "Bool"
     }
     index "is_deleted_idx" {
-      expr        = "(is_deleted)"
+      expr        = "is_deleted"
       type        = "minmax"
       granularity = 1
     }
@@ -3256,7 +3256,7 @@ database "posthog" {
     }
     column "version" {
       type         = "UInt64"
-      materialized = "(bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at)))"
+      materialized = "bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at))"
     }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/noshard/posthog.property_definitions"
@@ -5159,7 +5159,7 @@ database "posthog" {
       granularity = 1
     }
     index "is_deleted_idx" {
-      expr        = "(is_deleted)"
+      expr        = "is_deleted"
       type        = "minmax"
       granularity = 1
     }
@@ -5194,7 +5194,7 @@ database "posthog" {
       granularity = 1
     }
     index "minmax_historical_migration" {
-      expr        = "(historical_migration)"
+      expr        = "historical_migration"
       type        = "minmax"
       granularity = 1
     }
@@ -11317,8 +11317,8 @@ SQL
   view "persons_batch_export" {
     query = <<SQL
 WITH
-  new_persons AS (SELECT id, max(version) AS version, argMax(_timestamp, person.version) AS _timestamp2 FROM posthog.person WHERE (team_id = {team_id: Int64}) AND (id IN (SELECT id FROM posthog.person WHERE (team_id = {team_id: Int64}) AND (_timestamp >= {interval_start: DateTime64}) AND (_timestamp < {interval_end: DateTime64}))) GROUP BY id HAVING ((_timestamp2 >= {interval_start: DateTime64}) AND (_timestamp2 < {interval_end: DateTime64}))),
-  new_distinct_ids AS (SELECT argMax(person_id, person_distinct_id2.version) AS person_id FROM posthog.person_distinct_id2 WHERE (team_id = {team_id: Int64}) AND (distinct_id IN (SELECT distinct_id FROM posthog.person_distinct_id2 WHERE (team_id = {team_id: Int64}) AND (_timestamp >= {interval_start: DateTime64}) AND (_timestamp < {interval_end: DateTime64}))) GROUP BY distinct_id HAVING ((argMax(_timestamp, person_distinct_id2.version) >= {interval_start: DateTime64}) AND (argMax(_timestamp, person_distinct_id2.version) < {interval_end: DateTime64}))),
+  new_persons AS (SELECT id, max(version) AS version, argMax(_timestamp, person.version) AS _timestamp2 FROM posthog.person WHERE (team_id = {team_id: Int64}) AND (id IN (SELECT id FROM posthog.person WHERE (team_id = {team_id: Int64}) AND (_timestamp >= {interval_start: DateTime64}) AND (_timestamp < {interval_end: DateTime64}))) GROUP BY id HAVING (_timestamp2 >= {interval_start: DateTime64}) AND (_timestamp2 < {interval_end: DateTime64})),
+  new_distinct_ids AS (SELECT argMax(person_id, person_distinct_id2.version) AS person_id FROM posthog.person_distinct_id2 WHERE (team_id = {team_id: Int64}) AND (distinct_id IN (SELECT distinct_id FROM posthog.person_distinct_id2 WHERE (team_id = {team_id: Int64}) AND (_timestamp >= {interval_start: DateTime64}) AND (_timestamp < {interval_end: DateTime64}))) GROUP BY distinct_id HAVING (argMax(_timestamp, person_distinct_id2.version) >= {interval_start: DateTime64}) AND (argMax(_timestamp, person_distinct_id2.version) < {interval_end: DateTime64})),
   all_new_persons AS (SELECT id, version FROM new_persons UNION ALL SELECT id, max(version) FROM posthog.person WHERE (team_id = {team_id: Int64}) AND (id IN (new_distinct_ids)) GROUP BY id)
 SELECT
   p.team_id AS team_id,


### PR DESCRIPTION
Picks up [chschema#150](https://github.com/PostHog/chschema/pull/150): `load -exclude / -exclude-objects / -only`.

## Why

`load` was the only schema-reading command without `-exclude` — `introspect`, `diff`, `drift` and `plan` all have it:

| introspect | diff | drift | plan | **load (before)** |
|---|---|---|---|---|
| yes | yes | yes | yes | **no** |

So *"emit this layer minus these objects"* had no safe expression, and layer surgery fell back to hand-parsing HCL. Not academic: an ad-hoc parser in posthog-cloud-infra silently dropped three `raw "dictionary" "..."` blocks, because it matched `table|view|materialized_view|dictionary` and rebuilt the file from what it recognised. Filed as [chschema#149](https://github.com/PostHog/chschema/issues/149), fixed in #150.

## The bump is canonicalization-neutral

One golden moves — `golden/local-multi/data.hcl`, 6 lines stripping redundant parens:

```
-      expr        = "(is_deleted)"
+      expr        = "is_deleted"
-      materialized = "(bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + ...)"
+      materialized = "bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + ..."
```

**That is not this bump.** Regenerating under the OLD pin (`de64883`) produces the identical 6-line diff, so it is pre-existing formatting drift in the committed file. It survived because `check.sh` compares semantically via `hclexp diff`, and `"(is_deleted)"` and `"is_deleted"` are the same expression. Regenerated here so the tree is byte-consistent with its own pin again.

## Also: stop PATH beating the pin

`bin/hclexp` resolved `hclexp` on `$PATH` ahead of the pinned image — and ahead of an explicit `$HCLEXP_IMAGE`, so `HCLEXP_IMAGE=<new> bin/hclexp ...` silently ran whatever stale binary happened to be installed.

That cost real time while preparing this PR, twice: #150’s flags first looked *missing*, and this bump first looked like a *canonicalization change* — both were an ambient `~/go/bin/hclexp` shadowing the image under test. It is a wrong answer, not a loud failure, and goldens are canonicalization-sensitive, so "whatever is on PATH" is precisely what a pin exists to prevent.

New order: `$HCLEXP_BIN` → `$HCLEXP_IMAGE` → `bin/image.txt`. `$HCLEXP_BIN` is still how you ask for a local build on purpose.

## Verification

- `gen-golden.sh && gen-sql.sh && check.sh` green under `sha-5eadb87`.
- The 6-line golden diff reproduced byte-for-byte under `de64883`, proving pin-independence.
- `hclexp -layer roles/ops/shared -only events_team_daily_stats` → 1 object; `-exclude-objects` drops it. Flags confirmed live.