### PR TITLE
refactor(data-warehouse): migrate less_annoying_crm, linode, mailerlite (batch 25)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/less_annoying_crm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/less_annoying_crm.py
@@ -1,14 +1,18 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
+from typing import Any, Optional
 
-import requests
-import structlog
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.less_annoying_crm.settings import (
     LESS_ANNOYING_CRM_ENDPOINTS,
@@ -26,17 +30,23 @@ PAGE_SIZE = 500
 
 REQUEST_TIMEOUT_SECONDS = 60
 
-logger = structlog.get_logger(__name__)
-
-
-class LessAnnoyingCRMRetryableError(Exception):
-    """Raised for transient failures (429 / 5xx / connection) that are worth retrying."""
-
-
-class LessAnnoyingCRMError(Exception):
-    """Raised for terminal API errors. Carries the API's ErrorDescription so credential/permission
-    failures surface a friendly, matchable message (LACRM returns these as HTTP 400 with a JSON body,
-    not 401/403)."""
+# Errors (including invalid credentials) come back as an envelope carrying ErrorCode / ErrorDescription
+# — as an HTTP 400 body for bad requests, and defensively matched on any status. The 400 + "Invalid
+# credentials" case surfaces a message the source's non-retryable map matches to disable the sync with
+# actionable copy; any other error envelope fails loud rather than silently syncing 0 rows.
+LESS_ANNOYING_CRM_RESPONSE_ACTIONS = [
+    {
+        "status_code": 400,
+        "content": "Invalid credentials",
+        "action": "raise",
+        "message": "Less Annoying CRM API error: Invalid credentials.",
+    },
+    {
+        "content": '"ErrorCode"',
+        "action": "raise",
+        "message": "Less Annoying CRM API returned an error response.",
+    },
+]
 
 
 @dataclasses.dataclass
@@ -46,84 +56,68 @@ class LessAnnoyingCRMResumeConfig:
     page: int = 1
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    # LACRM sends the raw API key as the Authorization header value — no Bearer prefix, no OAuth.
-    return {"Authorization": api_key, "Content-Type": "application/json"}
+class LessAnnoyingCRMPaginator(BasePaginator):
+    """Page paginator for LACRM's RPC API.
+
+    LACRM pages via ``Page`` nested inside the request body's ``Parameters`` object (not a query
+    param), and signals more pages with a body-level ``HasMoreResults`` boolean, falling back to a
+    short-page heuristic when the flag is absent. No built-in paginator writes into a nested body key
+    or reads a boolean has-more flag, so this small subclass carries both plus resume on the page.
+    """
+
+    def __init__(self, page_size: int, page: int = 1) -> None:
+        super().__init__()
+        self.page_size = page_size
+        self.page = page
+
+    def _inject_page(self, request: Request) -> None:
+        if request.json is None:
+            request.json = {}
+        parameters = request.json.setdefault("Parameters", {})
+        parameters["Page"] = self.page
+
+    def init_request(self, request: Request) -> None:
+        self._inject_page(request)
+
+    def update_request(self, request: Request) -> None:
+        self._inject_page(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        records = data or []
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        # LACRM signals more pages via HasMoreResults. Fall back to a short-page heuristic if the flag
+        # is absent so we never loop forever on an endpoint that omits it.
+        has_more = body.get("HasMoreResults") if isinstance(body, dict) else None
+        if has_more is None:
+            has_more = len(records) >= self.page_size
+        if not has_more or not records:
+            self._has_next_page = False
+            return
+        self.page += 1
+        self._has_next_page = True
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.page already points at the next page to fetch (update_state incremented it).
+        return {"page": self.page} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        page = state.get("page")
+        if page is not None:
+            self.page = int(page)
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"LessAnnoyingCRMPaginator(page={self.page})"
 
 
-def _extract_records(data: Any, result_path: list[str]) -> list[dict[str, Any]]:
-    """Walk ``result_path`` to the record collection and normalize it to a list of dicts.
-
-    LACRM returns list endpoints under ``Results`` (or a bare array for users/teams). GetTasks nests
-    its results as an object keyed by id, so a dict at the leaf is expanded to its values."""
-    node = data
-    for key in result_path:
-        if not isinstance(node, dict):
-            return []
-        node = node.get(key)
-    if isinstance(node, dict):
-        return [v for v in node.values() if isinstance(v, dict)]
-    if isinstance(node, list):
-        return [item for item in node if isinstance(item, dict)]
-    return []
-
-
-def _is_error_body(data: Any) -> bool:
-    return isinstance(data, dict) and ("ErrorCode" in data or "ErrorDescription" in data)
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            LessAnnoyingCRMRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _call_function(
-    session: requests.Session,
-    api_key: str,
-    function: str,
-    parameters: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> Any:
-    response = session.post(
-        LESS_ANNOYING_CRM_BASE_URL,
-        headers=_get_headers(api_key),
-        json={"Function": function, "Parameters": parameters},
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise LessAnnoyingCRMRetryableError(
-            f"Less Annoying CRM API error (retryable): status={response.status_code}, function={function}"
-        )
-
-    # Errors (including invalid credentials) come back as HTTP 400 with a JSON body carrying
-    # ErrorCode / ErrorDescription. Surface the description so it can be matched as non-retryable.
-    try:
-        data = response.json()
-    except ValueError:
-        data = None
-
-    if not response.ok or _is_error_body(data):
-        description = data.get("ErrorDescription") if isinstance(data, dict) else None
-        message = description or f"HTTP {response.status_code}"
-        logger.error(f"Less Annoying CRM API error: function={function}, status={response.status_code}, body={message}")
-        raise LessAnnoyingCRMError(f"Less Annoying CRM API error for {function}: {message}")
-
-    return data
-
-
-def _build_parameters(config: LessAnnoyingCRMEndpointConfig, page: int) -> dict[str, Any]:
+def _build_parameters(config: LessAnnoyingCRMEndpointConfig) -> dict[str, Any]:
+    """Build the static ``Parameters`` body for an endpoint. ``Page`` is injected per request by the
+    paginator; everything here is constant for the whole sync."""
     parameters: dict[str, Any] = {}
     if config.paginated:
-        parameters["Page"] = page
         parameters["MaxNumberOfResults"] = PAGE_SIZE
     if config.date_window_params:
         start_param, end_param = config.date_window_params
@@ -140,76 +134,90 @@ def validate_credentials(api_key: str) -> bool:
     """Confirm the API key is genuine with the cheapest possible probe.
 
     ``GetUser`` takes no parameters and always returns the authenticated user, so it validates the
-    key without touching any specific resource's read permissions."""
+    key without touching any specific resource's read permissions. A bad key comes back as HTTP 400
+    with an ErrorCode / ErrorDescription envelope."""
     try:
         session = make_tracked_session(redact_values=(api_key,))
-        data = _call_function(session, api_key, "GetUser", {}, logger=logger)
-        return not _is_error_body(data)
+        response = session.post(
+            LESS_ANNOYING_CRM_BASE_URL,
+            headers={"Authorization": api_key, "Content-Type": "application/json"},
+            json={"Function": "GetUser", "Parameters": {}},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        if response.status_code != 200:
+            return False
+        data = response.json()
+        return not (isinstance(data, dict) and ("ErrorCode" in data or "ErrorDescription" in data))
     except Exception:
         return False
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[LessAnnoyingCRMResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = LESS_ANNOYING_CRM_ENDPOINTS[endpoint]
-    # Redact the key so it can never land in tracked HTTP request/response samples.
-    session = make_tracked_session(redact_values=(api_key,))
-
-    # Non-paginated reference tables (users, teams) are a single call.
-    if not config.paginated:
-        data = _call_function(session, api_key, config.function, _build_parameters(config, page=1), logger)
-        records = _extract_records(data, config.result_path)
-        if records:
-            yield records
-        return
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.page if resume else 1
-
-    while True:
-        data = _call_function(session, api_key, config.function, _build_parameters(config, page), logger)
-        records = _extract_records(data, config.result_path)
-
-        if records:
-            yield records
-
-        # LACRM signals more pages via HasMoreResults. Fall back to a short-page heuristic if the flag
-        # is absent so we never loop forever on an endpoint that omits it.
-        has_more = data.get("HasMoreResults") if isinstance(data, dict) else None
-        if has_more is None:
-            has_more = len(records) >= PAGE_SIZE
-        if not has_more or not records:
-            break
-
-        page += 1
-        # Save AFTER yielding so a crash re-yields the last page rather than skipping it.
-        resumable_source_manager.save_state(LessAnnoyingCRMResumeConfig(page=page))
 
 
 def less_annoying_crm_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[LessAnnoyingCRMResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = LESS_ANNOYING_CRM_ENDPOINTS[endpoint]
 
+    paginator: BasePaginator = (
+        LessAnnoyingCRMPaginator(page_size=PAGE_SIZE) if config.paginated else SinglePagePaginator()
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": LESS_ANNOYING_CRM_BASE_URL,
+            # LACRM sends the raw API key as the Authorization header value (no Bearer prefix). Framework
+            # auth redacts it from logs and error messages; only the non-secret content-type is set here.
+            "headers": {"Content-Type": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "Authorization", "location": "header"},
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": "",
+                    "method": "POST",
+                    "json": {"Function": config.function, "Parameters": _build_parameters(config)},
+                    "data_selector": config.data_selector,
+                    "paginator": paginator,
+                    "response_actions": LESS_ANNOYING_CRM_RESPONSE_ACTIONS,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if config.paginated and resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(LessAnnoyingCRMResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/settings.py
@@ -13,9 +13,11 @@ class LessAnnoyingCRMEndpointConfig:
     name: str
     # LACRM Function name sent in the request body (e.g. "GetContacts").
     function: str
-    # Keys to walk in the JSON response to reach the record collection. An empty list means the
-    # response body is itself the array of records (GetUsers / GetTeams return a bare JSON array).
-    result_path: list[str]
+    # jsonpath selecting the record collection in the response, or None when the body is itself the
+    # array of records (GetUsers / GetTeams return a bare JSON array). List endpoints nest under
+    # "Results"; GetTasks nests its results as an object keyed by id, so it uses "Results.*" to expand
+    # to the dict's values (one row per task) — a bare "Results" would yield the whole object as one row.
+    data_selector: Optional[str]
     primary_keys: list[str]
     # Whether the function pages via Page / MaxNumberOfResults. Small reference tables (users, teams)
     # return everything in one call and reject / ignore pagination params, so they're single-shot.
@@ -46,21 +48,21 @@ LESS_ANNOYING_CRM_ENDPOINTS: dict[str, LessAnnoyingCRMEndpointConfig] = {
     "users": LessAnnoyingCRMEndpointConfig(
         name="users",
         function="GetUsers",
-        result_path=[],
+        data_selector=None,
         primary_keys=["UserId"],
         paginated=False,
     ),
     "teams": LessAnnoyingCRMEndpointConfig(
         name="teams",
         function="GetTeams",
-        result_path=[],
+        data_selector=None,
         primary_keys=["TeamId"],
         paginated=False,
     ),
     "contacts": LessAnnoyingCRMEndpointConfig(
         name="contacts",
         function="GetContacts",
-        result_path=["Results"],
+        data_selector="Results",
         primary_keys=["ContactId"],
         partition_key="DateCreated",
         sort_by="DateCreated",
@@ -69,7 +71,7 @@ LESS_ANNOYING_CRM_ENDPOINTS: dict[str, LessAnnoyingCRMEndpointConfig] = {
     "tasks": LessAnnoyingCRMEndpointConfig(
         name="tasks",
         function="GetTasks",
-        result_path=["Results"],
+        data_selector="Results.*",
         primary_keys=["TaskId"],
         partition_key="DateCreated",
         date_window_params=("StartDate", "EndDate"),
@@ -78,7 +80,7 @@ LESS_ANNOYING_CRM_ENDPOINTS: dict[str, LessAnnoyingCRMEndpointConfig] = {
     "notes": LessAnnoyingCRMEndpointConfig(
         name="notes",
         function="GetNotes",
-        result_path=["Results"],
+        data_selector="Results",
         primary_keys=["NoteId"],
         partition_key="DateCreated",
         sort_direction="Ascending",
@@ -86,7 +88,7 @@ LESS_ANNOYING_CRM_ENDPOINTS: dict[str, LessAnnoyingCRMEndpointConfig] = {
     "events": LessAnnoyingCRMEndpointConfig(
         name="events",
         function="GetEvents",
-        result_path=["Results"],
+        data_selector="Results",
         primary_keys=["EventId"],
         partition_key="DateCreated",
     ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/source.py
@@ -137,6 +137,8 @@ API keys can't be retrieved after creation, so store the key somewhere safe when
         return less_annoying_crm_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every LACRM endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/tests/test_less_annoying_crm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/tests/test_less_annoying_crm.py
@@ -1,19 +1,17 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.less_annoying_crm import less_annoying_crm
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.less_annoying_crm.less_annoying_crm import (
     PAGE_SIZE,
-    LessAnnoyingCRMError,
     LessAnnoyingCRMResumeConfig,
-    LessAnnoyingCRMRetryableError,
-    _build_parameters,
-    _extract_records,
-    _is_error_body,
-    get_rows,
     less_annoying_crm_source,
     validate_credentials,
 )
@@ -22,200 +20,248 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.less_annoy
     LESS_ANNOYING_CRM_ENDPOINTS,
 )
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.less_annoying_crm.less_annoying_crm"
-
-LOGGER = MagicMock()
-
-
-def _response(status_code: int = 200, body: Any = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    if body is None:
-        response.json.side_effect = ValueError("no json")
-    else:
-        response.json.return_value = body
-    return response
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the less_annoying_crm module.
+LACRM_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.less_annoying_crm.less_annoying_crm.make_tracked_session"
+# tenacity sleeps between client retries; patch its clock so the retry test stays fast.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-def _session_returning(*responses: MagicMock) -> MagicMock:
-    session = MagicMock()
-    session.post.side_effect = list(responses)
-    return session
+def _response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
-def _manager(resume: LessAnnoyingCRMResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock(spec=ResumableSourceManager)
-    manager.can_resume.return_value = resume is not None
-    manager.load_state.return_value = resume
+def _make_manager(resume_state: LessAnnoyingCRMResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-class TestExtractRecords:
-    @pytest.mark.parametrize(
-        ("data", "result_path", "expected"),
-        [
-            # Bare top-level array (users / teams).
-            ([{"UserId": "1"}, {"UserId": "2"}], [], [{"UserId": "1"}, {"UserId": "2"}]),
-            # Wrapped list (contacts / notes / events).
-            ({"Results": [{"ContactId": "1"}]}, ["Results"], [{"ContactId": "1"}]),
-            # Object keyed by id (GetTasks) — expand to values.
-            (
-                {"Results": {"a": {"TaskId": "a"}, "b": {"TaskId": "b"}}},
-                ["Results"],
-                [{"TaskId": "a"}, {"TaskId": "b"}],
-            ),
-            # Missing key yields nothing rather than raising.
-            ({"Other": []}, ["Results"], []),
-            # Empty results.
-            ({"Results": []}, ["Results"], []),
-            # Non-collection leaf.
-            ({"Results": "nope"}, ["Results"], []),
-        ],
-    )
-    def test_extract_records(self, data: Any, result_path: list[str], expected: list[dict[str, Any]]) -> None:
-        assert _extract_records(data, result_path) == expected
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's JSON body AT SEND TIME.
+
+    ``request.json`` is a single dict mutated in place across pages (the paginator writes ``Page`` into
+    its nested ``Parameters``), so inspecting it after the run shows only the final state — snapshot a
+    deep copy when each request is prepared instead.
+    """
+    session.headers = {}
+    body_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        body_snapshots.append(json.loads(json.dumps(request.json or {})))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return body_snapshots
 
 
-class TestIsErrorBody:
-    @pytest.mark.parametrize(
-        ("data", "expected"),
-        [
-            ({"ErrorCode": "x", "ErrorDescription": "Invalid credentials."}, True),
-            ({"ErrorDescription": "boom"}, True),
-            ({"Results": []}, False),
-            ([{"UserId": "1"}], False),
-            (None, False),
-        ],
-    )
-    def test_is_error_body(self, data: Any, expected: bool) -> None:
-        assert _is_error_body(data) is expected
+def _source(endpoint: str, manager: mock.MagicMock):
+    return less_annoying_crm_source("secret-key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
 
 
-class TestBuildParameters:
-    def test_paginated_endpoint_sends_page_and_size(self) -> None:
-        params = _build_parameters(LESS_ANNOYING_CRM_ENDPOINTS["contacts"], page=3)
-        assert params["Page"] == 3
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_single_call_reads_bare_array(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(session, [_response([{"UserId": "1"}, {"UserId": "2"}])])
+
+        rows = _rows(_source("users", _make_manager()))
+
+        assert rows == [{"UserId": "1"}, {"UserId": "2"}]
+        assert session.send.call_count == 1
+        # Reference tables send no pagination params.
+        assert bodies[0]["Function"] == "GetUsers"
+        assert bodies[0]["Parameters"] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_when_has_more_results_false(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Results": [{"ContactId": "1"}], "HasMoreResults": False})])
+
+        manager = _make_manager()
+        rows = _rows(_source("contacts", manager))
+
+        assert rows == [{"ContactId": "1"}]
+        assert session.send.call_count == 1
+        # A single terminal page never checkpoints.
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_has_more_false_and_progresses_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(
+            session,
+            [
+                _response({"Results": [{"ContactId": "1"}], "HasMoreResults": True}),
+                _response({"Results": [{"ContactId": "2"}], "HasMoreResults": False}),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("contacts", manager))
+
+        assert rows == [{"ContactId": "1"}, {"ContactId": "2"}]
+        assert bodies[0]["Parameters"]["Page"] == 1
+        assert bodies[1]["Parameters"]["Page"] == 2
+        # Checkpoint saved after the first page (more remained), pointing at page 2.
+        manager.save_state.assert_called_once_with(LessAnnoyingCRMResumeConfig(page=2))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_page_without_flag_terminates(self, MockSession) -> None:
+        session = MockSession.return_value
+        # No HasMoreResults flag and a page shorter than PAGE_SIZE ends pagination via the heuristic.
+        _wire(session, [_response({"Results": [{"ContactId": "1"}]})])
+
+        rows = _rows(_source("contacts", _make_manager()))
+
+        assert rows == [{"ContactId": "1"}]
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(session, [_response({"Results": [{"ContactId": "9"}], "HasMoreResults": False})])
+
+        _rows(_source("contacts", _make_manager(LessAnnoyingCRMResumeConfig(page=4))))
+
+        assert bodies[0]["Parameters"]["Page"] == 4
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Results": [], "HasMoreResults": False})])
+
+        assert _rows(_source("contacts", _make_manager())) == []
+
+
+class TestRequestBody:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_contacts_send_page_size_and_sort(self, MockSession) -> None:
+        session = MockSession.return_value
+        bodies = _wire(session, [_response({"Results": [{"ContactId": "1"}], "HasMoreResults": False})])
+
+        _rows(_source("contacts", _make_manager()))
+
+        params = bodies[0]["Parameters"]
+        assert params["Page"] == 1
         assert params["MaxNumberOfResults"] == PAGE_SIZE
         assert params["SortBy"] == "DateCreated"
         assert params["SortDirection"] == "Ascending"
 
-    def test_non_paginated_endpoint_omits_pagination(self) -> None:
-        params = _build_parameters(LESS_ANNOYING_CRM_ENDPOINTS["users"], page=1)
-        assert "Page" not in params
-        assert "MaxNumberOfResults" not in params
-
-    def test_required_date_window_is_always_sent(self) -> None:
-        params = _build_parameters(LESS_ANNOYING_CRM_ENDPOINTS["tasks"], page=1)
-        assert "StartDate" in params
-        assert "EndDate" in params
-        # A wide window so a full refresh still returns every task.
-        assert params["StartDate"] < params["EndDate"]
-
-
-class TestCallFunction:
-    def test_success_returns_json(self) -> None:
-        session = _session_returning(_response(200, {"Results": [{"ContactId": "1"}]}))
-        data = less_annoying_crm._call_function(session, "key", "GetContacts", {"Page": 1}, LOGGER)
-        assert data == {"Results": [{"ContactId": "1"}]}
-
-    @pytest.mark.parametrize("status", [429, 500, 502, 503])
-    def test_retryable_statuses_raise_retryable(self, status: int) -> None:
-        session = _session_returning(*[_response(status) for _ in range(5)])
-        # Skip tenacity's real backoff sleeps so the test stays fast.
-        with patch("time.sleep"), pytest.raises(LessAnnoyingCRMRetryableError):
-            less_annoying_crm._call_function(session, "key", "GetContacts", {}, LOGGER)
-
-    def test_error_body_surfaces_description(self) -> None:
-        # LACRM returns credential failures as HTTP 400 with a JSON error body.
-        session = _session_returning(
-            _response(400, {"ErrorCode": "x", "ErrorDescription": "Invalid credentials. Please make sure."})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_tasks_send_required_date_window_and_expand_dict_results(self, MockSession) -> None:
+        session = MockSession.return_value
+        # GetTasks nests results as an object keyed by id — every value must become its own row.
+        bodies = _wire(
+            session,
+            [_response({"Results": {"a": {"TaskId": "a"}, "b": {"TaskId": "b"}}, "HasMoreResults": False})],
         )
-        with pytest.raises(LessAnnoyingCRMError, match="Invalid credentials"):
-            less_annoying_crm._call_function(session, "key", "GetUser", {}, LOGGER)
 
-    def test_error_body_on_200_still_raises(self) -> None:
-        session = _session_returning(_response(200, {"ErrorCode": "x", "ErrorDescription": "nope"}))
-        with pytest.raises(LessAnnoyingCRMError):
-            less_annoying_crm._call_function(session, "key", "GetUser", {}, LOGGER)
+        rows = _rows(_source("tasks", _make_manager()))
+
+        assert rows == [{"TaskId": "a"}, {"TaskId": "b"}]
+        params = bodies[0]["Parameters"]
+        assert params["StartDate"] < params["EndDate"]
+        assert params["SortDirection"] == "Ascending"
+        assert "SortBy" not in params
+
+
+class TestErrors:
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    @pytest.mark.parametrize("status", [429, 500, 502, 503])
+    def test_retryable_statuses_raise_retryable(self, MockSession, _sleep, status: int) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"Results": []}, status_code=status) for _ in range(5)])
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source("contacts", _make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_invalid_credentials_body_raises_matchable_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        # LACRM returns a bad key as HTTP 400 with an error envelope. The raised message must contain
+        # "Invalid credentials" so the source's non-retryable map disables the sync with friendly copy.
+        _wire(
+            session,
+            [_response({"ErrorCode": "x", "ErrorDescription": "Invalid credentials. Please check."}, status_code=400)],
+        )
+
+        with pytest.raises(ValueError, match="Invalid credentials"):
+            _rows(_source("contacts", _make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_error_envelope_fails_loud(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A success-status body carrying an error envelope must raise, not silently sync 0 rows.
+        _wire(session, [_response({"ErrorCode": "x", "ErrorDescription": "nope"})])
+
+        with pytest.raises(ValueError):
+            _rows(_source("contacts", _make_manager()))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sync_redacts_the_api_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"UserId": "1"}])])
+
+        _rows(_source("users", _make_manager()))
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("secret-key",)
 
 
 class TestValidateCredentials:
-    def test_valid_key_returns_true(self) -> None:
-        session = _session_returning(_response(200, {"UserId": "1", "Email": "a@b.co"}))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            assert validate_credentials("good-key") is True
+    @mock.patch(LACRM_SESSION_PATCH)
+    def test_valid_key_returns_true(self, mock_session) -> None:
+        mock_session.return_value.post.return_value = _response({"UserId": "1", "Email": "a@b.co"})
+        assert validate_credentials("good-key") is True
 
-    def test_invalid_key_returns_false(self) -> None:
-        session = _session_returning(_response(400, {"ErrorCode": "x", "ErrorDescription": "Invalid credentials."}))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            assert validate_credentials("bad-key") is False
+    @mock.patch(LACRM_SESSION_PATCH)
+    def test_invalid_key_status_returns_false(self, mock_session) -> None:
+        mock_session.return_value.post.return_value = _response(
+            {"ErrorCode": "x", "ErrorDescription": "Invalid credentials."}, status_code=400
+        )
+        assert validate_credentials("bad-key") is False
 
-    def test_probe_redacts_the_api_key(self) -> None:
-        session = _session_returning(_response(200, {"UserId": "1"}))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session) as make_session:
-            validate_credentials("secret-key")
-        assert make_session.call_args.kwargs["redact_values"] == ("secret-key",)
+    @mock.patch(LACRM_SESSION_PATCH)
+    def test_error_body_on_200_returns_false(self, mock_session) -> None:
+        mock_session.return_value.post.return_value = _response({"ErrorCode": "x", "ErrorDescription": "boom"})
+        assert validate_credentials("bad-key") is False
 
+    @mock.patch(LACRM_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
+        mock_session.return_value.post.side_effect = Exception("boom")
+        assert validate_credentials("key") is False
 
-class TestGetRows:
-    def test_sync_redacts_the_api_key(self) -> None:
-        session = _session_returning(_response(200, [{"UserId": "1"}]))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session) as make_session:
-            list(get_rows("secret-key", "users", LOGGER, _manager()))
-        assert make_session.call_args.kwargs["redact_values"] == ("secret-key",)
-
-    def test_non_paginated_single_call(self) -> None:
-        session = _session_returning(_response(200, [{"UserId": "1"}, {"UserId": "2"}]))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            pages = list(get_rows("key", "users", LOGGER, _manager()))
-        assert pages == [[{"UserId": "1"}, {"UserId": "2"}]]
-        assert session.post.call_count == 1
-
-    def test_stops_when_no_more_results(self) -> None:
-        session = _session_returning(_response(200, {"Results": [{"ContactId": "1"}], "HasMoreResults": False}))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            pages = list(get_rows("key", "contacts", LOGGER, _manager()))
-        assert pages == [[{"ContactId": "1"}]]
-        assert session.post.call_count == 1
-
-    def test_paginates_until_has_more_false(self) -> None:
-        page1 = _response(200, {"Results": [{"ContactId": "1"}], "HasMoreResults": True})
-        page2 = _response(200, {"Results": [{"ContactId": "2"}], "HasMoreResults": False})
-        session = _session_returning(page1, page2)
-        manager = _manager()
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            pages = list(get_rows("key", "contacts", LOGGER, manager))
-        assert pages == [[{"ContactId": "1"}], [{"ContactId": "2"}]]
-        # State saved after yielding the first page (more remained), pointing at page 2.
-        assert manager.save_state.call_args_list[0].args[0] == LessAnnoyingCRMResumeConfig(page=2)
-
-    def test_resumes_from_saved_page(self) -> None:
-        session = _session_returning(_response(200, {"Results": [{"ContactId": "9"}], "HasMoreResults": False}))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            list(get_rows("key", "contacts", LOGGER, _manager(LessAnnoyingCRMResumeConfig(page=4))))
-        assert session.post.call_args.kwargs["json"]["Parameters"]["Page"] == 4
-
-    def test_empty_first_page_yields_nothing(self) -> None:
-        session = _session_returning(_response(200, {"Results": [], "HasMoreResults": False}))
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            pages = list(get_rows("key", "contacts", LOGGER, _manager()))
-        assert pages == []
+    @mock.patch(LACRM_SESSION_PATCH)
+    def test_probe_redacts_the_api_key(self, mock_session) -> None:
+        mock_session.return_value.post.return_value = _response({"UserId": "1"})
+        validate_credentials("secret-key")
+        assert mock_session.call_args.kwargs["redact_values"] == ("secret-key",)
 
 
 class TestSourceResponse:
     @pytest.mark.parametrize("endpoint", sorted(ENDPOINTS))
     def test_primary_keys_match_settings(self, endpoint: str) -> None:
-        response = less_annoying_crm_source("key", endpoint, LOGGER, _manager())
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == LESS_ANNOYING_CRM_ENDPOINTS[endpoint].primary_keys
 
     def test_partitioned_endpoint_uses_datetime_mode(self) -> None:
-        response = less_annoying_crm_source("key", "contacts", LOGGER, _manager())
+        response = _source("contacts", _make_manager())
         assert response.partition_mode == "datetime"
         assert response.partition_keys == ["DateCreated"]
 
     def test_reference_table_is_not_partitioned(self) -> None:
-        response = less_annoying_crm_source("key", "users", LOGGER, _manager())
+        response = _source("users", _make_manager())
         assert response.partition_mode is None
         assert response.partition_keys is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/tests/test_less_annoying_crm_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/less_annoying_crm/tests/test_less_annoying_crm_source.py
@@ -95,8 +95,10 @@ class TestLessAnnoyingCRMSource:
         mocked.assert_called_once_with(
             api_key="test-key",
             endpoint="tasks",
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=manager,
+            db_incremental_field_last_value=None,
         )
 
     def test_canonical_descriptions_key_on_endpoint_names(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linode/linode.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linode/linode.py
@@ -1,23 +1,20 @@
 import json
-import random
 import dataclasses
-from collections.abc import Iterator
 from datetime import date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.linode.settings import (
-    LINODE_ENDPOINTS,
-    LinodeEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.linode.settings import LINODE_ENDPOINTS
 
 LINODE_BASE_URL = "https://api.linode.com/v4"
 
@@ -25,26 +22,18 @@ LINODE_BASE_URL = "https://api.linode.com/v4"
 # paginated-GET rate limit.
 PAGE_SIZE = 500
 
-# Cap on how long we honor a rate-limit Retry-After before retrying, so a misreported header can't
-# stall a worker indefinitely. The source iterator runs in a thread pool while the activity heartbeat
-# fires from the event loop, so a 60s wait here does not trip the heartbeat timeout.
-MAX_RETRY_AFTER_SECONDS = 60.0
+
+@dataclasses.dataclass
+class LinodeResumeConfig:
+    # Next page (1-indexed) to fetch. The X-Filter header (built from the run's fixed watermark) and
+    # page_size are constant across a run, so the page number alone is enough to resume.
+    next_page: int
 
 
-class LinodeRetryableError(Exception):
-    """Raised for 429/5xx responses so the tenacity layer retries. Carries the server's Retry-After
-    (seconds) when present so we can wait exactly as long as Linode asks."""
-
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
-
-
-def _get_headers(api_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_token}",
-        "Accept": "application/json",
-    }
+def _accept_headers() -> dict[str, str]:
+    # The Bearer token is supplied via the framework auth config so its value is redacted from logs
+    # and raised errors; only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def _format_filter_value(value: Any) -> Any:
@@ -63,103 +52,47 @@ def _build_x_filter(field: str, value: Any) -> dict[str, Any]:
     """Build the JSON X-Filter body. Always orders ascending on the cursor field so pages arrive in
     the order SourceResponse.sort_mode ("asc") promises; adds a `+gte` bound when a watermark exists.
 
-    The header is sent identically on every page request, so the server applies the filter and order
-    to the full result set — pagination naturally terminates at the watermark, no client-side stop
-    needed (unlike APIs that only window the first page)."""
+    The watermark is fixed for the whole run, so the header is built once and sent identically on
+    every page request — the server applies the filter and order to the full result set, and
+    pagination naturally terminates at the watermark (no client-side stop needed)."""
     x_filter: dict[str, Any] = {"+order_by": field, "+order": "asc"}
     if value is not None:
         x_filter[field] = {"+gte": _format_filter_value(value)}
     return x_filter
 
 
-@dataclasses.dataclass
-class LinodeResumeConfig:
-    # Next page (1-indexed) to fetch. The X-Filter header (built from the run's fixed watermark) and
-    # page_size are constant across a run, so the page number alone is enough to resume.
-    next_page: int
-
-
-def _page_url(path: str, page: int) -> str:
-    return f"{LINODE_BASE_URL}{path}?{urlencode({'page': page, 'page_size': PAGE_SIZE})}"
-
-
 def validate_credentials(api_token: str) -> tuple[bool, str | None]:
     """Confirm the token is genuine by hitting /profile, which any valid token can read regardless of
     its granted scopes — so a token that only has scopes for some endpoints still validates."""
-    try:
-        response = make_tracked_session(redact_values=(api_token,)).get(
-            f"{LINODE_BASE_URL}/profile", headers=_get_headers(api_token), timeout=10
-        )
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
-
-    if response.status_code == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{LINODE_BASE_URL}/profile",
+        headers={"Authorization": f"Bearer {api_token}", **_accept_headers()},
+    )
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status == 401:
         return False, "Invalid Linode API token"
+    if status is None:
+        return False, "Could not reach the Linode API"
     # Don't surface the raw response body: Linode error bodies can echo account/resource details, and
     # this message is persisted on the source. The status code alone is enough to diagnose.
-    return False, f"Linode API returned {response.status_code}"
+    return False, f"Linode API returned {status}"
 
 
-_backoff_wait = wait_exponential_jitter(initial=1, max=30)
-
-
-def _retry_wait(state: RetryCallState) -> float:
-    """Honor Linode's Retry-After on a rate limit (capped, plus jitter), else exponential backoff."""
-    if state.outcome is not None and state.outcome.failed:
-        exc = state.outcome.exception()
-        if isinstance(exc, LinodeRetryableError) and exc.retry_after is not None:
-            return min(float(exc.retry_after), MAX_RETRY_AFTER_SECONDS) + random.uniform(0, 1)
-    return _backoff_wait(state)
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            LinodeRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            # A mid-stream connection break on a chunked body; transient like ConnectionError but not a
-            # subclass of it, so it needs its own entry.
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=_retry_wait,
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        retry_after = response.headers.get("Retry-After")
-        raise LinodeRetryableError(
-            f"Linode API error (retryable): status={response.status_code}, url={url}",
-            retry_after=float(retry_after) if retry_after and retry_after.isdigit() else None,
-        )
-
-    if not response.ok:
-        # Log only status and URL, never response.text: Linode error bodies can echo account, billing,
-        # user, and audit data, and logs sit outside the warehouse table's access controls.
-        logger.error(f"Linode API error: status={response.status_code}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def get_rows(
+def linode_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[LinodeResumeConfig],
     should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
+    db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
-) -> Iterator[Any]:
+) -> SourceResponse:
     config = LINODE_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
 
+    headers = _accept_headers()
     # Attach the X-Filter header for incremental/append endpoints. Honor the user's chosen cursor
     # field, falling back to the endpoint's declared filterable field. On the first sync the watermark
     # is None, so we send only the ordering (no +gte bound) and pull the full available window.
@@ -167,71 +100,59 @@ def get_rows(
         cursor_field = incremental_field or config.incremental_field
         headers["X-Filter"] = json.dumps(_build_x_filter(cursor_field, db_incremental_field_last_value))
 
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-    session = make_tracked_session(redact_values=(api_token,))
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": LINODE_BASE_URL,
+            "headers": headers,
+            "auth": {"type": "bearer", "token": api_token},
+            # Linode returns {data, page, pages, results}; `pages` is the total page count, so the
+            # paginator stops after the last page rather than paying an extra empty-page request.
+            "paginator": PageNumberPaginator(base_page=1, page_param="page", total_path="pages"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"page_size": PAGE_SIZE},
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume.next_page if resume is not None else 1
-    if resume is not None:
-        logger.debug(f"Linode: resuming {endpoint} from page {page}")
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.next_page}
 
-    while True:
-        data = _fetch_page(session, _page_url(config.path, page), headers, logger)
-        items = data.get("data") or []
-        total_pages = data.get("pages") or 1
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; the paginator state already points at the next
+        # unfetched page and is saved AFTER the current page is yielded (and committed downstream), so
+        # a crash resumes at the next page without re-fetching committed rows or skipping any.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(LinodeResumeConfig(next_page=int(state["page"])))
 
-        for item in items:
-            batcher.batch(item)
-            if batcher.should_yield():
-                yield batcher.get_table()
-
-        if page >= total_pages:
-            break
-
-        # Advance the resume checkpoint only once the batcher has fully drained at this page boundary.
-        # The batcher aggregates rows across pages, so anything still buffered belongs to pages at or
-        # before this one and has not been yielded yet (and so not committed downstream). Persisting
-        # next_page while rows are buffered would skip them on resume — permanent loss for append-only
-        # endpoints. Holding the checkpoint until a drained boundary keeps resume at-least-once: a crash
-        # re-fetches from the last fully-committed page rather than dropping rows.
-        if not batcher.should_yield(include_incomplete_chunk=True):
-            resumable_source_manager.save_state(LinodeResumeConfig(next_page=page + 1))
-
-        page += 1
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
-
-def linode_source(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[LinodeResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Optional[Any] = None,
-    incremental_field: str | None = None,
-) -> SourceResponse:
-    endpoint_config: LinodeEndpointConfig = LINODE_ENDPOINTS[endpoint]
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
-        primary_keys=endpoint_config.primary_keys,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
         # The X-Filter header orders results ascending on the cursor field, so rows arrive oldest-first
         # and the watermark advances safely after each batch.
         sort_mode="asc",
         partition_count=1,
         partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="month" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linode/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linode/source.py
@@ -137,7 +137,8 @@ Create a personal access token in the [Linode Cloud Manager](https://cloud.linod
         return linode_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linode/tests/test_linode.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linode/tests/test_linode.py
@@ -1,26 +1,96 @@
 import json
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import Any, Optional
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.linode import linode
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.linode.linode import (
     PAGE_SIZE,
     LinodeResumeConfig,
-    LinodeRetryableError,
     _build_x_filter,
     _format_filter_value,
-    _page_url,
-    get_rows,
     linode_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.linode.settings import LINODE_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the linode module.
+LINODE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.linode.linode.make_tracked_session"
+)
+# Skip tenacity's backoff so retry tests don't actually sleep.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
+
+
+def _response(
+    items: Optional[list[dict[str, Any]]],
+    *,
+    page: int = 1,
+    pages: int = 1,
+    status: int = 200,
+    drop_data: bool = False,
+    content: Optional[bytes] = None,
+) -> Response:
+    resp = Response()
+    resp.status_code = status
+    if content is not None:
+        resp._content = content
+        return resp
+    body: dict[str, Any] = {"page": page, "pages": pages, "results": len(items or [])}
+    if not drop_data:
+        body["data"] = items or []
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: LinodeResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _source(endpoint: str = "volumes", manager: mock.MagicMock | None = None, **kwargs: Any) -> Any:
+    return linode_source(
+        api_token="tok",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager if manager is not None else _make_manager(),
+        **kwargs,
+    )
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatFilterValue:
@@ -65,16 +135,15 @@ class TestValidateCredentials:
         ]
     )
     def test_status_mapping(self, _name: str, status_code: int, expected_valid: bool) -> None:
-        response = MagicMock()
+        response = mock.MagicMock()
         response.status_code = status_code
-        response.text = "body"
-        with patch.object(linode, "make_tracked_session") as mock_session:
+        with mock.patch(LINODE_SESSION_PATCH) as mock_session:
             mock_session.return_value.get.return_value = response
             valid, _message = validate_credentials("tok")
         assert valid is expected_valid
 
     def test_network_error_is_not_valid(self) -> None:
-        with patch.object(linode, "make_tracked_session") as mock_session:
+        with mock.patch(LINODE_SESSION_PATCH) as mock_session:
             mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
             valid, message = validate_credentials("tok")
         assert valid is False
@@ -83,186 +152,177 @@ class TestValidateCredentials:
     def test_token_is_registered_for_redaction(self) -> None:
         # The PAT rides in an Authorization header the value-based scrubber can only mask if the token
         # is registered via redact_values; dropping it would leak the credential into HTTP telemetry.
-        response = MagicMock()
+        response = mock.MagicMock()
         response.status_code = 200
-        with patch.object(linode, "make_tracked_session") as mock_session:
+        with mock.patch(LINODE_SESSION_PATCH) as mock_session:
             mock_session.return_value.get.return_value = response
             validate_credentials("tok")
         assert mock_session.call_args.kwargs["redact_values"] == ("tok",)
 
     def test_error_status_does_not_leak_response_body(self) -> None:
         # Linode error bodies can echo account data; the persisted validation message must not carry it.
-        response = MagicMock()
+        response = mock.MagicMock()
         response.status_code = 500
         response.text = "secret account details"
-        with patch.object(linode, "make_tracked_session") as mock_session:
+        with mock.patch(LINODE_SESSION_PATCH) as mock_session:
             mock_session.return_value.get.return_value = response
             _valid, message = validate_credentials("tok")
         assert message is not None
         assert "secret account details" not in message
 
 
-class TestFetchPageRetries:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status_code: int) -> None:
-        response = MagicMock()
-        response.status_code = status_code
-        response.headers = {"Retry-After": "1"}
-        session = MagicMock()
-        session.get.return_value = response
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_across_all_pages(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response([{"id": 1}, {"id": 2}], page=1, pages=2),
+                _response([{"id": 3}], page=2, pages=2),
+            ],
+        )
 
-        with patch.object(linode._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(LinodeRetryableError):
-                linode._fetch_page(session, "https://api.linode.com/v4/volumes", {}, MagicMock())
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
 
-        # 5 attempts before giving up (reraise=True).
-        assert session.get.call_count == 5
-
-    def test_non_2xx_does_not_log_response_body(self) -> None:
-        # Error bodies can carry account/billing/audit data; logs live outside warehouse access
-        # controls, so a failing sync must not copy the raw body into them.
-        response = MagicMock()
-        response.status_code = 404
-        response.ok = False
-        response.text = "secret account details"
-        response.raise_for_status.side_effect = requests.RequestException("404")
-        session = MagicMock()
-        session.get.return_value = response
-        logger = MagicMock()
-
-        with pytest.raises(requests.RequestException):
-            linode._fetch_page(session, "https://api.linode.com/v4/volumes", {}, logger)
-
-        logged = " ".join(str(call) for call in logger.error.call_args_list)
-        assert "secret account details" not in logged
-
-    def test_transient_error_retried_then_succeeds(self) -> None:
-        good = MagicMock()
-        good.status_code = 200
-        good.ok = True
-        good.json.return_value = {"data": [], "pages": 1}
-        session = MagicMock()
-        session.get.side_effect = [requests.ReadTimeout("slow"), good]
-
-        with patch.object(linode._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            result = linode._fetch_page(session, "https://api.linode.com/v4/volumes", {}, MagicMock())
-
-        assert result == {"data": [], "pages": 1}
-        assert session.get.call_count == 2
-
-
-class _FakeResumableManager:
-    def __init__(self, state: LinodeResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[LinodeResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> LinodeResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: LinodeResumeConfig) -> None:
-        self.saved.append(data)
-
-
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager, pages_by_url: dict[str, Any], endpoint: str = "volumes", **incremental: Any
-    ) -> tuple[list[dict], list[dict[str, str]]]:
-        captured_headers: list[dict[str, str]] = []
-
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            captured_headers.append(dict(headers))
-            return pages_by_url[url]
-
-        rows: list[dict] = []
-        with patch.object(linode, "_fetch_page", fake_fetch):
-            for table in get_rows(
-                api_token="tok",
-                endpoint=endpoint,
-                logger=MagicMock(),
-                resumable_source_manager=manager,  # type: ignore[arg-type]
-                **incremental,
-            ):
-                rows.extend(table.to_pylist())
-        return rows, captured_headers
-
-    def test_paginates_across_all_pages(self) -> None:
-        pages = {
-            _page_url("/volumes", 1): {"data": [{"id": 1}, {"id": 2}], "page": 1, "pages": 2},
-            _page_url("/volumes", 2): {"data": [{"id": 3}], "page": 2, "pages": 2},
-        }
-        rows, _headers = self._collect(_FakeResumableManager(), pages)
         assert [r["id"] for r in rows] == [1, 2, 3]
+        assert params[0]["page"] == 1
+        assert params[0]["page_size"] == PAGE_SIZE
+        assert params[1]["page"] == 2
+        # Checkpoint saved after the first page (points at the next page); the last page ends it.
+        manager.save_state.assert_called_once_with(LinodeResumeConfig(next_page=2))
 
-    def test_resumes_from_saved_page(self) -> None:
-        # Fixtures omit page 1, so resuming anywhere other than page 2 fails loudly with a KeyError.
-        pages = {_page_url("/volumes", 2): {"data": [{"id": 3}], "page": 2, "pages": 2}}
-        rows, _headers = self._collect(_FakeResumableManager(LinodeResumeConfig(next_page=2)), pages)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        # Only page 2 is wired, so resuming anywhere other than page 2 fails loudly (StopIteration).
+        params = _wire(session, [_response([{"id": 3}], page=2, pages=2)])
+
+        manager = _make_manager(LinodeResumeConfig(next_page=2))
+        rows = _rows(_source(manager=manager))
+
+        assert params[0]["page"] == 2
         assert [r["id"] for r in rows] == [3]
 
-    def test_full_refresh_sends_no_x_filter(self) -> None:
-        pages = {_page_url("/volumes", 1): {"data": [{"id": 1}], "page": 1, "pages": 1}}
-        _rows, headers = self._collect(
-            _FakeResumableManager(),
-            pages,
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
-        )
-        assert all("X-Filter" not in h for h in headers)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_sends_no_x_filter(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}], pages=1)])
 
