### PR TITLE
refactor(data-warehouse): migrate oncehub, onepagecrm, onfleet, openai, pagerduty, pandadoc (batch 27)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/oncehub/oncehub.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/oncehub/oncehub.py
@@ -1,28 +1,30 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.oncehub.settings import ONCEHUB_ENDPOINTS
 
 ONCEHUB_BASE_URL = "https://api.oncehub.com/v2"
 # List endpoints accept a `limit` of 1-100 (default 10); the largest page minimises round trips
 # against OnceHub's tight 5 requests/second account rate limit.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm an API key is genuine. The key is account-wide, so one probe
 # validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/users"
 
 
-class OncehubRetryableError(Exception):
-    pass
+def _probe_headers(api_key: str) -> dict[str, str]:
+    return {"API-Key": api_key, "Accept": "application/json"}
 
 
 @dataclasses.dataclass
@@ -33,127 +35,134 @@ class OncehubResumeConfig:
     cursor: str | None = None
 
 
-def _headers(api_key: str) -> dict[str, str]:
-    return {"API-Key": api_key, "Accept": "application/json"}
+class OncehubCursorPaginator(BasePaginator):
+    """Cursor pagination for OnceHub v2 list endpoints.
 
+    OnceHub has no numeric offset — each next page is requested with ``after`` set to the previous
+    page's last object ID. A page's ``has_more`` flag (or an empty page) terminates the walk. The
+    saved cursor points at the next page to fetch, so a resumed run re-issues from there and merge
+    dedupes the re-pulled page on ``id``.
+    """
 
