### PR TITLE
feat(tasks): add negotiated cloud steering commands

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2568,6 +2568,7 @@ def signal_task_run_user_message(
     actor_user_id: int | None = None,
     message_id: str | None = None,
     actor_slack_user_id: str | None = None,
+    steer: bool = False,
 ) -> bool | None:
     """Queue a user_message follow-up signal on the run's workflow.
 
@@ -2587,7 +2588,15 @@ def signal_task_run_user_message(
         return None
     try:
         context = {"actor_slack_user_id": actor_slack_user_id} if actor_slack_user_id else None
-        signal_task_followup_message(run.workflow_id, content, artifact_ids, message_id, actor_user_id, context)
+        signal_task_followup_message(
+            run.workflow_id,
+            content,
+            artifact_ids,
+            message_id,
+            actor_user_id,
+            context,
+            steer=steer,
+        )
     except RPCError as e:
         if e.status == RPCStatusCode.NOT_FOUND:
             logger.warning("Follow-up signal target workflow gone for task run %s", run.id)

--- a/products/tasks/backend/feature_flags.py
+++ b/products/tasks/backend/feature_flags.py
@@ -1,0 +1,28 @@
+import logging
+
+from django.conf import settings
+
+import posthoganalytics
+
+logger = logging.getLogger(__name__)
+
+NATIVE_STEERING_SIGNALS_FEATURE_FLAG = "tasks-native-steering-signals"
+NATIVE_STEERING_SIGNALS_DISTINCT_ID = "tasks-native-steering-signals"
+
+
+def is_native_steering_signals_enabled() -> bool:
+    if settings.DEBUG:
+        return True
+
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                NATIVE_STEERING_SIGNALS_FEATURE_FLAG,
+                distinct_id=NATIVE_STEERING_SIGNALS_DISTINCT_ID,
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception("native_steering_signals_feature_flag_check_failed")
+        return False

--- a/products/tasks/backend/logic/services/agent_command.py
+++ b/products/tasks/backend/logic/services/agent_command.py
@@ -271,6 +271,7 @@ def send_user_message(
     auth_token: str | None = None,
     timeout: int = COMMAND_TIMEOUT_SECONDS,
     message_id: str | None = None,
+    steer: bool = False,
 ) -> CommandResult:
     """Send a user_message command to the sandbox agent.
 
@@ -285,6 +286,8 @@ def send_user_message(
         params["artifacts"] = artifacts
     if message_id:
         params["messageId"] = message_id
+    if steer:
+        params["steer"] = True
     return send_agent_command(
         task_run,
         method="user_message",

--- a/products/tasks/backend/logic/services/tests/test_agent_command.py
+++ b/products/tasks/backend/logic/services/tests/test_agent_command.py
@@ -353,6 +353,21 @@ class TestSendUserMessage:
         )
         assert result.success
 
+    @patch("products.tasks.backend.logic.services.agent_command.send_agent_command")
+    def test_sends_steer_flag(self, mock_send):
+        mock_send.return_value = CommandResult(success=True, status_code=200)
+        task_run = MagicMock()
+
+        send_user_message(task_run, "change direction", steer=True)
+
+        mock_send.assert_called_once_with(
+            task_run,
+            method="user_message",
+            params={"content": "change direction", "steer": True},
+            auth_token=None,
+            timeout=15,
+        )
+
 
 class TestSendCancel:
     @patch("products.tasks.backend.logic.services.agent_command.send_agent_command")

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2320,6 +2320,10 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         if method == "user_message":
             content = params.get("content")
             artifact_ids = params.get("artifact_ids")
+            steer = params.get("steer")
+
+            if steer is not None and not isinstance(steer, bool):
+                raise serializers.ValidationError({"params": "steer must be a boolean when provided"})
 
             normalized_content = None
             if content is not None:

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1543,6 +1543,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     content=command_params.get("content"),
                     artifact_ids=artifact_ids,
                     actor_user_id=request.user.id,
+                    steer=command_params.get("steer", False),
                 )
             except Exception:
                 # A synchronous web request can't retry the way the Temporal

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -17,9 +17,16 @@ from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.constants import SANDBOX_EVENT_INGEST_FEATURE_FLAG
 from products.tasks.backend.error_telemetry import truncate_error_message