-    def test_incremental_endpoint_attaches_x_filter_with_watermark(self) -> None:
+        _rows(
+            _source(
+                endpoint="volumes",
+                should_use_incremental_field=False,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
+        )
+        assert "X-Filter" not in session.headers
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_endpoint_attaches_x_filter_with_watermark(self, MockSession: mock.MagicMock) -> None:
         # A regression that stops threading the watermark into the X-Filter would silently revert
         # incremental events to a full refresh; assert the id `+gte` bound is present on the request.
-        pages = {_page_url("/account/events", 1): {"data": [{"id": 5}], "page": 1, "pages": 1}}
-        _rows, headers = self._collect(
-            _FakeResumableManager(),
-            pages,
-            endpoint="events",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=4,
-            incremental_field="id",
-        )
-        assert json.loads(headers[0]["X-Filter"]) == {"+order_by": "id", "+order": "asc", "id": {"+gte": 4}}
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 5}], pages=1)])
 
-    def test_page_size_is_maxed(self) -> None:
-        assert f"page_size={PAGE_SIZE}" in _page_url("/volumes", 1)
+        _rows(
+            _source(
+                endpoint="events",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=4,
+                incremental_field="id",
+            )
+        )
+        assert json.loads(session.headers["X-Filter"]) == {"+order_by": "id", "+order": "asc", "id": {"+gte": 4}}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_page_size_is_maxed(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 1}], pages=1)])
+
+        _rows(_source())
+        assert params[0]["page_size"] == PAGE_SIZE
         assert PAGE_SIZE == 500
 