-@retry(
-    retry=retry_if_exception_type((OncehubRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    cursor: str | None,
-    limit: int,
-    logger: FilteringBoundLogger,
-) -> tuple[list[dict[str, Any]], bool]:
-    params: dict[str, Any] = {"limit": limit}
-    if cursor is not None:
-        params["after"] = cursor
+    def __init__(self, cursor_param: str = "after") -> None:
+        super().__init__()
+        self.cursor_param = cursor_param
+        self._cursor: Optional[str] = None
 
-    response = session.get(
-        f"{ONCEHUB_BASE_URL}{path}",
-        params=params,
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
+    def init_request(self, request: Request) -> None:
+        self._apply(request)
 
-    # OnceHub rate limits at 5 req/s per account (429 with type "rate_limit_error"); back off and retry.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise OncehubRetryableError(f"OnceHub API error (retryable): status={response.status_code}, path={path}")
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        body = response.json()
+        has_more = bool(body.get("has_more")) if isinstance(body, dict) else False
+        # Stop on an empty page or once the API says there is no more — matching the hand-rolled walk.
+        if not data or not has_more:
+            self._has_next_page = False
+            return
+        self._cursor = data[-1]["id"]
+        self._has_next_page = True
 
-    if not response.ok:
-        logger.error(f"OnceHub API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
+    def update_request(self, request: Request) -> None:
+        self._apply(request)
 
-    data = response.json()
-    # OnceHub list endpoints wrap records in {"object": "list", "data": [...], "has_more": bool}.
-    if not isinstance(data, dict) or not isinstance(data.get("data"), list):
-        raise OncehubRetryableError(f"OnceHub returned an unexpected payload for {path}: {type(data).__name__}")
+    def _apply(self, request: Request) -> None:
+        if self._cursor is not None:
+            if request.params is None:
+                request.params = {}
+            request.params[self.cursor_param] = self._cursor
 
-    results: list[dict[str, Any]] = data["data"]
-    has_more = bool(data.get("has_more"))
-    return results, has_more
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor} if self._has_next_page and self._cursor is not None else None
 
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[OncehubResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = ONCEHUB_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    cursor = resume.cursor if resume else None
-    if resume and resume.cursor is not None:
-        logger.debug(f"OnceHub: resuming {endpoint} from cursor {cursor}")
-
-    while True:
-        items, has_more = _fetch_page(session, config.path, cursor, PAGE_SIZE, logger)
-        if items:
-            yield items
-
-        if not has_more or not items:
-            break
-
-        # Cursor pagination advances by the last item's object ID — OnceHub has no numeric offset.
-        cursor = items[-1]["id"]
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(OncehubResumeConfig(cursor=cursor))
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor = cursor
+            self._has_next_page = True
 
 
 def oncehub_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[OncehubResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = ONCEHUB_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ONCEHUB_BASE_URL,
+            # Only the non-secret Accept header goes here; the API key rides the framework auth config
+            # so it is redacted from logs and raised error messages.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_key, "name": "API-Key", "location": "header"},
+            "paginator": OncehubCursorPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": PAGE_SIZE},
+                    # OnceHub list endpoints wrap records in {"object": "list", "data": [...], "has_more": bool}.
+                    "data_selector": "data",
+                    # A 200 body that is not this envelope (missing `data`, or a bare/non-list payload)
+                    # means the response shape changed — fail loud instead of silently syncing 0 rows.
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.cursor is not None:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # the next page (already-yielded pages are persisted) and merge dedupes on the primary key.
+        if state and state.get("cursor") is not None:
+            resumable_source_manager.save_state(OncehubResumeConfig(cursor=str(state["cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the API key.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-    try:
-        response = session.get(f"{ONCEHUB_BASE_URL}{path}", params={"limit": 1}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to OnceHub: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"OnceHub returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_key)
-    if status == 200:
+    """Probe a cheap endpoint to validate the API key.
+
+    The key is account-wide, so one probe validates access to every list endpoint. ``200`` is valid;
+    ``401``/``403`` is an auth failure; any other outcome (unexpected status or an unreachable probe)
+    is reported as not validated.
+    """
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{ONCEHUB_BASE_URL}{DEFAULT_PROBE_PATH}?limit=1",
+        headers=_probe_headers(api_key),
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid OnceHub API key"
-    return False, message or "Could not validate OnceHub API key"
+    if status is None:
+        return False, "Could not validate OnceHub API key"
+    return False, f"OnceHub returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/oncehub/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/oncehub/source.py
@@ -129,6 +129,8 @@ You can generate an API key in [OnceHub](https://app.oncehub.com) under **Settin
         return oncehub_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every OnceHub endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/oncehub/tests/test_oncehub.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/oncehub/tests/test_oncehub.py
@@ -1,18 +1,19 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.oncehub import oncehub
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.oncehub.oncehub import (
     PAGE_SIZE,
     OncehubResumeConfig,
-    OncehubRetryableError,
-    check_access,
-    get_rows,
     oncehub_source,
     validate_credentials,
 )
@@ -21,184 +22,189 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.oncehub.se
     ONCEHUB_ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = oncehub._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# The RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the oncehub module.
+ONCEHUB_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.oncehub.oncehub.make_tracked_session"
+)
+# tenacity sleeps between retries; patch it so retry-path tests don't actually wait.
+TENACITY_SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResumableManager:
-    def __init__(self, state: OncehubResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[OncehubResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> OncehubResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: OncehubResumeConfig) -> None:
-        self.saved.append(data)
+def _response(items: list[dict[str, Any]] | None, has_more: bool, *, status: int = 200) -> Response:
+    body = {"object": "list", "data": items if items is not None else [], "has_more": has_more}
+    return _raw_response(body, status=status)
 
 
-def _full_page(prefix: str) -> list[dict]:
+def _raw_response(body: Any, *, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://api.oncehub.com/v2/bookings"
+    return resp
+
+
+def _make_manager(resume_state: OncehubResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _full_page(prefix: str) -> list[dict[str, Any]]:
     return [{"id": f"{prefix}-{i}"} for i in range(PAGE_SIZE)]
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        pages: dict[str | None, tuple[list[dict], bool]],
-        endpoint: str = "bookings",
-    ) -> list[dict]:
-        def fake_fetch(session: Any, path: str, cursor: str | None, limit: int, logger: Any) -> tuple[list[dict], bool]:
-            return pages[cursor]
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
-        monkeypatch.setattr(oncehub, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(oncehub, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="oncehub-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
+def _source(manager: mock.MagicMock, endpoint: str = "bookings") -> Any:
+    return oncehub_source(
+        api_key="oncehub-key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job",
+        resumable_source_manager=manager,
+    )
 
-    def test_single_page_has_more_false_yields_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {None: ([{"id": "BKNG-1"}, {"id": "BKNG-2"}], False)})
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_has_more_false_yields_and_stops(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "BKNG-1"}, {"id": "BKNG-2"}], has_more=False)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
         assert rows == [{"id": "BKNG-1"}, {"id": "BKNG-2"}]
+        assert session.send.call_count == 1
         # has_more is false, so we stop without persisting resume state.
-        assert manager.saved == []
+        manager.save_state.assert_not_called()
 
-    def test_follows_after_cursor_until_has_more_false(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        # First page is full with has_more true; the cursor becomes the last item's id.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_after_cursor_until_has_more_false(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
         first_page = _full_page("BKNG")
         last_id = first_page[-1]["id"]
-        pages: dict[str | None, tuple[list[dict], bool]] = {
-            None: (first_page, True),
-            last_id: ([{"id": "BKNG-final"}], False),
-        }
-        rows = self._collect(manager, monkeypatch, pages)
-        assert len(rows) == PAGE_SIZE + 1
-        # State is saved after the first page (cursor advances to the last id), then we stop.
-        assert [s.cursor for s in manager.saved] == [last_id]
-
-    def test_resumes_from_saved_cursor(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(OncehubResumeConfig(cursor="BKNG-99"))
-        # The initial (cursor=None) page must never be fetched on resume.
-        rows = self._collect(manager, monkeypatch, {"BKNG-99": ([{"id": "BKNG-100"}], False)})
-        assert rows == [{"id": "BKNG-100"}]
-
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {None: ([], False)})
-        assert rows == []
-        assert manager.saved == []
-
-
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else {"object": "list", "data": [], "has_more": False}
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+        params = _wire(
+            session, [_response(first_page, has_more=True), _response([{"id": "BKNG-final"}], has_more=False)]
         )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
 
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert len(rows) == PAGE_SIZE + 1
+        # First page carries only the limit; the second advances by the last item's id via `after`.
+        assert params[0] == {"limit": PAGE_SIZE}
+        assert params[1] == {"limit": PAGE_SIZE, "after": last_id}
+        # State is saved once after the first page (cursor = last id), then the short page ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == OncehubResumeConfig(cursor=last_id)
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "BKNG-100"}], has_more=False)])
+
+        manager = _make_manager(OncehubResumeConfig(cursor="BKNG-99"))
+        rows = _rows(_source(manager))
+
+        assert rows == [{"id": "BKNG-100"}]
+        # The initial (cursor-less) page must never be fetched on resume: the first request carries `after`.
+        assert session.send.call_count == 1
+        assert params[0] == {"limit": PAGE_SIZE, "after": "BKNG-99"}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], has_more=False)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == []
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_has_more_true_but_empty_page_stops_without_checkpoint(self, MockSession: mock.MagicMock) -> None:
+        # A truthy has_more with no items must still terminate (matches the hand-rolled `not items` guard).
+        session = MockSession.return_value
+        _wire(session, [_response([], has_more=True)])
+
+        manager = _make_manager()
+        rows = _rows(_source(manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+
+class TestErrorHandling:
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(OncehubRetryableError):
-            _fetch_page_unwrapped(session, "/bookings", None, PAGE_SIZE, MagicMock())
+    @mock.patch(TENACITY_SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_statuses_retry_then_raise(
+        self, _name: str, status: int, MockSession: mock.MagicMock, _sleep: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], has_more=False, status=status)] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(_source(_make_manager()))
+        # 429/5xx are retried by the client up to its attempt cap, then reraised.
+        assert session.send.call_count == 5
 
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_errors_raise_for_status(self, _name: str, status: int, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([], has_more=False, status=status)])
+
         with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "/bookings", None, PAGE_SIZE, MagicMock())
+            _rows(_source(_make_manager()))
+        # Permanent 4xx is not retried.
+        assert session.send.call_count == 1
 
-    def test_success_returns_data_and_has_more(self) -> None:
-        body = {"object": "list", "data": [{"id": "BKNG-1"}], "has_more": True}
-        session = self._session_returning(200, body)
-        results, has_more = _fetch_page_unwrapped(session, "/bookings", None, PAGE_SIZE, MagicMock())
-        assert results == [{"id": "BKNG-1"}]
-        assert has_more is True
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_raises_loudly(self, MockSession: mock.MagicMock) -> None:
+        # A 200 payload that is a bare list (not the {"data": [...]} envelope) means the shape changed.
+        session = MockSession.return_value
+        _wire(session, [_raw_response([{"id": "BKNG-1"}])])
 
-    def test_non_dict_body_is_retryable(self) -> None:
-        session = self._session_returning(200, [{"id": "BKNG-1"}])
-        with pytest.raises(OncehubRetryableError):
-            _fetch_page_unwrapped(session, "/bookings", None, PAGE_SIZE, MagicMock())
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(_make_manager()))
 
-    def test_missing_data_key_is_retryable(self) -> None:
-        session = self._session_returning(200, {"object": "list", "has_more": False})
-        with pytest.raises(OncehubRetryableError):
-            _fetch_page_unwrapped(session, "/bookings", None, PAGE_SIZE, MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_raises_loudly(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_raw_response({"object": "list", "has_more": False})])
 
-    def test_first_page_uses_limit_without_cursor(self) -> None:
-        session = self._session_returning(200)
-        _fetch_page_unwrapped(session, "/contacts", None, PAGE_SIZE, MagicMock())
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"limit": PAGE_SIZE}
-
-    def test_subsequent_page_sends_after_cursor(self) -> None:
-        session = self._session_returning(200)
-        _fetch_page_unwrapped(session, "/contacts", "CTC-42", PAGE_SIZE, MagicMock())
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"limit": PAGE_SIZE, "after": "CTC-42"}
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(_make_manager()))
 
 
-class TestCheckAccess:
-    @staticmethod
-    def _session(response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        return session
-
-    @parameterized.expand(
-        [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "OnceHub returned HTTP 500"),
-        ]
-    )
-    @patch(f"{oncehub.__name__}.make_tracked_session")
-    def test_status_mapping(
-        self,
-        _name: str,
-        status: int,
-        ok: bool,
-        expected_status: int,
-        expected_message: str | None,
-        mock_session: MagicMock,
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        mock_session.return_value = self._session(response)
-        assert check_access("oncehub-key") == (expected_status, expected_message)
-
-    @patch(f"{oncehub.__name__}.make_tracked_session")
-    def test_connection_error_maps_to_zero(self, mock_session: MagicMock) -> None:
-        mock_session.return_value = self._session(requests.ConnectionError("boom"))
-        status, message = check_access("oncehub-key")
-        assert status == 0
-        assert message is not None and "boom" in message
-
+class TestValidateCredentials:
     @parameterized.expand(
         [
             ("ok", 200, True, None),
@@ -207,31 +213,36 @@ class TestCheckAccess:
             ("server_error", 500, False, "OnceHub returned HTTP 500"),
         ]
     )
-    @patch(f"{oncehub.__name__}.make_tracked_session")
-    def test_validate_credentials(
+    @mock.patch(ONCEHUB_SESSION_PATCH)
+    def test_status_mapping(
         self,
         _name: str,
         status: int,
         expected_valid: bool,
         expected_message: str | None,
-        mock_session: MagicMock,
+        mock_session: mock.MagicMock,
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        mock_session.return_value = self._session(response)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
         assert validate_credentials("oncehub-key") == (expected_valid, expected_message)
+
+    @mock.patch(ONCEHUB_SESSION_PATCH)
+    def test_unreachable_probe_is_not_validated(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        assert validate_credentials("oncehub-key") == (False, "Could not validate OnceHub API key")
+
+    @mock.patch(ONCEHUB_SESSION_PATCH)
+    def test_probe_sends_api_key_header(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("oncehub-key")
+        _, kwargs = mock_session.return_value.get.call_args
+        assert kwargs["headers"]["API-Key"] == "oncehub-key"
 
 
 class TestOncehubSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        response = oncehub_source(
-            api_key="oncehub-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, MockSession: mock.MagicMock) -> None:
+        response = _source(_make_manager(), endpoint=endpoint)
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         # Lists paginate newest-first with no stable ascending order, so we don't partition.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/onepagecrm/onepagecrm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/onepagecrm/onepagecrm.py
@@ -1,16 +1,25 @@
-import base64
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import HttpBasicAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.jsonpath_utils import (
+    find_values,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.onepagecrm.settings import (
     ONEPAGECRM_ENDPOINTS,
     OnepagecrmEndpointConfig,
@@ -19,15 +28,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.onepagecrm
 ONEPAGECRM_BASE_URL = "https://app.onepagecrm.com/api/v3"
 # List endpoints accept a `per_page` of up to 100; the largest page minimises round trips.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
 # Cheap endpoint used to confirm the user ID / API key pair is genuine. The key grants read access
 # to the whole account, so one probe validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/contacts"
-
-
-class OnepagecrmRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -37,26 +40,6 @@ class OnepagecrmResumeConfig:
     # fresher watermark would renumber the pages and skip rows.
     page: int = 1
     modified_since: str | None = None
-
-
-def _basic_auth_token(user_id: str, api_key: str) -> str:
-    return base64.b64encode(f"{user_id}:{api_key}".encode("ascii")).decode("ascii")
-
-
-def _headers(user_id: str, api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Basic {_basic_auth_token(user_id, api_key)}",
-        "Accept": "application/json",
-    }
-
-
-def _make_session(user_id: str, api_key: str) -> requests.Session:
-    # Redact the derived Basic token as well as the raw key so neither survives in
-    # tracked-transport logs or captured samples if an upstream ever reflects it back.
-    return make_tracked_session(
-        headers=_headers(user_id, api_key),
-        redact_values=(api_key, _basic_auth_token(user_id, api_key)),
-    )
 
 
 def _to_epoch(value: Any) -> Optional[int]:
@@ -104,158 +87,155 @@ def modified_since_anchor(db_incremental_field_last_value: Any) -> str | None:
     return str(max(0, epoch - 1))
 
 
+class OnepagecrmPaginator(PageNumberPaginator):
+    """Page-number pagination for OnePageCRM list endpoints.
+
+    Responses carry `data.max_page` (the last page number); pagination stops after it. As a
+    defensive fallback for responses that omit `max_page`, a page shorter than the requested
+    `per_page` also terminates. An empty page always stops.
+    """
+
+    def __init__(self, page_size: int) -> None:
+        super().__init__(base_page=1, page=1, page_param="page", total_path="data.max_page")
+        self._page_size = page_size
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if self.stop_after_empty_page and (data is None or len(data) == 0):
+            self._has_next_page = False
+            return
+
+        self.page += 1
+
+        max_page = self._read_max_page(response)
+        if isinstance(max_page, int):
+            # `self.page` now points at the NEXT page; the last valid page is `max_page`
+            # (base_page=1), matching the hand-rolled `page >= max_page` stop.
+            self._has_next_page = self.page <= max_page
+            return
+
+        # `max_page` absent — fall back to short-page termination.
+        self._has_next_page = data is not None and len(data) >= self._page_size
+
+    def _read_max_page(self, response: Response) -> Optional[int]:
+        try:
+            values = find_values(self.total_path, response.json())
+        except Exception:
+            return None
+        if values and isinstance(values[0], int):
+            return values[0]
+        return None
+
+
+def _unwrap_map(item_key: Optional[str]):
+    # Paginated list responses wrap each record under its singular resource name
+    # (e.g. {"contact": {...}}); config endpoints vary — users/statuses wrap, lead_sources doesn't.
+    def _map(record: dict[str, Any]) -> dict[str, Any]:
+        if item_key is not None and isinstance(record.get(item_key), dict):
+            return record[item_key]
+        return record
+
+    return _map
+
+
 def _build_params(
     config: OnepagecrmEndpointConfig,
-    page: int,
     modified_since: str | None,
     should_use_incremental_field: bool,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
     if config.paginated:
-        params["page"] = page
+        # `page` is injected by the paginator; only the fixed page size is a static param.
         params["per_page"] = PAGE_SIZE
     if config.supports_sort:
         # Incremental runs sort by the cursor field so the per-batch watermark advances
-        # monotonically (sort_mode="asc"). Full-refresh runs sort by the immutable created_at so
-        # rows never shift into already-fetched pages mid-sync.
+        # monotonically (order=asc). Full-refresh runs sort by the immutable created_at so rows
+        # never shift into already-fetched pages mid-sync.
         params["sort_by"] = "modified_at" if should_use_incremental_field else "created_at"
         params["order"] = "asc"
-    if modified_since is not None:
+    if should_use_incremental_field and modified_since is not None:
         params["modified_since"] = modified_since
     return params
-
-
-def _unwrap_items(config: OnepagecrmEndpointConfig, raw_items: list[Any]) -> list[dict[str, Any]]:
-    # Paginated list responses wrap each record under its singular resource name
-    # (e.g. {"contact": {...}, "next_actions": [...]}); config endpoints vary — users/statuses wrap,
-    # lead_sources doesn't.
-    items: list[dict[str, Any]] = []
-    for raw in raw_items:
-        if not isinstance(raw, dict):
-            continue
-        if config.item_key is not None and isinstance(raw.get(config.item_key), dict):
-            items.append(raw[config.item_key])
-        else:
-            items.append(raw)
-    return items
-
-
-def get_rows(
-    user_id: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[OnepagecrmResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = ONEPAGECRM_ENDPOINTS[endpoint]
-    session = _make_session(user_id, api_key)
-
-    @retry(
-        retry=retry_if_exception_type((OnepagecrmRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(params: dict[str, Any]) -> dict[str, Any]:
-        response = session.get(
-            f"{ONEPAGECRM_BASE_URL}{config.path}",
-            params=params,
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise OnepagecrmRetryableError(
-                f"OnePageCRM API error (retryable): status={response.status_code}, path={config.path}"
-            )
-
-        if not response.ok:
-            logger.error(
-                f"OnePageCRM API error: status={response.status_code}, body={response.text}, path={config.path}"
-            )
-            response.raise_for_status()
-
-        body = response.json()
-        if not isinstance(body, dict):
-            raise OnepagecrmRetryableError(
-                f"OnePageCRM returned an unexpected payload for {config.path}: {type(body).__name__}"
-            )
-        return body
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None:
-        page = resume.page
-        modified_since = resume.modified_since
-        logger.debug(f"OnePageCRM: resuming {endpoint} from page {page} (modified_since={modified_since})")
-    else:
-        page = 1
-        modified_since = (
-            modified_since_anchor(db_incremental_field_last_value) if should_use_incremental_field else None
-        )
-
-    if not config.paginated:
-        body = fetch_page(_build_params(config, page, modified_since, should_use_incremental_field))
-        raw_items = body.get("data")
-        if not isinstance(raw_items, list):
-            raise OnepagecrmRetryableError(
-                f"OnePageCRM returned an unexpected 'data' field for {config.path}: {type(raw_items).__name__}"
-            )
-        items = _unwrap_items(config, raw_items)
-        if items:
-            yield items
-        return
-
-    while True:
-        body = fetch_page(_build_params(config, page, modified_since, should_use_incremental_field))
-        data = body.get("data")
-        if not isinstance(data, dict) or not isinstance(data.get(config.data_key), list):
-            raise OnepagecrmRetryableError(
-                f"OnePageCRM returned an unexpected 'data' field for {config.path}: {type(data).__name__}"
-            )
-
-        items = _unwrap_items(config, data[config.data_key])
-        if items:
-            yield items
-
-        # `max_page` marks the last page of the filtered listing; an empty or short page also
-        # terminates defensively in case it's ever missing.
-        max_page = data.get("max_page")
-        if not items:
-            break
-        if isinstance(max_page, int) and page >= max_page:
-            break
-        if not isinstance(max_page, int) and len(items) < PAGE_SIZE:
-            break
-
-        page += 1
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(OnepagecrmResumeConfig(page=page, modified_since=modified_since))
 
 
 def onepagecrm_source(
     user_id: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[OnepagecrmResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = ONEPAGECRM_ENDPOINTS[endpoint]
 
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume is not None:
+        initial_page = resume.page
+        # A fresher watermark must NOT replace the saved anchor: page numbers are only stable for
+        # the query the run started with.
+        modified_since = resume.modified_since
+    else:
+        initial_page = 1
+        modified_since = (
+            modified_since_anchor(db_incremental_field_last_value) if should_use_incremental_field else None
+        )
+
+    if config.paginated:
+        paginator = OnepagecrmPaginator(page_size=PAGE_SIZE)
+        data_selector = f"data.{config.data_key}"
+    else:
+        paginator = SinglePagePaginator()
+        data_selector = "data"
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ONEPAGECRM_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Framework Basic auth so the derived credential is redacted from logs and error
+            # messages instead of a hand-built Authorization header.
+            "auth": {"type": "http_basic", "username": user_id, "password": api_key},
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": _build_params(config, modified_since, should_use_incremental_field),
+                    "data_selector": data_selector,
+                    # A 200 body without the expected data key/list means the response shape
+                    # changed — fail loud instead of silently syncing 0 rows.
+                    "data_selector_required": True,
+                },
+                "data_map": _unwrap_map(config.item_key),
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = {"page": initial_page} if resume is not None else None
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on the primary key) rather than skipping it. The anchor the
+        # run started with is stored alongside the page so a resume re-issues the identical query.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(
+                OnepagecrmResumeConfig(page=int(state["page"]), modified_since=modified_since)
+            )
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            user_id=user_id,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         sort_mode="asc",
         partition_count=1,
@@ -266,31 +246,20 @@ def onepagecrm_source(
     )
 
 
-def check_access(user_id: str, api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
+def validate_credentials(user_id: str, api_key: str) -> tuple[bool, str | None]:
     """Probe a single endpoint to validate the user ID / API key pair.
 
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
+    The API key grants account-wide read access, so one probe validates every list endpoint.
     """
-    session = _make_session(user_id, api_key)
-    try:
-        response = session.get(f"{ONEPAGECRM_BASE_URL}{path}", params={"per_page": 1}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to OnePageCRM: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"OnePageCRM returned HTTP {response.status_code}"
-
-    return 200, None
-
-
-def validate_credentials(user_id: str, api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(user_id, api_key)
-    if status == 200:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{ONEPAGECRM_BASE_URL}{DEFAULT_PROBE_PATH}?per_page=1",
+        auth=HttpBasicAuth(username=user_id, password=api_key),
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid OnePageCRM user ID or API key"
-    return False, message or "Could not validate OnePageCRM credentials"
+    if status is None:
+        return False, "Could not connect to OnePageCRM"
+    return False, f"OnePageCRM returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/onepagecrm/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/onepagecrm/source.py
@@ -136,7 +136,8 @@ You can find your User ID and API key in [OnePageCRM](https://app.onepagecrm.com
             user_id=config.user_id,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/onepagecrm/tests/test_onepagecrm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/onepagecrm/tests/test_onepagecrm.py
@@ -1,15 +1,16 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
+import pytest
 from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.onepagecrm.onepagecrm import (
     OnepagecrmResumeConfig,
-    _build_params,
     _to_epoch,
-    get_rows,
     modified_since_anchor,
     onepagecrm_source,
     validate_credentials,
@@ -19,7 +20,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.onepagecrm
     ONEPAGECRM_ENDPOINTS,
 )
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.onepagecrm.onepagecrm"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the onepagecrm module.
+ONEPAGECRM_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.onepagecrm.onepagecrm.make_tracked_session"
+)
 
 
 def _make_manager(resume_state: OnepagecrmResumeConfig | None = None) -> mock.MagicMock:
@@ -29,11 +35,10 @@ def _make_manager(resume_state: OnepagecrmResumeConfig | None = None) -> mock.Ma
     return manager
 
 
-def _response(body: dict[str, Any], status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.status_code = status_code
-    resp.ok = status_code < 400
-    resp.json.return_value = body
+def _response(body: dict[str, Any]) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
     return resp
 
 
@@ -43,18 +48,54 @@ def _list_page(
     records: list[dict[str, Any]],
     page: int,
     max_page: Optional[int],
-) -> dict[str, Any]:
-    return {
-        "status": 0,
-        "message": "OK",
-        "data": {
-            data_key: [{item_key: record} for record in records],
-            "total_count": len(records),
-            "page": page,
-            "per_page": 100,
-            "max_page": max_page,
-        },
-    }
+) -> Response:
+    return _response(
+        {
+            "status": 0,
+            "message": "OK",
+            "data": {
+                data_key: [{item_key: record} for record in records],
+                "total_count": len(records),
+                "page": page,
+                "per_page": 100,
+                "max_page": max_page,
+            },
+        }
+    )
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages (the paginator injects ``page``),
+    so snapshot a copy when each request is prepared instead of inspecting the final state.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(session_mock: mock.MagicMock, endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return onepagecrm_source(
+        "uid",
+        "key",
+        endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        **kwargs,
+    )
 
 
 class TestToEpoch:
@@ -81,86 +122,77 @@ class TestToEpoch:
         assert modified_since_anchor(None) is None
 
 
-class TestBuildParams:
-    def test_incremental_run_sorts_by_cursor_and_filters(self):
-        params = _build_params(
-            ONEPAGECRM_ENDPOINTS["contacts"], page=3, modified_since="1699999999", should_use_incremental_field=True
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_max_page_and_unwraps_records(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _list_page("contacts", "contact", [{"id": "a1"}, {"id": "a2"}], page=1, max_page=2),
+                _list_page("contacts", "contact", [{"id": "a3"}], page=2, max_page=2),
+            ],
         )
-        assert params == {
-            "page": 3,
-            "per_page": 100,
-            "sort_by": "modified_at",
-            "order": "asc",
-            "modified_since": "1699999999",
-        }
-
-    def test_full_refresh_sorts_by_stable_creation_field(self):
-        params = _build_params(
-            ONEPAGECRM_ENDPOINTS["contacts"], page=1, modified_since=None, should_use_incremental_field=False
-        )
-        assert params == {"page": 1, "per_page": 100, "sort_by": "created_at", "order": "asc"}
-
-    def test_unpaginated_config_endpoint_sends_no_params(self):
-        params = _build_params(
-            ONEPAGECRM_ENDPOINTS["users"], page=1, modified_since=None, should_use_incremental_field=False
-        )
-        assert params == {}
-
-
-class TestGetRows:
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_paginates_until_max_page_and_unwraps_records(self, mock_session):
-        pages = [
-            _list_page("contacts", "contact", [{"id": "a1"}, {"id": "a2"}], page=1, max_page=2),
-            _list_page("contacts", "contact", [{"id": "a3"}], page=2, max_page=2),
-        ]
-        mock_session.return_value.get.side_effect = [_response(p) for p in pages]
 
         manager = _make_manager()
-        batches = list(get_rows("uid", "key", "contacts", mock.MagicMock(), manager))
+        rows = _rows(_source(session, "contacts", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["a1", "a2", "a3"]
-        assert mock_session.return_value.get.call_count == 2
+        assert [r["id"] for r in rows] == ["a1", "a2", "a3"]
+        assert session.send.call_count == 2
+        assert params[0]["page"] == 1
+        assert params[0]["per_page"] == 100
+        assert params[1]["page"] == 2
+        # Checkpoint saved after the first page (points at the next page); the last page ends it.
         manager.save_state.assert_called_once_with(OnepagecrmResumeConfig(page=2, modified_since=None))
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_incremental_run_pins_anchor_across_pages(self, mock_session):
-        pages = [
-            _list_page("deals", "deal", [{"id": "d1"}], page=1, max_page=2),
-            _list_page("deals", "deal", [{"id": "d2"}], page=2, max_page=2),
-        ]
-        mock_session.return_value.get.side_effect = [_response(p) for p in pages]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_sorts_by_stable_creation_field(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_list_page("contacts", "contact", [{"id": "a1"}], page=1, max_page=1)])
+
+        _rows(_source(session, "contacts", _make_manager()))
+
+        assert params[0]["sort_by"] == "created_at"
+        assert params[0]["order"] == "asc"
+        assert "modified_since" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_run_pins_anchor_across_pages(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _list_page("deals", "deal", [{"id": "d1"}], page=1, max_page=2),
+                _list_page("deals", "deal", [{"id": "d2"}], page=2, max_page=2),
+            ],
+        )
 
         manager = _make_manager()
-        list(
-            get_rows(
-                "uid",
-                "key",
+        _rows(
+            _source(
+                session,
                 "deals",
-                mock.MagicMock(),
                 manager,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=1700000000,
             )
         )
 
-        for call in mock_session.return_value.get.call_args_list:
-            assert call.kwargs["params"]["modified_since"] == "1699999999"
+        for snapshot in params:
+            assert snapshot["modified_since"] == "1699999999"
+            assert snapshot["sort_by"] == "modified_at"
         manager.save_state.assert_called_once_with(OnepagecrmResumeConfig(page=2, modified_since="1699999999"))
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_resumes_from_saved_page_and_saved_anchor(self, mock_session):
-        mock_session.return_value.get.return_value = _response(
-            _list_page("deals", "deal", [{"id": "d9"}], page=5, max_page=5)
-        )
-        manager = _make_manager(OnepagecrmResumeConfig(page=5, modified_since="1600000000"))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page_and_saved_anchor(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_list_page("deals", "deal", [{"id": "d9"}], page=5, max_page=5)])
 
-        list(
-            get_rows(
-                "uid",
-                "key",
+        manager = _make_manager(OnepagecrmResumeConfig(page=5, modified_since="1600000000"))
+        _rows(
+            _source(
+                session,
                 "deals",
-                mock.MagicMock(),
                 manager,
                 should_use_incremental_field=True,
                 # A fresher watermark must NOT replace the saved anchor: page numbers are only
@@ -169,29 +201,33 @@ class TestGetRows:
             )
         )
 
-        params = mock_session.return_value.get.call_args.kwargs["params"]
-        assert params["page"] == 5
-        assert params["modified_since"] == "1600000000"
+        assert params[0]["page"] == 5
+        assert params[0]["modified_since"] == "1600000000"
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_short_page_terminates_when_max_page_missing(self, mock_session):
-        body = _list_page("contacts", "contact", [{"id": "a1"}], page=1, max_page=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_page_terminates_when_max_page_missing(self, MockSession):
+        session = MockSession.return_value
+        page = _list_page("contacts", "contact", [{"id": "a1"}], page=1, max_page=None)
+        body = page.json()
         body["data"].pop("max_page")
-        mock_session.return_value.get.return_value = _response(body)
+        page._content = json.dumps(body).encode()
+        _wire(session, [page])
 
         manager = _make_manager()
-        batches = list(get_rows("uid", "key", "contacts", mock.MagicMock(), manager))
+        rows = _rows(_source(session, "contacts", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["a1"]
-        assert mock_session.return_value.get.call_count == 1
+        assert [r["id"] for r in rows] == ["a1"]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_empty_first_page_stops_without_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response(_list_page("contacts", "contact", [], 1, 1))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_stops_without_state(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_list_page("contacts", "contact", [], page=1, max_page=1)])
 
         manager = _make_manager()
-        assert list(get_rows("uid", "key", "contacts", mock.MagicMock(), manager)) == []
+        assert _rows(_source(session, "contacts", manager)) == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
     @parameterized.expand(
@@ -201,15 +237,24 @@ class TestGetRows:
             ("lead_sources", {"data": [{"id": "advertisement"}, {"id": "web"}]}, ["advertisement", "web"]),
         ]
     )
-    @mock.patch(f"{MODULE}.make_tracked_session")
-    def test_config_endpoints_yield_bare_array_records(self, endpoint, body, expected_ids, mock_session):
-        mock_session.return_value.get.return_value = _response(body)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_config_endpoints_yield_bare_array_records(self, endpoint, body, expected_ids, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response(body)])
 
-        manager = _make_manager()
-        batches = list(get_rows("uid", "key", endpoint, mock.MagicMock(), manager))
+        rows = _rows(_source(session, endpoint, _make_manager()))
 
-        assert [item["id"] for batch in batches for item in batch] == expected_ids
-        assert mock_session.return_value.get.call_count == 1
+        assert [r["id"] for r in rows] == expected_ids
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_raises_loudly(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"status": 0, "message": "OK"})])
+
+        # A 200 body missing the data list means the response shape changed — fail loud.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(_source(session, "contacts", _make_manager()))
 
 
 class TestValidateCredentials:
@@ -221,16 +266,16 @@ class TestValidateCredentials:
             (500, False, "OnePageCRM returned HTTP 500"),
         ]
     )
-    @mock.patch(f"{MODULE}.make_tracked_session")
+    @mock.patch(ONEPAGECRM_SESSION_PATCH)
     def test_status_mapping(self, status_code, expected_valid, expected_message, mock_session):
-        mock_session.return_value.get.return_value = _response({}, status_code=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         valid, message = validate_credentials("uid", "key")
 
         assert valid is expected_valid
         assert message == expected_message
 
-    @mock.patch(f"{MODULE}.make_tracked_session")
+    @mock.patch(ONEPAGECRM_SESSION_PATCH)
     def test_connection_error_reports_failure(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
 
@@ -244,7 +289,7 @@ class TestOnepagecrmSourceResponse:
     @parameterized.expand([(endpoint,) for endpoint in ENDPOINTS])
     def test_response_metadata_per_endpoint(self, endpoint):
         config = ONEPAGECRM_ENDPOINTS[endpoint]
-        response = onepagecrm_source("uid", "key", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(mock.MagicMock(), endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/onfleet/onfleet.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/onfleet/onfleet.py
@@ -1,33 +1,33 @@
-import base64
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
+from requests.auth import HTTPBasicAuth
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.onfleet.settings import (
     ONFLEET_ENDPOINTS,
     OnfleetEndpointConfig,
 )
 
 ONFLEET_BASE_URL = "https://onfleet.com/api/v2"
-# Onfleet enforces an internal 70s timeout on large list endpoints (e.g. /workers) before
-# returning a 502, so give each request room up to that boundary.
-REQUEST_TIMEOUT_SECONDS = 70
-MAX_RETRIES = 5
 # `/tasks/all` requires a `from` param; epoch 0 pulls the full history on the initial/full sync.
 DEFAULT_FROM_MS = 0
-
-
-class OnfleetRetryableError(Exception):
-    pass
+# Key carrying the `lastId` cursor in the `/tasks/all` response body and the query param used to
+# continue after it on the next page.
+_CURSOR_KEY = "lastId"
 
 
 @dataclasses.dataclass
@@ -37,18 +37,6 @@ class OnfleetResumeConfig:
     # The `from` epoch-ms lower bound in effect for this sync, re-sent on every page so the
     # server-side window stays applied across the whole paginated walk.
     from_ms: int
-
-
-def _basic_auth_token(api_key: str) -> str:
-    # Onfleet uses HTTP Basic auth with the API key as the username and an empty password.
-    return base64.b64encode(f"{api_key}:".encode("ascii")).decode("ascii")
-
-
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Basic {_basic_auth_token(api_key)}",
-        "Accept": "application/json",
-    }
 
 
 def _to_epoch_ms(value: Any) -> Optional[int]:
@@ -74,31 +62,187 @@ def _to_epoch_ms(value: Any) -> Optional[int]:
         return None
 
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    clean = {key: value for key, value in params.items() if value is not None}
-    if not clean:
-        return f"{ONFLEET_BASE_URL}{path}"
-    return f"{ONFLEET_BASE_URL}{path}?{urlencode(clean)}"
+class OnfleetTasksPaginator(BasePaginator):
+    """Cursor paginator for `/tasks/all`: the response body carries the next `lastId`, which is
+    sent back as a query param to fetch the following page.
+
+    Termination matches the hand-rolled walk it replaces: stop on a missing OR non-advancing
+    cursor (the server echoing the same `lastId` must not loop forever). Resume state is only
+    reported after a page that actually yielded rows, so a crash re-yields the last non-empty page
+    (merge dedupes) rather than checkpointing an empty page.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # The `lastId` that the NEXT request should carry (None on the first page).
+        self._cursor: Optional[str] = None
+        # Whether the most recent page returned any rows — gates whether a checkpoint is offered.
+        self._last_page_had_data = False
+
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume cursor to the first request.
+        if self._cursor is not None:
+            request.params = request.params or {}
+            request.params[_CURSOR_KEY] = self._cursor
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        self._last_page_had_data = bool(data)
+        try:
+            next_cursor = response.json().get(_CURSOR_KEY)
+        except Exception:
+            next_cursor = None
+        if next_cursor and next_cursor != self._cursor:
+            self._cursor = next_cursor
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        if self._has_next_page and self._cursor is not None:
+            request.params = request.params or {}
+            request.params[_CURSOR_KEY] = self._cursor
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # Only checkpoint after a page that yielded rows, mirroring the old "save after yielding
+        # items" behavior — an empty page with an advancing cursor is re-walked on resume.
+        if self._has_next_page and self._cursor is not None and self._last_page_had_data:
+            return {"cursor": self._cursor}
+        return None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor = cursor
+            self._has_next_page = True
 
 
-@retry(
-    retry=retry_if_exception_type((OnfleetRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> Any:
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+def _paginated_source(
+    api_key: str,
+    endpoint: str,
+    config: OnfleetEndpointConfig,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[OnfleetResumeConfig],
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+) -> Any:
+    from_ms = _to_epoch_ms(db_incremental_field_last_value) if should_use_incremental_field else None
+    if from_ms is None:
+        from_ms = DEFAULT_FROM_MS
 
-    # Onfleet rate-limits at 20 req/s org-wide (429) and returns 502 on the internal timeout.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise OnfleetRetryableError(f"Onfleet API error (retryable): status={response.status_code}, url={url}")
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"cursor": resume.last_id}
+            # Re-apply the window the interrupted sync used so resumed pages stay on it.
+            from_ms = resume.from_ms
 
-    if not response.ok:
-        logger.error(f"Onfleet API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ONFLEET_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Onfleet uses HTTP Basic auth with the API key as the username and an empty password.
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            "paginator": OnfleetTasksPaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # `from` is a static server-side window re-sent on every page; the paginator
+                    # only adds the `lastId` cursor.
+                    "params": {"from": from_ms},
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
 
-    return response.json()
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        if state and state.get("cursor") is not None:
+            resumable_source_manager.save_state(OnfleetResumeConfig(last_id=state["cursor"], from_ms=from_ms))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _single_batch_source(
+    api_key: str,
+    endpoint: str,
+    config: OnfleetEndpointConfig,
+    team_id: int,
+    job_id: str,
+    db_incremental_field_last_value: Any,
+) -> Any:
+    # Every non-`/tasks/all` endpoint returns its whole collection in one response with no
+    # pagination: a bare JSON array, or a single object (`/organization`) the framework wraps.
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": ONFLEET_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "http_basic", "username": api_key, "password": ""},
+            "paginator": SinglePagePaginator(),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {"path": config.path},
+            }
+        ],
+    }
+
+    return rest_api_resource(rest_config, team_id, job_id, db_incremental_field_last_value)
+
+
+def onfleet_source(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[OnfleetResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = ONFLEET_ENDPOINTS[endpoint]
+
+    if config.paginated:
+        resource = _paginated_source(
+            api_key=api_key,
+            endpoint=endpoint,
+            config=config,
+            team_id=team_id,
+            job_id=job_id,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        )
+    else:
+        resource = _single_batch_source(
+            api_key=api_key,
+            endpoint=endpoint,
+            config=config,
+            team_id=team_id,
+            job_id=job_id,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        # `/tasks/all` returns rows ascending by creation time; the single-batch endpoints are
+        # order-insensitive. Onfleet timestamps are epoch-ms integers, which the datetime
+        # partitioner would misbucket (it treats ints as epoch seconds), so partitioning is off.
+        sort_mode="asc",
+    )
 
 
 def get_credentials_status(api_key: str) -> Optional[int]:
@@ -107,115 +251,9 @@ def get_credentials_status(api_key: str) -> Optional[int]:
     `/organization` returns the caller's own organization — a light authenticated endpoint that
     only confirms the API key is genuine, not per-endpoint scope.
     """
-    try:
-        response = make_tracked_session().get(
-            f"{ONFLEET_BASE_URL}/organization", headers=_get_headers(api_key), timeout=10
-        )
-        return response.status_code
-    except Exception:
-        return None
-
-
-def _get_paginated_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    config: OnfleetEndpointConfig,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[OnfleetResumeConfig],
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> Iterator[list[dict[str, Any]]]:
-    """Walk `/tasks/all` via the `lastId` cursor, bounded by the server-side `from` window."""
-    from_ms = _to_epoch_ms(db_incremental_field_last_value) if should_use_incremental_field else None
-    if from_ms is None:
-        from_ms = DEFAULT_FROM_MS
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    last_id: str | None = None
-    if resume is not None:
-        last_id = resume.last_id
-        from_ms = resume.from_ms
-        logger.debug(f"Onfleet: resuming {config.name} from lastId={last_id}, from={from_ms}")
-
-    while True:
-        params: dict[str, Any] = {"from": from_ms}
-        if last_id:
-            params["lastId"] = last_id
-
-        data = _fetch(session, _build_url(config.path, params), headers, logger)
-        items = data.get(config.data_key, []) or []
-        next_id = data.get("lastId")
-
-        if items:
-            yield items
-            # Save AFTER yielding so a crash re-yields the last page rather than skipping it —
-            # merge dedupes the re-pulled rows on the primary key.
-            if next_id and next_id != last_id:
-                resumable_source_manager.save_state(OnfleetResumeConfig(last_id=next_id, from_ms=from_ms))
-
-        # A missing (or non-advancing) lastId marks the final page.
-        if not next_id or next_id == last_id:
-            break
-        last_id = next_id
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[OnfleetResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = ONFLEET_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = make_tracked_session()
-
-    if config.paginated:
-        yield from _get_paginated_rows(
-            session,
-            headers,
-            config,
-            logger,
-            resumable_source_manager,
-            should_use_incremental_field,
-            db_incremental_field_last_value,
-        )
-        return
-
-    # Every other endpoint returns the full collection in a single response with no pagination.
-    data = _fetch(session, _build_url(config.path, {}), headers, logger)
-    if config.single_object:
-        if data:
-            yield [data]
-    elif data:
-        yield data
-
-
-def onfleet_source(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[OnfleetResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Optional[Any] = None,
-) -> SourceResponse:
-    config = ONFLEET_ENDPOINTS[endpoint]
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
-        primary_keys=config.primary_keys,
-        # `/tasks/all` returns rows ascending by creation time; the single-batch endpoints are
-        # order-insensitive. Onfleet timestamps are epoch-ms integers, which the datetime
-        # partitioner would misbucket (it treats ints as epoch seconds), so partitioning is off.
-        sort_mode="asc",
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{ONFLEET_BASE_URL}/organization",
+        auth=HTTPBasicAuth(api_key, ""),
     )
+    return status

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/onfleet/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/onfleet/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import OnfleetSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.onfleet.onfleet import (
     OnfleetResumeConfig,
@@ -90,22 +93,12 @@ You can create an API key in your [Onfleet dashboard](https://onfleet.com/dashbo
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint, None) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-                should_sync_default=ONFLEET_ENDPOINTS[endpoint].should_sync_default,
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            should_sync_default={name: config.should_sync_default for name, config in ONFLEET_ENDPOINTS.items()},
+        )
 
     def validate_credentials(
         self, config: OnfleetSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -133,7 +126,8 @@ You can create an API key in your [Onfleet dashboard](https://onfleet.com/dashbo
         return onfleet_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/onfleet/tests/test_onfleet.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/onfleet/tests/test_onfleet.py
@@ -1,17 +1,18 @@
+import json
 import base64
 from datetime import UTC, date, datetime
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from unittest import mock
 
+import requests
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.onfleet.onfleet import (
     OnfleetResumeConfig,
-    _basic_auth_token,
-    _build_url,
     _to_epoch_ms,
     get_credentials_status,
-    get_rows,
     onfleet_source,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.onfleet.settings import (
@@ -19,7 +20,19 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.onfleet.se
     ONFLEET_ENDPOINTS,
 )
 
-_TRANSPORT = "products.warehouse_sources.backend.temporal.data_imports.sources.onfleet.onfleet.make_tracked_session"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# get_credentials_status builds its own tracked session in the onfleet module.
+ONFLEET_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.onfleet.onfleet.make_tracked_session"
+)
+
+
+def _response(body: Any, status_code: int = 200) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: OnfleetResumeConfig | None = None) -> mock.MagicMock:
@@ -29,10 +42,37 @@ def _make_manager(resume_state: OnfleetResumeConfig | None = None) -> mock.Magic
     return manager
 
 
-def _resp(body: Any) -> mock.MagicMock:
-    resp = mock.MagicMock(status_code=200, ok=True)
-    resp.json.return_value = body
-    return resp
+def _wire(session: mock.MagicMock, responses: list[requests.Response]) -> list[requests.PreparedRequest]:
+    """Wire a mock session, preparing each request through a real Session so the Basic-auth header
+    and per-page query string are built for real, and return the prepared requests in send order."""
+    session.headers = {}
+    real = requests.Session()
+    prepared: list[requests.PreparedRequest] = []
+
+    def _prepare(request: requests.Request) -> requests.PreparedRequest:
+        p = real.prepare_request(request)
+        prepared.append(p)
+        return p
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return prepared
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _query(prepared: requests.PreparedRequest) -> dict[str, str]:
+    return {k: v[0] for k, v in parse_qs(urlsplit(prepared.url).query).items()}
+
+
+def _run(endpoint: str, responses: list[requests.Response], manager: mock.MagicMock, **kwargs):
+    with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+        session = MockSession.return_value
+        prepared = _wire(session, responses)
+        rows = _rows(onfleet_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs))
+    return rows, prepared, session
 
 
 class TestToEpochMs:
@@ -57,136 +97,123 @@ class TestToEpochMs:
 class TestBasicAuth:
     def test_api_key_is_username_with_empty_password(self):
         # Onfleet Basic auth: API key as username, empty password.
-        assert base64.b64decode(_basic_auth_token("my-key")).decode() == "my-key:"
-
-
-class TestBuildUrl:
-    def test_no_params(self):
-        assert _build_url("/tasks/all", {}) == "https://onfleet.com/api/v2/tasks/all"
-
-    def test_drops_none_values_and_encodes(self):
-        url = _build_url("/tasks/all", {"from": 0, "lastId": None})
-        assert url == "https://onfleet.com/api/v2/tasks/all?from=0"
+        _rows_, prepared, _session = _run("workers", [_response([{"id": "w1"}])], _make_manager())
+        token = prepared[0].headers["Authorization"].removeprefix("Basic ")
+        assert base64.b64decode(token).decode() == "key:"
 
 
 class TestGetRowsPaginated:
-    @mock.patch(_TRANSPORT)
-    def test_paginates_via_last_id_and_stops_when_absent(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _resp({"lastId": "abc", "tasks": [{"id": "1"}, {"id": "2"}]}),
-            _resp({"tasks": [{"id": "3"}]}),  # no lastId -> final page
-        ]
+    def test_paginates_via_last_id_and_stops_when_absent(self):
         manager = _make_manager()
+        rows, prepared, _session = _run(
+            "tasks",
+            [
+                _response({"lastId": "abc", "tasks": [{"id": "1"}, {"id": "2"}]}),
+                _response({"tasks": [{"id": "3"}]}),  # no lastId -> final page
+            ],
+            manager,
+        )
 
-        batches = list(get_rows("key", "tasks", mock.MagicMock(), manager))
-
-        assert [row["id"] for batch in batches for row in batch] == ["1", "2", "3"]
+        assert [row["id"] for row in rows] == ["1", "2", "3"]
         # Second request continues after the first page's lastId.
-        assert "lastId=abc" in mock_session.return_value.get.call_args_list[1].args[0]
+        assert _query(prepared[1])["lastId"] == "abc"
         # State saved once (only while a next cursor exists), after yielding the page.
         manager.save_state.assert_called_once()
         assert manager.save_state.call_args.args[0].last_id == "abc"
 
-    @mock.patch(_TRANSPORT)
-    def test_resumes_from_saved_cursor(self, mock_session):
-        mock_session.return_value.get.return_value = _resp({"tasks": [{"id": "9"}]})
+    def test_resumes_from_saved_cursor(self):
         manager = _make_manager(OnfleetResumeConfig(last_id="saved", from_ms=1234))
+        _rows_, prepared, _session = _run("tasks", [_response({"tasks": [{"id": "9"}]})], manager)
 
-        list(get_rows("key", "tasks", mock.MagicMock(), manager))
+        first = _query(prepared[0])
+        assert first["lastId"] == "saved"
+        assert first["from"] == "1234"
 
-        first_url = mock_session.return_value.get.call_args_list[0].args[0]
-        assert "lastId=saved" in first_url
-        assert "from=1234" in first_url
-
-    @mock.patch(_TRANSPORT)
-    def test_incremental_from_value_used_as_epoch_ms(self, mock_session):
-        mock_session.return_value.get.return_value = _resp({"tasks": [{"id": "1"}]})
-        manager = _make_manager()
-
-        list(
-            get_rows(
-                "key",
-                "tasks",
-                mock.MagicMock(),
-                manager,
-                should_use_incremental_field=True,
-                db_incremental_field_last_value=1700000000000,
-            )
+    def test_incremental_from_value_used_as_epoch_ms(self):
+        _rows_, prepared, _session = _run(
+            "tasks",
+            [_response({"tasks": [{"id": "1"}]})],
+            _make_manager(),
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=1700000000000,
         )
+        assert _query(prepared[0])["from"] == "1700000000000"
 
-        assert "from=1700000000000" in mock_session.return_value.get.call_args_list[0].args[0]
+    def test_full_refresh_defaults_from_to_zero(self):
+        _rows_, prepared, _session = _run("tasks", [_response({"tasks": [{"id": "1"}]})], _make_manager())
+        assert _query(prepared[0])["from"] == "0"
 
-    @mock.patch(_TRANSPORT)
-    def test_full_refresh_defaults_from_to_zero(self, mock_session):
-        mock_session.return_value.get.return_value = _resp({"tasks": [{"id": "1"}]})
-        manager = _make_manager()
-
-        list(get_rows("key", "tasks", mock.MagicMock(), manager))
-
-        assert "from=0" in mock_session.return_value.get.call_args_list[0].args[0]
-
-    @mock.patch(_TRANSPORT)
-    def test_empty_page_with_advancing_cursor_keeps_paginating(self, mock_session):
+    def test_empty_page_with_advancing_cursor_keeps_paginating(self):
         # A page can be empty yet still carry an advancing lastId; pagination must continue
         # (not terminate) so later, non-empty pages are not skipped.
-        mock_session.return_value.get.side_effect = [
-            _resp({"lastId": "p2", "tasks": []}),
-            _resp({"tasks": [{"id": "1"}]}),  # no lastId -> final page
-        ]
         manager = _make_manager()
+        rows, prepared, _session = _run(
+            "tasks",
+            [
+                _response({"lastId": "p2", "tasks": []}),
+                _response({"tasks": [{"id": "1"}]}),  # no lastId -> final page
+            ],
+            manager,
+        )
 
-        batches = list(get_rows("key", "tasks", mock.MagicMock(), manager))
-
-        assert [row["id"] for batch in batches for row in batch] == ["1"]
-        assert "lastId=p2" in mock_session.return_value.get.call_args_list[1].args[0]
-        # No batch was yielded for the empty page, so no state was saved for it.
+        assert [row["id"] for row in rows] == ["1"]
+        assert _query(prepared[1])["lastId"] == "p2"
+        # No rows were yielded for the empty page, so no checkpoint was saved for it.
         manager.save_state.assert_not_called()
 
-    @mock.patch(_TRANSPORT)
-    def test_non_advancing_cursor_terminates(self, mock_session):
+    def test_non_advancing_cursor_terminates(self):
         # A repeated lastId must not loop forever.
-        mock_session.return_value.get.side_effect = [
-            _resp({"lastId": "x", "tasks": [{"id": "1"}]}),
-            _resp({"lastId": "x", "tasks": [{"id": "1"}]}),
-        ]
         manager = _make_manager()
+        rows, prepared, session = _run(
+            "tasks",
+            [
+                _response({"lastId": "x", "tasks": [{"id": "1"}]}),
+                _response({"lastId": "x", "tasks": [{"id": "1"}]}),
+            ],
+            manager,
+        )
 
-        batches = list(get_rows("key", "tasks", mock.MagicMock(), manager))
-
-        assert mock_session.return_value.get.call_count == 2
-        assert [row["id"] for batch in batches for row in batch] == ["1", "1"]
+        assert session.send.call_count == 2
+        assert [row["id"] for row in rows] == ["1", "1"]
 
 
 class TestGetRowsNonPaginated:
-    @mock.patch(_TRANSPORT)
-    def test_bare_array_endpoint_yields_once(self, mock_session):
-        mock_session.return_value.get.return_value = _resp([{"id": "w1"}, {"id": "w2"}])
+    def test_bare_array_endpoint_yields_once(self):
         manager = _make_manager()
+        rows, _prepared, session = _run("workers", [_response([{"id": "w1"}, {"id": "w2"}])], manager)
 
-        batches = list(get_rows("key", "workers", mock.MagicMock(), manager))
-
-        assert batches == [[{"id": "w1"}, {"id": "w2"}]]
-        assert mock_session.return_value.get.call_count == 1
+        assert rows == [{"id": "w1"}, {"id": "w2"}]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(_TRANSPORT)
-    def test_single_object_endpoint_wraps_in_list(self, mock_session):
-        mock_session.return_value.get.return_value = _resp({"id": "org1", "name": "Acme"})
+    def test_single_object_endpoint_wraps_in_list(self):
+        rows, _prepared, _session = _run("organization", [_response({"id": "org1", "name": "Acme"})], _make_manager())
+        assert rows == [{"id": "org1", "name": "Acme"}]
+
+
+class TestRetries:
+    @mock.patch("tenacity.nap.time.sleep")
+    def test_retryable_status_is_retried_then_succeeds(self, _mock_sleep):
+        # Onfleet rate-limits (429) and returns 5xx on its internal timeout; the client must
+        # retry those and then yield the successful page.
         manager = _make_manager()
-
-        batches = list(get_rows("key", "organization", mock.MagicMock(), manager))
-
-        assert batches == [[{"id": "org1", "name": "Acme"}]]
+        rows, _prepared, session = _run(
+            "workers",
+            [_response(None, status_code=429), _response([{"id": "w1"}])],
+            manager,
+        )
+        assert rows == [{"id": "w1"}]
+        assert session.send.call_count == 2
 
 
 class TestGetCredentialsStatus:
     @pytest.mark.parametrize("status_code", [200, 401, 403, 500])
-    @mock.patch(_TRANSPORT)
+    @mock.patch(ONFLEET_SESSION_PATCH)
     def test_returns_status_code(self, mock_session, status_code):
         mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert get_credentials_status("key") == status_code
 
-    @mock.patch(_TRANSPORT)
+    @mock.patch(ONFLEET_SESSION_PATCH)
     def test_returns_none_on_transport_error(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert get_credentials_status("key") is None
@@ -196,7 +223,7 @@ class TestOnfleetSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = ONFLEET_ENDPOINTS[endpoint]
-        response = onfleet_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = onfleet_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/openai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/openai.py
@@ -1,18 +1,25 @@
 import hashlib
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.openai.settings import (
     OPENAI_ENDPOINTS,
     OpenAIEndpointConfig,
@@ -28,26 +35,131 @@ ENTITY_PAGE_SIZE = 100
 DEFAULT_START_TIME = datetime(2020, 1, 1, tzinfo=UTC)
 
 
-class OpenAIRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class OpenAIResumeConfig:
     # Opaque pagination cursor: an `after` object id for CURSOR endpoints or a `next_page` token
     # for PAGE endpoints. None means "start at the first page".
     cursor: str | None = None
-    # Project fan-out only: the project whose resources we were paging when we saved state. A
-    # stable id (not a positional index) so projects added/removed between a crash and the retry
-    # can't resume us into the wrong project.
+    # Legacy project fan-out resume field (pre-framework): the project whose resources we were
+    # paging when we saved state. Kept so previously-saved state still parses; the framework's
+    # fan-out checkpoint below supersedes it, and an old-shape state restarts the fan-out fresh.
     project_id: str | None = None
+    # Project fan-out checkpoint from the framework:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    fanout_state: dict | None = None
 
 
-def _get_headers(api_key: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {api_key}",
-        "Accept": "application/json",
-    }
+class _EntityPaginator(BasePaginator):
+    """Entity list pagination: an `after` object-id cursor.
+
+    `last_id` drives the next page, falling back to the last item's id (`last_id` isn't documented on
+    every list response) so pagination keeps moving. `has_more` is the authoritative stop signal —
+    the API returns a `last_id` on the final page too, so a missing token alone can't be trusted.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._after: Optional[str] = None
+
+    def _apply(self, request: Request) -> None:
+        if self._after is not None:
+            if request.params is None:
+                request.params = {}
+            request.params["after"] = self._after
+
+    def init_request(self, request: Request) -> None:
+        # Apply a seeded resume cursor to the first request.
+        self._apply(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        if not isinstance(body, dict):
+            self._has_next_page = False
+            return
+        items = data or []
+        last_id = body.get("last_id") or (items[-1].get("id") if items and isinstance(items[-1], dict) else None)
+        if body.get("has_more") and last_id:
+            self._after = last_id
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        self._apply(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._after} if self._has_next_page and self._after is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._after = cursor
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return "_EntityPaginator()"
+
+
+class _BucketPaginator(BasePaginator):
+    """Usage/costs pagination: an opaque `next_page` token echoed back as the `page` query param,
+    gated by `has_more`.
+
+    An empty page ends the stream even if `has_more`/`next_page` are still set — the costs endpoint
+    is known to emit a `next_page` token past the last non-empty bucket page, which would otherwise
+    loop forever.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._page: Optional[str] = None
+
+    def _apply(self, request: Request) -> None:
+        if self._page is not None:
+            if request.params is None:
+                request.params = {}
+            request.params["page"] = self._page
+
+    def init_request(self, request: Request) -> None:
+        self._apply(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        if not isinstance(body, dict) or not data:
+            self._has_next_page = False
+            return
+        next_page = body.get("next_page")
+        if body.get("has_more") and next_page:
+            self._page = next_page
+            self._has_next_page = True
+        else:
+            self._has_next_page = False
+
+    def update_request(self, request: Request) -> None:
+        self._apply(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._page} if self._has_next_page and self._page is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._page = cursor
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return "_BucketPaginator()"
+
+
+def _headers() -> dict[str, str]:
+    # Auth (Bearer) is supplied via the framework auth config so its value is redacted from logs and
+    # raised errors; only the non-secret accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def _to_unix_seconds(value: Any) -> int:
@@ -60,6 +172,12 @@ def _to_unix_seconds(value: Any) -> int:
     return int(value)
 
 
+def _to_unix_seconds_optional(value: Any) -> Optional[int]:
+    """Like `_to_unix_seconds`, but passes None through so an unset watermark drops the filter param
+    (the client omits None-valued params) instead of raising."""
+    return None if value is None else _to_unix_seconds(value)
+
+
 def _from_unix_seconds(value: Any) -> datetime | None:
     """Convert an epoch-seconds field to a UTC datetime so the column lands as a real timestamp
     (needed for the DateTime incremental watermark and datetime partitioning)."""
@@ -68,55 +186,17 @@ def _from_unix_seconds(value: Any) -> datetime | None:
     return datetime.fromtimestamp(int(value), tz=UTC)
 
 
-def _build_url(path: str, params: dict[str, Any], multi_params: dict[str, list[str]] | None = None) -> str:
-    """Build a fully-encoded URL. `multi_params` values are repeated (e.g. group_by=a&group_by=b),
-    matching the official SDK's query serialization."""
-    query: list[tuple[str, str]] = [(k, str(v)) for k, v in params.items() if v is not None]
-    if multi_params:
-        for key, values in multi_params.items():
-            query.extend((key, v) for v in values)
-    encoded = urlencode(query)
-    url = f"{OPENAI_BASE_URL}{path}"
-    return f"{url}?{encoded}" if encoded else url
-
-
-@retry(
-    retry=retry_if_exception_type(
-        (
-            OpenAIRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    # The usage/costs endpoints have low (undocumented) rate limits, so back off generously on 429.
-    wait=wait_exponential_jitter(initial=2, max=60),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, headers=headers, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise OpenAIRetryableError(f"OpenAI API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"OpenAI API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
 def validate_credentials(api_key: str) -> bool:
     # A single cheap probe against the smallest list endpoint confirms the admin key is genuine.
-    url = _build_url("/v1/organization/projects", {"limit": 1})
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
-    except Exception:
-        return False
     # 200 => valid. 403 => valid key without a scope we probed here; still a real key, so accept it
     # at create time (sync-time 403s are caught by get_non_retryable_errors). 401 => bad key.
-    return response.status_code in (200, 403)
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{OPENAI_BASE_URL}/v1/organization/projects?limit=1",
+        headers={"Authorization": f"Bearer {api_key}", **_headers()},
+        ok_statuses=(200, 403),
+    )
+    return ok
 
 
 def _row_id(*parts: Any) -> str:
@@ -176,14 +256,6 @@ def _flatten_owner(item: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
-def _normalize_entity(endpoint: str, item: dict[str, Any]) -> dict[str, Any]:
-    if endpoint in ("admin_api_keys", "project_api_keys"):
-        return _flatten_owner(item)
-    if endpoint == "audit_logs":
-        return _normalize_audit_log(item)
-    return item
-
-
 def _normalize_audit_log(item: dict[str, Any]) -> dict[str, Any]:
     """Give audit log rows a stable column set.
 
@@ -200,247 +272,193 @@ def _normalize_audit_log(item: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
-def _bucket_params(
-    config: OpenAIEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> tuple[dict[str, Any], dict[str, list[str]]]:
-    params: dict[str, Any] = {"bucket_width": config.bucket_width}
-    if config.limit is not None:
-        params["limit"] = config.limit
-
-    # `start_time` is required. On an incremental run start from the watermark (already shifted
-    # back by the pipeline's lookback); otherwise fall back to the API launch era to pull all
-    # available history.
-    if should_use_incremental_field and db_incremental_field_last_value:
-        params["start_time"] = _to_unix_seconds(db_incremental_field_last_value)
-    else:
-        params["start_time"] = _to_unix_seconds(DEFAULT_START_TIME)
-
-    multi_params = {"group_by": config.group_by} if config.group_by else {}
-    return params, multi_params
+def _normalize_entity(endpoint: str, item: dict[str, Any]) -> dict[str, Any]:
+    if endpoint in ("admin_api_keys", "project_api_keys"):
+        return _flatten_owner(item)
+    if endpoint == "audit_logs":
+        return _normalize_audit_log(item)
+    return item
 
 
-def _iter_bucket_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[OpenAIResumeConfig],
-    config: OpenAIEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> Iterator[Any]:
-    params, multi_params = _bucket_params(config, should_use_incremental_field, db_incremental_field_last_value)
+def _make_bucket_data_map(config: OpenAIEndpointConfig) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
+    # One report page is a list of time buckets, each carrying grouped results — flatten to one row
+    # per result with the bucket window merged in. An empty bucket yields no rows.
+    def _explode(bucket: dict[str, Any]) -> list[dict[str, Any]]:
+        return [_flatten_bucket_result(config, bucket, result) for result in bucket.get("results") or []]
 
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume is not None and resume.cursor:
-        params["page"] = resume.cursor
-        logger.debug(f"OpenAI: resuming {config.name} from page cursor")
-
-    while True:
-        url = _build_url(config.path, params, multi_params)
-        data = _fetch_page(session, url, headers, logger)
-        next_page = data.get("next_page")
-        has_more = bool(data.get("has_more"))
-        buckets = data.get("data", [])
-
-        for bucket in buckets:
-            for result in bucket.get("results", []):
-                batcher.batch(_flatten_bucket_result(config, bucket, result))
-                # A single batch can split into several ready chunks, so drain them all before
-                # the next batch() call (which raises if `_ready` is still populated).
-                while batcher.should_yield():
-                    yield batcher.get_table()
-                    # Save only when a batch is actually committed, pointing at the next page. A
-                    # crash then resumes from a page whose predecessors are all in the yielded
-                    # batch, so no buffered rows are skipped; the overlap merge dedupes on the
-                    # primary key.
-                    if has_more and next_page:
-                        resumable_source_manager.save_state(OpenAIResumeConfig(cursor=next_page))
-
-        # The costs endpoint is known to sometimes return a next_page token for an empty page;
-        # treat an empty page as the end of the stream rather than looping on it.
-        if not buckets:
-            if has_more:
-                logger.debug(f"OpenAI: {config.name} returned an empty page with has_more=true, stopping pagination")
-            break
-        if not has_more or not next_page:
-            break
-        params["page"] = next_page
+    return _explode
 
 
-def _iter_cursor_pages(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    path: str,
-    base_params: dict[str, Any],
-    start_after: str | None = None,
-) -> Iterator[tuple[list[dict[str, Any]], str | None]]:
-    """Yield (items, last_id) for each page of a cursor-paginated entity endpoint."""
-    after = start_after
-    while True:
-        params = {**base_params, "limit": ENTITY_PAGE_SIZE}
-        if after:
-            params["after"] = after
-        url = _build_url(path, params)
-        data = _fetch_page(session, url, headers, logger)
+def _make_fanout_data_map(endpoint: str) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    # Project-scoped resource ids are only unique within a project, so the composite key carries the
+    # project id (injected by the fan-out as `_projects_id`).
+    def _stamp(row: dict[str, Any]) -> dict[str, Any]:
+        project_id = row.pop("_projects_id", None)
+        row = _normalize_entity(endpoint, row)
+        row["project_id"] = project_id
+        return row
 
-        items = data.get("data", [])
-        # Fall back to the last item's id: `last_id` isn't documented on every list response.
-        last_id = data.get("last_id") or (items[-1].get("id") if items else None)
-        yield items, last_id
-
-        if not data.get("has_more") or not last_id:
-            break
-        after = last_id
+    return _stamp
 
 
-def _iter_entity_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[OpenAIResumeConfig],
-    config: OpenAIEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> Iterator[Any]:
-    base_params: dict[str, Any] = {**config.extra_params}
-    if config.name == "audit_logs" and should_use_incremental_field and db_incremental_field_last_value:
-        # Bracket-style nested param, matching the official SDK's query serialization. `gte` (not
-        # `gt`) so same-second events that landed after the watermark was cut aren't skipped;
-        # merge dedupes the boundary overlap on `id`.
-        base_params["effective_at[gte]"] = _to_unix_seconds(db_incremental_field_last_value)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_after = resume.cursor if resume is not None else None
-
-    for items, last_id in _iter_cursor_pages(session, headers, logger, config.path, base_params, start_after):
-        for item in items:
-            batcher.batch(_normalize_entity(config.name, item))
-            while batcher.should_yield():
-                yield batcher.get_table()
-                if last_id:
-                    resumable_source_manager.save_state(OpenAIResumeConfig(cursor=last_id))
-
-
-def _iter_project_fan_out_rows(
-    session: requests.Session,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    batcher: Batcher,
-    resumable_source_manager: ResumableSourceManager[OpenAIResumeConfig],
-    config: OpenAIEndpointConfig,
-) -> Iterator[Any]:
-    """Fan out over every project, emitting the project id on each row for the composite key."""
-    project_ids = _list_all_project_ids(session, headers, logger)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    remaining = project_ids
-    resume_after: str | None = None
-    if resume is not None and resume.project_id and resume.project_id in project_ids:
-        remaining = project_ids[project_ids.index(resume.project_id) :]
-        resume_after = resume.cursor
-        logger.debug(f"OpenAI: resuming {config.name} from project_id={resume.project_id}")
-
-    for index, project_id in enumerate(remaining):
-        path = config.path.format(project_id=project_id)
-        after = resume_after
-        resume_after = None  # only the resumed-into project uses the saved cursor
-
-        for items, last_id in _iter_cursor_pages(session, headers, logger, path, {}, after):
-            for item in items:
-                row = {**_normalize_entity(config.name, item), "project_id": project_id}
-                batcher.batch(row)
-                while batcher.should_yield():
-                    yield batcher.get_table()
-                    if last_id:
-                        resumable_source_manager.save_state(OpenAIResumeConfig(cursor=last_id, project_id=project_id))
-
-        # Flush any incomplete batch before checkpointing to the next project, otherwise a crash
-        # between the state save and the final flush would drop this project's buffered rows.
-        while batcher.should_yield(include_incomplete_chunk=True):
-            yield batcher.get_table()
-
-        if index + 1 < len(remaining):
-            resumable_source_manager.save_state(OpenAIResumeConfig(cursor=None, project_id=remaining[index + 1]))
-
-
-def _list_all_project_ids(
-    session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[str]:
-    project_ids: list[str] = []
-    for items, _ in _iter_cursor_pages(
-        session, headers, logger, "/v1/organization/projects", {"include_archived": "true"}
-    ):
-        project_ids.extend(item["id"] for item in items if item.get("id"))
-    return project_ids
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[OpenAIResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[Any]:
-    config = OPENAI_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    batcher = Batcher(logger=logger, chunk_size=5000, chunk_size_bytes=100 * 1024 * 1024)
-    session = make_tracked_session()
-
+def _incremental_param(config: OpenAIEndpointConfig) -> Optional[tuple[str, dict[str, Any]]]:
+    """Server-side time-filter param for an incremental endpoint, or None for full-refresh lists."""
+    if not config.supports_incremental:
+        return None
     if config.pagination == PaginationType.PAGE:
-        yield from _iter_bucket_rows(
-            session,
-            headers,
-            logger,
-            batcher,
-            resumable_source_manager,
-            config,
-            should_use_incremental_field,
-            db_incremental_field_last_value,
-        )
-    elif config.fan_out_over_projects:
-        yield from _iter_project_fan_out_rows(session, headers, logger, batcher, resumable_source_manager, config)
-    else:
-        yield from _iter_entity_rows(
-            session,
-            headers,
-            logger,
-            batcher,
-            resumable_source_manager,
-            config,
-            should_use_incremental_field,
-            db_incremental_field_last_value,
-        )
-
-    while batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+        # `start_time` is required on every usage/costs request; the initial value floors a full
+        # refresh at the API launch era rather than sending no filter at all.
+        return "start_time", {
+            "type": "incremental",
+            "cursor_path": "start_time",
+            "initial_value": DEFAULT_START_TIME,
+            "convert": _to_unix_seconds_optional,
+        }
+    # audit_logs: a bracket-style nested param, matching the official SDK's serialization. Full
+    # refresh has no watermark, so the param resolves to None and is dropped.
+    return "effective_at[gte]", {
+        "type": "incremental",
+        "cursor_path": "effective_at",
+        "initial_value": None,
+        "convert": _to_unix_seconds_optional,
+    }
 
 
 def openai_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[OpenAIResumeConfig],
-    should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = OPENAI_ENDPOINTS[endpoint]
 
+    client_config: ClientConfig = {
+        "base_url": OPENAI_BASE_URL,
+        "headers": _headers(),
+        "auth": {"type": "bearer", "token": api_key},
+    }
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    if config.fan_out_over_projects:
+        # Project-scoped resources have no org-wide list endpoint; enumerate every project (archived
+        # included, since they are still referenced by historical usage/cost rows) and fetch the
+        # resource per project.
+        projects_config = OPENAI_ENDPOINTS["projects"]
+        rest_config: RESTAPIConfig = {
+            "client": client_config,
+            "resource_defaults": None,
+            "resources": [
+                {
+                    "name": "projects",
+                    "endpoint": {
+                        "path": projects_config.path,
+                        "params": {"limit": ENTITY_PAGE_SIZE, **projects_config.extra_params},
+                        "data_selector": "data",
+                        "paginator": _EntityPaginator(),
+                    },
+                },
+                {
+                    "name": endpoint,
+                    "endpoint": {
+                        "path": config.path,
+                        "params": {
+                            "limit": ENTITY_PAGE_SIZE,
+                            "project_id": {"type": "resolve", "resource": "projects", "field": "id"},
+                        },
+                        "data_selector": "data",
+                        "paginator": _EntityPaginator(),
+                    },
+                    "include_from_parent": ["id"],
+                    "data_map": _make_fanout_data_map(endpoint),
+                },
+            ],
+        }
+
+        # Only a framework-shaped checkpoint can seed the fan-out; a legacy (cursor, project_id)
+        # state restarts the fan-out fresh — the overlap merge dedupes on the composite key.
+        initial_fanout_state = resume.fanout_state if resume is not None else None
+
+        def save_fanout_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            if state:
+                resumable_source_manager.save_state(OpenAIResumeConfig(fanout_state=state))
+
+        resources = rest_api_resources(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_fanout_checkpoint,
+            initial_paginator_state=initial_fanout_state,
+        )
+        resource = next(r for r in resources if r.name == endpoint)
+    else:
+        data_map: Optional[Callable[[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]]
+        params: dict[str, Any]
+        if config.pagination == PaginationType.PAGE:
+            params = {"bucket_width": config.bucket_width}
+            if config.limit is not None:
+                params["limit"] = config.limit
+            if config.group_by:
+                # requests encodes a list value as one repeated query param per element.
+                params["group_by"] = config.group_by
+            paginator: BasePaginator = _BucketPaginator()
+            data_map = _make_bucket_data_map(config)
+        else:
+            params = {"limit": ENTITY_PAGE_SIZE, **config.extra_params}
+            paginator = _EntityPaginator()
+            data_map = (
+                (lambda item: _normalize_entity(endpoint, item))
+                if endpoint in ("admin_api_keys", "audit_logs")
+                else None
+            )
+
+        incremental = _incremental_param(config)
+        if incremental is not None:
+            params[incremental[0]] = incremental[1]
+
+        endpoint_resource: EndpointResource = {
+            "name": endpoint,
+            "endpoint": {
+                "path": config.path,
+                "params": params,
+                "data_selector": "data",
+                "paginator": paginator,
+            },
+            "data_map": data_map,
+        }
+
+        rest_config = {
+            "client": client_config,
+            "resource_defaults": None,
+            "resources": [endpoint_resource],
+        }
+
+        initial_paginator_state: Optional[dict[str, Any]] = None
+        if resume is not None and resume.cursor:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only while a next page remains; the checkpoint is saved AFTER a page is
+            # yielded, pointing at the next page, so a crash resumes from a page whose predecessors
+            # were all yielded — the overlap merge dedupes on the primary key.
+            if state and state.get("cursor"):
+                resumable_source_manager.save_state(OpenAIResumeConfig(cursor=state["cursor"]))
+
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         sort_mode=config.sort_mode,
         partition_count=1,
@@ -448,4 +466,5 @@ def openai_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/source.py
@@ -128,9 +128,9 @@ Create an Admin API key (prefixed `sk-admin...`) in your [OpenAI organization se
         return openai_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/tests/test_openai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/tests/test_openai.py
@@ -1,65 +1,97 @@
+import json
 from datetime import UTC, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.openai import openai
 from products.warehouse_sources.backend.temporal.data_imports.sources.openai.openai import (
     OpenAIResumeConfig,
-    _bucket_params,
-    _build_url,
     _flatten_bucket_result,
     _flatten_owner,
     _normalize_audit_log,
     _row_id,
-    get_rows,
+    openai_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.openai.settings import OPENAI_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.openai.source import OpenAISource
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the openai module.
+OPENAI_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.openai.openai.make_tracked_session"
+)
+# tenacity sleeps between retries — patch it so retryable-status tests don't actually wait.
+TENACITY_SLEEP_PATCH = "tenacity.nap.time.sleep"
 
-class _FakeResumableManager:
-    def __init__(self, state: OpenAIResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[OpenAIResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> OpenAIResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: OpenAIResumeConfig) -> None:
-        self.saved.append(data)
+PROJECT_USERS_PATH = "/v1/organization/projects/{project_id}/users"
 
 
-def _collect(
-    manager: _FakeResumableManager, monkeypatch: Any, responses: list[dict], endpoint: str, **kw: Any
-) -> list[dict]:
-    calls: list[str] = []
+def _response(body: dict[str, Any], status: int = 200, headers: dict[str, str] | None = None) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://api.openai.com/v1/organization/users"
+    if headers:
+        resp.headers.update(headers)
+    return resp
 
-    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-        calls.append(url)
-        return responses[len(calls) - 1]
 
-    monkeypatch.setattr(openai, "_fetch_page", fake_fetch)
+def _entity_page(items: list[dict[str, Any]], *, has_more: bool, last_id: str | None = None) -> Response:
+    body: dict[str, Any] = {"data": items, "has_more": has_more}
+    if last_id is not None:
+        body["last_id"] = last_id
+    return _response(body)
 
-    rows: list[dict] = []
-    for table in get_rows(
+
+def _bucket_page(buckets: list[dict[str, Any]], *, has_more: bool, next_page: str | None) -> Response:
+    return _response({"data": buckets, "has_more": has_more, "next_page": next_page})
+
+
+def _make_manager(resume_state: OpenAIResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, last_value: Any = None):
+    return openai_source(
         api_key="sk-admin-test",
         endpoint=endpoint,
-        logger=MagicMock(),
-        resumable_source_manager=manager,  # type: ignore[arg-type]
-        **kw,
-    ):
-        rows.extend(table.to_pylist())
-    manager._captured_calls = calls  # type: ignore[attr-defined]
-    return rows
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+        db_incremental_field_last_value=last_value,
+    )
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestRowId:
@@ -80,38 +112,6 @@ class TestRowId:
         # position, and positions stay aligned so distinct dimension tuples never collide either.
         assert _row_id(None, "x") != _row_id("", "x")
         assert _row_id(None, "x") != _row_id("x", None)
-
-
-class TestBuildUrl:
-    def test_repeats_multi_params(self) -> None:
-        url = _build_url("/v1/organization/usage/completions", {"limit": 31}, {"group_by": ["model", "project_id"]})
-        assert url.count("group_by=") == 2
-        assert "limit=31" in url
-
-    def test_drops_none_values(self) -> None:
-        url = _build_url("/v1/organization/users", {"limit": 100, "after": None})
-        assert "after" not in url
-
-
-class TestBucketParams:
-    def test_incremental_uses_watermark_as_unix_start_time(self) -> None:
-        config = OPENAI_ENDPOINTS["usage_completions"]
-        watermark = datetime(2026, 3, 4, 0, 0, 0, tzinfo=UTC)
-        params, multi = _bucket_params(
-            config, should_use_incremental_field=True, db_incremental_field_last_value=watermark
-        )
-        assert params["start_time"] == int(watermark.timestamp())
-        assert params["bucket_width"] == "1d"
-        assert params["limit"] == 31
-        assert multi == {"group_by": config.group_by}
-
-    def test_full_refresh_falls_back_to_api_launch_era(self) -> None:
-        # Without a watermark we must still send the required start_time; the API launch era pulls
-        # all available history without requesting decades of empty pre-launch buckets.
-        config = OPENAI_ENDPOINTS["costs"]
-        params, _ = _bucket_params(config, should_use_incremental_field=False, db_incremental_field_last_value=None)
-        assert params["start_time"] == int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
-        assert params["limit"] == 180
 
 
 class TestFlattenBucketResult:
@@ -184,202 +184,423 @@ class TestNormalizeAuditLog:
         assert row["effective_at"] == datetime(2024, 8, 1, tzinfo=UTC)
 
 
+class TestBucketParams:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_uses_watermark_as_unix_start_time(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_bucket_page([], has_more=False, next_page=None)])
+
+        watermark = datetime(2026, 3, 4, 0, 0, 0, tzinfo=UTC)
+        _rows(_source("usage_completions", _make_manager(), last_value=watermark))
+
+        config = OPENAI_ENDPOINTS["usage_completions"]
+        assert params[0]["params"]["start_time"] == int(watermark.timestamp())
+        assert params[0]["params"]["bucket_width"] == "1d"
+        assert params[0]["params"]["limit"] == 31
+        # requests encodes the list as one repeated group_by query param per dimension.
+        assert params[0]["params"]["group_by"] == config.group_by
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_falls_back_to_api_launch_era(self, MockSession) -> None:
+        # Without a watermark we must still send the required start_time; the API launch era pulls
+        # all available history without requesting decades of empty pre-launch buckets.
+        session = MockSession.return_value
+        params = _wire(session, [_bucket_page([], has_more=False, next_page=None)])
+
+        _rows(_source("costs", _make_manager()))
+
+        assert params[0]["params"]["start_time"] == int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
+        assert params[0]["params"]["limit"] == 180
+
+
 class TestBucketPagination:
-    def test_follows_next_page_until_has_more_false(self, monkeypatch: Any) -> None:
-        responses = [
-            {
-                "data": [{"start_time": 1, "end_time": 2, "results": [{"model": "a"}]}],
-                "has_more": True,
-                "next_page": "PAGE2",
-            },
-            {
-                "data": [{"start_time": 2, "end_time": 3, "results": [{"model": "b"}]}],
-                "has_more": False,
-                "next_page": None,
-            },
-        ]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, responses, "usage_completions")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_next_page_until_has_more_false(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _bucket_page(
+                    [{"start_time": 1, "end_time": 2, "results": [{"model": "a"}]}], has_more=True, next_page="PAGE2"
+                ),
+                _bucket_page(
+                    [{"start_time": 2, "end_time": 3, "results": [{"model": "b"}]}], has_more=False, next_page=None
+                ),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("usage_completions", manager))
+
         assert [r["model"] for r in rows] == ["a", "b"]
-        # Second request must carry the page token from the first response.
-        assert "page=PAGE2" in manager._captured_calls[1]  # type: ignore[attr-defined]
+        # Second request must carry the page token from the first response; the first must not.
+        assert "page" not in params[0]["params"]
+        assert params[1]["params"]["page"] == "PAGE2"
+        # Checkpoint saved after the first page was yielded, pointing at the next page.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == OpenAIResumeConfig(cursor="PAGE2")
 
-    def test_resumes_from_saved_page_cursor(self, monkeypatch: Any) -> None:
-        responses = [
-            {
-                "data": [{"start_time": 2, "end_time": 3, "results": [{"model": "b"}]}],
-                "has_more": False,
-                "next_page": None,
-            },
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_explodes_every_result_in_a_bucket(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _bucket_page(
+                    [
+                        {"start_time": 1722470400, "end_time": 1722556800, "results": [{"model": "a"}, {"model": "b"}]},
+                        {"start_time": 1722556800, "end_time": 1722643200, "results": []},
+                    ],
+                    has_more=False,
+                    next_page=None,
+                ),
+            ],
+        )
+
+        rows = _rows(_source("usage_completions", _make_manager()))
+
+        # Two rows from the first bucket (bucket window merged into each), none from the empty one.
+        assert [(r["model"], r["start_time"]) for r in rows] == [
+            ("a", datetime(2024, 8, 1, tzinfo=UTC)),
+            ("b", datetime(2024, 8, 1, tzinfo=UTC)),
         ]
-        manager = _FakeResumableManager(OpenAIResumeConfig(cursor="PAGE2"))
-        rows = _collect(manager, monkeypatch, responses, "usage_completions")
-        assert [r["model"] for r in rows] == ["b"]
-        assert "page=PAGE2" in manager._captured_calls[0]  # type: ignore[attr-defined]
 
-    def test_empty_page_with_next_page_token_stops_pagination(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _bucket_page(
+                    [{"start_time": 2, "end_time": 3, "results": [{"model": "b"}]}], has_more=False, next_page=None
+                )
+            ],
+        )
+
+        manager = _make_manager(OpenAIResumeConfig(cursor="PAGE2"))
+        rows = _rows(_source("usage_completions", manager))
+
+        assert [r["model"] for r in rows] == ["b"]
+        assert params[0]["params"]["page"] == "PAGE2"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_with_next_page_token_stops_pagination(self, MockSession) -> None:
         # The costs endpoint is known to return a next_page token alongside an empty page; without
         # the guard, pagination would loop on the empty tail forever.
-        responses = [
-            {
-                "data": [{"start_time": 1, "end_time": 2, "results": [{"line_item": "x"}]}],
-                "has_more": True,
-                "next_page": "PAGE2",
-            },
-            {"data": [], "has_more": True, "next_page": "PAGE3"},
-        ]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, responses, "costs")
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _bucket_page(
+                    [{"start_time": 1, "end_time": 2, "results": [{"line_item": "x"}]}],
+                    has_more=True,
+                    next_page="PAGE2",
+                ),
+                _bucket_page([], has_more=True, next_page="PAGE3"),
+            ],
+        )
+
+        rows = _rows(_source("costs", _make_manager()))
+
         assert [r["line_item"] for r in rows] == ["x"]
-        assert len(manager._captured_calls) == 2  # type: ignore[attr-defined]
-
-    def test_drains_every_chunk_when_a_batch_splits(self, monkeypatch: Any) -> None:
-        # A batch can split into several ready chunks (byte/offset caps). Force it with tiny limits:
-        # if the loop only pops one chunk per batch, the next batch() raises and rows go missing.
-        real_batcher = openai.Batcher
-
-        def tiny_batcher(**_: Any) -> openai.Batcher:
-            return real_batcher(logger=MagicMock(), chunk_size=4, chunk_size_bytes=10**12, max_table_bytes=1)
-
-        monkeypatch.setattr(openai, "Batcher", tiny_batcher)
-
-        results = [{"model": f"m{i}"} for i in range(8)]
-        responses = [
-            {
-                "data": [{"start_time": 1, "end_time": 2, "results": results}],
-                "has_more": False,
-                "next_page": None,
-            }
-        ]
-        rows = _collect(_FakeResumableManager(), monkeypatch, responses, "usage_completions")
-        assert sorted(r["model"] for r in rows) == [f"m{i}" for i in range(8)]
+        assert session.send.call_count == 2
 
 
 class TestEntityPagination:
-    def test_cursor_pagination_uses_after_and_stops(self, monkeypatch: Any) -> None:
-        responses = [
-            {"data": [{"id": "user_1"}], "has_more": True, "last_id": "user_1"},
-            {"data": [{"id": "user_2"}], "has_more": False, "last_id": "user_2"},
-        ]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, responses, "users")
-        assert [r["id"] for r in rows] == ["user_1", "user_2"]
-        assert "after=user_1" in manager._captured_calls[1]  # type: ignore[attr-defined]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_cursor_pagination_uses_after_and_stops(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _entity_page([{"id": "user_1"}], has_more=True, last_id="user_1"),
+                # Final page still carries a last_id — has_more must stop the walk with no extra call.
+                _entity_page([{"id": "user_2"}], has_more=False, last_id="user_2"),
+            ],
+        )
 
-    def test_falls_back_to_last_item_id_when_last_id_missing(self, monkeypatch: Any) -> None:
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
+        assert [r["id"] for r in rows] == ["user_1", "user_2"]
+        assert "after" not in params[0]["params"]
+        assert params[0]["params"]["limit"] == 100
+        assert params[1]["params"]["after"] == "user_1"
+        assert session.send.call_count == 2
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == OpenAIResumeConfig(cursor="user_1")
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_falls_back_to_last_item_id_when_last_id_missing(self, MockSession) -> None:
         # `last_id` isn't documented on every list response; the last item's id must keep
         # pagination moving instead of stopping after page one.
-        responses = [
-            {"data": [{"id": "user_1"}], "has_more": True},
-            {"data": [{"id": "user_2"}], "has_more": False},
-        ]
-        manager = _FakeResumableManager()
-        rows = _collect(manager, monkeypatch, responses, "users")
-        assert [r["id"] for r in rows] == ["user_1", "user_2"]
-        assert "after=user_1" in manager._captured_calls[1]  # type: ignore[attr-defined]
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _entity_page([{"id": "user_1"}], has_more=True),
+                _entity_page([{"id": "user_2"}], has_more=False),
+            ],
+        )
 
-    def test_admin_api_keys_flatten_owner(self, monkeypatch: Any) -> None:
-        responses = [
-            {
-                "data": [{"id": "key_1", "owner": {"type": "user", "id": "user_1", "name": "Ada"}}],
-                "has_more": False,
-                "last_id": "key_1",
-            }
-        ]
-        rows = _collect(_FakeResumableManager(), monkeypatch, responses, "admin_api_keys")
+        rows = _rows(_source("users", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["user_1", "user_2"]
+        assert params[1]["params"]["after"] == "user_1"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_after_cursor(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_entity_page([{"id": "user_6"}], has_more=False, last_id="user_6")])
+
+        _rows(_source("users", _make_manager(OpenAIResumeConfig(cursor="user_5"))))
+
+        assert params[0]["params"]["after"] == "user_5"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_admin_api_keys_flatten_owner(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _entity_page(
+                    [{"id": "key_1", "owner": {"type": "user", "id": "user_1", "name": "Ada"}}],
+                    has_more=False,
+                    last_id="key_1",
+                )
+            ],
+        )
+
+        rows = _rows(_source("admin_api_keys", _make_manager()))
+
         assert rows[0]["owner_id"] == "user_1"
         assert "owner" not in rows[0]
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_projects_include_archived(self, MockSession) -> None:
+        # Archived projects are still referenced by historical usage/cost rows, so the dimension
+        # table must stay complete.
+        session = MockSession.return_value
+        params = _wire(session, [_entity_page([{"id": "proj_1"}], has_more=False, last_id="proj_1")])
+
+        _rows(_source("projects", _make_manager()))
+
+        assert params[0]["params"]["include_archived"] == "true"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows(self, MockSession) -> None:
+        # The legacy implementation tolerated a body without `data` (0 rows); preserve that.
+        session = MockSession.return_value
+        _wire(session, [_response({"has_more": False})])
+
+        assert _rows(_source("users", _make_manager())) == []
+
 
 class TestAuditLogs:
-    def test_incremental_applies_effective_at_filter(self, monkeypatch: Any) -> None:
-        responses = [
-            {"data": [{"id": "audit_log-1", "type": "project.created", "effective_at": 1722470400}], "has_more": False}
-        ]
-        manager = _FakeResumableManager()
-        watermark = datetime(2026, 3, 4, tzinfo=UTC)
-        _collect(
-            manager,
-            monkeypatch,
-            responses,
-            "audit_logs",
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=watermark,
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_applies_effective_at_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(
+                    {
+                        "data": [{"id": "audit_log-1", "type": "project.created", "effective_at": 1722470400}],
+                        "has_more": False,
+                    }
+                )
+            ],
         )
-        # Bracket-style nested param (URL-encoded), matching the official SDK's serialization.
-        assert f"effective_at%5Bgte%5D={int(watermark.timestamp())}" in manager._captured_calls[0]  # type: ignore[attr-defined]
 
-    def test_full_refresh_sends_no_effective_at_filter(self, monkeypatch: Any) -> None:
-        responses = [
-            {"data": [{"id": "audit_log-1", "type": "project.created", "effective_at": 1722470400}], "has_more": False}
-        ]
-        manager = _FakeResumableManager()
-        _collect(manager, monkeypatch, responses, "audit_logs")
-        assert "effective_at" not in manager._captured_calls[0]  # type: ignore[attr-defined]
+        watermark = datetime(2026, 3, 4, tzinfo=UTC)
+        _rows(_source("audit_logs", _make_manager(), last_value=watermark))
+
+        # Bracket-style nested param, matching the official SDK's serialization.
+        assert params[0]["params"]["effective_at[gte]"] == int(watermark.timestamp())
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_sends_no_effective_at_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response(
+                    {
+                        "data": [{"id": "audit_log-1", "type": "project.created", "effective_at": 1722470400}],
+                        "has_more": False,
+                    }
+                )
+            ],
+        )
+
+        _rows(_source("audit_logs", _make_manager()))
+
+        assert "effective_at[gte]" not in params[0]["params"]
 
 
 class TestProjectFanOut:
-    def test_emits_one_row_per_project_resource_with_composite_key(self, monkeypatch: Any) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_emits_one_row_per_project_resource_with_composite_key(self, MockSession) -> None:
         # First response lists projects, then one page per project's users.
-        responses = [
-            {"data": [{"id": "proj_1"}, {"id": "proj_2"}], "has_more": False, "last_id": "proj_2"},
-            {"data": [{"id": "user_1"}], "has_more": False, "last_id": "user_1"},
-            {"data": [{"id": "user_1"}], "has_more": False, "last_id": "user_1"},
-        ]
-        rows = _collect(_FakeResumableManager(), monkeypatch, responses, "project_users")
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _entity_page([{"id": "proj_1"}, {"id": "proj_2"}], has_more=False, last_id="proj_2"),
+                _entity_page([{"id": "user_1"}], has_more=False, last_id="user_1"),
+                _entity_page([{"id": "user_1"}], has_more=False, last_id="user_1"),
+            ],
+        )
+
+        rows = _rows(_source("project_users", _make_manager()))
+
         assert [(r["project_id"], r["id"]) for r in rows] == [("proj_1", "user_1"), ("proj_2", "user_1")]
+        # The framework's parent-key column must not leak into the row shape.
+        assert all("_projects_id" not in r for r in rows)
+        assert params[0]["url"].endswith("/v1/organization/projects")
+        assert params[0]["params"]["include_archived"] == "true"
+        assert params[1]["url"].endswith("/v1/organization/projects/proj_1/users")
+        assert params[2]["url"].endswith("/v1/organization/projects/proj_2/users")
 
-    def test_flushes_each_projects_rows_before_checkpointing_next(self, monkeypatch: Any) -> None:
-        # A project's buffered rows must be yielded before the resume cursor advances to the next
-        # project; otherwise a crash before the final flush would lose them (they'd never be re-read
-        # on resume, which starts at the checkpointed next project).
-        responses = [
-            {"data": [{"id": "proj_1"}, {"id": "proj_2"}], "has_more": False, "last_id": "proj_2"},
-            {"data": [{"id": "user_a"}], "has_more": False, "last_id": "user_a"},
-            {"data": [{"id": "user_b"}], "has_more": False, "last_id": "user_b"},
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_project_api_keys_flatten_owner_and_stamp_project(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _entity_page([{"id": "proj_1"}], has_more=False, last_id="proj_1"),
+                _entity_page(
+                    [{"id": "key_1", "owner": {"type": "user", "user": {"id": "user_1", "name": "Ada"}}}],
+                    has_more=False,
+                    last_id="key_1",
+                ),
+            ],
+        )
+
+        rows = _rows(_source("project_api_keys", _make_manager()))
+
+        assert rows[0]["project_id"] == "proj_1"
+        assert rows[0]["owner_id"] == "user_1"
+        assert "owner" not in rows[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_completed_projects(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _entity_page([{"id": "proj_1"}, {"id": "proj_2"}], has_more=False, last_id="proj_2"),
+                _entity_page([{"id": "user_1"}], has_more=False, last_id="user_1"),
+                _entity_page([{"id": "user_2"}], has_more=False, last_id="user_2"),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(_source("project_users", manager))
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved, "fan-out must checkpoint progress"
+        assert all(isinstance(state, OpenAIResumeConfig) and state.fanout_state for state in saved)
+        final = saved[-1].fanout_state
+        assert final["completed"] == [
+            PROJECT_USERS_PATH.format(project_id="proj_1"),
+            PROJECT_USERS_PATH.format(project_id="proj_2"),
         ]
-        calls: list[str] = []
+        assert final["current"] is None
 
-        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
-            calls.append(url)
-            return responses[len(calls) - 1]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_skipping_completed_projects(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _entity_page([{"id": "proj_1"}, {"id": "proj_2"}], has_more=False, last_id="proj_2"),
+                # Only proj_2's users are fetched — proj_1 completed before the crash.
+                _entity_page([{"id": "user_2"}], has_more=False, last_id="user_2"),
+            ],
+        )
 
-        monkeypatch.setattr(openai, "_fetch_page", fake_fetch)
+        resume = OpenAIResumeConfig(
+            fanout_state={
+                "completed": [PROJECT_USERS_PATH.format(project_id="proj_1")],
+                "current": None,
+                "child_state": None,
+            }
+        )
+        rows = _rows(_source("project_users", _make_manager(resume)))
 
-        events: list[tuple[str, Any]] = []
+        assert [(r["project_id"], r["id"]) for r in rows] == [("proj_2", "user_2")]
+        assert session.send.call_count == 2
+        assert params[1]["url"].endswith("/v1/organization/projects/proj_2/users")
 
-        class _RecordingManager(_FakeResumableManager):
-            def save_state(self, data: OpenAIResumeConfig) -> None:
-                super().save_state(data)
-                events.append(("save", data.project_id))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_resume_state_restarts_fan_out_fresh(self, MockSession) -> None:
+        # Pre-framework state carried (cursor, project_id). It still parses, but the fan-out restarts
+        # from scratch — the overlap merge dedupes on the composite key.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _entity_page([{"id": "proj_1"}], has_more=False, last_id="proj_1"),
+                _entity_page([{"id": "user_1"}], has_more=False, last_id="user_1"),
+            ],
+        )
 
-        manager = _RecordingManager()
-        for table in get_rows(
-            api_key="sk-admin-test",
-            endpoint="project_users",
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            for row in table.to_pylist():
-                events.append(("yield", row["project_id"]))
+        resume = OpenAIResumeConfig(cursor="user_0", project_id="proj_1")
+        rows = _rows(_source("project_users", _make_manager(resume)))
 
-        assert events.index(("yield", "proj_1")) < events.index(("save", "proj_2"))
+        assert [(r["project_id"], r["id"]) for r in rows] == [("proj_1", "user_1")]
+
+    def test_saved_state_shapes_still_parse(self) -> None:
+        # ResumableSourceManager._load_json does dataclass(**saved) — every historical shape must
+        # keep parsing after the migration.
+        assert OpenAIResumeConfig(**{"cursor": "PAGE2", "project_id": None}) == OpenAIResumeConfig(cursor="PAGE2")
+        assert OpenAIResumeConfig(**{"cursor": "u1", "project_id": "proj_2"}).project_id == "proj_2"
+        assert OpenAIResumeConfig(**{"fanout_state": {"completed": []}}).fanout_state == {"completed": []}
+
+
+class TestRetries:
+    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
+    @mock.patch(TENACITY_SLEEP_PATCH, return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried_then_succeeds(self, _name: str, status: int, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status=status),
+                _entity_page([{"id": "user_1"}], has_more=False, last_id="user_1"),
+            ],
+        )
+
+        rows = _rows(_source("users", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["user_1"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises_without_retry(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "unauthorized"}, status=401)])
+
+        with pytest.raises(requests.HTTPError):
+            _rows(_source("users", _make_manager()))
+        assert session.send.call_count == 1
 
 
 class TestValidateCredentials:
     @parameterized.expand([("ok", 200, True), ("forbidden_scope", 403, True), ("unauthorized", 401, False)])
     def test_status_mapping(self, _name: str, status: int, expected: bool) -> None:
         # 403 is accepted at create time (real key, unprobed scope); 401 means a bad key.
-        response = MagicMock(status_code=status)
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(openai, "make_tracked_session", return_value=session):
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=status)
+        with mock.patch(OPENAI_SESSION_PATCH, return_value=session):
             assert validate_credentials("sk-admin-test") is expected
 
     def test_network_error_is_invalid(self) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = requests.ConnectionError("boom")
-        with patch.object(openai, "make_tracked_session", return_value=session):
+        with mock.patch(OPENAI_SESSION_PATCH, return_value=session):
             assert validate_credentials("sk-admin-test") is False
 
 
@@ -412,24 +633,3 @@ class TestNonRetryableErrors:
     def test_transient_errors_remain_retryable(self, _name: str, other_error: str) -> None:
         non_retryable = OpenAISource().get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable)
-
-
-class TestFetchPage:
-    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        response = MagicMock(status_code=status, ok=False)
-        session = MagicMock()
-        session.get.return_value = response
-        with patch.object(openai._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
-            with pytest.raises(openai.OpenAIRetryableError):
-                openai._fetch_page(session, "https://api.openai.com/v1/organization/users", {}, MagicMock())
-        assert session.get.call_count == 5  # exhausts the retry budget
-
-    def test_client_error_raises_for_status_without_retry(self) -> None:
-        response = MagicMock(status_code=401, ok=False, text="unauthorized")
-        response.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=response)
-        session = MagicMock()
-        session.get.return_value = response
-        with pytest.raises(requests.HTTPError):
-            openai._fetch_page(session, "https://api.openai.com/v1/organization/users", {}, MagicMock())
-        assert session.get.call_count == 1

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/pagerduty.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/pagerduty.py
@@ -1,16 +1,19 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.settings import (
     PAGERDUTY_ENDPOINTS,
     PagerDutyEndpointConfig,
@@ -24,21 +27,14 @@ PAGE_SIZE = 100
 # PagerDuty rejects requests where `offset + limit` exceeds 10,000 with an HTTP 400.
 # Stop paginating before we cross it. Incremental endpoints stay well under this because
 # the `since` filter bounds the window; full-refresh endpoints could in theory truncate
-# on very large accounts (logged when it happens).
+# on very large accounts.
 MAX_OFFSET = 10_000
-
-# Retry/throttle settings kept near the top for easy tuning.
-RETRY_ATTEMPTS = 5
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class PagerDutyRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class PagerDutyResumeConfig:
-    offset: int
+    # Row offset of the next unfetched page — PagerDuty list endpoints paginate with limit/offset.
+    offset: int = 0
 
 
 def _format_incremental_value(value: Any) -> str:
@@ -51,6 +47,12 @@ def _format_incremental_value(value: Any) -> str:
     return str(value)
 
 
+def _format_incremental_value_or_none(value: Any) -> Optional[str]:
+    # None means no watermark yet (first incremental sync) — return None so the framework drops the
+    # `since` param entirely rather than sending the literal string "None".
+    return _format_incremental_value(value) if value is not None else None
+
+
 def _get_headers(api_token: str) -> dict[str, str]:
     return {
         "Authorization": f"Token token={api_token}",
@@ -59,23 +61,73 @@ def _get_headers(api_token: str) -> dict[str, str]:
     }
 
 
-def _build_params(
-    config: PagerDutyEndpointConfig,
-    offset: int,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE, "offset": offset}
+class PagerDutyPaginator(BasePaginator):
+    """Offset paginator driven by PagerDuty's body-level ``more`` flag.
 
-    if config.supports_since:
-        # created_at is immutable, so an ascending sort means new rows append to the end
-        # and never shift pages we've already read. We send this on every sync (not just
-        # incremental ones) so full refreshes paginate over a stable ordering too.
-        params["sort_by"] = "created_at:asc"
-        if should_use_incremental_field and db_incremental_field_last_value:
-            params["since"] = _format_incremental_value(db_incremental_field_last_value)
+    PagerDuty signals another page with a ``more: true`` boolean rather than page fullness, and
+    rejects ``offset + limit > 10000`` with an HTTP 400 — so we stop before crossing that ceiling.
+    Neither shape is expressible with the built-in ``OffsetPaginator`` (which keys on a body ``total``
+    or a short page), hence this small local paginator. Resume is supported via the row offset.
+    """
 
-    return params
+    def __init__(self, limit: int = PAGE_SIZE, maximum_offset: int = MAX_OFFSET, offset: int = 0) -> None:
+        super().__init__()
+        self.limit = limit
+        self.maximum_offset = maximum_offset
+        self.offset = offset
+
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["limit"] = self.limit
+        request.params["offset"] = self.offset
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        # Empty page: stop without advancing (the API returned nothing more to read).
+        if not data:
+            self._has_next_page = False
+            return
+
+        try:
+            more = bool(response.json().get("more", False))
+        except Exception:
+            more = False
+        if not more:
+            self._has_next_page = False
+            return
+
+        self.offset += self.limit
+        # PagerDuty 400s when offset + limit exceeds MAX_OFFSET; stop before requesting that page
+        # (results may be truncated on very large full-refresh accounts).
+        if self.offset + self.limit > self.maximum_offset:
+            self._has_next_page = False
+            return
+
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["offset"] = self.offset
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.offset already points at the next page to fetch (update_state incremented it).
+        return {"offset": self.offset} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        offset = state.get("offset")
+        if offset is not None:
+            self.offset = int(offset)
+            self._has_next_page = True
+
+
+def _non_secret_headers() -> dict[str, str]:
+    # Auth (the `Token token=...` Authorization header) is supplied via the framework auth config so
+    # its value is redacted from logs and errors; only the non-secret headers are set here.
+    return {
+        "Accept": "application/vnd.pagerduty+json;version=2",
+        "Content-Type": "application/json",
+    }
 
 
 def validate_credentials(api_token: str, endpoint: Optional[str] = None) -> tuple[bool, int, str | None]:
@@ -88,108 +140,102 @@ def validate_credentials(api_token: str, endpoint: Optional[str] = None) -> tupl
     path = config.path if config else "/users"
     url = f"{PAGERDUTY_BASE_URL}{path}?{urlencode({'limit': 1})}"
 
-    try:
-        response = make_tracked_session().get(url, headers=_get_headers(api_token), timeout=10)
-    except requests.exceptions.RequestException as e:
-        return False, 0, str(e)
-
-    if response.status_code == 200:
-        return True, 200, None
-    if response.status_code == 401:
-        return False, 401, "Invalid PagerDuty API key"
-    if response.status_code == 403:
-        return False, 403, "Your PagerDuty API key does not have access to this resource"
-
-    try:
-        message = response.json().get("error", {}).get("message", response.text)
-    except Exception:
-        message = response.text
-    return False, response.status_code, message
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PagerDutyResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[Any]:
-    config = PAGERDUTY_ENDPOINTS[endpoint]
-    headers = _get_headers(api_token)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume_config.offset if resume_config is not None else 0
-    if resume_config is not None:
-        logger.debug(f"PagerDuty: resuming {endpoint} from offset {offset}")
-
-    @retry(
-        retry=retry_if_exception_type((PagerDutyRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        url,
+        headers=_get_headers(api_token),
     )
-    def fetch_page(page_offset: int) -> dict:
-        params = _build_params(config, page_offset, should_use_incremental_field, db_incremental_field_last_value)
-        url = f"{PAGERDUTY_BASE_URL}{config.path}?{urlencode(params)}"
-        response = make_tracked_session().get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise PagerDutyRetryableError(f"PagerDuty API error (retryable): status={response.status_code}, url={url}")
-
-        if not response.ok:
-            logger.error(f"PagerDuty API error: status={response.status_code}, body={response.text}, url={url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(offset)
-
-        items = data.get(config.envelope_key, [])
-        if not items:
-            break
-
-        yield items
-
-        if not data.get("more", False):
-            break
-
-        offset += PAGE_SIZE
-        if offset + PAGE_SIZE > MAX_OFFSET:
-            logger.warning(
-                f"PagerDuty: reached max offset {MAX_OFFSET} for endpoint '{endpoint}'; "
-                f"stopping pagination (results may be truncated)"
-            )
-            break
-
-        # Save AFTER yielding so a crash re-fetches the last page; merge dedupes on primary key.
-        resumable_source_manager.save_state(PagerDutyResumeConfig(offset=offset))
+    if ok:
+        return True, status if status is not None else 200, None
+    if status is None:
+        return False, 0, "Could not reach PagerDuty"
+    if status == 401:
+        return False, 401, "Invalid PagerDuty API key"
+    if status == 403:
+        return False, 403, "Your PagerDuty API key does not have access to this resource"
+    return False, status, f"PagerDuty API error (status {status})"
 
 
 def pagerduty_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PagerDutyResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
-    config = PAGERDUTY_ENDPOINTS[endpoint]
+    config: PagerDutyEndpointConfig = PAGERDUTY_ENDPOINTS[endpoint]
+
+    params: dict[str, Any] = {}
+    if config.supports_since:
+        # created_at is immutable, so an ascending sort means new rows append to the end and never
+        # shift pages we've already read. Sent on every sync (not just incremental ones) so full
+        # refreshes paginate over a stable ordering too.
+        params["sort_by"] = "created_at:asc"
+        if should_use_incremental_field:
+            # The framework injects the watermark as `since`; on the first incremental sync the value
+            # is None and the param is dropped, so we only bound the window once we have a cursor.
+            params["since"] = {
+                "type": "incremental",
+                "cursor_path": "created_at",
+                "initial_value": None,
+                "convert": _format_incremental_value_or_none,
+            }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": PAGERDUTY_BASE_URL,
+            "headers": _non_secret_headers(),
+            "auth": {
+                "type": "api_key",
+                "api_key": f"Token token={api_token}",
+                "name": "Authorization",
+                "location": "header",
+            },
+            "paginator": PagerDutyPaginator(limit=PAGE_SIZE, maximum_offset=MAX_OFFSET),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # A missing envelope key yields no rows and stops pagination — the API returning an
+                    # unexpected shape isn't treated as fatal here (matches the prior data.get(key, [])).
+                    "data_selector": config.envelope_key,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields the
+        # last page (merge dedupes) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(PagerDutyResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
-        # We always request created_at ascending where a sort is available, and full-refresh
-        # endpoints replace wholesale, so ascending is correct everywhere.
+        # We always request created_at ascending where a sort is available, and full-refresh endpoints
+        # replace wholesale, so ascending is correct everywhere.
         sort_mode="asc",
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/settings.py
@@ -81,3 +81,9 @@ PAGERDUTY_ENDPOINTS: dict[str, PagerDutyEndpointConfig] = {
 }
 
 ENDPOINTS = tuple(PAGERDUTY_ENDPOINTS.keys())
+
+# Per-endpoint incremental fields for build_endpoint_schemas; only `incidents` exposes a
+# server-side `since` filter with a controllable sort, so only it is incremental-capable.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: cfg.incremental_fields for name, cfg in PAGERDUTY_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import PagerDutySourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.pagerduty import (
     PagerDutyResumeConfig,
@@ -28,7 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.settings import (
     ENDPOINTS,
-    PAGERDUTY_ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -87,19 +90,8 @@ You can create a read-only API key in your PagerDuty account under **Integration
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=PAGERDUTY_ENDPOINTS[endpoint].supports_since,
-                supports_append=False,
-                incremental_fields=PAGERDUTY_ENDPOINTS[endpoint].incremental_fields,
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # incidents mutates after creation, so it merges (incremental) but is never append-only.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names, merge_only={"incidents"})
 
     def validate_credentials(
         self, config: PagerDutySourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -134,7 +126,8 @@ You can create a read-only API key in your PagerDuty account under **Integration
         return pagerduty_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/tests/test_pagerduty.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pagerduty/tests/test_pagerduty.py
@@ -1,62 +1,76 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.pagerduty import (
     PAGE_SIZE,
     PagerDutyResumeConfig,
-    _build_params,
     _format_incremental_value,
     _get_headers,
-    get_rows,
     pagerduty_source,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.settings import PAGERDUTY_ENDPOINTS
 
-PAGERDUTY_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.pagerduty"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the pagerduty module.
+PAGERDUTY_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.pagerduty.pagerduty.make_tracked_session"
+)
 
 
-class FakeResumableManager:
-    """In-memory stand-in for ResumableSourceManager that records saved state."""
-
-    def __init__(self, resume_state: Optional[PagerDutyResumeConfig] = None) -> None:
-        self._resume_state = resume_state
-        self.saved_states: list[PagerDutyResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._resume_state is not None
-
-    def load_state(self) -> Optional[PagerDutyResumeConfig]:
-        return self._resume_state
-
-    def save_state(self, data: PagerDutyResumeConfig) -> None:
-        self.saved_states.append(data)
+def _response(items: Optional[list[dict[str, Any]]], *, more: bool = False, envelope: str = "incidents") -> Response:
+    body: dict[str, Any] = {"more": more}
+    if items is not None:
+        body[envelope] = items
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    resp.url = "https://api.pagerduty.com/incidents"
+    return resp
 
 
-def _mock_response(status_code: int = 200, body: Any = None, text: str = "") -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = 200 <= status_code < 300
-    response.text = text
-    response.json.return_value = body if body is not None else {}
-    if not response.ok:
-        error_response = requests.Response()
-        error_response.status_code = status_code
-        response.raise_for_status.side_effect = requests.HTTPError(
-            f"{status_code} Client Error: error for url: https://api.pagerduty.com", response=error_response
-        )
-    return response
+def _error_response(status_code: int) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps({"error": {"message": "boom"}}).encode()
+    resp.url = "https://api.pagerduty.com/incidents"
+    return resp
 
 
-def _patch_session(get_side_effect: Any) -> Any:
-    session = MagicMock()
-    session.get.side_effect = get_side_effect
-    return patch(f"{PAGERDUTY_MODULE}.make_tracked_session", return_value=session), session
+def _make_manager(resume_state: Optional[PagerDutyResumeConfig] = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list that captures each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatIncrementalValue:
@@ -80,35 +94,263 @@ class TestHeaders:
         assert headers["Accept"] == "application/vnd.pagerduty+json;version=2"
 
 
-class TestBuildParams:
-    def test_full_refresh_incremental_endpoint_sends_stable_sort_only(self) -> None:
-        params = _build_params(
-            PAGERDUTY_ENDPOINTS["incidents"],
-            offset=0,
-            should_use_incremental_field=False,
-            db_incremental_field_last_value=None,
-        )
-        assert params == {"limit": PAGE_SIZE, "offset": 0, "sort_by": "created_at:asc"}
+class TestAuth:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_token_sent_as_pagerduty_authorization_header(self, MockSession) -> None:
+        # The framework auth config must reproduce PagerDuty's `Token token=<key>` scheme.
+        session = MockSession.return_value
+        captured: dict[str, Any] = {}
 
-    def test_incremental_endpoint_sends_since(self) -> None:
-        params = _build_params(
-            PAGERDUTY_ENDPOINTS["incidents"],
-            offset=200,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
-        )
-        assert params["offset"] == 200
-        assert params["sort_by"] == "created_at:asc"
-        assert params["since"] == "2026-01-01T00:00:00+00:00"
+        def _prepare(request: Any) -> mock.MagicMock:
+            request.auth(request)
+            captured["auth"] = request.headers.get("Authorization")
+            return mock.MagicMock()
 
-    def test_non_incremental_endpoint_has_no_sort_or_since(self) -> None:
-        params = _build_params(
-            PAGERDUTY_ENDPOINTS["users"],
-            offset=0,
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+        session.headers = {}
+        session.prepare_request.side_effect = _prepare
+        session.send.side_effect = [_response([{"id": "1"}], more=False)]
+
+        _rows(pagerduty_source("tok_abc", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert captured["auth"] == "Token token=tok_abc"
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_yields_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "1"}, {"id": "2"}], more=True),
+                _response([{"id": "3"}], more=False),
+            ],
         )
-        assert params == {"limit": PAGE_SIZE, "offset": 0}
+
+        rows = _rows(
+            pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert [r["id"] for r in rows] == ["1", "2", "3"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_advances_offset_between_pages(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response([{"id": "1"}], more=True),
+                _response([{"id": "2"}], more=False),
+            ],
+        )
+
+        _rows(pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == PAGE_SIZE
+        assert params[1]["offset"] == PAGE_SIZE
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_more_flag_drives_continuation_regardless_of_page_size(self, MockSession) -> None:
+        # A short page (1 item) with more=True must still continue — PagerDuty's `more` boolean,
+        # not page fullness, is the authoritative "another page" signal.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "1"}], more=True),
+                _response([{"id": "2"}], more=False),
+            ],
+        )
+
+        rows = _rows(
+            pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert [r["id"] for r in rows] == ["1", "2"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_more_false_stops(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "1"}], more=False)])
+
+        rows = _rows(
+            pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert [r["id"] for r in rows] == ["1"]
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_stops_iteration(self, MockSession) -> None:
+        session = MockSession.return_value
+        # more=True but no items — a missing/empty envelope must stop rather than loop forever.
+        _wire(session, [_response([], more=True)])
+
+        rows = _rows(
+            pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert rows == []
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_envelope_key_stops_without_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, more=True)])
+
+        rows = _rows(
+            pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_uses_envelope_key_per_endpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "svc_1"}], more=False, envelope="services")])
+
+        rows = _rows(
+            pagerduty_source("tok", "services", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert [r["id"] for r in rows] == ["svc_1"]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_before_crossing_max_offset(self, MockSession) -> None:
+        # PagerDuty 400s when offset + limit exceeds 10000. Full pages that always report more=True
+        # must stop before requesting offset=10000 (the first page whose offset+limit would exceed).
+        session = MockSession.return_value
+        session.headers = {}
+        offsets: list[int] = []
+
+        def _prepare(request: Any) -> mock.MagicMock:
+            offsets.append(request.params["offset"])
+            return mock.MagicMock()
+
+        session.prepare_request.side_effect = _prepare
+        # Always more=True — only the offset ceiling can stop it.
+        session.send.side_effect = [_response([{"id": str(i)}], more=True) for i in range(200)]
+
+        _rows(pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert offsets[0] == 0
+        assert offsets[-1] == 9900
+        assert 10000 not in offsets
+
+
+class TestResume:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "x"}], more=False)])
+
+        manager = _make_manager(PagerDutyResumeConfig(offset=PAGE_SIZE))
+        _rows(pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=manager))
+        assert params[0]["offset"] == PAGE_SIZE
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_next_offset_after_each_continued_page(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "1"}], more=True),
+                _response([{"id": "2"}], more=False),
+            ],
+        )
+
+        manager = _make_manager()
+        _rows(pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=manager))
+        # Checkpoint saved once (next offset) after the first page; the final page (more=False) saves nothing.
+        saved = [c.args[0] for c in manager.save_state.call_args_list]
+        assert saved == [PagerDutyResumeConfig(offset=PAGE_SIZE)]
+
+
+class TestIncremental:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_endpoint_sends_since_and_sort(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "1"}], more=False)])
+
+        _rows(
+            pagerduty_source(
+                "tok",
+                "incidents",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        assert params[0]["sort_by"] == "created_at:asc"
+        assert params[0]["since"] == "2026-01-01T00:00:00+00:00"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_endpoint_without_watermark_omits_since(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "1"}], more=False)])
+
+        _rows(
+            pagerduty_source(
+                "tok",
+                "incidents",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=None,
+            )
+        )
+        assert params[0]["sort_by"] == "created_at:asc"
+        assert "since" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_incremental_endpoint_sends_stable_sort_only(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "1"}], more=False)])
+
+        _rows(pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert params[0]["sort_by"] == "created_at:asc"
+        assert "since" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_incremental_endpoint_has_no_sort_or_since(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": "1"}], more=False, envelope="users")])
+
+        _rows(
+            pagerduty_source(
+                "tok",
+                "users",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        assert "sort_by" not in params[0]
+        assert "since" not in params[0]
+
+
+class TestRetries:
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_on_429_then_succeeds(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_error_response(429), _response([{"id": "1"}], more=False)])
+
+        rows = _rows(
+            pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert [r["id"] for r in rows] == ["1"]
+        assert session.send.call_count == 2
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_on_500_then_succeeds(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        _wire(session, [_error_response(500), _response([{"id": "1"}], more=False)])
+
+        rows = _rows(
+            pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+        assert [r["id"] for r in rows] == ["1"]
+        assert session.send.call_count == 2
 
 
 class TestValidateCredentials:
@@ -122,119 +364,54 @@ class TestValidateCredentials:
         ],
     )
     def test_status_mapping(self, status_code: int, expected_ok: bool, expected_status: int) -> None:
-        ctx, _ = _patch_session([_mock_response(status_code, body={}, text="boom")])
-        with ctx:
+        with mock.patch(PAGERDUTY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
             ok, status, _error = validate_credentials("tok")
         assert ok is expected_ok
         assert status == expected_status
 
     def test_transport_failure_returns_zero_status(self) -> None:
-        ctx, _ = _patch_session(requests.ConnectionError("no network"))
-        with ctx:
+        with mock.patch(PAGERDUTY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.side_effect = Exception("no network")
             ok, status, error = validate_credentials("tok")
         assert ok is False
         assert status == 0
-        assert error == "no network"
+        assert error is not None
+
+    def test_custom_messages_per_status(self) -> None:
+        with mock.patch(PAGERDUTY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=401)
+            assert validate_credentials("tok")[2] == "Invalid PagerDuty API key"
+        with mock.patch(PAGERDUTY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=403)
+            assert validate_credentials("tok")[2] == "Your PagerDuty API key does not have access to this resource"
 
     def test_uses_endpoint_path_when_schema_given(self) -> None:
-        ctx, session = _patch_session([_mock_response(200)])
-        with ctx:
+        with mock.patch(PAGERDUTY_SESSION_PATCH) as mock_session:
+            mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
             validate_credentials("tok", endpoint="incidents")
-        called_url = session.get.call_args.args[0]
+            called_url = mock_session.return_value.get.call_args.args[0]
         assert called_url.startswith("https://api.pagerduty.com/incidents?")
-
-
-class TestGetRows:
-    def test_paginates_and_yields_lists_of_dicts(self) -> None:
-        page1 = _mock_response(200, body={"incidents": [{"id": "1"}, {"id": "2"}], "more": True})
-        page2 = _mock_response(200, body={"incidents": [{"id": "3"}], "more": False})
-        manager = FakeResumableManager()
-
-        ctx, session = _patch_session([page1, page2])
-        with ctx:
-            batches = list(
-                get_rows("tok", "incidents", MagicMock(), manager)  # type: ignore[arg-type]
-            )
-
-        assert batches == [[{"id": "1"}, {"id": "2"}], [{"id": "3"}]]
-        assert session.get.call_count == 2
-
-    def test_saves_state_after_yielding_each_page(self) -> None:
-        page1 = _mock_response(200, body={"incidents": [{"id": "1"}], "more": True})
-        page2 = _mock_response(200, body={"incidents": [{"id": "2"}], "more": False})
-        manager = FakeResumableManager()
-
-        ctx, _ = _patch_session([page1, page2])
-        with ctx:
-            list(get_rows("tok", "incidents", MagicMock(), manager))  # type: ignore[arg-type]
-
-        # State is checkpointed once (the next offset) after the first page is yielded;
-        # the final page sets more=False so no further checkpoint is written.
-        assert [s.offset for s in manager.saved_states] == [PAGE_SIZE]
-
-    def test_advances_offset_between_pages(self) -> None:
-        page1 = _mock_response(200, body={"incidents": [{"id": "1"}], "more": True})
-        page2 = _mock_response(200, body={"incidents": [{"id": "2"}], "more": False})
-        manager = FakeResumableManager()
-
-        ctx, session = _patch_session([page1, page2])
-        with ctx:
-            list(get_rows("tok", "incidents", MagicMock(), manager))  # type: ignore[arg-type]
-
-        first_url = session.get.call_args_list[0].args[0]
-        second_url = session.get.call_args_list[1].args[0]
-        assert "offset=0" in first_url
-        assert f"offset={PAGE_SIZE}" in second_url
-
-    def test_resumes_from_saved_offset(self) -> None:
-        manager = FakeResumableManager(resume_state=PagerDutyResumeConfig(offset=PAGE_SIZE))
-        page = _mock_response(200, body={"incidents": [{"id": "x"}], "more": False})
-
-        ctx, session = _patch_session([page])
-        with ctx:
-            list(get_rows("tok", "incidents", MagicMock(), manager))  # type: ignore[arg-type]
-
-        assert f"offset={PAGE_SIZE}" in session.get.call_args_list[0].args[0]
-
-    def test_empty_page_stops_iteration(self) -> None:
-        page = _mock_response(200, body={"incidents": [], "more": True})
-        manager = FakeResumableManager()
-
-        ctx, session = _patch_session([page])
-        with ctx:
-            batches = list(get_rows("tok", "incidents", MagicMock(), manager))  # type: ignore[arg-type]
-
-        assert batches == []
-        assert session.get.call_count == 1
-
-    def test_uses_envelope_key_per_endpoint(self) -> None:
-        page = _mock_response(200, body={"services": [{"id": "svc_1"}], "more": False})
-        manager = FakeResumableManager()
-
-        ctx, _ = _patch_session([page])
-        with ctx:
-            batches = list(get_rows("tok", "services", MagicMock(), manager))  # type: ignore[arg-type]
-
-        assert batches == [[{"id": "svc_1"}]]
 
 
 class TestPagerDutySourceResponse:
     def test_incidents_partitioned_on_created_at(self) -> None:
-        response = pagerduty_source("tok", "incidents", MagicMock(), MagicMock())
+        response = pagerduty_source("tok", "incidents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.primary_keys == ["id"]
         assert response.partition_keys == ["created_at"]
         assert response.partition_mode == "datetime"
+        assert response.partition_format == "week"
         assert response.sort_mode == "asc"
 
     def test_unpartitioned_endpoint_has_no_partition_settings(self) -> None:
-        response = pagerduty_source("tok", "users", MagicMock(), MagicMock())
+        response = pagerduty_source("tok", "users", team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.primary_keys == ["id"]
         assert response.partition_keys is None
         assert response.partition_mode is None
 
     @pytest.mark.parametrize("endpoint", list(PAGERDUTY_ENDPOINTS.keys()))
     def test_every_endpoint_builds_a_response(self, endpoint: str) -> None:
-        response = pagerduty_source("tok", endpoint, MagicMock(), MagicMock())
+        response = pagerduty_source("tok", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.name == endpoint
         assert response.primary_keys == [PAGERDUTY_ENDPOINTS[endpoint].primary_key]
         assert callable(response.items)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/pandadoc.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/pandadoc.py
@@ -1,17 +1,21 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-from urllib3.util.retry import Retry
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.settings import (
     PANDADOC_ENDPOINTS,
     PandaDocEndpointConfig,
@@ -20,14 +24,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.s
 PANDADOC_BASE_URL = "https://api.pandadoc.com/public/v1"
 # PandaDoc list pages cap at 100 items.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-# Default rate limit is ~60 req/min (sandbox keys are far lower), so honor 429s
-# with exponential backoff.
-MAX_RETRY_ATTEMPTS = 5
-
-
-class PandaDocRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -38,10 +34,21 @@ class PandaDocResumeConfig:
     page: int
 
 
-def _get_session(api_key: str) -> requests.Session:
-    return make_tracked_session(
-        headers={"Authorization": f"API-Key {api_key}"}, redact_values=(api_key,), retry=Retry(total=0)
-    )
+class PandaDocPagePaginator(PageNumberPaginator):
+    """1-based page paginator that stops as soon as a page returns fewer than PAGE_SIZE rows.
+
+    PandaDoc list responses carry no total, so the hand-rolled source terminated on the first
+    short page rather than paying one extra empty-page request. The built-in only stops on an
+    empty page, so extend it to also stop on a partial page and keep termination identical.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(base_page=1, page_param="page")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        if data is not None and len(data) < PAGE_SIZE:
+            self._has_next_page = False
 
 
 def _format_date_filter(value: Any) -> str:
@@ -54,18 +61,22 @@ def _format_date_filter(value: Any) -> str:
     return str(value)
 
 
-def _build_params(
+def _build_query_params(
     config: PandaDocEndpointConfig,
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Any,
     incremental_field: str | None,
-    page: int,
 ) -> dict[str, Any]:
+    """Static per-run query params — everything except the paginator-managed page number.
+
+    Covers the page size plus, for endpoints that expose server-side date filters (only
+    documents), the incremental filter param and the sort order. These are constant across a
+    run, so they can be injected as endpoint params while the paginator owns the page number.
+    """
     params: dict[str, Any] = {}
 
     if config.paginated:
         params["count"] = PAGE_SIZE
-        params["page"] = page
 
     if not config.incremental_params:
         return params
@@ -86,87 +97,11 @@ def _build_params(
     return params
 
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    if not params:
-        return f"{PANDADOC_BASE_URL}{path}"
-    return f"{PANDADOC_BASE_URL}{path}?{urlencode(params)}"
-
-
-def validate_credentials(api_key: str) -> bool:
-    """Confirm the API key is valid with a cheap one-document listing probe."""
-    try:
-        response = _get_session(api_key).get(
-            _build_url("/documents", {"count": 1, "page": 1}),
-            timeout=10,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PandaDocResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = PANDADOC_ENDPOINTS[endpoint]
-    session = _get_session(api_key)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    page = resume_config.page if resume_config is not None else 1
-    if resume_config is not None:
-        logger.debug(f"PandaDoc: resuming {endpoint} from page {page}")
-
-    @retry(
-        retry=retry_if_exception_type((PandaDocRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise PandaDocRetryableError(
-                f"PandaDoc API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"PandaDoc API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        url = _build_url(
-            config.path,
-            _build_params(
-                config, should_use_incremental_field, db_incremental_field_last_value, incremental_field, page
-            ),
-        )
-        data = fetch_page(url)
-        items = data.get(config.data_key, []) or []
-
-        if items:
-            yield items
-
-        if not config.paginated or len(items) < PAGE_SIZE:
-            break
-
-        page += 1
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(PandaDocResumeConfig(page=page))
-
-
 def pandadoc_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PandaDocResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -174,17 +109,57 @@ def pandadoc_source(
 ) -> SourceResponse:
     config = PANDADOC_ENDPOINTS[endpoint]
 
+    params = _build_query_params(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+    paginator = PandaDocPagePaginator() if config.paginated else SinglePagePaginator()
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": PANDADOC_BASE_URL,
+            # Auth is supplied via the framework so the key is redacted from logs and errors;
+            # PandaDoc uses an "API-Key <key>" Authorization scheme rather than a bare Bearer.
+            "auth": {"type": "api_key", "api_key": f"API-Key {api_key}", "name": "Authorization"},
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Every list endpoint wraps its rows in "results"; a missing key is treated as
+                    # an empty page (matching the hand-rolled source), so this is not required.
+                    "data_selector": config.data_key,
+                    "paginator": paginator,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"page": resume.page}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("page") is not None:
+            resumable_source_manager.save_state(PandaDocResumeConfig(page=int(state["page"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
@@ -192,4 +167,15 @@ def pandadoc_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
+        column_hints=resource.column_hints,
     )
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Confirm the API key is valid with a cheap one-document listing probe."""
+    ok, _status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{PANDADOC_BASE_URL}/documents?count=1&page=1",
+        headers={"Authorization": f"API-Key {api_key}"},
+    )
+    return ok

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import PandaDocSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc import (
     PandaDocResumeConfig,
@@ -93,21 +96,7 @@ You can find your API key in the [PandaDoc developer dashboard](https://app.pand
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=INCREMENTAL_FIELDS.get(endpoint) is not None,
-                supports_append=INCREMENTAL_FIELDS.get(endpoint) is not None,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: PandaDocSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -129,7 +118,8 @@ You can find your API key in the [PandaDoc developer dashboard](https://app.pand
         return pandadoc_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pandadoc/tests/test_pandadoc.py
@@ -1,17 +1,18 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc import (
     PAGE_SIZE,
     PandaDocResumeConfig,
-    _build_params,
-    _build_url,
+    _build_query_params,
     _format_date_filter,
-    get_rows,
     pandadoc_source,
     validate_credentials,
 )
@@ -19,6 +20,23 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.s
     ENDPOINTS,
     PANDADOC_ENDPOINTS,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the pandadoc module.
+PANDADOC_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
+)
+
+
+def _response(items: list[dict[str, Any]] | None, *, drop_results: bool = False) -> Response:
+    body: dict[str, Any] = {}
+    if not drop_results:
+        body["results"] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: PandaDocResumeConfig | None = None) -> mock.MagicMock:
@@ -28,12 +46,28 @@ def _make_manager(resume_state: PandaDocResumeConfig | None = None) -> mock.Magi
     return manager
 
 
-def _response(items: list[dict[str, Any]]) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {"results": items}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Wire a mock session; capture each request's params AND auth AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the
+    run shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    auth_snapshots: list[Any] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        auth_snapshots.append(request.auth)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, auth_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatDateFilter:
@@ -50,90 +84,75 @@ class TestFormatDateFilter:
         assert _format_date_filter(value) == expected
 
 
-class TestBuildParams:
+class TestBuildQueryParams:
     def test_incremental_documents_uses_modified_from_filter(self):
-        params = _build_params(
+        params = _build_query_params(
             PANDADOC_ENDPOINTS["documents"],
             should_use_incremental_field=True,
             db_incremental_field_last_value=datetime(2024, 1, 1, tzinfo=UTC),
             incremental_field="date_modified",
-            page=1,
         )
 
         assert params["modified_from"] == "2024-01-01T00:00:00.000000Z"
         assert params["order_by"] == "date_modified"
         assert params["count"] == PAGE_SIZE
-        assert params["page"] == 1
+        # The page number is owned by the paginator, not the static params.
+        assert "page" not in params
 
     def test_incremental_documents_honors_date_created_cursor(self):
-        params = _build_params(
+        params = _build_query_params(
             PANDADOC_ENDPOINTS["documents"],
             should_use_incremental_field=True,
             db_incremental_field_last_value=datetime(2024, 1, 1, tzinfo=UTC),
             incremental_field="date_created",
-            page=2,
         )
 
         assert params["created_from"] == "2024-01-01T00:00:00.000000Z"
         assert params["order_by"] == "date_created"
-        assert params["page"] == 2
 
     def test_incremental_without_last_value_falls_back_to_full_refresh_sort(self):
-        params = _build_params(
+        params = _build_query_params(
             PANDADOC_ENDPOINTS["documents"],
             should_use_incremental_field=True,
             db_incremental_field_last_value=None,
             incremental_field="date_modified",
-            page=1,
         )
 
         assert "modified_from" not in params
         assert params["order_by"] == "date_created"
 
     def test_unknown_cursor_field_falls_back_to_full_refresh_sort(self):
-        params = _build_params(
+        params = _build_query_params(
             PANDADOC_ENDPOINTS["documents"],
             should_use_incremental_field=True,
             db_incremental_field_last_value=datetime(2024, 1, 1, tzinfo=UTC),
             incremental_field="nope",
-            page=1,
         )
 
         assert params["order_by"] == "date_created"
         assert "modified_from" not in params
 
     @pytest.mark.parametrize("endpoint", ["templates", "forms", "document_folders", "template_folders"])
-    def test_paginated_non_incremental_endpoints_only_page(self, endpoint):
-        params = _build_params(
+    def test_paginated_non_incremental_endpoints_only_count(self, endpoint):
+        params = _build_query_params(
             PANDADOC_ENDPOINTS[endpoint],
             should_use_incremental_field=False,
             db_incremental_field_last_value=None,
             incremental_field=None,
-            page=3,
         )
 
-        assert params == {"count": PAGE_SIZE, "page": 3}
+        assert params == {"count": PAGE_SIZE}
 
     @pytest.mark.parametrize("endpoint", ["contacts", "members"])
     def test_unpaginated_endpoints_have_no_params(self, endpoint):
-        params = _build_params(
+        params = _build_query_params(
             PANDADOC_ENDPOINTS[endpoint],
             should_use_incremental_field=False,
             db_incremental_field_last_value=None,
             incremental_field=None,
-            page=1,
         )
 
         assert params == {}
-
-
-class TestBuildUrl:
-    def test_no_params(self):
-        assert _build_url("/contacts", {}) == "https://api.pandadoc.com/public/v1/contacts"
-
-    def test_with_params(self):
-        url = _build_url("/documents", {"count": 100, "page": 1})
-        assert url == "https://api.pandadoc.com/public/v1/documents?count=100&page=1"
 
 
 class TestValidateCredentials:
@@ -146,9 +165,7 @@ class TestValidateCredentials:
             (500, False),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
-    )
+    @mock.patch(PANDADOC_SESSION_PATCH)
     def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
         response = mock.MagicMock()
         response.status_code = status_code
@@ -156,96 +173,122 @@ class TestValidateCredentials:
 
         assert validate_credentials("key") is expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
-    )
+    @mock.patch(PANDADOC_SESSION_PATCH)
+    def test_validate_credentials_sends_api_key_header(self, mock_session):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+
+        validate_credentials("key")
+
+        headers = mock_session.return_value.get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "API-Key key"
+
+    @mock.patch(PANDADOC_SESSION_PATCH)
     def test_validate_credentials_swallows_exceptions(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("key") is False
 
 
-class TestGetRows:
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
-    )
-    def test_paginates_until_short_page(self, mock_session):
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page(self, MockSession):
+        session = MockSession.return_value
         full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
-        mock_session.return_value.get.side_effect = [
-            _response(full_page),
-            _response([{"id": "last"}]),
-        ]
+        params, _auth = _wire(session, [_response(full_page), _response([{"id": "last"}])])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "documents", mock.MagicMock(), manager))
+        rows = _rows(pandadoc_source("key", "documents", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert len(batches) == 2
-        assert batches[1] == [{"id": "last"}]
+        assert rows[-1] == {"id": "last"}
+        assert len(rows) == PAGE_SIZE + 1
+        assert params[0]["page"] == 1
+        assert params[1]["page"] == 2
         # State saved once, after the first (full) page, pointing at page 2.
         manager.save_state.assert_called_once()
-        assert manager.save_state.call_args.args[0].page == 2
-        second_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert parse_qs(urlparse(second_url).query)["page"] == ["2"]
+        assert manager.save_state.call_args.args[0] == PandaDocResumeConfig(page=2)
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
-    )
-    def test_resumes_from_saved_page(self, mock_session):
-        mock_session.return_value.get.return_value = _response([{"id": "9"}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_api_key_auth_carried_on_request(self, MockSession):
+        session = MockSession.return_value
+        _params, auth = _wire(session, [_response([{"id": "a"}])])
+
+        _rows(
+            pandadoc_source("secret-key", "documents", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
+
+        assert isinstance(auth[0], APIKeyAuth)
+        assert auth[0].api_key == "API-Key secret-key"
+        assert auth[0].name == "Authorization"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_page(self, MockSession):
+        session = MockSession.return_value
+        params, _auth = _wire(session, [_response([{"id": "9"}])])
 
         manager = _make_manager(PandaDocResumeConfig(page=5))
-        list(get_rows("key", "documents", mock.MagicMock(), manager))
+        _rows(pandadoc_source("key", "documents", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert parse_qs(urlparse(url).query)["page"] == ["5"]
+        assert params[0]["page"] == 5
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
-    )
-    def test_unpaginated_endpoint_fetches_once(self, mock_session):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unpaginated_endpoint_fetches_once(self, MockSession):
+        session = MockSession.return_value
         full_page = [{"user_id": str(i)} for i in range(PAGE_SIZE)]
-        mock_session.return_value.get.return_value = _response(full_page)
+        params, _auth = _wire(session, [_response(full_page)])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "members", mock.MagicMock(), manager))
+        rows = _rows(pandadoc_source("key", "members", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert len(batches) == 1
-        assert mock_session.return_value.get.call_count == 1
+        assert len(rows) == PAGE_SIZE
+        assert session.send.call_count == 1
+        # Unpaginated endpoints send neither a page nor a count param.
+        assert "page" not in params[0]
+        assert "count" not in params[0]
         manager.save_state.assert_not_called()
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
-    )
-    def test_incremental_request_includes_filter(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_request_includes_filter(self, MockSession):
+        session = MockSession.return_value
+        params, _auth = _wire(session, [_response([])])
 
         manager = _make_manager()
-        list(
-            get_rows(
+        _rows(
+            pandadoc_source(
                 "key",
                 "documents",
-                mock.MagicMock(),
-                manager,
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=manager,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2024, 1, 1, tzinfo=UTC),
                 incremental_field="date_modified",
             )
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        query = parse_qs(urlparse(url).query)
-        assert query["modified_from"] == ["2024-01-01T00:00:00.000000Z"]
-        assert query["order_by"] == ["date_modified"]
+        assert params[0]["modified_from"] == "2024-01-01T00:00:00.000000Z"
+        assert params[0]["order_by"] == "date_modified"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pandadoc.pandadoc.make_tracked_session"
-    )
-    def test_empty_response_stops_without_saving_state(self, mock_session):
-        mock_session.return_value.get.return_value = _response([])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_response_stops_without_saving_state(self, MockSession):
+        session = MockSession.return_value
+        _params, _auth = _wire(session, [_response([])])
 
         manager = _make_manager()
-        batches = list(get_rows("key", "documents", mock.MagicMock(), manager))
+        rows = _rows(pandadoc_source("key", "documents", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert batches == []
+        assert rows == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_results_key_is_treated_as_empty_page(self, MockSession):
+        session = MockSession.return_value
+        _params, _auth = _wire(session, [_response(None, drop_results=True)])
+
+        manager = _make_manager()
+        # The hand-rolled source treated a missing "results" key as an empty page, not an error.
+        rows = _rows(pandadoc_source("key", "documents", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert rows == []
         manager.save_state.assert_not_called()
 
 
@@ -253,7 +296,7 @@ class TestPandaDocSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = PANDADOC_ENDPOINTS[endpoint]
-        response = pandadoc_source("key", endpoint, mock.MagicMock(), _make_manager())
+        response = pandadoc_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]


### PR DESCRIPTION
## Problem

Batch 27 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **oncehub**
- **onepagecrm**
- **onfleet**
- **openai**
- **pagerduty**
- **pandadoc**

Not migrated this batch (left hand-rolled, valid blocker):
- **openrouter** — the `/activity` endpoint uses a client-side date-window day-by-day transport (wall-clock 30-day window + client-side watermark clamp, one request per UTC day) that the framework's response-driven paginators and server-side incremental injection can't express, alongside offset/single-request endpoints.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 6 migrated dirs + `common/rest_source/tests/` — 491 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-26 PR (#71929); merge in order.
