### PR TITLE
refactor(data-warehouse): migrate papersign, plausible, postmark, productboard, ramp (batch 29)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/papersign.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/papersign.py
@@ -1,15 +1,17 @@
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.papersign.settings import (
     PAPERSIGN_ENDPOINTS,
     PapersignEndpointConfig,
@@ -21,12 +23,6 @@ BASE_URL = "https://api.paperform.co/v1"
 # `limit` is capped server-side at 100; the default is 20. We request the max to minimise round trips.
 PAGE_SIZE = 100
 
-REQUEST_TIMEOUT_SECONDS = 60
-
-
-class PapersignRetryableError(Exception):
-    pass
-
 
 @dataclasses.dataclass
 class PapersignResumeConfig:
@@ -37,19 +33,142 @@ class PapersignResumeConfig:
     skip: int = 0
 
 
-def _get_session(api_token: str) -> requests.Session:
-    # `redact_values` masks the bearer token in logged URLs and captured HTTP samples, so an
-    # operator-enabled capture never persists a customer's API key.
-    return make_tracked_session(
-        headers={"Authorization": f"Bearer {api_token}", "Accept": "application/json"},
-        redact_values=(api_token,),
+class PapersignPaginator(BasePaginator):
+    """limit/skip offset pagination for Papersign list endpoints.
+
+    Termination mirrors the hand-rolled loop exactly: stop on an empty page, on a page shorter than
+    the limit (a defensive backstop for the folders/spaces endpoints whose pagination is
+    undocumented), or when the authoritative `has_more` flag is false. `skip` advances by the number
+    of rows actually returned, and resume persists the *current* page's offset so a crash re-fetches
+    it (merge dedupes) rather than skipping still-buffered rows.
+    """
+
+    def __init__(self, limit: int) -> None:
+        super().__init__()
+        self.limit = limit
+        # Offset of the next request to issue (0, or a seeded resume offset).
+        self.skip = 0
+        # Offset of the page just fetched — persisted on resume so a crash re-pulls it.
+        self._current_skip = 0
+
+    def init_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["skip"] = self.skip
+        request.params["limit"] = self.limit
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        rows = data or []
+        # `skip` still holds the offset of the request that just completed.
+        self._current_skip = self.skip
+
+        body = response.json()
+        has_more = isinstance(body, dict) and bool(body.get("has_more"))
+
+        if len(rows) == 0 or len(rows) < self.limit or not has_more:
+            self._has_next_page = False
+            return
+
+        self._has_next_page = True
+        self.skip += len(rows)
+
+    def update_request(self, request: Request) -> None:
+        if request.params is None:
+            request.params = {}
+        request.params["skip"] = self.skip
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # Persist the offset of the page we've already fetched, not the next one.
+        return {"skip": self._current_skip}
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        skip = state.get("skip")
+        if skip is not None:
+            self.skip = int(skip)
+            self._has_next_page = True
+
+
+def papersign_source(
+    api_token: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[PapersignResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config: PapersignEndpointConfig = PAPERSIGN_ENDPOINTS[endpoint]
+
+    params: dict[str, Any] = {}
+    if config.supports_sort:
+        # Ascending by created_at keeps offset pagination stable: rows created during the sync
+        # append at the end rather than shifting the offsets of pages we've already read.
+        params["sort"] = "ASC"
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BASE_URL,
+            # Auth (Bearer) goes through the framework auth config so the token is redacted from
+            # every raised error message; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_token},
+            "paginator": PapersignPaginator(limit=PAGE_SIZE),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    # Rows live under `results.<resource>`. `data_selector_required` makes a 200 body
+                    # missing that path raise loudly instead of silently syncing 0 rows — on a
+                    # full-refresh table that would otherwise wipe previously synced data.
+                    "data_selector": f"results.{config.results_key}",
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"skip": resume.skip}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("skip") is not None:
+            resumable_source_manager.save_state(PapersignResumeConfig(skip=int(state["skip"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
     )
 
+    partition_kwargs: dict[str, Any] = {}
+    if config.partition_key is not None:
+        partition_kwargs = {
+            "partition_count": 1,
+            "partition_size": 1,
+            "partition_mode": "datetime",
+            "partition_format": "month",
+            "partition_keys": [config.partition_key],
+        }
 
-def _build_url(path: str, params: dict[str, Any]) -> str:
-    if not params:
-        return f"{BASE_URL}{path}"
-    return f"{BASE_URL}{path}?{urlencode(params, doseq=True)}"
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=config.primary_keys,
+        # Documents arrive ascending (we request `sort=ASC`); folders/spaces are small full scans.
+        sort_mode="asc",
+        column_hints=resource.column_hints,
+        **partition_kwargs,
+    )
 
 
 def validate_credentials(api_token: str) -> tuple[bool, str | None]:
@@ -59,121 +178,22 @@ def validate_credentials(api_token: str) -> tuple[bool, str | None]:
     list endpoint is sufficient. A 401 means the token is wrong; a 403 means the token is valid but
     the plan doesn't include Papersign API access. Anything else reachable counts as valid.
     """
-    url = _build_url("/papersign/spaces", {"limit": 1})
-    try:
-        response = _get_session(api_token).get(url, timeout=10)
-    except Exception:
-        return False, "Could not reach Paperform. Check your network and try again."
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{BASE_URL}/papersign/spaces?limit=1",
+        headers={"Authorization": f"Bearer {api_token}", "Accept": "application/json"},
+    )
 
-    if response.status_code == 200:
+    if ok:
         return True, None
-    if response.status_code == 401:
+    if status is None:
+        return False, "Could not reach Paperform. Check your network and try again."
+    if status == 401:
         return False, "Invalid Paperform API key. Create a new key on your Paperform account page and reconnect."
-    if response.status_code == 403:
+    if status == 403:
         return (
             False,
             "This Paperform API key does not have Papersign API access. The Papersign API requires a paid "
             "Paperform plan — upgrade the plan, then reconnect.",
         )
-    return False, f"Paperform API returned an unexpected status ({response.status_code}) while validating credentials."
-
-
-@retry(
-    retry=retry_if_exception_type((PapersignRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> dict[str, Any]:
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-
-    # Paperform is rate limited per minute and returns 429 with a Retry-After header when exceeded.
-    # The exact threshold is undocumented, so we back off exponentially rather than trusting the
-    # header. 5xx are transient too.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise PapersignRetryableError(f"Paperform API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Paperform API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PapersignResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = PAPERSIGN_ENDPOINTS[endpoint]
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = _get_session(api_token)
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    skip: int = resume.skip if resume is not None else 0
-    if resume is not None:
-        logger.debug(f"Papersign: resuming {endpoint} from skip={skip}")
-
-    while True:
-        params: dict[str, Any] = {"limit": PAGE_SIZE, "skip": skip}
-        if config.supports_sort:
-            # Ascending by created_at keeps offset pagination stable: rows created during the sync
-            # append at the end rather than shifting the offsets of pages we've already read.
-            params["sort"] = "ASC"
-
-        data = _fetch_page(session, _build_url(config.path, params), logger)
-        # Index strictly rather than `.get(..., [])`: `results` and its resource key are required
-        # fields of the documented response. A malformed 200 (e.g. during an upstream incident) must
-        # raise KeyError and fail the sync loudly, not silently yield zero rows — on a full-refresh
-        # table that would replace all previously synced data with an empty table.
-        rows = data["results"][config.results_key]
-        if not rows:
-            break
-
-        yield rows
-        # Save the offset of the page we just yielded (not the next one) AFTER yielding, so a crash
-        # re-fetches this page rather than skipping rows still buffered. Merge dedupes on the
-        # primary key.
-        resumable_source_manager.save_state(PapersignResumeConfig(skip=skip))
-
-        # `has_more` is the authoritative end-of-list signal. The short-page check is a defensive
-        # backstop for the folders/spaces endpoints, whose pagination is undocumented: if one ignores
-        # `skip` yet still reports `has_more=true`, a full-page loop could otherwise never terminate.
-        # A page shorter than the limit is always the last one.
-        if not data.get("has_more") or len(rows) < PAGE_SIZE:
-            break
-        skip += len(rows)
-
-
-def papersign_source(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PapersignResumeConfig],
-) -> SourceResponse:
-    endpoint_config: PapersignEndpointConfig = PAPERSIGN_ENDPOINTS[endpoint]
-
-    partition_kwargs: dict[str, Any] = {}
-    if endpoint_config.partition_key is not None:
-        partition_kwargs = {
-            "partition_count": 1,
-            "partition_size": 1,
-            "partition_mode": "datetime",
-            "partition_format": "month",
-            "partition_keys": [endpoint_config.partition_key],
-        }
-
-    return SourceResponse(
-        name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=endpoint_config.primary_keys,
-        # Documents arrive ascending (we request `sort=ASC`); folders/spaces are small full scans.
-        sort_mode="asc",
-        **partition_kwargs,
-    )
+    return False, f"Paperform API returned an unexpected status ({status}) while validating credentials."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/source.py
@@ -134,6 +134,8 @@ The Papersign API requires a paid Paperform plan (Standard or Business tier)."""
         return papersign_source(
             api_token=config.api_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Papersign endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/tests/test_papersign.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/tests/test_papersign.py
@@ -1,74 +1,221 @@
+import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
-from unittest.mock import MagicMock, patch
+import pytest
+from unittest import mock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.papersign import papersign
 from products.warehouse_sources.backend.temporal.data_imports.sources.papersign.papersign import (
     BASE_URL,
     PAGE_SIZE,
     PapersignResumeConfig,
-    _build_url,
-    get_rows,
     papersign_source,
     validate_credentials,
 )
 
-
-def _ok_json_response(payload: dict | None = None, status_code: int = 200) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.json.return_value = payload if payload is not None else {}
-    response.raise_for_status = MagicMock()
-    return response
-
-
-class _FakeResumableManager:
-    def __init__(self, state: PapersignResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[PapersignResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> PapersignResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: PapersignResumeConfig) -> None:
-        self.saved.append(data)
+# The RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the papersign module.
+PAPERSIGN_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.papersign.papersign.make_tracked_session"
+)
 
 
-def _page(results_key: str, rows: list[dict[str, Any]], has_more: bool) -> dict[str, Any]:
-    return {
-        "status": "ok",
-        "results": {results_key: rows},
-        "total": len(rows),
-        "has_more": has_more,
-        "limit": PAGE_SIZE,
-        "skip": 0,
-    }
+def _page_response(
+    results_key: str,
+    rows: list[dict[str, Any]] | None,
+    has_more: bool,
+    *,
+    drop_results: bool = False,
+) -> Response:
+    body: dict[str, Any] = {"status": "ok", "total": 0, "has_more": has_more, "limit": PAGE_SIZE, "skip": 0}
+    if not drop_results:
+        body["results"] = {results_key: rows or []}
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _docs(count: int, start: int = 0) -> list[dict[str, Any]]:
     return [{"id": f"doc-{start + i}", "created_at_utc": "2026-01-01T00:00:00Z"} for i in range(count)]
 
 
-class TestBuildUrl:
-    def test_no_params(self) -> None:
-        assert _build_url("/papersign/spaces", {}) == f"{BASE_URL}/papersign/spaces"
+def _make_manager(resume_state: PapersignResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def test_with_params_is_urlencoded(self) -> None:
-        url = _build_url("/papersign/documents", {"limit": 100, "skip": 200, "sort": "ASC"})
-        assert url == f"{BASE_URL}/papersign/documents?limit=100&skip=200&sort=ASC"
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return papersign_source(
+        api_token="tok",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager,
+    )
+
+
+class TestPagination:
+    def test_single_page_terminates_when_has_more_false(self) -> None:
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            params = _wire(session, [_page_response("documents", _docs(3), has_more=False)])
+
+            rows = _rows(_source("documents", _make_manager()))
+
+        assert [r["id"] for r in rows] == ["doc-0", "doc-1", "doc-2"]
+        assert len(params) == 1
+        assert params[0]["skip"] == 0
+        assert params[0]["limit"] == PAGE_SIZE
+        # Documents are the only endpoint that gets an explicit ascending sort.
+        assert params[0]["sort"] == "ASC"
+
+    def test_walks_pages_incrementing_skip(self) -> None:
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            params = _wire(
+                session,
+                [
+                    _page_response("documents", _docs(PAGE_SIZE, start=0), has_more=True),
+                    _page_response("documents", _docs(PAGE_SIZE, start=PAGE_SIZE), has_more=True),
+                    _page_response("documents", _docs(50, start=2 * PAGE_SIZE), has_more=False),
+                ],
+            )
+
+            rows = _rows(_source("documents", _make_manager()))
+
+        assert len(rows) == 2 * PAGE_SIZE + 50
+        # skip advances by the number of rows actually returned on each page.
+        assert [p["skip"] for p in params] == [0, PAGE_SIZE, 2 * PAGE_SIZE]
+
+    def test_short_page_terminates_even_if_has_more_true(self) -> None:
+        # Guards the folders/spaces infinite-loop case: an endpoint that ignores `skip` but keeps
+        # reporting has_more=true must still stop once a page comes back shorter than the limit.
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            params = _wire(session, [_page_response("folders", [{"id": i} for i in range(3)], has_more=True)])
+
+            rows = _rows(_source("folders", _make_manager()))
+
+        assert len(rows) == 3
+        assert len(params) == 1
+
+    def test_stops_when_results_empty(self) -> None:
+        # has_more lies (True) but the page is empty — we must still terminate, not loop forever.
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            params = _wire(session, [_page_response("documents", [], has_more=True)])
+
+            rows = _rows(_source("documents", _make_manager()))
+
+        assert rows == []
+        assert len(params) == 1
+
+    def test_folders_endpoint_sends_no_sort(self) -> None:
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            params = _wire(session, [_page_response("folders", [{"id": 1, "name": "F"}], has_more=False)])
+
+            _rows(_source("folders", _make_manager()))
+
+        assert "sort" not in params[0]
+
+    def test_resume_uses_saved_skip(self) -> None:
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            params = _wire(session, [_page_response("documents", _docs(2, start=200), has_more=False)])
+
+            _rows(_source("documents", _make_manager(PapersignResumeConfig(skip=200))))
+
+        # First request must continue from the saved offset, not restart at 0.
+        assert params[0]["skip"] == 200
+
+    def test_saves_only_already_fetched_offsets(self) -> None:
+        # The "save current page, not next" invariant: every persisted offset must be one we've
+        # already fetched, so a crash re-fetches (merge dedupes) rather than skipping buffered rows.
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            manager = _make_manager()
+            params = _wire(
+                session,
+                [
+                    _page_response("documents", _docs(PAGE_SIZE, start=0), has_more=True),
+                    _page_response("documents", _docs(PAGE_SIZE, start=PAGE_SIZE), has_more=True),
+                    _page_response("documents", _docs(10, start=2 * PAGE_SIZE), has_more=False),
+                ],
+            )
+
+            _rows(_source("documents", manager))
+
+        fetched_skips = {p["skip"] for p in params}
+        assert manager.save_state.called, "expected a checkpoint after a yielded page"
+        saved_skips = [call.args[0].skip for call in manager.save_state.call_args_list]
+        assert all(skip in fetched_skips for skip in saved_skips)
+
+    def test_missing_results_key_raises_loudly(self) -> None:
+        # A 200 body without `results.documents` means the response shape changed — fail loud,
+        # not silently sync 0 rows (which would wipe a full-refresh table).
+        with mock.patch(CLIENT_SESSION_PATCH) as MockSession:
+            session = MockSession.return_value
+            _wire(session, [_page_response("documents", None, has_more=False, drop_results=True)])
+
+            with pytest.raises(ValueError, match="matched nothing"):
+                _rows(_source("documents", _make_manager()))
+
+
+class TestSourceResponse:
+    def test_documents_partitions_on_created_at(self) -> None:
+        with mock.patch(CLIENT_SESSION_PATCH):
+            response = _source("documents", _make_manager())
+        assert response.name == "documents"
+        assert response.primary_keys == ["id"]
+        assert response.sort_mode == "asc"
+        assert response.partition_mode == "datetime"
+        assert response.partition_keys == ["created_at_utc"]
+
+    @parameterized.expand(["folders", "spaces"])
+    def test_untimestamped_endpoints_are_not_partitioned(self, endpoint: str) -> None:
+        # folders and spaces carry no stable datetime field, so they must not declare a datetime
+        # partition (partitioning on a missing column would break the sync).
+        with mock.patch(CLIENT_SESSION_PATCH):
+            response = _source(endpoint, _make_manager())
+        assert response.name == endpoint
+        assert response.primary_keys == ["id"]
+        assert response.partition_mode is None
+        assert response.partition_keys is None
 
 
 class TestValidateCredentials:
-    @patch.object(papersign, "make_tracked_session")
-    def test_returns_true_on_200(self, mock_session: MagicMock) -> None:
-        mock_session.return_value.get.return_value = _ok_json_response({"results": {"spaces": []}})
+    @mock.patch(PAPERSIGN_SESSION_PATCH)
+    def test_returns_true_on_200(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
 
         success, error = validate_credentials("tok")
 
@@ -84,11 +231,11 @@ class TestValidateCredentials:
             (500, "unexpected status"),
         ]
     )
-    @patch.object(papersign, "make_tracked_session")
+    @mock.patch(PAPERSIGN_SESSION_PATCH)
     def test_returns_false_on_http_status(
-        self, status_code: int, expected_substring: str, mock_session: MagicMock
+        self, status_code: int, expected_substring: str, mock_session: mock.MagicMock
     ) -> None:
-        mock_session.return_value.get.return_value = _ok_json_response(status_code=status_code)
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
 
         success, error = validate_credentials("tok")
 
@@ -96,156 +243,20 @@ class TestValidateCredentials:
         assert error is not None
         assert expected_substring.lower() in error.lower()
 
-    @patch.object(papersign, "make_tracked_session")
-    def test_redacts_token_in_tracked_session(self, mock_session: MagicMock) -> None:
+    @mock.patch(PAPERSIGN_SESSION_PATCH)
+    def test_redacts_token_in_tracked_session(self, mock_session: mock.MagicMock) -> None:
         # The bearer token must be passed to redact_values so it's masked in logged URLs and captured
         # HTTP samples. Dropping this would leak customers' API keys into the capture pipeline.
-        mock_session.return_value.get.return_value = _ok_json_response({"results": {"spaces": []}})
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
         validate_credentials("secret-token")
         assert mock_session.call_args.kwargs.get("redact_values") == ("secret-token",)
 
-    @patch.object(papersign, "make_tracked_session")
-    def test_returns_false_on_network_error(self, mock_session: MagicMock) -> None:
-        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+    @mock.patch(PAPERSIGN_SESSION_PATCH)
+    def test_returns_false_on_network_error(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
 
         success, error = validate_credentials("tok")
 
         assert success is False
         assert error is not None
         assert "could not reach paperform" in error.lower()
-
-
-class TestGetRows:
-    @staticmethod
-    def _run(
-        manager: _FakeResumableManager,
-        pages: list[dict[str, Any]],
-        endpoint: str = "documents",
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-        """Drive get_rows against a queue of page responses. Returns (rows, recorded_requests)."""
-        queue = list(pages)
-        recorded: list[dict[str, Any]] = []
-
-        def fake_fetch(session: Any, url: str, logger: Any) -> dict[str, Any]:
-            query = parse_qs(urlparse(url).query)
-            recorded.append(
-                {
-                    "url": url,
-                    "skip": int(query["skip"][0]) if "skip" in query else None,
-                    "limit": int(query["limit"][0]) if "limit" in query else None,
-                    "sort": query["sort"][0] if "sort" in query else None,
-                }
-            )
-            return queue.pop(0)
-
-        with patch.object(papersign, "_fetch_page", side_effect=fake_fetch):
-            rows: list[dict[str, Any]] = []
-            for page in get_rows(
-                api_token="tok",
-                endpoint=endpoint,
-                logger=MagicMock(),
-                resumable_source_manager=manager,  # type: ignore[arg-type]
-            ):
-                rows.extend(page)
-        return rows, recorded
-
-    def test_single_page_terminates_when_has_more_false(self) -> None:
-        manager = _FakeResumableManager()
-        rows, recorded = self._run(manager, [_page("documents", _docs(3), has_more=False)])
-
-        assert [r["id"] for r in rows] == ["doc-0", "doc-1", "doc-2"]
-        assert len(recorded) == 1
-        assert recorded[0]["skip"] == 0
-        assert recorded[0]["limit"] == PAGE_SIZE
-        # Documents are the only endpoint that gets an explicit ascending sort.
-        assert recorded[0]["sort"] == "ASC"
-
-    def test_walks_pages_incrementing_skip(self) -> None:
-        manager = _FakeResumableManager()
-        pages = [
-            _page("documents", _docs(PAGE_SIZE, start=0), has_more=True),
-            _page("documents", _docs(PAGE_SIZE, start=PAGE_SIZE), has_more=True),
-            _page("documents", _docs(50, start=2 * PAGE_SIZE), has_more=False),
-        ]
-        rows, recorded = self._run(manager, pages)
-
-        assert len(rows) == 2 * PAGE_SIZE + 50
-        # skip advances by the number of rows actually returned on each page.
-        assert [r["skip"] for r in recorded] == [0, PAGE_SIZE, 2 * PAGE_SIZE]
-
-    def test_short_page_terminates_even_if_has_more_true(self) -> None:
-        # Guards the folders/spaces infinite-loop case: an endpoint that ignores `skip` but keeps
-        # reporting has_more=true must still stop once a page comes back shorter than the limit.
-        manager = _FakeResumableManager()
-        rows, recorded = self._run(
-            manager, [_page("folders", [{"id": i} for i in range(3)], has_more=True)], endpoint="folders"
-        )
-        assert len(rows) == 3
-        assert len(recorded) == 1
-
-    def test_stops_when_results_empty(self) -> None:
-        manager = _FakeResumableManager()
-        # has_more lies (True) but the page is empty — we must still terminate, not loop forever.
-        rows, recorded = self._run(manager, [_page("documents", [], has_more=True)])
-
-        assert rows == []
-        assert len(recorded) == 1
-
-    def test_folders_endpoint_sends_no_sort(self) -> None:
-        manager = _FakeResumableManager()
-        _rows, recorded = self._run(
-            manager, [_page("folders", [{"id": 1, "name": "F"}], has_more=False)], endpoint="folders"
-        )
-        assert recorded[0]["sort"] is None
-
-    def test_resume_uses_saved_skip(self) -> None:
-        manager = _FakeResumableManager(PapersignResumeConfig(skip=200))
-        _rows, recorded = self._run(manager, [_page("documents", _docs(2, start=200), has_more=False)])
-
-        # First request must continue from the saved offset, not restart at 0.
-        assert recorded[0]["skip"] == 200
-
-    def test_saves_only_already_fetched_offsets_after_yield(self) -> None:
-        # The "save current page, not next" invariant: every persisted offset must be one we've
-        # already fetched, so a crash re-fetches (merge dedupes) rather than skipping buffered rows.
-        manager = _FakeResumableManager()
-        pages = [
-            _page("documents", _docs(PAGE_SIZE, start=0), has_more=True),
-            _page("documents", _docs(PAGE_SIZE, start=PAGE_SIZE), has_more=True),
-            _page("documents", _docs(10, start=2 * PAGE_SIZE), has_more=False),
-        ]
-        _rows, recorded = self._run(manager, pages)
-
-        fetched_skips = {r["skip"] for r in recorded}
-        assert manager.saved, "expected a save after each yielded page"
-        assert all(saved.skip in fetched_skips for saved in manager.saved)
-
-
-class TestPapersignSourceResponse:
-    def test_documents_partitions_on_created_at(self) -> None:
-        response = papersign_source(
-            api_token="tok",
-            endpoint="documents",
-            logger=MagicMock(),
-            resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-        )
-        assert response.name == "documents"
-        assert response.primary_keys == ["id"]
-        assert response.sort_mode == "asc"
-        assert response.partition_mode == "datetime"
-        assert response.partition_keys == ["created_at_utc"]
-
-    @parameterized.expand(["folders", "spaces"])
-    def test_untimestamped_endpoints_are_not_partitioned(self, endpoint: str) -> None:
-        # folders and spaces carry no stable datetime field, so they must not declare a datetime
-        # partition (partitioning on a missing column would break the sync).
-        response = papersign_source(
-            api_token="tok",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
-        )
-        assert response.name == endpoint
-        assert response.primary_keys == ["id"]
-        assert response.partition_mode is None
-        assert response.partition_keys is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/tests/test_papersign_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/papersign/tests/test_papersign_source.py
@@ -132,9 +132,9 @@ class TestPapersignPipelineWiring:
 
         inputs = MagicMock()
         inputs.schema_name = "documents"
+        inputs.team_id = 7
+        inputs.job_id = "job-1"
         manager = MagicMock()
-        logger = MagicMock()
-        inputs.logger = logger
 
         with patch.object(source_module, "papersign_source", side_effect=fake_source) as mock_source:
             result = PapersignSource().source_for_pipeline(_config(api_token="abc"), manager, inputs)
@@ -144,4 +144,5 @@ class TestPapersignPipelineWiring:
         assert captured["api_token"] == "abc"
         assert captured["endpoint"] == "documents"
         assert captured["resumable_source_manager"] is manager
-        assert captured["logger"] is logger
+        assert captured["team_id"] == 7
+        assert captured["job_id"] == "job-1"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/plausible.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/plausible.py
@@ -1,16 +1,17 @@
-import time
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Optional
 from urllib.parse import urlparse
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.settings import (
     DEFAULT_BACKFILL_DAYS,
@@ -25,15 +26,6 @@ QUERY_PATH = "/api/v2/query"
 
 # Stats API v2 caps pagination.limit at 10000 rows per page.
 DEFAULT_PAGE_LIMIT = 10000
-REQUEST_TIMEOUT_SECONDS = 120
-# Default rate limit is 600 requests/hour per API key. We can't enforce a global budget here, so we
-# add a light per-request throttle and lean on retry/backoff to absorb 429s.
-REQUEST_THROTTLE_SECONDS = 0.25
-MAX_RETRY_ATTEMPTS = 5
-
-
-class PlausibleRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -69,16 +61,6 @@ def hostname_of(host: Optional[str]) -> str:
     return urlparse(resolve_host(host)).hostname or ""
 
 
-def _get_session(api_key: str) -> requests.Session:
-    # `host` is user-supplied, so pin redirects off: validation and the outbound request must stay
-    # on the same target (SSRF defense-in-depth). The key is redacted from logged URLs/samples.
-    return make_tracked_session(
-        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-        redact_values=(api_key,),
-        allow_redirects=False,
-    )
-
-
 def _to_date(value: Any) -> Optional[date]:
     if isinstance(value, datetime):
         return value.date()
@@ -90,19 +72,6 @@ def _to_date(value: Any) -> Optional[date]:
         except ValueError:
             return None
     return None
-
-
-def _build_query(config: PlausibleEndpointConfig, site_id: str, start: date, end: date, offset: int) -> dict[str, Any]:
-    return {
-        "site_id": site_id,
-        "metrics": config.metrics,
-        "date_range": [start.isoformat(), end.isoformat()],
-        "dimensions": config.dimensions,
-        # Ascending by day so the pipeline's incremental watermark only ever advances forward.
-        "order_by": [["time:day", "asc"]],
-        "pagination": {"limit": DEFAULT_PAGE_LIMIT, "offset": offset},
-        "include": {"total_rows": True},
-    }
 
 
 def _normalize_row(config: PlausibleEndpointConfig, result: dict[str, Any]) -> dict[str, Any]:
@@ -117,34 +86,65 @@ def _normalize_row(config: PlausibleEndpointConfig, result: dict[str, Any]) -> d
     return row
 
 
-@retry(
-    retry=retry_if_exception_type((PlausibleRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-    wait=wait_exponential_jitter(initial=2, max=90),
-    reraise=True,
-)
-def _query(
-    session: requests.Session, url: str, payload: dict[str, Any], logger: FilteringBoundLogger
-) -> dict[str, Any]:
-    # Throttle every call, including tenacity retries, so a retry storm can't blow past the rate
-    # limit on top of the backoff.
-    time.sleep(REQUEST_THROTTLE_SECONDS)
-    response = session.post(url, json=payload, timeout=REQUEST_TIMEOUT_SECONDS)
+class PlausiblePaginator(BasePaginator):
+    """Offset pagination for the Stats API v2 query endpoint.
 
-    if response.status_code == 429 or response.status_code >= 500:
-        raise PlausibleRetryableError(f"Plausible API error (retryable): status={response.status_code}")
+    The offset/limit live nested under ``pagination`` in the POST body (not a flat top-level key),
+    and the grand total is at ``meta.total_rows``, so the built-in OffsetPaginator (flat JSON keys)
+    can't express it. Termination mirrors the hand-rolled loop: stop on a short page OR once the next
+    offset reaches ``total_rows``.
+    """
 
-    if not response.ok:
-        logger.error(f"Plausible API error: status={response.status_code}, body={response.text[:500]}")
-        response.raise_for_status()
+    def __init__(self, limit: int, offset: int = 0) -> None:
+        super().__init__()
+        self.limit = limit
+        self.offset = offset
 
-    return response.json()
+    def _set_pagination(self, request: Request) -> None:
+        if request.json is None:
+            request.json = {}
+        request.json["pagination"] = {"limit": self.limit, "offset": self.offset}
+
+    def init_request(self, request: Request) -> None:
+        self._set_pagination(request)
+
+    def update_request(self, request: Request) -> None:
+        self._set_pagination(request)
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        results = data or []
+        try:
+            total_rows = response.json().get("meta", {}).get("total_rows")
+        except Exception:
+            total_rows = None
+
+        next_offset = self.offset + self.limit
+        reached_end = len(results) < self.limit or (total_rows is not None and next_offset >= total_rows)
+        self.offset = next_offset
+        self._has_next_page = not reached_end
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # self.offset already points at the next page to fetch (update_state advanced it).
+        return {"offset": self.offset} if self._has_next_page else None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        offset = state.get("offset")
+        if offset is not None:
+            self.offset = int(offset)
+            self._has_next_page = True
 
 
 def validate_credentials(host: Optional[str], site_id: str, api_key: str) -> tuple[bool, str | None]:
     """Confirm the instance is reachable and the key can read the site's stats."""
     try:
-        response = _get_session(api_key).post(
+        # `host` is user-supplied, so pin redirects off: validation and the outbound request must
+        # stay on the same target (SSRF defense-in-depth). The key is redacted from logged samples.
+        session = make_tracked_session(
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            redact_values=(api_key,),
+            allow_redirects=False,
+        )
+        response = session.post(
             f"{resolve_host(host)}{QUERY_PATH}",
             # Cheapest possible probe: one metric over a short relative range, no dimensions.
             json={"site_id": site_id, "metrics": ["visitors"], "date_range": "7d"},
@@ -167,20 +167,11 @@ def validate_credentials(host: Optional[str], site_id: str, api_key: str) -> tup
     return False, message or f"Plausible returned status {response.status_code}."
 
 
-def get_rows(
-    host: Optional[str],
-    site_id: str,
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PlausibleResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = PLAUSIBLE_ENDPOINTS[endpoint]
-    session = _get_session(api_key)
-    url = f"{resolve_host(host)}{QUERY_PATH}"
-
+def _resolve_window(
+    resume_config: Optional[PlausibleResumeConfig],
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+) -> tuple[date, date]:
     today = datetime.now(tz=UTC).date()
     start = today - timedelta(days=DEFAULT_BACKFILL_DAYS)
     if should_use_incremental_field:
@@ -190,9 +181,7 @@ def get_rows(
             # on the (date, ...) primary key overwrite the changed rows.
             start = watermark - timedelta(days=REPORT_LOOKBACK_DAYS)
     end = today
-    offset = 0
 
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
     if resume_config is not None:
         resumed_start = _to_date(resume_config.date_range_start)
         resumed_end = _to_date(resume_config.date_range_end)
@@ -200,32 +189,10 @@ def get_rows(
             start = resumed_start
         if resumed_end is not None:
             end = resumed_end
-        offset = resume_config.offset or 0
-        logger.debug(f"Plausible: resuming {endpoint} from offset={offset}, range={start}..{end}")
 
     if start > end:
         start = end
-
-    while True:
-        body = _query(session, url, _build_query(config, site_id, start, end, offset), logger)
-        results = body.get("results", []) or []
-
-        rows = [_normalize_row(config, result) for result in results]
-        if rows:
-            yield rows
-
-        total_rows = body.get("meta", {}).get("total_rows")
-        next_offset = offset + DEFAULT_PAGE_LIMIT
-        reached_end = len(results) < DEFAULT_PAGE_LIMIT or (total_rows is not None and next_offset >= total_rows)
-        if reached_end:
-            break
-
-        offset = next_offset
-        # Save AFTER yielding so a crash resumes on the next unfetched page (already-yielded rows
-        # are deduped by the primary key on merge).
-        resumable_source_manager.save_state(
-            PlausibleResumeConfig(offset=offset, date_range_start=start.isoformat(), date_range_end=end.isoformat())
-        )
+    return start, end
 
 
 def plausible_source(
@@ -233,25 +200,77 @@ def plausible_source(
     site_id: str,
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PlausibleResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = PLAUSIBLE_ENDPOINTS[endpoint]
 
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    start, end = _resolve_window(resume_config, should_use_incremental_field, db_incremental_field_last_value)
+    start_iso, end_iso = start.isoformat(), end.isoformat()
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resume_config is not None:
+        initial_paginator_state = {"offset": resume_config.offset or 0}
+
+    body: dict[str, Any] = {
+        "site_id": site_id,
+        "metrics": config.metrics,
+        "date_range": [start_iso, end_iso],
+        "dimensions": config.dimensions,
+        # Ascending by day so the pipeline's incremental watermark only ever advances forward.
+        "order_by": [["time:day", "asc"]],
+        "include": {"total_rows": True},
+    }
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": resolve_host(host),
+            "headers": {"Content-Type": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            # `host` is user-supplied: reject redirects so a request (and the Authorization header)
+            # can't be bounced off the validated target.
+            "allow_redirects": False,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": QUERY_PATH,
+                    "method": "POST",
+                    "json": body,
+                    "data_selector": "results",
+                    "paginator": PlausiblePaginator(limit=DEFAULT_PAGE_LIMIT),
+                },
+                "data_map": lambda result, config=config: _normalize_row(config, result),
+            }
+        ],
+    }
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-fetches
+        # the last page (merge dedupes on the primary key) rather than skipping it. The window is
+        # pinned so the resumed query keeps a consistent total_rows/ordering.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(
+                PlausibleResumeConfig(offset=int(state["offset"]), date_range_start=start_iso, date_range_end=end_iso)
+            )
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value if should_use_incremental_field else None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            host=host,
-            site_id=site_id,
-            api_key=api_key,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=list(config.primary_keys),
         # Reports are pulled oldest-day-first (order_by time:day asc), so the cursor only moves forward.
         sort_mode="asc",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/source.py
@@ -161,7 +161,8 @@ Works with Plausible Cloud and self-hosted instances. Create an API key under **
             site_id=config.site_id,
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
@@ -1,14 +1,17 @@
+import copy
+import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
 from unittest import mock
 
+from requests import Response
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible import plausible as plausible_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.plausible import (
     PlausibleResumeConfig,
     _normalize_row,
-    get_rows,
     hostname_of,
     normalize_host,
     plausible_source,
@@ -22,6 +25,19 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.
 )
 
 _MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.plausible.plausible"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+
+
+def _result(dimensions: list[Any], metrics: list[Any]) -> dict[str, Any]:
+    return {"dimensions": dimensions, "metrics": metrics}
+
+
+def _response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: PlausibleResumeConfig | None = None) -> mock.MagicMock:
@@ -31,17 +47,40 @@ def _make_manager(resume_state: PlausibleResumeConfig | None = None) -> mock.Mag
     return manager
 
 
-def _response(body: Any, status_code: int = 200) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = body
-    resp.status_code = status_code
-    resp.ok = status_code < 400
-    resp.text = str(body)
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and snapshot each request's JSON body AT SEND TIME.
+
+    The paginator mutates ``request.json`` in place across pages, so inspecting it after the run shows
+    only the final state — snapshot a deep copy when each request is prepared instead.
+    """
+    session.headers = {}
+    body_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        body_snapshots.append(copy.deepcopy(request.json) or {})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return body_snapshots
 
 
-def _result(dimensions: list[Any], metrics: list[Any]) -> dict[str, Any]:
-    return {"dimensions": dimensions, "metrics": metrics}
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(**overrides: Any):
+    kwargs: dict[str, Any] = {
+        "host": "https://plausible.io",
+        "site_id": "example.com",
+        "api_key": "key",
+        "endpoint": "timeseries",
+        "team_id": 1,
+        "job_id": "j",
+        "resumable_source_manager": _make_manager(),
+    }
+    kwargs.update(overrides)
+    return plausible_source(**kwargs)
 
 
 class TestNormalizeHost:
@@ -98,7 +137,7 @@ class TestNormalizeRow:
 class TestValidateCredentials:
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_valid_credentials(self, mock_session):
-        mock_session.return_value.post.return_value = _response({"results": [{"metrics": [1]}]})
+        mock_session.return_value.post.return_value = mock.MagicMock(status_code=200)
 
         ok, error = validate_credentials("https://plausible.io", "example.com", "key")
         assert ok is True
@@ -120,7 +159,9 @@ class TestValidateCredentials:
     )
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_failure_status_codes(self, mock_session, status_code, fragment):
-        mock_session.return_value.post.return_value = _response({}, status_code=status_code)
+        resp = mock.MagicMock(status_code=status_code)
+        resp.json.return_value = {}
+        mock_session.return_value.post.return_value = resp
 
         ok, error = validate_credentials("https://plausible.io", "example.com", "bad")
         assert ok is False
@@ -135,19 +176,24 @@ class TestValidateCredentials:
         assert error is not None and "reach" in error
 
 
-@mock.patch(f"{_MODULE}.time.sleep")
 class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_builds_query_and_yields_normalized_rows(self, mock_session, mock_sleep):
-        mock_session.return_value.post.return_value = _response(
-            {"results": [_result(["2024-01-01", "Google"], [10, 12, 30, 0.5, 60, 40])], "meta": {"total_rows": 1}}
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_builds_query_and_yields_normalized_rows(self, MockSession):
+        session = MockSession.return_value
+        bodies = _wire(
+            session,
+            [
+                _response(
+                    {
+                        "results": [_result(["2024-01-01", "Google"], [10, 12, 30, 0.5, 60, 40])],
+                        "meta": {"total_rows": 1},
+                    }
+                )
+            ],
         )
 
-        batches = list(
-            get_rows("https://plausible.io", "example.com", "key", "sources", mock.MagicMock(), _make_manager())
-        )
+        rows = _rows(_source(endpoint="sources"))
 
-        rows = [row for batch in batches for row in batch]
         assert rows == [
             {
                 "date": "2024-01-01",
@@ -160,14 +206,14 @@ class TestGetRows:
                 "events": 40,
             }
         ]
-        body = mock_session.return_value.post.call_args.kwargs["json"]
-        assert body["dimensions"] == ["time:day", "visit:source"]
-        assert body["order_by"] == [["time:day", "asc"]]
-        assert body["include"] == {"total_rows": True}
-        assert body["pagination"]["offset"] == 0
+        assert bodies[0]["dimensions"] == ["time:day", "visit:source"]
+        assert bodies[0]["order_by"] == [["time:day", "asc"]]
+        assert bodies[0]["include"] == {"total_rows": True}
+        assert bodies[0]["pagination"]["offset"] == 0
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_paginates_until_short_page_and_saves_state(self, mock_session, mock_sleep):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page_and_saves_state(self, MockSession):
+        session = MockSession.return_value
         # Shrink the page size so two small pages exercise the offset pagination loop.
         with mock.patch.object(plausible_module, "DEFAULT_PAGE_LIMIT", 2):
             page1 = {
@@ -175,73 +221,62 @@ class TestGetRows:
                 "meta": {"total_rows": 3},
             }
             page2 = {"results": [_result(["2024-01-03"], [3, 3, 3, 0, 0, 3])], "meta": {"total_rows": 3}}
-            mock_session.return_value.post.side_effect = [_response(page1), _response(page2)]
+            bodies = _wire(session, [_response(page1), _response(page2)])
 
             manager = _make_manager()
-            batches = list(
-                get_rows("https://plausible.io", "example.com", "key", "timeseries", mock.MagicMock(), manager)
-            )
+            batches = list(_source(endpoint="timeseries", resumable_source_manager=manager).items())
 
         assert [len(batch) for batch in batches] == [2, 1]
         # The second request advances the offset past the first page.
-        second_body = mock_session.return_value.post.call_args_list[1].kwargs["json"]
-        assert second_body["pagination"]["offset"] == 2
+        assert bodies[1]["pagination"]["offset"] == 2
         # State is saved once, after the first page, pointing at the next offset.
-        assert [call.args[0].offset for call in manager.save_state.call_args_list] == [2]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0].offset == 2
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_incremental_watermark_slides_window_back_by_lookback(self, mock_session, mock_sleep):
-        mock_session.return_value.post.return_value = _response({"results": [], "meta": {"total_rows": 0}})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_watermark_slides_window_back_by_lookback(self, MockSession):
+        session = MockSession.return_value
+        bodies = _wire(session, [_response({"results": [], "meta": {"total_rows": 0}})])
 
-        list(
-            get_rows(
-                "https://plausible.io",
-                "example.com",
-                "key",
-                "timeseries",
-                mock.MagicMock(),
-                _make_manager(),
+        _rows(
+            _source(
+                endpoint="timeseries",
                 should_use_incremental_field=True,
                 db_incremental_field_last_value="2024-06-01",
             )
         )
 
-        body = mock_session.return_value.post.call_args.kwargs["json"]
         expected_start = (datetime(2024, 6, 1, tzinfo=UTC).date() - timedelta(days=REPORT_LOOKBACK_DAYS)).isoformat()
-        assert body["date_range"][0] == expected_start
+        assert bodies[0]["date_range"][0] == expected_start
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resume_state_pins_offset_and_window(self, mock_session, mock_sleep):
-        mock_session.return_value.post.return_value = _response({"results": [], "meta": {"total_rows": 0}})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resume_state_pins_offset_and_window(self, MockSession):
+        session = MockSession.return_value
+        bodies = _wire(session, [_response({"results": [], "meta": {"total_rows": 0}})])
 
         manager = _make_manager(
             PlausibleResumeConfig(offset=4, date_range_start="2024-01-01", date_range_end="2024-01-31")
         )
-        list(get_rows("https://plausible.io", "example.com", "key", "timeseries", mock.MagicMock(), manager))
+        _rows(_source(endpoint="timeseries", resumable_source_manager=manager))
 
-        body = mock_session.return_value.post.call_args.kwargs["json"]
-        assert body["pagination"]["offset"] == 4
-        assert body["date_range"] == ["2024-01-01", "2024-01-31"]
+        assert bodies[0]["pagination"]["offset"] == 4
+        assert bodies[0]["date_range"] == ["2024-01-01", "2024-01-31"]
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_http_error_raises(self, mock_session, mock_sleep):
-        error_response = _response({"error": "bad query"}, status_code=400)
-        error_response.raise_for_status.side_effect = Exception("400 Client Error")
-        mock_session.return_value.post.return_value = error_response
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_http_error_raises(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "bad query"}, status_code=400)])
 
-        with pytest.raises(Exception, match="400 Client Error"):
-            list(
-                get_rows("https://plausible.io", "example.com", "key", "timeseries", mock.MagicMock(), _make_manager())
-            )
+        with pytest.raises(Exception, match="400"):
+            _rows(_source(endpoint="timeseries"))
 
 
 class TestPlausibleSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
-    def test_response_metadata_per_endpoint(self, endpoint):
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_response_metadata_per_endpoint(self, MockSession, endpoint):
         config = PLAUSIBLE_ENDPOINTS[endpoint]
-        response = plausible_source(
-            "https://plausible.io", "example.com", "key", endpoint, mock.MagicMock(), _make_manager()
-        )
+        response = _source(endpoint=endpoint)
 
         assert response.name == endpoint
         assert response.primary_keys == config.primary_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/postmark.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/postmark.py
@@ -17,37 +17,64 @@ Two upstream constraints worth knowing about:
   data beyond that window is simply unavailable from the API.
 """
 
+import logging
 import dataclasses
-from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlencode
+from typing import Any, Optional
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+    SinglePagePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.postmark.settings import (
     POSTMARK_ENDPOINTS,
     POSTMARK_MAX_PAGE_SIZE,
     POSTMARK_MAX_WINDOW,
-    PostmarkEndpointConfig,
 )
 
+logger = logging.getLogger(__name__)
+
 POSTMARK_BASE_URL = "https://api.postmarkapp.com"
-
-
-class PostmarkRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class PostmarkResumeConfig:
     # Offset of the next page to fetch on paginated list endpoints.
     next_offset: int = 0
+
+
+class _WindowCappedOffsetPaginator(OffsetPaginator):
+    """OffsetPaginator that warns when it stops because it hit Postmark's 10,000-row window.
+
+    Postmark caps `count + offset` at 10,000 on its paginated list endpoints, so a full
+    refresh can only reach the most recent 10,000 rows. `maximum_offset` handles the stop;
+    this subclass adds the same diagnostic warning the hand-rolled loop emitted so an
+    operator can see that older rows were left behind rather than silently dropped.
+    """
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        super().update_state(response, data)
+        # Only the maximum_offset boundary sets offset >= maximum_offset on stop; a short/empty
+        # page stops with offset still below the window (see OffsetPaginator.update_state).
+        if not self.has_next_page and self.maximum_offset is not None and self.offset >= self.maximum_offset:
+            total: Any = None
+            try:
+                total = response.json().get("TotalCount")
+            except Exception:
+                pass
+            logger.warning(
+                f"Postmark: reached the {self.maximum_offset}-row API window (TotalCount={total}); "
+                "older rows cannot be synced via this endpoint."
+            )
 
 
 def _get_headers(server_token: str) -> dict[str, str]:
@@ -60,145 +87,98 @@ def _get_headers(server_token: str) -> dict[str, str]:
 def validate_credentials(server_token: str) -> bool:
     # /message-streams is a cheap read-only call any valid server token can make. Postmark
     # returns 401 (ErrorCode 10) for an invalid/missing token and 200 otherwise.
-    url = f"{POSTMARK_BASE_URL}/message-streams"
-    try:
+    ok, _status = validate_via_probe(
         # `X-Postmark-Server-Token` is not in the sample-capture header denylist, so mask the
         # token by value to keep it out of any captured HTTP sample.
-        session = make_tracked_session(headers=_get_headers(server_token), redact_values=(server_token,))
-        response = session.get(url, timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-@retry(
-    retry=retry_if_exception_type((PostmarkRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch(session: requests.Session, url: str, logger: FilteringBoundLogger) -> dict:
-    response = session.get(url, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise PostmarkRetryableError(f"Postmark API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Postmark API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
-
-
-def _iter_flat_endpoint(
-    session: requests.Session,
-    config: PostmarkEndpointConfig,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    """Fetch a list endpoint that returns its whole payload in a single response."""
-    url = f"{POSTMARK_BASE_URL}{config.path}"
-    data = _fetch(session, url, logger)
-    items = data.get(config.data_key) or []
-    if items:
-        yield items
-
-
-def _iter_paginated_endpoint(
-    session: requests.Session,
-    config: PostmarkEndpointConfig,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PostmarkResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    """Iterate a list endpoint with Postmark's offset/count pagination (max 10,000 window)."""
-    page_size = min(config.page_size or POSTMARK_MAX_PAGE_SIZE, POSTMARK_MAX_PAGE_SIZE)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset: int = resume_config.next_offset if resume_config else 0
-    if offset:
-        logger.debug(f"Postmark: resuming {config.name} from offset={offset}")
-
-    while offset < POSTMARK_MAX_WINDOW:
-        count = min(page_size, POSTMARK_MAX_WINDOW - offset)
-        query = urlencode({"count": count, "offset": offset})
-        url = f"{POSTMARK_BASE_URL}{config.path}?{query}"
-
-        data = _fetch(session, url, logger)
-        items = data.get(config.data_key) or []
-
-        if items:
-            yield items
-
-        # A short page means we've reached the end of the available rows.
-        if len(items) < count:
-            break
-
-        # Advance before the next fetch, then persist so a crash resumes at the next page
-        # rather than re-scanning from the start (merge dedupes the re-yielded boundary).
-        offset += count
-        resumable_source_manager.save_state(PostmarkResumeConfig(next_offset=offset))
-
-        if offset >= POSTMARK_MAX_WINDOW:
-            total = data.get("TotalCount")
-            logger.warning(
-                f"Postmark: reached the {POSTMARK_MAX_WINDOW}-row API window for {config.name} "
-                f"(TotalCount={total}); older rows cannot be synced via this endpoint."
-            )
-
-
-def get_rows(
-    server_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PostmarkResumeConfig],
-) -> Iterator[Any]:
-    config = POSTMARK_ENDPOINTS[endpoint]
-
-    # Align the batcher chunk size with the page size for paginated endpoints so each page
-    # yields its own table before we persist the resume offset for the next page. With a
-    # larger chunk size, several pages would buffer in memory while the offset advances, and
-    # a mid-buffer failure could resume past rows that were never yielded — a silent data gap.
-    chunk_size = config.page_size or 2000
-    batcher = Batcher(logger=logger, chunk_size=chunk_size, chunk_size_bytes=100 * 1024 * 1024)
-
-    # One tracked session for the whole sync — keeps urllib3's TLS connection warm across
-    # pages, and every request inherits the auth headers. The server token is also masked by
-    # value since `X-Postmark-Server-Token` is not in the sample-capture header denylist.
-    session = make_tracked_session(headers=_get_headers(server_token), redact_values=(server_token,))
-
-    if config.page_size is None:
-        source_iter = _iter_flat_endpoint(session, config, logger)
-    else:
-        source_iter = _iter_paginated_endpoint(session, config, logger, resumable_source_manager)
-
-    for batch in source_iter:
-        batcher.batch(batch)
-        if batcher.should_yield():
-            yield batcher.get_table()
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
+        lambda: make_tracked_session(redact_values=(server_token,)),
+        f"{POSTMARK_BASE_URL}/message-streams",
+        headers=_get_headers(server_token),
+    )
+    return ok
 
 
 def postmark_source(
     server_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PostmarkResumeConfig],
 ) -> SourceResponse:
-    endpoint_config = POSTMARK_ENDPOINTS[endpoint]
+    config = POSTMARK_ENDPOINTS[endpoint]
+
+    params: dict[str, Any] = {}
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    resume_hook = None
+
+    if config.page_size is None:
+        # Flat endpoints return their whole payload in a single response.
+        paginator: Any = SinglePagePaginator()
+    else:
+        # Offset/count pagination capped at the 10,000-row API window. `count` is Postmark's
+        # per-page size param; termination is a short/empty page or the window boundary.
+        page_size = min(config.page_size, POSTMARK_MAX_PAGE_SIZE)
+        paginator = _WindowCappedOffsetPaginator(
+            limit=page_size,
+            offset_param="offset",
+            limit_param="count",
+            total_path=None,
+            maximum_offset=POSTMARK_MAX_WINDOW,
+        )
+
+        if resumable_source_manager.can_resume():
+            resume = resumable_source_manager.load_state()
+            if resume is not None:
+                initial_paginator_state = {"offset": resume.next_offset}
+
+        def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+            # Persist only when a next page remains; save AFTER a page is yielded so a crash
+            # re-yields the last page (merge dedupes) rather than skipping it.
+            if state and state.get("offset") is not None:
+                resumable_source_manager.save_state(PostmarkResumeConfig(next_offset=int(state["offset"])))
+
+        resume_hook = save_checkpoint
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": POSTMARK_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            "auth": {
+                "type": "api_key",
+                "api_key": server_token,
+                "name": "X-Postmark-Server-Token",
+                "location": "header",
+            },
+            "paginator": paginator,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    "data_selector": config.data_key,
+                },
+            }
+        ],
+    }
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,  # full refresh only — no incremental watermark
+        resume_hook=resume_hook,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            server_token=server_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
-        primary_keys=[endpoint_config.primary_key],
+        items=lambda: resource,
+        primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,
-        partition_mode="datetime" if endpoint_config.partition_key else None,
-        partition_format="month" if endpoint_config.partition_key else None,
-        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/source.py
@@ -132,6 +132,7 @@ The token grants read access to the following server-level resources:
         return postmark_source(
             server_token=config.server_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark.py
@@ -1,15 +1,15 @@
-from urllib.parse import parse_qs, urlparse
+import json
+from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark import (
     POSTMARK_BASE_URL,
     PostmarkResumeConfig,
-    get_rows,
     postmark_source,
     validate_credentials,
 )
@@ -19,32 +19,53 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postmark.s
     POSTMARK_MAX_WINDOW,
 )
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the postmark module.
+POSTMARK_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session"
+)
 
-def _mock_manager(can_resume: bool = False, state: PostmarkResumeConfig | None = None) -> MagicMock:
-    manager = MagicMock(spec=ResumableSourceManager)
-    manager.can_resume.return_value = can_resume
-    manager.load_state.return_value = state
-    manager.save_state = MagicMock()
+
+def _response(body: dict[str, Any], *, status: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp._content = json.dumps(body).encode()
+    resp.url = POSTMARK_BASE_URL
+    return resp
+
+
+def _make_manager(resume_state: PostmarkResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-def _mock_response(status_code: int = 200, json_payload: dict | None = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.json.return_value = json_payload or {}
-    response.text = "" if response.ok else "error body"
+def _wire(session: mock.MagicMock, responses: list[Response] | Any) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
 
-    def _raise_for_status():
-        if not response.ok:
-            raise Exception(f"{status_code} Client Error")
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when
+    each request is prepared rather than inspecting the final mutated state.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
 
-    response.raise_for_status.side_effect = _raise_for_status
-    return response
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
 
 
-def _query_of(url: str) -> dict[str, list[str]]:
-    return parse_qs(urlparse(url).query)
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(endpoint: str, manager: mock.MagicMock):
+    return postmark_source("test-token", endpoint, team_id=1, job_id="j", resumable_source_manager=manager)
 
 
 class TestValidateCredentials:
@@ -56,125 +77,113 @@ class TestValidateCredentials:
             ("server_500", 500, False),
         ]
     )
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_validate_credentials(self, _name: str, status_code: int, expected: bool, mock_session: MagicMock) -> None:
-        mock_session.return_value.get.return_value = _mock_response(status_code=status_code)
+    @mock.patch(POSTMARK_SESSION_PATCH)
+    def test_validate_credentials(self, _name: str, status_code: int, expected: bool, mock_session: mock.MagicMock):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("test-token") is expected
 
-        # Auth token is bound to the session headers; URL is on `.get(...)`.
-        session_kwargs = mock_session.call_args.kwargs
-        assert session_kwargs["headers"]["X-Postmark-Server-Token"] == "test-token"
-        # The token is also masked by value so it never lands in a captured HTTP sample.
-        assert session_kwargs["redact_values"] == ("test-token",)
-        called_args, _ = mock_session.return_value.get.call_args
-        assert called_args[0] == f"{POSTMARK_BASE_URL}/message-streams"
+        # The probe session masks the token by value so it never lands in a captured HTTP sample.
+        assert mock_session.call_args.kwargs["redact_values"] == ("test-token",)
+        # The token is carried in the X-Postmark-Server-Token header against /message-streams.
+        get_args, get_kwargs = mock_session.return_value.get.call_args
+        assert get_args[0] == f"{POSTMARK_BASE_URL}/message-streams"
+        assert get_kwargs["headers"]["X-Postmark-Server-Token"] == "test-token"
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_validate_credentials_network_error_returns_false(self, mock_session: MagicMock) -> None:
+    @mock.patch(POSTMARK_SESSION_PATCH)
+    def test_validate_credentials_network_error_returns_false(self, mock_session: mock.MagicMock):
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("test-token") is False
 
 
 class TestFlatEndpoint:
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_message_streams_yields_single_batch(self, mock_session: MagicMock) -> None:
-        rows = [{"ID": "outbound", "Name": "Transactional", "CreatedAt": "2026-01-01T00:00:00Z"}]
-        mock_session.return_value.get.return_value = _mock_response(json_payload={"MessageStreams": rows})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_message_streams_yields_single_batch(self, MockSession):
+        session = MockSession.return_value
+        rows_in = [{"ID": "outbound", "Name": "Transactional", "CreatedAt": "2026-01-01T00:00:00Z"}]
+        params = _wire(session, [_response({"MessageStreams": rows_in})])
 
-        tables = list(get_rows("test-token", "message_streams", MagicMock(), _mock_manager()))
+        rows = _rows(_source("message_streams", _make_manager()))
 
-        assert len(tables) == 1
-        assert tables[0].num_rows == 1
-        assert tables[0].column("ID").to_pylist() == ["outbound"]
-
+        assert [r["ID"] for r in rows] == ["outbound"]
+        assert session.send.call_count == 1
         # The sync session masks the token by value to keep it out of captured HTTP samples.
-        assert mock_session.call_args.kwargs["redact_values"] == ("test-token",)
+        assert MockSession.call_args.kwargs["redact_values"] == ("test-token",)
+        # Flat endpoints fetch with no pagination params.
+        assert params[0] == {}
 
-        # Flat endpoints fetch the bare path with no pagination params.
-        called_url = mock_session.return_value.get.call_args[0][0]
-        assert called_url == f"{POSTMARK_BASE_URL}/message-streams"
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_flat_endpoint_empty_response_yields_nothing(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"MessageStreams": []})])
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_flat_endpoint_empty_response_yields_nothing(self, mock_session: MagicMock) -> None:
-        mock_session.return_value.get.return_value = _mock_response(json_payload={"MessageStreams": []})
-
-        tables = list(get_rows("test-token", "message_streams", MagicMock(), _mock_manager()))
-
-        assert tables == []
+        assert _rows(_source("message_streams", _make_manager())) == []
 
 
 class TestOffsetPagination:
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_paginates_until_short_page_and_saves_state(self, mock_session: MagicMock) -> None:
-        # First page is full (500 rows) so we ask for a second; second page is short -> stop.
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_short_page_and_saves_state(self, MockSession):
+        session = MockSession.return_value
         page1 = [{"MessageID": f"m{i}", "ReceivedAt": "2026-01-01T00:00:00Z"} for i in range(500)]
         page2 = [{"MessageID": f"m{i}", "ReceivedAt": "2026-01-01T00:00:00Z"} for i in range(500, 510)]
+        params = _wire(
+            session,
+            [
+                _response({"TotalCount": 510, "Messages": page1}),
+                _response({"TotalCount": 510, "Messages": page2}),
+            ],
+        )
 
-        mock_session.return_value.get.side_effect = [
-            _mock_response(json_payload={"TotalCount": 510, "Messages": page1}),
-            _mock_response(json_payload={"TotalCount": 510, "Messages": page2}),
-        ]
+        manager = _make_manager()
+        rows = _rows(_source("messages_outbound", manager))
 
-        manager = _mock_manager()
-        tables = list(get_rows("test-token", "messages_outbound", MagicMock(), manager))
-
-        assert sum(t.num_rows for t in tables) == 510
-        assert mock_session.return_value.get.call_count == 2
-
-        first_q = _query_of(mock_session.return_value.get.call_args_list[0].args[0])
-        second_q = _query_of(mock_session.return_value.get.call_args_list[1].args[0])
-        assert first_q["offset"] == ["0"] and first_q["count"] == ["500"]
-        assert second_q["offset"] == ["500"]
+        assert len(rows) == 510
+        assert session.send.call_count == 2
+        assert params[0]["offset"] == 0 and params[0]["count"] == 500
+        assert params[1]["offset"] == 500
 
         # State is saved once, after the first (full) page, pointing at the next offset.
         manager.save_state.assert_called_once()
-        saved: PostmarkResumeConfig = manager.save_state.call_args[0][0]
-        assert saved.next_offset == 500
+        assert manager.save_state.call_args.args[0] == PostmarkResumeConfig(next_offset=500)
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_single_short_page_does_not_save_state(self, mock_session: MagicMock) -> None:
-        page = [{"MessageID": "m1", "ReceivedAt": "2026-01-01T00:00:00Z"}]
-        mock_session.return_value.get.return_value = _mock_response(json_payload={"TotalCount": 1, "Messages": page})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_single_short_page_does_not_save_state(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({"TotalCount": 1, "Messages": [{"MessageID": "m1"}]})])
 
-        manager = _mock_manager()
-        tables = list(get_rows("test-token", "messages_outbound", MagicMock(), manager))
+        manager = _make_manager()
+        rows = _rows(_source("messages_outbound", manager))
 
-        assert sum(t.num_rows for t in tables) == 1
-        assert mock_session.return_value.get.call_count == 1
+        assert len(rows) == 1
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_resumes_from_saved_offset(self, mock_session: MagicMock) -> None:
-        page = [{"MessageID": "m501", "ReceivedAt": "2026-01-01T00:00:00Z"}]
-        mock_session.return_value.get.return_value = _mock_response(json_payload={"TotalCount": 501, "Messages": page})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession):
+        session = MockSession.return_value
+        params = _wire(session, [_response({"TotalCount": 501, "Messages": [{"MessageID": "m501"}]})])
 
-        manager = _mock_manager(can_resume=True, state=PostmarkResumeConfig(next_offset=500))
-        list(get_rows("test-token", "messages_outbound", MagicMock(), manager))
+        manager = _make_manager(PostmarkResumeConfig(next_offset=500))
+        _rows(_source("messages_outbound", manager))
 
-        first_q = _query_of(mock_session.return_value.get.call_args_list[0].args[0])
-        assert first_q["offset"] == ["500"]
+        assert params[0]["offset"] == 500
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_stops_at_10k_window_and_warns(self, mock_session: MagicMock) -> None:
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.logger")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_stops_at_10k_window_and_warns(self, MockSession, mock_logger):
+        session = MockSession.return_value
         # Every page is full, so pagination would continue forever if not for the window cap.
         full_page = [{"MessageID": f"m{i}", "ReceivedAt": "2026-01-01T00:00:00Z"} for i in range(500)]
-        mock_session.return_value.get.return_value = _mock_response(
-            json_payload={"TotalCount": 99999, "Messages": full_page}
-        )
+        params = _wire(session, lambda *a, **k: _response({"TotalCount": 99999, "Messages": full_page}))
 
-        manager = _mock_manager()
-        logger = MagicMock()
-        list(get_rows("test-token", "messages_outbound", logger, manager))
+        _rows(_source("messages_outbound", _make_manager()))
 
         # 10,000 / 500 = 20 pages, then the loop terminates at the window boundary.
-        assert mock_session.return_value.get.call_count == POSTMARK_MAX_WINDOW // 500
-        logger.warning.assert_called_once()
-
-        last_q = _query_of(mock_session.return_value.get.call_args_list[-1].args[0])
-        assert int(last_q["offset"][0]) + int(last_q["count"][0]) == POSTMARK_MAX_WINDOW
+        assert session.send.call_count == POSTMARK_MAX_WINDOW // 500
+        mock_logger.warning.assert_called_once()
+        assert params[-1]["offset"] + params[-1]["count"] == POSTMARK_MAX_WINDOW
 
 
-class TestEndpointPrimaryKeys:
+class TestEndpointDataKeys:
     @parameterized.expand(
         [
             ("messages_outbound", "Messages", "MessageID"),
@@ -184,56 +193,59 @@ class TestEndpointPrimaryKeys:
             ("message_streams", "MessageStreams", "ID"),
         ]
     )
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_reads_correct_data_key(
-        self, endpoint: str, data_key: str, primary_key: str, mock_session: MagicMock
-    ) -> None:
-        rows = [{primary_key: "x1"}]
-        mock_session.return_value.get.return_value = _mock_response(json_payload={data_key: rows, "TotalCount": 1})
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_reads_correct_data_key(self, endpoint: str, data_key: str, primary_key: str, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({data_key: [{primary_key: "x1"}], "TotalCount": 1})])
 
-        tables = list(get_rows("test-token", endpoint, MagicMock(), _mock_manager()))
+        rows = _rows(_source(endpoint, _make_manager()))
 
-        assert len(tables) == 1
-        assert tables[0].column(primary_key).to_pylist() == ["x1"]
+        assert [r[primary_key] for r in rows] == ["x1"]
 
 
 class TestSourceResponseShape:
     @parameterized.expand([(name,) for name in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        response = postmark_source("test-token", endpoint, MagicMock(), _mock_manager())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, _MockSession):
+        response = _source(endpoint, _make_manager())
 
-        endpoint_config = POSTMARK_ENDPOINTS[endpoint]
+        config = POSTMARK_ENDPOINTS[endpoint]
         assert response.name == endpoint
-        assert response.primary_keys == [endpoint_config.primary_key]
+        assert response.primary_keys == [config.primary_key]
 
-        if endpoint_config.partition_key:
+        if config.partition_key:
             assert response.partition_mode == "datetime"
             assert response.partition_format == "month"
-            assert response.partition_keys == [endpoint_config.partition_key]
+            assert response.partition_keys == [config.partition_key]
         else:
             assert response.partition_mode is None
             assert response.partition_keys is None
 
 
 class TestRetryable:
-    @patch("tenacity.nap.time.sleep")
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_429_retries_until_success(self, mock_session: MagicMock, _mock_sleep: MagicMock) -> None:
-        mock_session.return_value.get.side_effect = [
-            _mock_response(status_code=429),
-            _mock_response(json_payload={"MessageStreams": [{"ID": "outbound"}]}),
-        ]
+    @mock.patch("tenacity.nap.time.sleep")
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_429_retries_until_success(self, MockSession, _mock_sleep):
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response({}, status=429),
+                _response({"MessageStreams": [{"ID": "outbound"}]}),
+            ],
+        )
 
-        tables = list(get_rows("test-token", "message_streams", MagicMock(), _mock_manager()))
+        rows = _rows(_source("message_streams", _make_manager()))
 
-        assert len(tables) == 1
-        assert mock_session.return_value.get.call_count == 2
+        assert [r["ID"] for r in rows] == ["outbound"]
+        assert session.send.call_count == 2
 
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.postmark.postmark.make_tracked_session")
-    def test_401_does_not_retry_and_raises(self, mock_session: MagicMock) -> None:
-        mock_session.return_value.get.return_value = _mock_response(status_code=401)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_401_does_not_retry_and_raises(self, MockSession):
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=401)])
 
         with pytest.raises(Exception):
-            list(get_rows("test-token", "message_streams", MagicMock(), _mock_manager()))
+            _rows(_source("message_streams", _make_manager()))
 
-        assert mock_session.return_value.get.call_count == 1
+        assert session.send.call_count == 1

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark_source.py
@@ -104,6 +104,7 @@ class TestPostmarkSource:
         mock_postmark_source.assert_called_once_with(
             server_token=self.config.server_token,
             endpoint="messages_outbound",
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/productboard.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/productboard.py
@@ -1,17 +1,18 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import quote
 
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.productboard.settings import (
     PRODUCTBOARD_ENDPOINTS,
 )
@@ -19,20 +20,16 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.productboa
 PRODUCTBOARD_BASE_URL = "https://api.productboard.com/v2"
 
 
-class ProductboardRetryableError(Exception):
-    pass
-
-
 @dataclasses.dataclass
 class ProductboardResumeConfig:
+    # Full URL of the next unfetched page — Productboard returns it in the `links.next` body field.
     next_url: str
 
 
-def _get_headers(access_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json",
-    }
+def _non_secret_headers() -> dict[str, str]:
+    # Bearer auth is supplied via the framework auth config so its value is redacted from logs and
+    # error messages; only the non-secret Accept header is set here.
+    return {"Accept": "application/json"}
 
 
 def _format_incremental_value(value: Any) -> str:
@@ -52,18 +49,6 @@ def _format_incremental_value(value: Any) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _build_url(base_url: str, params: dict[str, Any]) -> str:
-    """Build a URL, percent-encoding values but keeping literal param keys.
-
-    Productboard's entity filter uses the bracket key `type[]`, which we preserve
-    verbatim while still encoding values (e.g. ISO timestamps containing `:`).
-    """
-    if not params:
-        return base_url
-    parts = [f"{key}={quote(str(value), safe='')}" for key, value in params.items()]
-    return f"{base_url}?{'&'.join(parts)}"
-
-
 def _build_initial_params(
     endpoint: str,
     should_use_incremental_field: bool,
@@ -74,6 +59,8 @@ def _build_initial_params(
     params: dict[str, Any] = {}
 
     if config.entity_type:
+        # The `type[]` bracket key percent-encodes on the wire (`type%5B%5D=...`), which is
+        # what Productboard's `/entities` filter expects.
         params["type[]"] = config.entity_type
 
     if config.supports_incremental and should_use_incremental_field and db_incremental_field_last_value:
@@ -85,110 +72,11 @@ def _build_initial_params(
     return params
 
 
-def validate_credentials(access_token: str, path: str) -> tuple[bool, int | None, str | None]:
-    """Probe a single Productboard endpoint. Returns (ok, status_code, message)."""
-    try:
-        response = make_tracked_session().get(
-            f"{PRODUCTBOARD_BASE_URL}{path}",
-            headers=_get_headers(access_token),
-            timeout=10,
-        )
-    except requests.exceptions.RequestException as e:
-        return False, None, str(e)
-
-    if response.ok:
-        return True, response.status_code, None
-
-    try:
-        message = response.json().get("message")
-    except Exception:
-        message = response.text or None
-
-    return False, response.status_code, message
-
-
-def get_rows(
-    access_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[ProductboardResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-    incremental_field: str | None = None,
-) -> Iterator[Any]:
-    config = PRODUCTBOARD_ENDPOINTS[endpoint]
-    headers = _get_headers(access_token)
-    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
-
-    params = _build_initial_params(
-        endpoint, should_use_incremental_field, db_incremental_field_last_value, incremental_field
-    )
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url = resume_config.next_url
-        logger.debug(f"Productboard: resuming from URL: {url}")
-    else:
-        url = _build_url(f"{PRODUCTBOARD_BASE_URL}{config.path}", params)
-
-    @retry(
-        retry=retry_if_exception_type((ProductboardRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict:
-        response = make_tracked_session().get(page_url, headers=headers, timeout=60)
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise ProductboardRetryableError(
-                f"Productboard API error (retryable): status={response.status_code}, url={page_url}"
-            )
-
-        if not response.ok:
-            logger.error(f"Productboard API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-
-        items = data.get("data", [])
-        if not items:
-            break
-
-        next_url = data.get("links", {}).get("next")
-
-        # Checkpoint the CURRENT page URL, not the next one: the batcher buffers across
-        # page boundaries, so a yield can flush rows from several pages at once. On
-        # resume we re-fetch this page and rely on primary-key merge to dedupe the rows
-        # already yielded. Advancing the checkpoint to next_url here would strand any
-        # current-page rows still buffered (not yet yielded) if we crashed mid-page.
-        checkpoint_url = url
-
-        for item in items:
-            batcher.batch(item)
-
-            if batcher.should_yield():
-                yield batcher.get_table()
-                # Save state after yielding (not before) so a crash re-yields the last
-                # batch rather than skipping it.
-                resumable_source_manager.save_state(ProductboardResumeConfig(next_url=checkpoint_url))
-
-        if not next_url:
-            break
-
-        url = next_url
-
-    if batcher.should_yield(include_incomplete_chunk=True):
-        yield batcher.get_table()
-
-
 def productboard_source(
     access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[ProductboardResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
@@ -196,17 +84,56 @@ def productboard_source(
 ) -> SourceResponse:
     config = PRODUCTBOARD_ENDPOINTS[endpoint]
 
+    params = _build_initial_params(
+        endpoint, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    )
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": PRODUCTBOARD_BASE_URL,
+            "headers": _non_secret_headers(),
+            "auth": {"type": "bearer", "token": access_token},
+            # Next-page URL lives in the response body under `links.next`; absence of it ends the sync.
+            "paginator": JSONResponsePaginator(next_url_path="links.next"),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": params,
+                    "data_selector": "data",
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only while a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes on primary key) rather than skipping it.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(ProductboardResumeConfig(next_url=state["next_url"]))
+
+    # The incremental watermark is applied by `_build_initial_params` as a Productboard-specific server
+    # filter param, so the framework's generic incremental injection is not used here.
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            access_token=access_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         sort_mode=config.sort_mode,
         partition_count=1,
@@ -214,4 +141,14 @@ def productboard_source(
         partition_mode="datetime" if config.partition_key else None,
         partition_format="week" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
+    )
+
+
+def validate_credentials(access_token: str, path: str) -> tuple[bool, int | None]:
+    """Probe a single Productboard endpoint. Returns (ok, status_code)."""
+    return validate_via_probe(
+        lambda: make_tracked_session(redact_values=(access_token,)),
+        f"{PRODUCTBOARD_BASE_URL}{path}",
+        headers={"Authorization": f"Bearer {access_token}", **_non_secret_headers()},
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import ProductboardSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard import (
     ProductboardResumeConfig,
@@ -79,26 +82,12 @@ class ProductboardSource(ResumableSource[ProductboardSourceConfig, ProductboardR
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=PRODUCTBOARD_ENDPOINTS[endpoint].supports_incremental,
-                supports_append=PRODUCTBOARD_ENDPOINTS[endpoint].supports_incremental,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: ProductboardSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        ok, status, message = validate_productboard_credentials(config.access_token, _probe_path(schema_name))
+        ok, status = validate_productboard_credentials(config.access_token, _probe_path(schema_name))
         if ok:
             return True, None
 
@@ -110,9 +99,9 @@ class ProductboardSource(ResumableSource[ProductboardSourceConfig, ProductboardR
         if status == 403:
             if schema_name is None:
                 return True, None
-            return False, message or "Your access token is missing the required scope for this resource"
+            return False, "Your access token is missing the required scope for this resource"
 
-        return False, message or "Failed to validate Productboard credentials"
+        return False, "Failed to validate Productboard credentials"
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ProductboardResumeConfig]:
         return ResumableSourceManager[ProductboardResumeConfig](inputs, ProductboardResumeConfig)
@@ -126,7 +115,8 @@ class ProductboardSource(ResumableSource[ProductboardSourceConfig, ProductboardR
         return productboard_source(
             access_token=config.access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/tests/test_productboard.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/tests/test_productboard.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+import json
 from datetime import UTC, date, datetime, timedelta, timezone
 from typing import Any
 
@@ -6,50 +6,61 @@ import pytest
 from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard import (
     ProductboardResumeConfig,
     _build_initial_params,
-    _build_url,
     _format_incremental_value,
-    get_rows,
     productboard_source,
     validate_credentials,
 )
 
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the productboard module.
+PRODUCTBOARD_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.make_tracked_session"
+)
 
-def _make_response(json_body: Any, status_code: int = 200) -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.ok = status_code < 400
-    response.json.return_value = json_body
-    response.text = ""
-    return response
-
-
-def _session_returning(responses: list[mock.MagicMock]) -> mock.MagicMock:
-    session = mock.MagicMock()
-    session.get.side_effect = responses
-    return session
+NOTES_URL = "https://api.productboard.com/v2/notes"
 
 
-class _FakeBatcher:
-    """Yields every batched item immediately so each page boundary exercises the
-    save_state-after-yield path that the real (5000-row) batcher only hits at scale."""
+def _response(body: dict[str, Any]) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    return resp
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._items: list[Any] = []
 
-    def batch(self, item: Any) -> None:
-        self._items.append(item)
+def _make_manager(resume_state: ProductboardResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
-    def should_yield(self, include_incomplete_chunk: bool = False) -> bool:
-        return len(self._items) > 0
 
-    def get_table(self) -> list[Any]:
-        items = self._items
-        self._items = []
-        return items
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and capture each request's url + params AT SEND TIME.
+
+    The paginator mutates the single ``Request`` in place across pages (rewriting ``url`` and
+    clearing ``params`` as it follows ``links.next``), so inspecting it after the run shows only the
+    final state — snapshot a copy when each request is prepared instead.
+    """
+    session.headers = {}
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        snapshots.append({"url": request.url, "params": dict(request.params or {})})
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestFormatIncrementalValue:
@@ -70,30 +81,6 @@ class TestFormatIncrementalValue:
         # An aware non-UTC datetime is converted to UTC before formatting.
         value = datetime(2023, 10, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=2)))
         assert _format_incremental_value(value) == "2023-10-01T10:00:00Z"
-
-
-class TestBuildUrl:
-    @pytest.mark.parametrize(
-        "base_url, params, expected",
-        [
-            # No params returns the bare URL.
-            ("https://api.productboard.com/v2/notes", {}, "https://api.productboard.com/v2/notes"),
-            # The bracket entity-filter key is kept literal.
-            (
-                "https://api.productboard.com/v2/entities",
-                {"type[]": "feature"},
-                "https://api.productboard.com/v2/entities?type[]=feature",
-            ),
-            # Values (e.g. ISO timestamps) are percent-encoded.
-            (
-                "https://api.productboard.com/v2/notes",
-                {"updatedFrom": "2023-10-01T10:00:00Z"},
-                "https://api.productboard.com/v2/notes?updatedFrom=2023-10-01T10%3A00%3A00Z",
-            ),
-        ],
-    )
-    def test_build_url(self, base_url, params, expected):
-        assert _build_url(base_url, params) == expected
 
 
 class TestBuildInitialParams:
@@ -129,114 +116,123 @@ class TestBuildInitialParams:
 
 class TestValidateCredentials:
     @pytest.mark.parametrize(
-        "status_code, json_body, expected",
+        "status_code, expected",
         [
-            (200, {"data": []}, (True, 200, None)),
-            (401, {"message": "Unauthorized"}, (False, 401, "Unauthorized")),
-            (403, {"message": "Forbidden"}, (False, 403, "Forbidden")),
-            (500, {"message": "Server error"}, (False, 500, "Server error")),
+            (200, (True, 200)),
+            (401, (False, 401)),
+            (403, (False, 403)),
+            (500, (False, 500)),
         ],
     )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.make_tracked_session"
-    )
-    def test_status_mapping(self, mock_session, status_code, json_body, expected):
-        mock_session.return_value.get.return_value = _make_response(json_body, status_code)
+    @mock.patch(PRODUCTBOARD_SESSION_PATCH)
+    def test_status_mapping(self, mock_session, status_code, expected):
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
         assert validate_credentials("token", "/notes") == expected
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.make_tracked_session"
-    )
-    def test_request_exception_returns_message(self, mock_session):
+    @mock.patch(PRODUCTBOARD_SESSION_PATCH)
+    def test_request_exception_returns_no_status(self, mock_session):
+        # A probe must never raise out of validate_credentials; a transport error means "not validated".
         mock_session.return_value.get.side_effect = requests.exceptions.ConnectionError("boom")
-        ok, status, message = validate_credentials("token", "/notes")
-        assert ok is False
-        assert status is None
-        assert "boom" in (message or "")
+        assert validate_credentials("token", "/notes") == (False, None)
 
 
-class TestGetRows:
-    def _collect(self, iterator: Iterable[Any]) -> list[Any]:
-        return list(iterator)
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.make_tracked_session"
-    )
-    def test_paginates_until_no_next_link(self, mock_session):
-        page1 = _make_response(
-            {
-                "data": [{"id": "1"}, {"id": "2"}],
-                "links": {"next": "https://api.productboard.com/v2/notes?pageCursor=c2"},
-            }
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_until_no_next_link(self, MockSession):
+        session = MockSession.return_value
+        page2_url = f"{NOTES_URL}?pageCursor=c2"
+        snaps = _wire(
+            session,
+            [
+                _response({"data": [{"id": "1"}, {"id": "2"}], "links": {"next": page2_url}}),
+                _response({"data": [{"id": "3"}], "links": {}}),
+            ],
         )
-        page2 = _make_response({"data": [{"id": "3"}], "links": {}})
-        mock_session.return_value = _session_returning([page1, page2])
 
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
-
-        rows: list[dict] = []
-        for table in get_rows("token", "notes", mock.MagicMock(), manager):
-            rows.extend(table.to_pylist())
+        rows = _rows(
+            productboard_source("token", "notes", team_id=1, job_id="j", resumable_source_manager=_make_manager())
+        )
 
         assert [r["id"] for r in rows] == ["1", "2", "3"]
-        # First page uses the constructed URL, second follows links.next verbatim.
-        assert (
-            mock_session.return_value.get.call_args_list[0].args[0].startswith("https://api.productboard.com/v2/notes")
+        assert session.send.call_count == 2
+        # First page uses the constructed base URL; the second follows links.next verbatim.
+        assert snaps[0]["url"].startswith(NOTES_URL)
+        assert snaps[1]["url"] == page2_url
+        assert snaps[1]["params"] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_state(self, MockSession):
+        session = MockSession.return_value
+        resume_url = f"{NOTES_URL}?pageCursor=resume"
+        snaps = _wire(session, [_response({"data": [{"id": "9"}], "links": {}})])
+
+        manager = _make_manager(ProductboardResumeConfig(next_url=resume_url))
+        rows = _rows(productboard_source("token", "notes", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert [r["id"] for r in rows] == ["9"]
+        # The seeded next_url drives the very first request, with no leftover base params.
+        assert snaps[0]["url"] == resume_url
+        assert snaps[0]["params"] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoints_next_url_after_each_page(self, MockSession):
+        # Save state points at the page still to fetch (links.next), saved after the current page is
+        # yielded; the final page (no next link) records no checkpoint.
+        session = MockSession.return_value
+        page2_url = f"{NOTES_URL}?pageCursor=c2"
+        _wire(
+            session,
+            [
+                _response({"data": [{"id": "1"}], "links": {"next": page2_url}}),
+                _response({"data": [{"id": "2"}], "links": {}}),
+            ],
         )
-        assert mock_session.return_value.get.call_args_list[1].args[0].endswith("pageCursor=c2")
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.Batcher",
-        _FakeBatcher,
-    )
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.make_tracked_session"
-    )
-    def test_checkpoints_current_page_not_next(self, mock_session):
-        # The checkpoint must be the page we just processed, so resume re-fetches it and
-        # merge-dedupes — never the next page (which would strand still-buffered rows).
-        page1_url = "https://api.productboard.com/v2/notes"
-        page2_url = "https://api.productboard.com/v2/notes?pageCursor=c2"
-        page1 = _make_response({"data": [{"id": "1"}], "links": {"next": page2_url}})
-        page2 = _make_response({"data": [{"id": "2"}], "links": {}})
-        mock_session.return_value = _session_returning([page1, page2])
+        manager = _make_manager()
+        _rows(productboard_source("token", "notes", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == ProductboardResumeConfig(next_url=page2_url)
 
-        list(get_rows("token", "notes", mock.MagicMock(), manager))
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing(self, MockSession):
+        session = MockSession.return_value
+        manager = _make_manager()
+        _wire(session, [_response({"data": [], "links": {}})])
 
-        saved = [call.args[0] for call in manager.save_state.call_args_list]
-        assert all(isinstance(s, ProductboardResumeConfig) for s in saved)
-        # First page's yield checkpoints the first page URL (not page2_url), second the second.
-        assert [s.next_url for s in saved] == [page1_url, page2_url]
+        rows = _rows(productboard_source("token", "notes", team_id=1, job_id="j", resumable_source_manager=manager))
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.make_tracked_session"
-    )
-    def test_resumes_from_saved_state(self, mock_session):
-        resume_url = "https://api.productboard.com/v2/notes?pageCursor=resume"
-        page = _make_response({"data": [{"id": "9"}], "links": {}})
-        mock_session.return_value = _session_returning([page])
+        assert rows == []
+        manager.save_state.assert_not_called()
 
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = ProductboardResumeConfig(next_url=resume_url)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_entity_endpoint_sends_type_filter(self, MockSession):
+        session = MockSession.return_value
+        snaps = _wire(session, [_response({"data": [{"id": "f1"}], "links": {}})])
 
-        list(get_rows("token", "notes", mock.MagicMock(), manager))
+        _rows(productboard_source("token", "features", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
 
-        assert mock_session.return_value.get.call_args_list[0].args[0] == resume_url
+        assert snaps[0]["params"]["type[]"] == "feature"
 
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.productboard.productboard.make_tracked_session"
-    )
-    def test_empty_first_page_yields_nothing(self, mock_session):
-        mock_session.return_value = _session_returning([_make_response({"data": [], "links": {}})])
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = False
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_notes_incremental_sends_server_filter(self, MockSession):
+        session = MockSession.return_value
+        snaps = _wire(session, [_response({"data": [{"id": "n1"}], "links": {}})])
 
-        assert list(get_rows("token", "notes", mock.MagicMock(), manager)) == []
+        _rows(
+            productboard_source(
+                "token",
+                "notes",
+                team_id=1,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2023, 10, 1, 10, 0, 0, tzinfo=UTC),
+                incremental_field="updatedAt",
+            )
+        )
+
+        assert snaps[0]["params"] == {"updatedFrom": "2023-10-01T10:00:00Z"}
 
 
 class TestProductboardSourceResponse:
@@ -249,8 +245,11 @@ class TestProductboardSourceResponse:
             ("members", "asc", None),
         ],
     )
-    def test_source_response_metadata(self, endpoint, expected_sort, expected_partition_keys):
-        response = productboard_source("token", endpoint, mock.MagicMock(), mock.MagicMock())
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_metadata(self, MockSession, endpoint, expected_sort, expected_partition_keys):
+        response = productboard_source(
+            "token", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager()
+        )
 
         assert response.name == endpoint
         assert response.primary_keys == ["id"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/tests/test_productboard_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/productboard/tests/test_productboard_source.py
@@ -99,13 +99,13 @@ class TestProductboardSource:
     @pytest.mark.parametrize(
         "probe_return, schema_name, expected_valid, expected_message",
         [
-            ((True, 200, None), None, True, None),
-            ((False, 401, "Unauthorized"), None, False, "Invalid Productboard access token"),
+            ((True, 200), None, True, None),
+            ((False, 401), None, False, "Invalid Productboard access token"),
             # 403 at source-create means a valid token that just lacks scope for the probe endpoint.
-            ((False, 403, "Forbidden"), None, True, None),
+            ((False, 403), None, True, None),
             # 403 on a specific schema means the user can't sync that endpoint.
-            ((False, 403, "Forbidden"), "notes", False, "Forbidden"),
-            ((False, 500, "Server error"), None, False, "Server error"),
+            ((False, 403), "notes", False, "Your access token is missing the required scope for this resource"),
+            ((False, 500), None, False, "Failed to validate Productboard credentials"),
         ],
     )
     @mock.patch(
@@ -144,6 +144,8 @@ class TestProductboardSource:
     def test_source_for_pipeline_plumbs_arguments(self, mock_productboard_source):
         inputs = mock.MagicMock()
         inputs.schema_name = "notes"
+        inputs.team_id = 123
+        inputs.job_id = "job-1"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2023-10-01T00:00:00Z"
         inputs.incremental_field = "updatedAt"
@@ -155,6 +157,8 @@ class TestProductboardSource:
         kwargs = mock_productboard_source.call_args.kwargs
         assert kwargs["access_token"] == "pb-token"
         assert kwargs["endpoint"] == "notes"
+        assert kwargs["team_id"] == 123
+        assert kwargs["job_id"] == "job-1"
         assert kwargs["resumable_source_manager"] is manager
         assert kwargs["should_use_incremental_field"] is True
         assert kwargs["db_incremental_field_last_value"] == "2023-10-01T00:00:00Z"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/ramp.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/ramp.py
@@ -1,21 +1,28 @@
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urlsplit
 
 import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from requests import Request, Response
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.ramp.settings import (
-    RAMP_ENDPOINTS,
-    TOKEN_SCOPES,
-    RampEndpointConfig,
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAuth2Auth,
+    OAuth2AuthRequestError,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.ramp.settings import RAMP_ENDPOINTS, TOKEN_SCOPES
 
 RAMP_HOSTS = {
     "production": "https://api.ramp.com",
@@ -23,23 +30,13 @@ RAMP_HOSTS = {
 }
 # Ramp list pages cap at 100 items.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
-# ~100 req/min per token; 429s back off.
-MAX_RETRY_ATTEMPTS = 5
-
-
-class RampRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
 class RampResumeConfig:
-    # Ramp paginates via the self-contained page.next URL.
-    next_url: str
-
-
-def _get_session(client_secret: str) -> requests.Session:
-    return make_tracked_session(redact_values=(client_secret,))
+    # Ramp paginates via the self-contained page.next URL. Optional/defaulted so previously
+    # saved state (which always carried next_url) still parses via dataclass(**saved).
+    next_url: Optional[str] = None
 
 
 def _base_url(environment: str) -> str:
@@ -49,29 +46,27 @@ def _base_url(environment: str) -> str:
     return host
 
 
-def _assert_trusted_url(url: str, environment: str) -> str:
-    """Pin a pagination/resume URL to the configured Ramp host before forwarding the bearer token.
-
-    Both the API-derived ``page.next`` value and the Redis-persisted resume URL are
-    attacker-influenceable, so we refuse to send credentials anywhere other than the
-    environment's own scheme + host."""
-    base = urlsplit(_base_url(environment))
-    target = urlsplit(url)
-    if (target.scheme, target.netloc) != (base.scheme, base.netloc):
-        raise ValueError(f"Refusing to send Ramp credentials to untrusted URL host: {target.netloc or url!r}")
-    return url
+def _api_base_url(environment: str) -> str:
+    return f"{_base_url(environment)}/developer/v1"
 
 
-def _mint_token(session: requests.Session, environment: str, client_id: str, client_secret: str) -> str:
-    """Exchange client credentials for a bearer token (~10 day lifetime)."""
-    response = session.post(
-        f"{_base_url(environment)}/developer/v1/token",
-        data={"grant_type": "client_credentials", "scope": TOKEN_SCOPES},
-        auth=(client_id, client_secret),
-        timeout=REQUEST_TIMEOUT_SECONDS,
+def _token_url(environment: str) -> str:
+    return f"{_api_base_url(environment)}/token"
+
+
+def _make_auth(environment: str, client_id: str, client_secret: str) -> OAuth2Auth:
+    """Ramp uses OAuth2 client-credentials with HTTP Basic client auth.
+
+    Tokens last ~10 days; the framework mints one lazily, caches it for the run, and re-mints
+    on expiry — replacing the pre-framework mint-once-then-reactive-401-remint handling."""
+    return OAuth2Auth(
+        token_url=_token_url(environment),
+        client_id=client_id,
+        client_secret=client_secret,
+        grant_type="client_credentials",
+        scopes=TOKEN_SCOPES,
+        client_auth_method="basic",
     )
-    response.raise_for_status()
-    return response.json()["access_token"]
 
 
 def _format_timestamp(value: Any) -> str:
@@ -84,107 +79,46 @@ def _format_timestamp(value: Any) -> str:
     return str(value)
 
 
-def _build_initial_url(
-    environment: str,
-    config: RampEndpointConfig,
-    should_use_incremental_field: bool,
-    db_incremental_field_last_value: Any,
-) -> str:
-    params: dict[str, Any] = {"page_size": PAGE_SIZE}
-    if (
-        config.incremental_param is not None
-        and should_use_incremental_field
-        and db_incremental_field_last_value is not None
-    ):
-        params[config.incremental_param] = _format_timestamp(db_incremental_field_last_value)
-    return f"{_base_url(environment)}/developer/v1{config.path}?{urlencode(params)}"
+class RampPaginator(JSONResponsePaginator):
+    """Follow Ramp's self-contained ``page.next`` link, stopping on an empty page.
+
+    Ramp returns a ``page.next`` URL until the listing is exhausted; the hand-rolled source
+    also stopped as soon as a page came back empty (even if a ``next`` link was still present),
+    so mirror that guard here. Resume state (the pending ``next_url``) is inherited from the
+    base next-url paginator."""
+
+    def __init__(self) -> None:
+        super().__init__(next_url_path="page.next")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+        super().update_state(response, data)
 
 
 def validate_credentials(environment: str, client_id: str, client_secret: str) -> tuple[bool, str | None]:
     """Confirm the developer app credentials are valid by minting a token.
 
-    Distinguishes a genuine credential rejection (4xx) from a transient connectivity problem so the
-    user sees an actionable message instead of a blanket "invalid credentials"."""
+    Distinguishes a genuine credential rejection (permanent 4xx from the token endpoint) from a
+    transient connectivity problem so the user sees an actionable message instead of a blanket
+    "invalid credentials"."""
+    auth = _make_auth(environment, client_id, client_secret)
+    # Force the lazy token mint through the public auth callable; a bad credential raises here.
+    probe = Request(method="GET", url=_api_base_url(environment)).prepare()
     try:
-        _mint_token(_get_session(client_secret), environment, client_id, client_secret)
-    except requests.HTTPError as e:
-        status = e.response.status_code if e.response is not None else None
-        if status in (401, 403):
+        auth(probe)
+    except OAuth2AuthRequestError as e:
+        if e.is_permanent:
             return (
                 False,
                 "Ramp rejected the credentials. Check the client ID and secret, and that the developer "
                 "app has the required scopes.",
             )
-        return False, f"Unexpected response from Ramp (status {status})."
+        return False, "Ramp is temporarily unavailable. Please check your selected environment and retry."
     except requests.RequestException as e:
         return False, f"Could not reach Ramp ({e}). Please check your network and selected environment, then retry."
     return True, None
-
-
-def get_rows(
-    environment: str,
-    client_id: str,
-    client_secret: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[RampResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Any = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config = RAMP_ENDPOINTS[endpoint]
-    session = _get_session(client_secret)
-    token = _mint_token(session, environment, client_id, client_secret)
-
-    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
-        url: str = _assert_trusted_url(resume_config.next_url, environment)
-        logger.debug(f"Ramp: resuming {endpoint} from URL: {url}")
-    else:
-        url = _build_initial_url(environment, config, should_use_incremental_field, db_incremental_field_last_value)
-
-    @retry(
-        retry=retry_if_exception_type((RampRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=1, max=60),
-        reraise=True,
-    )
-    def fetch_page(page_url: str) -> dict[str, Any]:
-        nonlocal token
-        response = session.get(page_url, headers={"Authorization": f"Bearer {token}"}, timeout=REQUEST_TIMEOUT_SECONDS)
-
-        # Tokens last ~10 days; re-mint once defensively if one ever expires
-        # mid-sync.
-        if response.status_code == 401:
-            token = _mint_token(session, environment, client_id, client_secret)
-            response = session.get(
-                page_url, headers={"Authorization": f"Bearer {token}"}, timeout=REQUEST_TIMEOUT_SECONDS
-            )
-
-        if response.status_code == 429 or response.status_code >= 500:
-            raise RampRetryableError(f"Ramp API error (retryable): status={response.status_code}, url={page_url}")
-
-        if not response.ok:
-            logger.error(f"Ramp API error: status={response.status_code}, body={response.text}, url={page_url}")
-            response.raise_for_status()
-
-        return response.json()
-
-    while True:
-        data = fetch_page(url)
-        items = data.get("data", []) or []
-
-        if items:
-            yield items
-
-        next_url = (data.get("page") or {}).get("next")
-        if not next_url or not items:
-            break
-
-        next_url = _assert_trusted_url(next_url, environment)
-        # Save state AFTER yielding the page so a crash re-yields the last page
-        # (merge dedupes on primary key) rather than skipping it.
-        resumable_source_manager.save_state(RampResumeConfig(next_url=next_url))
-        url = next_url
 
 
 def ramp_source(
@@ -192,25 +126,64 @@ def ramp_source(
     client_id: str,
     client_secret: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[RampResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = RAMP_ENDPOINTS[endpoint]
+    auth = _make_auth(environment, client_id, client_secret)
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    params: dict[str, Any] = {"page_size": PAGE_SIZE}
+    if (
+        config.incremental_param is not None
+        and should_use_incremental_field
+        and db_incremental_field_last_value is not None
+    ):
+        params[config.incremental_param] = _format_timestamp(db_incremental_field_last_value)
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resume is not None and resume.next_url is not None:
+        initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # The framework calls the hook AFTER a page is yielded and only while a next page remains,
+        # so a crash re-yields the last batch (merge dedupes on primary key) rather than skipping it.
+        if state is not None and state.get("next_url") is not None:
+            resumable_source_manager.save_state(RampResumeConfig(next_url=state["next_url"]))
+
+    endpoint_config: Endpoint = {
+        "path": config.path,
+        "params": params,
+        "data_selector": "data",
+        "paginator": RampPaginator(),
+    }
+    client_config: ClientConfig = {
+        "base_url": _api_base_url(environment),
+        "auth": auth,
+        # Pin every request — including page.next links and the seeded resume URL — to the
+        # configured Ramp host so a tampered next/resume link can't exfiltrate the bearer token.
+        "allowed_hosts": [],
+    }
+    rest_config: RESTAPIConfig = {
+        "client": client_config,
+        "resources": [{"name": endpoint, "endpoint": endpoint_config}],
+    }
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            environment=environment,
-            client_id=client_id,
-            client_secret=client_secret,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-        ),
+        items=lambda: resource,
         primary_keys=[config.primary_key],
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/source.py
@@ -20,6 +20,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAUTH2_PERMANENT_ERROR_MARKER,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import RampSourceConfig
@@ -59,10 +62,9 @@ class RampSource(ResumableSource[RampSourceConfig, RampResumeConfig]):
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            "401 Client Error: Unauthorized for url: https://api.ramp.com/developer/v1/token": "Ramp authentication failed. Please check your client ID and client secret.",
-            "401 Client Error: Unauthorized for url: https://demo-api.ramp.com/developer/v1/token": "Ramp authentication failed. Please check your client ID and client secret (and that they match the selected environment).",
-            "400 Client Error: Bad Request for url: https://api.ramp.com/developer/v1/token": "Ramp rejected the token request. Please check that your developer app has the required read scopes granted.",
-            "400 Client Error: Bad Request for url: https://demo-api.ramp.com/developer/v1/token": "Ramp rejected the token request. Please check that your developer app has the required read scopes granted.",
+            # Permanent token-exchange failures (invalid_client, bad request, missing scopes, …)
+            # all carry the framework's stable marker; transient 429/5xx token errors don't.
+            OAUTH2_PERMANENT_ERROR_MARKER: "Ramp authentication failed. Please check your client ID and client secret (and that they match the selected environment and have the required read scopes).",
             "403 Client Error: Forbidden for url: https://api.ramp.com": "Ramp denied access. Please check that your developer app has the read scope for this dataset.",
             "403 Client Error: Forbidden for url: https://demo-api.ramp.com": "Ramp denied access. Please check that your developer app has the read scope for this dataset.",
         }
@@ -155,7 +157,8 @@ A Ramp admin can create a developer app under Settings > Developer API. Grant it
             client_id=config.client_id,
             client_secret=config.client_secret,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/tests/test_ramp.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/tests/test_ramp.py
@@ -1,18 +1,18 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
 import requests
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.ramp.ramp import (
     PAGE_SIZE,
     RampResumeConfig,
     _base_url,
     _format_timestamp,
-    get_rows,
     ramp_source,
     validate_credentials,
 )
@@ -22,7 +22,37 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.ramp.setti
     TOKEN_SCOPES,
 )
 
-_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.ramp.ramp"
+# The RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# OAuth2Auth mints tokens through its own tracked session in the auth module.
+AUTH_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth.make_tracked_session"
+)
+
+
+def _response(payload: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(payload).encode()
+    resp.url = "https://api.ramp.com/developer/v1/test"
+    return resp
+
+
+def _page(items: list[dict[str, Any]], next_url: str | None = None) -> dict[str, Any]:
+    return {"data": items, "page": {"next": next_url}}
+
+
+def _token_response(status_code: int = 200, expires_in: int = 864000) -> mock.MagicMock:
+    # OAuth2Auth reads the token exchange body via response.raw.read (stream=True).
+    resp = mock.MagicMock()
+    resp.status_code = status_code
+    body: dict[str, Any] = (
+        {"access_token": "the-token", "expires_in": expires_in, "token_type": "Bearer"}
+        if status_code < 300
+        else {"error": "invalid_client"}
+    )
+    resp.raw.read.return_value = json.dumps(body).encode()
+    return resp
 
 
 def _make_manager(resume_state: RampResumeConfig | None = None) -> mock.MagicMock:
@@ -32,20 +62,50 @@ def _make_manager(resume_state: RampResumeConfig | None = None) -> mock.MagicMoc
     return manager
 
 
-def _token_response() -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {"access_token": "the-token", "expires_in": 864000}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock RESTClient session and snapshot each request AT PREPARE TIME.
+
+    ``request.params`` is one dict mutated in place across pages, so inspecting it after the run
+    shows only the final state — snapshot a copy when each request is prepared instead. A real
+    ``requests.Session`` does the preparing so the OAuth2 auth (token mint + Bearer header) is
+    actually applied, letting tests assert on the minted Authorization header and the request URLs.
+    """
+    session.headers = {}
+    real_session = requests.Session()
+    snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> requests.PreparedRequest:
+        prepared = real_session.prepare_request(request)
+        snapshots.append({"params": dict(request.params or {}), "url": prepared.url, "headers": dict(prepared.headers)})
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return snapshots
 
 
-def _page_response(items: list[dict[str, Any]], next_url: str | None = None) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.json.return_value = {"data": items, "page": {"next": next_url}}
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _source(
+    endpoint: str,
+    manager: mock.MagicMock,
+    *,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+):
+    return ramp_source(
+        environment="production",
+        client_id="cid",
+        client_secret="sec",
+        endpoint=endpoint,
+        team_id=1,
+        job_id="job-1",
+        resumable_source_manager=manager,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+    )
 
 
 class TestBaseUrl:
@@ -73,34 +133,32 @@ class TestFormatTimestamp:
 
 
 class TestValidateCredentials:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(AUTH_SESSION_PATCH)
     def test_valid_when_token_mints(self, mock_session):
         mock_session.return_value.post.return_value = _token_response()
         assert validate_credentials("production", "cid", "sec") == (True, None)
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(AUTH_SESSION_PATCH)
     def test_mint_requests_documented_scopes(self, mock_session):
         mock_session.return_value.post.return_value = _token_response()
 
         validate_credentials("production", "cid", "sec")
 
-        body = mock_session.return_value.post.call_args.kwargs["data"]
-        assert body == {"grant_type": "client_credentials", "scope": TOKEN_SCOPES}
-        assert mock_session.return_value.post.call_args.kwargs["auth"] == ("cid", "sec")
+        call = mock_session.return_value.post.call_args
+        # HTTP Basic client auth: credentials ride in the auth tuple, scopes in the form body.
+        assert call.args[0] == "https://api.ramp.com/developer/v1/token"
+        assert call.kwargs["data"] == {"grant_type": "client_credentials", "scope": TOKEN_SCOPES}
+        assert call.kwargs["auth"] == ("cid", "sec")
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(AUTH_SESSION_PATCH)
     def test_invalid_when_token_mint_rejected(self, mock_session):
-        error_response = mock.MagicMock()
-        error_response.status_code = 401
-        resp = mock.MagicMock()
-        resp.raise_for_status.side_effect = requests.HTTPError("401 Client Error", response=error_response)
-        mock_session.return_value.post.return_value = resp
+        mock_session.return_value.post.return_value = _token_response(status_code=401)
 
         is_valid, message = validate_credentials("production", "cid", "sec")
         assert is_valid is False
         assert "credentials" in (message or "")
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
+    @mock.patch(AUTH_SESSION_PATCH)
     def test_transient_error_is_not_reported_as_invalid_credentials(self, mock_session):
         mock_session.return_value.post.side_effect = requests.ConnectionError("connection refused")
 
@@ -110,129 +168,165 @@ class TestValidateCredentials:
 
 
 class TestGetRows:
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_paginates_via_page_next_url(self, mock_session):
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_via_page_next_url(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
         next_url = "https://api.ramp.com/developer/v1/transactions?start=abc&page_size=100"
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [
-            _page_response([{"id": "t1"}], next_url=next_url),
-            _page_response([{"id": "t2"}]),
-        ]
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "t1"}], next_url=next_url)),
+                _response(_page([{"id": "t2"}])),
+            ],
+        )
 
         manager = _make_manager()
-        batches = list(get_rows("production", "cid", "sec", "transactions", mock.MagicMock(), manager))
+        rows = _rows(_source("transactions", manager))
 
-        assert [item["id"] for batch in batches for item in batch] == ["t1", "t2"]
+        assert [row["id"] for row in rows] == ["t1", "t2"]
         manager.save_state.assert_called_once()
         assert manager.save_state.call_args.args[0].next_url == next_url
-        assert mock_session.return_value.get.call_args_list[1].args[0] == next_url
+        # The self-contained page.next link is followed verbatim on the second request.
+        assert snapshots[1]["url"] == next_url
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_incremental_transactions_use_from_date(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _page_response([])
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_incremental_transactions_use_from_date(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_response(_page([]))])
 
-        manager = _make_manager()
-        list(
-            get_rows(
-                "production",
-                "cid",
-                "sec",
+        _rows(
+            _source(
                 "transactions",
-                mock.MagicMock(),
-                manager,
+                _make_manager(),
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
             )
         )
 
-        url = mock_session.return_value.get.call_args.args[0]
-        query = parse_qs(urlparse(url).query)
-        assert query["from_date"] == ["2024-01-02T00:00:00Z"]
-        assert query["page_size"] == [str(PAGE_SIZE)]
+        assert snapshots[0]["params"]["from_date"] == "2024-01-02T00:00:00Z"
+        assert snapshots[0]["params"]["page_size"] == PAGE_SIZE
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_full_refresh_has_no_from_date(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _page_response([])
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_full_refresh_has_no_from_date(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_response(_page([]))])
 
-        manager = _make_manager()
-        list(get_rows("production", "cid", "sec", "users", mock.MagicMock(), manager))
+        _rows(_source("users", _make_manager()))
 
-        url = mock_session.return_value.get.call_args.args[0]
-        assert urlparse(url).path == "/developer/v1/users"
-        assert "from_date" not in parse_qs(urlparse(url).query)
+        assert "/developer/v1/users" in snapshots[0]["url"]
+        assert "from_date" not in snapshots[0]["params"]
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_remints_token_on_401(self, mock_session):
-        expired = mock.MagicMock()
-        expired.status_code = 401
-        expired.ok = False
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.side_effect = [expired, _page_response([{"id": "t1"}])]
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_remints_token_when_expired_mid_run(self, MockSession, MockAuth):
+        # expires_in=0 forces a re-mint per request — the deterministic stand-in for a sync
+        # outliving the token lifetime. Replaces the pre-framework reactive-401 re-mint.
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response(expires_in=0)
+        _wire(
+            session,
+            [
+                _response(_page([{"id": "t1"}], next_url="https://api.ramp.com/developer/v1/transactions?p=2")),
+                _response(_page([{"id": "t2"}])),
+            ],
+        )
 
-        manager = _make_manager()
-        batches = list(get_rows("production", "cid", "sec", "transactions", mock.MagicMock(), manager))
+        rows = _rows(_source("transactions", _make_manager()))
 
-        assert batches == [[{"id": "t1"}]]
-        assert mock_session.return_value.post.call_count == 2
+        assert [row["id"] for row in rows] == ["t1", "t2"]
+        assert MockAuth.return_value.post.call_count == 2
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_resumes_from_saved_url(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _page_response([])
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_mints_token_once_and_sends_bearer(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(
+            session,
+            [
+                _response(_page([{"id": "t1"}], next_url="https://api.ramp.com/developer/v1/transactions?p=2")),
+                _response(_page([{"id": "t2"}])),
+            ],
+        )
 
+        _rows(_source("transactions", _make_manager()))
+
+        # One mint covers the whole run while the ~10-day token is unexpired.
+        assert MockAuth.return_value.post.call_count == 1
+        assert all(s["headers"]["Authorization"] == "Bearer the-token" for s in snapshots)
+
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_url(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
         resume_url = "https://api.ramp.com/developer/v1/transactions?start=resume"
+        snapshots = _wire(session, [_response(_page([]))])
+
         manager = _make_manager(RampResumeConfig(next_url=resume_url))
-        list(get_rows("production", "cid", "sec", "transactions", mock.MagicMock(), manager))
+        _rows(_source("transactions", manager))
 
-        assert mock_session.return_value.get.call_args_list[0].args[0] == resume_url
+        assert snapshots[0]["url"] == resume_url
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_empty_page_with_next_url_stops(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _page_response(
-            [], next_url="https://api.ramp.com/developer/v1/transactions?start=loop"
-        )
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_with_next_url_stops(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(session, [_response(_page([], next_url="https://api.ramp.com/developer/v1/transactions?start=loop"))])
 
         manager = _make_manager()
-        batches = list(get_rows("production", "cid", "sec", "transactions", mock.MagicMock(), manager))
+        rows = _rows(_source("transactions", manager))
 
-        assert batches == []
+        assert rows == []
+        assert session.send.call_count == 1
         manager.save_state.assert_not_called()
 
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_rejects_off_host_next_url(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
-        mock_session.return_value.get.return_value = _page_response(
-            [{"id": "t1"}], next_url="https://evil.example.com/developer/v1/transactions"
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_off_host_next_url(self, MockSession, MockAuth):
+        # SSRF guard: a page.next pointing off the configured Ramp host is rejected before the
+        # request (and its bearer token) leaves the process.
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(
+            session,
+            [_response(_page([{"id": "t1"}], next_url="https://evil.example.com/developer/v1/transactions"))],
         )
 
-        manager = _make_manager()
         with pytest.raises(ValueError):
-            list(get_rows("production", "cid", "sec", "transactions", mock.MagicMock(), manager))
+            _rows(_source("transactions", _make_manager()))
 
-        manager.save_state.assert_not_called()
-
-    @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_rejects_off_host_resume_url(self, mock_session):
-        mock_session.return_value.post.return_value = _token_response()
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_rejects_off_host_resume_url(self, MockSession, MockAuth):
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        _wire(session, [])
 
         manager = _make_manager(RampResumeConfig(next_url="https://evil.example.com/developer/v1/transactions"))
         with pytest.raises(ValueError):
-            list(get_rows("production", "cid", "sec", "transactions", mock.MagicMock(), manager))
+            _rows(_source("transactions", manager))
+
+        manager.save_state.assert_not_called()
 
 
 class TestRampSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_response_metadata_per_endpoint(self, endpoint):
         config = RAMP_ENDPOINTS[endpoint]
-        response = ramp_source("production", "cid", "sec", endpoint, mock.MagicMock(), _make_manager())
+        response = _source(endpoint, _make_manager())
 
         assert response.name == endpoint
         assert response.primary_keys == [config.primary_key]
-        # Ordering within incremental windows is undocumented — desc defers
-        # the watermark commit to run completion.
+        # Ordering within incremental windows is undocumented — desc defers the watermark commit
+        # to run completion.
         assert response.sort_mode == ("desc" if config.incremental_fields else "asc")
         if config.partition_key:
             assert response.partition_mode == "datetime"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/tests/test_ramp_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/tests/test_ramp_source.py
@@ -56,8 +56,9 @@ class TestRampSource:
     @pytest.mark.parametrize(
         "observed_error",
         [
-            "401 Client Error: Unauthorized for url: https://api.ramp.com/developer/v1/token",
-            "400 Client Error: Bad Request for url: https://demo-api.ramp.com/developer/v1/token",
+            # Permanent OAuth2 token-exchange failures carry the framework's stable marker.
+            "HTTP 401 from the OAuth2 token endpoint: invalid_client [oauth2_token_config_error]",
+            "HTTP 400 from the OAuth2 token endpoint: invalid_scope [oauth2_token_config_error]",
             "403 Client Error: Forbidden for url: https://api.ramp.com/developer/v1/transactions",
         ],
     )


### PR DESCRIPTION
## Problem

Batch 29 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

## Changes

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **papersign**
- **plausible**
- **postmark**
- **productboard**
- **ramp**

Not migrated this batch (left hand-rolled, valid blockers):
- **planhat** — a non-list HTTP-200 body is classified retryable; the framework's `data_selector_required` makes it a permanent error and `response_actions` can't content-match "not a list".
- **printify** — same HTTP-200 body-shape retryable classification (bare string / dict-without-`data` / `{"data": <object>}`), which the framework can't reproduce without silent-corruption or permanent-error regressions.

## How did you test this code?

- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 5 migrated dirs + `common/rest_source/tests/` — 380 passed.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-28 PR; merge in order.