-    def test_sync_session_registers_token_for_redaction(self) -> None:
-        # Same leak surface as validation: the sync session sends the PAT on every paginated request,
-        # so it must register the token for value-based masking.
-        pages = {_page_url("/volumes", 1): {"data": [{"id": 1}], "page": 1, "pages": 1}}
-        with patch.object(linode, "make_tracked_session") as mock_session:
-            self._collect(_FakeResumableManager(), pages)
-        assert mock_session.call_args.kwargs["redact_values"] == ("tok",)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_sync_session_registers_token_for_redaction(self, MockSession: mock.MagicMock) -> None:
+        # The PAT rides on the Authorization header of every paginated request, so it must be
+        # registered for value-based masking in HTTP telemetry.
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}], pages=1)])
 
-    def test_checkpoint_only_advances_past_fully_drained_pages(self) -> None:
-        # The resume checkpoint must never advance past a page while rows from it are still buffered
-        # (unyielded, so uncommitted downstream) — doing so would skip them on resume, permanent loss
-        # for append-only endpoints. chunk_size is 2000, so:
-        #   page 1 (2000 rows) yields one chunk and drains the batcher -> checkpoint page 2.
-        #   page 2 (2001 rows) yields a chunk but leaves a 1-row tail buffered -> must NOT checkpoint.
-        pages = {
-            _page_url("/volumes", 1): {"data": [{"id": i} for i in range(2000)], "page": 1, "pages": 3},
-            _page_url("/volumes", 2): {"data": [{"id": 2000 + i} for i in range(2001)], "page": 2, "pages": 3},
-            _page_url("/volumes", 3): {"data": [{"id": 9001}], "page": 3, "pages": 3},
-        }
-        manager = _FakeResumableManager()
-        rows, _headers = self._collect(manager, pages)
-        assert len(rows) == 4002
-        # Only the drained page-1 boundary checkpoints; the straddling page-2 boundary is held back.
-        assert manager.saved == [LinodeResumeConfig(next_page=2)]
+        _rows(_source())
+        assert MockSession.call_args.kwargs["redact_values"] == ("tok",)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoint_advances_per_committed_page(self, MockSession: mock.MagicMock) -> None:
+        # Each page is yielded (and committed downstream) before its checkpoint is saved, and the
+        # checkpoint points at the NEXT unfetched page — so a crash resumes there without re-fetching
+        # committed rows or skipping any (the guarantee the append-only endpoints rely on). The final
+        # page has no next page, so it saves nothing.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": 1}], page=1, pages=3),
+                _response([{"id": 2}], page=2, pages=3),
+                _response([{"id": 3}], page=3, pages=3),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source(manager=manager))
+
+        assert [r["id"] for r in rows] == [1, 2, 3]
+        assert manager.save_state.call_args_list == [
+            mock.call(LinodeResumeConfig(next_page=2)),
+            mock.call(LinodeResumeConfig(next_page=3)),
+        ]
+
+
+class TestRetries:
+    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_are_retried_then_reraised(
+        self, _name: str, status_code: int, MockSession: mock.MagicMock, _sleep: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, status=status_code, content=b"{}") for _ in range(5)])
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source())
+
+        # 5 attempts before giving up (reraise=True).
+        assert session.send.call_count == 5
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_transient_error_retried_then_succeeds(self, MockSession: mock.MagicMock, _sleep: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, status=500, content=b"{}"), _response([{"id": 1}], pages=1)])
+
+        rows = _rows(_source())
+
+        assert [r["id"] for r in rows] == [1]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_message_excludes_response_body(self, MockSession: mock.MagicMock) -> None:
+        # Error bodies can carry account/billing/audit data; a failing sync must not copy the raw body
+        # into the raised (and later persisted) error message.
+        session = MockSession.return_value
+        _wire(session, [_response(None, status=404, content=b'{"errors":[{"reason":"secret account details"}]}')])
+
+        with pytest.raises(Exception) as exc_info:
+            _rows(_source())
+        assert "secret account details" not in str(exc_info.value)
 
 
 class TestLinodeSource:
     def test_sort_mode_is_ascending(self) -> None:
