### PR TITLE
fix(data-warehouse): partition matomo visits by month, not per row

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/matomo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/matomo.py
@@ -274,8 +274,9 @@ def matomo_source(
             db_incremental_field_last_value=db_incremental_field_last_value,
         ),
         primary_keys=list(config.primary_keys),
-        partition_count=1,
-        partition_size=1,
+        partition_mode=config.partition_mode,
+        partition_keys=config.partition_keys,
+        partition_format=config.partition_format,
         # Visits are fetched ascending by serverTimestamp; report days are
         # walked oldest-first — both cursors only move forward.
         sort_mode="asc",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/settings.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, Optional
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    PartitionFormat,
+    PartitionMode,
+)
 from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
 
 # Reports for recent days change until archiving completes, so incremental
@@ -33,6 +37,12 @@ class MatomoEndpointConfig:
     method: str
     primary_keys: list[str] = field(default_factory=lambda: ["id"])
     incremental_fields: list[IncrementalField] = field(default_factory=list)
+    # Delta partitioning for this endpoint. Left unset (None) means the table is written
+    # unpartitioned — correct for the tiny per-day report tables. `visits` sets a datetime
+    # scheme so merges only touch recent partitions instead of one partition per row.
+    partition_mode: Optional[PartitionMode] = None
+    partition_keys: Optional[list[str]] = None
+    partition_format: Optional[PartitionFormat] = None
 
 
 MATOMO_ENDPOINTS: dict[str, MatomoEndpointConfig] = {
@@ -51,6 +61,12 @@ MATOMO_ENDPOINTS: dict[str, MatomoEndpointConfig] = {
                 "field_type": IncrementalFieldType.Numeric,
             },
         ],
+        # Bucket by ISO week of the visit's server timestamp. idVisit is an incrementing
+        # integer, so without this the pipeline auto-selects numerical mode and (with the old
+        # partition_size=1) created one Delta partition per visit.
+        partition_mode="datetime",
+        partition_keys=["serverTimestamp"],
+        partition_format="week",
     ),
     # Per-day aggregate reports, date-partitioned via period=day&date=...
     # with the day injected as `_date`.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/settings.py
@@ -61,12 +61,14 @@ MATOMO_ENDPOINTS: dict[str, MatomoEndpointConfig] = {
                 "field_type": IncrementalFieldType.Numeric,
             },
         ],
-        # Bucket by ISO week of the visit's server timestamp. idVisit is an incrementing
-        # integer, so without this the pipeline auto-selects numerical mode and (with the old
-        # partition_size=1) created one Delta partition per visit.
+        # Bucket by month of the visit's server timestamp. idVisit is an incrementing integer,
+        # so without this the pipeline auto-selects numerical mode and (with the old
+        # partition_size=1) created one Delta partition per visit. Month is the coarsest tier;
+        # the auto-repartitioner only steps finer (month -> week -> day -> hour), so starting
+        # here gives it the most headroom if a partition ever outgrows the byte budget.
         partition_mode="datetime",
         partition_keys=["serverTimestamp"],
-        partition_format="week",
+        partition_format="month",
     ),
     # Per-day aggregate reports, date-partitioned via period=day&date=...
     # with the day injected as `_date`.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/tests/test_matomo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/tests/test_matomo.py
@@ -289,7 +289,7 @@ class TestMatomoSourceResponse:
         [
             # visits' primary key idVisit is an incrementing int, so it must ship an explicit
             # datetime scheme — otherwise the pipeline buckets one Delta partition per visit.
-            ("visits", "datetime", ["serverTimestamp"], "week"),
+            ("visits", "datetime", ["serverTimestamp"], "month"),
             ("visits_summary", None, None, None),
             ("referrers", None, None, None),
         ],

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/tests/test_matomo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/tests/test_matomo.py
@@ -283,3 +283,23 @@ class TestMatomoSourceResponse:
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
         assert response.sort_mode == "asc"