+from products.tasks.backend.feature_flags import is_native_steering_signals_enabled
 from products.tasks.backend.metrics import observe_task_run_workflow_start
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.build_image.workflow import BuildSandboxImageInput
+from products.tasks.backend.temporal.constants import (
+    SEND_STEER_SIGNAL,
+    STEERING_PROTOCOL_QUERY,
+    STEERING_PROTOCOL_QUERY_TIMEOUT,
+    STEERING_PROTOCOL_VERSION,
+)
 from products.tasks.backend.temporal.process_task.workflow import ProcessTaskInput
 from products.tasks.backend.temporal.slack_relay.activities import RelaySlackMessageInput
 
@@ -472,14 +479,34 @@ def signal_task_followup_message(
     message_id: str | None = None,
     actor_user_id: int | None = None,
     context: dict[str, Any] | None = None,
+    *,
+    steer: bool = False,
 ) -> None:
-    """New per-message fields go in ``context`` — the positional signal args
-    are frozen for worker deploy compat."""
+    """Legacy positional signal args stay frozen for worker deploy compatibility."""
     client = sync_connect()
     handle = client.get_workflow_handle(workflow_id)
-    asyncio.run(
-        handle.signal("send_followup_message", args=[message, artifact_ids, message_id, actor_user_id, context])
-    )
+
+    async def signal() -> None:
+        signal_name = "send_followup_message"
+        if steer and is_native_steering_signals_enabled():
+            try:
+                protocol_version = await handle.query(
+                    STEERING_PROTOCOL_QUERY,
+                    rpc_timeout=STEERING_PROTOCOL_QUERY_TIMEOUT,
+                )
+            except Exception:
+                logger.info(
+                    "task_followup_steering_capability_unavailable",
+                    extra={"workflow_id": workflow_id},
+                    exc_info=True,
+                )
+            else:
+                if isinstance(protocol_version, int) and protocol_version >= STEERING_PROTOCOL_VERSION:
+                    signal_name = SEND_STEER_SIGNAL
+        signal_args = [message, artifact_ids, message_id, actor_user_id, context]
+        await handle.signal(signal_name, args=signal_args)
+
+    asyncio.run(signal())
 
 
 def signal_agent_text_delta(workflow_id: str, text: str) -> None:

--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -91,12 +91,25 @@ ACK_TIMEOUT = timedelta(seconds=60)
 # under different ack_ids still work normally.
 MAX_ACK_RETRIES = 5
 
+# Versioned signal for steer delivery. Keeping the legacy follow-up signal's
+# positional arguments unchanged makes mixed-worker rolling deployments safe.
+SEND_STEER_SIGNAL = "send_steer_message"
+STEERING_PROTOCOL_QUERY = "steering_protocol_version"
+STEERING_PROTOCOL_VERSION = 1
+# Capability discovery must never delay the durable legacy signal path when a
+# workflow worker is unavailable or too busy to answer queries.
+STEERING_PROTOCOL_QUERY_TIMEOUT = timedelta(seconds=2)
+
 # Cooldown after a failed outbound-signal flush on the child side. The child's
 # main loop wakes whenever `_pending_outbound` is non-empty; if the parent is
 # unreachable the re-queued items would otherwise keep waking the loop
 # immediately, starving the inactivity timer. Sleeping after a partial-failure
 # flush rate-limits retries.
 OUTBOUND_RETRY_BACKOFF = timedelta(seconds=10)
+# Final child cleanup must not wait forever for a parent workflow that has
+# already closed or remains unreachable. This caps the total attempts made by
+# the terminal flush before the child records the undelivered signals and exits.
+MAX_FINAL_OUTBOUND_FLUSH_ATTEMPTS = 5
 
 DEFAULT_CI_MESSAGE = f"""\
 You are re-entering this run to address CI feedback on the pull request you opened.

--- a/products/tasks/backend/temporal/process_task/activities/__init__.py
+++ b/products/tasks/backend/temporal/process_task/activities/__init__.py
@@ -40,7 +40,7 @@ from .relay_sandbox_events import (
     relay_sandbox_events_deferred_completion,
 )
 from .run_wizard import RunWizardInput, run_wizard
-from .send_followup_to_sandbox import SendFollowupToSandboxInput, send_followup_to_sandbox
+from .send_followup_to_sandbox import STEER_DECLINED_OUTCOME, SendFollowupToSandboxInput, send_followup_to_sandbox
 from .send_permission_response_to_sandbox import (
     PostPermissionDeliveryFailureInput,
     SendPermissionDenialGuidanceInput,
@@ -99,6 +99,7 @@ __all__ = [
     "SendPermissionDenialGuidanceInput",
     "SendPermissionResponseToSandboxInput",
     "SendFollowupToSandboxInput",
+    "STEER_DECLINED_OUTCOME",
     "cleanup_sandbox",
     "complete_run_stream",
     "create_resume_snapshot",

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -50,6 +50,7 @@ REFRESH_RETRY_DELAY_SECONDS = 0.5
 # Application failures that write an error sentinel raise non-retryable.
 SEND_FOLLOWUP_MAX_ATTEMPTS = 3
 SEND_FOLLOWUP_HEARTBEAT_INTERVAL_SECONDS = 15
+STEER_DECLINED_OUTCOME = "steer_declined"
 
 
 @dataclass
@@ -66,11 +67,12 @@ class SendFollowupToSandboxInput:
     actor_user_id: int | None = None
     # Signal context, passed through from PendingFollowup.
     context: dict[str, Any] | None = None
+    steer: bool = False
 
 
 @activity.defn
 @close_db_connections
-def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
+def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> str | None:
     """Send a follow-up user message to the sandbox and write result markers to Redis.
 
     Called by the workflow when it receives a send_followup_message signal from the
