### PR TITLE
feat(session-replay): typed rrweb parse output in the anonymizer crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-replay-anonymizer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",

--- a/rust/replay-anonymizer-node/Cargo.toml
+++ b/rust/replay-anonymizer-node/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib"]
 # Safe here: the addon only runs in PostHog's Node ingestion workers, never in V8
 # sandboxed-pointer environments (Electron), where external buffers abort the VM.
 neon = { workspace = true, features = ["external-buffers"] }
-posthog-replay-anonymizer = { path = "../replay-anonymizer" }
+# default-features = false: the offline typed-parse module has no place in the ingestion cdylib.
+posthog-replay-anonymizer = { path = "../replay-anonymizer", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/replay-anonymizer/Cargo.toml
+++ b/rust/replay-anonymizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-replay-anonymizer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "PII scrubber for rrweb session-replay events: text/URL redaction, native image blur, and canvas/cv neutralization"
 license = "MIT"
@@ -9,6 +9,12 @@ repository = "https://github.com/PostHog/posthog"
 
 [lints]
 workspace = true
+
+[features]
+default = ["typed-parse"]
+# Typed rrweb parse output (the `typed` module) for offline consumers. The Node addon builds with
+# `default-features = false` so the AST types stay out of the ingestion cdylib entirely.
+typed-parse = []
 
 [dependencies]
 ahash = { workspace = true }

--- a/rust/replay-anonymizer/README.md
+++ b/rust/replay-anonymizer/README.md
@@ -9,6 +9,8 @@ Consumers:
 
 Behavior is pinned by the JSON fixtures under `tests/fixtures/`, shared with the Node addon's Jest suite. Scrubbing operates on untrusted input; the public entry points contain panics and convert them to errors, so callers fail closed (drop the message) without their own `catch_unwind`. Under `panic = "abort"` that backstop cannot run — builds that must fail closed need `panic = "unwind"`.
 
+Offline consumers (JSONL of individual events rather than Kafka messages) get a dedicated surface: `anonymize_line` scrubs one line (bare event or `["window_id", event]` tuple), `AllowLists::from_json_bytes` loads the shipped `{ text, url }` document and `AllowLists::default()` embeds the production default lists, and the default `typed-parse` feature adds `parse_scrubbed_event` — scrub-then-parse to a typed rrweb AST (envelope, DOM tree, mutations, interactions) with `cv` payloads transparently decompressed. The Node addon builds with `default-features = false`, so none of the typed surface exists on the ingestion hot path.
+
 ## Releasing
 
 Publishing to crates.io is automated by `.github/workflows/publish-replay-anonymizer-crate.yml`:

--- a/rust/replay-anonymizer/src/lib.rs
+++ b/rust/replay-anonymizer/src/lib.rs
@@ -18,9 +18,11 @@
 //!
 //! The stable crates.io surface is what this page documents: [`AllowLists`], [`Ctx`], the event
 //! entry points ([`anonymize_message`], [`anonymize_event`], [`anonymize_line`] and friends), the
-//! byte-buffer snapshot pipeline ([`anonymize_kafka_payload`] and friends), and the rrweb routing
-//! constants in [`event`]. Everything `#[doc(hidden)]` stays `pub` only for this workspace (the
-//! Node addon, the parity tests) — it is internal and may change or disappear in any release.
+//! byte-buffer snapshot pipeline ([`anonymize_kafka_payload`] and friends), the rrweb routing
+//! constants in [`event`], and — behind the default `typed-parse` feature — the typed rrweb parse
+//! in [`typed`] ([`parse_scrubbed_event`]). Everything `#[doc(hidden)]` stays `pub` only for this
+//! workspace (the Node addon, the parity tests) — it is internal and may change or disappear in
+//! any release.
 
 pub mod allow_lists;
 #[doc(hidden)]
@@ -48,6 +50,8 @@ pub mod scan;
 pub mod snapshot;
 #[doc(hidden)]
 pub mod text;
+#[cfg(feature = "typed-parse")]
+pub mod typed;
 mod unwind;
 #[doc(hidden)]
 pub mod url;
@@ -64,6 +68,8 @@ pub use snapshot::{
     anonymize_kafka_payload, anonymize_kafka_payload_opts, AnonymizeOpts, AnonymizedMessage,
     FailKind, Failure, Route,
 };
+#[cfg(feature = "typed-parse")]
+pub use typed::{parse_scrubbed_event, parse_scrubbed_event_with_ctx};
 
 /// Shared helpers for the image-neutralization tests across modules.
 #[cfg(test)]

--- a/rust/replay-anonymizer/src/typed.rs
+++ b/rust/replay-anonymizer/src/typed.rs
@@ -1,0 +1,750 @@
+//! Typed rrweb parse output for offline consumers (feature `typed-parse`).
+//!
+//! [`parse_scrubbed_event`] scrubs a JSONL line with the same routing as
+//! [`crate::anonymize_line`], then hands back a typed [`Event`] — envelope, FullSnapshot DOM tree,
+//! Mutation adds/removes/attributes/texts, interaction/input/scroll data — with every `cv`
+//! payload (whole-event blobs and per-field Mutation compression, gzip or zstd) transparently
+//! decompressed. Scrub-then-parse is one call by design: there is no way to obtain an unscrubbed
+//! AST from this module.
+//!
+//! This is additive and offline-only. Nothing on the scrubbing hot path
+//! ([`crate::anonymize_message`], [`crate::snapshot`], [`crate::bytewalk`]) references this
+//! module; without the `typed-parse` feature (the Node addon build) it is not even compiled.
+//!
+//! Payload shapes the renderer does not fold — canvas, stylesheet, plugin, custom, unknown types
+//! and sources — pass through as scrubbed generic JSON ([`EventData::Other`] /
+//! [`IncrementalData::Other`]) and are *not* cv-decompressed.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Deserializer, Serialize};
+use simd_json::borrowed::Value;
+use simd_json::StaticNode;
+
+use crate::allow_lists::AllowLists;
+use crate::context::Ctx;
+use crate::event::{route_event, SOURCE_MUTATION, TYPE_FULL_SNAPSHOT, TYPE_INCREMENTAL, TYPE_META};
+use crate::json::{
+    as_f64, as_object_mut, as_small_uint, parse_untrusted, reject_if_too_deep, string_value,
+};
+
+/// rrweb `EventType` for the envelope's raw `type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+#[repr(u8)]
+pub enum EventType {
+    DomContentLoaded = 0,
+    Load = 1,
+    FullSnapshot = 2,
+    IncrementalSnapshot = 3,
+    Meta = 4,
+    Custom = 5,
+    Plugin = 6,
+}
+
+impl EventType {
+    pub const fn from_u8(n: u8) -> Option<Self> {
+        Some(match n {
+            0 => Self::DomContentLoaded,
+            1 => Self::Load,
+            2 => Self::FullSnapshot,
+            3 => Self::IncrementalSnapshot,
+            4 => Self::Meta,
+            5 => Self::Custom,
+            6 => Self::Plugin,
+            _ => return None,
+        })
+    }
+}
+
+/// rrweb `IncrementalSource` for an IncrementalSnapshot's raw `source`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+#[repr(u8)]
+pub enum IncrementalSource {
+    Mutation = 0,
+    MouseMove = 1,
+    MouseInteraction = 2,
+    Scroll = 3,
+    ViewportResize = 4,
+    Input = 5,
+    TouchMove = 6,
+    MediaInteraction = 7,
+    StyleSheetRule = 8,
+    CanvasMutation = 9,
+    Font = 10,
+    Log = 11,
+    Drag = 12,
+    StyleDeclaration = 13,
+    Selection = 14,
+    AdoptedStyleSheet = 15,
+    CustomElement = 16,
+}
+
+impl IncrementalSource {
+    pub const fn from_u8(n: u8) -> Option<Self> {
+        Some(match n {
+            0 => Self::Mutation,
+            1 => Self::MouseMove,
+            2 => Self::MouseInteraction,
+            3 => Self::Scroll,
+            4 => Self::ViewportResize,
+            5 => Self::Input,
+            6 => Self::TouchMove,
+            7 => Self::MediaInteraction,
+            8 => Self::StyleSheetRule,
+            9 => Self::CanvasMutation,
+            10 => Self::Font,
+            11 => Self::Log,
+            12 => Self::Drag,
+            13 => Self::StyleDeclaration,
+            14 => Self::Selection,
+            15 => Self::AdoptedStyleSheet,
+            16 => Self::CustomElement,
+            _ => return None,
+        })
+    }
+}
+
+macro_rules! u8_enum_conversions {
+    ($($ty:ty),+) => {$(
+        impl TryFrom<u8> for $ty {
+            type Error = String;
+            fn try_from(n: u8) -> Result<Self, String> {
+                Self::from_u8(n).ok_or_else(|| {
+                    format!(concat!("invalid ", stringify!($ty), " value: {}"), n)
+                })
+            }
+        }
+        impl From<$ty> for u8 {
+            fn from(v: $ty) -> u8 {
+                v as u8
+            }
+        }
+    )+};
+}
+
+/// rrweb `MouseInteractions` for a MouseInteraction's `type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+#[repr(u8)]
+pub enum MouseInteractionKind {
+    MouseUp = 0,
+    MouseDown = 1,
+    Click = 2,
+    ContextMenu = 3,
+    DblClick = 4,
+    Focus = 5,
+    Blur = 6,
+    TouchStart = 7,
+    TouchMoveDeparted = 8,
+    TouchEnd = 9,
+    TouchCancel = 10,
+}
+
+impl MouseInteractionKind {
+    pub const fn from_u8(n: u8) -> Option<Self> {
+        Some(match n {
+            0 => Self::MouseUp,
+            1 => Self::MouseDown,
+            2 => Self::Click,
+            3 => Self::ContextMenu,
+            4 => Self::DblClick,
+            5 => Self::Focus,
+            6 => Self::Blur,
+            7 => Self::TouchStart,
+            8 => Self::TouchMoveDeparted,
+            9 => Self::TouchEnd,
+            10 => Self::TouchCancel,
+            _ => return None,
+        })
+    }
+}
+
+/// rrweb `PointerTypes` for a MouseInteraction's optional `pointerType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+#[repr(u8)]
+pub enum PointerType {
+    Mouse = 0,
+    Pen = 1,
+    Touch = 2,
+}
+
+impl PointerType {
+    pub const fn from_u8(n: u8) -> Option<Self> {
+        Some(match n {
+            0 => Self::Mouse,
+            1 => Self::Pen,
+            2 => Self::Touch,
+            _ => return None,
+        })
+    }
+}
+
+u8_enum_conversions!(
+    EventType,
+    IncrementalSource,
+    MouseInteractionKind,
+    PointerType
+);
+
+/// One typed, scrubbed rrweb event. `ty` is the raw envelope `type` (it can exceed the
+/// [`EventType`] range for future rrweb versions — those carry [`EventData::Other`]).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Event {
+    /// From the PostHog `["window_id", event]` tuple wrapping; `None` for a bare event line.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    #[serde(rename = "type")]
+    pub ty: u8,
+    /// Epoch milliseconds. rrweb allows fractional timestamps; they truncate here.
+    pub timestamp: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delay: Option<i64>,
+    pub data: EventData,
+}
+
+impl Event {
+    pub const fn event_type(&self) -> Option<EventType> {
+        EventType::from_u8(self.ty)
+    }
+}
+
+/// The typed payloads the offline renderer folds; everything else passes through as scrubbed
+/// generic JSON in `Other`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum EventData {
+    FullSnapshot(FullSnapshotData),
+    Incremental(IncrementalData),
+    Meta(MetaData),
+    Other(serde_json::Value),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum IncrementalData {
+    Mutation(MutationData),
+    MouseInteraction(MouseInteractionData),
+    Scroll(ScrollData),
+    Input(InputData),
+    Other(serde_json::Value),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FullSnapshotData {
+    pub node: SerializedNodeWithId,
+    pub initial_offset: InitialOffset,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InitialOffset {
+    pub top: f64,
+    pub left: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedNodeWithId {
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_id: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_shadow_host: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_shadow: Option<bool>,
+    #[serde(flatten)]
+    pub node: SerializedNode,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SerializedNode {
+    Document(DocumentNode),
+    DocumentType(DocumentTypeNode),
+    Element(ElementNode),
+    Text(TextNode),
+    Cdata(CdataNode),
+    Comment(CommentNode),
+}
+
+/// rrweb serialized-node `type`, used only to dispatch [`SerializedNode`]'s (de)serialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+#[repr(u8)]
+enum NodeType {
+    Document = 0,
+    DocumentType = 1,
+    Element = 2,
+    Text = 3,
+    Cdata = 4,
+    Comment = 5,
+}
+
+impl NodeType {
+    const fn from_u8(n: u8) -> Option<Self> {
+        Some(match n {
+            0 => Self::Document,
+            1 => Self::DocumentType,
+            2 => Self::Element,
+            3 => Self::Text,
+            4 => Self::Cdata,
+            5 => Self::Comment,
+            _ => return None,
+        })
+    }
+}
+
+u8_enum_conversions!(NodeType);
+
+// Avoids serde's untagged-enum trial-and-error: dispatch on `type`.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NodeHelper {
+    #[serde(rename = "type")]
+    ty: NodeType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tag_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    attributes: Option<BTreeMap<String, AttrValue>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    child_nodes: Option<Vec<SerializedNodeWithId>>,
+    #[serde(rename = "isSVG", default, skip_serializing_if = "Option::is_none")]
+    is_svg: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    need_block: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    is_custom: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    text_content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    is_style: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    public_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    system_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    compat_mode: Option<String>,
+}
+
+fn empty_helper(ty: NodeType) -> NodeHelper {
+    NodeHelper {
+        ty,
+        tag_name: None,
+        attributes: None,
+        child_nodes: None,
+        is_svg: None,
+        need_block: None,
+        is_custom: None,
+        text_content: None,
+        is_style: None,
+        name: None,
+        public_id: None,
+        system_id: None,
+        compat_mode: None,
+    }
+}
+
+impl<'de> Deserialize<'de> for SerializedNode {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let h = NodeHelper::deserialize(d)?;
+        Ok(match h.ty {
+            NodeType::Document => SerializedNode::Document(DocumentNode {
+                child_nodes: h.child_nodes.unwrap_or_default(),
+                compat_mode: h.compat_mode,
+            }),
+            NodeType::DocumentType => SerializedNode::DocumentType(DocumentTypeNode {
+                name: h.name.unwrap_or_default(),
+                public_id: h.public_id.unwrap_or_default(),
+                system_id: h.system_id.unwrap_or_default(),
+            }),
+            NodeType::Element => SerializedNode::Element(ElementNode {
+                tag_name: h.tag_name.unwrap_or_default(),
+                attributes: h.attributes.unwrap_or_default(),
+                child_nodes: h.child_nodes.unwrap_or_default(),
+                is_svg: h.is_svg,
+                need_block: h.need_block,
+                is_custom: h.is_custom,
+            }),
+            NodeType::Text => SerializedNode::Text(TextNode {
+                text_content: h.text_content.unwrap_or_default(),
+                is_style: h.is_style,
+            }),
+            NodeType::Cdata => SerializedNode::Cdata(CdataNode {
+                text_content: h.text_content,
+            }),
+            NodeType::Comment => SerializedNode::Comment(CommentNode {
+                text_content: h.text_content.unwrap_or_default(),
+            }),
+        })
+    }
+}
+
+impl Serialize for SerializedNode {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        let h = match self {
+            SerializedNode::Document(v) => NodeHelper {
+                child_nodes: Some(v.child_nodes.clone()),
+                compat_mode: v.compat_mode.clone(),
+                ..empty_helper(NodeType::Document)
+            },
+            SerializedNode::DocumentType(v) => NodeHelper {
+                name: Some(v.name.clone()),
+                public_id: Some(v.public_id.clone()),
+                system_id: Some(v.system_id.clone()),
+                ..empty_helper(NodeType::DocumentType)
+            },
+            SerializedNode::Element(v) => NodeHelper {
+                tag_name: Some(v.tag_name.clone()),
+                attributes: Some(v.attributes.clone()),
+                child_nodes: Some(v.child_nodes.clone()),
+                is_svg: v.is_svg,
+                need_block: v.need_block,
+                is_custom: v.is_custom,
+                ..empty_helper(NodeType::Element)
+            },
+            SerializedNode::Text(v) => NodeHelper {
+                text_content: Some(v.text_content.clone()),
+                is_style: v.is_style,
+                ..empty_helper(NodeType::Text)
+            },
+            SerializedNode::Cdata(v) => NodeHelper {
+                text_content: v.text_content.clone(),
+                ..empty_helper(NodeType::Cdata)
+            },
+            SerializedNode::Comment(v) => NodeHelper {
+                text_content: Some(v.text_content.clone()),
+                ..empty_helper(NodeType::Comment)
+            },
+        };
+        h.serialize(s)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentNode {
+    pub child_nodes: Vec<SerializedNodeWithId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compat_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentTypeNode {
+    pub name: String,
+    pub public_id: String,
+    pub system_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElementNode {
+    pub tag_name: String,
+    pub attributes: BTreeMap<String, AttrValue>,
+    pub child_nodes: Vec<SerializedNodeWithId>,
+    #[serde(rename = "isSVG", skip_serializing_if = "Option::is_none")]
+    pub is_svg: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub need_block: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_custom: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextNode {
+    pub text_content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_style: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CdataNode {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_content: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentNode {
+    pub text_content: String,
+}
+
+/// An rrweb attribute value: string, number, bool, `null`, or the structured sentinels rrweb uses
+/// (e.g. the `rr_captured_*` style objects).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AttrValue {
+    Str(String),
+    Num(f64),
+    Bool(bool),
+    Null,
+    Obj(BTreeMap<String, AttrValue>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MutationData {
+    pub source: IncrementalSource, // == Mutation (0)
+    #[serde(default)]
+    pub texts: Vec<TextMutation>,
+    #[serde(default)]
+    pub attributes: Vec<AttributeMutation>,
+    #[serde(default)]
+    pub removes: Vec<RemovedNodeMutation>,
+    #[serde(default)]
+    pub adds: Vec<AddedNodeMutation>,
+    #[serde(
+        default,
+        rename = "isAttachIframe",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub is_attach_iframe: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TextMutation {
+    pub id: i64,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AttributeMutation {
+    pub id: i64,
+    pub attributes: BTreeMap<String, AttrValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovedNodeMutation {
+    pub parent_id: i64,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_shadow: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddedNodeMutation {
+    pub parent_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_id: Option<i64>,
+    pub next_id: Option<i64>,
+    pub node: SerializedNodeWithId,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MouseInteractionData {
+    pub source: IncrementalSource, // == MouseInteraction (2)
+    #[serde(rename = "type")]
+    pub kind: MouseInteractionKind,
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub x: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub y: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pointer_type: Option<PointerType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScrollData {
+    pub source: IncrementalSource, // == Scroll (3)
+    pub id: i64,
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InputData {
+    pub source: IncrementalSource, // == Input (5)
+    pub id: i64,
+    pub text: String,
+    pub is_checked: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_triggered: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetaData {
+    pub href: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Typed, scrubbed rrweb event from one JSONL line (bare event or `["window_id", event]` tuple).
+/// Offline/non-hot-path only: this parse allocates an AST.
+///
+/// `Ok(None)` mirrors [`crate::anonymize_line`]'s policy — JSON that parses but is not
+/// recognizably an rrweb event (wrong shape, or a missing/non-numeric `type` or `timestamp`).
+/// `Err` = the line could not be scrubbed or its typed payload is malformed; fail closed, the
+/// caller must drop the line.
+pub fn parse_scrubbed_event(allow: &AllowLists, line: &mut [u8]) -> Result<Option<Event>> {
+    parse_scrubbed_event_with_ctx(&Ctx::new(allow), line)
+}
+
+/// [`parse_scrubbed_event`] with a caller-owned [`Ctx`] — same memo/budget semantics as
+/// [`crate::anonymize_line_with_ctx`].
+pub fn parse_scrubbed_event_with_ctx(ctx: &Ctx<'_>, line: &mut [u8]) -> Result<Option<Event>> {
+    crate::unwind::contain_unwind(
+        || {
+            reject_if_too_deep(line, "jsonl line")?;
+            let root = parse_untrusted(line).context("parse jsonl line")?;
+            ctx.reset_cv_budget();
+            let (window_id, mut event) = match root {
+                event @ Value::Object(_) => (None, event),
+                Value::Array(items) => {
+                    let mut it = items.into_iter();
+                    match (it.next(), it.next(), it.next()) {
+                        (Some(Value::String(id)), Some(event @ Value::Object(_)), None) => {
+                            (Some(id.into_owned()), event)
+                        }
+                        _ => return Ok(None),
+                    }
+                }
+                _ => return Ok(None),
+            };
+            route_event(ctx, &mut event)?;
+            build_typed(ctx, window_id, event)
+        },
+        |msg| anyhow::anyhow!("panic while parsing scrubbed event: {msg}"),
+    )
+}
+
+fn build_typed(
+    ctx: &Ctx<'_>,
+    window_id: Option<String>,
+    mut event: Value<'_>,
+) -> Result<Option<Event>> {
+    let obj = as_object_mut(&mut event).expect("caller matched an object");
+    let Some(ty) = obj.get("type").and_then(as_small_uint) else {
+        return Ok(None);
+    };
+    let Some(timestamp) = obj.get("timestamp").and_then(as_f64) else {
+        return Ok(None);
+    };
+    let delay = obj.get("delay").and_then(as_f64).map(|d| d as i64);
+    let compressed = crate::event::is_compressed_marker(obj.get("cv"));
+    let mut data = obj
+        .remove("data")
+        .unwrap_or(Value::Static(StaticNode::Null));
+
+    let source = crate::json::as_object(&data)
+        .and_then(|d| d.get("source"))
+        .and_then(as_small_uint);
+
+    if compressed {
+        decompress_cv_fields(ctx, ty, source, &mut data)?;
+    }
+
+    let typed = match ty {
+        TYPE_FULL_SNAPSHOT if crate::json::is_object(&data) => {
+            EventData::FullSnapshot(from_value(data).context("typed FullSnapshot data")?)
+        }
+        TYPE_INCREMENTAL => EventData::Incremental(match source.map(IncrementalSource::from_u8) {
+            Some(Some(IncrementalSource::Mutation)) => {
+                IncrementalData::Mutation(from_value(data).context("typed Mutation data")?)
+            }
+            Some(Some(IncrementalSource::MouseInteraction)) => IncrementalData::MouseInteraction(
+                from_value(data).context("typed MouseInteraction data")?,
+            ),
+            Some(Some(IncrementalSource::Scroll)) => {
+                IncrementalData::Scroll(from_value(data).context("typed Scroll data")?)
+            }
+            Some(Some(IncrementalSource::Input)) => {
+                IncrementalData::Input(from_value(data).context("typed Input data")?)
+            }
+            _ => IncrementalData::Other(from_value(data).context("generic incremental data")?),
+        }),
+        TYPE_META if crate::json::is_object(&data) => {
+            EventData::Meta(from_value(data).context("typed Meta data")?)
+        }
+        _ => EventData::Other(from_value(data).context("generic event data")?),
+    };
+
+    Ok(Some(Event {
+        window_id,
+        ty,
+        timestamp: timestamp as i64,
+        delay,
+        data: typed,
+    }))
+}
+
+/// Replace compressed `cv` payloads inside `data` with their decoded JSON, so the typed output is
+/// transparently decompressed: the whole-blob FullSnapshot string, and each present Mutation
+/// sub-field string (`texts`/`attributes`/`removes`/`adds` — `removes` is never re-emitted by the
+/// scrub, so it can still be gzip while its siblings are zstd; the magic sniff handles both).
+fn decompress_cv_fields(
+    ctx: &Ctx<'_>,
+    ty: u8,
+    source: Option<u8>,
+    data: &mut Value<'_>,
+) -> Result<()> {
+    match (ty, source, &mut *data) {
+        (TYPE_FULL_SNAPSHOT, _, Value::String(s)) => {
+            *data = decode_cv_string(ctx, s).context("decompress cv FullSnapshot data")?;
+        }
+        (TYPE_INCREMENTAL, Some(SOURCE_MUTATION), Value::Object(obj)) => {
+            for sub_key in ["texts", "attributes", "removes", "adds"] {
+                let Some(Value::String(s)) = obj.get(sub_key) else {
+                    continue;
+                };
+                if s.is_empty() {
+                    obj.insert(
+                        crate::json::key(sub_key),
+                        Value::Array(Box::new(Vec::new())),
+                    );
+                    continue;
+                }
+                let decoded = decode_cv_string(ctx, s)
+                    .with_context(|| format!("decompress cv mutation sub-field `{sub_key}`"))?;
+                obj.insert(crate::json::key(sub_key), decoded);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn decode_cv_string(ctx: &Ctx<'_>, s: &str) -> Result<Value<'static>> {
+    let raw = crate::cv::latin1_to_bytes(s)?;
+    let mut decompressed = ctx.decompress_cv(&raw)?;
+    reject_if_too_deep(&decompressed, "cv payload")?;
+    // Round-trip through owned JSON: the decompressed scratch buffer dies at return, so the
+    // borrowed parse cannot escape this function.
+    let parsed = parse_untrusted(&mut decompressed).context("parse cv payload")?;
+    Ok(string_to_owned_value(parsed))
+}
+
+/// Rebuild a borrowed simd-json value as `'static` (owning every string).
+fn string_to_owned_value(v: Value<'_>) -> Value<'static> {
+    match v {
+        Value::Static(s) => Value::Static(s),
+        Value::String(s) => string_value(s.into_owned()),
+        Value::Array(items) => Value::Array(Box::new(
+            items.into_iter().map(string_to_owned_value).collect(),
+        )),
+        Value::Object(obj) => {
+            let mut out = simd_json::borrowed::Object::with_capacity(obj.len());
+            for (k, val) in obj.into_iter() {
+                out.insert(
+                    std::borrow::Cow::Owned(k.into_owned()),
+                    string_to_owned_value(val),
+                );
+            }
+            Value::Object(Box::new(out))
+        }
+    }
+}
+
+fn from_value<T: serde::de::DeserializeOwned>(value: Value<'_>) -> Result<T> {
+    simd_json::serde::from_borrowed_value(value).map_err(anyhow::Error::from)
+}

--- a/rust/replay-anonymizer/tests/typed.rs
+++ b/rust/replay-anonymizer/tests/typed.rs
@@ -1,0 +1,271 @@
+//! Typed-parse (`typed-parse` feature) contract tests: scrub-then-parse returns a typed rrweb
+//! AST that is already scrubbed and transparently cv-decompressed. The scrubbing hot path is
+//! pinned elsewhere (parity + differential suites); nothing here touches it — the typed module
+//! is not even compiled into the addon build (`default-features = false`).
+#![cfg(feature = "typed-parse")]
+
+use std::io::Write;
+use std::path::Path;
+
+use posthog_replay_anonymizer::typed::{
+    AttrValue, Event, EventData, EventType, IncrementalData, SerializedNode,
+};
+use posthog_replay_anonymizer::{anonymize_line, parse_scrubbed_event, AllowLists};
+use serde_json::json;
+
+fn latin1(bytes: &[u8]) -> String {
+    bytes.iter().map(|&b| b as char).collect()
+}
+
+// The SDK wire format for cv payloads: gzip stored as latin-1 codepoints.
+fn gzip_latin1(json: &[u8]) -> String {
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(json).unwrap();
+    latin1(&enc.finish().unwrap())
+}
+
+fn parse(allow: &AllowLists, line: &str) -> Option<Event> {
+    let mut bytes = line.as_bytes().to_vec();
+    parse_scrubbed_event(allow, &mut bytes).unwrap()
+}
+
+fn allow_hello() -> AllowLists {
+    AllowLists::new(["hello"], Vec::<String>::new())
+}
+
+fn full_snapshot_data() -> serde_json::Value {
+    json!({
+        "node": { "type": 0, "id": 1, "childNodes": [
+            { "type": 2, "id": 2, "tagName": "html", "attributes": {}, "childNodes": [
+                { "type": 2, "id": 3, "tagName": "body", "attributes": { "class": "main" }, "childNodes": [
+                    { "type": 3, "id": 4, "textContent": "hello John Fakename" }
+                ]}
+            ]}
+        ]},
+        "initialOffset": { "top": 1.0, "left": 2.0 }
+    })
+}
+
+#[test]
+fn full_snapshot_parses_to_a_scrubbed_typed_tree() {
+    let allow = allow_hello();
+    let line = json!({ "type": 2, "timestamp": 1700000000000i64, "data": full_snapshot_data() })
+        .to_string();
+    let event = parse(&allow, &line).expect("a full snapshot is recognizable");
+
+    assert_eq!(event.event_type(), Some(EventType::FullSnapshot));
+    assert_eq!(event.timestamp, 1700000000000);
+    let EventData::FullSnapshot(snap) = &event.data else {
+        panic!("expected FullSnapshot data, got {:?}", event.data);
+    };
+    assert_eq!(snap.initial_offset.top, 1.0);
+    assert_eq!(snap.node.id, 1);
+
+    let SerializedNode::Document(doc) = &snap.node.node else {
+        panic!("root must be a Document");
+    };
+    let html = &doc.child_nodes[0];
+    let SerializedNode::Element(html_el) = &html.node else {
+        panic!("expected the html element");
+    };
+    assert_eq!((html.id, html_el.tag_name.as_str()), (2, "html"));
+
+    let body = &html_el.child_nodes[0];
+    let SerializedNode::Element(body_el) = &body.node else {
+        panic!("expected the body element");
+    };
+    assert_eq!(body_el.tag_name, "body");
+    assert_eq!(
+        body_el.attributes.get("class"),
+        Some(&AttrValue::Str("main".to_string()))
+    );
+
+    let SerializedNode::Text(text) = &body_el.child_nodes[0].node else {
+        panic!("expected the text node");
+    };
+    // The typed tree is already scrubbed: no way to reach an unscrubbed AST.
+    assert_eq!(text.text_content, "hello **** ********");
+}
+
+#[test]
+fn mutation_parses_to_scrubbed_typed_subfields() {
+    let allow = allow_hello();
+    let rr_src = "https://cdn.fake.test/avatars/john.fakename.png";
+    let line = json!({ "type": 3, "timestamp": 1.0, "data": {
+        "source": 0,
+        "texts": [{ "id": 5, "value": "hello secret" }],
+        "attributes": [{ "id": 6, "attributes": { "rr_src": rr_src } }],
+        "removes": [{ "parentId": 7, "id": 8 }],
+        "adds": [{ "parentId": 9, "nextId": null,
+                   "node": { "type": 3, "id": 10, "textContent": "hello secret" } }],
+    }})
+    .to_string();
+    let event = parse(&allow, &line).unwrap();
+
+    let EventData::Incremental(IncrementalData::Mutation(m)) = &event.data else {
+        panic!("expected Mutation data, got {:?}", event.data);
+    };
+    assert_eq!(
+        (m.texts[0].id, m.texts[0].value.as_deref()),
+        (5, Some("hello ******"))
+    );
+
+    assert_eq!(m.attributes[0].id, 6);
+    let AttrValue::Str(scrubbed_src) = &m.attributes[0].attributes["rr_src"] else {
+        panic!("rr_src must stay a string");
+    };
+    assert_ne!(
+        scrubbed_src, rr_src,
+        "the rr_src URL must be scrubbed (#68858)"
+    );
+    assert!(!scrubbed_src.contains("john"), "got: {scrubbed_src}");
+
+    assert_eq!((m.removes[0].parent_id, m.removes[0].id), (7, 8));
+
+    assert_eq!((m.adds[0].parent_id, m.adds[0].next_id), (9, None));
+    let SerializedNode::Text(added) = &m.adds[0].node.node else {
+        panic!("expected the added text node");
+    };
+    assert_eq!(added.text_content, "hello ******");
+}
+
+#[test]
+fn cv_full_snapshot_parses_like_its_uncompressed_twin_gzip_and_zstd() {
+    let allow = allow_hello();
+    let data = full_snapshot_data();
+
+    let plain = json!({ "type": 2, "timestamp": 1.0, "data": data }).to_string();
+    let gzip = json!({ "type": 2, "timestamp": 1.0, "cv": "2024-10",
+                       "data": gzip_latin1(data.to_string().as_bytes()) })
+    .to_string();
+    // The anonymizer re-emits changed cv payloads as zstd — its output IS the zstd twin.
+    let zstd = anonymize_line(&allow, &mut gzip.clone().into_bytes())
+        .unwrap()
+        .expect("the scrub rewrites the cv payload");
+
+    let expected = parse(&allow, &plain).unwrap();
+    assert_eq!(
+        parse(&allow, &gzip).unwrap(),
+        expected,
+        "gzip cv twin diverged"
+    );
+    assert_eq!(
+        parse(&allow, &zstd).unwrap(),
+        expected,
+        "zstd cv twin diverged"
+    );
+}
+
+#[test]
+fn cv_mutation_subfields_parse_like_their_uncompressed_twins_gzip_and_zstd() {
+    let allow = allow_hello();
+    let texts = json!([{ "id": 5, "value": "hello secret" }]);
+    let removes = json!([{ "parentId": 7, "id": 8 }]);
+
+    let plain = json!({ "type": 3, "timestamp": 1.0,
+                        "data": { "source": 0, "texts": texts, "removes": removes } })
+    .to_string();
+    let gzip = json!({ "type": 3, "timestamp": 1.0, "cv": "2024-10", "data": {
+        "source": 0,
+        "texts": gzip_latin1(texts.to_string().as_bytes()),
+        "removes": gzip_latin1(removes.to_string().as_bytes()),
+    }})
+    .to_string();
+    // Re-emitted sub-fields become zstd; `removes` is not scrub-routed and stays gzip, so this
+    // twin also covers mixed-format payloads.
+    let zstd = anonymize_line(&allow, &mut gzip.clone().into_bytes())
+        .unwrap()
+        .expect("the scrub rewrites the texts sub-field");
+
+    let expected = parse(&allow, &plain).unwrap();
+    assert_eq!(
+        parse(&allow, &gzip).unwrap(),
+        expected,
+        "gzip cv twin diverged"
+    );
+    assert_eq!(
+        parse(&allow, &zstd).unwrap(),
+        expected,
+        "zstd cv twin diverged"
+    );
+}
+
+#[test]
+fn tuple_lines_carry_the_window_id_and_bare_lines_do_not() {
+    let allow = allow_hello();
+    let event_json = json!({ "type": 3, "timestamp": 2.5,
+                             "data": { "source": 3, "id": 4, "x": 1.0, "y": 2.0 } });
+
+    let tuple = parse(&allow, &json!(["w-1", event_json]).to_string()).unwrap();
+    assert_eq!(tuple.window_id.as_deref(), Some("w-1"));
+    assert_eq!(tuple.event_type(), Some(EventType::IncrementalSnapshot));
+    assert_eq!(tuple.timestamp, 2, "fractional timestamps truncate");
+    let EventData::Incremental(IncrementalData::Scroll(scroll)) = &tuple.data else {
+        panic!("expected Scroll data, got {:?}", tuple.data);
+    };
+    assert_eq!((scroll.id, scroll.x, scroll.y), (4, 1.0, 2.0));
+
+    let bare = parse(&allow, &event_json.to_string()).unwrap();
+    assert_eq!(bare.window_id, None);
+    assert_eq!(bare.data, tuple.data);
+
+    // Not recognizably an event: same policy as `anonymize_line`.
+    assert!(parse(&allow, r#"["w-1","not an event"]"#).is_none());
+    assert!(
+        parse(&allow, r#"{"type":2}"#).is_none(),
+        "missing timestamp"
+    );
+}
+
+#[test]
+fn unmodeled_types_and_sources_pass_through_as_scrubbed_generic_json() {
+    let allow = allow_hello();
+
+    // Unknown incremental source (selection, 14) stays generic.
+    let line = json!({ "type": 3, "timestamp": 1.0,
+                       "data": { "source": 14, "ranges": [] } })
+    .to_string();
+    let event = parse(&allow, &line).unwrap();
+    let EventData::Incremental(IncrementalData::Other(v)) = &event.data else {
+        panic!("expected Other incremental data, got {:?}", event.data);
+    };
+    assert_eq!(v["source"], 14);
+
+    // Custom event (type 5) payload is generic but still scrubbed.
+    let line = json!({ "type": 5, "timestamp": 1.0,
+                       "data": { "tag": "note", "payload": "hello secret" } })
+    .to_string();
+    let event = parse(&allow, &line).unwrap();
+    assert_eq!(event.event_type(), Some(EventType::Custom));
+    let EventData::Other(v) = &event.data else {
+        panic!("expected Other event data, got {:?}", event.data);
+    };
+    assert_eq!(v["payload"], "hello ******");
+}
+
+/// Every shared scrub fixture must round-trip the typed parse without an error — the typed
+/// surface may downgrade an event to `Other`, but it must never fail on payloads the scrubbers
+/// accept.
+#[test]
+fn every_shared_event_fixture_parses() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/events.json");
+    let cases: Vec<serde_json::Value> =
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    assert!(!cases.is_empty());
+    for case in &cases {
+        let strings = |key: &str| -> Vec<String> {
+            case["allow"][key]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let allow = AllowLists::new(strings("text"), strings("url"));
+        let mut line = serde_json::to_vec(&case["event"]).unwrap();
+        parse_scrubbed_event(&allow, &mut line)
+            .unwrap_or_else(|e| panic!("fixture {} failed the typed parse: {e:#}", case["name"]));
+    }
+}


### PR DESCRIPTION
## Problem

MLHog's session-replay-to-text renderer folds typed rrweb events (envelope, FullSnapshot DOM tree, Mutation adds/removes/attributes/texts, interactions) into a DOM mirror. Because `posthog-replay-anonymizer` only exposes byte-in/byte-out scrubbing, MLHog maintains a second Rust rrweb parser (~1,400 lines plus tests) to get that typed view. Exposing typed output here lets that duplicate parser be deleted, leaving one rrweb implementation in the monorepo.

Stacked on #71954 (typed cv transparency needs its zstd sniffing). Item 6 of the same brief.

## Changes

New `typed` module behind a default `typed-parse` feature:

- `parse_scrubbed_event(allow, line)` / `parse_scrubbed_event_with_ctx(ctx, line)`: scrub one JSONL line (bare event or `["window_id", event]` tuple, same routing and `Ok(None)` policy as `anonymize_line`), then return a typed `Event`. Scrub-then-parse is a single call by design, so an unscrubbed AST is unreachable.
- Typed surface: envelope (`type`, truncated-ms `timestamp`, optional `delay` and window id), `FullSnapshotData` (full serialized-node tree with `AttrValue` string/number/bool/null/object values), `MutationData` (adds/removes/attributes/texts), `MouseInteractionData`, `ScrollData`, `InputData`, `MetaData`. Everything else — canvas, stylesheet, plugin, custom, unknown types and sources — passes through as scrubbed generic JSON in `Other` variants (and is not cv-decompressed). All types derive `Serialize` for the renderer's JSON IR; enums round-trip as their rrweb numeric values.
- cv transparency: whole-blob FullSnapshot strings and per-field Mutation compression are decompressed in the typed output, gzip and zstd both (`removes` is never re-emitted by the scrub, so a re-scrubbed line can legitimately hold zstd and gzip sub-fields side by side — the magic sniff from #71954 handles the mix).
- Zero hot-path cost: nothing on the scrubbing path references the module, and the Node addon now depends with `default-features = false`, so the AST types are not compiled into the ingestion cdylib at all.
- Bumps the crate to 0.2.0. After both PRs merge, releasing is: tag the merged commit `posthog-replay-anonymizer/v0.2.0` and push the tag (trusted publishing does the rest).

The type shapes deliberately mirror MLHog's existing `prepare::schema` parser (same serde field contracts, including the type-dispatched node deserialization) so the swap on their side is mechanical, but owned (`String`/`BTreeMap`) rather than borrowed since the typed output outlives the parse scratch. One deviation from a plain port: instead of `serde_repr`, the u8 enums use `#[serde(try_from = "u8", into = "u8")]` to avoid a new proc-macro dependency.

## How did you test this code?

`cargo test` with the feature on (default) and off, plus the addon build with `default-features = false` and clippy (CI toolchain 1.91.1) in both configurations. New integration suite `tests/typed.rs`, each catching a regression nothing else covers:

- FullSnapshot parses to a typed Document → html → body tree whose text is already scrubbed (`John Fakename` asterisked) — the "no unscrubbed AST" contract.
- Mutation typed output carries correct ids/parent ids and a scrubbed `rr_src` attribute value.
- cv FullSnapshot and per-field Mutation parse identically to their uncompressed twins, gzip and zstd each (the zstd twins are built by round-tripping the gzip twin through `anonymize_line`, i.e. the crate's own re-emit).
- Tuple lines capture the window id, bare lines don't; unrecognizable shapes return `Ok(None)`.
- Every shared scrub fixture in `tests/fixtures/events.json` round-trips the typed parse without error.

Not done from this session: running MLHog's renderer against the typed output.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Crate README and rustdoc updated in the same PR. No posthog.com docs cover this crate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) from the same MLHog feature-request brief as #71954; Robbie directed the work. Decisions worth knowing at review: the feature defaults on (so crates.io consumers and CI get it) with the addon opting out, rather than defaulting off (which would have left the typed tests unexercised by `cargo test`/nextest in CI); unknown incremental sources and event types downgrade to `Other` instead of erroring so future rrweb versions don't kill whole lines, while malformed payloads of *known* shapes still fail closed; timestamps are `i64` ms per the brief, with fractional inputs truncating (documented on the field).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*