### PR TITLE
fix(data-warehouse): flip cdc snapshot to streaming at load completion on v3

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -825,6 +825,35 @@ def update_sync_type_config_keys(
         return config
 
 
+def mark_initial_sync_complete(schema_id: str | uuid.UUID, team_id: int) -> None:
+    """Mark a schema's first successful sync complete. Shared by the V2 pipelines and the V3 loader.
+
+    On the False→True transition, a CDC schema still in snapshot mode moves to
+    ``cdc_mode="streaming"`` in the same row lock. Callers must only invoke this once the
+    run's data has durably landed in the destination table — the streaming flip is what lets
+    the CDC workflow start enqueuing (and flushing deferred) WAL merge runs, and merges
+    against a half-loaded snapshot corrupt the table. Locked for the same reason as
+    ``update_sync_type_config_keys``: the CDC extract activity appends ``cdc_deferred_runs``
+    to ``sync_type_config`` concurrently, and an unlocked read-modify-write here could
+    clobber a deferred run.
+    """
+    with transaction.atomic():
+        schema = ExternalDataSchema.objects.select_for_update().exclude(deleted=True).get(id=schema_id, team_id=team_id)
+        if schema.initial_sync_complete:
+            return
+
+        schema.initial_sync_complete = True
+        update_fields = ["initial_sync_complete", "updated_at"]
+
+        if schema.is_cdc and schema.cdc_mode == "snapshot":
+            config = schema.sync_type_config or {}
+            config["cdc_mode"] = "streaming"
+            schema.sync_type_config = config
+            update_fields.append("sync_type_config")
+
+        schema.save(update_fields=update_fields)
+
+
 def get_all_schemas_for_source_id(source_id: str, team_id: int):
     return list(ExternalDataSchema.objects.exclude(deleted=True).filter(team_id=team_id, source_id=source_id).all())
 

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -851,7 +851,7 @@ def mark_initial_sync_complete(schema_id: str | uuid.UUID, team_id: int) -> None
             schema.sync_type_config = config
             update_fields.append("sync_type_config")
 
-        schema.save(update_fields=update_fields)
+        schema.save(update_fields=update_fields, skip_activity_log=True)
 
 
 def get_all_schemas_for_source_id(source_id: str, team_id: int):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
@@ -22,7 +22,10 @@ from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.logger import get_logger
 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_schema import (
+    ExternalDataSchema,
+    mark_initial_sync_complete,
+)
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers import (
@@ -120,21 +123,7 @@ async def update_last_synced_at(job_id: str, schema_id: str, team_id: int) -> No
 
 
 async def set_initial_sync_complete(schema_id: str, team_id: int) -> None:
-    @database_sync_to_async_pool
-    def _update():
-        schema = ExternalDataSchema.objects.exclude(deleted=True).get(id=schema_id, team_id=team_id)
-        if not schema.initial_sync_complete:
-            schema.initial_sync_complete = True
-            update_fields = ["initial_sync_complete"]
-
-            # CDC snapshot → streaming transition
-            if schema.is_cdc and schema.cdc_mode == "snapshot":
-                schema.sync_type_config["cdc_mode"] = "streaming"
-                update_fields.append("sync_type_config")
-
-            schema.save(update_fields=update_fields)
-
-    await _update()
+    await database_sync_to_async_pool(mark_initial_sync_complete)(schema_id=schema_id, team_id=team_id)
 
 
 async def validate_schema_and_update_table(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -515,9 +515,7 @@ class PipelineV3(Generic[ResumableData]):
 
         await advance_xmin_state(self._resource, self._schema, self._logger, log_prefix="V3 Pipeline: ")
 
-        # initial_sync_complete (and the CDC snapshot→streaming flip inside it) is set by the
-        # loader's post-load, not here: extraction finishing only means the batches are enqueued,
-        # and CDC streaming must not start until the snapshot's data has landed in Delta.
+        # initial_sync_complete is set by the loader's post-load after data lands in Delta.
 
         await self._logger.ainfo(
             f"V3 Pipeline: Extraction complete",

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -69,7 +69,6 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     observe_and_project_table,
     source_uses_delta_write_column_selection,
 )
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import set_initial_sync_complete
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.metrics import (
     get_batches_produced_metric,
     get_pipeline_run_duration_metric,
@@ -516,9 +515,9 @@ class PipelineV3(Generic[ResumableData]):
 
         await advance_xmin_state(self._resource, self._schema, self._logger, log_prefix="V3 Pipeline: ")
 
-        if not self._schema.initial_sync_complete:
-            await self._logger.adebug("V3 Pipeline: Setting initial_sync_complete on schema")
-            await set_initial_sync_complete(schema_id=self._schema.id, team_id=self._job.team_id)
+        # initial_sync_complete (and the CDC snapshot→streaming flip inside it) is set by the
+        # loader's post-load, not here: extraction finishing only means the batches are enqueued,
+        # and CDC streaming must not start until the snapshot's data has landed in Delta.
 
         await self._logger.ainfo(
             f"V3 Pipeline: Extraction complete",

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -18,6 +18,7 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import (
     ExternalDataSchema,
     apply_incremental_lookback,
+    mark_initial_sync_complete,
     process_incremental_value,
     update_sync_type_config_keys,
 )
@@ -373,6 +374,90 @@ class TestUpdateSyncTypeConfigKeys(BaseTest):
         assert stale.sync_type_config["cdc_last_log_position"] == "0/100"  # the copy really was stale
         schema.refresh_from_db()
         assert schema.sync_type_config["cdc_last_log_position"] == "0/900"
+
+
+class TestMarkInitialSyncComplete(BaseTest):
+    """The shared first-sync-complete transition (V2 pipelines + V3 loader post-load), whose
+    False→True edge is what moves a CDC schema out of snapshot mode into streaming."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Postgres",
+        )
+
+    def _create(
+        self, sync_type: str, sync_type_config: dict, *, initial_sync_complete: bool = False
+    ) -> ExternalDataSchema:
+        return ExternalDataSchema.objects.create(
+            team_id=self.team.pk,
+            source=self.source,
+            name="users",
+            sync_type=sync_type,
+            sync_type_config=sync_type_config,
+            initial_sync_complete=initial_sync_complete,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                # First completion of a CDC snapshot flips it to streaming; keys written
+                # concurrently by the CDC extract activity (deferred runs) must survive the flip.
+                "cdc_snapshot_flips_to_streaming_preserving_other_keys",
+                "cdc",
+                {"cdc_mode": "snapshot", "cdc_deferred_runs": [{"run_uuid": "a"}], "dwh_storage_key": "users"},
+                False,
+                True,
+                {"cdc_mode": "streaming", "cdc_deferred_runs": [{"run_uuid": "a"}], "dwh_storage_key": "users"},
+            ),
+            (
+                # Already-streaming CDC schema (re-run after a reset) completes without a config rewrite.
+                "cdc_already_streaming_config_unchanged",
+                "cdc",
+                {"cdc_mode": "streaming"},
+                False,
+                True,
+                {"cdc_mode": "streaming"},
+            ),
+            (
+                # Non-CDC schemas must never get a cdc_mode key injected.
+                "non_cdc_config_untouched",
+                "incremental",
+                {"incremental_field": "id"},
+                False,
+                True,
+                {"incremental_field": "id"},
+            ),
+            (
+                # Only the False→True transition flips: a schema manually put back into snapshot
+                # mode must not be flipped to streaming by a later run's completion.
+                "already_complete_is_noop_even_in_snapshot_mode",
+                "cdc",
+                {"cdc_mode": "snapshot"},
+                True,
+                True,
+                {"cdc_mode": "snapshot"},
+            ),
+        ]
+    )
+    def test_transition(
+        self,
+        _name: str,
+        sync_type: str,
+        config: dict,
+        initial_flag: bool,
+        expected_flag: bool,
+        expected_config: dict,
+    ) -> None:
+        schema = self._create(sync_type, config, initial_sync_complete=initial_flag)
+        mark_initial_sync_complete(schema.id, self.team.pk)
+        schema.refresh_from_db()
+        assert schema.initial_sync_complete == expected_flag
+        assert schema.sync_type_config == expected_config
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

When change data capture is enabled on a schema, it starts in `cdc_mode="snapshot"`: the initial full table load runs as a regular sync job, and WAL changes read in the meantime are written to S3 but their queue notifications are deferred into `sync_type_config["cdc_deferred_runs"]`. Only once the schema flips to `cdc_mode="streaming"` does the CDC workflow flush those deferred runs and start enqueuing live merges. That flip is what guarantees CDC merges never run against a half-loaded table.

On the V2 pipeline the flip happens inside `set_initial_sync_complete`, called at the end of the (synchronous, extract-equals-load) pipeline run, so it fires after the data has landed.

On the V3 pipeline extract and load are decoupled, but the extract-side finalization also called `set_initial_sync_complete` right after enqueuing the final batch. That flips the schema to streaming while the snapshot batches are still sitting in the Postgres queue, possibly long before the loader commits them to Delta. Two concrete failure modes:

- the CDC workflow's next cycle sees `streaming` plus deferred runs and flushes WAL merge runs into the queue while snapshot batches are still loading, and queue ordering across runs is best-effort only (a `waiting_retry` backoff on a snapshot batch lets a merge run's batch through), so an `incremental_merge` can execute against a partially seeded table
- a Temporal retry of the extract activity after the early flip hits the `CDCHandledExternally` short-circuit ("streaming mode - handled by CDCExtractionWorkflow") and the run completes green without the snapshot ever landing

## Changes

```mermaid
flowchart LR
    E1{{V3 extract}} --> Q1[postgres queue] --> L1{{V3 loader}} --> D1[delta table]
    E1 -. flips cdc_mode too early .-> S1[schema: streaming]
    S1 -. deferred WAL runs flushed .-> Q1
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class E1,L1 phBlue;
    class S1 phRed;
    class Q1,D1 phGray;
```

```mermaid
flowchart LR
    E2{{V3 extract}} --> Q2[postgres queue] --> L2{{V3 loader}} --> D2[delta table]
    L2 -- post-load, data landed --> S2[schema: streaming]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class E2,L2 phBlue;
    class S2 phYellow;
    class Q2,D2 phGray;
```

- Extracted the transition into a shared `mark_initial_sync_complete` in `models/external_data_schema.py`, next to `update_sync_type_config_keys` and using the same `select_for_update` row lock. The old implementation was an unlocked read-modify-write of `sync_type_config`, racing the CDC extract activity's concurrent `cdc_deferred_runs` appends (a lost update there silently drops a deferred WAL run). The transition-only semantics are unchanged: the flip fires only on the False→True edge of `initial_sync_complete`.
- `pipeline_sync.set_initial_sync_complete` is now a thin async wrapper over the shared helper, so the V2 non-dlt pipeline and the shared post-load (`common/load.py`, which the V3 loader runs on the final batch) keep their existing call sites.
- Removed the extract-side call from the V3 pipeline finalization. On V3 the transition now happens exactly once, in the loader's post-load, after the Delta commit, compaction, and table registration.

> [!NOTE]
> Historically CDC snapshots ran on the V2 pipeline, where the timing was correct, which is why this hasn't bitten yet: 14 days of production queue data contain zero snapshot batches from CDC schemas. As the V3 rollout flag ramps, new CDC enablements start snapshotting through V3, which makes this timing fix a prerequisite for CDC-on-V3 onboarding.

## How did you test this code?

Added `TestMarkInitialSyncComplete` (4 parameterized cases) in `products/warehouse_sources/backend/tests/test_models.py`. Regressions each case catches, which no existing test covered (nothing pinned `set_initial_sync_complete` at all):

- `cdc_snapshot_flips_to_streaming_preserving_other_keys`: removing the CDC branch (schema stuck in snapshot forever) or regressing to a wholesale config replace that drops concurrently written `cdc_deferred_runs`
- `cdc_already_streaming_config_unchanged`: an unconditional config rewrite on re-runs
- `non_cdc_config_untouched`: injecting `cdc_mode` into non-CDC schemas
- `already_complete_is_noop_even_in_snapshot_mode`: dropping the transition guard, so a later run's completion would flip a schema that was deliberately put back into snapshot mode

Ran the new tests plus the adjacent suites (`test_models.py`, `pipeline_v3/test_pipeline.py`, `common/test/test_load.py`): 105 passed. I did not test this manually against a live CDC source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change; internal pipeline timing fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: `/writing-tests` (test gate), `hogli ci:preflight --fix` before pushing. The bug was found while investigating whether the V3 loader should get a CDC-dedicated consumer fleet: tracing how snapshot-before-streaming ordering is enforced showed the only `cdc_mode` writer lived in the V2 pipeline, and the V3 extract finalization called the same helper too early. I first assumed the flip never fired on V3 at all; reading the call sites corrected that to "fires at extract time, before load", which is the version this PR fixes. Considered adding a mock-based test asserting the V3 finalize no longer calls the helper, and rejected it as vacuous choreography (the function is no longer referenced there); the constraint is documented with a comment at the former call site instead.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*