@@ -95,7 +97,7 @@ def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
     heartbeat_thread = threading.Thread(target=lambda: heartbeat_ctx.run(_heartbeat_loop), daemon=True)
     heartbeat_thread.start()
     try:
-        _deliver_followup(input)
+        return _deliver_followup(input)
     finally:
         stop_heartbeat.set()
         heartbeat_thread.join(timeout=2)
@@ -115,7 +117,21 @@ def _is_duplicate_delivery(result_data: dict[str, Any] | None) -> bool:
     return isinstance(result, dict) and result.get("duplicate") is True
 
 
-def _deliver_followup(input: SendFollowupToSandboxInput) -> None:
+def _is_steered(result_data: dict[str, Any] | None) -> bool:
+    if not isinstance(result_data, dict):
+        return False
+    result = result_data.get("result")
+    return isinstance(result, dict) and result.get("steered") is True
+
+
+def _is_steer_declined(result_data: dict[str, Any] | None) -> bool:
+    if not isinstance(result_data, dict):
+        return False
+    result = result_data.get("result")
+    return isinstance(result, dict) and result.get("steered") is False
+
+
+def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
     try:
         task_run = TaskRun.objects.select_related("task__created_by", "task__team").get(id=input.run_id)
     except TaskRun.DoesNotExist:
@@ -162,8 +178,15 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> None:
     # Rebind the sandbox's MCP session to this actor before the turn. On an
     # actor transition this must rebind or clear the prior session; if it can't,
     # fail closed rather than run the turn under the previous actor's creds.
-    # Same-actor and first-bind refreshes stay best-effort.
-    if not _refresh_sandbox_mcp(task_run, input.posthog_mcp_scopes, auth_token, actor_user=actor_user, state=state):
+    # A steer joins the active turn, so it cannot interrupt that turn with a
+    # session refresh.
+    if not input.steer and not _refresh_sandbox_mcp(
+        task_run,
+        input.posthog_mcp_scopes,
+        auth_token,
+        actor_user=actor_user,
+        state=state,
+    ):
         error_msg = "Could not rebind sandbox MCP credentials for the follow-up actor"
         raise RuntimeError(f"send_followup failed: {error_msg}")
     artifacts = None
@@ -185,6 +208,7 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> None:
         auth_token=auth_token,
         timeout=FOLLOWUP_TIMEOUT_SECONDS,
         message_id=input.message_id,
+        steer=input.steer,
     )
     logger.info(
         "send_followup_to_sandbox_attempted",
@@ -200,7 +224,13 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> None:
                 run_id=input.run_id,
                 attempt=_current_attempt(),
             )
-            return
+            return None
+        if _is_steered(result.data):
+            logger.info("send_followup_steered", run_id=input.run_id)
+            return None
+        if input.steer and _is_steer_declined(result.data):
+            logger.info("send_followup_steer_declined", run_id=input.run_id)
+            return STEER_DECLINED_OUTCOME
         _write_turn_complete(input.run_id, _get_stop_reason(result.data), run_uses_dedicated_stream(task_run.state))
         logger.info("send_followup_delivered", run_id=input.run_id)
     elif result.turn_in_flight:
@@ -251,6 +281,8 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> None:
         _write_error_and_complete(input.run_id, error_msg, run_uses_dedicated_stream(task_run.state))
         # Propagate failure to the workflow.
         raise ApplicationError(f"send_followup failed: {error_msg}", non_retryable=True)
+
+    return None
 
 
 def _refresh_sandbox_mcp(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
@@ -65,3 +65,38 @@ class TestSendFollowupToSandbox(BaseTest):
         payload = mock_conn.xadd.call_args.args[1]["data"]
         event = json.loads(payload)
         self.assertEqual(event["notification"]["params"]["stopReason"], "max_tokens")
+
+    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox._refresh_sandbox_mcp")
+    @patch(
+        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_tasks_stream_redis_sync"
+    )
+    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_user_message")
+    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.TaskRun.objects")
+    def test_steer_skips_refresh_and_synthetic_turn_complete(
+        self,
+        mock_task_run_objects,
+        mock_send_user_message,
+        mock_get_tasks_stream_redis_sync,
+        mock_refresh_sandbox_mcp,
+    ):
+        task_run = MagicMock()
+        task_run.task.created_by = None
+        mock_task_run_objects.select_related.return_value.get.return_value = task_run
+        mock_send_user_message.return_value = MagicMock(
+            success=True,
+            data={"result": {"stopReason": "steered", "steered": True}},
+        )
+
+        send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-123", message="change direction", steer=True))
+
+        mock_refresh_sandbox_mcp.assert_not_called()
+        mock_send_user_message.assert_called_once_with(
+            task_run,
+            "change direction",
+            artifacts=None,
+            auth_token=None,
+            timeout=1800,
+            message_id=None,
+            steer=True,
+        )
+        mock_get_tasks_stream_redis_sync.assert_not_called()

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -9,6 +9,7 @@ from products.tasks.backend.logic.services.agent_command import CommandResult
 from products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox import (
     REFRESH_RETRY_DELAY_SECONDS,
     SEND_FOLLOWUP_MAX_ATTEMPTS,
+    STEER_DECLINED_OUTCOME,
     SendFollowupToSandboxInput,
     _refresh_sandbox_mcp,
     send_followup_to_sandbox,
@@ -579,6 +580,21 @@ class TestSendFollowupTurnTimeout:
 
         send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-1", message="hi", message_id="m-1"))
 
+        _patches["error"].assert_not_called()
+        _patches["turn_complete"].assert_not_called()
+
+    def test_declined_steer_returns_for_normal_requeue_without_markers(self, _patches):
+        _patches["user_msg"].return_value = CommandResult(
+            success=True,
+            status_code=200,
+            data={"result": {"steered": False, "stopReason": STEER_DECLINED_OUTCOME}},
+        )
+
+        outcome = send_followup_to_sandbox(
+            SendFollowupToSandboxInput(run_id="run-1", message="hi", message_id="m-1", steer=True)
+        )
+
+        assert outcome == STEER_DECLINED_OUTCOME
         _patches["error"].assert_not_called()
         _patches["turn_complete"].assert_not_called()
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -7831,7 +7831,30 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         self.assertEqual(data["jsonrpc"], "2.0")
         self.assertTrue(data["result"]["queued"])
 
-        mock_signal_followup.assert_called_once_with(run.workflow_id, "Hello agent", [], None, self.user.id, None)
+        mock_signal_followup.assert_called_once_with(
+            run.workflow_id, "Hello agent", [], None, self.user.id, None, steer=False
+        )
+
+    @patch("products.tasks.backend.temporal.client.signal_task_followup_message")
+    def test_command_signals_steer_intent(self, mock_signal_followup):
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {
+                "jsonrpc": "2.0",
+                "method": "user_message",
+                "params": {"content": "Change direction", "steer": True},
+                "id": "req-steer",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_signal_followup.assert_called_once_with(
+            run.workflow_id, "Change direction", [], None, self.user.id, None, steer=True
+        )
 
     @patch("products.tasks.backend.temporal.client.signal_task_followup_message")
     def test_command_user_message_requires_code_access(self, mock_signal_followup):
@@ -7867,7 +7890,9 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.json()["result"]["queued"])
-        mock_signal_followup.assert_called_once_with(run.workflow_id, "Hello agent", [], None, self.user.id, None)
+        mock_signal_followup.assert_called_once_with(
+            run.workflow_id, "Hello agent", [], None, self.user.id, None, steer=False
+        )
 
     @patch("products.tasks.backend.temporal.client.signal_task_followup_message")
     def test_command_signals_user_message_artifact_ids(self, mock_signal_followup):
@@ -7900,7 +7925,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.json()["result"]["queued"])
         mock_signal_followup.assert_called_once_with(
-            run.workflow_id, "See attached", ["artifact-123"], None, self.user.id, None
+            run.workflow_id, "See attached", ["artifact-123"], None, self.user.id, None, steer=False
         )
 
     @patch("products.tasks.backend.temporal.client.signal_task_followup_message")

--- a/products/tasks/backend/tests/test_temporal_client.py
+++ b/products/tasks/backend/tests/test_temporal_client.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock, Mock, patch
 
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from asgiref.sync import async_to_sync
 from parameterized import parameterized
@@ -16,7 +16,107 @@ from products.tasks.backend.temporal.client import (
     execute_task_processing_workflow_async,
     redispatch_orphaned_task_run,
     resume_task_in_cloud_workflow,
+    signal_task_followup_message,
 )
+from products.tasks.backend.temporal.constants import (
+    SEND_STEER_SIGNAL,
+    STEERING_PROTOCOL_QUERY,
+    STEERING_PROTOCOL_QUERY_TIMEOUT,
+)
+
+
+@override_settings(DEBUG=False)
+class TestSignalTaskFollowupMessage(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                False,
+                True,
+                None,
+                "send_followup_message",
+                ["hello", ["artifact-1"], "message-1", 42, {"actor_slack_user_id": "U1"}],
+            ),
+            (
+                True,
+                False,
+                1,
+                "send_followup_message",
+                ["hello", ["artifact-1"], "message-1", 42, {"actor_slack_user_id": "U1"}],
+            ),
+            (
+                True,
+                True,
+                1,
+                SEND_STEER_SIGNAL,
+                ["hello", ["artifact-1"], "message-1", 42, {"actor_slack_user_id": "U1"}],
+            ),
+            (
+                True,
+                True,
+                RuntimeError("query not registered"),
+                "send_followup_message",
+                ["hello", ["artifact-1"], "message-1", 42, {"actor_slack_user_id": "U1"}],
+            ),
+            (
+                True,
+                True,
+                TimeoutError("query timed out"),
+                "send_followup_message",
+                ["hello", ["artifact-1"], "message-1", 42, {"actor_slack_user_id": "U1"}],
+            ),
+            (
+                True,
+                RuntimeError("feature flag unavailable"),
+                1,
+                "send_followup_message",
+                ["hello", ["artifact-1"], "message-1", 42, {"actor_slack_user_id": "U1"}],
+            ),
+        ]
+    )
+    def test_capability_gates_versioned_signal_and_preserves_sender_fields(
+        self,
+        steer: bool,
+        feature_flag_result: bool | Exception,
+        query_result: int | Exception | None,
+        expected_signal: str,
+        expected_args: list[object],
+    ) -> None:
+        handle = Mock()
+        handle.signal = AsyncMock()
+        handle.query = AsyncMock()
+        if isinstance(query_result, Exception):
+            handle.query.side_effect = query_result
+        else:
+            handle.query.return_value = query_result
+        client = Mock()
+        client.get_workflow_handle.return_value = handle
+
+        with (
+            patch("products.tasks.backend.feature_flags.posthoganalytics.feature_enabled") as feature_enabled,
+            patch("products.tasks.backend.temporal.client.sync_connect", return_value=client),
+        ):
+            if isinstance(feature_flag_result, Exception):
+                feature_enabled.side_effect = feature_flag_result
+            else:
+                feature_enabled.return_value = feature_flag_result
+            signal_task_followup_message(
+                "workflow-id",
+                "hello",
+                ["artifact-1"],
+                "message-1",
+                42,
+                {"actor_slack_user_id": "U1"},
+                steer=steer,
+            )
+
+        handle.signal.assert_awaited_once_with(expected_signal, args=expected_args)
+        if steer and feature_flag_result is True:
+            handle.query.assert_awaited_once_with(
+                STEERING_PROTOCOL_QUERY,
+                rpc_timeout=STEERING_PROTOCOL_QUERY_TIMEOUT,
+            )
+        else:
+            handle.query.assert_not_awaited()
 
 
 @override_settings(DEBUG=False)


### PR DESCRIPTION
## Problem

Active cloud runs cannot distinguish steerable commands from queued follow-ups end to end.

## Changes

Adds steer intent, stable message IDs, and capability negotiation across the command API and Temporal client.