+
+    @pytest.mark.parametrize(
+        "endpoint,expected_mode,expected_keys,expected_format",
+        [
+            # visits' primary key idVisit is an incrementing int, so it must ship an explicit
+            # datetime scheme — otherwise the pipeline buckets one Delta partition per visit.
+            ("visits", "datetime", ["serverTimestamp"], "week"),
+            ("visits_summary", None, None, None),
+            ("referrers", None, None, None),
+        ],
+    )
+    def test_partition_scheme_per_endpoint(self, endpoint, expected_mode, expected_keys, expected_format):
+        response = matomo_source("https://m.example.com", "1", "token", endpoint, mock.MagicMock(), _make_manager())
+
+        assert response.partition_mode == expected_mode
+        assert response.partition_keys == expected_keys
+        assert response.partition_format == expected_format
+        # partition_size=1 is what caused the per-row explosion; it must never come back.
+        assert response.partition_size is None
+        assert response.partition_count is None


### PR DESCRIPTION
## Problem

A Matomo `visits` sync never finished its first backfill. Runs executed for hours and then got cancelled for overrunning their budget.

Root cause: the Matomo connector hardcoded `partition_count=1, partition_size=1` for every endpoint. For `visits` the primary key is `idVisit`, an incrementing integer, so the partition selector resolves that to **numerical** mode and buckets at `idVisit // 1` — one Delta partition, and one file, per visit. The table became a swarm of single-row partitions, and every merge then enumerates all files' metadata and folds in one row at a time (~0.7s each). At that rate the backfill can't complete before the activity is cancelled, so it never lands.

Two things hid this:

- The partition-size measurement looked tiny because each partition holds a single visit, not because the table was empty.
- The auto-repartitioner only reacts to partitions that are too big in **bytes**, so a "too many tiny partitions" explosion is invisible to it, and Delta compaction can't merge across partition directories.

## Changes

- `visits` now ships an explicit datetime partition scheme keyed on `serverTimestamp` at **monthly** granularity, via the source-level partition overrides `SourceResponse` already supports. Incremental runs (cursored on `serverTimestamp`) touch only the newest month or two instead of one partition per row.
- Dropped the hardcoded `partition_count=1, partition_size=1`. Report endpoints (keyed on `_date`, one row per day) now write unpartitioned, which is correct at their size.

Why month and not a finer tier: the auto-repartitioner only ever steps **finer** (month → week → day → hour), never coarser. Starting at the coarsest tier gives it the most headroom to self-tune if a partition ever exceeds the byte budget, and avoids permanently slicing low-volume instances into many tiny partitions with no way to coalesce.

> [!NOTE]
> This fixes the connector for every Matomo source. Existing `visits` tables carry the old per-`idVisit` physical layout, and the pipeline won't re-layout an existing table in place, so a stuck schema needs a resync with `reset_pipeline=true` to rebuild under the new scheme. Cheap when the table never finished loading.

## How did you test this code?

Automated (run by me, the agent):

- `pytest .../sources/matomo/tests/test_matomo.py` — 30 passed. Added `test_partition_scheme_per_endpoint` asserting `visits` gets `datetime`/`serverTimestamp`/`month` and report endpoints stay unpartitioned, with `partition_size`/`partition_count` both `None`.
- `ruff check` clean; `mypy --cache-fine-grained` clean on the changed modules.

The new test guards the exact regression this PR fixes: if someone reintroduces `partition_size=1` or drops the datetime override, `visits` falls back to per-row partitioning and the test fails. No existing test asserted the partition scheme. I did not run a live backfill against a Matomo instance.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: Luke Belton.

Investigated with Claude (Opus 4.8) in PostHog Code. The debugging started from a hypothesis that partitioning was too coarse (a single md5 bucket forcing whole-table rewrites); reading the job's merge logs flipped it — the real failure was the opposite, one partition per row. Along the way I confirmed the Matomo `visits` incremental strategy itself is sound (bounded `minTimestamp` extraction on last-action time, a finality window larger than the default visit timeout, upsert on `idVisit`), so the fix stayed on the partition scheme rather than the sync logic. Granularity was set to month (over an initial week) so the byte-based auto-repartitioner keeps full room to step finer as needed.

Skills invoked: `/writing-tests` (to gate the regression test).

Not covered here: a separate, apparently-transient object-storage-via-proxy error seen on an earlier run (`proxy authorization required` while loading S3 credentials). If it recurs it's infra, not this code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
