### PR TITLE
refactor(data-warehouse): migrate justcall, k6_cloud, koyeb, lago, launchdarkly, lemlist (batch 24)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/justcall/justcall.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/justcall/justcall.py
@@ -1,39 +1,54 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.justcall.settings import (
-    JUSTCALL_ENDPOINTS,
-    JustCallEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import IncrementalConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.justcall.settings import JUSTCALL_ENDPOINTS
 
 JUSTCALL_BASE_URL = "https://api.justcall.io/v2.1"
 # JustCall caps list pages at 100 items across the v2.1 list endpoints.
 PAGE_SIZE = 100
 # v2.1 list endpoints are 0-indexed ("page 0 indicates first page").
 FIRST_PAGE = 0
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-
-
-class JustCallRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class JustCallResumeConfig:
     # Next 0-indexed page to fetch. The cursor filter (`from_datetime`) is recomputed from the
     # unchanged job inputs on resume, so only the page position needs persisting.
-    page: int
+    page: int = FIRST_PAGE
+
+
+class JustCallPageNumberPaginator(PageNumberPaginator):
+    """0-indexed page pagination over JustCall's ``{"data": [...]}`` list envelopes.
+
+    JustCall's list endpoints report no total count, so — like the hand-rolled loop this replaces —
+    a page shorter than the requested size (or an empty page) is the last page. Stopping on a short
+    page avoids the extra empty-page request the plain ``PageNumberPaginator`` would pay, and keeps
+    the request count identical to the original loop.
+    """
+
+    def __init__(self, page_size: int) -> None:
+        super().__init__(base_page=FIRST_PAGE, page_param="page")
+        self._page_size = page_size
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and data is not None and len(data) < self._page_size:
+            self._has_next_page = False
 
 
 def _get_headers(api_key: str, api_secret: str) -> dict[str, str]:
@@ -43,17 +58,6 @@ def _get_headers(api_key: str, api_secret: str) -> dict[str, str]:
         "Authorization": f"{api_key}:{api_secret}",
         "Accept": "application/json",
     }
-
-
-def _make_session(api_key: str, api_secret: str) -> requests.Session:
-    # Register the raw credential values (and the combined Authorization header value) for
-    # value-based redaction, since the auth scheme puts the secret in a nonstandard raw header
-    # value that name-based scrubbers can't recognise. This keeps the credentials masked in
-    # request logs and captured HTTP samples on a failed sync.
-    return make_tracked_session(
-        headers=_get_headers(api_key, api_secret),
-        redact_values=(api_key, api_secret, f"{api_key}:{api_secret}"),
-    )
 
 
 def _format_cursor(value: Any) -> Optional[str]:
@@ -76,22 +80,98 @@ def _format_cursor(value: Any) -> Optional[str]:
     return text[:10]
 
 
-def _build_params(config: JustCallEndpointConfig, page: int, from_value: Optional[str]) -> dict[str, Any]:
-    params: dict[str, Any] = {"page": page, "per_page": PAGE_SIZE, "order": config.order}
+def justcall_source(
+    api_key: str,
+    api_secret: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[JustCallResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = JUSTCALL_ENDPOINTS[endpoint]
+
+    # `order` is set per endpoint; page/per_page/from_datetime are added by the paginator and the
+    # incremental config below. Ascending order keeps already-paged results stable under concurrent
+    # inserts and lets the incremental watermark advance monotonically.
+    params: dict[str, Any] = {"per_page": PAGE_SIZE, "order": config.order}
+
+    incremental: Optional[IncrementalConfig] = None
     if config.incremental_cursor:
         # `sort=datetime` orders by call/SMS time; combined with `order=asc` the watermark advances
-        # monotonically. `from_datetime` is only meaningful on the endpoints that support it.
+        # monotonically. `from_datetime` is only meaningful on the endpoints that support it, and
+        # only when a watermark is present (a None value is dropped from the query string).
         params["sort"] = "datetime"
-        if from_value is not None:
-            params["from_datetime"] = from_value
-    return params
+        incremental = {"start_param": "from_datetime", "convert": _format_cursor}
 
+    # Only endpoints with a server-side `from_datetime` filter honor the incremental cursor; the
+    # rest are full refresh regardless of what the pipeline passes.
+    last_value = (
+        db_incremental_field_last_value if (should_use_incremental_field and config.incremental_cursor) else None
+    )
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    clean_params = {key: value for key, value in params.items() if value is not None}
-    if not clean_params:
-        return f"{JUSTCALL_BASE_URL}{path}"
-    return f"{JUSTCALL_BASE_URL}{path}?{urlencode(clean_params)}"
+    endpoint_config: dict[str, Any] = {
+        "name": endpoint,
+        "endpoint": {
+            "path": config.path,
+            "params": params,
+            "data_selector": "data",
+        },
+    }
+    if incremental is not None:
+        endpoint_config["endpoint"]["incremental"] = incremental
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": JUSTCALL_BASE_URL,
+            # Only the non-secret Accept header goes here; the credential rides on the framework
+            # auth config so it's redacted from any raised error message and captured HTTP sample.
+            "headers": {"Accept": "application/json"},
+            "auth": {
+                "type": "api_key",
+                "api_key": f"{api_key}:{api_secret}",
+                "name": "Authorization",
+                "location": "header",
+            },
+            "paginator": JustCallPageNumberPaginator(page_size=PAGE_SIZE),
+        },
+        "resources": [endpoint_config],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # from the saved page rather than skipping it — the primary-key merge dedupes the overlap.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(JustCallResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=[config.primary_key],
+        sort_mode="asc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.incremental_cursor else None,
+        partition_format="week" if config.incremental_cursor else None,
+        partition_keys=[config.incremental_cursor] if config.incremental_cursor else None,
+        column_hints=resource.column_hints,
+    )
 
 
 def validate_credentials(api_key: str, api_secret: str) -> bool:
@@ -100,115 +180,9 @@ def validate_credentials(api_key: str, api_secret: str) -> bool:
     `/phone-numbers` is a tiny account-level list available to any valid JustCall key, so it makes a
     good token check without pulling call/message history.
     """
-    try:
-        response = _make_session(api_key, api_secret).get(
-            _build_url("/phone-numbers", {"page": FIRST_PAGE, "per_page": 1}),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    api_secret: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[JustCallResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = JUSTCALL_ENDPOINTS[endpoint]
-    session = _make_session(api_key, api_secret)
-
-    # Only endpoints with a server-side `from_datetime` filter honor the incremental cursor; the
-    # rest are full refresh regardless of what the pipeline passes.
-    from_value = (
-        _format_cursor(db_incremental_field_last_value)
-        if should_use_incremental_field and config.incremental_cursor
-        else None
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key, api_secret, f"{api_key}:{api_secret}")),
+        f"{JUSTCALL_BASE_URL}/phone-numbers?page={FIRST_PAGE}&per_page=1",
+        headers=_get_headers(api_key, api_secret),
     )
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume_config.page if resume_config is not None else FIRST_PAGE
-    if resume_config is not None:
-        logger.debug(f"JustCall: resuming {endpoint} from page {page}")
-
-    @retry(
-        retry=retry_if_exception_type((JustCallRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # JustCall rate-limits per API key on both a minutely burst window and an hourly window,
-        # returning 429 on breach. Exponential backoff with jitter is sufficient here.
-        if response.status_code == 429 or response.status_code >= 500:
-            raise JustCallRetryableError(
-                f"JustCall API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            # Deliberately not logging the response body: these endpoints return calls, texts, and
-            # contacts, so a raw error payload could copy customer PII (or echoed credentials) into
-            # logs. Status and endpoint are enough to debug an auth/permission failure.
-            logger.error(f"JustCall API error: status={response.status_code}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    # Page forward, rebuilding the query each time so `from_datetime`/`sort`/`order` stay attached to
-    # every request. This deliberately does not follow the response's `next_page_link`: we can't
-    # verify that link preserves the time filter on later pages, and dropping it would re-walk each
-    # endpoint's full history every incremental sync. A short page (< PAGE_SIZE) marks the end.
-    while True:
-        url = _build_url(config.path, _build_params(config, page, from_value))
-        data = fetch_page(url)
-        items = data.get("data", []) or []
-
-        if items:
-            yield items
-            # Save the page we just yielded (not the next one) AFTER yielding it, so a crash
-            # re-fetches and re-yields this page rather than skipping it — the primary-key merge
-            # dedupes the overlap.
-            resumable_source_manager.save_state(JustCallResumeConfig(page=page))
-
-        if len(items) < PAGE_SIZE:
-            break
-
-        page += 1
-
-
-def justcall_source(
-    api_key: str,
-    api_secret: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[JustCallResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Optional[Any] = None,
-) -> SourceResponse:
-    config = JUSTCALL_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            api_secret=api_secret,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
-        primary_keys=[config.primary_key],
-        sort_mode="asc",
-        partition_count=1,
-        partition_size=1,
-        partition_mode="datetime" if config.incremental_cursor else None,
-        partition_format="week" if config.incremental_cursor else None,
-        partition_keys=[config.incremental_cursor] if config.incremental_cursor else None,
-    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/justcall/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/justcall/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import JustCallSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.justcall.justcall import (
     JustCallResumeConfig,
@@ -97,23 +100,7 @@ Generate an API key and secret under **Account Settings → Developers (APIs and
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = []
-        for endpoint in ENDPOINTS:
-            incremental_fields = INCREMENTAL_FIELDS.get(endpoint, [])
-            schemas.append(
-                SourceSchema(
-                    name=endpoint,
-                    supports_incremental=bool(incremental_fields),
-                    supports_append=bool(incremental_fields),
-                    incremental_fields=incremental_fields,
-                )
-            )
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: JustCallSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -136,7 +123,8 @@ Generate an API key and secret under **Account Settings → Developers (APIs and
             api_key=config.api_key,
             api_secret=config.api_secret,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/justcall/tests/test_justcall.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/justcall/tests/test_justcall.py
@@ -1,15 +1,15 @@
+import json
 from datetime import date, datetime
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.justcall.justcall import (
     JustCallResumeConfig,
-    _build_params,
-    _build_url,
     _format_cursor,
-    get_rows,
     justcall_source,
     validate_credentials,
 )
@@ -18,7 +18,17 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.justcall.s
     JUSTCALL_ENDPOINTS,
 )
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.justcall.justcall"
+# validate_credentials builds its own tracked session in the justcall module.
+JUSTCALL_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.justcall.justcall"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+
+
+def _response(items: list[dict[str, Any]]) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps({"data": items, "next_page_link": None}).encode()
+    return resp
 
 
 def _make_manager(resume_state: JustCallResumeConfig | None = None) -> mock.MagicMock:
@@ -28,17 +38,40 @@ def _make_manager(resume_state: JustCallResumeConfig | None = None) -> mock.Magi
     return manager
 
 
-def _page(items: list[dict[str, Any]]) -> dict[str, Any]:
-    return {"data": items, "next_page_link": None}
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-def _responses(pages: list[dict[str, Any]]) -> list[mock.MagicMock]:
-    out = []
-    for page in pages:
-        resp = mock.MagicMock(status_code=200, ok=True)
-        resp.json.return_value = page
-        out.append(resp)
-    return out
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(
+    session: mock.MagicMock,
+    responses: list[Response],
+    endpoint: str,
+    manager: mock.MagicMock,
+    **kwargs: Any,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    params = _wire(session, responses)
+    rows = _rows(
+        justcall_source("key", "secret", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
+    )
+    return rows, params
 
 
 class TestFormatCursor:
@@ -59,142 +92,127 @@ class TestFormatCursor:
         assert _format_cursor(value) == expected
 
 
-class TestBuildParams:
-    def test_incremental_endpoint_sorts_by_datetime_ascending(self):
-        params = _build_params(JUSTCALL_ENDPOINTS["calls"], page=0, from_value=None)
-        assert params["sort"] == "datetime"
-        assert params["order"] == "asc"
-        assert params["per_page"] == 100
-        assert params["page"] == 0
-        assert "from_datetime" not in params
+class TestRequestParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_endpoint_sorts_by_datetime_ascending(self, MockSession):
+        session = MockSession.return_value
+        _, params = _run(session, [_response([{"id": 1}])], "calls", _make_manager())
 
-    def test_incremental_endpoint_includes_from_datetime_when_set(self):
-        params = _build_params(JUSTCALL_ENDPOINTS["calls"], page=2, from_value="2021-08-25")
-        assert params["from_datetime"] == "2021-08-25"
-        assert params["page"] == 2
+        assert params[0]["sort"] == "datetime"
+        assert params[0]["order"] == "asc"
+        assert params[0]["per_page"] == 100
+        assert params[0]["page"] == 0
+        # No watermark passed → no server-side time filter on the request.
+        assert "from_datetime" not in params[0]
 
-    def test_full_refresh_endpoint_has_no_sort_or_filter(self):
-        params = _build_params(JUSTCALL_ENDPOINTS["users"], page=0, from_value="2021-08-25")
-        assert "sort" not in params
-        # A full-refresh endpoint never carries a time filter, even if a value is passed in.
-        assert "from_datetime" not in params
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_endpoint_has_no_sort_or_filter(self, MockSession):
+        # `users` has no server-side time filter, so an incremental value must not leak into the request.
+        session = MockSession.return_value
+        _, params = _run(
+            session,
+            [_response([{"id": 1}])],
+            "users",
+            _make_manager(),
+            should_use_incremental_field=True,
+            db_incremental_field_last_value="2021-08-25",
+        )
 
-    def test_phone_numbers_uses_uppercase_order(self):
-        params = _build_params(JUSTCALL_ENDPOINTS["phone_numbers"], page=0, from_value=None)
-        assert params["order"] == "ASC"
+        assert "sort" not in params[0]
+        assert "from_datetime" not in params[0]
+        assert params[0]["order"] == "asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_phone_numbers_uses_uppercase_order(self, MockSession):
+        session = MockSession.return_value
+        _, params = _run(session, [_response([{"id": 1}])], "phone_numbers", _make_manager())
+
+        assert params[0]["order"] == "ASC"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_carries_from_datetime(self, MockSession):
+        session = MockSession.return_value
+        _, params = _run(
+            session,
+            [_response([{"id": 1, "call_user_date": "2021-08-25"}])],
+            "calls",
+            _make_manager(),
+            should_use_incremental_field=True,
+            db_incremental_field_last_value="2021-08-25",
+        )
+
+        assert params[0]["from_datetime"] == "2021-08-25"
+        assert params[0]["sort"] == "datetime"
 
 
-class TestBuildUrl:
-    def test_no_params(self):
-        assert _build_url("/calls", {}) == "https://api.justcall.io/v2.1/calls"
+class TestPagination:
+    @mock.patch(f"{JUSTCALL_MODULE}.PAGE_SIZE", 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession):
+        # A full page (== PAGE_SIZE) continues; a short page ends pagination with no extra request.
+        session = MockSession.return_value
+        rows, params = _run(
+            session,
+            [_response([{"id": 1}, {"id": 2}]), _response([{"id": 3}])],
+            "users",
+            _make_manager(),
+        )
 
-    def test_drops_none_and_encodes(self):
-        url = _build_url("/calls", {"page": 0, "per_page": 100, "from_datetime": None})
-        assert url == "https://api.justcall.io/v2.1/calls?page=0&per_page=100"
+        assert [r["id"] for r in rows] == [1, 2, 3]
+        assert session.send.call_count == 2
+        assert params[0]["page"] == 0
+        assert params[1]["page"] == 1
+
+    @mock.patch(f"{JUSTCALL_MODULE}.PAGE_SIZE", 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_then_short_page_checkpoints_next_page(self, MockSession):
+        # The first full page checkpoints the next page to fetch; the terminal short page does not.
+        session = MockSession.return_value
+        manager = _make_manager()
+        _run(session, [_response([{"id": 1}, {"id": 2}]), _response([{"id": 3}])], "users", manager)
+
+        manager.save_state.assert_called_once_with(JustCallResumeConfig(page=1))
+
+    @mock.patch(f"{JUSTCALL_MODULE}.PAGE_SIZE", 2)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_stops_without_saving(self, MockSession):
+        session = MockSession.return_value
+        manager = _make_manager()
+        rows, _ = _run(session, [_response([])], "calls", manager)
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession):
+        session = MockSession.return_value
+        _, params = _run(session, [_response([{"id": 9}])], "calls", _make_manager(JustCallResumeConfig(page=5)))
+
+        assert params[0]["page"] == 5
 
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
-    @mock.patch(f"{MODULE}.make_tracked_session")
+    @mock.patch(f"{JUSTCALL_MODULE}.make_tracked_session")
     def test_status_mapping(self, mock_session, status_code, expected):
         response = mock.MagicMock(status_code=status_code)
         mock_session.return_value.get.return_value = response
         assert validate_credentials("key", "secret") is expected
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
+    @mock.patch(f"{JUSTCALL_MODULE}.make_tracked_session")
     def test_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("key", "secret") is False
-
-
-class TestGetRows:
-    @mock.patch(f"{MODULE}.PAGE_SIZE", 2)
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_paginates_until_short_page(self, mock_session):
-        # Full page (== PAGE_SIZE) continues; a short page ends pagination.
-        mock_session.return_value.get.side_effect = _responses([_page([{"id": 1}, {"id": 2}]), _page([{"id": 3}])])
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "secret", "users", mock.MagicMock(), manager))
-
-        assert [item["id"] for batch in batches for item in batch] == [1, 2, 3]
-        assert mock_session.return_value.get.call_count == 2
-        # Each yielded page is checkpointed after it is yielded, by its own page number.
-        assert manager.save_state.call_args_list == [
-            mock.call(JustCallResumeConfig(page=0)),
-            mock.call(JustCallResumeConfig(page=1)),
-        ]
-
-    @mock.patch(f"{MODULE}.PAGE_SIZE", 2)
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_empty_first_page_stops_without_saving(self, mock_session):
-        mock_session.return_value.get.side_effect = _responses([_page([])])
-
-        manager = _make_manager()
-        batches = list(get_rows("key", "secret", "calls", mock.MagicMock(), manager))
-
-        assert batches == []
-        manager.save_state.assert_not_called()
-
-    @mock.patch(f"{MODULE}.PAGE_SIZE", 2)
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_resumes_from_saved_page(self, mock_session):
-        mock_session.return_value.get.side_effect = _responses([_page([{"id": 9}])])
-
-        manager = _make_manager(JustCallResumeConfig(page=5))
-        list(get_rows("key", "secret", "calls", mock.MagicMock(), manager))
-
-        requested_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "page=5" in requested_url
-
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_incremental_request_carries_from_datetime(self, mock_session):
-        mock_session.return_value.get.side_effect = _responses([_page([{"id": 1, "call_user_date": "2021-08-25"}])])
-
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                "secret",
-                "calls",
-                mock.MagicMock(),
-                manager,
-                should_use_incremental_field=True,
-                db_incremental_field_last_value="2021-08-25",
-            )
-        )
-
-        url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "from_datetime=2021-08-25" in url
-        assert "sort=datetime" in url
-
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_full_refresh_endpoint_ignores_incremental_value(self, mock_session):
-        # `users` has no server-side time filter, so an incremental value must not leak into the request.
-        mock_session.return_value.get.side_effect = _responses([_page([{"id": 1}])])
-
-        manager = _make_manager()
-        list(
-            get_rows(
-                "key",
-                "secret",
-                "users",
-                mock.MagicMock(),
-                manager,
-                should_use_incremental_field=True,
-                db_incremental_field_last_value="2021-08-25",
-            )
-        )
-
-        url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "from_datetime" not in url
 
 
 class TestJustCallSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = JUSTCALL_ENDPOINTS[endpoint]
-        response = justcall_source("key", "secret", endpoint, mock.MagicMock(), _make_manager())
+        response = justcall_source(
+            "key", "secret", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/k6_cloud.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/k6_cloud.py
@@ -1,20 +1,24 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode, urljoin, urlparse
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud.settings import (
-    K6_CLOUD_ENDPOINTS,
-    K6CloudEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BaseNextUrlPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import Endpoint
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud.settings import K6_CLOUD_ENDPOINTS
 
 # Grafana Cloud k6 pins the current REST API under a single global host + version path.
 K6_CLOUD_HOST = "api.k6.io"
@@ -23,10 +27,6 @@ K6_CLOUD_BASE_URL = f"https://{K6_CLOUD_HOST}/cloud/v6"
 # $top caps at 1000 rows per page (the documented maximum).
 PAGE_SIZE = 1000
 REQUEST_TIMEOUT_SECONDS = 60
-
-
-class K6CloudRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -54,134 +54,16 @@ def _format_rfc3339(value: Any) -> str:
     return str(value)
 
 
-def _build_initial_params(
-    config: K6CloudEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, str]:
-    params: dict[str, str] = {}
+def _created_after_value(value: Any) -> Optional[str]:
+    """Convert the incremental cursor into k6's `created_after` filter value.
 
