### PR TITLE
fix(insights): stop month/quarter/year intervals including events before date_from

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_boxplot_trends_query_runner.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_boxplot_trends_query_runner.ambr
@@ -279,7 +279,7 @@
          max(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS max_val,
          avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS mean_val
   FROM events AS e
-  WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2023-10-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2023-12-31 23:59:59', 'UTC'))))
+  WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2023-10-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2023-12-31 23:59:59', 'UTC'))))
   GROUP BY day_start
   ORDER BY day_start ASC
   LIMIT 100 SETTINGS readonly=2,
@@ -306,7 +306,7 @@
          max(accurateCastOrNull(if(notEquals(toJSONString(e.properties.^revenue), '{}'), toJSONString(e.properties.^revenue), if(isNull(e.properties.revenue), NULL, if(startsWith(dynamicType(e.properties.revenue), 'DateTime'), replaceOne(toString(e.properties.revenue), ' ', 'T'), if(or(startsWith(dynamicType(e.properties.revenue), 'Array'), startsWith(dynamicType(e.properties.revenue), 'Map'), startsWith(dynamicType(e.properties.revenue), 'Tuple')), toJSONString(e.properties.revenue), toString(e.properties.revenue))))), 'Float64')) AS max_val,
          avg(accurateCastOrNull(if(notEquals(toJSONString(e.properties.^revenue), '{}'), toJSONString(e.properties.^revenue), if(isNull(e.properties.revenue), NULL, if(startsWith(dynamicType(e.properties.revenue), 'DateTime'), replaceOne(toString(e.properties.revenue), ' ', 'T'), if(or(startsWith(dynamicType(e.properties.revenue), 'Array'), startsWith(dynamicType(e.properties.revenue), 'Map'), startsWith(dynamicType(e.properties.revenue), 'Tuple')), toJSONString(e.properties.revenue), toString(e.properties.revenue))))), 'Float64')) AS mean_val
   FROM events_json AS e
-  WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2023-10-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2023-12-31 23:59:59', 'UTC'))))
+  WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2023-10-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2023-12-31 23:59:59', 'UTC'))))
   GROUP BY day_start
   ORDER BY day_start ASC
   LIMIT 100 SETTINGS readonly=2,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_slope_graph_trends_query_runner.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_slope_graph_trends_query_runner.ambr
@@ -267,7 +267,7 @@
        (SELECT count() AS total,
                toStartOfMonth(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-03-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-01-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-02-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-31 23:59:59', 6, 'UTC')))))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-03-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-01-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-02-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-31 23:59:59', 6, 'UTC')))))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -298,7 +298,7 @@
        (SELECT count() AS total,
                toStartOfMonth(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events_json AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-03-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-01-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-02-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-31 23:59:59', 6, 'UTC')))))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-03-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-01-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-02-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-03-31 23:59:59', 6, 'UTC')))))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -453,7 +453,7 @@
        (SELECT count() AS total,
                toStartOfMonth(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-04-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-06-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-04-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-15 23:59:59', 6, 'UTC')))))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-04-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-06-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-04-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-15 23:59:59', 6, 'UTC')))))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -484,7 +484,7 @@
        (SELECT count() AS total,
                toStartOfMonth(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events_json AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-04-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-06-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-04-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-15 23:59:59', 6, 'UTC')))))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-04-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-06-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-04-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-15 23:59:59', 6, 'UTC')))))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -927,7 +927,7 @@
        (SELECT count() AS total,
                toStartOfMonth(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-05-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-05-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-31 23:59:59', 6, 'UTC')))))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-05-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-05-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-31 23:59:59', 6, 'UTC')))))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -958,7 +958,7 @@
        (SELECT count() AS total,
                toStartOfMonth(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events_json AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-05-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-05-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-31 23:59:59', 6, 'UTC')))))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2024-05-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2024-05-31 23:59:59', 'UTC'))), equals(e.event, '$pageview'), or(and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), less(e.timestamp, parseDateTime64BestEffortOrNull('2024-06-01 00:00:00', 6, 'UTC'))), and(greaterOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-01 00:00:00', 6, 'UTC')), lessOrEquals(e.timestamp, parseDateTime64BestEffortOrNull('2024-05-31 23:59:59', 6, 'UTC')))))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -2404,7 +2404,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         self._test_events_with_dates(
             dates=["2020-06-2", "2020-07-30"],
             interval="month",
-            date_from="2020-6-7",  # should round down to 6-1
+            date_from="2020-6-7",  # rounds labels down to 6-1 but only includes events on or after date_from
             date_to="2020-7-30",
             result=[
                 {
@@ -2421,8 +2421,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                         "properties": [],
                     },
                     "label": "event_name",
-                    "count": 2.0,
-                    "data": [1.0, 1.0],
+                    "count": 1.0,
+                    "data": [0.0, 1.0],
                     "labels": ["Jun 2020", "Jul 2020"],
                     "days": ["2020-06-01", "2020-07-01"],
                 }

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -7072,7 +7072,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
         flush_persons_and_events()
 
-        # Test 1: Without explicitDate, filtering last 7 days with monthly interval includes entire month
+        # Test 1: Without explicitDate, filtering last 7 days with monthly interval only includes events in range
         with freeze_time("2020-01-31 23:59:59"):
             response_default = TrendsQueryRunner(
                 query=TrendsQuery(
@@ -7085,9 +7085,9 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(1, len(response_default.results))
         self.assertEqual(
-            31,
+            8,
             response_default.results[0]["count"],
-            "Without explicitDate, includes entire month due to interval boundary adjustment",
+            "Without explicitDate, only includes events within the date range, not the entire month",
         )
 
         # Test 2: With explicitDate=True and explicit dates, STILL has issues (gets 6 instead of 7)

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -365,15 +365,17 @@ class QueryDateRange:
         return self.date_to_start_of_interval_hogql(self.date_from_as_hogql())
 
     def date_from_with_adjusted_start_of_interval_hogql(self) -> ast.Call:
-        if self.interval_name == "week":
-            # in `where` queries with week intervals, we need to return the date_from instead of the start of the week
-            # this ensures that we only fetch records after the date_from
+        if self.interval_name in ("week", "month", "quarter", "year"):
+            # in `where` queries with intervals coarser than a day, filter from the start of `date_from`'s day
+            # rather than the start of the interval bucket. This ensures we only fetch records at or after
+            # date_from, matching how the day interval already behaves and keeping grouped totals consistent
+            # with the selected date range.
             return ast.Call(
                 name="toStartOfInterval",
                 args=[
                     self.date_from_as_hogql(),
                     ast.Call(
-                        name=f"toIntervalDay",
+                        name="toIntervalDay",
                         args=[ast.Constant(value=1)],
                     ),
                 ],

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -118,6 +118,29 @@ class TestQueryDateRange(APIBaseTest):
 
     @parameterized.expand(
         [
+            ("week", IntervalType.WEEK),
+            ("month", IntervalType.MONTH),
+            ("quarter", IntervalType.QUARTER),
+            ("year", IntervalType.YEAR),
+        ]
+    )
+    def test_adjusted_start_of_interval_filters_from_start_of_day(self, _name, interval):
+        # For intervals coarser than a day, the WHERE lower bound must round `date_from` down to the start of
+        # its day, not the start of the interval bucket — otherwise a relative range shorter than the bucket
+        # (e.g. "last 7 days" grouped by month) pulls in events from before date_from. Guards against the guard
+        # being narrowed to only some of these intervals again.
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        adjusted = QueryDateRange(
+            team=self.team, date_range=DateRange(date_from="-3d"), interval=interval, now=now
+        ).date_from_with_adjusted_start_of_interval_hogql()
+
+        self.assertEqual(adjusted.name, "toStartOfInterval")
+        interval_period = adjusted.args[1]
+        assert isinstance(interval_period, ast.Call)
+        self.assertEqual(interval_period.name, "toIntervalDay")
+
+    @parameterized.expand(
+        [
             # now is 2021-08-25T10:00Z (a Wednesday): clip to the end of the last complete interval
             ("day", IntervalType.DAY, "-7d", "2021-08-24T23:59:59.999999Z"),
             ("week_sunday_start", IntervalType.WEEK, "-30d", "2021-08-21T23:59:59.999999Z"),


### PR DESCRIPTION
## Problem

A trend insight grouped by **month** (also **quarter** / **year**) didn't respect the date range when the range was shorter than the bucket. For a relative range like "last 7 days" grouped by month, the `WHERE` clause rounded `date_from` back to the start of the interval bucket (the 1st of the month), so events from before `date_from` were counted. The grouped total then disagreed with a table view of the same range.

Weeks were already fixed for exactly this in [#36803](https://github.com/PostHog/posthog/pull/53711) — the guard just never got generalized to the coarser intervals. A previous attempt ([#53711](https://github.com/PostHog/posthog/pull/53711)) was reverted in [#53739](https://github.com/PostHog/posthog/pull/53739); this redoes it and additionally covers quarter (which #53711 missed).

Context: [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1784285277644629?thread_ts=1784285277.644629&cid=C0368RPHLQH).

## Changes

- Generalize the week guard in `date_from_with_adjusted_start_of_interval_hogql` to cover **week / month / quarter / year**: the `WHERE` lower bound now truncates to the start of `date_from`'s day rather than the start of the interval bucket, matching how the day interval already behaves.
- Explicitly calendar-picked dates are unaffected — they set `explicitDate`, which bypasses the start-of-interval adjustment, so only relative ranges change.

Note the bucket *label* still comes from the start of the interval (e.g. the first bar reads "Jul"), while the data is filtered from `date_from` — the same partial-leading-bucket behavior weeks already have, now applied consistently.

## How did you test this code?

I (the agent) could not run the ClickHouse-backed suite or regenerate snapshots in this environment (no local ClickHouse/pytest). Automated changes made:

- Added a parameterized unit test in `test_query_date_range.py` asserting the adjusted lower bound uses day granularity (`toIntervalDay`) for week/month/quarter/year — guards against the guard being narrowed back to a subset of intervals (the exact gap #53711 shipped).
- Updated two existing behavior tests (`test_trends.py`, `test_trends_query_runner.py`) that asserted the old over-counting behavior, mirroring the corrected expectations from #53711.
- `ruff check` / `ruff format` pass; all four Python files compile.

The `.ambr` snapshot files that render month-interval `WHERE` clauses (`toIntervalMonth(1)` → `toIntervalDay(1)`) still need regeneration — expected to be handled by the snapshot-regeneration CI bot, as on #53711.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Opus 4.8) at @sampennington's direction from a Slack thread. Investigated the revert history of #53711/#53739 and the original week fix (#36803) to confirm the mechanism, then generalized the guard rather than re-patching a single interval. Invoked the repo `/writing-tests` skill before touching tests; chose a cheap unit-level SQL-generation assertion over duplicating the expensive ClickHouse-backed interval test for quarter/year. Snapshot regeneration deferred to CI.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1784285277644629?thread_ts=1784285277.644629&cid=C0368RPHLQH)*
