### PR TITLE
feat(data-warehouse): promote cloudflare source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
@@ -57,7 +57,7 @@ class CloudflareSource(SimpleSource[CloudflareSourceConfig]):
 Create an API token in the [Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens) with read permissions for Account Settings, Zone, and DNS. DNS records are synced from every zone the token can access.""",
             iconPath="/static/services/cloudflare.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/cloudflare",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             fields=cast(
                 list[FieldType],
                 [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_source.py
@@ -23,7 +23,7 @@ class TestCloudflareSource:
 
         assert config.name.value == "Cloudflare"
         assert config.label == "Cloudflare"
-        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.releaseStatus == ReleaseStatus.BETA
         assert config.unreleasedSource is None
         assert config.iconPath == "/static/services/cloudflare.svg"
 


### PR DESCRIPTION
## Problem

The Cloudflare data-warehouse source shipped as alpha. It has now cleared the bar for beta:

- Used by at least 30 teams (currently 42, need ≥ 30).
- Import error rate below 5.0% over the last 7 days (currently 0.3%, need < 5.0%).

## Changes

Set `releaseStatus` from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA` in the Cloudflare source config. This is the value the `/api/public_source_configs/` endpoint surfaces for the source.

No behavior, schema, or sync-logic changes. The source has no `unreleasedSource` flag or `featureFlag` gate, so there was no coupled gating metadata to remove. This is a status label promotion only.

## How did you test this code?

Updated the existing source-config test assertion and ran it:

```
pytest products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_source.py::TestCloudflareSource::test_get_source_config
```

1 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Change requested by @Gilbert09. I (Claude) made the edit after reading the `/implementing-warehouse-sources` skill to confirm the release-status conventions (use the `ReleaseStatus` enum, beta is a soft label on a visible source, no gating flag to touch). Confirmed the only place the stage lives for this source is `releaseStatus` in `get_source_config`, updated it and the matching test, and checked open PRs (including @Gilbert09's own) to rule out a duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
