### PR TITLE
fix(mcp): run eval harness MCP server with renamed dev script

### DIFF
--- a/products/posthog_ai/eval_harness/harness/services.py
+++ b/products/posthog_ai/eval_harness/harness/services.py
@@ -89,7 +89,7 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
     Pointed at the in-process Django live server (which uses the test DB).
     Uses a non-default port to avoid conflicts with a running dev MCP server.
 
-    Runs the Node-native Hono server via ``pnpm dev:hono``. In production the
+    Runs the Node-native Hono server via ``pnpm dev``. In production the
     Cloudflare Worker is now a proxy that forwards to a regional Hono
     deployment, so Hono is what real users hit.
     """
@@ -101,7 +101,7 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
     api_url = live_server_url
 
     # The Hono server reads config directly from process env — no wrangler
-    # --var wiring needed. PORT picks the listen port; the dev:hono script
+    # --var wiring needed. PORT picks the listen port; the dev script
     # bundles via esbuild then spawns Node on the bundle.
     env = {
         **os.environ,
@@ -124,7 +124,7 @@ def start_mcp_server(live_server_url: str) -> Callable[[], None]:
     _, stop = LONG_LIVED_SUBPROCESSES.start(
         name="MCP server",
         port=MCP_PORT,
-        cmd=["pnpm", "dev:hono"],
+        cmd=["pnpm", "dev"],
         cwd=mcp_dir,
         env=env,
         log_prefix="mcp",


### PR DESCRIPTION
## Problem

Every sandboxed eval run currently dies during bootstrap with:

```
SubprocessStartupError: MCP server subprocess exited with code 254 during startup.
```

because the harness starts the MCP server with `pnpm dev:hono`, and that script was renamed to `dev` in #70298. pnpm exits with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "dev:hono" not found`.

## Changes

One-liner in `products/posthog_ai/eval_harness/harness/services.py`: `cmd=["pnpm", "dev"]`, plus the two comment/docstring mentions of the old script name.

## How did you test this code?

Hit the failure on a real `hogli evals eval_governed_metrics --eval <case>` run, applied this change, and the MCP server now boots past the previous exit-254 startup failure. No automated test added: this is a subprocess command string, and the cheapest honest check is the eval harness run that exercises it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code while validating a new data-catalog eval case: the run failed at MCP startup in a fresh worktree, and bisecting the branch state showed `services/mcp/package.json` renamed `dev:hono` to `dev` while the harness kept the old invocation. Kept as a standalone one-line fix so it can land ahead of any eval-content PRs.