### PR TITLE
feat(ingestion-consumer): peer awareness via own-service EndpointSlices

### DIFF
--- a/rust/common/k8s-awareness/src/lib.rs
+++ b/rust/common/k8s-awareness/src/lib.rs
@@ -1,6 +1,7 @@
 mod detection;
 mod discovery;
 mod endpoints;
+mod peers;
 pub mod types;
 mod watcher;
 
@@ -9,5 +10,6 @@ pub use discovery::{
     discover_controller, get_pod, list_pods_by_selector, DiscoveredPod, DiscoveryError,
 };
 pub use endpoints::watch_service_members;
+pub use peers::{PeerSet, PeerTracker};
 pub use types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
 pub use watcher::{K8sAwareness, K8sAwarenessError};

--- a/rust/common/k8s-awareness/src/peers.rs
+++ b/rust/common/k8s-awareness/src/peers.rs
@@ -1,0 +1,194 @@
+//! Peer awareness: the ready members of a pod's own Service, in a canonical
+//! order every replica agrees on, plus this pod's position among them.
+//!
+//! A thin consumer of [`crate::watch_service_members`]: each replica follows
+//! its own Service's membership and maintains a [`PeerSet`] snapshot — the
+//! sorted ready peer IPs and this pod's index within them (located via its own
+//! pod IP). Because every replica sees the same EndpointSlices and applies the
+//! same ordering, `(self_index, peer_count)` is a coordination-free agreement,
+//! usable for deterministic subsetting, ring slicing, or any scheme where
+//! replicas must partition work without talking to each other.
+//!
+//! Snapshots are read from hot paths, so they sit behind an `Arc` swap in a
+//! `std::sync::RwLock`: readers clone an `Arc` and never block on the watcher.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::sync::{Arc, RwLock};
+
+use kube::Client;
+use metrics::gauge;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Point-in-time view of a Service's ready members.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PeerSet {
+    /// Ready peer pod IPs, sorted — the canonical order all replicas agree on.
+    pub peers: Vec<IpAddr>,
+    /// This pod's position in `peers`. `None` until this pod is itself a ready
+    /// endpoint (e.g. during startup, or while failing readiness probes).
+    pub self_index: Option<usize>,
+}
+
+impl PeerSet {
+    pub fn peer_count(&self) -> usize {
+        self.peers.len()
+    }
+}
+
+/// Tracks the ready members of one Service. Construct with the pod's own IP,
+/// then drive it from the shared membership watch via [`PeerTracker::watch`],
+/// or apply membership directly with [`PeerTracker::set_peers`] (tests,
+/// non-K8s setups).
+pub struct PeerTracker {
+    self_ip: IpAddr,
+    current: RwLock<Arc<PeerSet>>,
+}
+
+impl PeerTracker {
+    pub fn new(self_ip: IpAddr) -> Arc<Self> {
+        Arc::new(Self {
+            self_ip,
+            current: RwLock::new(Arc::new(PeerSet::default())),
+        })
+    }
+
+    /// The current peer set. Cheap (one `Arc` clone); safe on hot paths.
+    pub fn snapshot(&self) -> Arc<PeerSet> {
+        Arc::clone(&self.current.read().unwrap())
+    }
+
+    /// Replace the peer membership with `addrs`, recomputing order and self
+    /// index.
+    pub fn set_peers(&self, addrs: &HashSet<IpAddr>) {
+        let mut peers: Vec<IpAddr> = addrs.iter().copied().collect();
+        peers.sort_unstable();
+        let self_index = peers.iter().position(|ip| *ip == self.self_ip);
+        *self.current.write().unwrap() = Arc::new(PeerSet { peers, self_index });
+    }
+
+    /// Watch `service_name`'s EndpointSlices in `namespace` and keep this
+    /// tracker in sync until `cancel` fires.
+    pub fn watch(
+        self: &Arc<Self>,
+        client: Client,
+        namespace: String,
+        service_name: String,
+        cancel: CancellationToken,
+    ) -> JoinHandle<()> {
+        let (members, _watch_task) =
+            crate::watch_service_members(client, namespace, service_name.clone(), cancel.clone());
+        self.follow(members, service_name, cancel)
+    }
+
+    /// Apply every update from a membership receiver until `cancel` fires or
+    /// the sender goes away. Split from [`PeerTracker::watch`] so tests can
+    /// drive the loop with a plain channel.
+    pub fn follow(
+        self: &Arc<Self>,
+        mut members: watch::Receiver<HashSet<IpAddr>>,
+        service_name: String,
+        cancel: CancellationToken,
+    ) -> JoinHandle<()> {
+        let tracker = Arc::clone(self);
+        tokio::spawn(async move {
+            let service_label: Arc<str> = Arc::from(service_name.as_str());
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => return,
+                    changed = members.changed() => {
+                        if changed.is_err() {
+                            return;
+                        }
+                        let addrs = members.borrow_and_update().clone();
+                        tracker.set_peers(&addrs);
+                        let set = tracker.snapshot();
+                        gauge!(
+                            "k8s_awareness_peer_count",
+                            "service" => Arc::clone(&service_label),
+                        )
+                        .set(set.peer_count() as f64);
+                        // -1 means "self not (yet) a ready member".
+                        gauge!(
+                            "k8s_awareness_peer_index",
+                            "service" => Arc::clone(&service_label),
+                        )
+                        .set(set.self_index.map_or(-1.0, |i| i as f64));
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::watch as tokio_watch;
+
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn test_set_peers_sorts_canonically_and_locates_self() {
+        // Insertion order must not matter: two replicas fed the same set in a
+        // different order have to agree on every peer's index.
+        let tracker = PeerTracker::new(ip("10.0.0.5"));
+        tracker.set_peers(&HashSet::from([
+            ip("10.0.0.9"),
+            ip("10.0.0.5"),
+            ip("10.0.0.1"),
+        ]));
+
+        let set = tracker.snapshot();
+        assert_eq!(
+            set.peers,
+            vec![ip("10.0.0.1"), ip("10.0.0.5"), ip("10.0.0.9")]
+        );
+        assert_eq!(set.self_index, Some(1));
+        assert_eq!(set.peer_count(), 3);
+    }
+
+    #[test]
+    fn test_self_index_none_until_self_is_ready() {
+        let tracker = PeerTracker::new(ip("10.0.0.5"));
+        tracker.set_peers(&HashSet::from([ip("10.0.0.1"), ip("10.0.0.9")]));
+        assert_eq!(tracker.snapshot().self_index, None);
+
+        // Self becomes a ready endpoint → gains an index.
+        tracker.set_peers(&HashSet::from([
+            ip("10.0.0.1"),
+            ip("10.0.0.9"),
+            ip("10.0.0.5"),
+        ]));
+        assert_eq!(tracker.snapshot().self_index, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_follow_applies_membership_updates() {
+        let tracker = PeerTracker::new(ip("10.0.0.2"));
+        let (tx, rx) = tokio_watch::channel(HashSet::new());
+        let cancel = CancellationToken::new();
+        let handle = tracker.follow(rx, "svc".to_string(), cancel.clone());
+
+        tx.send(HashSet::from([ip("10.0.0.2"), ip("10.0.0.1")]))
+            .unwrap();
+        // The follower runs on the runtime; wait for the update to land.
+        for _ in 0..100 {
+            if tracker.snapshot().peer_count() == 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        let set = tracker.snapshot();
+        assert_eq!(set.peers, vec![ip("10.0.0.1"), ip("10.0.0.2")]);
+        assert_eq!(set.self_index, Some(1));
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+}

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -225,6 +225,20 @@ pub struct Config {
     #[envconfig(from = "INGESTION_ROUTING_STRATEGY", default = "binpack")]
     pub routing_strategy: RoutingStrategy,
 
+    // ---- Peer awareness ----
+    /// Kubernetes Service whose EndpointSlices list this consumer's own peer
+    /// pods. Enables coordination-free peer awareness (each pod's stable index
+    /// among its replicas), the basis for deterministic aperture routing.
+    /// Empty (default) disables it. The Service is looked up in the pod's own
+    /// namespace (`POD_NAMESPACE`).
+    #[envconfig(from = "PEER_SERVICE_NAME", default = "")]
+    pub peer_service_name: String,
+
+    /// This pod's IP from the downward API, used to locate self in the peer
+    /// Service's EndpointSlices. Required when PEER_SERVICE_NAME is set.
+    #[envconfig(from = "POD_IP")]
+    pub pod_ip: Option<String>,
+
     // ---- Worker health / registry ----
     /// How often to probe each worker's /_ready endpoint (milliseconds).
     #[envconfig(default = "5000")]

--- a/rust/ingestion-consumer/src/debug_recorder.rs
+++ b/rust/ingestion-consumer/src/debug_recorder.rs
@@ -176,6 +176,11 @@ pub struct DebugState {
     pub group_id: String,
     pub workers: Vec<WorkerStatus>,
     pub dispatcher: DispatcherLoad,
+    /// This pod's index among its ready peers; `None` while not yet ready or
+    /// when peer awareness is disabled.
+    pub peer_index: Option<usize>,
+    /// Ready peer count; `None` when peer awareness is disabled.
+    pub peer_count: Option<usize>,
     pub events: Vec<DebugEvent>,
 }
 
@@ -186,6 +191,10 @@ pub struct DebugLoad {
     pub group_id: String,
     pub workers: Vec<WorkerStatus>,
     pub dispatcher: DispatcherLoad,
+    /// See [`DebugState::peer_index`].
+    pub peer_index: Option<usize>,
+    /// See [`DebugState::peer_count`].
+    pub peer_count: Option<usize>,
 }
 
 /// Bounded rolling event buffer plus a broadcast channel for live subscribers.

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -225,6 +225,33 @@ async fn async_main(config: Config) -> Result<()> {
     };
     let _discovery_handle = discovery.start(Arc::clone(&registry), discovery_token.clone());
 
+    // Peer awareness: track this consumer's own ready replicas via its
+    // Service's EndpointSlices, giving every pod a stable agreed index among
+    // its peers (the basis for deterministic aperture routing). Fails open:
+    // misconfiguration disables peer awareness rather than blocking startup.
+    let peer_tracker: Option<Arc<k8s_awareness::PeerTracker>> =
+        if config.peer_service_name.is_empty() {
+            None
+        } else if let Some(self_ip) = config.pod_ip.as_deref().and_then(|s| s.parse().ok()) {
+            let client = kube::Client::try_default()
+                .await
+                .context("Failed to create Kubernetes client for peer discovery")?;
+            let tracker = k8s_awareness::PeerTracker::new(self_ip);
+            tracker.watch(
+                client,
+                config.worker_namespace.clone(),
+                config.peer_service_name.clone(),
+                discovery_token.clone(),
+            );
+            Some(tracker)
+        } else {
+            error!(
+                pod_ip = ?config.pod_ip,
+                "PEER_SERVICE_NAME is set but POD_IP is missing or invalid; peer awareness disabled"
+            );
+            None
+        };
+
     // Reap drained workers: once a departed worker has finished its in-flight
     // batches (or hit the drain timeout), remove it from the registry and prune
     // its transport semaphore. No-op in static mode (workers never drain).
@@ -298,6 +325,7 @@ async fn async_main(config: Config) -> Result<()> {
         {
             let registry = Arc::clone(&registry);
             let dispatcher = Arc::clone(&dispatcher);
+            let peer_tracker = peer_tracker.clone();
             let group_id = group_id.clone();
             let secret = Arc::clone(&secret);
             app = app.route(
@@ -310,6 +338,7 @@ async fn async_main(config: Config) -> Result<()> {
                             &group_id,
                             &registry,
                             &dispatcher,
+                            &peer_tracker,
                         )))
                     };
                     ready(result)
@@ -320,6 +349,7 @@ async fn async_main(config: Config) -> Result<()> {
             let recorder = Arc::clone(recorder);
             let registry = Arc::clone(&registry);
             let dispatcher = Arc::clone(&dispatcher);
+            let peer_tracker = peer_tracker.clone();
             let group_id = group_id.clone();
             let secret = Arc::clone(&secret);
             app = app.route(
@@ -328,11 +358,14 @@ async fn async_main(config: Config) -> Result<()> {
                     let result = if !debug_authorized(&headers, &secret) {
                         Err(axum::http::StatusCode::UNAUTHORIZED)
                     } else {
-                        let load = build_debug_load(&group_id, &registry, &dispatcher);
+                        let load =
+                            build_debug_load(&group_id, &registry, &dispatcher, &peer_tracker);
                         Ok(axum::Json(DebugState {
                             group_id: load.group_id,
                             workers: load.workers,
                             dispatcher: load.dispatcher,
+                            peer_index: load.peer_index,
+                            peer_count: load.peer_count,
                             events: recorder.backlog(),
                         }))
                     };
@@ -489,7 +522,15 @@ fn build_debug_load(
     group_id: &str,
     registry: &ingestion_consumer::worker_registry::WorkerRegistry,
     dispatcher: &Dispatcher,
+    peer_tracker: &Option<Arc<k8s_awareness::PeerTracker>>,
 ) -> DebugLoad {
+    let (peer_index, peer_count) = match peer_tracker {
+        Some(tracker) => {
+            let peers = tracker.snapshot();
+            (peers.self_index, Some(peers.peer_count()))
+        }
+        None => (None, None),
+    };
     let dispatcher_load = dispatcher.debug_load();
     let workers = registry
         .health_snapshots()
@@ -516,5 +557,7 @@ fn build_debug_load(
         group_id: group_id.to_string(),
         workers,
         dispatcher: dispatcher_load,
+        peer_index,
+        peer_count,
     }
 }


### PR DESCRIPTION
## Problem

Stacked on #71914. The deterministic-aperture routing work (context in #71890) needs each dispatcher to know its stable position among its own replicas, so the fleet can partition the worker ring without coordinating. Kubernetes offers no downward-API primitive for "index among replicas" or "replica count" on a Deployment, and replica count is dynamic under autoscaling — so membership has to be observed, not injected.

## Changes

- Add `k8s_awareness::PeerTracker`, a thin consumer of the shared membership watch from #71914: it follows the consumer's own Service's EndpointSlices, sorts ready peer IPs canonically, and locates self via the chart-injected `POD_IP`. Every replica computes the same ordering from the same EndpointSlices, so `(self_index, peer_count)` is agreed without peer communication.
- Wire it into the ingestion consumer behind `PEER_SERVICE_NAME` (empty default = disabled). Misconfiguration fails open with an error log rather than blocking startup; `self_index` is `None` until the pod itself is a ready endpoint.
- Surface `peer_index`/`peer_count` in `/debug/load` and `/debug/state`, plus `k8s_awareness_peer_{count,index}` gauges (`peer_index` reports −1 while self is not a ready member).
- No routing behavior changes; enabling in dev needs `PEER_SERVICE_NAME: "ingestion-analytics-main"` in the consumer chart values (Service and EndpointSlice RBAC already exist).

## How did you test this code?

- `cargo test -p k8s-awareness -p ingestion-consumer`, fmt, clippy `--all-targets --all-features`, shear — all clean.
- New tests and the regression each catches: canonical ordering independent of insertion order (two replicas disagreeing on peer indices would silently break ring partitioning); `self_index` staying `None` until self is a ready endpoint (an unready pod claiming a slice); the `follow` loop applying membership updates from the watch channel (subscription wiring silently dropping updates).
- Not manually tested against a live cluster yet; verification plan is deploying to dev and checking each pod reports a distinct stable index covering 0..n-1 via `/debug/state`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Config documented in `config.rs` doc comments; no user-facing docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude Code (Fable 5) implemented it. Part of the deterministic-aperture routing plan (Finagle-style ring slices per dispatcher; a follow-up PR adds the routing strategy itself). Decisions: EndpointSlice-based peer identity was chosen over StatefulSet ordinals (no ordinal source for replica count, plus deployment-model churn) and over deriving slices from Kafka partition assignment (considered, viable, but couples ring logic to the consumer's Kafka membership; may be revisited). An earlier standalone PeerTracker draft duplicated the EndpointSlice watch; José caught it, which led to the #71914 consolidation this PR now builds on. Skills invoked: /writing-tests.
