### PR TITLE
refactor(data-warehouse): migrate paddle, paperform, pipedrive (batch 28)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/paddle.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/paddle.py
@@ -4,27 +4,35 @@ from typing import Any, Optional
 
 import requests
 from dateutil import parser
-from structlog.types import FilteringBoundLogger
 
 from products.warehouse_sources.backend.models.external_table_definitions import get_dlt_mapping_for_external_table
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import (
     DEFAULT_RETRY,
     make_tracked_session,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.paddle.settings import (
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
 
 PADDLE_BASE_URL = "https://api.paddle.com"
+PAGE_SIZE = 200
 
 
 @dataclasses.dataclass
 class PaddleResumeConfig:
-    next_url: str
+    # Self-contained next-page URL from Paddle's `meta.pagination.next`. Empty once the sync is done.
+    next_url: str = ""
 
 
 class PaddlePermissionError(Exception):
@@ -62,87 +70,14 @@ def _get_paddle_session(api_key: str) -> requests.Session:
     )
 
 
-def paddle_request(session: requests.Session, method: str, url: str, **kwargs) -> requests.Response:
-    response = session.request(method, url, **kwargs)
-    return response
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    db_incremental_field_last_value: Optional[Any],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PaddleResumeConfig],
-    should_use_incremental_field: bool = False,
-):
-    url = f"{PADDLE_BASE_URL}/{endpoint}"
-    params: dict[str, Any] = {"per_page": 200}
-    incremental_field_config = INCREMENTAL_FIELDS.get(endpoint, [])
-    incremental_field_name = incremental_field_config[0]["field"] if incremental_field_config else None
-
-    params["order_by"] = f"{incremental_field_name}[ASC]" if incremental_field_name else "id[ASC]"
-
-    if should_use_incremental_field and incremental_field_name:
-        if db_incremental_field_last_value:
-            params[f"{incremental_field_name}[GT]"] = _format_paddle_datetime_query_value(
-                db_incremental_field_last_value
-            )
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config and resume_config.next_url:
-        url = resume_config.next_url
-        params = {}
-
-    batcher = Batcher(logger=logger)
-    session = _get_paddle_session(api_key)
-    seen_urls: set[str] = set()
-
-    while url:
-        if url in seen_urls:
-            break
-        seen_urls.add(url)
-
-        response = paddle_request(session, "GET", url, params=params)
-
-        response.raise_for_status()
-        data = response.json()
-
-        items = data.get("data", [])
-
-        for item in items:
-            batcher.batch(item)
-
-            if batcher.should_yield():
-                py_table = batcher.get_table()
-                yield py_table
-
-        meta = data.get("meta", {})
-        pagination = meta.get("pagination", {})
-        next_url = pagination.get("next")
-        if next_url == url or next_url in seen_urls:
-            next_url = None
-
-        url = next_url
-        params = {}
-
-        if batcher.should_yield(include_incomplete_chunk=not url):
-            py_table = batcher.get_table()
-            if py_table.num_rows > 0:
-                yield py_table
-
-        if url:
-            resumable_source_manager.save_state(PaddleResumeConfig(next_url=url))
-        else:
-            resumable_source_manager.save_state(PaddleResumeConfig(next_url=""))
-
-
 def paddle_source(
     api_key: str,
     endpoint: str,
-    db_incremental_field_last_value: Optional[Any],
-    should_use_incremental_field: bool,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PaddleResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
+    should_use_incremental_field: bool = False,
 ) -> SourceResponse:
     column_mapping = get_dlt_mapping_for_external_table(f"paddle_{endpoint.lower()}")
     column_hints = {key: value.get("data_type") for key, value in column_mapping.items()}