-    if config.paginated:
-        params["$top"] = str(PAGE_SIZE)
-
-    if config.order_by:
-        params["$orderby"] = config.order_by
-
-    if config.time_filter_param and should_use_incremental_field and db_incremental_field_last_value is not None:
-        # `created_after` is inclusive, so the boundary row is re-fetched each sync and
-        # deduped on the `id` primary key by the merge.
-        params[config.time_filter_param] = _format_rfc3339(db_incremental_field_last_value)
-
-    return params
-
-
-@retry(
-    retry=retry_if_exception_type((K6CloudRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    params: Optional[dict[str, str]],
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise K6CloudRetryableError(f"k6 Cloud API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"k6 Cloud API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def validate_credentials(api_token: str, stack_id: str, schema_name: Optional[str] = None) -> tuple[bool, bool]:
-    """Probe Grafana Cloud k6 to confirm the token + stack id work.
-
-    Returns ``(is_valid, is_forbidden)``. ``is_forbidden`` distinguishes a 403
-    (token is genuine but lacks access) from a 401 (bad token) so the caller can
-    accept access gaps at source-create time but reject them for a specific schema.
+    Returns ``None`` when there is no watermark so the client drops the param entirely — a
+    full-refresh sync (or the first incremental run before a watermark exists) must send no
+    time filter, exactly as the hand-rolled source did.
     """
-    config = K6_CLOUD_ENDPOINTS.get(schema_name) if schema_name else None
-
-    if config is not None:
-        # For a specific schema, probe that endpoint so the check reflects real access.
-        params = {"$top": "1"} if config.paginated else {}
-        url = f"{K6_CLOUD_BASE_URL}{config.path}"
-        if params:
-            url = f"{url}?{urlencode(params)}"
-    else:
-        # `/auth` validates the token and stack access without touching any resource.
-        url = f"{K6_CLOUD_BASE_URL}/auth"
-
-    try:
-        with make_tracked_session() as session:
-            response = session.get(url, headers=_get_headers(api_token, stack_id), timeout=REQUEST_TIMEOUT_SECONDS)
-    except Exception:
-        return False, False
-
-    if response.status_code == 403:
-        return False, True
-
-    return response.status_code == 200, False
-
-
-def get_rows(
-    api_token: str,
-    stack_id: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[K6CloudResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = K6_CLOUD_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token, stack_id)
-
-    initial_params = _build_initial_params(config, should_use_incremental_field, db_incremental_field_last_value)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    # The `@nextLink` is an absolute URL that already carries the filter + `$skip` offset,
-    # so on resume (and on every page after the first) we fetch it with no extra params.
-    if resume_config is not None and resume_config.next_url:
-        # Resume state comes back from Redis, so re-pin it to the k6 origin before we send the token.
-        url: str = _require_k6_origin(resume_config.next_url)
-        params: Optional[dict[str, str]] = None
-        logger.debug(f"k6 Cloud: resuming {endpoint} from saved next link")
-    else:
-        url = f"{K6_CLOUD_BASE_URL}{config.path}"
-        params = initial_params
-
-    # One session reused across every page so urllib3 keeps the connection alive; the `with`
-    # closes it promptly even if the consumer abandons the generator early.
-    with make_tracked_session() as session:
-        while True:
-            data = _fetch_page(session, url, params, headers, logger)
-
-            # Fail fast if the payload is missing `value` — an empty table is a bug, not a valid sync.
-            items = data["value"]
-            next_url = data.get("@nextLink")
-
-            if items:
-                yield items
-                # Save state only after yielding, so a crash re-yields the last page rather
-                # than skipping it (merge dedupes on the primary key). Only persist when more
-                # pages remain — there's nothing to resume into on the final page.
-                if config.paginated and next_url:
-                    resumable_source_manager.save_state(K6CloudResumeConfig(next_url=_absolute_url(url, next_url)))
-
-            if not config.paginated or not next_url:
-                break
-
-            # Advance to the next page before the next fetch, otherwise we loop on this page.
-            url = _absolute_url(url, next_url)
-            params = None
+    if value is None:
+        return None
+    return _format_rfc3339(value)
 
 
 def _require_k6_origin(url: str) -> str:
@@ -209,28 +91,104 @@ def _absolute_url(current_url: str, next_link: str) -> str:
     return _require_k6_origin(resolved)
 
 
+class K6NextLinkPaginator(BaseNextUrlPaginator):
+    """Follow k6's `@nextLink` body field, pinned to the k6 https origin.
+
+    Mirrors the hand-rolled source's SSRF guard: any relative link is resolved against the page
+    just fetched, and every next/resume URL must be https on the k6 host before the credential-
+    bearing request is sent, so a tampered `@nextLink` (or poisoned Redis resume state) can't
+    redirect the bearer token off-origin.
+    """
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        next_link = body.get("@nextLink") if isinstance(body, dict) else None
+        if next_link:
+            self._next_url = _absolute_url(response.url, next_link)
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_url = state.get("next_url")
+        if next_url:
+            self._next_url = _require_k6_origin(next_url)
+            self._has_next_page = True
+
+
 def k6_cloud_source(
     api_token: str,
     stack_id: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[K6CloudResumeConfig],
-    should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = K6_CLOUD_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {}
+    if config.paginated:
+        params["$top"] = str(PAGE_SIZE)
+    if config.order_by:
+        params["$orderby"] = config.order_by
+
+    endpoint_config: Endpoint = {
+        "path": config.path,
+        "params": params,
+        # A 200 body without `value` means the response shape changed — fail loud instead of
+        # silently syncing 0 rows (the hand-rolled source raised KeyError here).
+        "data_selector": "value",
+        "data_selector_required": True,
+        # load_zones returns every row in one page (no $skip/$top, no @nextLink).
+        "paginator": K6NextLinkPaginator() if config.paginated else SinglePagePaginator(),
+    }
+    if config.time_filter_param is not None:
+        endpoint_config["incremental"] = {
+            "start_param": config.time_filter_param,
+            "cursor_path": "created",
+            "convert": _created_after_value,
+        }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": K6_CLOUD_BASE_URL,
+            # Auth (Bearer) goes through the framework auth config so its value is redacted from
+            # errors/logs; only the non-secret stack id + accept headers are set here.
+            "headers": {"X-Stack-Id": stack_id, "Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_token},
+        },
+        "resources": [{"name": endpoint, "endpoint": endpoint_config}],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_url:
+            # Pinned by the paginator's set_resume_state before the token is sent.
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the `id` primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(K6CloudResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            stack_id=stack_id,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -238,3 +196,31 @@ def k6_cloud_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
     )
+
+
+def validate_credentials(api_token: str, stack_id: str, schema_name: Optional[str] = None) -> tuple[bool, bool]:
+    """Probe Grafana Cloud k6 to confirm the token + stack id work.
+
+    Returns ``(is_valid, is_forbidden)``. ``is_forbidden`` distinguishes a 403
+    (token is genuine but lacks access) from a 401 (bad token) so the caller can
+    accept access gaps at source-create time but reject them for a specific schema.
+    """
+    config = K6_CLOUD_ENDPOINTS.get(schema_name) if schema_name else None
+
+    if config is not None:
+        # For a specific schema, probe that endpoint so the check reflects real access.
+        params = {"$top": "1"} if config.paginated else {}
+        url = f"{K6_CLOUD_BASE_URL}{config.path}"
+        if params:
+            url = f"{url}?{urlencode(params)}"
+    else:
+        # `/auth` validates the token and stack access without touching any resource.
+        url = f"{K6_CLOUD_BASE_URL}/auth"
+
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        url,
+        headers=_get_headers(api_token, stack_id),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    return ok, status == 403

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import K6CloudSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud.k6_cloud import (
     K6CloudResumeConfig,
@@ -109,22 +112,14 @@ Create a Personal API token (or use a Grafana Stack API token) and find your sta
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = K6_CLOUD_ENDPOINTS[endpoint]
-            has_incremental = endpoint_config.time_filter_param is not None and bool(INCREMENTAL_FIELDS.get(endpoint))
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=has_incremental,
-                supports_append=has_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # Only test_runs carries incremental fields, so build_endpoint_schemas marks exactly it
+        # incremental/append (matching the endpoint's `created_after` server-side filter).
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            should_sync_default={name: cfg.should_sync_default for name, cfg in K6_CLOUD_ENDPOINTS.items()},
+        )
 
     def validate_credentials(
         self, config: K6CloudSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -156,9 +151,9 @@ Create a Personal API token (or use a Grafana Stack API token) and find your sta
             api_token=config.api_token,
             stack_id=config.stack_id,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/tests/test_k6_cloud.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/tests/test_k6_cloud.py
@@ -1,22 +1,95 @@
+import json
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import Any, Optional
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import HTTPError, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud import k6_cloud
 from products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud.k6_cloud import (
+    K6_CLOUD_BASE_URL,
     K6CloudResumeConfig,
     _absolute_url,
-    _build_initial_params,
     _format_rfc3339,
-    get_rows,
+    k6_cloud_source,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud.settings import K6_CLOUD_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the k6_cloud module.
+K6_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud.k6_cloud.make_tracked_session"
+)
+
+
+def _response(
+    url: str,
+    value: Optional[list[dict[str, Any]]] = None,
+    *,
+    next_link: Optional[str] = None,
+    drop_value: bool = False,
+    status: int = 200,
+) -> Response:
+    body: dict[str, Any] = {}
+    if not drop_value:
+        body["value"] = value or []
+    if next_link is not None:
+        body["@nextLink"] = next_link
+    resp = Response()
+    resp.status_code = status
+    resp.url = url
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: K6CloudResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Wire a mock session; return (param_snapshots, url_snapshots) captured AT SEND TIME.
+
+    ``request.params``/``request.url`` are mutated in place across pages, so snapshotting a copy
+    when each request is prepared is the only way to see per-page state.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, url_snapshots
+
+
+def _source(
+    endpoint: str,
+    manager: mock.MagicMock,
+    db_incremental_field_last_value: Any = None,
+) -> Any:
+    return k6_cloud_source(
+        api_token="tok",
+        stack_id="1",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatRfc3339:
@@ -33,45 +106,6 @@ class TestFormatRfc3339:
         result = _format_rfc3339(value)
         assert result == expected
         assert "+00:00" not in result
-
-
-class TestBuildInitialParams:
-    def test_test_runs_incremental_adds_created_after_and_no_orderby(self) -> None:
-        # The top-level test_runs endpoint rejects $orderby, so it must never be sent there.
-        params = _build_initial_params(
-            K6_CLOUD_ENDPOINTS["test_runs"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
-        )
-        assert params["created_after"] == "2026-03-04T02:58:14.000Z"
-        assert params["$top"] == "1000"
-        assert "$orderby" not in params
-
-    def test_test_runs_full_refresh_has_no_time_filter(self) -> None:
-        params = _build_initial_params(
-            K6_CLOUD_ENDPOINTS["test_runs"],
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=None,
-        )
-        assert "created_after" not in params
-
-    def test_projects_sends_orderby_but_no_time_filter(self) -> None:
-        # Projects has no server-side time filter, so passing a last value must not add one.
-        params = _build_initial_params(
-            K6_CLOUD_ENDPOINTS["projects"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
-        )
-        assert params["$orderby"] == "created"
-        assert "created_after" not in params
-
-    def test_load_zones_is_not_paginated(self) -> None:
-        params = _build_initial_params(
-            K6_CLOUD_ENDPOINTS["load_zones"],
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=None,
-        )
-        assert "$top" not in params
 
 
 class TestAbsoluteUrl:
@@ -107,135 +141,190 @@ class TestAbsoluteUrl:
             _absolute_url("https://api.k6.io/cloud/v6/test_runs", next_link)
 
 
-class _FakeResumableManager:
-    def __init__(self, state: K6CloudResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[K6CloudResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> K6CloudResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: K6CloudResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(manager: _FakeResumableManager, monkeypatch: Any, pages: dict[str, Any], endpoint: str) -> list[dict]:
-        def fake_fetch(session: Any, url: str, params: Any, headers: Any, logger: Any) -> dict:
-            return pages[url]
-
-        monkeypatch.setattr(k6_cloud, "_fetch_page", fake_fetch)
-
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_token="tok",
-            stack_id="1",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
-
-    def test_follows_next_link_pagination(self, monkeypatch: Any) -> None:
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_next_link_and_progresses(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        base = "https://api.k6.io/cloud/v6/test_runs"
         next_url = "https://api.k6.io/cloud/v6/test_runs?$skip=1000&$top=1000"
-        pages = {
-            "https://api.k6.io/cloud/v6/test_runs": {
-                "value": [{"id": 1}, {"id": 2}],
-                "@nextLink": next_url,
-            },
-            next_url: {"value": [{"id": 3}], "@nextLink": None},
-        }
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, pages, "test_runs")
+        _params, urls = _wire(
+            session,
+            [
+                _response(base, [{"id": 1}, {"id": 2}], next_link=next_url),
+                _response(next_url, [{"id": 3}], next_link=None),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("test_runs", manager))
+
         assert rows == [{"id": 1}, {"id": 2}, {"id": 3}]
+        # Second request follows the @nextLink URL rather than re-hitting the base path.
+        assert urls[0] == base
+        assert urls[1] == next_url
 
-    def test_saves_state_after_each_page_except_last(self, monkeypatch: Any) -> None:
-        next_url = "https://api.k6.io/cloud/v6/test_runs?$skip=1000&$top=1000"
-        pages = {
-            "https://api.k6.io/cloud/v6/test_runs": {"value": [{"id": 1}], "@nextLink": next_url},
-            next_url: {"value": [{"id": 2}], "@nextLink": None},
-        }
-        manager = _FakeResumableManager()
-        self._collect(manager, monkeypatch, pages, "test_runs")
-        # State is saved once (after the first page); the final page has no next link to persist.
-        assert [s.next_url for s in manager.saved] == [next_url]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_top_param_present_for_paginated_endpoint(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response("https://api.k6.io/cloud/v6/test_runs", [{"id": 1}])])
 
-    def test_resumes_from_saved_next_link(self, monkeypatch: Any) -> None:
-        resume_url = "https://api.k6.io/cloud/v6/test_runs?$skip=2000&$top=1000"
-        pages = {resume_url: {"value": [{"id": 9}], "@nextLink": None}}
-        manager = _FakeResumableManager(K6CloudResumeConfig(next_url=resume_url))
-        rows = self._collect(manager, monkeypatch, pages, "test_runs")
-        assert rows == [{"id": 9}]
+        _rows(_source("test_runs", _make_manager()))
+        assert params[0]["$top"] == "1000"
 
-    def test_rejects_poisoned_resume_url(self, monkeypatch: Any) -> None:
-        # Resume state is loaded from Redis; a poisoned next link must not leak credentials off-origin.
-        manager = _FakeResumableManager(K6CloudResumeConfig(next_url="https://evil.example.com/steal"))
-        with pytest.raises(ValueError):
-            self._collect(manager, monkeypatch, {}, "test_runs")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_load_zones_has_no_top_param(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response("https://api.k6.io/cloud/v6/load_zones", [{"id": 1}])])
 
-    def test_missing_value_key_raises(self, monkeypatch: Any) -> None:
-        # A 200 whose body lacks `value` is an unexpected format — fail loud rather than empty the table.
-        pages = {"https://api.k6.io/cloud/v6/load_zones": {"@nextLink": None}}
-        manager = _FakeResumableManager()
-        with pytest.raises(KeyError):
-            self._collect(manager, monkeypatch, pages, "load_zones")
+        _rows(_source("load_zones", _make_manager()))
+        assert "$top" not in params[0]
 
-    def test_non_paginated_endpoint_reads_single_page(self, monkeypatch: Any) -> None:
-        # load_zones returns everything in one response with no @nextLink and never saves state.
-        pages = {
-            "https://api.k6.io/cloud/v6/load_zones": {"value": [{"id": 1}, {"id": 2}]},
-        }
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, pages, "load_zones")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_projects_sends_orderby(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response("https://api.k6.io/cloud/v6/projects", [{"id": 1}])])
+
+        _rows(_source("projects", _make_manager()))
+        assert params[0]["$orderby"] == "created"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_test_runs_never_sends_orderby(self, MockSession: mock.MagicMock) -> None:
+        # The top-level test_runs endpoint rejects $orderby, so it must never be sent there.
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response("https://api.k6.io/cloud/v6/test_runs", [{"id": 1}])])
+
+        _rows(_source("test_runs", _make_manager()))
+        assert "$orderby" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_endpoint_reads_single_page_and_ignores_next_link(self, MockSession: mock.MagicMock) -> None:
+        # load_zones returns everything in one response; even a stray @nextLink must not be followed.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [_response("https://api.k6.io/cloud/v6/load_zones", [{"id": 1}, {"id": 2}], next_link="ignored")],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("load_zones", manager))
+
         assert rows == [{"id": 1}, {"id": 2}]
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_value_key_raises_loudly(self, MockSession: mock.MagicMock) -> None:
+        # A 200 body without `value` is an unexpected shape — fail loud rather than empty the table.
+        session = MockSession.return_value
+        _wire(session, [_response("https://api.k6.io/cloud/v6/load_zones", drop_value=True)])
+
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source("load_zones", _make_manager()))
 
 
-class TestFetchPageRetries:
-    @parameterized.expand(
-        [
-            ("rate_limited", 429),
-            ("server_error", 503),
-        ]
-    )
-    def test_retryable_status_is_retried_then_succeeds(self, _name: str, status: int) -> None:
-        bad = MagicMock()
-        bad.status_code = status
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = {"value": []}
+class TestIncremental:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_created_after_added_when_last_value_present(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response("https://api.k6.io/cloud/v6/test_runs", [{"id": 1}])])
 
-        session = MagicMock()
-        session.get.side_effect = [bad, good]
+        _rows(
+            _source(
+                "test_runs",
+                _make_manager(),
+                db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            )
+        )
+        assert params[0]["created_after"] == "2026-03-04T02:58:14.000Z"
 
-        with patch.object(k6_cloud._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = k6_cloud._fetch_page(session, "https://api.k6.io/cloud/v6/test_runs", None, {}, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_time_filter_on_full_refresh(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response("https://api.k6.io/cloud/v6/test_runs", [{"id": 1}])])
 
-        assert result == {"value": []}
-        assert session.get.call_count == 2
+        _rows(_source("test_runs", _make_manager(), db_incremental_field_last_value=None))
+        assert "created_after" not in params[0]
 
-    def test_client_error_raises_immediately(self) -> None:
-        # A 401/403 is not retryable — raise_for_status must surface it on the first attempt.
-        error_response = requests.Response()
-        error_response.status_code = 401
-        bad = MagicMock()
-        bad.status_code = 401
-        bad.ok = False
-        bad.text = "unauthorized"
-        bad.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=error_response)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_projects_never_sends_time_filter(self, MockSession: mock.MagicMock) -> None:
+        # Projects has no server-side time filter, so a passed-in watermark must not add one.
+        session = MockSession.return_value
+        params, _urls = _wire(session, [_response("https://api.k6.io/cloud/v6/projects", [{"id": 1}])])
 
-        session = MagicMock()
-        session.get.return_value = bad
+        _rows(_source("projects", _make_manager(), db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC)))
+        assert "created_after" not in params[0]
 
-        with pytest.raises(requests.HTTPError):
-            k6_cloud._fetch_page(session, "https://api.k6.io/cloud/v6/test_runs", None, {}, MagicMock())
-        assert session.get.call_count == 1
+
+class TestResume:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_state_after_each_page_except_last(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        base = "https://api.k6.io/cloud/v6/test_runs"
+        next_url = "https://api.k6.io/cloud/v6/test_runs?$skip=1000&$top=1000"
+        _wire(
+            session,
+            [
+                _response(base, [{"id": 1}], next_link=next_url),
+                _response(next_url, [{"id": 2}], next_link=None),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("test_runs", manager))
+
+        # State is saved once (pointing at the next page); the final page has no link to persist.
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [K6CloudResumeConfig(next_url=next_url)]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_next_link(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        resume_url = "https://api.k6.io/cloud/v6/test_runs?$skip=2000&$top=1000"
+        _params, urls = _wire(session, [_response(resume_url, [{"id": 9}], next_link=None)])
+
+        manager = _make_manager(K6CloudResumeConfig(next_url=resume_url))
+        rows = _rows(_source("test_runs", manager))
+
+        assert rows == [{"id": 9}]
+        # The first (only) request goes straight to the saved next link, not the base path.
+        assert urls[0] == resume_url
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_poisoned_resume_url(self, MockSession: mock.MagicMock) -> None:
+        # Resume state is loaded from Redis; a poisoned next link must not leak credentials off-origin.
+        session = MockSession.return_value
+        _wire(session, [])
+
+        manager = _make_manager(K6CloudResumeConfig(next_url="https://evil.example.com/steal"))
+        with pytest.raises(ValueError):
+            _rows(_source("test_runs", manager))
+
+
+class TestRetries:
+    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(
+        self, _name: str, status: int, MockSession: mock.MagicMock, _sleep: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        url = "https://api.k6.io/cloud/v6/test_runs"
+        _wire(session, [_response(url, status=status), _response(url, [{"id": 1}], next_link=None)])
+
+        rows = _rows(_source("test_runs", _make_manager()))
+
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises_immediately(self, MockSession: mock.MagicMock) -> None:
+        # A 401 is not retryable — raise_for_status surfaces it on the first attempt.
+        session = MockSession.return_value
+        _wire(session, [_response("https://api.k6.io/cloud/v6/test_runs", status=401)])
+
+        with pytest.raises(HTTPError):
+            _rows(_source("test_runs", _make_manager()))
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
@@ -250,30 +339,21 @@ class TestValidateCredentials:
     def test_status_mapping(
         self, _name: str, status: int, schema_name: str | None, expected: tuple[bool, bool]
     ) -> None:
-        response = MagicMock()
+        response = mock.MagicMock()
         response.status_code = status
-        # `validate_credentials` opens the session as a context manager, so the `with` target
-        # must be the same mock we configure `.get` on.
-        session = MagicMock()
-        session.__enter__.return_value = session
-        session.get.return_value = response
-
-        with patch.object(k6_cloud, "make_tracked_session", return_value=session):
+        with mock.patch(K6_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = response
             assert validate_credentials("tok", "1", schema_name) == expected
 
     def test_network_error_is_invalid_not_forbidden(self) -> None:
-        session = MagicMock()
-        session.__enter__.return_value = session
-        session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(k6_cloud, "make_tracked_session", return_value=session):
+        with mock.patch(K6_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.side_effect = Exception("boom")
             assert validate_credentials("tok", "1") == (False, False)
 
     def test_schemaless_probe_hits_auth_endpoint(self) -> None:
-        response = MagicMock()
+        response = mock.MagicMock()
         response.status_code = 200
-        session = MagicMock()
-        session.__enter__.return_value = session
-        session.get.return_value = response
-        with patch.object(k6_cloud, "make_tracked_session", return_value=session):
+        with mock.patch(K6_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = response
             validate_credentials("tok", "1")
-        assert session.get.call_args[0][0].endswith("/cloud/v6/auth")
+        assert mock_session.return_value.get.call_args[0][0] == f"{K6_CLOUD_BASE_URL}/auth"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/tests/test_k6_cloud_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/k6_cloud/tests/test_k6_cloud_source.py
@@ -18,6 +18,8 @@ INCREMENTAL_ENDPOINTS = {"test_runs"}
 def _make_inputs(**overrides: Any) -> mock.MagicMock:
     inputs = mock.MagicMock()
     inputs.schema_name = overrides.get("schema_name", "test_runs")
+    inputs.team_id = overrides.get("team_id", 123)
+    inputs.job_id = overrides.get("job_id", "job-1")
     inputs.should_use_incremental_field = overrides.get("should_use_incremental_field", False)
     inputs.db_incremental_field_last_value = overrides.get("db_incremental_field_last_value", None)
     return inputs
@@ -126,6 +128,8 @@ class TestK6CloudSource:
     def test_source_for_pipeline_passes_arguments(self, mock_k6_cloud_source: mock.MagicMock) -> None:
         inputs = _make_inputs(
             schema_name="test_runs",
+            team_id=456,
+            job_id="job-9",
             should_use_incremental_field=True,
             db_incremental_field_last_value="2026-01-01T00:00:00Z",
         )
@@ -137,8 +141,9 @@ class TestK6CloudSource:
         assert kwargs["api_token"] == self.config.api_token
         assert kwargs["stack_id"] == self.config.stack_id
         assert kwargs["endpoint"] == "test_runs"
+        assert kwargs["team_id"] == 456
+        assert kwargs["job_id"] == "job-9"
         assert kwargs["resumable_source_manager"] is manager
-        assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2026-01-01T00:00:00Z"
 
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.k6_cloud.source.k6_cloud_source")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/koyeb/koyeb.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/koyeb/koyeb.py
@@ -1,20 +1,19 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.koyeb.settings import (
-    KOYEB_ENDPOINTS,
-    KoyebEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.koyeb.settings import KOYEB_ENDPOINTS
 
 KOYEB_BASE_URL = "https://app.koyeb.com"
 
@@ -23,16 +22,16 @@ PAGE_SIZE = 100
 
 # Backstop against an endpoint that ignores `offset` (which would otherwise re-serve page one
 # forever). Resumable state means an interrupted sync picks back up, so this is a runaway guard,
-# not a coverage limit — at 100 rows/page it allows ~1M rows before warning.
+# not a coverage limit — at 100 rows/page it allows ~1M rows before stopping.
 MAX_PAGES = 10_000
 
 # /v1/usages/details requires a time window; Koyeb launched in 2019, so this floor covers any
 # organization's full usage history.
 USAGE_WINDOW_START = "2019-01-01T00:00:00Z"
 
-
-class KoyebRetryableError(Exception):
-    pass
+# Placeholder written over plaintext secrets pulled out of deployment definitions, so the column
+# still shows a value existed without exposing it.
+REDACTED_SECRET = "[redacted by PostHog]"
 
 
 @dataclasses.dataclass
@@ -41,11 +40,6 @@ class KoyebResumeConfig:
     # endpoint supports `order`), so rows appended mid-sync land after the offset and can't shift
     # earlier pages underneath it.
     offset: int = 0
-
-
-# Placeholder written over plaintext secrets pulled out of deployment definitions, so the column
-# still shows a value existed without exposing it.
-REDACTED_SECRET = "[redacted by PostHog]"
 
 
 def _scrub_definition_secrets(row: dict[str, Any]) -> dict[str, Any]:
@@ -93,161 +87,126 @@ def _format_time_value(value: Any) -> str:
     return str(value)
 
 
-def _build_params(
-    config: KoyebEndpointConfig,
-    offset: int,
-    starting_time_value: Any,
-    ending_time_value: str | None = None,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE, "offset": offset}
-
-    if config.supports_order:
-        params["order"] = "asc"
-
-    if config.requires_time_window:
-        params["starting_time"] = USAGE_WINDOW_START
-        params["ending_time"] = ending_time_value or _format_time_value(datetime.now(UTC))
-    elif config.starting_time_param and starting_time_value is not None:
-        params[config.starting_time_param] = _format_time_value(starting_time_value)
-
-    return params
-
-
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    return f"{KOYEB_BASE_URL}{path}?{urlencode(params)}"
-
-
-@retry(
-    retry=retry_if_exception_type((KoyebRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, timeout=60)
-
-    # Koyeb publishes no rate limits; treat 429 and any 5xx as transient and let tenacity back
-    # off. A bad/revoked token (401/403) is raised below via raise_for_status() and matched by
-    # get_non_retryable_errors() so the sync stops.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise KoyebRetryableError(f"Koyeb API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Koyeb API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
 def validate_credentials(api_token: str) -> tuple[bool, str | None]:
     """Confirm the API token is genuine via GET /v1/account/profile — the cheapest authenticated
     probe. Koyeb tokens are organization-scoped with no per-resource permissions, so one probe
     covers every endpoint."""
-    try:
-        response = make_tracked_session().get(
-            f"{KOYEB_BASE_URL}/v1/account/profile", headers=_get_headers(api_token), timeout=10
-        )
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
-
-    if response.status_code == 200:
-        return True, None
-    if response.status_code in (401, 403):
-        return False, "Invalid or unauthorized Koyeb API token"
-    return False, f"Koyeb API error: {response.status_code}"
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[KoyebResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = KOYEB_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-    # One session reused across every page so urllib3 keeps the connection alive. Endpoints whose
-    # rows get secret-scrubbed also opt out of HTTP sample capture: capture stores the raw response
-    # body before _scrub_definition_secrets runs, and the capture path's name-based scrubbers can't
-    # recognise plaintext env values or config-file content.
-    session = make_tracked_session(capture=not config.scrub_definition_secrets)
-
-    cutoff = (
-        db_incremental_field_last_value
-        if (should_use_incremental_field and config.starting_time_param and db_incremental_field_last_value is not None)
-        else None
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{KOYEB_BASE_URL}/v1/account/profile",
+        headers=_get_headers(api_token),
     )
-    # Fixed once per run so the window (and therefore the row set behind the offsets) doesn't
-    # drift while paginating.
-    ending_time = _format_time_value(datetime.now(UTC)) if config.requires_time_window else None
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume else 0
-    if resume is not None:
-        logger.debug(f"Koyeb: resuming {endpoint} from offset={offset}")
-
-    page_count = 0
-    while True:
-        url = _build_url(config.path, _build_params(config, offset, cutoff, ending_time))
-        data = _fetch_page(session, url, headers, logger)
-
-        items = data.get(config.response_data_key) or []
-        if not items:
-            break
-
-        if config.scrub_definition_secrets:
-            for item in items:
-                if isinstance(item, dict):
-                    _scrub_definition_secrets(item)
-
-        # Some Koyeb replies carry `has_next`; the rest only echo pagination params, so a short
-        # page is the fallback end-of-list signal (an exact-multiple total costs one extra empty
-        # page, caught above).
-        has_next = data.get("has_next")
-        is_last_page = has_next is False or (has_next is None and len(items) < PAGE_SIZE)
-
-        yield items
-        offset += len(items)
-        page_count += 1
-
-        if is_last_page:
-            break
-        if page_count >= MAX_PAGES:
-            logger.warning(f"Koyeb: {endpoint} hit MAX_PAGES={MAX_PAGES}; remaining pages skipped")
-            break
-        # Checkpoint AFTER the page has been yielded so a crash re-fetches at most the in-flight
-        # page instead of skipping it.
-        resumable_source_manager.save_state(KoyebResumeConfig(offset=offset))
+    if ok:
+        return True, None
+    if status in (401, 403):
+        return False, "Invalid or unauthorized Koyeb API token"
+    if status is None:
+        return False, "Could not reach the Koyeb API"
+    return False, f"Koyeb API error: {status}"
 
 
 def koyeb_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[KoyebResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
-    endpoint_config = KOYEB_ENDPOINTS[endpoint]
+    config = KOYEB_ENDPOINTS[endpoint]
+
+    params: dict[str, Any] = {}
+    if config.supports_order:
+        # Always request ascending so offset pagination stays stable while new rows are appended.
+        params["order"] = "asc"
+    if config.requires_time_window:
+        # /v1/usages/details rejects requests without a window; fix `ending_time` once per run so the
+        # row set behind the offsets doesn't drift while paginating.
+        params["starting_time"] = USAGE_WINDOW_START
+        params["ending_time"] = _format_time_value(datetime.now(UTC))
+
+    endpoint_config: dict[str, Any] = {
+        "path": config.path,
+        "params": params,
+        # A missing data key yields an empty page and stops the paginator, matching the old
+        # `data.get(key) or []` (no raise on a shape change).
+        "data_selector": config.response_data_key,
+    }
+
+    # Only `instances` documents a server-side `starting_time` filter, and only inject it in
+    # incremental mode — full refresh omits it entirely, as before. Merge dedupes the overlap on `id`.
+    if (
+        should_use_incremental_field
+        and config.starting_time_param
+        and not config.requires_time_window
+        and db_incremental_field_last_value is not None
+    ):
+        endpoint_config["incremental"] = {
+            "start_param": config.starting_time_param,
+            "convert": _format_time_value,
+        }
+
+    client: dict[str, Any] = {
+        "base_url": KOYEB_BASE_URL,
+        # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs
+        # and raised errors; only the non-secret Accept header is set here.
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": api_token},
+        # Koyeb has no top-level `total`; termination is short/empty page. `maximum_offset` backstops
+        # an endpoint that ignores `offset` from re-serving page one forever.
+        "paginator": OffsetPaginator(
+            limit=PAGE_SIZE,
+            total_path=None,
+            maximum_offset=MAX_PAGES * PAGE_SIZE,
+        ),
+    }
+    if config.scrub_definition_secrets:
+        # HTTP sample capture stores the raw response body BEFORE the definition scrub runs, and the
+        # capture path's name-based scrubbers can't recognise plaintext env values or config-file
+        # content — so secret-scrubbed endpoints opt their session out of capture entirely.
+        client["session"] = make_tracked_session(capture=False, redact_values=(api_token,))
+
+    resource_config: dict[str, Any] = {"name": endpoint, "endpoint": endpoint_config}
+    if config.scrub_definition_secrets:
+        # Redact plaintext secrets embedded in deployment definitions before they are persisted.
+        resource_config["data_map"] = _scrub_definition_secrets
+
+    rest_config: RESTAPIConfig = {
+        "client": client,
+        "resources": [resource_config],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the in-flight page (merge dedupes) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(KoyebResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
-        primary_keys=endpoint_config.primary_keys,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
         # Endpoints with an `order` param are requested ascending; the rest are full refresh only,
         # where the watermark is never consulted.
         sort_mode="asc",
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="month" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/koyeb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/koyeb/source.py
@@ -128,7 +128,8 @@ Create an API token under [API settings](https://app.koyeb.com/user/settings/api
         return koyeb_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/koyeb/tests/test_koyeb.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/koyeb/tests/test_koyeb.py
@@ -1,66 +1,78 @@
+import json
 from datetime import UTC, date, datetime, timedelta, timezone
 from typing import Any
 
-from unittest.mock import MagicMock, patch
+from unittest import mock
+from unittest.mock import MagicMock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.koyeb import koyeb
 from products.warehouse_sources.backend.temporal.data_imports.sources.koyeb.koyeb import (
-    PAGE_SIZE,
     USAGE_WINDOW_START,
     KoyebResumeConfig,
-    _build_params,
     _format_time_value,
-    get_rows,
     koyeb_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.koyeb.settings import KOYEB_ENDPOINTS
 
-
-class _FakeResumableManager:
-    def __init__(self, state: KoyebResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[KoyebResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> KoyebResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: KoyebResumeConfig) -> None:
-        self.saved.append(data)
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# Secret-scrubbed endpoints (and validate_credentials) build their session in the koyeb module.
+KOYEB_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.koyeb.koyeb.make_tracked_session"
+)
 
 
-def _patch_fetch(monkeypatch: Any, responses: list[dict]) -> list[str]:
-    """Replace _fetch_page with a queue that returns canned pages in order, recording each URL."""
-    calls: list[str] = []
-    queue = list(responses)
-
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-        calls.append(url)
-        return queue.pop(0)
-
-    monkeypatch.setattr(koyeb, "_fetch_page", fake_fetch)
-    return calls
+def _response(data_key: str, items: list[dict[str, Any]] | None, *, has_next: bool | None = None) -> Response:
+    body: dict[str, Any] = {data_key: items if items is not None else []}
+    if has_next is not None:
+        body["has_next"] = has_next
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _collect(endpoint: str, manager: _FakeResumableManager, monkeypatch: Any, responses: list[dict], **kwargs: Any):
-    calls = _patch_fetch(monkeypatch, responses)
-    rows: list[dict] = []
-    for batch in get_rows(
+def _make_manager(resume_state: KoyebResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session, returning a list that snapshots each request's url/params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _run(endpoint: str, **kwargs: Any):
+    return koyeb_source(
         api_token="t",
         endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-        should_use_incremental_field=kwargs.get("should_use_incremental_field", False),
-        db_incremental_field_last_value=kwargs.get("db_incremental_field_last_value"),
-    ):
-        rows.extend(batch)
-    return rows, calls
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=kwargs.pop("manager", _make_manager()),
+        **kwargs,
+    )
 
 
 class TestFormatTimeValue:
@@ -82,164 +94,194 @@ class TestFormatTimeValue:
         assert _format_time_value(value) == expected
 
 
-class TestBuildParams:
+class TestValidateCredentials:
     @parameterized.expand(
         [
-            ("plain_endpoint", "apps", None, {"limit": PAGE_SIZE, "offset": 0}),
-            # Endpoints with an `order` param are always requested ascending so offset pagination
-            # stays stable while rows are appended mid-sync.
-            ("ordered_endpoint", "app_events", None, {"limit": PAGE_SIZE, "offset": 0, "order": "asc"}),
-            (
-                "incremental_instances",
-                "instances",
-                datetime(2024, 5, 1, tzinfo=UTC),
-                {"limit": PAGE_SIZE, "offset": 0, "order": "asc", "starting_time": "2024-05-01T00:00:00Z"},
-            ),
-            # apps has no server-side time filter, so a watermark must not become a query param.
-            (
-                "no_time_filter_drops_cutoff",
-                "apps",
-                datetime(2024, 5, 1, tzinfo=UTC),
-                {"limit": PAGE_SIZE, "offset": 0},
-            ),
+            ("ok", 200, True, None),
+            ("unauthorized", 401, False, "Invalid or unauthorized Koyeb API token"),
+            ("forbidden", 403, False, "Invalid or unauthorized Koyeb API token"),
+            ("server_error", 500, False, "Koyeb API error: 500"),
         ]
     )
-    def test_build_params(self, _name: str, endpoint: str, cutoff: Any, expected: dict[str, Any]) -> None:
-        assert _build_params(KOYEB_ENDPOINTS[endpoint], 0, cutoff) == expected
+    @mock.patch(KOYEB_SESSION_PATCH)
+    def test_status_mapping(
+        self, _name: str, status: int, expected_ok: bool, expected_error: str | None, mock_session
+    ) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        ok, error = validate_credentials("token")
+        assert ok is expected_ok
+        assert error == expected_error
 
-    def test_usage_details_always_sends_required_window(self) -> None:
-        # /v1/usages/details rejects requests without a time window, so both bounds must be present
-        # even on a full refresh.
-        params = _build_params(KOYEB_ENDPOINTS["usage_details"], 200, None, "2026-01-01T00:00:00Z")
-        assert params["starting_time"] == USAGE_WINDOW_START
-        assert params["ending_time"] == "2026-01-01T00:00:00Z"
-        assert params["offset"] == 200
-        assert params["order"] == "asc"
-
-
-class TestValidateCredentials:
-    @parameterized.expand([(200, True), (401, False), (403, False), (500, False)])
-    def test_status_mapping(self, status: int, expected_ok: bool) -> None:
-        response = requests.Response()
-        response.status_code = status
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(koyeb, "make_tracked_session", lambda *a, **k: session):
-            ok, error = validate_credentials("token")
-
-        assert ok is expected_ok, f"status={status}"
-        assert (error is None) is expected_ok, f"status={status}"
-
-    def test_request_exception_is_handled(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError("boom")
-        monkeypatch.setattr(koyeb, "make_tracked_session", lambda *a, **k: session)
-
+    @mock.patch(KOYEB_SESSION_PATCH)
+    def test_transport_error_is_invalid(self, mock_session) -> None:
+        # validate_via_probe swallows any transport failure and reports "not validated".
+        mock_session.return_value.get.side_effect = Exception("boom")
         ok, error = validate_credentials("token")
         assert ok is False
-        assert error == "boom"
+        assert error is not None
 
 
-class TestGetRows:
-    def test_follows_offset_pagination_with_has_next(self, monkeypatch: Any) -> None:
-        responses = [
-            {"apps": [{"id": str(i)} for i in range(PAGE_SIZE)], "has_next": True},
-            {"apps": [{"id": "last"}], "has_next": False},
-        ]
-        rows, calls = _collect("apps", _FakeResumableManager(), monkeypatch, responses)
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_offset_pagination_and_progresses(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": str(i)} for i in range(100)]
+        snaps = _wire(
+            session, [_response("apps", full_page, has_next=True), _response("apps", [{"id": "last"}], has_next=False)]
+        )
 
-        assert len(rows) == PAGE_SIZE + 1
-        assert "offset=0" in calls[0]
-        assert f"offset={PAGE_SIZE}" in calls[1]
-        assert len(calls) == 2
+        manager = _make_manager()
+        rows = _rows(_run("apps", manager=manager))
 
-    def test_short_page_without_has_next_terminates(self, monkeypatch: Any) -> None:
-        # Some replies (e.g. secrets) carry no has_next; a short page is the end-of-list signal.
-        responses = [{"secrets": [{"id": "s1"}, {"id": "s2"}]}]
-        rows, calls = _collect("secrets", _FakeResumableManager(), monkeypatch, responses)
+        assert len(rows) == 101
+        assert session.send.call_count == 2
+        assert snaps[0]["params"]["offset"] == 0
+        assert snaps[0]["params"]["limit"] == 100
+        assert snaps[1]["params"]["offset"] == 100
+        # Checkpoint saved after the first full page (points at the next page); short page ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == KoyebResumeConfig(offset=100)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_terminates_without_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response("secrets", [{"id": "s1"}, {"id": "s2"}])])
+
+        manager = _make_manager()
+        rows = _rows(_run("secrets", manager=manager))
 
         assert [r["id"] for r in rows] == ["s1", "s2"]
-        assert len(calls) == 1
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
 
-    def test_full_page_without_has_next_fetches_until_empty_page(self, monkeypatch: Any) -> None:
-        # An exact-multiple total with no has_next only stops on the following empty page.
-        responses: list[dict] = [
-            {"secrets": [{"id": str(i)} for i in range(PAGE_SIZE)]},
-            {"secrets": []},
-        ]
-        rows, calls = _collect("secrets", _FakeResumableManager(), monkeypatch, responses)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_page_without_has_next_fetches_until_empty_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": str(i)} for i in range(100)]
+        _wire(session, [_response("secrets", full_page), _response("secrets", [])])
 
-        assert len(rows) == PAGE_SIZE
-        assert len(calls) == 2
+        rows = _rows(_run("secrets"))
 
-    def test_saves_offset_after_each_completed_page(self, monkeypatch: Any) -> None:
-        responses = [
-            {"apps": [{"id": str(i)} for i in range(PAGE_SIZE)], "has_next": True},
-            {"apps": [{"id": str(i)} for i in range(PAGE_SIZE)], "has_next": True},
-            {"apps": [{"id": "last"}], "has_next": False},
-        ]
-        manager = _FakeResumableManager()
-        _collect("apps", manager, monkeypatch, responses)
+        assert len(rows) == 100
+        assert session.send.call_count == 2
 
-        # No checkpoint after the final page — the walk is complete, nothing left to resume into.
-        assert manager.saved == [KoyebResumeConfig(offset=PAGE_SIZE), KoyebResumeConfig(offset=PAGE_SIZE * 2)]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("apps", [{"id": "1"}], has_next=False)])
 
-    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
-        responses = [{"apps": [{"id": "1"}], "has_next": False}]
-        manager = _FakeResumableManager(KoyebResumeConfig(offset=300))
-        rows, calls = _collect("apps", manager, monkeypatch, responses)
+        rows = _rows(_run("apps", manager=_make_manager(KoyebResumeConfig(offset=300))))
 
         assert [r["id"] for r in rows] == ["1"]
-        assert "offset=300" in calls[0]
+        assert snaps[0]["params"]["offset"] == 300
 
-    def test_incremental_instances_sends_starting_time(self, monkeypatch: Any) -> None:
-        responses = [{"instances": [{"id": "i1"}], "has_next": False}]
-        _, calls = _collect(
-            "instances",
-            _FakeResumableManager(),
-            monkeypatch,
-            responses,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2024, 5, 1, tzinfo=UTC),
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_uses_response_data_key_and_path_per_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Event streams return rows under "events", not the endpoint name.
+        snaps = _wire(session, [_response("events", [{"id": "e1"}], has_next=False)])
+
+        rows = _rows(_run("deployment_events"))
+
+        assert [r["id"] for r in rows] == ["e1"]
+        assert snaps[0]["url"].endswith("/v1/deployment_events")
+
+
+class TestQueryParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_order_param_present_for_ordered_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("events", [{"id": "e1"}], has_next=False)])
+        _rows(_run("app_events"))
+        assert snaps[0]["params"]["order"] == "asc"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_order_param_for_plain_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("apps", [{"id": "a"}], has_next=False)])
+        _rows(_run("apps"))
+        assert "order" not in snaps[0]["params"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_instances_sends_starting_time(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("instances", [{"id": "i1"}], has_next=False)])
+        _rows(
+            _run(
+                "instances",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2024, 5, 1, tzinfo=UTC),
+            )
         )
+        assert snaps[0]["params"]["starting_time"] == "2024-05-01T00:00:00Z"
+        assert snaps[0]["params"]["order"] == "asc"
 
-        assert "starting_time=2024-05-01T00%3A00%3A00Z" in calls[0]
-        assert "order=asc" in calls[0]
-
-    def test_full_refresh_instances_omits_starting_time(self, monkeypatch: Any) -> None:
-        responses = [{"instances": [{"id": "i1"}], "has_next": False}]
-        _, calls = _collect(
-            "instances",
-            _FakeResumableManager(),
-            monkeypatch,
-            responses,
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=datetime(2024, 5, 1, tzinfo=UTC),
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_instances_omits_starting_time(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("instances", [{"id": "i1"}], has_next=False)])
+        _rows(
+            _run(
+                "instances",
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=datetime(2024, 5, 1, tzinfo=UTC),
+            )
         )
+        assert "starting_time" not in snaps[0]["params"]
 
-        assert "starting_time" not in calls[0]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_endpoint_without_time_filter_drops_cutoff(self, MockSession) -> None:
+        # apps has no server-side time filter, so a watermark must not become a query param.
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("apps", [{"id": "a"}], has_next=False)])
+        _rows(
+            _run(
+                "apps",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2024, 5, 1, tzinfo=UTC),
+            )
+        )
+        assert "starting_time" not in snaps[0]["params"]
 
-    def test_deployment_definition_secrets_are_redacted(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_usage_details_always_sends_required_window(self, MockSession) -> None:
+        session = MockSession.return_value
+        snaps = _wire(session, [_response("usage_details", [{"instance_id": "x", "started_at": "t"}], has_next=False)])
+        _rows(_run("usage_details"))
+        assert snaps[0]["params"]["starting_time"] == USAGE_WINDOW_START
+        assert "ending_time" in snaps[0]["params"]
+        assert snaps[0]["params"]["order"] == "asc"
+
+
+class TestSecretScrubbing:
+    @mock.patch(KOYEB_SESSION_PATCH)
+    def test_deployment_definition_secrets_are_redacted(self, mock_session) -> None:
         # Deployment definitions embed plaintext env values and config-file content; leaving them
         # in place would expose credentials to anyone with warehouse-query access.
-        responses = [
-            {
-                "deployments": [
-                    {
-                        "id": "d1",
-                        "definition": {
-                            "env": [
-                                {"key": "DB_PASSWORD", "value": "hunter2"},
-                                {"key": "API_KEY", "secret": "my-secret-ref"},
-                            ],
-                            "config_files": [{"path": "/etc/app.conf", "content": "token=abc123"}],
-                        },
-                    }
-                ],
-                "has_next": False,
-            }
-        ]
-        rows, _ = _collect("deployments", _FakeResumableManager(), monkeypatch, responses)
+        session = mock_session.return_value
+        _wire(
+            session,
+            [
+                _response(
+                    "deployments",
+                    [
+                        {
+                            "id": "d1",
+                            "definition": {
+                                "env": [
+                                    {"key": "DB_PASSWORD", "value": "hunter2"},
+                                    {"key": "API_KEY", "secret": "my-secret-ref"},
+                                ],
+                                "config_files": [{"path": "/etc/app.conf", "content": "token=abc123"}],
+                            },
+                        }
+                    ],
+                    has_next=False,
+                )
+            ],
+        )
+
+        rows = _rows(_run("deployments"))
 
         env = rows[0]["definition"]["env"]
         assert env[0] == {"key": "DB_PASSWORD", "value": "[redacted by PostHog]"}
@@ -250,53 +292,38 @@ class TestGetRows:
             "content": "[redacted by PostHog]",
         }
 
-    def test_non_deployment_rows_pass_through_untouched(self, monkeypatch: Any) -> None:
-        # Only definition-bearing endpoints are scrubbed; a stray `value`/`content` elsewhere stays.
-        responses = [{"secrets": [{"id": "s1", "value": "keep-me"}]}]
-        rows, _ = _collect("secrets", _FakeResumableManager(), monkeypatch, responses)
-
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_deployment_rows_pass_through_untouched(self, MockSession) -> None:
+        # Only definition-bearing endpoints are scrubbed; a stray `value` elsewhere stays.
+        session = MockSession.return_value
+        _wire(session, [_response("secrets", [{"id": "s1", "value": "keep-me"}], has_next=False)])
+        rows = _rows(_run("secrets"))
         assert rows[0] == {"id": "s1", "value": "keep-me"}
 
-    def test_sample_capture_disabled_only_for_secret_scrubbed_endpoints(self, monkeypatch: Any) -> None:
-        # HTTP sample capture stores the raw response body before the definition scrub runs, so
-        # secret-scrubbed endpoints must opt their session out of capture while the rest stay in.
-        session_kwargs: list[dict] = []
+    @mock.patch(CLIENT_SESSION_PATCH)
+    @mock.patch(KOYEB_SESSION_PATCH)
+    def test_capture_disabled_only_for_secret_scrubbed_endpoints(self, mock_koyeb_session, mock_client_session) -> None:
+        # HTTP sample capture stores the raw body before the definition scrub runs, so secret-scrubbed
+        # endpoints must build a capture-off session; the rest let RESTClient build its own (capture on).
+        _wire(mock_koyeb_session.return_value, [_response("deployments", [], has_next=False)])
+        _rows(_run("deployments"))
+        assert mock_koyeb_session.call_args.kwargs["capture"] is False
 
-        def fake_session(**kwargs: Any) -> Any:
-            session_kwargs.append(kwargs)
-            return MagicMock()
-
-        monkeypatch.setattr(koyeb, "make_tracked_session", fake_session)
-        _patch_fetch(monkeypatch, [{"deployments": [], "has_next": False}, {"apps": [], "has_next": False}])
-        for endpoint in ("deployments", "apps"):
-            list(
-                get_rows(
-                    api_token="t",
-                    endpoint=endpoint,
-                    logger=MagicMock(),
-                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-                )
-            )
-
-        assert session_kwargs == [{"capture": False}, {"capture": True}]
-
-    def test_uses_response_data_key_per_endpoint(self, monkeypatch: Any) -> None:
-        # Event streams all return their rows under "events", not the endpoint name.
-        responses = [{"events": [{"id": "e1"}], "has_next": False}]
-        rows, calls = _collect("deployment_events", _FakeResumableManager(), monkeypatch, responses)
-
-        assert [r["id"] for r in rows] == ["e1"]
-        assert "/v1/deployment_events" in calls[0]
+        mock_koyeb_session.reset_mock()
+        _wire(mock_client_session.return_value, [_response("apps", [], has_next=False)])
+        _rows(_run("apps"))
+        mock_koyeb_session.assert_not_called()
 
 
-class TestKoyebSource:
+class TestSourceResponse:
     @parameterized.expand([(name,) for name in KOYEB_ENDPOINTS])
     def test_source_response_per_endpoint(self, endpoint: str) -> None:
         config = KOYEB_ENDPOINTS[endpoint]
         response = koyeb_source(
             api_token="t",
             endpoint=endpoint,
-            logger=MagicMock(),
+            team_id=1,
+            job_id="j",
             resumable_source_manager=MagicMock(),
         )
         assert response.name == endpoint

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lago/lago.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lago/lago.py
@@ -4,7 +4,7 @@ Lago is an open-source usage-based billing platform offered both as Lago Cloud
 (``https://api.getlago.com``) and self-hosted (a customer-supplied host), so the API base URL
 must be configurable. Auth is a single Bearer API key. List endpoints are page-number paginated
 (``page`` / ``per_page``) and wrap their records under a resource key alongside a ``meta`` object
-that carries ``next_page``.
+that carries ``total_pages`` / ``next_page``.
 
 Every stream is full-refresh. Lago's REST API exposes no universal server-side ``created_at`` /
 ``updated_at`` cursor across resources — only a handful of endpoints offer ad-hoc date filters
@@ -12,6 +12,11 @@ Every stream is full-refresh. Lago's REST API exposes no universal server-side `
 record-creation timestamp, so they are unsafe to treat as an incremental cursor. Incremental sync
 can be layered on later for a specific endpoint once its server-side filter is verified against the
 live API.
+
+Pagination, retries, auth-header redaction, and the redirect / off-host SSRF guards are provided by
+the shared ``rest_source`` framework (page-number paginator, ``allowed_hosts`` host-pinning,
+``allow_redirects=False``). The DNS-based internal-IP check for customer-supplied self-hosted hosts
+has no framework equivalent, so it stays here as a run-time pre-check.
 """
 
 import re
@@ -21,12 +26,17 @@ from typing import Any, Optional
 from urllib.parse import urlencode, urlparse
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _is_host_safe
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.lago.settings import (
     LAGO_ENDPOINTS,
@@ -36,17 +46,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.lago.setti
 DEFAULT_API_HOST = "https://api.getlago.com"
 API_VERSION_PATH = "/api/v1"
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-MAX_RETRY_AFTER_SECONDS = 60
-
 HOST_NOT_ALLOWED_ERROR = "Lago API URL is not allowed"
-
-
-class LagoRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
 
 
 class LagoHostNotAllowedError(Exception):
@@ -98,6 +98,10 @@ def validate_credentials(
     At source-create (``schema_name is None``) a 403 is accepted: the token is valid but may lack
     permission for this particular probe. A scoped probe (``schema_name`` set) treats 403 as a hard
     failure.
+
+    Kept hand-rolled rather than routed through ``validate_via_probe`` because the probe must run
+    with ``allow_redirects=False`` and reject any 3xx — the validated host could 3xx to an internal
+    address, defeating the internal-IP check below (SSRF). ``validate_via_probe`` follows redirects.
     """
     base_url = normalize_base_url(api_url)
     host = _host_of(base_url)
@@ -142,121 +146,80 @@ def validate_credentials(
         return False, response.text
 
 
-def _parse_retry_after(response: requests.Response) -> float | None:
-    """Honor a whole-second ``Retry-After`` on 429. HTTP-date forms are ignored."""
-    raw = response.headers.get("Retry-After")
-    if raw and raw.strip().isdigit():
-        return min(float(raw.strip()), MAX_RETRY_AFTER_SECONDS)
-    return None
-
-
-def _retry_wait(retry_state: RetryCallState) -> float:
-    """Use a server-provided Retry-After when present, else exponential backoff."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, LagoRetryableError) and exc.retry_after is not None:
-        return exc.retry_after
-    return wait_exponential_jitter(initial=1, max=30)(retry_state)
-
-
-def get_rows(
-    api_url: Optional[str],
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[LagoResumeConfig],
-    team_id: int,
-) -> Iterator[list[dict[str, Any]]]:
-    config: LagoEndpointConfig = LAGO_ENDPOINTS[endpoint]
-    base_url = normalize_base_url(api_url)
-    host = _host_of(base_url)
-
-    # Re-check at run time (not just at source-create) in case the URL was edited or now resolves
-    # to an internal address (SSRF / DNS rebinding). Only enforced on cloud.
-    host_ok, host_err = _is_host_safe(host, team_id)
-    if not host_ok:
-        raise LagoHostNotAllowedError(host_err or HOST_NOT_ALLOWED_ERROR)
-
-    headers = _get_headers(api_key)
-    request_url = f"{base_url}{config.path}"
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume_config.next_page if resume_config is not None else 1
-    if resume_config is not None:
-        logger.debug(f"Lago: resuming {endpoint} from page {page}")
-
-    @retry(
-        retry=retry_if_exception_type((LagoRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=_retry_wait,
-        reraise=True,
-    )
-    def fetch_page(page_number: int) -> requests.Response:
-        query = urlencode({"page": page_number, "per_page": config.page_size})
-        # Don't follow redirects: an attacker-controlled host could 3xx to an internal address,
-        # bypassing the host validation done before the request (SSRF).
-        response = make_tracked_session().get(
-            f"{request_url}?{query}", headers=headers, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False
-        )
-
-        if response.status_code == 429 or response.status_code >= 500:
-            retry_after = _parse_retry_after(response) if response.status_code == 429 else None
-            raise LagoRetryableError(
-                f"Lago API error (retryable): status={response.status_code}, url={request_url}",
-                retry_after=retry_after,
-            )
-
-        # A 3xx isn't an error status (`response.ok` is True), so reject it explicitly rather than
-        # silently parsing the redirect body as data.
-        if response.is_redirect or response.is_permanent_redirect:
-            raise LagoHostNotAllowedError(
-                f"Lago API returned an unexpected redirect (status={response.status_code}); refusing to follow it"
-            )
-
-        if not response.ok:
-            logger.error(f"Lago API error: status={response.status_code}, body={response.text}, url={request_url}")
-            response.raise_for_status()
-
-        return response
-
-    while True:
-        response = fetch_page(page)
-        body = response.json()
-        rows = body.get(config.data_key) or []
-        if not isinstance(rows, list) or not rows:
-            break
-
-        yield rows
-
-        next_page = (body.get("meta") or {}).get("next_page")
-        if not next_page:
-            break
-        page = int(next_page)
-
-        # Checkpoint AFTER yielding the page: a crash before this write re-yields the page on resume
-        # (dedupes on the primary key), while a crash after it resumes at the next page.
-        resumable_source_manager.save_state(LagoResumeConfig(next_page=page))
-
-
 def lago_source(
     api_url: Optional[str],
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[LagoResumeConfig],
     team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[LagoResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
-    config = LAGO_ENDPOINTS[endpoint]
+    config: LagoEndpointConfig = LAGO_ENDPOINTS[endpoint]
+    base_url = normalize_base_url(api_url)
+    host = _host_of(base_url)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted from
+            # logs and raised errors; only the non-secret accept/content headers are set here.
+            "headers": {"Accept": "application/json", "Content-Type": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            # Pin every request to the base host and refuse redirects: a self-hosted host is
+            # customer-controlled, so a tampered pagination link or a 3xx to an internal address must
+            # not carry the Authorization header off-host (SSRF). `allowed_hosts=[]` means
+            # "same host as base_url only".
+            "allowed_hosts": [],
+            "allow_redirects": False,
+            # Page-number pagination; `meta.total_pages` stops after the last page so no extra empty
+            # page is fetched. `stop_after_empty_page` (default) covers a 0-row / missing-key body.
+            "paginator": PageNumberPaginator(base_page=1, total_path="meta.total_pages"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"per_page": config.page_size},
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.next_page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on `lago_id`) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(LagoResumeConfig(next_page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    def items() -> Iterator[list[dict[str, Any]]]:
+        # Re-check at run time (not just at source-create) in case the URL was edited or now resolves
+        # to an internal address (SSRF / DNS rebinding). Only enforced on cloud.
+        host_ok, host_err = _is_host_safe(host, team_id)
+        if not host_ok:
+            raise LagoHostNotAllowedError(host_err or HOST_NOT_ALLOWED_ERROR)
+        yield from resource
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_url=api_url,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            team_id=team_id,
-        ),
+        items=items,
         primary_keys=[config.primary_key],
         # Full-refresh replace: Lago exposes no `sort` param and no incremental cursor, so there is
         # no watermark to checkpoint. The default ascending mode is harmless here.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lago/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lago/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import LagoSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.lago.lago import (
     HOST_NOT_ALLOWED_ERROR,
@@ -64,19 +67,7 @@ class LagoSource(ResumableSource[LagoSourceConfig, LagoResumeConfig]):
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                supports_append=bool(INCREMENTAL_FIELDS.get(endpoint)),
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: LagoSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -96,9 +87,10 @@ class LagoSource(ResumableSource[LagoSourceConfig, LagoResumeConfig]):
             api_url=config.api_url,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
-            resumable_source_manager=resumable_source_manager,
             team_id=inputs.team_id,
+            job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Lago endpoint is full refresh
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lago/tests/test_lago.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lago/tests/test_lago.py
@@ -1,35 +1,97 @@
+import json
 from typing import Any, Optional
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.lago import lago as lago_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.lago.lago import (
+    DEFAULT_API_HOST,
     LagoHostNotAllowedError,
     LagoResumeConfig,
-    get_rows,
     lago_source,
     normalize_base_url,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.lago.settings import LAGO_ENDPOINTS
 
-
-def _response(*, status_code: int = 200, json_data: Any = None, text: str = "") -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 400
-    response.is_redirect = status_code in (301, 302, 303, 307, 308)
-    response.is_permanent_redirect = status_code in (301, 308)
-    response.text = text
-    response.json.return_value = json_data
-    response.headers = {}
-    return response
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# tenacity sleeps between the client's retries; short-circuit it so retry tests don't wait.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-def _page(rows: list[dict[str, Any]], next_page: Optional[int]) -> mock.MagicMock:
-    return _response(json_data={"customers": rows, "meta": {"next_page": next_page}})
+def _page(
+    rows: Optional[list[dict[str, Any]]],
+    *,
+    total_pages: int = 1,
+    next_page: Optional[int] = None,
+    data_key: str = "customers",
+    status_code: int = 200,
+    drop_data: bool = False,
+) -> Response:
+    body: dict[str, Any] = {"meta": {"total_pages": total_pages, "next_page": next_page}}
+    if not drop_data:
+        body[data_key] = rows if rows is not None else []
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _redirect(status_code: int = 302) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.headers["Location"] = "https://internal.example.com/api/v1/customers"
+    resp._content = b""
+    return resp
+
+
+def _make_manager(resume_state: Optional[LagoResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's query params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so a copy is snapshotted when each
+    request is prepared. ``prepared.url`` is set to the real request URL so the client's
+    host-pinning check (allowed_hosts) resolves a real hostname rather than a MagicMock.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        prepared.is_redirect = False
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(manager, *, endpoint: str = "customers", api_url: Optional[str] = None, team_id: int = 1):
+    return lago_source(
+        api_url=api_url,
+        api_key="key",
+        endpoint=endpoint,
+        team_id=team_id,
+        job_id="job-1",
+        resumable_source_manager=manager,
+    )
 
 
 class TestNormalizeBaseUrl:
@@ -60,22 +122,31 @@ class TestValidateCredentials:
             session.get.return_value = response
         return mock.patch.object(lago_module, "make_tracked_session", return_value=session)
 
+    def _resp(self, *, status_code=200, json_data=None, text=""):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        response.is_redirect = status_code in (301, 302, 303, 307, 308)
+        response.is_permanent_redirect = status_code in (301, 308)
+        response.text = text
+        response.json.return_value = json_data
+        return response
+
     def test_success(self):
-        with self._patch_session(_response(status_code=200)):
+        with self._patch_session(self._resp(status_code=200)):
             assert validate_credentials(None, "key") == (True, None)
 
     def test_invalid_key(self):
-        with self._patch_session(_response(status_code=401)):
+        with self._patch_session(self._resp(status_code=401)):
             valid, msg = validate_credentials(None, "key")
             assert valid is False
             assert msg == "Invalid Lago API key"
 
     def test_403_at_source_create_is_accepted(self):
-        with self._patch_session(_response(status_code=403)):
+        with self._patch_session(self._resp(status_code=403)):
             assert validate_credentials(None, "key", schema_name=None) == (True, None)
 
     def test_403_for_scoped_probe_fails(self):
-        with self._patch_session(_response(status_code=403)):
+        with self._patch_session(self._resp(status_code=403)):
             valid, msg = validate_credentials(None, "key", schema_name="invoices")
             assert valid is False
             assert msg is not None
@@ -89,7 +160,7 @@ class TestValidateCredentials:
             assert "boom" in (msg or "")
 
     def test_rejects_redirect_response(self):
-        with self._patch_session(_response(status_code=302)) as patched:
+        with self._patch_session(self._resp(status_code=302)) as patched:
             valid, msg = validate_credentials(None, "key")
             assert valid is False
             assert msg == lago_module.HOST_NOT_ALLOWED_ERROR
@@ -98,7 +169,7 @@ class TestValidateCredentials:
     def test_blocks_unsafe_host(self):
         with (
             mock.patch.object(lago_module, "_is_host_safe", return_value=(False, "internal address")),
-            self._patch_session(_response(status_code=200)) as patched,
+            self._patch_session(self._resp(status_code=200)) as patched,
         ):
             valid, msg = validate_credentials("http://10.0.0.1", "key", team_id=99)
             assert valid is False
@@ -106,7 +177,7 @@ class TestValidateCredentials:
             patched.return_value.get.assert_not_called()
 
     def test_probe_hits_configured_host(self):
-        with self._patch_session(_response(status_code=200)) as patched:
+        with self._patch_session(self._resp(status_code=200)) as patched:
             validate_credentials("https://billing.example.com", "key")
             url = patched.return_value.get.call_args.args[0]
             assert url.startswith("https://billing.example.com/api/v1/customers")
@@ -115,14 +186,7 @@ class TestValidateCredentials:
 class TestLagoSourceResponse:
     @pytest.mark.parametrize("endpoint", list(LAGO_ENDPOINTS.keys()))
     def test_response_shape(self, endpoint):
-        response = lago_source(
-            api_url=None,
-            api_key="key",
-            endpoint=endpoint,
-            logger=mock.MagicMock(),
-            resumable_source_manager=mock.MagicMock(),
-            team_id=1,
-        )
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["lago_id"]
         assert response.sort_mode == "asc"
@@ -131,124 +195,153 @@ class TestLagoSourceResponse:
         assert response.partition_format == "month"
 
 
-class TestGetRows:
-    def _run(self, manager, responses, team_id=1, api_url=None):
-        session = mock.MagicMock()
-        session.get.side_effect = responses
-        with mock.patch.object(lago_module, "make_tracked_session", return_value=session):
-            rows: list[dict[str, Any]] = []
-            for batch in get_rows(
-                api_url=api_url,
-                api_key="key",
-                endpoint="customers",
-                logger=mock.MagicMock(),
-                resumable_source_manager=manager,
-                team_id=team_id,
-            ):
-                rows.extend(batch)
-        return rows, session
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_progresses_page(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _page([{"lago_id": "1"}, {"lago_id": "2"}], total_pages=2, next_page=2),
+                _page([{"lago_id": "3"}], total_pages=2, next_page=None),
+            ],
+        )
 
-    def test_paginates_via_meta_next_page(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        page1 = _page([{"lago_id": "1"}, {"lago_id": "2"}], next_page=2)
-        page2 = _page([{"lago_id": "3"}], next_page=None)
-        rows, session = self._run(manager, [page1, page2])
+        rows = _rows(_source(_make_manager()))
 
         assert [r["lago_id"] for r in rows] == ["1", "2", "3"]
-        # First request page=1, second request page=2 (from meta.next_page).
-        first_qs = parse_qs(urlparse(session.get.call_args_list[0].args[0]).query)
-        second_qs = parse_qs(urlparse(session.get.call_args_list[1].args[0]).query)
-        assert first_qs["page"] == ["1"]
-        assert second_qs["page"] == ["2"]
+        # First request page=1, second request page=2, both carry per_page.
+        assert params[0]["page"] == 1
+        assert params[0]["per_page"] == 100
+        assert params[1]["page"] == 2
 
-    def test_saves_next_page_after_yielding(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        page1 = _page([{"lago_id": "1"}], next_page=2)
-        page2 = _page([{"lago_id": "2"}], next_page=None)
-        self._run(manager, [page1, page2])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_saves_next_page_after_yielding(self, MockSession):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page([{"lago_id": "1"}], total_pages=2, next_page=2),
+                _page([{"lago_id": "2"}], total_pages=2, next_page=None),
+            ],
+        )
 
-        # State is saved once (after page 1, pointing at page 2); the last page has no next_page.
+        manager = _make_manager()
+        _rows(_source(manager))
+
+        # State is saved once (after page 1, pointing at page 2); the last page ends pagination.
         assert manager.save_state.call_count == 1
         saved = manager.save_state.call_args.args[0]
         assert isinstance(saved, LagoResumeConfig)
         assert saved.next_page == 2
 
-    def test_resumes_from_saved_state(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = LagoResumeConfig(next_page=3)
-        rows, session = self._run(manager, [_page([{"lago_id": "9"}], next_page=None)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_page([{"lago_id": "9"}], total_pages=3, next_page=None)])
 
-        first_qs = parse_qs(urlparse(session.get.call_args_list[0].args[0]).query)
-        assert first_qs["page"] == ["3"]
+        rows = _rows(_source(_make_manager(LagoResumeConfig(next_page=3))))
+
+        assert params[0]["page"] == 3
         assert [r["lago_id"] for r in rows] == ["9"]
 
-    def test_empty_page_terminates(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        rows, session = self._run(manager, [_page([], next_page=2)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_terminates(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([], total_pages=1, next_page=2)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == []
-        assert session.get.call_count == 1
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    def test_does_not_follow_redirects(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        with pytest.raises(LagoHostNotAllowedError):
-            self._run(manager, [_response(status_code=302)])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_nothing_and_stops(self, MockSession):
+        # The old transport treated a missing collection key as a terminal empty page (not an error);
+        # data_selector is not marked required, so an absent key yields 0 rows and stops.
+        session = MockSession.return_value
+        _wire(session, [_page(None, drop_data=True)])
 
-    def test_passes_allow_redirects_false(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        _rows, session = self._run(manager, [_page([{"lago_id": "1"}], next_page=None)])
-        assert session.get.call_args.kwargs["allow_redirects"] is False
+        rows = _rows(_source(_make_manager()))
 
-    def test_raises_when_host_not_allowed(self):
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_per_endpoint_path_and_data_key(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([{"lago_id": "p1"}], data_key="plans", total_pages=1, next_page=None)])
+
+        rows = _rows(_source(_make_manager(), endpoint="plans"))
+
+        assert [r["lago_id"] for r in rows] == ["p1"]
+        assert urlparse(session.prepare_request.call_args_list[0].args[0].url).path.endswith("/plans")
+
+
+class TestRedirectAndHostGuards:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_redirect(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_redirect(302)])
+
+        # allow_redirects=False in the client config surfaces a 3xx as a loud, non-retryable error.
+        with pytest.raises(ValueError, match="redirect"):
+            _rows(_source(_make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_does_not_follow_redirects(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([{"lago_id": "1"}], total_pages=1, next_page=None)])
+
+        _rows(_source(_make_manager()))
+        assert session.send.call_args.kwargs["allow_redirects"] is False
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_when_host_not_allowed(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([{"lago_id": "1"}], total_pages=1, next_page=None)])
+
         with mock.patch.object(lago_module, "_is_host_safe", return_value=(False, "internal address")):
             with pytest.raises(LagoHostNotAllowedError):
-                self._run(manager, [_page([{"lago_id": "1"}], next_page=None)])
+                _rows(_source(_make_manager()))
+        # The SSRF pre-check fires before any request leaves the process.
+        session.send.assert_not_called()
 
+
+class TestRetries:
     @pytest.mark.parametrize("status_code", [429, 503])
-    def test_retries_retryable_status_then_succeeds(self, status_code):
-        # End-to-end: a retryable status raises LagoRetryableError, tenacity retries, and the
-        # subsequent 200 yields rows. Guards against accidentally dropping the retry predicate.
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-        responses = [_response(status_code=status_code), _page([{"lago_id": "r1"}], next_page=None)]
-        with mock.patch.object(lago_module, "_retry_wait", return_value=0):
-            rows, session = self._run(manager, responses)
-        assert [r["lago_id"] for r in rows] == ["r1"]
-        assert session.get.call_count == 2
-
-
-class TestRetryAfter:
-    @pytest.mark.parametrize(
-        "header, expected",
-        [
-            ({"Retry-After": "5"}, 5.0),
-            ({"Retry-After": "  9 "}, 9.0),
-            ({"Retry-After": "100000"}, 60.0),
-            ({"Retry-After": "Wed, 21 Oct 2025 07:28:00 GMT"}, None),
-            ({}, None),
-        ],
-    )
-    def test_parse_retry_after(self, header, expected):
-        from products.warehouse_sources.backend.temporal.data_imports.sources.lago.lago import _parse_retry_after
-
-        response = mock.MagicMock()
-        response.headers = header
-        assert _parse_retry_after(response) == expected
-
-    def test_retry_wait_prefers_retry_after(self):
-        from products.warehouse_sources.backend.temporal.data_imports.sources.lago.lago import (
-            LagoRetryableError,
-            _retry_wait,
+    @mock.patch(SLEEP_PATCH, return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_retryable_status_then_succeeds(self, MockSession, _sleep, status_code):
+        # A retryable status raises inside the client, tenacity retries, and the subsequent 200
+        # yields rows. Guards against dropping the retry behavior in the migration.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _page([], total_pages=1, next_page=None, status_code=status_code),
+                _page([{"lago_id": "r1"}], total_pages=1, next_page=None),
+            ],
         )
 
-        state = mock.MagicMock()
-        state.outcome.exception.return_value = LagoRetryableError("rate limited", retry_after=7.0)
-        assert _retry_wait(state) == 7.0
+        rows = _rows(_source(_make_manager()))
+
+        assert [r["lago_id"] for r in rows] == ["r1"]
+        assert session.send.call_count == 2
+
+
+class TestBaseUrl:
+    def test_default_host_constant(self):
+        assert DEFAULT_API_HOST == "https://api.getlago.com"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_requests_target_base_host(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_page([{"lago_id": "1"}], total_pages=1, next_page=None)])
+
+        _rows(_source(_make_manager()))
+        parsed = urlparse(session.prepare_request.call_args_list[0].args[0].url)
+        assert parsed.hostname == "api.getlago.com"
+        assert parsed.path == "/api/v1/customers"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lago/tests/test_lago_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lago/tests/test_lago_source.py
@@ -98,6 +98,7 @@ class TestLagoSource:
         inputs = mock.MagicMock()
         inputs.schema_name = "invoices"
         inputs.team_id = 42
+        inputs.job_id = "job-1"
         manager = mock.MagicMock()
 
         self.source.source_for_pipeline(self.config, manager, inputs)
@@ -109,6 +110,7 @@ class TestLagoSource:
         assert kwargs["endpoint"] == "invoices"
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["team_id"] == 42
+        assert kwargs["job_id"] == "job-1"
 
     def test_canonical_descriptions_cover_core_tables(self):
         descriptions = self.source.get_canonical_descriptions()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/launchdarkly/launchdarkly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/launchdarkly/launchdarkly.py
@@ -1,15 +1,21 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BaseNextUrlPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.settings import (
     LAUNCHDARKLY_ENDPOINTS,
     LaunchDarklyEndpointConfig,
@@ -18,24 +24,21 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.launchdark
 API_HOST = "https://app.launchdarkly.com"
 BASE_URL = f"{API_HOST}/api/v2"
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRY_ATTEMPTS = 5
-MAX_RETRY_WAIT_SECONDS = 60
-
-
-class LaunchDarklyRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None):
-        super().__init__(message)
-        self.retry_after = retry_after
+# Parent resource name for fan-out endpoints. Named singular so include_from_parent injects the
+# project key under `_project_key` (make_parent_key_name(name, "key") == f"_{name}_key"), matching
+# the column the hand-rolled source emitted.
+PROJECTS_PARENT_NAME = "project"
 
 
 @dataclasses.dataclass
 class LaunchDarklyResumeConfig:
-    # Full URL of the next page to fetch ("" once a resource is exhausted).
+    # Full URL of the next page to fetch for a top-level endpoint ("" once exhausted).
     next_url: str = ""
-    # For fan-out endpoints, the project currently being paginated ("" for top-level
-    # endpoints or before the first project starts).
+    # Retained for backwards compatibility with resume state saved by the previous
+    # implementation; unused by the current code.
     project_key: str = ""
+    # Framework fan-out resume state ({"completed": [...], "current": ..., "child_state": ...}).
+    fanout_state: Optional[dict[str, Any]] = None
 
 
 def _get_headers(access_token: str) -> dict[str, str]:
@@ -47,10 +50,6 @@ def _get_headers(access_token: str) -> dict[str, str]:
     }
 
 
-def _initial_url(path: str, page_size: int) -> str:
-    return f"{BASE_URL}{path}?{urlencode({'limit': page_size})}"
-
-
 def _resolve_url(href: str) -> str:
     # LaunchDarkly returns relative hrefs (e.g. "/api/v2/projects?limit=20&offset=20").
     if href.startswith("http"):
@@ -58,171 +57,159 @@ def _resolve_url(href: str) -> str:
     return f"{API_HOST}{href}"
 
 
-def _next_url_from(data: dict[str, Any]) -> str | None:
-    links = data.get("_links") or {}
-    next_link = links.get("next") or {}
-    href = next_link.get("href")
-    return _resolve_url(href) if href else None
+class LaunchDarklyLinkPaginator(BaseNextUrlPaginator):
+    """Follows LaunchDarkly's ``_links.next.href`` pagination.
 
+    The href is usually a relative path, so it's resolved against the API host before the next
+    request is sent. Resume (``get_resume_state``/``set_resume_state`` on the next URL) is inherited
+    from ``BaseNextUrlPaginator``.
+    """
 
-def _wait_strategy(retry_state: Any) -> float:
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, LaunchDarklyRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_WAIT_SECONDS)
-    return min(2.0**retry_state.attempt_number, MAX_RETRY_WAIT_SECONDS)
-
-
-@retry(
-    retry=retry_if_exception_type((LaunchDarklyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=_wait_strategy,
-    reraise=True,
-)
-def _fetch_page(url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict[str, Any]:
-    response = make_tracked_session().get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429:
-        retry_after_header = response.headers.get("Retry-After")
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         try:
-            # Retry-After is normally integer seconds, but tolerate fractional values too.
-            retry_after = float(retry_after_header) if retry_after_header else None
-        except ValueError:
-            # A non-numeric value (e.g. an HTTP-date) falls back to exponential backoff.
-            retry_after = None
-        logger.warning(f"LaunchDarkly rate limited (429), retrying. retry_after={retry_after_header}, url={url}")
-        raise LaunchDarklyRetryableError(f"LaunchDarkly rate limited: url={url}", retry_after=retry_after)
+            body = response.json()
+        except Exception:
+            body = {}
+        links = (body.get("_links") if isinstance(body, dict) else None) or {}
+        next_link = links.get("next") or {}
+        href = next_link.get("href")
+        if href:
+            self._next_url = _resolve_url(href)
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
 
-    if response.status_code >= 500:
-        raise LaunchDarklyRetryableError(f"LaunchDarkly server error: status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"LaunchDarkly API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+    def __str__(self) -> str:
+        return "LaunchDarklyLinkPaginator()"
 
 
-def validate_credentials(access_token: str, path: str = "/caller-identity") -> int | None:
-    """Probe an endpoint and return the HTTP status code (or None on transport failure)."""
-    try:
-        response = make_tracked_session().get(f"{BASE_URL}{path}", headers=_get_headers(access_token), timeout=10)
-        return response.status_code
-    except Exception:
-        return None
+def _client_config(access_token: str) -> dict[str, Any]:
+    return {
+        "base_url": BASE_URL,
+        # Only the non-secret Accept header goes here; the access token rides on the framework auth
+        # so it's scrubbed from any raised error message.
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "api_key", "api_key": access_token, "name": "Authorization", "location": "header"},
+    }
 
 
-def _fetch_project_keys(headers: dict[str, str], logger: FilteringBoundLogger) -> list[str]:
-    keys: list[str] = []
-    url: str | None = _initial_url("/projects", LAUNCHDARKLY_ENDPOINTS["projects"].page_size)
-    while url:
-        data = _fetch_page(url, headers, logger)
-        # `key` is the identifier every fan-out URL is built from; fail fast rather than
-        # silently dropping a project (and all its environments/flags/metrics) if it's absent.
-        for item in data.get("items", []):
-            keys.append(item["key"])
-        url = _next_url_from(data)
-    return keys
-
-
-def _paginate_resource(
-    start_url: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[LaunchDarklyResumeConfig],
-    project_key: str,
-) -> Iterator[list[dict[str, Any]]]:
-    url: str | None = start_url
-    while url:
-        data = _fetch_page(url, headers, logger)
-        items = data.get("items", [])
-
-        if project_key:
-            for item in items:
-                item["_project_key"] = project_key
-
-        if items:
-            yield items
-
-        next_url = _next_url_from(data)
-        # Save state AFTER yielding so a heartbeat-timeout crash re-fetches from the next
-        # page rather than re-emitting the page we just yielded (merge dedupes regardless).
-        resumable_source_manager.save_state(LaunchDarklyResumeConfig(next_url=next_url or "", project_key=project_key))
-        url = next_url
-
-
-def _get_fanout_rows(
+def _build_toplevel_resource(
     config: LaunchDarklyEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[LaunchDarklyResumeConfig],
-    resume: LaunchDarklyResumeConfig | None,
-) -> Iterator[list[dict[str, Any]]]:
-    project_keys = _fetch_project_keys(headers, logger)
-    if not project_keys:
-        logger.warning(f"LaunchDarkly: no projects found, nothing to sync for endpoint={config.name}")
-        return
-
-    start_idx = 0
-    resume_url: str | None = None
-    if resume is not None and resume.project_key and resume.project_key in project_keys:
-        idx = project_keys.index(resume.project_key)
-        if resume.next_url:
-            # Mid-project: pick up at the saved page within that project.
-            start_idx = idx
-            resume_url = resume.next_url
-        else:
-            # The saved project finished (empty next_url marker); start at the next one.
-            start_idx = idx + 1
-
-    for i in range(start_idx, len(project_keys)):
-        project_key = project_keys[i]
-        if i == start_idx and resume_url:
-            start_url = resume_url
-        else:
-            start_url = _initial_url(config.path.format(project_key=project_key), config.page_size)
-        yield from _paginate_resource(start_url, headers, logger, resumable_source_manager, project_key)
-
-
-def get_rows(
     access_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[LaunchDarklyResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = LAUNCHDARKLY_ENDPOINTS[endpoint]
-    headers = _get_headers(access_token)
+    resume: Optional[LaunchDarklyResumeConfig],
+) -> Resource:
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(access_token),
+        "resources": [
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": config.page_size},
+                    "data_selector": "items",
+                    "paginator": LaunchDarklyLinkPaginator(),
+                },
+            }
+        ],
+    }
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-
-    if config.requires_project:
-        yield from _get_fanout_rows(config, headers, logger, resumable_source_manager, resume)
-        return
-
+    initial_paginator_state: Optional[dict[str, Any]] = None
     if resume is not None and resume.next_url:
-        logger.debug(f"LaunchDarkly: resuming endpoint={endpoint} from url={resume.next_url}")
-        start_url = resume.next_url
-    else:
-        start_url = _initial_url(config.path, config.page_size)
+        initial_paginator_state = {"next_url": resume.next_url}
 
-    yield from _paginate_resource(start_url, headers, logger, resumable_source_manager, project_key="")
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded (only while a next page remains) so a crash re-fetches the
+        # next page rather than re-emitting the one just yielded (merge dedupes regardless).
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(LaunchDarklyResumeConfig(next_url=state["next_url"]))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _build_fanout_resource(
+    config: LaunchDarklyEndpointConfig,
+    access_token: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[LaunchDarklyResumeConfig],
+    resume: Optional[LaunchDarklyResumeConfig],
+) -> Resource:
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(access_token),
+        "resources": [
+            {
+                "name": PROJECTS_PARENT_NAME,
+                "endpoint": {
+                    "path": "/projects",
+                    "params": {"limit": LAUNCHDARKLY_ENDPOINTS["projects"].page_size},
+                    "data_selector": "items",
+                    "paginator": LaunchDarklyLinkPaginator(),
+                },
+            },
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {
+                        "project_key": {"type": "resolve", "resource": PROJECTS_PARENT_NAME, "field": "key"},
+                        "limit": config.page_size,
+                    },
+                    "data_selector": "items",
+                    "paginator": LaunchDarklyLinkPaginator(),
+                },
+                # Injects the parent project's key into every child row as `_project_key`.
+                "include_from_parent": ["key"],
+            },
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resume is not None and resume.fanout_state:
+        initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        resumable_source_manager.save_state(LaunchDarklyResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(resource for resource in resources if resource.name == config.name)
 
 
 def launchdarkly_source(
     access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[LaunchDarklyResumeConfig],
 ) -> SourceResponse:
     config = LAUNCHDARKLY_ENDPOINTS[endpoint]
 
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    if config.requires_project:
+        resource = _build_fanout_resource(config, access_token, team_id, job_id, resumable_source_manager, resume)
+    else:
+        resource = _build_toplevel_resource(config, access_token, team_id, job_id, resumable_source_manager, resume)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            access_token=access_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_key,
         # LaunchDarkly timestamps are epoch-millisecond integers and the datetime
         # partitioner expects epoch-seconds, so partitioning is intentionally left off to
@@ -230,3 +217,13 @@ def launchdarkly_source(
         partition_mode=None,
         partition_keys=None,
     )
+
+
+def validate_credentials(access_token: str, path: str = "/caller-identity") -> int | None:
+    """Probe an endpoint and return the HTTP status code (or None on transport failure)."""
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_token,)),
+        f"{BASE_URL}{path}",
+        headers=_get_headers(access_token),
+    )
+    return status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/launchdarkly/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/launchdarkly/source.py
@@ -150,6 +150,7 @@ You can create a personal or service access token in your [LaunchDarkly account 
         return launchdarkly_source(
             access_token=config.access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/launchdarkly/tests/test_launchdarkly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/launchdarkly/tests/test_launchdarkly.py
@@ -1,16 +1,16 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly import (
     API_HOST,
     BASE_URL,
     LaunchDarklyResumeConfig,
-    _initial_url,
-    _next_url_from,
     _resolve_url,
-    get_rows,
     launchdarkly_source,
     validate_credentials,
 )
@@ -18,6 +18,14 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.launchdark
     ENDPOINTS,
     LAUNCHDARKLY_ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the launchdarkly module.
+LD_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
+)
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
 def _make_manager(resume_state: LaunchDarklyResumeConfig | None = None) -> mock.MagicMock:
@@ -27,25 +35,46 @@ def _make_manager(resume_state: LaunchDarklyResumeConfig | None = None) -> mock.
     return manager
 
 
-def _page(items: list[dict[str, Any]], next_href: str | None = None) -> dict[str, Any]:
+def _response(items: list[dict[str, Any]], next_href: str | None = None, status_code: int = 200) -> Response:
     links: dict[str, Any] = {}
     if next_href:
         links["next"] = {"href": next_href}
-    return {"items": items, "_links": links}
-
-
-def _resp(page: dict[str, Any], status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = page
+    resp = Response()
     resp.status_code = status_code
-    resp.ok = 200 <= status_code < 300
+    resp.url = f"{BASE_URL}/members"
+    resp._content = json.dumps({"items": items, "_links": links}).encode()
     return resp
 
 
-class TestUrlHelpers:
-    def test_initial_url_includes_limit(self):
-        assert _initial_url("/projects", 20) == f"{BASE_URL}/projects?limit=20"
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session; capture each request's URL and params AT SEND TIME.
 
+    The paginator mutates ``request.url``/``request.params`` in place across pages, so a copy is
+    snapshotted when each request is prepared.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return launchdarkly_source("token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
+
+
+class TestUrlHelpers:
     @pytest.mark.parametrize(
         "href, expected",
         [
@@ -56,203 +85,209 @@ class TestUrlHelpers:
     def test_resolve_url(self, href, expected):
         assert _resolve_url(href) == expected
 
-    @pytest.mark.parametrize(
-        "data, expected",
-        [
-            ({"_links": {"next": {"href": "/api/v2/members?offset=20"}}}, f"{API_HOST}/api/v2/members?offset=20"),
-            ({"_links": {}}, None),
-            ({}, None),
-            ({"_links": {"next": {}}}, None),
-        ],
-    )
-    def test_next_url_from(self, data, expected):
-        assert _next_url_from(data) == expected
-
 
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code", [200, 401, 403, 500])
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(LD_SESSION_PATCH)
     def test_returns_status_code(self, mock_session, status_code):
-        response = mock.MagicMock(status_code=status_code)
-        mock_session.return_value.get.return_value = response
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("api-token") == status_code
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(LD_SESSION_PATCH)
     def test_uses_no_bearer_prefix(self, mock_session):
-        response = mock.MagicMock(status_code=200)
-        mock_session.return_value.get.return_value = response
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("api-secret-token")
         headers = mock_session.return_value.get.call_args.kwargs["headers"]
         assert headers["Authorization"] == "api-secret-token"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(LD_SESSION_PATCH)
     def test_returns_none_on_exception(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("api-token") is None
 
 
 class TestGetRowsTopLevel:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_paginates_via_links_next(self, mock_session):
-        pages = [
-            _page([{"_id": "1"}, {"_id": "2"}], "/api/v2/members?limit=20&offset=20"),
-            _page([{"_id": "3"}], None),
-        ]
-        mock_session.return_value.get.side_effect = [_resp(p) for p in pages]
+        session = mock_session.return_value
+        snaps = _wire(
+            session,
+            [
+                _response([{"_id": "1"}, {"_id": "2"}], "/api/v2/members?limit=20&offset=20"),
+                _response([{"_id": "3"}], None),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("token", "members", mock.MagicMock(), manager))
+        rows = _rows(_source("members", manager))
 
-        assert [item["_id"] for batch in batches for item in batch] == ["1", "2", "3"]
+        assert [item["_id"] for item in rows] == ["1", "2", "3"]
         # No project key injected for top-level endpoints.
-        assert all("_project_key" not in item for batch in batches for item in batch)
-        # State saved after every page (final save records the empty next_url marker).
-        saved_urls = [call.args[0].next_url for call in manager.save_state.call_args_list]
-        assert saved_urls == [f"{API_HOST}/api/v2/members?limit=20&offset=20", ""]
+        assert all("_project_key" not in item for item in rows)
+        # First page targets the base path; second follows the (resolved) _links.next href.
+        assert snaps[0]["url"] == f"{BASE_URL}/members"
+        assert snaps[0]["params"]["limit"] == 20
+        assert snaps[1]["url"] == f"{API_HOST}/api/v2/members?limit=20&offset=20"
+        # One checkpoint, saved after the first page (points at the next URL); the last page saves none.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == LaunchDarklyResumeConfig(
+            next_url=f"{API_HOST}/api/v2/members?limit=20&offset=20"
+        )
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_resumes_from_saved_state(self, mock_session):
-        mock_session.return_value.get.return_value = _resp(_page([{"_id": "9"}], None))
+        session = mock_session.return_value
+        snaps = _wire(session, [_response([{"_id": "9"}], None)])
 
         resume_url = f"{API_HOST}/api/v2/members?limit=20&offset=80"
         manager = _make_manager(LaunchDarklyResumeConfig(next_url=resume_url))
+        _rows(_source("members", manager))
 
-        list(get_rows("token", "members", mock.MagicMock(), manager))
+        assert snaps[0]["url"] == resume_url
 
-        assert mock_session.return_value.get.call_args_list[0].args[0] == resume_url
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_empty_response_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _resp(_page([], None))
+        session = mock_session.return_value
+        _wire(session, [_response([], None)])
 
         manager = _make_manager()
-        batches = list(get_rows("token", "members", mock.MagicMock(), manager))
-
-        assert batches == []
+        assert _rows(_source("members", manager)) == []
+        manager.save_state.assert_not_called()
 
 
 class TestGetRowsFanout:
-    def _fanout_side_effect(self) -> list[mock.MagicMock]:
-        # 1) project list, 2) environments for proj1, 3) environments for proj2
-        return [
-            _resp(_page([{"key": "proj1"}, {"key": "proj2"}], None)),
-            _resp(_page([{"_id": "e1"}], None)),
-            _resp(_page([{"_id": "e2"}], None)),
-        ]
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_iterates_projects_and_injects_project_key(self, mock_session):
-        mock_session.return_value.get.side_effect = self._fanout_side_effect()
+        session = mock_session.return_value
+        snaps = _wire(
+            session,
+            [
+                _response([{"key": "proj1"}, {"key": "proj2"}], None),
+                _response([{"_id": "e1"}], None),
+                _response([{"_id": "e2"}], None),
+            ],
+        )
 
-        manager = _make_manager()
-        batches = list(get_rows("token", "environments", mock.MagicMock(), manager))
+        rows = _rows(_source("environments", _make_manager()))
 
-        rows = [item for batch in batches for item in batch]
         assert rows == [
             {"_id": "e1", "_project_key": "proj1"},
             {"_id": "e2", "_project_key": "proj2"},
         ]
+        urls = [snap["url"] for snap in snaps]
+        assert urls[0] == f"{BASE_URL}/projects"
+        assert urls[1] == f"{BASE_URL}/projects/proj1/environments"
+        assert urls[2] == f"{BASE_URL}/projects/proj2/environments"
 
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert urls[0] == f"{BASE_URL}/projects?limit=20"
-        assert urls[1] == f"{BASE_URL}/projects/proj1/environments?limit=20"
-        assert urls[2] == f"{BASE_URL}/projects/proj2/environments?limit=20"
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_metrics_compose_path(self, mock_session):
+        session = mock_session.return_value
+        snaps = _wire(
+            session,
+            [
+                _response([{"key": "proj1"}], None),
+                _response([{"_id": "m1"}], None),
+            ],
+        )
+        _rows(_source("metrics", _make_manager()))
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
-    def test_flags_compose_metrics_path(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _resp(_page([{"key": "proj1"}], None)),
-            _resp(_page([{"_id": "m1"}], None)),
-        ]
-        list(get_rows("token", "metrics", mock.MagicMock(), _make_manager()))
+        assert snaps[1]["url"] == f"{BASE_URL}/metrics/proj1"
 
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert urls[1] == f"{BASE_URL}/metrics/proj1?limit=20"
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_resume_skips_completed_project(self, mock_session):
-        # proj1 was finished last run (empty next_url marker); resume must start at proj2.
-        mock_session.return_value.get.side_effect = [
-            _resp(_page([{"key": "proj1"}, {"key": "proj2"}], None)),
-            _resp(_page([{"_id": "e2"}], None)),
-        ]
-        manager = _make_manager(LaunchDarklyResumeConfig(next_url="", project_key="proj1"))
+        session = mock_session.return_value
+        # proj1 already fully synced last run; resume must start at proj2.
+        snaps = _wire(
+            session,
+            [
+                _response([{"key": "proj1"}, {"key": "proj2"}], None),
+                _response([{"_id": "e2"}], None),
+            ],
+        )
+        manager = _make_manager(
+            LaunchDarklyResumeConfig(
+                fanout_state={"completed": ["/projects/proj1/environments"], "current": None, "child_state": None}
+            )
+        )
 
-        batches = list(get_rows("token", "environments", mock.MagicMock(), manager))
+        rows = _rows(_source("environments", manager))
 
-        rows = [item for batch in batches for item in batch]
         assert rows == [{"_id": "e2", "_project_key": "proj2"}]
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        # projects list + proj2 environments only (proj1 skipped)
-        assert urls == [f"{BASE_URL}/projects?limit=20", f"{BASE_URL}/projects/proj2/environments?limit=20"]
+        urls = [snap["url"] for snap in snaps]
+        assert urls == [f"{BASE_URL}/projects", f"{BASE_URL}/projects/proj2/environments"]
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_resume_midproject_uses_saved_url(self, mock_session):
+        session = mock_session.return_value
         resume_url = f"{BASE_URL}/projects/proj1/environments?limit=20&offset=20"
-        mock_session.return_value.get.side_effect = [
-            _resp(_page([{"key": "proj1"}, {"key": "proj2"}], None)),
-            _resp(_page([{"_id": "e1b"}], None)),
-            _resp(_page([{"_id": "e2"}], None)),
-        ]
-        manager = _make_manager(LaunchDarklyResumeConfig(next_url=resume_url, project_key="proj1"))
+        snaps = _wire(
+            session,
+            [
+                _response([{"key": "proj1"}, {"key": "proj2"}], None),
+                _response([{"_id": "e1b"}], None),
+                _response([{"_id": "e2"}], None),
+            ],
+        )
+        manager = _make_manager(
+            LaunchDarklyResumeConfig(
+                fanout_state={
+                    "completed": [],
+                    "current": "/projects/proj1/environments",
+                    "child_state": {"next_url": resume_url},
+                }
+            )
+        )
 
-        list(get_rows("token", "environments", mock.MagicMock(), manager))
+        _rows(_source("environments", manager))
 
-        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
+        urls = [snap["url"] for snap in snaps]
         assert urls == [
-            f"{BASE_URL}/projects?limit=20",
+            f"{BASE_URL}/projects",
             resume_url,
-            f"{BASE_URL}/projects/proj2/environments?limit=20",
+            f"{BASE_URL}/projects/proj2/environments",
         ]
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_no_projects_yields_nothing(self, mock_session):
-        mock_session.return_value.get.return_value = _resp(_page([], None))
+        session = mock_session.return_value
+        _wire(session, [_response([], None)])
 
-        batches = list(get_rows("token", "flags", mock.MagicMock(), _make_manager()))
-        assert batches == []
+        assert _rows(_source("flags", _make_manager())) == []
 
 
 class TestRetryAndErrors:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.launchdarkly.launchdarkly.make_tracked_session"
-    )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_4xx_raises(self, mock_session):
-        resp = _resp(_page([], None), status_code=403)
-        resp.raise_for_status.side_effect = Exception("403 Client Error")
-        mock_session.return_value.get.return_value = resp
+        session = mock_session.return_value
+        _wire(session, [_response([], None, status_code=403)])
 
         with pytest.raises(Exception, match="403 Client Error"):
-            list(get_rows("token", "members", mock.MagicMock(), _make_manager()))
+            _rows(_source("members", _make_manager()))
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_429_is_retried_then_succeeds(self, mock_session, _mock_sleep):
+        session = mock_session.return_value
+        # A 429 is retryable at the client layer; the retry re-issues and succeeds.
+        _wire(
+            session,
+            [
+                _response([], None, status_code=429),
+                _response([{"_id": "1"}], None),
+            ],
+        )
+
+        rows = _rows(_source("members", _make_manager()))
+        assert [item["_id"] for item in rows] == ["1"]
 
 
 class TestLaunchDarklySourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata_per_endpoint(self, mock_session, endpoint):
+        mock_session.return_value.headers = {}
         config = LAUNCHDARKLY_ENDPOINTS[endpoint]
-        response = launchdarkly_source("token", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_key

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lemlist/lemlist.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lemlist/lemlist.py
@@ -1,29 +1,25 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Optional
-from urllib.parse import urlencode
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.settings import (
-    LEMLIST_ENDPOINTS,
-    LemlistEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.settings import LEMLIST_ENDPOINTS
 
 LEMLIST_BASE_URL = "https://api.lemlist.com/api"
 # lemlist caps list pages at 100 rows and rate-limits to 20 requests / 2s per API key.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class LemlistRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -63,138 +59,87 @@ def _clamp_future_value_to_now(value: Any) -> Any:
     return value
 
 
-def _build_params(
-    config: LemlistEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {}
-
-    if config.requires_version_v2:
-        params["version"] = "v2"
-
-    if config.request_sort_by:
-        params["sortBy"] = config.request_sort_by
-    if config.request_sort_order:
-        params["sortOrder"] = config.request_sort_order
-
-    if config.supports_incremental and should_use_incremental_field:
-        floor = db_incremental_field_last_value
-        if floor is None and config.default_lookback_days:
-            floor = datetime.now(UTC) - timedelta(days=config.default_lookback_days)
-        if floor is not None:
-            params["minDate"] = _format_incremental_value(_clamp_future_value_to_now(floor))
-
-    return params
-
-
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    url = f"{LEMLIST_BASE_URL}{path}"
-    if not params:
-        return url
-    return f"{url}?{urlencode(params)}"
-
-
-@retry(
-    retry=retry_if_exception_type((LemlistRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(
-    session: requests.Session, url: str, api_key: str, logger: FilteringBoundLogger
-) -> list[dict[str, Any]] | dict[str, Any]:
-    # lemlist uses HTTP Basic auth with an empty username and the API key as the password.
-    response = session.get(url, auth=("", api_key), timeout=REQUEST_TIMEOUT_SECONDS)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise LemlistRetryableError(f"lemlist API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"lemlist API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def validate_credentials(api_key: str) -> bool:
-    # `/team` is the cheapest authenticated probe — no pagination, single object.
-    url = _build_url(LEMLIST_ENDPOINTS["team"].path, {})
-    try:
-        response = make_tracked_session(redact_values=(api_key,)).get(
-            url, auth=("", api_key), timeout=REQUEST_TIMEOUT_SECONDS
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[LemlistResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = LEMLIST_ENDPOINTS[endpoint]
-    # One session reused across pages so urllib3 keeps the connection alive.
-    session = make_tracked_session(redact_values=(api_key,))
-    base_params = _build_params(config, should_use_incremental_field, db_incremental_field_last_value)
-
-    if not config.paginate:
-        data = _fetch(session, _build_url(config.path, base_params), api_key, logger)
-        # `/team` returns a single object; the other non-paginated endpoints return an array.
-        if config.single_object:
-            if isinstance(data, dict):
-                yield [data]
-        elif isinstance(data, list) and data:
-            yield data
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume is not None else 0
-
-    while True:
-        params = {**base_params, "limit": PAGE_SIZE, "offset": offset}
-        page = _fetch(session, _build_url(config.path, params), api_key, logger)
-
-        # Paginated endpoints always return a JSON array; guard against an unexpected object.
-        if not isinstance(page, list) or not page:
-            break
-
-        yield page
-
-        # A short page means we've reached the end — lemlist has no explicit "next" signal.
-        if len(page) < PAGE_SIZE:
-            break
-
-        offset += PAGE_SIZE
-        # Save AFTER yielding (and only when more pages remain) so a crash re-yields the last page
-        # rather than skipping it — merge dedupes on the primary key.
-        resumable_source_manager.save_state(LemlistResumeConfig(offset=offset))
-
-
 def lemlist_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[LemlistResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = LEMLIST_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {}
+    if config.requires_version_v2:
+        params["version"] = "v2"
+    if config.request_sort_by:
+        params["sortBy"] = config.request_sort_by
+    if config.request_sort_order:
+        params["sortOrder"] = config.request_sort_order
+
+    # lemlist has no top-level `total`; the OffsetPaginator terminates on a short/empty page.
+    # Non-paginated endpoints (team, team/senders) return their whole result in one response.
+    endpoint_config: dict[str, Any] = {
+        "path": config.path,
+        "params": params,
+        "paginator": OffsetPaginator(limit=PAGE_SIZE, total_path=None) if config.paginate else SinglePagePaginator(),
+    }
+
+    use_incremental = config.supports_incremental and should_use_incremental_field
+    if use_incremental:
+        # Only /activities honours the server-side minDate filter. Without a stored watermark yet,
+        # bound the first sync by the configured lookback rather than pulling the whole history.
+        initial_value: Optional[datetime] = None
+        if config.default_lookback_days:
+            initial_value = datetime.now(UTC) - timedelta(days=config.default_lookback_days)
+        endpoint_config["incremental"] = {
+            "start_param": "minDate",
+            "cursor_path": "createdAt",
+            "initial_value": initial_value,
+            # Clamp a future watermark to now and render it in the Z-suffixed format lemlist expects.
+            "convert": lambda value: _format_incremental_value(_clamp_future_value_to_now(value)),
+        }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": LEMLIST_BASE_URL,
+            # lemlist uses HTTP Basic auth with an empty username and the API key as the password.
+            # Supplied via the framework auth config so the key is redacted from logs and errors.
+            "auth": {"type": "http_basic", "username": "", "password": api_key},
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": endpoint_config,
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.paginate and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(LemlistResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if use_incremental else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
@@ -203,3 +148,13 @@ def lemlist_source(
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode=config.sort_mode,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    # `/team` is the cheapest authenticated probe — no pagination, single object.
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{LEMLIST_BASE_URL}/team",
+        auth=HttpBasicAuth(username="", password=api_key),
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lemlist/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lemlist/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import LemlistSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.lemlist import (
     LemlistResumeConfig,
@@ -29,7 +32,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.le
 from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.settings import (
     ENDPOINTS,
     INCREMENTAL_FIELDS,
-    LEMLIST_ENDPOINTS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -92,21 +94,7 @@ You can generate an API key in your lemlist **Settings > Integrations** page."""
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        def _build_schema(endpoint: str) -> SourceSchema:
-            endpoint_config = LEMLIST_ENDPOINTS[endpoint]
-            return SourceSchema(
-                name=endpoint,
-                supports_incremental=endpoint_config.supports_incremental,
-                supports_append=endpoint_config.supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=endpoint_config.should_sync_default,
-            )
-
-        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: LemlistSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -128,7 +116,8 @@ You can generate an API key in your lemlist **Settings > Integrations** page."""
         return lemlist_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/lemlist/tests/test_lemlist.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/lemlist/tests/test_lemlist.py
@@ -1,41 +1,80 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist import lemlist
 from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.lemlist import (
     PAGE_SIZE,
     LemlistResumeConfig,
-    _build_params,
-    _build_url,
     _clamp_future_value_to_now,
     _format_incremental_value,
-    get_rows,
     lemlist_source,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.settings import LEMLIST_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the lemlist module.
+LEMLIST_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.lemlist.lemlist.make_tracked_session"
+)
+# tenacity sleeps between retries; patch it so the retryable-path test doesn't actually wait.
+TENACITY_SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResumableManager:
-    def __init__(self, state: LemlistResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[LemlistResumeConfig] = []
+def _response(payload: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp.url = "https://api.lemlist.com/api/probe"
+    resp._content = json.dumps(payload).encode()
+    return resp
 
-    def can_resume(self) -> bool:
-        return self._state is not None
 
-    def load_state(self) -> LemlistResumeConfig | None:
-        return self._state
+def _make_manager(resume_state: LemlistResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def save_state(self, data: LemlistResumeConfig) -> None:
-        self.saved.append(data)
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None, **kwargs: Any):
+    return lemlist_source(
+        api_key="key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        **kwargs,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatIncrementalValue:
@@ -74,149 +113,155 @@ class TestClampFutureValueToNow:
         assert _clamp_future_value_to_now("cursor") == "cursor"
 
 
-class TestBuildParams:
-    def test_campaigns_requests_version_and_stable_sort(self) -> None:
-        params = _build_params(
-            LEMLIST_ENDPOINTS["campaigns"], should_use_incremental_field=False, db_incremental_field_last_value=None
-        )
-        assert params == {"version": "v2", "sortBy": "createdAt", "sortOrder": "asc"}
+class TestRequestParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_campaigns_requests_version_and_stable_sort(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "cam_1"}])])
+        _rows(_source("campaigns"))
+        assert params[0]["version"] == "v2"
+        assert params[0]["sortBy"] == "createdAt"
+        assert params[0]["sortOrder"] == "asc"
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == PAGE_SIZE
 
-    def test_campaigns_never_sends_mindate(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_campaigns_never_sends_mindate(self, MockSession) -> None:
         # Campaigns has no server-side date filter, so even an incremental request must not add minDate.
-        params = _build_params(
-            LEMLIST_ENDPOINTS["campaigns"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 5, 11, tzinfo=UTC),
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "cam_1"}])])
+        _rows(
+            _source(
+                "campaigns",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 5, 11, tzinfo=UTC),
+            )
         )
-        assert "minDate" not in params
+        assert "minDate" not in params[0]
 
-    def test_activities_incremental_sets_mindate(self) -> None:
-        params = _build_params(
-            LEMLIST_ENDPOINTS["activities"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 5, 11, 0, 0, 0, tzinfo=UTC),
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_activities_incremental_sets_mindate(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "act_1"}])])
+        _rows(
+            _source(
+                "activities",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 5, 11, 0, 0, 0, tzinfo=UTC),
+            )
         )
-        assert params["minDate"] == "2026-05-11T00:00:00Z"
-        assert params["version"] == "v2"
+        assert params[0]["minDate"] == "2026-05-11T00:00:00Z"
+        assert params[0]["version"] == "v2"
 
     @freeze_time("2026-06-15T12:00:00Z")
-    def test_activities_first_sync_uses_lookback_window(self) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_activities_first_sync_uses_lookback_window(self, MockSession) -> None:
         # No stored watermark -> bound the first sync by the configured lookback instead of full history.
-        params = _build_params(
-            LEMLIST_ENDPOINTS["activities"], should_use_incremental_field=True, db_incremental_field_last_value=None
-        )
-        assert params["minDate"] == "2025-06-15T12:00:00Z"
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "act_1"}])])
+        _rows(_source("activities", should_use_incremental_field=True, db_incremental_field_last_value=None))
+        assert params[0]["minDate"] == "2025-06-15T12:00:00Z"
 
     @freeze_time("2026-06-15T12:00:00Z")
-    def test_activities_future_watermark_clamped(self) -> None:
-        params = _build_params(
-            LEMLIST_ENDPOINTS["activities"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2027, 1, 1, tzinfo=UTC),
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_activities_future_watermark_clamped(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "act_1"}])])
+        _rows(
+            _source(
+                "activities",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2027, 1, 1, tzinfo=UTC),
+            )
         )
-        assert params["minDate"] == "2026-06-15T12:00:00Z"
+        assert params[0]["minDate"] == "2026-06-15T12:00:00Z"
 
-    def test_activities_full_refresh_has_no_mindate(self) -> None:
-        params = _build_params(
-            LEMLIST_ENDPOINTS["activities"], should_use_incremental_field=False, db_incremental_field_last_value=None
-        )
-        assert "minDate" not in params
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_activities_full_refresh_has_no_mindate(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "act_1"}])])
+        _rows(_source("activities", should_use_incremental_field=False, db_incremental_field_last_value=None))
+        assert "minDate" not in params[0]
 
 
 class TestValidateCredentials:
-    @pytest.mark.parametrize("status_code,expected", [(200, True), (401, False), (404, False)])
-    def test_status_mapping(self, status_code: int, expected: bool, monkeypatch: Any) -> None:
-        response = MagicMock(status_code=status_code)
-        session = MagicMock()
-        session.get.return_value = response
-        monkeypatch.setattr(lemlist, "make_tracked_session", lambda **_: session)
+    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("not_found", 404, False)])
+    @mock.patch(LEMLIST_SESSION_PATCH)
+    def test_status_mapping(self, _name: str, status_code: int, expected: bool, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("key") is expected
 
-    def test_exception_returns_false(self, monkeypatch: Any) -> None:
-        session = MagicMock()
-        session.get.side_effect = requests.ConnectionError()
-        monkeypatch.setattr(lemlist, "make_tracked_session", lambda **_: session)
+    @mock.patch(LEMLIST_SESSION_PATCH)
+    def test_exception_returns_false(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError()
         assert validate_credentials("key") is False
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        endpoint: str, manager: _FakeResumableManager, monkeypatch: Any, pages: dict[str, Any], **kwargs: Any
-    ) -> list[dict]:
-        def fake_fetch(session: Any, url: str, api_key: str, logger: Any) -> Any:
-            result = pages[url]
-            if isinstance(result, Exception):
-                raise result
-            return result
-
-        monkeypatch.setattr(lemlist, "_fetch", fake_fetch)
-
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(batch)
-        return rows
-
-    def _campaigns_url(self, offset: int) -> str:
-        return _build_url(
-            "/campaigns",
-            {"version": "v2", "sortBy": "createdAt", "sortOrder": "asc", "limit": PAGE_SIZE, "offset": offset},
-        )
-
-    def test_single_object_endpoint_wraps_into_one_row(self, monkeypatch: Any) -> None:
-        pages = {_build_url("/team", {}): {"_id": "tea_1", "name": "Acme"}}
-        rows = self._collect("team", _FakeResumableManager(), monkeypatch, pages)
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_object_endpoint_wraps_into_one_row(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"_id": "tea_1", "name": "Acme"})])
+        rows = _rows(_source("team"))
         assert rows == [{"_id": "tea_1", "name": "Acme"}]
+        assert session.send.call_count == 1
 
-    def test_non_paginated_array_endpoint_yields_once(self, monkeypatch: Any) -> None:
-        pages = {_build_url("/team/senders", {}): [{"userId": "usr_1"}, {"userId": "usr_2"}]}
-        rows = self._collect("team_senders", _FakeResumableManager(), monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_array_endpoint_yields_once(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"userId": "usr_1"}, {"userId": "usr_2"}])])
+        rows = _rows(_source("team_senders"))
         assert rows == [{"userId": "usr_1"}, {"userId": "usr_2"}]
+        assert session.send.call_count == 1
 
-    def test_short_first_page_terminates(self, monkeypatch: Any) -> None:
-        pages = {self._campaigns_url(0): [{"_id": "cam_1"}, {"_id": "cam_2"}]}
-        manager = _FakeResumableManager()
-        rows = self._collect("campaigns", manager, monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_terminates(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"_id": "cam_1"}, {"_id": "cam_2"}])])
+        manager = _make_manager()
+        rows = _rows(_source("campaigns", manager))
         assert rows == [{"_id": "cam_1"}, {"_id": "cam_2"}]
+        assert session.send.call_count == 1
         # A short page is the last page, so no resume state is persisted.
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_paginates_until_short_page(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession) -> None:
+        session = MockSession.return_value
         full_page = [{"_id": f"cam_{i}"} for i in range(PAGE_SIZE)]
-        pages = {
-            self._campaigns_url(0): full_page,
-            self._campaigns_url(PAGE_SIZE): [{"_id": "cam_last"}],
-        }
-        manager = _FakeResumableManager()
-        rows = self._collect("campaigns", manager, monkeypatch, pages)
+        params = _wire(session, [_response(full_page), _response([{"_id": "cam_last"}])])
+        manager = _make_manager()
+        rows = _rows(_source("campaigns", manager))
         assert len(rows) == PAGE_SIZE + 1
         assert rows[-1] == {"_id": "cam_last"}
+        assert params[0]["offset"] == 0
+        assert params[1]["offset"] == PAGE_SIZE
         # State is saved once, after the first full page, pointing at the next offset.
-        assert manager.saved == [LemlistResumeConfig(offset=PAGE_SIZE)]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == LemlistResumeConfig(offset=PAGE_SIZE)
 
-    def test_resume_starts_from_saved_offset(self, monkeypatch: Any) -> None:
-        pages = {self._campaigns_url(PAGE_SIZE): [{"_id": "cam_resumed"}]}
-        manager = _FakeResumableManager(LemlistResumeConfig(offset=PAGE_SIZE))
-        rows = self._collect("campaigns", manager, monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_starts_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "cam_resumed"}])])
+        manager = _make_manager(LemlistResumeConfig(offset=PAGE_SIZE))
+        rows = _rows(_source("campaigns", manager))
         assert rows == [{"_id": "cam_resumed"}]
+        assert params[0]["offset"] == PAGE_SIZE
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        pages: dict[str, list[dict[str, Any]]] = {self._campaigns_url(0): []}
-        rows = self._collect("campaigns", _FakeResumableManager(), monkeypatch, pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+        manager = _make_manager()
+        rows = _rows(_source("campaigns", manager))
         assert rows == []
+        manager.save_state.assert_not_called()
 
 
-class TestLemlistSourceResponse:
+class TestSourceResponse:
     def test_activities_response_is_incremental_desc_and_partitioned(self) -> None:
-        response = lemlist_source(
-            api_key="key", endpoint="activities", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source("activities")
         assert response.name == "activities"
         assert response.primary_keys == ["_id"]
         assert response.sort_mode == "desc"
@@ -224,16 +269,12 @@ class TestLemlistSourceResponse:
         assert response.partition_mode == "datetime"
 
     def test_campaigns_response_is_full_refresh_asc(self) -> None:
-        response = lemlist_source(
-            api_key="key", endpoint="campaigns", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source("campaigns")
         assert response.sort_mode == "asc"
         assert response.partition_keys == ["createdAt"]
 
     def test_team_senders_response_has_no_partitioning(self) -> None:
-        response = lemlist_source(
-            api_key="key", endpoint="team_senders", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source("team_senders")
         assert response.primary_keys == ["userId"]
         assert response.partition_keys is None
         assert response.partition_mode is None
@@ -241,18 +282,21 @@ class TestLemlistSourceResponse:
 
 class TestRetryClassification:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status_code: int) -> None:
-        # Call the undecorated function so we assert the classification, not tenacity's retry loop.
-        session = MagicMock()
-        session.get.return_value = MagicMock(status_code=status_code, ok=False)
-        with pytest.raises(lemlist.LemlistRetryableError):
-            lemlist._fetch.__wrapped__(session, "https://api.lemlist.com/api/campaigns", "key", MagicMock())  # type: ignore[attr-defined]
+    @mock.patch(TENACITY_SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(self, _name: str, status_code: int, MockSession, _sleep) -> None:
+        # A 429/5xx is retried by the client; a subsequent success completes the sync.
+        session = MockSession.return_value
+        _wire(session, [_response([], status_code=status_code), _response([{"_id": "cam_1"}])])
+        rows = _rows(_source("campaigns"))
+        assert rows == [{"_id": "cam_1"}]
+        assert session.send.call_count == 2
 
-    def test_client_error_raises_for_status(self) -> None:
-        # A 4xx (other than 429) is a permanent error surfaced via raise_for_status.
-        response = MagicMock(status_code=401, ok=False)
-        response.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=response)
-        session = MagicMock()
-        session.get.return_value = response
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises_and_is_not_retried(self, MockSession) -> None:
+        # A 4xx (other than 429) is a permanent error surfaced via raise_for_status — no retry.
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unauthorized"}, status_code=401)])
         with pytest.raises(requests.HTTPError):
-            lemlist._fetch.__wrapped__(session, "https://api.lemlist.com/api/campaigns", "key", MagicMock())  # type: ignore[attr-defined]
+            _rows(_source("campaigns"))
+        assert session.send.call_count == 1


### PR DESCRIPTION
## Problem

Batch 24 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **justcall**
- **k6_cloud**
- **koyeb**
- **lago**
- **launchdarkly**
- **lemlist**

Not migrated this batch (left hand-rolled, valid blocker):
- **langfuse** — transport-level security for a customer-controlled self-hosted host: dynamic private-IP SSRF resolution (beyond static host-pinning) and streamed body size/time caps; not expressible via the framework client or a local paginator.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 6 migrated dirs + `common/rest_source/tests/` — 470 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-23 PR (#71916); merge in order.