-        response = linode_source(
-            api_token="tok", endpoint="events", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
-        assert response.sort_mode == "asc"
+        assert _source(endpoint="events").sort_mode == "asc"
 
     @parameterized.expand(
         [
@@ -275,9 +335,7 @@ class TestLinodeSource:
     def test_partitioning_matches_stable_field(
         self, endpoint: str, partition_key: str | None, partitioned: bool
     ) -> None:
-        response = linode_source(
-            api_token="tok", endpoint=endpoint, logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
+        response = _source(endpoint=endpoint)
         if partitioned:
             assert response.partition_keys == [partition_key]
             assert response.partition_mode == "datetime"
@@ -286,8 +344,5 @@ class TestLinodeSource:
             assert response.partition_mode is None
 
     def test_primary_keys_come_from_endpoint_config(self) -> None:
-        response = linode_source(
-            api_token="tok", endpoint="users", logger=MagicMock(), resumable_source_manager=MagicMock()
-        )
-        assert response.primary_keys == ["username"]
+        assert _source(endpoint="users").primary_keys == ["username"]
         assert LINODE_ENDPOINTS["events"].primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/mailerlite.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/mailerlite.py
@@ -1,27 +1,25 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from requests.exceptions import ChunkedEncodingError
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.settings import MAILERLITE_ENDPOINTS
 
 MAILERLITE_BASE_URL = "https://connect.mailerlite.com/api"
 
 # MailerLite caps list endpoints at 100 rows per page; default is 25.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class MailerLiteRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -30,119 +28,102 @@ class MailerLiteResumeConfig:
     next_url: str
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-    }
+class MailerLiteNextUrlPaginator(JSONResponsePaginator):
+    """Follows the absolute ``links.next`` URL MailerLite returns for both cursor (subscribers) and
+    page-number (everything else) pagination — but only while it stays on the canonical MailerLite
+    host. A tampered or compromised response pointing ``next`` off-host is ignored (pagination
+    stops after the current page) so our authenticated request can't be redirected to an internal
+    address and leak the API key carried in the Authorization header. Off-host *resume* URLs are
+    rejected up front by the client's ``allowed_hosts`` guard instead.
+    """
 
+    def __init__(self) -> None:
+        super().__init__(next_url_path="links.next")
 
-def _build_initial_url(path: str) -> str:
-    return f"{MAILERLITE_BASE_URL}{path}?{urlencode({'limit': PAGE_SIZE})}"
-
-
-def validate_credentials(api_key: str, path: str = "/subscribers") -> bool:
-    """Confirm the API key is genuine with one cheap probe against a list endpoint."""
-    url = f"{MAILERLITE_BASE_URL}{path}?{urlencode({'limit': 1})}"
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[MailerLiteResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = MAILERLITE_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url = resume_config.next_url
-        # Guard the persisted resume URL too — only ever saved from a host-pinned `links.next`,
-        # but re-check so a tampered Redis state can't redirect our authenticated request (SSRF).
-        if not url.startswith(MAILERLITE_BASE_URL):
-            raise ValueError(f"MailerLite resume state contains an unexpected URL: {url!r}")
-        logger.debug(f"MailerLite: resuming {endpoint} from URL: {url}")
-    else:
-        url = _build_initial_url(config.path)
-
-    @retry(
-        # ChunkedEncodingError is a transient mid-stream connection drop while reading the
-        # response body (e.g. "Connection broken: InvalidChunkLength"). It subclasses
-        # RequestException directly, not ConnectionError, so it must be listed explicitly to be
-        # retried rather than failing the whole import on a single dropped connection.
-        retry=retry_if_exception_type(
-            (MailerLiteRetryableError, requests.ReadTimeout, requests.ConnectionError, ChunkedEncodingError)
-        ),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise MailerLiteRetryableError(
-                f"MailerLite API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"MailerLite API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-
-        items = data.get("data", [])
-        if items:
-            yield items
-
-        # Both cursor (subscribers) and page-number (everything else) pagination return an
-        # absolute next-page URL in `links.next`, or `None` on the last page.
-        next_url = data.get("links", {}).get("next")
-        if not next_url:
-            break
-
-        # Only follow pagination URLs that stay on the canonical MailerLite host, so a tampered or
-        # compromised API response can't point our authenticated request at an internal address
-        # (SSRF) and leak the API key carried in the Authorization header.
-        if not isinstance(next_url, str) or not next_url.startswith(MAILERLITE_BASE_URL):
-            logger.warning(f"MailerLite: ignoring off-host pagination URL: {next_url!r}")
-            break
-
-        # Save state only after yielding the current page, so a crash re-yields the last page
-        # (merge dedupes on primary key) instead of skipping it.
-        resumable_source_manager.save_state(MailerLiteResumeConfig(next_url=next_url))
-        url = next_url
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if self._has_next_page and (
+            not isinstance(self._next_url, str) or not self._next_url.startswith(MAILERLITE_BASE_URL)
+        ):
+            self._has_next_page = False
+            self._next_url = None
 
 
 def mailerlite_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[MailerLiteResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     endpoint_config = MAILERLITE_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": MAILERLITE_BASE_URL,
+            # Auth (Bearer) goes through the framework auth config so its value is redacted from
+            # logs and raised errors; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": MailerLiteNextUrlPaginator(),
+            # Pin every request — including a seeded resume URL — to the MailerLite host so a
+            # tampered pagination/resume link can't exfiltrate the Authorization header (SSRF).
+            "allowed_hosts": [],
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": endpoint_config.path,
+                    "params": {"limit": PAGE_SIZE},
+                    # Every list response wraps its rows in {"data": [...], "links": {...}, "meta": {...}};
+                    # a missing/empty "data" is a legit zero-row page, not an error.
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(MailerLiteResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=["id"],
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if endpoint_config.partition_key else None,
         partition_format="month" if endpoint_config.partition_key else None,
         partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str, path: str = "/subscribers") -> bool:
+    """Confirm the API key is genuine with one cheap probe against a list endpoint."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{MAILERLITE_BASE_URL}{path}?limit=1",
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import MailerLiteSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite import (
     MailerLiteResumeConfig,
@@ -91,20 +94,9 @@ You can create an API key in your [MailerLite integrations settings](https://das
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        # MailerLite exposes no server-side timestamp filter, so every endpoint is full-refresh only.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # MailerLite exposes no server-side timestamp filter, so every endpoint is full-refresh only
+        # (no incremental fields → build_endpoint_schemas marks each supports_incremental=False).
+        return build_endpoint_schemas(ENDPOINTS, {}, names)
 
     def validate_credentials(
         self, config: MailerLiteSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -128,6 +120,7 @@ You can create an API key in your [MailerLite integrations settings](https://das
         return mailerlite_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/tests/test_mailerlite.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/tests/test_mailerlite.py
@@ -1,5 +1,4 @@
 import json
-from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -8,15 +7,24 @@ from unittest.mock import MagicMock, patch
 from requests import Response
 from requests.exceptions import ChunkedEncodingError, HTTPError
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite import (
     MAILERLITE_BASE_URL,
     MailerLiteResumeConfig,
-    get_rows,
     mailerlite_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.settings import ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the mailerlite module.
+MAILERLITE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite.make_tracked_session"
+)
 
 
 def _make_response(body: dict[str, Any], status_code: int = 200) -> Response:
@@ -27,59 +35,71 @@ def _make_response(body: dict[str, Any], status_code: int = 200) -> Response:
     return resp
 
 
-def _page(items: list[dict[str, Any]], next_url: str | None) -> dict[str, Any]:
-    return {"data": items, "links": {"next": next_url}, "meta": {}}
+def _page(items: list[dict[str, Any]], next_url: str | None) -> Response:
+    return _make_response({"data": items, "links": {"next": next_url}, "meta": {}})
 
 
-def _drive_get_rows(
-    endpoint: str, manager: MagicMock, responses: list[Response]
-) -> tuple[list[list[dict[str, Any]]], list[str]]:
-    """Run get_rows against a mocked tracked session, returning (yielded_batches, fetched_urls)."""
-    fetched_urls: list[str] = []
-    response_iter = iter(responses)
-
-    def fake_get(url: str, *_args: Any, **_kwargs: Any) -> Response:
-        fetched_urls.append(url)
-        return next(response_iter)
-
-    with patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite.make_tracked_session"
-    ) as MockSession:
-        mock_session = MockSession.return_value
-        mock_session.get.side_effect = fake_get
-
-        batches = list(get_rows("test-key", endpoint, MagicMock(), manager))
-        return batches, fetched_urls
+def _make_manager(resume: MailerLiteResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = resume is not None
+    manager.load_state.return_value = resume
+    return manager
 
 
-class TestGetRows:
+def _wire(session: MagicMock, responses: Any) -> list[str]:
+    """Wire a mock session and return the URLs each request is actually sent to.
+
+    ``_check_allowed_host`` reads ``prepared.url``, so prepare_request must return a real
+    ``PreparedRequest`` whose URL reflects the request's URL + params for that page. The
+    next-page URL is followed with an empty params dict, so its ``prepared.url`` echoes the
+    absolute ``links.next`` exactly.
+    """
+    session.headers = {}
+    sent_urls: list[str] = []
+
+    def _prepare(request: Any) -> Any:
+        prepared = request.prepare()
+        sent_urls.append(prepared.url)
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return sent_urls
+
+
+def _run(endpoint: str, manager: MagicMock, responses: Any) -> tuple[list[list[dict[str, Any]]], list[str], MagicMock]:
+    with patch(CLIENT_SESSION_PATCH) as MockSession:
+        session = MockSession.return_value
+        sent_urls = _wire(session, responses)
+        source = mailerlite_source(
+            api_key="test-key", endpoint=endpoint, team_id=1, job_id="j", resumable_source_manager=manager
+        )
+        batches = list(source.items())
+    return batches, sent_urls, session
+
+
+class TestPagination:
     def test_follows_links_next_across_pages(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
         next_url = f"{MAILERLITE_BASE_URL}/subscribers?cursor=abc&limit=100"
-        responses = [
-            _make_response(_page([{"id": "1"}], next_url)),
-            _make_response(_page([{"id": "2"}], None)),
-        ]
+        responses = [_page([{"id": "1"}], next_url), _page([{"id": "2"}], None)]
 
-        batches, fetched_urls = _drive_get_rows("subscribers", manager, responses)
+        batches, sent_urls, _ = _run("subscribers", _make_manager(), responses)
 
         assert batches == [[{"id": "1"}], [{"id": "2"}]]
-        assert fetched_urls[0] == f"{MAILERLITE_BASE_URL}/subscribers?limit=100"
-        assert fetched_urls[1] == next_url
+        assert sent_urls[0] == f"{MAILERLITE_BASE_URL}/subscribers?limit=100"
+        assert sent_urls[1] == next_url
 
     def test_saves_state_after_each_non_terminal_page(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
         next_url_1 = f"{MAILERLITE_BASE_URL}/groups?page=2&limit=100"
         next_url_2 = f"{MAILERLITE_BASE_URL}/groups?page=3&limit=100"
+        manager = _make_manager()
         responses = [
-            _make_response(_page([{"id": "1"}], next_url_1)),
-            _make_response(_page([{"id": "2"}], next_url_2)),
-            _make_response(_page([{"id": "3"}], None)),
+            _page([{"id": "1"}], next_url_1),
+            _page([{"id": "2"}], next_url_2),
+            _page([{"id": "3"}], None),
         ]
 
-        _drive_get_rows("groups", manager, responses)
+        _run("groups", manager, responses)
 
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [
@@ -88,100 +108,39 @@ class TestGetRows:
         ]
 
     def test_terminal_single_page_does_not_save_state(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        responses = [_make_response(_page([{"id": "only"}], None))]
+        manager = _make_manager()
 
-        _drive_get_rows("groups", manager, responses)
+        _run("groups", manager, [_page([{"id": "only"}], None)])
 
         manager.save_state.assert_not_called()
 
     def test_resume_starts_from_saved_url(self) -> None:
         resumed_url = f"{MAILERLITE_BASE_URL}/subscribers?cursor=resumed&limit=100"
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = MailerLiteResumeConfig(next_url=resumed_url)
-        responses = [_make_response(_page([{"id": "9"}], None))]
+        manager = _make_manager(MailerLiteResumeConfig(next_url=resumed_url))
 
-        _, fetched_urls = _drive_get_rows("subscribers", manager, responses)
+        _, sent_urls, _ = _run("subscribers", manager, [_page([{"id": "9"}], None)])
 
-        assert fetched_urls == [resumed_url]
+        assert sent_urls == [resumed_url]
         manager.load_state.assert_called_once()
 
     def test_does_not_load_state_when_cannot_resume(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        responses = [_make_response(_page([{"id": "1"}], None))]
+        manager = _make_manager()
 
-        _drive_get_rows("subscribers", manager, responses)
+        _run("subscribers", manager, [_page([{"id": "1"}], None)])
 
         manager.load_state.assert_not_called()
 
     def test_empty_page_yields_nothing_and_stops(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        responses = [_make_response(_page([], None))]
+        manager = _make_manager()
 
-        batches, _ = _drive_get_rows("groups", manager, responses)
+        batches, _, _ = _run("groups", manager, [_page([], None)])
 
         assert batches == []
         manager.save_state.assert_not_called()
 
-    def test_chunked_encoding_error_is_retried(self) -> None:
-        # A mid-stream connection drop while reading the body raises ChunkedEncodingError, which
-        # must be retried so a single dropped connection doesn't fail the whole import.
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-
-        good_response = _make_response(_page([{"id": "1"}], None))
-        attempts: Iterator[ChunkedEncodingError | Response] = iter(
-            [
-                ChunkedEncodingError("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)"),
-                good_response,
-            ]
-        )
-
-        def fake_get(url: str, *_args: Any, **_kwargs: Any) -> Response:
-            result = next(attempts)
-            if isinstance(result, Exception):
-                raise result
-            return result
-
-        with (
-            patch(
-                "products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite.make_tracked_session"
-            ) as MockSession,
-            patch("tenacity.nap.time.sleep"),
-        ):
-            MockSession.return_value.get.side_effect = fake_get
-            batches = list(get_rows("test-key", "subscribers", MagicMock(), manager))
-
-        assert batches == [[{"id": "1"}]]
-        assert MockSession.return_value.get.call_count == 2
-
-    def test_chunked_encoding_error_eventually_reraises(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-
-        with (
-            patch(
-                "products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite.make_tracked_session"
-            ) as MockSession,
-            patch("tenacity.nap.time.sleep"),
-        ):
-            MockSession.return_value.get.side_effect = ChunkedEncodingError("Connection broken")
-            with pytest.raises(ChunkedEncodingError):
-                list(get_rows("test-key", "subscribers", MagicMock(), manager))
-
-        assert MockSession.return_value.get.call_count == 5
-
     def test_non_retryable_status_raises(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        responses = [_make_response({"message": "Not Found"}, status_code=404)]
-
         with pytest.raises(HTTPError):
-            _drive_get_rows("groups", manager, responses)
+            _run("groups", _make_manager(), [_make_response({"message": "Not Found"}, status_code=404)])
 
     @pytest.mark.parametrize(
         "off_host_url",
@@ -192,24 +151,56 @@ class TestGetRows:
         ],
     )
     def test_off_host_next_url_is_ignored(self, off_host_url: str) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-        responses = [_make_response(_page([{"id": "1"}], off_host_url))]
+        # The custom paginator drops a tampered off-host ``next`` link, so we yield the first page
+        # and stop without ever issuing (or checkpointing) the off-host request.
+        manager = _make_manager()
 
-        batches, fetched_urls = _drive_get_rows("subscribers", manager, responses)
+        batches, sent_urls, _ = _run("subscribers", manager, [_page([{"id": "1"}], off_host_url)])
 
-        # The tampered next URL is dropped: we yield the first page and stop without following it.
         assert batches == [[{"id": "1"}]]
-        assert fetched_urls == [f"{MAILERLITE_BASE_URL}/subscribers?limit=100"]
+        assert sent_urls == [f"{MAILERLITE_BASE_URL}/subscribers?limit=100"]
         manager.save_state.assert_not_called()
 
     def test_off_host_resume_url_raises(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = MailerLiteResumeConfig(next_url="http://169.254.169.254/latest/meta-data/")
+        # A seeded resume URL pointing off-host is rejected by the client's allowed_hosts guard
+        # before the authenticated request leaves the process.
+        manager = _make_manager(MailerLiteResumeConfig(next_url="http://169.254.169.254/latest/meta-data/"))
 
-        with pytest.raises(ValueError, match="unexpected URL"):
-            _drive_get_rows("subscribers", manager, [])
+        with pytest.raises(ValueError, match="disallowed host"):
+            _run("subscribers", manager, [])
+
+
+class TestRetry:
+    def test_chunked_encoding_error_is_retried(self) -> None:
+        # A mid-stream connection drop while reading the body raises ChunkedEncodingError, which the
+        # client reissues so a single dropped connection doesn't fail the whole import.
+        manager = _make_manager()
+        good = _page([{"id": "1"}], None)
+
+        with patch(CLIENT_SESSION_PATCH) as MockSession, patch("tenacity.nap.time.sleep"):
+            session = MockSession.return_value
+            _wire(session, [ChunkedEncodingError("Connection broken: InvalidChunkLength"), good])
+            source = mailerlite_source(
+                api_key="test-key", endpoint="subscribers", team_id=1, job_id="j", resumable_source_manager=manager
+            )
+            batches = list(source.items())
+
+        assert batches == [[{"id": "1"}]]
+        assert session.send.call_count == 2
+
+    def test_chunked_encoding_error_eventually_reraises(self) -> None:
+        manager = _make_manager()
+
+        with patch(CLIENT_SESSION_PATCH) as MockSession, patch("tenacity.nap.time.sleep"):
+            session = MockSession.return_value
+            _wire(session, ChunkedEncodingError("Connection broken"))
+            source = mailerlite_source(
+                api_key="test-key", endpoint="subscribers", team_id=1, job_id="j", resumable_source_manager=manager
+            )
+            with pytest.raises(RESTClientRetryableError):
+                list(source.items())
+
+        assert session.send.call_count == 5
 
 
 class TestValidateCredentials:
@@ -218,23 +209,21 @@ class TestValidateCredentials:
         [(200, True), (401, False), (403, False), (500, False)],
     )
     def test_status_maps_to_bool(self, status_code: int, expected: bool) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite.make_tracked_session"
-        ) as MockSession:
+        with patch(MAILERLITE_SESSION_PATCH) as MockSession:
             MockSession.return_value.get.return_value = _make_response({}, status_code=status_code)
             assert validate_credentials("key") is expected
 
     def test_exception_returns_false(self) -> None:
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.mailerlite.mailerlite.make_tracked_session"
-        ) as MockSession:
+        with patch(MAILERLITE_SESSION_PATCH) as MockSession:
             MockSession.return_value.get.side_effect = Exception("boom")
             assert validate_credentials("key") is False
 
 
-class TestMailerLiteSource:
+class TestMailerLiteSourceResponse:
     def test_partitioned_endpoint_response_shape(self) -> None:
-        response = mailerlite_source("key", "subscribers", MagicMock(), MagicMock(spec=ResumableSourceManager))
+        response = mailerlite_source(
+            api_key="key", endpoint="subscribers", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
 
         assert response.name == "subscribers"
         assert response.primary_keys == ["id"]
@@ -243,7 +232,9 @@ class TestMailerLiteSource:
         assert response.partition_keys == ["created_at"]
 
     def test_unpartitioned_endpoint_has_no_partition(self) -> None:
-        response = mailerlite_source("key", "fields", MagicMock(), MagicMock(spec=ResumableSourceManager))
+        response = mailerlite_source(
+            api_key="key", endpoint="fields", team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
 
         assert response.partition_mode is None
         assert response.partition_format is None
@@ -251,6 +242,8 @@ class TestMailerLiteSource:
 
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_every_endpoint_builds_a_response(self, endpoint: str) -> None:
-        response = mailerlite_source("key", endpoint, MagicMock(), MagicMock(spec=ResumableSourceManager))
+        response = mailerlite_source(
+            api_key="key", endpoint=endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
         assert response.name == endpoint
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/tests/test_mailerlite_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/tests/test_mailerlite_source.py
@@ -80,7 +80,8 @@ class TestMailerLiteSourceClass:
     def test_source_for_pipeline_plumbing(self) -> None:
         inputs = MagicMock(spec=SourceInputs)
         inputs.schema_name = "subscribers"
-        inputs.logger = MagicMock()
+        inputs.team_id = 7
+        inputs.job_id = "job-1"
         manager = MagicMock(spec=ResumableSourceManager)
 
         with patch(
@@ -90,6 +91,7 @@ class TestMailerLiteSourceClass:
             mock_source.assert_called_once_with(
                 api_key="test-key",
                 endpoint="subscribers",
-                logger=inputs.logger,
+                team_id=7,
+                job_id="job-1",
                 resumable_source_manager=manager,
             )


### PR DESCRIPTION
## Problem

Batch 25 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **less_annoying_crm**
- **linode**
- **mailerlite**

Not migrated this batch (left hand-rolled, valid blockers):
- **lob** — client-side incremental watermark guard with early termination (stops before following a non-empty `next_url` once a page predates the watermark).
- **luma** — guests fan-out pins events-page-cursor resume the framework's dependent-resource fan-out can't honor (it re-fetches the whole parent list each run).
- **mailgun** — events endpoint needs client-side watermark early-termination (zero requests inside the consistency-lag window) and a per-sync wall-clock-computed `end` filter param.
- **mistral_ai** — wrapped endpoints defensively accept both `{"data":[...]}` and a bare-array body; dual-shape extraction isn't expressible with a single jsonpath `data_selector`.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 3 migrated dirs + `common/rest_source/tests/` — 291 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-24 PR (#71920); merge in order.