@@ -150,18 +85,60 @@ def paddle_source(
     incremental_field_config = INCREMENTAL_FIELDS.get(endpoint, [])
     incremental_field_name = incremental_field_config[0]["field"] if incremental_field_config else None
 
-    def items():
-        yield from get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            should_use_incremental_field=should_use_incremental_field,
-            resumable_source_manager=resumable_source_manager,
-            logger=logger,
-        )
+    params: dict[str, Any] = {"per_page": PAGE_SIZE}
+    params["order_by"] = f"{incremental_field_name}[ASC]" if incremental_field_name else "id[ASC]"
+
+    # Server-side incremental filter: Paddle supports a `<field>[GT]` query param, so only rows newer
+    # than the last-synced watermark are returned. The paginator's self-contained `next` links carry
+    # this filter forward, so it's set once on the first request.
+    if should_use_incremental_field and incremental_field_name and db_incremental_field_last_value:
+        params[f"{incremental_field_name}[GT]"] = _format_paddle_datetime_query_value(db_incremental_field_last_value)
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": PADDLE_BASE_URL,
+            "headers": {"Content-Type": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": JSONResponsePaginator(next_url_path="meta.pagination.next"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": endpoint,
+                    "params": params,
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.next_url:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded so a crash re-yields the last page (merge dedupes) rather than
+        # skipping it. Persist the self-contained next-page URL while pages remain, and an empty
+        # marker once the last page is reached.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(PaddleResumeConfig(next_url=str(state["next_url"])))
+        else:
+            resumable_source_manager.save_state(PaddleResumeConfig(next_url=""))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
-        items=items,
+        items=lambda: resource,
         primary_keys=["id"],
         name=endpoint,
         column_hints=column_hints,
@@ -176,12 +153,15 @@ def paddle_source(
 
 def validate_credentials(api_key: str, table_name: Optional[str] = None) -> bool:
     endpoints_to_check = [table_name] if table_name else ENDPOINTS
-    session = _get_paddle_session(api_key)
 
     for endpoint in endpoints_to_check:
-        response = paddle_request(session, "GET", f"{PADDLE_BASE_URL}/{endpoint}")
-        if response.status_code == 403:
+        ok, status = validate_via_probe(
+            lambda: _get_paddle_session(api_key),
+            f"{PADDLE_BASE_URL}/{endpoint}",
+        )
+        if status == 403:
             raise PaddlePermissionError(f"Missing permissions for {endpoint}")
-        response.raise_for_status()
+        if not ok:
+            return False
 
     return True

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/source.py
@@ -18,7 +18,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import PaddleSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.paddle.paddle import (
     PaddlePermissionError,
@@ -104,21 +107,7 @@ class PaddleSource(ResumableSource[PaddleSourceConfig, PaddleResumeConfig]):
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=bool(PADDLE_INCREMENTAL_FIELDS.get(endpoint)),
-                supports_append=bool(PADDLE_INCREMENTAL_FIELDS.get(endpoint)),
-                incremental_fields=PADDLE_INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in PADDLE_ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(PADDLE_ENDPOINTS, PADDLE_INCREMENTAL_FIELDS, names)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[PaddleResumeConfig]:
         return ResumableSourceManager[PaddleResumeConfig](inputs, PaddleResumeConfig)
@@ -132,8 +121,9 @@ class PaddleSource(ResumableSource[PaddleSourceConfig, PaddleResumeConfig]):
         return paddle_source(
             api_key=config.paddle_api_key,
             endpoint=inputs.schema_name,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value,
-            logger=inputs.logger,
-            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/tests/test_paddle.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/tests/test_paddle.py
@@ -1,11 +1,233 @@
-from typing import cast
+import json
+from typing import Any, cast
 
+import pytest
+from unittest import mock
+
+from requests import Response
 from requests.adapters import HTTPAdapter
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.paddle.paddle import (
     PADDLE_BASE_URL,
+    PaddlePermissionError,
+    PaddleResumeConfig,
     _get_paddle_session,
+    paddle_source,
+    validate_credentials,
 )
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the paddle module.
+PADDLE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.paddle.paddle.make_tracked_session"
+)
+
+
+def _response(items: list[dict[str, Any]] | None, *, next_url: str | None = None, drop_data: bool = False) -> Response:
+    body: dict[str, Any] = {"meta": {"pagination": {"per_page": 200, "next": next_url}}}
+    if not drop_data:
+        body["data"] = items or []
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: PaddleResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Wire a mock session, capturing each request's params AND url AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    url_snapshots: list[str] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        url_snapshots.append(request.url)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, url_snapshots
+
+
+def _source(endpoint: str, manager: mock.MagicMock, **kwargs: Any):
+    return paddle_source("key", endpoint, team_id=1, job_id="j", resumable_source_manager=manager, **kwargs)
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_body_next_url_and_terminates(self, MockSession) -> None:
+        session = MockSession.return_value
+        next_url = f"{PADDLE_BASE_URL}/customers?after=c_1"
+        params, urls = _wire(
+            session,
+            [
+                _response([{"id": "c_1"}], next_url=next_url),
+                _response([{"id": "c_2"}], next_url=None),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
+
+        assert [r["id"] for r in rows] == ["c_1", "c_2"]
+        # First request hits the base path with list params; second follows the self-contained next URL.
+        assert params[0]["per_page"] == 200
+        assert params[0]["order_by"] == "id[ASC]"
+        assert urls[0] == f"{PADDLE_BASE_URL}/customers"
+        assert urls[1] == next_url
+        # The next URL already carries every query param, so the follow-up request drops the originals.
+        assert params[1] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_makes_one_request(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": "a"}, {"id": "b"}], next_url=None)])
+
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
+
+        assert [r["id"] for r in rows] == ["a", "b"]
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_data_key_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_data=True)])
+
+        # Paddle treats a body without "data" leniently (0 rows), not as a hard error.
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
+        assert rows == []
+
+
+class TestIncremental:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_field_adds_server_side_filter(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response([{"id": "t_1"}], next_url=None)])
+
+        manager = _make_manager()
+        _rows(
+            _source(
+                "transactions",
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value="2024-01-02T03:04:05Z",
+            )
+        )
+
+        assert params[0]["order_by"] == "billed_at[ASC]"
+        assert params[0]["billed_at[GT]"] == "2024-01-02T03:04:05Z"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_filter_without_incremental_flag(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response([{"id": "t_1"}], next_url=None)])
+
+        manager = _make_manager()
+        _rows(
+            _source("transactions", manager, should_use_incremental_field=False, db_incremental_field_last_value=None)
+        )
+
+        # order_by still points at the incremental field, but no watermark filter is applied.
+        assert params[0]["order_by"] == "billed_at[ASC]"
+        assert "billed_at[GT]" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_no_filter_without_last_value(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, _ = _wire(session, [_response([{"id": "t_1"}], next_url=None)])
+
+        manager = _make_manager()
+        _rows(_source("transactions", manager, should_use_incremental_field=True, db_incremental_field_last_value=None))
+
+        assert "billed_at[GT]" not in params[0]
+
+
+class TestResume:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_next_url_then_empties_on_completion(self, MockSession) -> None:
+        session = MockSession.return_value
+        next_url = f"{PADDLE_BASE_URL}/customers?after=c_1"
+        _wire(session, [_response([{"id": "c_1"}], next_url=next_url), _response([{"id": "c_2"}], next_url=None)])
+
+        manager = _make_manager()
+        _rows(_source("customers", manager))
+
+        # Saved after each page: the next-page URL while pages remain, then an empty marker at the end.
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [PaddleResumeConfig(next_url=next_url), PaddleResumeConfig(next_url="")]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_next_url(self, MockSession) -> None:
+        session = MockSession.return_value
+        saved_url = f"{PADDLE_BASE_URL}/customers?after=saved"
+        params, urls = _wire(session, [_response([{"id": "c_9"}], next_url=None)])
+
+        manager = _make_manager(PaddleResumeConfig(next_url=saved_url))
+        rows = _rows(_source("customers", manager))
+
+        assert [r["id"] for r in rows] == ["c_9"]
+        # A resumed run starts at the saved next-page URL with no re-appended list params.
+        assert urls[0] == saved_url
+        assert params[0] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_saved_url_starts_fresh(self, MockSession) -> None:
+        session = MockSession.return_value
+        params, urls = _wire(session, [_response([{"id": "c_1"}], next_url=None)])
+
+        manager = _make_manager(PaddleResumeConfig(next_url=""))
+        _rows(_source("customers", manager))
+
+        # An empty saved marker means the previous sync finished — start from the base path again.
+        assert urls[0] == f"{PADDLE_BASE_URL}/customers"
+        assert params[0]["per_page"] == 200
+
+
+class TestValidateCredentials:
+    @mock.patch(PADDLE_SESSION_PATCH)
+    def test_ok(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("key") is True
+
+    @mock.patch(PADDLE_SESSION_PATCH)
+    def test_single_table_probes_one_endpoint(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        assert validate_credentials("key", "customers") is True
+        assert mock_session.return_value.get.call_count == 1
+
+    @mock.patch(PADDLE_SESSION_PATCH)
+    def test_permission_error_on_403(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=403)
+        with pytest.raises(PaddlePermissionError, match="Missing permissions for"):
+            validate_credentials("key")
+
+    @mock.patch(PADDLE_SESSION_PATCH)
+    def test_unauthorized_returns_false(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=401)
+        assert validate_credentials("key") is False
+
+    @mock.patch(PADDLE_SESSION_PATCH)
+    def test_swallows_exceptions(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key") is False
 
 
 class TestPaddleSession:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/paperform.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/paperform.py
@@ -1,17 +1,28 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.datetime_utils import (
     coerce_datetime_to_utc,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    Endpoint,
+    EndpointResource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.paperform.settings import (
     PAPERFORM_ENDPOINTS,
     PaperformEndpointConfig,
@@ -21,29 +32,29 @@ PAPERFORM_BASE_URL = "https://api.paperform.co/v1"
 # Paginated list endpoints cap `limit` at 100 (default 20); the largest page minimises round trips
 # against the 60 req/min rate limit.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
 # Cheap endpoint used to confirm an API key is genuine. The key is account-wide, so one probe
 # validates the credential for every Standard API endpoint.
 DEFAULT_PROBE_PATH = "/forms"
+# The account-level list that every form-scoped endpoint fans out over.
+FORMS_ENDPOINT = "forms"
 
-
-class PaperformRetryableError(Exception):
-    pass
+# The Bearer token rides in the Authorization header via the framework auth config, so the client
+# redacts it from every raised error message; only these non-secret headers go through client config.
+NON_SECRET_HEADERS = {"Accept": "application/json"}
 
 
 @dataclasses.dataclass
 class PaperformResumeConfig:
-    # `after_id` cursor for the next page to fetch. None starts a list at its first page.
+    # `after_id` cursor for the next page of a top-level list (forms, spaces). None starts at page one.
     cursor: str | None = None
-    # The form currently being processed. A stable form-ID bookmark (not a positional index) so a
-    # form added or removed between a crash and the retry can't resume us into the wrong form. None
-    # for the account-level endpoints (forms, spaces).
+    # Retained for backward compatibility with resume state written before the rest_source migration
+    # (which bookmarked a form id). New writes leave it None; the fan-out checkpoint lives in
+    # `fanout_state` instead.
     form_id: str | None = None
-
-
-def _headers(api_key: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    # Framework fan-out checkpoint for form-scoped endpoints:
+    # {"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}.
+    # None (e.g. an old-shape checkpoint) means start the fan-out fresh — the merge dedupes re-pulls.
+    fanout_state: dict[str, Any] | None = None
 
 
 def _format_after_date(value: Any) -> str:
@@ -58,206 +69,235 @@ def _format_after_date(value: Any) -> str:
     return normalized_value.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _page_params(cursor: str | None, after_date: str | None) -> dict[str, Any]:
-    # Ascending creation order keeps already-fetched pages stable while new rows arrive (they only
-    # ever append) and matches the pipeline's ascending incremental watermark bookkeeping.
-    params: dict[str, Any] = {"limit": PAGE_SIZE, "sort": "ASC"}
-    if cursor is not None:
-        # The API documents `after_date` as overwritten by `after_id`, so only the first page
-        # carries the watermark; later pages advance purely on the id cursor.
-        params["after_id"] = cursor
-    elif after_date is not None:
-        params["after_date"] = after_date
-    return params
+class PaperformCursorPaginator(BasePaginator):
+    """`after_id` cursor pagination: the next page's cursor is the last row's ``id``.
+
+    Termination is driven by the response's ``has_more`` flag (or an empty page), not by cursor
+    absence — the last page still carries rows with ids, so a plain cursor paginator would loop.
+    Once the cursor is active it also drops the incremental ``after_date`` param, which Paperform
+    ignores in the presence of ``after_id``; this mirrors the hand-rolled transport that only sent
+    the watermark on each form's first page.
+    """
+
+    def __init__(self, cursor_param: str = "after_id", date_param: str = "after_date") -> None:
+        super().__init__()
+        self.cursor_param = cursor_param
+        self.date_param = date_param
+        self._cursor: Optional[str] = None
+
+    def _apply_cursor(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params[self.cursor_param] = self._cursor
+        # after_id supersedes after_date on the server; drop it so later pages advance purely on
+        # the id cursor (and so the request shape matches the pre-migration transport).
+        request.params.pop(self.date_param, None)
+
+    def init_request(self, request: Request) -> None:
+        # Only fires with a seeded resume cursor; the first fresh page keeps after_date untouched.
+        if self._cursor is not None:
+            self._apply_cursor(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        has_more = False
+        try:
+            body = response.json()
+            has_more = bool(body.get("has_more")) if isinstance(body, dict) else False
+        except Exception:
+            has_more = False
+
+        if not has_more or not data:
+            self._has_next_page = False
+            return
+
+        self._cursor = str(data[-1]["id"])
+        self._has_next_page = True
+
+    def update_request(self, request: Request) -> None:
+        if self._cursor is not None:
+            self._apply_cursor(request)
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        return {"cursor": self._cursor} if self._has_next_page and self._cursor is not None else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        cursor = state.get("cursor")
+        if cursor is not None:
+            self._cursor = cursor
+            self._has_next_page = True
+
+    def __str__(self) -> str:
+        return f"PaperformCursorPaginator(cursor={self._cursor})"
 
 
-@retry(
-    retry=retry_if_exception_type((PaperformRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=wait_exponential_jitter(initial=1, max=60),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    params: dict[str, Any],
-    logger: FilteringBoundLogger,
-) -> dict[str, Any]:
-    response = session.get(
-        f"{PAPERFORM_BASE_URL}{path}",
-        params=params,
-        timeout=REQUEST_TIMEOUT_SECONDS,
+def _data_selector(config: PaperformEndpointConfig) -> str:
+    # Quote the key so hyphenated results keys (e.g. `partial-submissions`) aren't parsed as a
+    # jsonpath subtraction.
+    return f"results.'{config.results_key}'"
+
+
+def _client_config(api_key: str) -> dict[str, Any]:
+    return {
+        "base_url": PAPERFORM_BASE_URL,
+        "headers": NON_SECRET_HEADERS,
+        "auth": {"type": "bearer", "token": api_key},
+    }
+
+
+def _rename_form_id(row: dict[str, Any]) -> dict[str, Any]:
+    # `include_from_parent=["id"]` injects the parent form id under `_forms_id`; surface it as
+    # `form_id` so the composite ["form_id", ...] key is unique across the whole table. A submission
+    # already carries its own form_id (the same value), so overwriting it is a no-op in practice.
+    if "_forms_id" in row:
+        row["form_id"] = row.pop("_forms_id")
+    return row
+
+
+def _top_level_source(
+    api_key: str,
+    config: PaperformEndpointConfig,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[PaperformResumeConfig],
+):
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.cursor is not None:
+            initial_paginator_state = {"cursor": resume.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("cursor") is not None:
+            resumable_source_manager.save_state(PaperformResumeConfig(cursor=str(state["cursor"])))
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [
+            {
+                "name": config.name,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {"limit": PAGE_SIZE, "sort": "ASC"},
+                    "data_selector": _data_selector(config),
+                    # A 200 body without the expected results key means the response shape changed —
+                    # fail loud instead of silently syncing 0 rows.
+                    "data_selector_required": True,
+                    "paginator": PaperformCursorPaginator(),
+                },
+            }
+        ],
+    }
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
     )
 
-    # Paperform rate-limits at 60 req/min and returns 429 with rate-limit headers; exponential
-    # backoff comfortably outlasts the one-minute window.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise PaperformRetryableError(f"Paperform API error (retryable): status={response.status_code}, path={path}")
 
-    if not response.ok:
-        logger.error(f"Paperform API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
-
-    data = response.json()
-    if not isinstance(data, dict):
-        raise PaperformRetryableError(f"Paperform returned an unexpected payload for {path}: {type(data).__name__}")
-
-    return data
-
-
-def _extract_rows(data: dict[str, Any], config: PaperformEndpointConfig, path: str) -> list[dict[str, Any]]:
-    # Every list endpoint wraps rows as {"results": {"<resource>": [...]}, "has_more": bool, ...}.
-    results = data.get("results")
-    if not isinstance(results, dict) or not isinstance(results.get(config.results_key), list):
-        raise PaperformRetryableError(f"Paperform returned an unexpected 'results' payload for {path}")
-    return results[config.results_key]
-
-
-def _iter_pages(
-    session: requests.Session,
-    config: PaperformEndpointConfig,
-    path: str,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[PaperformResumeConfig],
-    start_cursor: str | None,
-    after_date: str | None,
-    form_id: str | None,
-) -> Iterator[list[dict[str, Any]]]:
-    """Page through a paginated list endpoint, yielding one page of raw rows at a time.
-
-    Saves resume state AFTER yielding each page (pointing at the next page) so a crash re-fetches
-    the in-flight page rather than skipping it — the merge dedupes the re-pulled rows on the
-    primary key.
-    """
-    cursor = start_cursor
-    while True:
-        data = _fetch_page(session, path, _page_params(cursor, after_date), logger)
-        items = _extract_rows(data, config, path)
-
-        if items:
-            yield items
-
-        # `has_more` is false (or the page came back empty) once we've reached the end of the list.
-        if not data.get("has_more") or not items:
-            break
-
-        cursor = str(items[-1]["id"])
-        manager.save_state(PaperformResumeConfig(cursor=cursor, form_id=form_id))
-
-
-def _iter_form_ids(session: requests.Session, logger: FilteringBoundLogger) -> Iterator[str]:
-    """Page through /forms and yield each form id, for fanning out form-scoped endpoints."""
-    cursor: str | None = None
-    while True:
-        data = _fetch_page(session, "/forms", _page_params(cursor, after_date=None), logger)
-        items = _extract_rows(data, PAPERFORM_ENDPOINTS["forms"], "/forms")
-        for item in items:
-            yield str(item["id"])
-        if not data.get("has_more") or not items:
-            break
-        cursor = str(items[-1]["id"])
-
-
-def _get_top_level_rows(
-    session: requests.Session,
-    config: PaperformEndpointConfig,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[PaperformResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    resume = manager.load_state() if manager.can_resume() else None
-    start_cursor = resume.cursor if resume else None
-    yield from _iter_pages(session, config, config.path, logger, manager, start_cursor, after_date=None, form_id=None)
-
-
-def _get_form_scoped_rows(
-    session: requests.Session,
-    config: PaperformEndpointConfig,
-    logger: FilteringBoundLogger,
-    manager: ResumableSourceManager[PaperformResumeConfig],
-    after_date: str | None,
-) -> Iterator[list[dict[str, Any]]]:
-    """Fan a form-scoped endpoint out over every form, injecting `form_id` into each row.
-
-    Fields, products, and coupons don't carry their form id in the response, so we add it here to
-    keep the composite ["form_id", ...] key unique across the whole table. Submissions already
-    include `form_id` — the payload value wins over the injected one.
-    """
-    form_ids = list(_iter_form_ids(session, logger))
-
-    # Resolve the saved form-ID bookmark to the slice of forms still to process. If the bookmarked
-    # form no longer exists (deleted between runs), start over — merge dedupes the re-pulled rows.
-    resume = manager.load_state() if manager.can_resume() else None
-    remaining = form_ids
-    resume_cursor: str | None = None
-    if resume is not None and resume.form_id is not None and resume.form_id in form_ids:
-        remaining = form_ids[form_ids.index(resume.form_id) :]
-        resume_cursor = resume.cursor
-        logger.debug(f"Paperform: resuming {config.name} from form_id={resume.form_id}, cursor={resume_cursor}")
-
-    for index, form_id in enumerate(remaining):
-        path = config.path.format(form_id=form_id)
-        start_cursor = resume_cursor  # only the resumed-into form uses the saved cursor
-        resume_cursor = None
-
-        if config.paginated:
-            for items in _iter_pages(session, config, path, logger, manager, start_cursor, after_date, form_id):
-                yield [{"form_id": form_id, **item} for item in items]
-        else:
-            # Fields, products, and coupons return the whole collection in one response.
-            data = _fetch_page(session, path, {}, logger)
-            items = _extract_rows(data, config, path)
-            if items:
-                yield [{"form_id": form_id, **item} for item in items]
-
-        # Advance the bookmark to the next form so a crash between forms resumes correctly. Its
-        # first page is fetched fresh (cursor=None).
-        if index + 1 < len(remaining):
-            manager.save_state(PaperformResumeConfig(cursor=None, form_id=remaining[index + 1]))
-
-
-def get_rows(
+def _form_scoped_source(
     api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
+    config: PaperformEndpointConfig,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PaperformResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Optional[Any] = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = PAPERFORM_ENDPOINTS[endpoint]
-    # One session reused across every page (and every form, for fan-out) so urllib3 keeps the
-    # connection alive instead of re-handshaking per request. The API key is redacted from logs.
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
+    db_incremental_field_last_value: Optional[Any],
+):
+    initial_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None and resume.fanout_state:
+            initial_state = resume.fanout_state
 
-    after_date: str | None = None
-    if should_use_incremental_field and config.incremental_fields and db_incremental_field_last_value is not None:
-        after_date = _format_after_date(db_incremental_field_last_value)
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # The dependent-resource hook always hands back a dict snapshotting fan-out progress
+        # (completed parents + the in-flight parent's child cursor); persist each advance.
+        resumable_source_manager.save_state(PaperformResumeConfig(fanout_state=state))
 
-    if config.form_scoped:
-        yield from _get_form_scoped_rows(session, config, logger, resumable_source_manager, after_date)
+    forms_config = PAPERFORM_ENDPOINTS[FORMS_ENDPOINT]
+    parent_resource: EndpointResource = {
+        "name": FORMS_ENDPOINT,
+        "endpoint": {
+            "path": forms_config.path,
+            "params": {"limit": PAGE_SIZE, "sort": "ASC"},
+            "data_selector": _data_selector(forms_config),
+            "data_selector_required": True,
+            "paginator": PaperformCursorPaginator(),
+        },
+    }
+
+    child_params: dict[str, Any] = {
+        "form_id": {"type": "resolve", "resource": FORMS_ENDPOINT, "field": "id"},
+    }
+    child_endpoint: Endpoint = {
+        "path": config.path,
+        "data_selector": _data_selector(config),
+        "data_selector_required": True,
+    }
+    if config.paginated:
+        child_params["limit"] = PAGE_SIZE
+        child_params["sort"] = "ASC"
+        child_endpoint["paginator"] = PaperformCursorPaginator()
     else:
-        yield from _get_top_level_rows(session, config, logger, resumable_source_manager)
+        # Fields, products, and coupons return the whole collection in one response.
+        child_endpoint["paginator"] = SinglePagePaginator()
+
+    if config.incremental_fields and db_incremental_field_last_value is not None:
+        child_endpoint["incremental"] = {
+            "start_param": "after_date",
+            "cursor_path": config.incremental_fields[0]["field"],
+            "convert": _format_after_date,
+        }
+
+    child_endpoint["params"] = child_params
+    child_resource: EndpointResource = {
+        "name": config.name,
+        "include_from_parent": ["id"],
+        "data_map": _rename_form_id,
+        "endpoint": child_endpoint,
+    }
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resources": [parent_resource, child_resource],
+    }
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_state,
+    )
+    return next(resource for resource in resources if resource.name == config.name)
 
 
 def paperform_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PaperformResumeConfig],
-    should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = PAPERFORM_ENDPOINTS[endpoint]
 
+    if config.form_scoped:
+        resource = _form_scoped_source(
+            api_key, config, team_id, job_id, resumable_source_manager, db_incremental_field_last_value
+        )
+    else:
+        resource = _top_level_source(api_key, config, team_id, job_id, resumable_source_manager)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         # We request `sort=ASC` (creation order) on every paginated endpoint, so rows arrive
         # oldest-first within each form and the ascending watermark bookkeeping is correct.
@@ -267,33 +307,22 @@ def paperform_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(api_key: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the API key.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(headers=_headers(api_key), redact_values=(api_key,))
-    try:
-        response = session.get(f"{PAPERFORM_BASE_URL}{path}", params={"limit": 1}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Paperform: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Paperform returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_key)
-    if status == 200:
+    """Probe a single endpoint to validate the account-wide API key.
+
+    Preserves the per-status messaging: 401 means a bad key, 403 means a valid key on a plan that
+    gates API access, anything else surfaces the status (or a connection failure).
+    """
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
+        f"{PAPERFORM_BASE_URL}{DEFAULT_PROBE_PATH}?limit=1",
+        headers={"Authorization": f"Bearer {api_key}", **NON_SECRET_HEADERS},
+    )
+    if ok:
         return True, None
     if status == 401:
         return False, "Invalid Paperform API key"
@@ -304,4 +333,6 @@ def validate_credentials(api_key: str) -> tuple[bool, str | None]:
             False,
             "Your Paperform plan does not include API access. API access requires a Pro, Business, or Agency plan.",
         )
-    return False, message or "Could not validate Paperform API key"
+    if status is None:
+        return False, "Could not connect to Paperform to validate the API key"
+    return False, f"Paperform returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import PaperformSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.paperform.paperform import (
     PaperformResumeConfig,
@@ -27,6 +30,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.paperform.
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.paperform.settings import (
+    ENDPOINTS,
     INCREMENTAL_FIELDS,
     PAPERFORM_ENDPOINTS,
 )
@@ -90,21 +94,7 @@ You can create an API key under **Account → Developer** in [Paperform](https:/
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas: list[SourceSchema] = []
-        for endpoint in PAPERFORM_ENDPOINTS:
-            if names is not None and endpoint not in names:
-                continue
-            incremental_fields = INCREMENTAL_FIELDS.get(endpoint, [])
-            supports_incremental = bool(incremental_fields)
-            schemas.append(
-                SourceSchema(
-                    name=endpoint,
-                    supports_incremental=supports_incremental,
-                    supports_append=supports_incremental,
-                    incremental_fields=incremental_fields,
-                )
-            )
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: PaperformSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -127,9 +117,9 @@ You can create an API key under **Account → Developer** in [Paperform](https:/
         return paperform_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field
             else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/tests/test_paperform.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/tests/test_paperform.py
@@ -1,20 +1,17 @@
+import json
 from datetime import UTC, datetime
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import HTTPError, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.paperform import paperform
 from products.warehouse_sources.backend.temporal.data_imports.sources.paperform.paperform import (
     PAGE_SIZE,
     PaperformResumeConfig,
-    PaperformRetryableError,
     _format_after_date,
-    check_access,
-    get_rows,
     paperform_source,
     validate_credentials,
 )
@@ -23,11 +20,34 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.paperform.
     PAPERFORM_ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = paperform._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module; validate_credentials
+# builds its own tracked session in the paperform module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+PAPERFORM_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.paperform.paperform.make_tracked_session"
+)
+# tenacity sleeps between retries; patch it so the retry-path test doesn't actually wait.
+TENACITY_SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResumableManager:
+def _resp(results_key: str, items: list[dict[str, Any]], *, has_more: bool = False, status: int = 200) -> Response:
+    body = {"status": "ok", "results": {results_key: items}, "has_more": has_more, "total": len(items)}
+    resp = Response()
+    resp.status_code = status
+    resp.url = "https://api.paperform.co/v1/forms"
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _raw_resp(body: Any, *, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.url = "https://api.paperform.co/v1/forms"
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+class _FakeManager:
     def __init__(self, state: PaperformResumeConfig | None = None) -> None:
         self._state = state
         self.saved: list[PaperformResumeConfig] = []
@@ -42,178 +62,253 @@ class _FakeResumableManager:
         self.saved.append(data)
 
 
-def _envelope(results_key: str, items: list[dict], has_more: bool = False) -> dict:
-    return {"status": "ok", "results": {results_key: items}, "has_more": has_more, "total": len(items)}
+def _capture(session: mock.MagicMock, responses: list[Response]) -> list[tuple[str, dict[str, Any]]]:
+    """Wire a mock session and capture each request's (url, params) AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so a copy must be taken as
+    each request is prepared rather than inspected after the run.
+    """
+    session.headers = {}
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        calls.append((request.url, dict(request.params or {})))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return calls
 
 
-class _FakeFetch:
-    """Dispatches on (path, after_id cursor) and records every call's params."""
-
-    def __init__(self, pages: dict[tuple[str, str | None], dict]) -> None:
-        self._pages = pages
-        self.calls: list[tuple[str, dict]] = []
-
-    def __call__(self, session: Any, path: str, params: dict, logger: Any) -> dict:
-        self.calls.append((path, params))
-        return self._pages[(path, params.get("after_id"))]
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager,
-        monkeypatch: Any,
-        fetch: _FakeFetch,
-        endpoint: str,
-        **kwargs: Any,
-    ) -> list[dict]:
-        monkeypatch.setattr(paperform, "_fetch_page", fetch)
-        monkeypatch.setattr(paperform, "make_tracked_session", lambda **_: MagicMock())
+def _build(
+    manager: _FakeManager,
+    endpoint: str,
+    responses: list[Response],
+    MockSession: mock.MagicMock,
+    **kwargs: Any,
+) -> tuple[list[dict[str, Any]], list[tuple[str, dict[str, Any]]]]:
+    session = MockSession.return_value
+    calls = _capture(session, responses)
+    response = paperform_source(
+        api_key="pf-key",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job",
+        resumable_source_manager=manager,  # type: ignore[arg-type]
+        **kwargs,
+    )
+    return _rows(response), calls
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_key="pf-key",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-            **kwargs,
-        ):
-            rows.extend(batch)
-        return rows
 
-    def test_top_level_single_page_yields_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        fetch = _FakeFetch({("/forms", None): _envelope("forms", [{"id": "f1"}, {"id": "f2"}])})
-        rows = self._collect(manager, monkeypatch, fetch, "forms")
+class TestTopLevel:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_page_yields_and_stops(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        rows, calls = _build(manager, "forms", [_resp("forms", [{"id": "f1"}, {"id": "f2"}])], MockSession)
+
         assert rows == [{"id": "f1"}, {"id": "f2"}]
-        # has_more is false, so we stop without persisting resume state.
+        assert len(calls) == 1
+        assert calls[0][1] == {"limit": PAGE_SIZE, "sort": "ASC"}
+        # has_more is false, so no resume state is persisted.
         assert manager.saved == []
 
-    def test_top_level_follows_after_id_cursor_until_has_more_false(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        fetch = _FakeFetch(
-            {
-                ("/forms", None): _envelope("forms", [{"id": "f1"}, {"id": "f2"}], has_more=True),
-                ("/forms", "f2"): _envelope("forms", [{"id": "f3"}]),
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_after_id_cursor_until_has_more_false(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        rows, calls = _build(
+            manager,
+            "forms",
+            [
+                _resp("forms", [{"id": "f1"}, {"id": "f2"}], has_more=True),
+                _resp("forms", [{"id": "f3"}]),
+            ],
+            MockSession,
         )
-        rows = self._collect(manager, monkeypatch, fetch, "forms")
+
         assert [r["id"] for r in rows] == ["f1", "f2", "f3"]
-        # State is saved after the first page (cursor advances to the last id), then we stop.
-        assert [(s.cursor, s.form_id) for s in manager.saved] == [("f2", None)]
+        # Page one carries no cursor; page two advances on the last id of page one.
+        assert "after_id" not in calls[0][1]
+        assert calls[1][1]["after_id"] == "f2"
         # Every page requests the largest page size in stable ascending creation order.
-        assert all(p["limit"] == PAGE_SIZE and p["sort"] == "ASC" for _, p in fetch.calls)
+        assert all(params["limit"] == PAGE_SIZE and params["sort"] == "ASC" for _url, params in calls)
+        # Checkpoint saved after the first page (points at the next page), then pagination ends.
+        assert [s.cursor for s in manager.saved] == ["f2"]
 
-    def test_top_level_resumes_from_saved_cursor(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(PaperformResumeConfig(cursor="f2"))
-        # The initial (cursor=None) page must never be fetched on resume.
-        fetch = _FakeFetch({("/forms", "f2"): _envelope("forms", [{"id": "f3"}])})
-        rows = self._collect(manager, monkeypatch, fetch, "forms")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_cursor(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager(PaperformResumeConfig(cursor="f2"))
+        rows, calls = _build(manager, "forms", [_resp("forms", [{"id": "f3"}])], MockSession)
+
         assert rows == [{"id": "f3"}]
+        # The resumed run starts at the saved cursor rather than re-fetching page one.
+        assert calls[0][1]["after_id"] == "f2"
 
-    def test_fan_out_injects_form_id_and_bookmarks_next_form(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        fetch = _FakeFetch(
-            {
-                ("/forms", None): _envelope("forms", [{"id": "f1"}, {"id": "f2"}]),
-                ("/forms/f1/submissions", None): _envelope("submissions", [{"id": "s1"}, {"id": "s2"}], has_more=True),
-                ("/forms/f1/submissions", "s2"): _envelope("submissions", [{"id": "s3"}]),
-                ("/forms/f2/submissions", None): _envelope("submissions", [{"id": "s4"}]),
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_missing_results_key_fails_loud(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        # A 200 body without the expected results key means the response shape changed.
+        with pytest.raises(ValueError, match="matched nothing"):
+            _build(manager, "forms", [_raw_resp({"status": "ok", "results": {}})], MockSession)
+
+
+class TestFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_injects_form_id_and_paginates_each_form(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        rows, calls = _build(
+            manager,
+            "submissions",
+            [
+                _resp("forms", [{"id": "f1"}, {"id": "f2"}]),
+                _resp("submissions", [{"id": "s1"}, {"id": "s2"}], has_more=True),
+                _resp("submissions", [{"id": "s3"}]),
+                _resp("submissions", [{"id": "s4"}]),
+            ],
+            MockSession,
         )
-        rows = self._collect(manager, monkeypatch, fetch, "submissions")
+
         assert rows == [
             {"form_id": "f1", "id": "s1"},
             {"form_id": "f1", "id": "s2"},
             {"form_id": "f1", "id": "s3"},
             {"form_id": "f2", "id": "s4"},
         ]
-        # Mid-form page cursor, then the bookmark advancing to the next form (fresh first page).
-        assert [(s.cursor, s.form_id) for s in manager.saved] == [("s2", "f1"), (None, "f2")]
+        # Fan-out progress is checkpointed so a crash resumes mid-stream.
+        assert manager.saved
+        assert manager.saved[-1].fanout_state is not None
 
-    def test_fan_out_resumes_from_bookmarked_form_and_cursor(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(PaperformResumeConfig(cursor="s9", form_id="f2"))
-        fetch = _FakeFetch(
-            {
-                ("/forms", None): _envelope("forms", [{"id": "f1"}, {"id": "f2"}]),
-                ("/forms/f2/submissions", "s9"): _envelope("submissions", [{"id": "s10"}]),
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_skips_completed_forms(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager(
+            PaperformResumeConfig(
+                fanout_state={
+                    "completed": ["/forms/f1/submissions"],
+                    "current": "/forms/f2/submissions",
+                    "child_state": {"cursor": "s9"},
+                }
+            )
         )
-        rows = self._collect(manager, monkeypatch, fetch, "submissions")
-        # f1 was fully processed before the crash and must not be re-fetched.
+        rows, calls = _build(
+            manager,
+            "submissions",
+            [
+                _resp("forms", [{"id": "f1"}, {"id": "f2"}]),
+                _resp("submissions", [{"id": "s10"}]),
+            ],
+            MockSession,
+        )
+
+        # f1 was fully synced before the crash and must not be re-fetched; f2 resumes at its cursor.
         assert rows == [{"form_id": "f2", "id": "s10"}]
+        urls = [url for url, _params in calls]
+        assert "https://api.paperform.co/v1/forms/f1/submissions" not in urls
+        submission_call = next(params for url, params in calls if url.endswith("/forms/f2/submissions"))
+        assert submission_call["after_id"] == "s9"
 
-    def test_fan_out_restarts_when_bookmarked_form_no_longer_exists(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(PaperformResumeConfig(cursor="s9", form_id="deleted-form"))
-        fetch = _FakeFetch(
-            {
-                ("/forms", None): _envelope("forms", [{"id": "f1"}]),
-                ("/forms/f1/submissions", None): _envelope("submissions", [{"id": "s1"}]),
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_old_shape_resume_state_restarts_fresh(self, MockSession: mock.MagicMock) -> None:
+        # Resume state written before the migration only bookmarked a form id; it can't seed the
+        # framework fan-out, so the whole fan-out restarts (the merge dedupes re-pulled rows).
+        manager = _FakeManager(PaperformResumeConfig(cursor="s9", form_id="deleted-form"))
+        rows, _calls = _build(
+            manager,
+            "submissions",
+            [
+                _resp("forms", [{"id": "f1"}]),
+                _resp("submissions", [{"id": "s1"}]),
+            ],
+            MockSession,
         )
-        rows = self._collect(manager, monkeypatch, fetch, "submissions")
+
         assert rows == [{"form_id": "f1", "id": "s1"}]
 
-    def test_fan_out_non_paginated_endpoint_fetches_each_form_once(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        fetch = _FakeFetch(
-            {
-                ("/forms", None): _envelope("forms", [{"id": "f1"}, {"id": "f2"}]),
-                ("/forms/f1/products", None): _envelope("products", [{"SKU": "P-1"}]),
-                ("/forms/f2/products", None): _envelope("products", []),
-            }
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_endpoint_fetches_each_form_once(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        rows, calls = _build(
+            manager,
+            "products",
+            [
+                _resp("forms", [{"id": "f1"}, {"id": "f2"}]),
+                _resp("products", [{"SKU": "P-1"}]),
+                _resp("products", []),
+            ],
+            MockSession,
         )
-        rows = self._collect(manager, monkeypatch, fetch, "products")
+
         assert rows == [{"form_id": "f1", "SKU": "P-1"}]
         # Non-paginated child requests carry no pagination params.
-        product_calls = [params for path, params in fetch.calls if path.endswith("/products")]
+        product_calls = [params for url, params in calls if url.endswith("/products")]
         assert product_calls == [{}, {}]
 
-    def test_incremental_watermark_only_on_first_page_of_each_form(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        fetch = _FakeFetch(
-            {
-                ("/forms", None): _envelope("forms", [{"id": "f1"}, {"id": "f2"}]),
-                ("/forms/f1/submissions", None): _envelope("submissions", [{"id": "s1"}], has_more=True),
-                ("/forms/f1/submissions", "s1"): _envelope("submissions", [{"id": "s2"}]),
-                ("/forms/f2/submissions", None): _envelope("submissions", []),
-            }
-        )
-        self._collect(
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_watermark_first_page_of_each_form_only(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        _rows_out, calls = _build(
             manager,
-            monkeypatch,
-            fetch,
             "submissions",
-            should_use_incremental_field=True,
+            [
+                _resp("forms", [{"id": "f1"}, {"id": "f2"}]),
+                _resp("submissions", [{"id": "s1"}], has_more=True),
+                _resp("submissions", [{"id": "s2"}]),
+                _resp("submissions", []),
+            ],
+            MockSession,
             db_incremental_field_last_value=datetime(2024, 1, 2, 3, 4, 5, 999999, tzinfo=UTC),
         )
-        params_by_call = {(path, params.get("after_id")): params for path, params in fetch.calls}
-        # The forms listing that drives the fan-out is never date-filtered.
-        assert "after_date" not in params_by_call[("/forms", None)]
-        # Each form's first page carries the watermark (truncated down to whole seconds)...
-        assert params_by_call[("/forms/f1/submissions", None)]["after_date"] == "2024-01-02T03:04:05Z"
-        assert params_by_call[("/forms/f2/submissions", None)]["after_date"] == "2024-01-02T03:04:05Z"
-        # ...and later pages advance purely on after_id (the API ignores after_date alongside it).
-        assert "after_date" not in params_by_call[("/forms/f1/submissions", "s1")]
 
-    def test_full_refresh_ignores_stale_watermark(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        fetch = _FakeFetch(
-            {
-                ("/forms", None): _envelope("forms", [{"id": "f1"}]),
-                ("/forms/f1/partial-submissions", None): _envelope("partial-submissions", [{"id": "p1"}]),
-            }
-        )
+        by_url_cursor = {(url, params.get("after_id")): params for url, params in calls}
+        # The forms listing that drives the fan-out is never date-filtered.
+        assert "after_date" not in by_url_cursor[("https://api.paperform.co/v1/forms", None)]
+        # Each form's first page carries the watermark (truncated down to whole seconds)...
+        f1_first = by_url_cursor[("https://api.paperform.co/v1/forms/f1/submissions", None)]
+        f2_first = by_url_cursor[("https://api.paperform.co/v1/forms/f2/submissions", None)]
+        assert f1_first["after_date"] == "2024-01-02T03:04:05Z"
+        assert f2_first["after_date"] == "2024-01-02T03:04:05Z"
+        # ...and later pages advance purely on after_id (after_id supersedes after_date server-side).
+        assert "after_date" not in by_url_cursor[("https://api.paperform.co/v1/forms/f1/submissions", "s1")]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_ignores_stale_watermark(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
         # partial_submissions declares no incremental fields, so a leftover watermark must not filter.
-        self._collect(
+        _rows_out, calls = _build(
             manager,
-            monkeypatch,
-            fetch,
             "partial_submissions",
-            should_use_incremental_field=True,
+            [
+                _resp("forms", [{"id": "f1"}]),
+                _resp("partial-submissions", [{"id": "p1"}]),
+            ],
+            MockSession,
             db_incremental_field_last_value=datetime(2024, 1, 1, tzinfo=UTC),
         )
-        assert all("after_date" not in params for _, params in fetch.calls)
+
+        assert all("after_date" not in params for _url, params in calls)
+
+
+class TestRetryAndErrors:
+    @mock.patch(TENACITY_SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_is_retried(self, MockSession: mock.MagicMock, _sleep: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        # A 500 is retried by the client; the follow-up 200 completes the page.
+        rows, _calls = _build(
+            manager,
+            "forms",
+            [_resp("forms", [], status=500), _resp("forms", [{"id": "f1"}])],
+            MockSession,
+        )
+        assert rows == [{"id": "f1"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises(self, MockSession: mock.MagicMock) -> None:
+        manager = _FakeManager()
+        with pytest.raises(HTTPError):
+            _build(manager, "forms", [_resp("forms", [], status=401)], MockSession)
 
 
 class TestFormatAfterDate:
@@ -228,53 +323,7 @@ class TestFormatAfterDate:
         assert _format_after_date(value) == expected
 
 
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else _envelope("forms", [])
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
-        )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(PaperformRetryableError):
-            _fetch_page_unwrapped(session, "/forms", {}, MagicMock())
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "/forms", {}, MagicMock())
-
-    def test_non_dict_body_is_retryable(self) -> None:
-        session = self._session_returning(200, [{"id": "f1"}])
-        with pytest.raises(PaperformRetryableError):
-            _fetch_page_unwrapped(session, "/forms", {}, MagicMock())
-
-    def test_missing_results_key_raises_retryable_on_extract(self) -> None:
-        config = PAPERFORM_ENDPOINTS["forms"]
-        with pytest.raises(PaperformRetryableError):
-            paperform._extract_rows({"status": "ok", "results": {}}, config, "/forms")
-
-
-class TestCheckAccess:
-    @staticmethod
-    def _session(response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        return session
-
+class TestValidateCredentials:
     @parameterized.expand(
         [
             ("ok", 200, True, None),
@@ -288,38 +337,36 @@ class TestCheckAccess:
             ("server_error", 500, False, "Paperform returned HTTP 500"),
         ]
     )
-    @patch(f"{paperform.__name__}.make_tracked_session")
-    def test_validate_credentials(
+    @mock.patch(PAPERFORM_SESSION_PATCH)
+    def test_maps_status_to_message(
         self,
         _name: str,
         status: int,
         expected_valid: bool,
         expected_message: str | None,
-        mock_session: MagicMock,
+        mock_session: mock.MagicMock,
     ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        mock_session.return_value = self._session(response)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
         assert validate_credentials("pf-key") == (expected_valid, expected_message)
 
-    @patch(f"{paperform.__name__}.make_tracked_session")
-    def test_connection_error_maps_to_zero(self, mock_session: MagicMock) -> None:
-        mock_session.return_value = self._session(requests.ConnectionError("boom"))
-        status, message = check_access("pf-key")
-        assert status == 0
-        assert message is not None and "boom" in message
+    @mock.patch(PAPERFORM_SESSION_PATCH)
+    def test_connection_error_is_not_validated(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        valid, message = validate_credentials("pf-key")
+        assert valid is False
+        assert message == "Could not connect to Paperform to validate the API key"
 
 
-class TestPaperformSourceResponse:
+class TestSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
+    def test_shape(self, endpoint: str) -> None:
         config = PAPERFORM_ENDPOINTS[endpoint]
         response = paperform_source(
             api_key="pf-key",
             endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
+            team_id=1,
+            job_id="job",
+            resumable_source_manager=_FakeManager(),  # type: ignore[arg-type]
         )
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys
@@ -331,7 +378,7 @@ class TestPaperformSourceResponse:
             assert response.partition_mode is None
 
     def test_form_scoped_endpoints_include_form_id_in_primary_key(self) -> None:
-        # This table aggregates rows across every form, so per-form identifiers (submission id,
+        # These tables aggregate rows across every form, so per-form identifiers (submission id,
         # field key, SKU, coupon code) are only unique with the parent form id in the key.
         for config in PAPERFORM_ENDPOINTS.values():
             if config.form_scoped:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/tests/test_paperform_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paperform/tests/test_paperform_source.py
@@ -114,6 +114,8 @@ class TestPaperformSource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
         inputs = mock.MagicMock()
         inputs.schema_name = "submissions"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2024-01-01T00:00:00Z"
         manager = mock.MagicMock()
@@ -124,8 +126,9 @@ class TestPaperformSource:
         kwargs = mock_source.call_args.kwargs
         assert kwargs["api_key"] == "pf-key"
         assert kwargs["endpoint"] == "submissions"
+        assert kwargs["team_id"] == 123
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
-        assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2024-01-01T00:00:00Z"
 
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.paperform.source.paperform_source")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/pipedrive.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/pipedrive.py
@@ -1,16 +1,21 @@
 import re
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
 from urllib.parse import urlencode
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    JSONResponseCursorPaginator,
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.settings import (
     PIPEDRIVE_ENDPOINTS,
     PipedriveEndpointConfig,
@@ -18,8 +23,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.
 
 # Pipedrive caps list pages at 500 items (default 100).
 PAGE_SIZE = 500
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
 
 _SUBDOMAIN_RE = re.compile(r"^[a-z0-9-]+$")
 
@@ -32,15 +35,16 @@ _INVALID_COMPANY_DOMAIN_ERROR = (
 )
 
 
-class PipedriveRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class PipedriveResumeConfig:
-    # Full URL (query string included, token is sent via header so never present here) of the
-    # next page to fetch. Unifies cursor (v2) and offset (v1) pagination behind one resume key.
-    next_url: str
+    # Legacy field written by the hand-rolled paginator: the full next-page URL. Kept (optional,
+    # defaulted) so previously saved resume state still parses via ``dataclass(**saved)``. No longer
+    # written; a resume that carries only this restarts the endpoint from the beginning (merge
+    # dedupes any re-yielded rows).
+    next_url: Optional[str] = None
+    # Framework paginator resume snapshot: ``{"offset": N}`` for v1 offset endpoints or
+    # ``{"cursor": "…"}`` for v2 cursor endpoints. Seeds ``initial_paginator_state`` on resume.
+    paginator_state: Optional[dict[str, Any]] = None
 
 
 def normalize_company_domain(raw: str) -> str:
@@ -75,29 +79,19 @@ def _build_url(company_domain: str, path: str, params: dict[str, Any]) -> str:
     return f"{url}?{urlencode(clean_params)}"
 
 
-def _initial_url(company_domain: str, config: PipedriveEndpointConfig) -> str:
-    params: dict[str, Any] = {"limit": PAGE_SIZE}
-    if config.pagination == "offset":
-        params["start"] = 0
-    return _build_url(company_domain, config.path, params)
-
-
-def _next_url(company_domain: str, config: PipedriveEndpointConfig, response: dict[str, Any]) -> Optional[str]:
-    additional_data = response.get("additional_data") or {}
-
+def _build_paginator(config: PipedriveEndpointConfig) -> BasePaginator:
     if config.pagination == "cursor":
-        next_cursor = additional_data.get("next_cursor")
-        if not next_cursor:
-            return None
-        return _build_url(company_domain, config.path, {"limit": PAGE_SIZE, "cursor": next_cursor})
-
-    pagination = additional_data.get("pagination") or {}
-    if not pagination.get("more_items_in_collection"):
-        return None
-    next_start = pagination.get("next_start")
-    if next_start is None:
-        return None
-    return _build_url(company_domain, config.path, {"limit": PAGE_SIZE, "start": next_start})
+        # v2 endpoints: opaque cursor in the response body; ``limit`` rides in the endpoint params.
+        return JSONResponseCursorPaginator(cursor_path="additional_data.next_cursor", cursor_param="cursor")
+    # v1 endpoints: start/limit offset. No top-level total; termination is a short/empty page.
+    return OffsetPaginator(
+        limit=PAGE_SIZE,
+        offset=0,
+        offset_param="start",
+        limit_param="limit",
+        total_path=None,
+        stop_after_empty_page=True,
+    )
 
 
 def validate_credentials(company_domain: str, api_token: str) -> Optional[int]:
@@ -105,98 +99,90 @@ def validate_credentials(company_domain: str, api_token: str) -> Optional[int]:
 
     ``/api/v1/users/me`` resolves the token's own user and is reachable by any valid token.
     """
-    # Built outside the `try` so an invalid-domain `ValueError` from `_build_url` propagates to
-    # the caller rather than being swallowed into `None` by the broad transport-error handler.
+    # Built outside the probe so an invalid-domain `ValueError` from `_build_url` propagates to the
+    # caller rather than being swallowed into `None` by the probe's broad transport-error handler.
     url = _build_url(company_domain, "/api/v1/users/me", {})
-    try:
-        session = make_tracked_session(headers=_get_headers(api_token), redact_values=(api_token,))
-        response = session.get(url, timeout=10)
-        return response.status_code
-    except Exception:
-        return None
-
-
-def get_rows(
-    company_domain: str,
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PipedriveResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = PIPEDRIVE_ENDPOINTS[endpoint]
-    # `redact_values` masks the token (sent via the custom `x-api-token` header, which the
-    # name-based denylist can't catch) in logged URLs and captured HTTP samples.
-    session = make_tracked_session(headers=_get_headers(api_token), redact_values=(api_token,))
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url: str = resume_config.next_url
-        logger.debug(f"Pipedrive: resuming {endpoint} from URL: {url}")
-    else:
-        url = _initial_url(company_domain, config)
-
-    @retry(
-        retry=retry_if_exception_type((PipedriveRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
+    _ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        url,
+        headers=_get_headers(api_token),
     )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # Pipedrive uses token-based rate limiting; 429s and transient 5xx are retried with
-        # exponential backoff.
-        if response.status_code == 429 or response.status_code >= 500:
-            raise PipedriveRetryableError(
-                f"Pipedrive API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Pipedrive API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-        items = data.get("data") or []
-
-        if items:
-            yield items
-
-        next_url = _next_url(company_domain, config, data)
-        if not next_url:
-            break
-
-        # Save the next-page pointer only after the current page has been processed (yielded
-        # above when it had rows), so a crash resumes at this page rather than past it. Merge
-        # dedupes on primary key any rows re-yielded on resume.
-        resumable_source_manager.save_state(PipedriveResumeConfig(next_url=next_url))
-        url = next_url
+    return status
 
 
 def pipedrive_source(
     company_domain: str,
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PipedriveResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = PIPEDRIVE_ENDPOINTS[endpoint]
 
+    params: dict[str, Any] = {}
+    if config.pagination == "cursor":
+        # The cursor paginator only injects ``cursor``; ``limit`` must be a static param.
+        params["limit"] = PAGE_SIZE
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": base_url(company_domain),
+            # Only the non-secret Accept header here; the token travels via framework auth so it's
+            # redacted from logged URLs, headers, sampled bodies, and raised error messages.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "api_key", "api_key": api_token, "name": "x-api-token", "location": "header"},
+            "paginator": _build_paginator(config),
+            # base_url host (`{subdomain}.pipedrive.com`) is implicitly allowed; `[]` pins every
+            # request — including resume URLs — to it, matching the source's SSRF posture.
+            "allowed_hosts": [],
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Mirrors the old `data.get("data") or []`: a 200 body without `data` yields an
+                    # empty page rather than raising (not required).
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        # Only new-shape paginator state can seed a resume; legacy `next_url`-only state restarts
+        # the endpoint from the beginning (merge dedupes the re-yielded rows).
+        if resume is not None and resume.paginator_state:
+            initial_paginator_state = resume.paginator_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; saved AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state:
+            resumable_source_manager.save_state(PipedriveResumeConfig(paginator_state=state))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            company_domain=company_domain,
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/source.py
@@ -147,6 +147,8 @@ You can find your personal API token in Pipedrive under **Settings > Personal pr
             company_domain=normalize_company_domain(config.company_domain),
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Pipedrive endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py
@@ -1,20 +1,84 @@
-from typing import Any
+import json
+from typing import Any, Optional
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive import (
     PAGE_SIZE,
     PipedriveResumeConfig,
-    _initial_url,
-    _next_url,
     base_url,
-    get_rows,
     normalize_company_domain,
     pipedrive_source,
     validate_credentials,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.settings import PIPEDRIVE_ENDPOINTS
+
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the pipedrive module.
+PIPEDRIVE_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive.make_tracked_session"
+)
+
+
+def _response(
+    items: Optional[list[dict[str, Any]]],
+    additional_data: Optional[dict[str, Any]] = None,
+    *,
+    drop_data: bool = False,
+    status: int = 200,
+) -> Response:
+    body: dict[str, Any] = {}
+    if not drop_data:
+        body["data"] = items or []
+    if additional_data is not None:
+        body["additional_data"] = additional_data
+    resp = Response()
+    resp.status_code = status
+    resp.reason = "Unauthorized" if status == 401 else "OK"
+    resp.url = f"https://acme.pipedrive.com/api/v2/deals?limit={PAGE_SIZE}"
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _make_manager(resume_state: PipedriveResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(
+    session: mock.MagicMock, responses: list[Response], *, prepared_url: Optional[str] = None
+) -> list[dict[str, Any]]:
+    """Wire a mock session; return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so snapshot a copy when each
+    request is prepared. The prepared request carries a real on-host URL so the client's SSRF
+    host check (allowed_hosts is pinned) sees a valid host.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = prepared_url or "https://acme.pipedrive.com/api/v2/deals"
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return pipedrive_source("acme", "token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
 
 
 class TestNormalizeCompanyDomain:
@@ -60,76 +124,20 @@ class TestNormalizeCompanyDomain:
         assert base_url("https://MyCompany.pipedrive.com") == "https://mycompany.pipedrive.com"
 
 
-class TestInitialUrl:
-    def test_cursor_endpoint_only_sets_limit(self) -> None:
-        url = _initial_url("acme", PIPEDRIVE_ENDPOINTS["deals"])
-        assert url == f"https://acme.pipedrive.com/api/v2/deals?limit={PAGE_SIZE}"
-
-    def test_offset_endpoint_sets_start_and_limit(self) -> None:
-        url = _initial_url("acme", PIPEDRIVE_ENDPOINTS["activities"])
-        assert url == f"https://acme.pipedrive.com/api/v1/activities?limit={PAGE_SIZE}&start=0"
-
-
-class TestNextUrl:
-    def test_cursor_returns_next_page_url(self) -> None:
-        config = PIPEDRIVE_ENDPOINTS["deals"]
-        response = {"data": [{"id": 1}], "additional_data": {"next_cursor": "abc123"}}
-        assert _next_url("acme", config, response) == (
-            f"https://acme.pipedrive.com/api/v2/deals?limit={PAGE_SIZE}&cursor=abc123"
-        )
-
-    @pytest.mark.parametrize(
-        "additional_data",
-        [
-            {},
-            {"next_cursor": None},
-            {"next_cursor": ""},
-        ],
-    )
-    def test_cursor_terminates_when_no_next_cursor(self, additional_data: dict[str, Any]) -> None:
-        config = PIPEDRIVE_ENDPOINTS["deals"]
-        assert _next_url("acme", config, {"data": [], "additional_data": additional_data}) is None
-
-    def test_offset_returns_next_page_url(self) -> None:
-        config = PIPEDRIVE_ENDPOINTS["activities"]
-        response = {
-            "data": [{"id": 1}],
-            "additional_data": {"pagination": {"more_items_in_collection": True, "next_start": 500}},
-        }
-        assert _next_url("acme", config, response) == (
-            f"https://acme.pipedrive.com/api/v1/activities?limit={PAGE_SIZE}&start=500"
-        )
-
-    @pytest.mark.parametrize(
-        "additional_data",
-        [
-            {},
-            {"pagination": {"more_items_in_collection": False, "next_start": 500}},
-            {"pagination": {"more_items_in_collection": True}},
-        ],
-    )
-    def test_offset_terminates(self, additional_data: dict[str, Any]) -> None:
-        config = PIPEDRIVE_ENDPOINTS["activities"]
-        assert _next_url("acme", config, {"data": [], "additional_data": additional_data}) is None
-
-
 class TestValidateCredentials:
     @pytest.mark.parametrize("status_code", [200, 401, 403, 500])
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive.make_tracked_session"
-    )
+    @mock.patch(PIPEDRIVE_SESSION_PATCH)
     def test_returns_status_code(self, mock_session: mock.MagicMock, status_code: int) -> None:
         mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("acme", "token") == status_code
-        called_url = mock_session.return_value.get.call_args.args[0]
-        assert called_url == "https://acme.pipedrive.com/api/v1/users/me"
-        # Auth header and token redaction are configured on the session, not the request.
-        assert mock_session.call_args.kwargs["headers"]["x-api-token"] == "token"
+
+        get_call = mock_session.return_value.get.call_args
+        assert get_call.args[0] == "https://acme.pipedrive.com/api/v1/users/me"
+        # Auth header travels on the probe request; token redaction is configured on the session.
+        assert get_call.kwargs["headers"]["x-api-token"] == "token"
         assert mock_session.call_args.kwargs["redact_values"] == ("token",)
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive.make_tracked_session"
-    )
+    @mock.patch(PIPEDRIVE_SESSION_PATCH)
     def test_returns_none_on_transport_error(self, mock_session: mock.MagicMock) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("acme", "token") is None
@@ -139,77 +147,152 @@ class TestValidateCredentials:
             validate_credentials("evil.com", "token")
 
 
-class TestGetRows:
-    def _manager(self, resume_state: PipedriveResumeConfig | None = None) -> mock.MagicMock:
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = resume_state is not None
-        manager.load_state.return_value = resume_state
-        return manager
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive.make_tracked_session"
-    )
-    def test_paginates_cursor_endpoint_and_saves_state_after_yield(self, mock_session: mock.MagicMock) -> None:
-        page1 = mock.MagicMock(status_code=200, ok=True)
-        page1.json.return_value = {"data": [{"id": 1}], "additional_data": {"next_cursor": "c2"}}
-        page2 = mock.MagicMock(status_code=200, ok=True)
-        page2.json.return_value = {"data": [{"id": 2}], "additional_data": {"next_cursor": None}}
-        mock_session.return_value.get.side_effect = [page1, page2]
-
-        manager = self._manager()
-        batches = list(get_rows("acme", "token", "deals", mock.MagicMock(), manager))
-
-        assert batches == [[{"id": 1}], [{"id": 2}]]
-        # The session masks the token in logged URLs and captured samples.
-        assert mock_session.call_args.kwargs["redact_values"] == ("token",)
-        # State is saved once: after the first page is yielded, pointing at page 2.
-        manager.save_state.assert_called_once_with(
-            PipedriveResumeConfig(next_url=f"https://acme.pipedrive.com/api/v2/deals?limit={PAGE_SIZE}&cursor=c2")
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_cursor_endpoint_and_saves_state_after_yield(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(
+            session,
+            [
+                _response([{"id": 1}], {"next_cursor": "c2"}),
+                _response([{"id": 2}], {"next_cursor": None}),
+            ],
         )
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive.make_tracked_session"
-    )
-    def test_resumes_from_saved_state(self, mock_session: mock.MagicMock) -> None:
-        page = mock.MagicMock(status_code=200, ok=True)
-        page.json.return_value = {"data": [{"id": 9}], "additional_data": {"next_cursor": None}}
-        mock_session.return_value.get.return_value = page
+        manager = _make_manager()
+        rows = _rows(_source("deals", manager))
 
-        resume_url = f"https://acme.pipedrive.com/api/v2/deals?limit={PAGE_SIZE}&cursor=resume-me"
-        manager = self._manager(PipedriveResumeConfig(next_url=resume_url))
+        assert rows == [{"id": 1}, {"id": 2}]
+        # First page carries only limit; the cursor is injected on the second request.
+        assert params[0] == {"limit": PAGE_SIZE}
+        assert params[1] == {"limit": PAGE_SIZE, "cursor": "c2"}
+        # State saved once, after the first page (pointing at the cursor for page 2); final page saves nothing.
+        manager.save_state.assert_called_once_with(PipedriveResumeConfig(paginator_state={"cursor": "c2"}))
 
-        batches = list(get_rows("acme", "token", "deals", mock.MagicMock(), manager))
+    @pytest.mark.parametrize("terminal_cursor", [{}, {"next_cursor": None}, {"next_cursor": ""}])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_cursor_terminates_when_no_next_cursor(
+        self, MockSession: mock.MagicMock, terminal_cursor: dict[str, Any]
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}], terminal_cursor)])
 
-        assert batches == [[{"id": 9}]]
-        assert mock_session.return_value.get.call_args.args[0] == resume_url
+        manager = _make_manager()
+        rows = _rows(_source("deals", manager))
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive.make_tracked_session"
-    )
-    def test_single_page_endpoint_without_pagination(self, mock_session: mock.MagicMock) -> None:
-        page = mock.MagicMock(status_code=200, ok=True)
-        page.json.return_value = {"data": [{"id": 1}, {"id": 2}]}
-        mock_session.return_value.get.return_value = page
-
-        manager = self._manager()
-        batches = list(get_rows("acme", "token", "users", mock.MagicMock(), manager))
-
-        assert batches == [[{"id": 1}, {"id": 2}]]
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.pipedrive.pipedrive.make_tracked_session"
-    )
-    def test_raises_on_non_retryable_error(self, mock_session: mock.MagicMock) -> None:
-        page = mock.MagicMock(status_code=401, ok=False, text="unauthorized")
-        page.raise_for_status.side_effect = Exception("401 Client Error")
-        mock_session.return_value.get.return_value = page
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_offset_endpoint_and_progresses_start(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        full_page = [{"id": i} for i in range(PAGE_SIZE)]
+        params = _wire(
+            session,
+            [
+                _response(full_page, {"pagination": {"more_items_in_collection": True, "next_start": PAGE_SIZE}}),
+                _response([{"id": 9999}], {"pagination": {"more_items_in_collection": False}}),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("activities", manager))
+
+        assert [r["id"] for r in rows] == [*range(PAGE_SIZE), 9999]
+        # OffsetPaginator injects start + limit; a full page advances start by the page size.
+        assert params[0] == {"start": 0, "limit": PAGE_SIZE}
+        assert params[1] == {"start": PAGE_SIZE, "limit": PAGE_SIZE}
+        # Short second page ends pagination; checkpoint saved once after the first (full) page.
+        manager.save_state.assert_called_once_with(PipedriveResumeConfig(paginator_state={"offset": PAGE_SIZE}))
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"id": 1}, {"id": 2}], {"pagination": {"more_items_in_collection": False}})])
+
+        manager = _make_manager()
+        rows = _rows(_source("users", manager))
+
+        assert rows == [{"id": 1}, {"id": 2}]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_cursor_from_saved_paginator_state(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 9}], {"next_cursor": None})])
+
+        manager = _make_manager(PipedriveResumeConfig(paginator_state={"cursor": "resume-me"}))
+        rows = _rows(_source("deals", manager))
+
+        assert rows == [{"id": 9}]
+        # The saved cursor seeds the very first request.
+        assert params[0] == {"limit": PAGE_SIZE, "cursor": "resume-me"}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_offset_from_saved_paginator_state(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 9}], {"pagination": {"more_items_in_collection": False}})])
+
+        manager = _make_manager(PipedriveResumeConfig(paginator_state={"offset": 500}))
+        _rows(_source("activities", manager))
+
+        assert params[0] == {"start": 500, "limit": PAGE_SIZE}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_legacy_next_url_resume_starts_fresh(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"id": 1}], {"next_cursor": None})])
+
+        # Old-shape state (full next_url, no paginator_state) still parses but restarts the endpoint.
+        manager = _make_manager(
+            PipedriveResumeConfig(next_url=f"https://acme.pipedrive.com/api/v2/deals?limit={PAGE_SIZE}&cursor=old")
+        )
+        rows = _rows(_source("deals", manager))
+
+        assert rows == [{"id": 1}]
+        assert params[0] == {"limit": PAGE_SIZE}
+        assert "cursor" not in params[0]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_raises_on_non_retryable_error(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(None, drop_data=True, status=401)])
 
         with pytest.raises(Exception, match="401 Client Error"):
-            list(get_rows("acme", "token", "deals", mock.MagicMock(), self._manager()))
+            _rows(_source("deals", _make_manager()))
+
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_transient_server_error_then_succeeds(
+        self, MockSession: mock.MagicMock, _mock_sleep: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response(None, drop_data=True, status=500),
+                _response([{"id": 7}], {"next_cursor": None}),
+            ],
+        )
+
+        rows = _rows(_source("deals", _make_manager()))
+
+        assert rows == [{"id": 7}]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_off_host_request(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        # A prepared URL off the pinned pipedrive host must be refused before the request leaves.
+        _wire(session, [_response([{"id": 1}])], prepared_url="https://evil.example.com/steal")
+
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("deals", _make_manager()))
 
 
-class TestPipedriveSource:
+class TestPipedriveSourcePartitioning:
     @pytest.mark.parametrize(
         "endpoint, expected_partition_keys, expected_mode",
         [
@@ -219,11 +302,17 @@ class TestPipedriveSource:
             ("deal_fields", None, None),
         ],
     )
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_source_response_partitioning(
-        self, endpoint: str, expected_partition_keys: list[str] | None, expected_mode: str | None
+        self,
+        MockSession: mock.MagicMock,
+        endpoint: str,
+        expected_partition_keys: list[str] | None,
+        expected_mode: str | None,
     ) -> None:
-        response = pipedrive_source("acme", "token", endpoint, mock.MagicMock(), mock.MagicMock())
+        response = _source(endpoint, _make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         assert response.partition_keys == expected_partition_keys
         assert response.partition_mode == expected_mode
+        assert response.partition_format == ("week" if expected_mode else None)


### PR DESCRIPTION
## Problem

Batch 28 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **paddle**
- **paperform**
- **pipedrive**

Not migrated this batch (left hand-rolled, valid blockers):
- **packagist** — config-driven package/vendor-expansion request set with no parent REST resource to fan out from, plus batched `packages[]` advisory requests (not one-request-per-row).
- **pendo** — list endpoints chunk a single whole-array GET response client-side with mid-response row-offset resume; also mixes two transport modes (GET whole-array lists + POST aggregation with nested-pipeline skip/limit).
- **persona** — client-side incremental watermark early-termination (drops below-watermark rows and stops before `links.next` is exhausted).
- **personio** — reactive mid-sync 401 token re-mint (and its auth-revoked permanent-error classification) pinned by tests; the framework's OAuth2 auth only re-mints proactively on expiry.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 3 migrated dirs + `common/rest_source/tests/` — 278 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-27 PR; merge in order.
