### PR TITLE
refactor(data-warehouse): malformed-body-retryable + migrate groq, planhat, pretix, raygun (batch 30)

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -314,6 +314,9 @@ def create_resources(
                     None if has_dependent_resource else initial_paginator_state
                 ),
                 data_selector_required: bool = bool(endpoint_config.get("data_selector_required")),
+                data_selector_malformed_retryable: bool = bool(
+                    endpoint_config.get("data_selector_malformed_retryable")
+                ),
             ) -> Iterator[list[Any]]:
                 if incremental_object:
                     params = _set_incremental_params(
@@ -335,6 +338,7 @@ def create_resources(
                     resume_hook=resume_hook,
                     initial_paginator_state=initial_paginator_state,
                     data_selector_required=data_selector_required,
+                    data_selector_malformed_retryable=data_selector_malformed_retryable,
                 ):
                     yield list(convert_types(page, columns_config))
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -99,6 +99,23 @@ def _retry_wait_seconds(state: RetryCallState) -> float:
 Hooks = dict[str, list[Any]]
 
 
+def _body_shape_is_list(body: Any, data_selector: Optional[TJsonPath]) -> bool:
+    """Whether ``body`` carries the expected list of rows once ``data_selector`` is applied.
+
+    Mirrors ``_extract_response``'s shape rules: with a selector the key must be present and
+    resolve to a list; without one the whole body must be a list. Used by the retryable-body
+    check so a 200 whose payload is the wrong shape (a truncating proxy, a transient error
+    envelope) is retried rather than failing loud or being silently ingested as a single row.
+    """
+    if data_selector:
+        matches: Any = find_values(data_selector, body)
+        if not matches:
+            return False
+        value = matches[0] if isinstance(matches, list) and len(matches) == 1 else matches
+        return isinstance(value, list)
+    return isinstance(body, list)
+
+
 class RESTClient:
     def __init__(
         self,
@@ -176,9 +193,21 @@ class RESTClient:
         resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
         initial_paginator_state: Optional[dict[str, Any]] = None,
         data_selector_required: bool = False,
+        data_selector_malformed_retryable: bool = False,
     ) -> Iterator[list[Any]]:
         paginator = copy.deepcopy(paginator) if paginator else copy.deepcopy(self.paginator)
         hooks = hooks or {}
+
+        # When set, a 200 whose parsed body isn't the expected list shape is RETRIED (not failed
+        # loud): the check runs inside the retry-wrapped ``_send_request`` so a transient malformed
+        # payload is reissued. This reproduces sources that defensively classify an unexpected
+        # 200-body shape as retryable. Distinct from ``data_selector_required`` (permanent fail-loud).
+        malformed_check: Optional[Callable[[Any], None]] = None
+        if data_selector_malformed_retryable:
+
+            def malformed_check(body: Any) -> None:
+                if not _body_shape_is_list(body, data_selector):
+                    raise RESTClientRetryableError("Unexpected 200 response body shape (expected a list of rows)")
 
         # `requests` serializes None values as the literal string "None" in the
         # query string — drop them so optional/incremental params that are not
@@ -200,7 +229,7 @@ class RESTClient:
 
         while True:
             try:
-                response, body = self._send_request(request, hooks)
+                response, body = self._send_request(request, hooks, body_check=malformed_check)
             except IgnoreResponseException:
                 break
 
@@ -224,7 +253,9 @@ class RESTClient:
         wait=_retry_wait_seconds,
         reraise=True,
     )
-    def _send_request(self, request: Request, hooks: Hooks) -> tuple[Response, Any]:
+    def _send_request(
+        self, request: Request, hooks: Hooks, body_check: Optional[Callable[[Any], None]] = None
+    ) -> tuple[Response, Any]:
         prepared = self.session.prepare_request(request)
         # Fail loud on a pagination/resume URL that points off the expected host before the
         # request (and its Authorization header) ever leaves the process. Raised outside the
@@ -279,6 +310,11 @@ class RESTClient:
             if not response.content or not response.content.strip():
                 return response, None
             raise RESTClientRetryableError(self._redact(f"Malformed JSON response from {response.url}: {e}")) from e
+
+        # Runs inside the retry loop so an unexpected-but-parseable 200 body (wrong shape) can be
+        # reissued as retryable rather than surfacing as a permanent error or a garbage row.
+        if body_check is not None and body is not None:
+            body_check(body)
 
         return response, body
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_malformed_body_retryable.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_malformed_body_retryable.py
@@ -1,0 +1,102 @@
+import json
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client"
+
+
+def _make_response(body: Any) -> Response:
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://api.example.com/items"
+    return resp
+
+
+class TestMalformedBodyRetryable:
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_malformed_then_valid_recovers(self, MockSession, _sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        # A dict-without-the-selector-key (wrong shape) then a proper page.
+        mock_session.send.side_effect = [
+            _make_response({"error": "temporary glitch"}),
+            _make_response({"data": [{"id": 1}]}),
+        ]
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(
+            client.paginate(
+                path="/items",
+                data_selector="data",
+                paginator=SinglePagePaginator(),
+                data_selector_malformed_retryable=True,
+            )
+        )
+
+        assert pages == [[{"id": 1}]]
+        assert mock_session.send.call_count == 2
+
+    @pytest.mark.parametrize(
+        "bad_body",
+        [
+            pytest.param("just a string", id="bare_string"),
+            pytest.param({"error": "nope"}, id="dict_without_key"),
+            pytest.param({"data": {"id": 1}}, id="key_present_but_not_a_list"),
+        ],
+    )
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_persistent_malformed_body_reraises_retryable(self, MockSession, _sleep, bad_body) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_response(bad_body)
+
+        client = RESTClient(base_url="https://api.example.com", max_retry_attempts=3)
+        with pytest.raises(RESTClientRetryableError, match="Unexpected 200 response body shape"):
+            list(
+                client.paginate(
+                    path="/items",
+                    data_selector="data",
+                    paginator=SinglePagePaginator(),
+                    data_selector_malformed_retryable=True,
+                )
+            )
+        assert mock_session.send.call_count == 3
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_valid_list_body_is_not_retried(self, MockSession, _sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_response({"data": [{"id": 1}, {"id": 2}]})
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(
+            client.paginate(
+                path="/items",
+                data_selector="data",
+                paginator=SinglePagePaginator(),
+                data_selector_malformed_retryable=True,
+            )
+        )
+
+        assert pages == [[{"id": 1}, {"id": 2}]]
+        assert mock_session.send.call_count == 1

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_multilevel_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_multilevel_fanout.py
@@ -24,6 +24,7 @@ def _paginate_stub(pages_by_path: dict[str, list[dict[str, Any]]]):
         resume_hook=None,
         initial_paginator_state=None,
         data_selector_required=False,
+        **kwargs,
     ):
         yield pages_by_path[path]
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/typing.py
@@ -249,6 +249,12 @@ class Endpoint(TypedDict, total=False):
     # instead of yielding an empty page — fail-loud on an unexpected/changed API response shape,
     # rather than silently syncing 0 rows. A present-but-empty list is still a valid 0-row page.
     data_selector_required: Optional[bool]
+    # When True, a 200 whose parsed body isn't the expected list shape (selector matches nothing, or
+    # the matched value / selector-less body isn't a list) raises a RETRYABLE error and the request is
+    # reissued — for sources that defensively treat an unexpected 200-body shape as transient. This is
+    # the retryable counterpart of ``data_selector_required`` (which fails loud permanently); set at
+    # most one of the two.
+    data_selector_malformed_retryable: Optional[bool]
     response_actions: Optional[list[ResponseAction]]
     incremental: Optional[IncrementalConfig]
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/groq/groq.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/groq/groq.py
@@ -1,27 +1,21 @@
-from collections.abc import Iterator
-from typing import Any
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
-
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    JSONResponseCursorPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.groq.settings import (
     GROQ_ENDPOINTS,
     GroqEndpointConfig,
 )
 
 GROQ_BASE_URL = "https://api.groq.com/openai/v1"
-
-# Bounds cursor pagination on `batches` so a malformed `next_cursor` (or an API that echoes the same
-# cursor) can't loop forever. A structured warning is logged if the cap is ever reached. Per-org
-# batch-job history is tiny, so this ceiling is far above any realistic page count.
-MAX_PAGES = 1000
-
-
-class GroqRetryableError(Exception):
-    pass
 
 
 def _get_headers(api_key: str) -> dict[str, str]:
@@ -31,115 +25,61 @@ def _get_headers(api_key: str) -> dict[str, str]:
     }
 
 
-@retry(
-    retry=retry_if_exception_type(
-        (
-            GroqRetryableError,
-            requests.ReadTimeout,
-            requests.ConnectionError,
-            requests.exceptions.ChunkedEncodingError,
-        )
-    ),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    url: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    params: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    response = session.get(url, headers=headers, params=params, timeout=60)
-
-    # Groq applies org-level rate limits and returns 429 with a Retry-After header; tenacity's
-    # backoff covers the wait. 5xx are transient too.
-    if response.status_code == 429 or response.status_code >= 500:
-        raise GroqRetryableError(f"Groq API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Groq API error: status={response.status_code}, body={response.text}, url={url}")
-        # The API key rides in the Authorization header, not the URL, so raise_for_status()'s message
-        # (which includes the URL) is safe to surface.
-        response.raise_for_status()
-
-    body = response.json()
-    if not isinstance(body, dict):
-        raise GroqRetryableError(f"Groq API returned an unexpected non-object response for url={url}")
-    return body
-
-
-def _next_cursor(body: dict[str, Any]) -> str | None:
-    """Extract the next-page cursor from a Groq list response.
-
-    Groq's batches endpoint documents cursor pagination via a `paging` object carrying `next_cursor`,
-    passed back as the `cursor` query param. This could not be verified against the live API (no
-    credentials were available), so absence of a `paging` object is treated as "single page" — the
-    common case for the tiny per-org datasets these endpoints return.
-    """
-    paging = body.get("paging")
-    if isinstance(paging, dict):
-        cursor = paging.get("next_cursor")
-        if cursor:
-            return str(cursor)
-    return None
-
-
-def get_rows(
-    api_key: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[list[dict[str, Any]]]:
-    config = GROQ_ENDPOINTS[endpoint]
-    headers = _get_headers(api_key)
-    # One session reused across pages so urllib3 keeps the connection alive. The API key rides in the
-    # Authorization header, so it's redacted from logged URLs and captured samples, and redirects are
-    # disabled so the bearer token is never replayed to another host.
-    session = make_tracked_session(redact_values=(api_key,), allow_redirects=False)
-    url = f"{GROQ_BASE_URL}{config.path}"
-
-    cursor: str | None = None
-    for page in range(MAX_PAGES):
-        params = {"cursor": cursor} if cursor else None
-        body = _fetch_page(session, url, headers, logger, params=params)
-
-        # All three list endpoints wrap results as {"object": "list", "data": [...]}.
-        items = body.get("data", [])
-        if not isinstance(items, list):
-            raise GroqRetryableError(f"Groq API returned an unexpected non-list data field for url={url}")
-        if items:
-            yield items
-
-        if not config.paginated:
-            return
-
-        cursor = _next_cursor(body)
-        if not cursor:
-            return
-
-        if page == MAX_PAGES - 1:
-            logger.warning(
-                f"Groq: hit MAX_PAGES={MAX_PAGES} paginating {endpoint}; stopping. Some rows may be missing."
-            )
+def _paginator_for(config: GroqEndpointConfig) -> BasePaginator:
+    # Only `batches` paginates, via a body cursor in `paging.next_cursor` echoed back as the `cursor`
+    # query param. An empty/absent cursor (or a non-dict `paging`) ends pagination. files and models
+    # are single flat `data` arrays with no documented pagination.
+    if config.paginated:
+        return JSONResponseCursorPaginator(cursor_path="paging.next_cursor", cursor_param="cursor")
+    return SinglePagePaginator()
 
 
 def groq_source(
     api_key: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
 ) -> SourceResponse:
     config: GroqEndpointConfig = GROQ_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GROQ_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so the token is redacted from
+            # logs and raised error messages; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_key},
+            "paginator": _paginator_for(config),
+            # Redirects disabled so the bearer token is never replayed to another host.
+            "allow_redirects": False,
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # All three list endpoints wrap results as {"object": "list", "data": [...]}.
+                    "data_selector": "data",
+                    # A 200 whose body isn't the expected shape (non-object, or `data` not a list) is
+                    # treated as a transient malformation and retried, not ingested as a stray row.
+                    "data_selector_malformed_retryable": True,
+                },
+            }
+        ],
+    }
+
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(api_key=api_key, endpoint=endpoint, logger=logger),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime",
         partition_format="month",
         partition_keys=[config.partition_key],
+        column_hints=resource.column_hints,
     )
 
 
@@ -151,10 +91,8 @@ def validate_credentials(api_key: str) -> tuple[bool, int | None]:
     if not api_key.strip():
         return False, None
 
-    try:
-        session = make_tracked_session(redact_values=(api_key,), allow_redirects=False)
-        response = session.get(f"{GROQ_BASE_URL}/models", headers=_get_headers(api_key), timeout=10)
-    except Exception:
-        return False, None
-
-    return response.status_code == 200, response.status_code
+    return validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,), allow_redirects=False),
+        f"{GROQ_BASE_URL}/models",
+        headers=_get_headers(api_key),
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/groq/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/groq/source.py
@@ -125,5 +125,6 @@ Create an API key in the [Groq console](https://console.groq.com/keys). Groq exp
         return groq_source(
             api_key=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/groq/tests/test_groq.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/groq/tests/test_groq.py
@@ -1,49 +1,62 @@
+import json
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import requests
 from parameterized import parameterized
+from requests import Response
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.groq.groq import (
     GROQ_BASE_URL,
-    GroqRetryableError,
-    _fetch_page,
     _get_headers,
-    _next_cursor,
-    get_rows,
     groq_source,
     validate_credentials,
 )
 
-MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.groq.groq"
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the groq module.
+GROQ_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.groq.groq.make_tracked_session"
+# Backoff sleeps happen inside tenacity; patch its clock so retry tests don't actually wait.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-def _response(*, body: Any = None, status: int = 200, ok: bool = True) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status
-    response.ok = ok
-    response.text = "" if body is None else str(body)
-    response.json.return_value = body if body is not None else {}
-    if not ok:
-        response.raise_for_status.side_effect = requests.HTTPError(
-            f"{status} Client Error: Unauthorized for url: {GROQ_BASE_URL}/models", response=response
-        )
-    return response
+def _response(body: Any, *, status: int = 200, reason: str = "OK") -> Response:
+    resp = Response()
+    resp.status_code = status
+    resp.reason = reason
+    resp.url = f"{GROQ_BASE_URL}/batches"
+    resp.headers["Content-Type"] = "application/json"
+    resp._content = b"" if body is None else json.dumps(body).encode()
+    return resp
 
 
-def _session_returning(responses: list[MagicMock]) -> MagicMock:
-    session = MagicMock()
-    session.get.side_effect = responses
-    return session
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Wire a mock session, snapshotting each request's params and auth AT PREPARE TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so a copy is taken per page.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+    auth_snapshots: list[Any] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        auth_snapshots.append(request.auth)
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots, auth_snapshots
 
 
-def _collect_rows(batches: Any) -> list[dict]:
-    rows: list[dict] = []
-    for batch in batches:
-        rows.extend(batch)
-    return rows
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
 
 class TestGroq:
@@ -52,81 +65,115 @@ class TestGroq:
         assert headers["Authorization"] == "Bearer gsk_secret"
         assert headers["Accept"] == "application/json"
 
-    @parameterized.expand(
-        [
-            ("cursor_present", {"paging": {"next_cursor": "abc"}}, "abc"),
-            ("no_paging", {"data": []}, None),
-            ("empty_cursor", {"paging": {"next_cursor": ""}}, None),
-            ("null_cursor", {"paging": {"next_cursor": None}}, None),
-            ("paging_not_dict", {"paging": "nope"}, None),
-        ]
-    )
-    def test_next_cursor(self, _name: str, body: dict, expected: str | None) -> None:
-        assert _next_cursor(body) == expected
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_batches_follows_cursor_across_pages(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        params, auths = _wire(
+            session,
+            [
+                _response({"data": [{"id": "batch_1"}], "paging": {"next_cursor": "cur1"}}),
+                _response({"data": [{"id": "batch_2"}], "paging": {"next_cursor": "cur2"}}),
+                _response({"data": [{"id": "batch_3"}]}),  # no cursor -> last page
+            ],
+        )
 
-    def test_fetch_page_returns_body_on_success(self) -> None:
-        session = _session_returning([_response(body={"object": "list", "data": [{"id": "batch_1"}]})])
-        body = _fetch_page(session, f"{GROQ_BASE_URL}/batches", _get_headers("k"), MagicMock())
-        assert body == {"object": "list", "data": [{"id": "batch_1"}]}
+        rows = _rows(groq_source("gsk_k", "batches", team_id=1, job_id="j"))
 
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403)])
-    def test_fetch_page_client_error_raises(self, _name: str, status: int) -> None:
-        session = _session_returning([_response(status=status, ok=False)])
-        with pytest.raises(requests.HTTPError):
-            _fetch_page(session, f"{GROQ_BASE_URL}/models", _get_headers("k"), MagicMock())
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 503)])
-    def test_fetch_page_retryable_status_retries_then_raises(self, _name: str, status: int) -> None:
-        session = _session_returning([_response(status=status, ok=False)] * 5)
-        with patch("time.sleep"), pytest.raises(GroqRetryableError):
-            _fetch_page(session, f"{GROQ_BASE_URL}/models", _get_headers("k"), MagicMock())
-        assert session.get.call_count == 5
-
-    def test_fetch_page_non_dict_body_is_retryable(self) -> None:
-        session = _session_returning([_response(body=["unexpected"])] * 5)
-        with patch("time.sleep"), pytest.raises(GroqRetryableError):
-            _fetch_page(session, f"{GROQ_BASE_URL}/models", _get_headers("k"), MagicMock())
+        assert [r["id"] for r in rows] == ["batch_1", "batch_2", "batch_3"]
+        assert session.send.call_count == 3
+        # The cursor from each page must be forwarded as the `cursor` param on the next request.
+        assert "cursor" not in params[0]
+        assert params[1]["cursor"] == "cur1"
+        assert params[2]["cursor"] == "cur2"
+        # The bearer token rides on the framework auth, not a hand-built header.
+        assert auths[0].token == "gsk_k"
 
     @parameterized.expand([("files",), ("models",)])
-    def test_get_rows_non_paginated_reads_single_page(self, endpoint: str) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_paginated_reads_single_page(self, endpoint: str, MockSession: mock.MagicMock) -> None:
         # files and models are flat `data` arrays; the transport must not attempt a second request
         # even if a stray cursor is present in the body.
-        responses = [_response(body={"data": [{"id": "a"}, {"id": "b"}], "paging": {"next_cursor": "x"}})]
-        session = _session_returning(responses)
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            rows = _collect_rows(get_rows("k", endpoint, MagicMock()))
+        session = MockSession.return_value
+        _wire(session, [_response({"data": [{"id": "a"}, {"id": "b"}], "paging": {"next_cursor": "x"}})])
+
+        rows = _rows(groq_source("gsk_k", endpoint, team_id=1, job_id="j"))
+
         assert [r["id"] for r in rows] == ["a", "b"]
-        assert session.get.call_count == 1
+        assert session.send.call_count == 1
 
-    def test_get_rows_batches_follows_cursor_across_pages(self) -> None:
-        responses = [
-            _response(body={"data": [{"id": "batch_1"}], "paging": {"next_cursor": "cur1"}}),
-            _response(body={"data": [{"id": "batch_2"}], "paging": {"next_cursor": "cur2"}}),
-            _response(body={"data": [{"id": "batch_3"}]}),  # no cursor -> last page
-        ]
-        session = _session_returning(responses)
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            rows = _collect_rows(get_rows("k", "batches", MagicMock()))
-        assert [r["id"] for r in rows] == ["batch_1", "batch_2", "batch_3"]
-        assert session.get.call_count == 3
-        # The cursor from each page must be forwarded as the `cursor` param on the next request.
-        cursors = [call.kwargs["params"] for call in session.get.call_args_list]
-        assert cursors == [None, {"cursor": "cur1"}, {"cursor": "cur2"}]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_data_page_yields_no_rows(self, MockSession: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({"data": []})])
 
-    def test_get_rows_skips_empty_data_page(self) -> None:
-        responses = [_response(body={"data": []})]
-        session = _session_returning(responses)
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            rows = _collect_rows(get_rows("k", "models", MagicMock()))
+        rows = _rows(groq_source("gsk_k", "models", team_id=1, job_id="j"))
+
         assert rows == []
+        assert session.send.call_count == 1
 
-    def test_get_rows_non_list_data_is_retryable(self) -> None:
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_dict_body_is_retried_then_reraises(self, MockSession: mock.MagicMock, _sleep: mock.MagicMock) -> None:
+        # A non-object body (bare array) is an unexpected shape; the request is reissued and, if it
+        # never recovers, surfaces as a retryable error after the attempt cap.
+        session = MockSession.return_value
+        _wire(session, [_response(["unexpected"])] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(groq_source("gsk_k", "models", team_id=1, job_id="j"))
+        assert session.send.call_count == 5
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_data_is_retried_then_reraises(self, MockSession: mock.MagicMock, _sleep: mock.MagicMock) -> None:
         # A `data` field that isn't a list (error payload or changed API shape) must not be yielded as
-        # a page of rows; it breaks the Iterator[list[dict]] contract.
-        responses = [_response(body={"data": {"unexpected": "object"}})]
-        session = _session_returning(responses)
-        with patch(f"{MODULE}.make_tracked_session", return_value=session), pytest.raises(GroqRetryableError):
-            _collect_rows(get_rows("k", "models", MagicMock()))
+        # rows; it is treated as a transient malformation and reissued.
+        session = MockSession.return_value
+        _wire(session, [_response({"data": {"unexpected": "object"}})] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(groq_source("gsk_k", "models", team_id=1, job_id="j"))
+        assert session.send.call_count == 5
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_malformed_body_then_valid_recovers(self, MockSession: mock.MagicMock, _sleep: mock.MagicMock) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(["glitch"]), _response({"data": [{"id": "batch_1"}]})])
+
+        rows = _rows(groq_source("gsk_k", "models", team_id=1, job_id="j"))
+
+        assert [r["id"] for r in rows] == ["batch_1"]
+        assert session.send.call_count == 2
+
+    @parameterized.expand([("rate_limited", 429, "Too Many Requests"), ("server_error", 503, "Service Unavailable")])
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retryable_status_retries_then_raises(
+        self, _name: str, status: int, reason: str, MockSession: mock.MagicMock, _sleep: mock.MagicMock
+    ) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response({}, status=status, reason=reason)] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(groq_source("gsk_k", "models", team_id=1, job_id="j"))
+        assert session.send.call_count == 5
+
+    @parameterized.expand([("unauthorized", 401, "Unauthorized"), ("forbidden", 403, "Forbidden")])
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_client_error_raises_http_error_without_retry(
+        self, _name: str, status: int, reason: str, MockSession: mock.MagicMock
+    ) -> None:
+        # 401/403 are credential/permission failures — never retried, surfaced as an HTTPError whose
+        # message carries the stable status text that get_non_retryable_errors matches on.
+        session = MockSession.return_value
+        _wire(session, [_response({"error": "denied"}, status=status, reason=reason)])
+
+        with pytest.raises(requests.HTTPError) as exc_info:
+            _rows(groq_source("gsk_k", "models", team_id=1, job_id="j"))
+        assert f"{status} Client Error" in str(exc_info.value)
+        assert "https://api.groq.com" in str(exc_info.value)
+        assert session.send.call_count == 1
 
     @parameterized.expand(
         [
@@ -136,7 +183,8 @@ class TestGroq:
         ]
     )
     def test_groq_source_maps_primary_keys_and_partitioning(self, endpoint: str, partition_key: str) -> None:
-        response = groq_source("k", endpoint, MagicMock())
+        # No network: SourceResponse metadata is built eagerly, rows only on iteration.
+        response = groq_source("gsk_k", endpoint, team_id=1, job_id="j")
         assert response.name == endpoint
         assert response.primary_keys == ["id"]
         assert response.partition_mode == "datetime"
@@ -144,39 +192,37 @@ class TestGroq:
 
     @parameterized.expand(
         [
-            ("empty_key", "   ", None, None, False, None),
-            ("valid", "gsk_ok", 200, True, True, 200),
-            ("invalid", "gsk_bad", 401, False, False, 401),
+            ("valid", 200, True, True, 200),
+            ("invalid", 401, False, False, 401),
+            ("forbidden", 403, False, False, 403),
         ]
     )
     def test_validate_credentials(
         self,
         _name: str,
-        api_key: str,
-        status: int | None,
+        status: int,
         ok: bool,
         expected_ok: bool,
         expected_status: int | None,
     ) -> None:
-        session = MagicMock()
-        if status is not None:
-            session.get.return_value = _response(status=status, ok=ok, body={})
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
-            result_ok, result_status = validate_credentials(api_key)
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=status)
+        with mock.patch(GROQ_SESSION_PATCH, return_value=session):
+            result_ok, result_status = validate_credentials("gsk_ok")
         assert result_ok is expected_ok
         assert result_status == expected_status
 
     def test_validate_credentials_empty_key_skips_request(self) -> None:
-        with patch(f"{MODULE}.make_tracked_session") as make_session:
+        with mock.patch(GROQ_SESSION_PATCH) as make_session:
             ok, status = validate_credentials("   ")
         assert ok is False
         assert status is None
         make_session.assert_not_called()
 
     def test_validate_credentials_swallows_transport_error(self) -> None:
-        session = MagicMock()
+        session = mock.MagicMock()
         session.get.side_effect = requests.ConnectionError("boom")
-        with patch(f"{MODULE}.make_tracked_session", return_value=session):
+        with mock.patch(GROQ_SESSION_PATCH, return_value=session):
             ok, status = validate_credentials("gsk_x")
         assert ok is False
         assert status is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planhat/planhat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planhat/planhat.py
@@ -1,27 +1,25 @@
 import dataclasses
-from collections.abc import Iterator
 from typing import Any, Optional
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.planhat.settings import PLANHAT_ENDPOINTS
 
 PLANHAT_BASE_URL = "https://api.planhat.com"
 # Planhat list endpoints default to a `limit` of 100; the largest common page minimises round trips.
 PAGE_SIZE = 100
-REQUEST_TIMEOUT_SECONDS = 60
 # Cheap endpoint used to confirm an API token is genuine. The token is account-wide, so one probe
 # validates access to every list endpoint.
 DEFAULT_PROBE_PATH = "/companies"
-
-
-class PlanhatRetryableError(Exception):
-    pass
 
 
 @dataclasses.dataclass
@@ -31,120 +29,85 @@ class PlanhatResumeConfig:
     offset: int = 0
 
 
-def _headers(api_token: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_token}", "Accept": "application/json"}
-
-
-@retry(
-    retry=retry_if_exception_type((PlanhatRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
-    reraise=True,
-)
-def _fetch_page(
-    session: requests.Session,
-    path: str,
-    offset: int,
-    limit: int,
-    logger: FilteringBoundLogger,
-) -> list[dict[str, Any]]:
-    response = session.get(
-        f"{PLANHAT_BASE_URL}{path}",
-        params={"limit": limit, "offset": offset},
-        timeout=REQUEST_TIMEOUT_SECONDS,
-    )
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise PlanhatRetryableError(f"Planhat API error (retryable): status={response.status_code}, path={path}")
-
-    if not response.ok:
-        logger.error(f"Planhat API error: status={response.status_code}, body={response.text}, path={path}")
-        response.raise_for_status()
-
-    data = response.json()
-    # Planhat list endpoints return a bare JSON array of records.
-    if not isinstance(data, list):
-        raise PlanhatRetryableError(f"Planhat returned an unexpected payload for {path}: {type(data).__name__}")
-    return data
-
-
-def get_rows(
-    api_token: str,
-    endpoint: str,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PlanhatResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    config = PLANHAT_ENDPOINTS[endpoint]
-    session = make_tracked_session(headers=_headers(api_token), redact_values=(api_token,))
-
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    offset = resume.offset if resume else 0
-    if resume and resume.offset > 0:
-        logger.debug(f"Planhat: resuming {endpoint} from offset {offset}")
-
-    while True:
-        items = _fetch_page(session, config.path, offset, PAGE_SIZE, logger)
-        if items:
-            yield items
-
-        # A short page (or an empty one) means we've reached the end of the collection.
-        if len(items) < PAGE_SIZE:
-            break
-
-        offset += PAGE_SIZE
-        # Save AFTER yielding so a crash re-fetches from the next page (already-yielded pages are
-        # persisted); merge dedupes the re-pulled page on the primary key.
-        resumable_source_manager.save_state(PlanhatResumeConfig(offset=offset))
-
-
 def planhat_source(
     api_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PlanhatResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = PLANHAT_ENDPOINTS[endpoint]
 
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": PLANHAT_BASE_URL,
+            # Auth (Bearer) is supplied via the framework auth config so its value is redacted from
+            # logs and raised error messages; only the non-secret Accept header is set here.
+            "headers": {"Accept": "application/json"},
+            "auth": {"type": "bearer", "token": api_token},
+            # Planhat has no top-level `total`; termination is a short/empty page (OffsetPaginator default).
+            "paginator": OffsetPaginator(limit=PAGE_SIZE, total_path=None),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    # Planhat list endpoints return a bare JSON array of records; a 200 body that
+                    # isn't a list is treated as a transient shape glitch and retried.
+                    "data_selector_malformed_retryable": True,
+                },
+            }
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        if resume is not None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(PlanhatResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
+        column_hints=resource.column_hints,
     )
 
 
-def check_access(api_token: str, path: str = DEFAULT_PROBE_PATH) -> tuple[int, Optional[str]]:
-    """Probe a single endpoint to validate the API token.
-
-    Returns ``(status, message)``: ``200`` reachable, ``401``/``403`` auth failure, ``0`` for a
-    connection problem, other HTTP status otherwise.
-    """
-    session = make_tracked_session(headers=_headers(api_token), redact_values=(api_token,))
-    try:
-        # Ask for a single row so the probe stays cheap regardless of account size.
-        response = session.get(f"{PLANHAT_BASE_URL}{path}", params={"limit": 1, "offset": 0}, timeout=15)
-    except Exception as e:
-        return 0, f"Could not connect to Planhat: {e}"
-
-    if response.status_code in (401, 403):
-        return response.status_code, None
-
-    if not response.ok:
-        return response.status_code, f"Planhat returned HTTP {response.status_code}"
-
-    return 200, None
-
-
 def validate_credentials(api_token: str) -> tuple[bool, str | None]:
-    status, message = check_access(api_token)
-    if status == 200:
+    """Probe a single endpoint to validate the account-wide API token.
+
+    The token grants read access to every list endpoint, so one cheap probe (a single row from
+    ``/companies``) confirms access for all schemas.
+    """
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,)),
+        f"{PLANHAT_BASE_URL}{DEFAULT_PROBE_PATH}?limit=1&offset=0",
+        headers={"Authorization": f"Bearer {api_token}", "Accept": "application/json"},
+    )
+    if ok:
         return True, None
     if status in (401, 403):
         return False, "Invalid Planhat API token"
-    return False, message or "Could not validate Planhat API token"
+    if status is None:
+        return False, "Could not validate Planhat API token"
+    return False, f"Planhat returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planhat/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planhat/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import PlanhatSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.planhat.planhat import (
     PlanhatResumeConfig,
@@ -28,6 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.planhat.pl
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.planhat.settings import (
     ENDPOINTS,
+    INCREMENTAL_FIELDS,
     PLANHAT_ENDPOINTS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -94,19 +98,8 @@ You can create an API access token from a Private App under **Settings → Servi
     ) -> list[SourceSchema]:
         # Every endpoint is full refresh only — Planhat's list endpoints expose no reliably
         # ordered server-side timestamp filter, so there is no incremental cursor to advance.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=[],
-            )
-            for endpoint in ENDPOINTS
-        ]
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-        return schemas
+        # INCREMENTAL_FIELDS is empty, so build_endpoint_schemas yields full-refresh-only schemas.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: PlanhatSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -129,6 +122,8 @@ You can create an API access token from a Private App under **Settings → Servi
         return planhat_source(
             api_token=config.api_key,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Planhat endpoint is full refresh
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planhat/tests/test_planhat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planhat/tests/test_planhat.py
@@ -1,19 +1,18 @@
+import json
 from typing import Any
 
 import pytest
 from unittest import mock
-from unittest.mock import MagicMock
 
-import requests
 from parameterized import parameterized
+from requests import Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.planhat import planhat
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.planhat.planhat import (
     PAGE_SIZE,
     PlanhatResumeConfig,
-    PlanhatRetryableError,
-    check_access,
-    get_rows,
     planhat_source,
     validate_credentials,
 )
@@ -22,199 +21,190 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.planhat.se
     PLANHAT_ENDPOINTS,
 )
 
-# Call the undecorated function so the tenacity retry/backoff wrapper doesn't slow failure-path tests.
-_fetch_page_unwrapped = planhat._fetch_page.__wrapped__  # type: ignore[attr-defined]
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# validate_credentials builds its own tracked session in the planhat module.
+PLANHAT_SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.planhat.planhat.make_tracked_session"
+)
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-class _FakeResumableManager:
-    def __init__(self, state: PlanhatResumeConfig | None = None) -> None:
-        self._state = state
-        self.saved: list[PlanhatResumeConfig] = []
-
-    def can_resume(self) -> bool:
-        return self._state is not None
-
-    def load_state(self) -> PlanhatResumeConfig | None:
-        return self._state
-
-    def save_state(self, data: PlanhatResumeConfig) -> None:
-        self.saved.append(data)
+def _response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://api.planhat.com/companies"
+    return resp
 
 
-def _full_page(start_id: int) -> list[dict]:
+def _make_manager(resume_state: PlanhatResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _wire(session: mock.MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+    """Wire a mock session and return a list capturing each request's params AT SEND TIME.
+
+    ``request.params`` is a single dict mutated in place across pages, so snapshot a copy when each
+    request is prepared instead of inspecting the shared dict after the run.
+    """
+    session.headers = {}
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        param_snapshots.append(dict(request.params or {}))
+        return mock.MagicMock()
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return param_snapshots
+
+
+def _full_page(start_id: int) -> list[dict[str, Any]]:
     return [{"_id": str(start_id + i)} for i in range(PAGE_SIZE)]
 
 
-class TestGetRows:
-    @staticmethod
-    def _collect(
-        manager: _FakeResumableManager, monkeypatch: Any, pages: dict[int, list[dict]], endpoint: str = "companies"
-    ) -> list[dict]:
-        def fake_fetch(session: Any, path: str, offset: int, limit: int, logger: Any) -> list[dict]:
-            return pages[offset]
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
 
-        monkeypatch.setattr(planhat, "_fetch_page", fake_fetch)
-        monkeypatch.setattr(planhat, "make_tracked_session", lambda **kwargs: MagicMock())
 
-        rows: list[dict] = []
-        for batch in get_rows(
-            api_token="ph-token",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=manager,  # type: ignore[arg-type]
-        ):
-            rows.extend(batch)
-        return rows
+class TestPagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_paginates_and_progresses_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response(_full_page(0)), _response([{"_id": "c_last"}])])
 
-    def test_single_short_page_yields_and_stops(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {0: [{"_id": "1"}, {"_id": "2"}]})
-        assert rows == [{"_id": "1"}, {"_id": "2"}]
-        # The page is short (< PAGE_SIZE), so we stop without persisting resume state.
-        assert manager.saved == []
+        manager = _make_manager()
+        rows = _rows(planhat_source("tok", "companies", team_id=1, job_id="j", resumable_source_manager=manager))
 
-    def test_follows_offset_pagination_until_short_page(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        pages = {0: _full_page(0), PAGE_SIZE: [{"_id": "999"}]}
-        rows = self._collect(manager, monkeypatch, pages)
-        assert len(rows) == PAGE_SIZE + 1
-        # State is saved after the first full page (offset advances to PAGE_SIZE), then we stop.
-        assert [s.offset for s in manager.saved] == [PAGE_SIZE]
+        assert [r["_id"] for r in rows] == [*(str(i) for i in range(PAGE_SIZE)), "c_last"]
+        assert params[0]["offset"] == 0
+        assert params[0]["limit"] == PAGE_SIZE
+        assert params[1]["offset"] == PAGE_SIZE
+        # Checkpoint saved after the first full page (points at the next page); short page ends it.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0] == PlanhatResumeConfig(offset=PAGE_SIZE)
 
-    def test_resumes_from_saved_offset(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager(PlanhatResumeConfig(offset=PAGE_SIZE))
-        # Offset 0 must never be fetched on resume.
-        pages = {PAGE_SIZE: [{"_id": "5"}]}
-        rows = self._collect(manager, monkeypatch, pages)
-        assert rows == [{"_id": "5"}]
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_short_first_page_makes_one_request_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([{"_id": "1"}, {"_id": "2"}])])
 
-    def test_empty_first_page_yields_nothing(self, monkeypatch: Any) -> None:
-        manager = _FakeResumableManager()
-        rows = self._collect(manager, monkeypatch, {0: []})
+        manager = _make_manager()
+        rows = _rows(planhat_source("tok", "companies", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert [r["_id"] for r in rows] == ["1", "2"]
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_first_page_yields_nothing_and_no_checkpoint(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response([])])
+
+        manager = _make_manager()
+        rows = _rows(planhat_source("tok", "companies", team_id=1, job_id="j", resumable_source_manager=manager))
+
         assert rows == []
-        assert manager.saved == []
+        assert session.send.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_offset(self, MockSession) -> None:
+        session = MockSession.return_value
+        params = _wire(session, [_response([{"_id": "5"}])])
+
+        manager = _make_manager(PlanhatResumeConfig(offset=PAGE_SIZE))
+        rows = _rows(planhat_source("tok", "companies", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert [r["_id"] for r in rows] == ["5"]
+        # Offset 0 must never be fetched on resume — the first request targets the saved offset.
+        assert params[0]["offset"] == PAGE_SIZE
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_request_targets_endpoint_path(self, MockSession) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        captured: list[str] = []
+
+        def _prepare(request: Any) -> mock.MagicMock:
+            captured.append(request.url)
+            return mock.MagicMock()
+
+        session.prepare_request.side_effect = _prepare
+        session.send.side_effect = [_response([{"_id": "1"}])]
+
+        _rows(planhat_source("tok", "endusers", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+        assert captured[0] == "https://api.planhat.com/endusers"
 
 
-class TestFetchPage:
-    def _session_returning(self, status_code: int, body: Any = None) -> MagicMock:
-        response = MagicMock()
-        response.status_code = status_code
-        response.ok = status_code < 400
-        response.json.return_value = body if body is not None else []
-        response.text = ""
-        response.raise_for_status.side_effect = (
-            requests.HTTPError(f"{status_code} error", response=response) if status_code >= 400 else None
+class TestMalformedBody:
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_non_list_body_is_retried_then_reraises(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.return_value = mock.MagicMock()
+        # A 200 body that is not a bare array (an error object) — retried, never ingested as a row.
+        session.send.return_value = _response({"error": "nope"})
+
+        with pytest.raises(RESTClientRetryableError, match="Unexpected 200 response body shape"):
+            _rows(planhat_source("tok", "companies", team_id=1, job_id="j", resumable_source_manager=_make_manager()))
+
+        # Exhausts the client's default retry budget (5 attempts) before giving up.
+        assert session.send.call_count == 5
+
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_malformed_then_valid_recovers(self, MockSession, _sleep) -> None:
+        session = MockSession.return_value
+        session.headers = {}
+        session.prepare_request.return_value = mock.MagicMock()
+        session.send.side_effect = [_response({"error": "glitch"}), _response([{"_id": "1"}])]
+
+        rows = _rows(
+            planhat_source("tok", "companies", team_id=1, job_id="j", resumable_source_manager=_make_manager())
         )
-        session = MagicMock()
-        session.get.return_value = response
-        return session
-
-    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
-    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(PlanhatRetryableError):
-            _fetch_page_unwrapped(session, "/companies", 0, PAGE_SIZE, MagicMock())
-
-    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
-    def test_client_errors_raise_for_status(self, _name: str, status: int) -> None:
-        session = self._session_returning(status)
-        with pytest.raises(requests.HTTPError):
-            _fetch_page_unwrapped(session, "/companies", 0, PAGE_SIZE, MagicMock())
-
-    def test_success_returns_list_body(self) -> None:
-        body = [{"_id": "1"}]
-        session = self._session_returning(200, body)
-        result = _fetch_page_unwrapped(session, "/companies", 0, PAGE_SIZE, MagicMock())
-        assert result == body
-
-    def test_non_list_body_is_retryable(self) -> None:
-        session = self._session_returning(200, {"error": "nope"})
-        with pytest.raises(PlanhatRetryableError):
-            _fetch_page_unwrapped(session, "/companies", 0, PAGE_SIZE, MagicMock())
-
-    def test_request_uses_limit_and_offset_params(self) -> None:
-        session = self._session_returning(200, [])
-        _fetch_page_unwrapped(session, "/endusers", 200, PAGE_SIZE, MagicMock())
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"limit": PAGE_SIZE, "offset": 200}
+        assert [r["_id"] for r in rows] == ["1"]
+        assert session.send.call_count == 2
 
 
-class TestCheckAccess:
-    @staticmethod
-    def _session(response: Any) -> MagicMock:
-        session = MagicMock()
-        if isinstance(response, Exception):
-            session.get.side_effect = response
-        else:
-            session.get.return_value = response
-        return session
-
-    @staticmethod
-    def _patch_session(session: MagicMock) -> Any:
-        # A context manager rather than the monkeypatch fixture — parameterized.expand hides the
-        # fixture from pytest's injector, so patch explicitly instead.
-        return mock.patch.object(planhat, "make_tracked_session", lambda **kwargs: session)
-
+class TestValidateCredentials:
     @parameterized.expand(
         [
-            ("ok", 200, True, 200, None),
-            ("unauthorized", 401, False, 401, None),
-            ("forbidden", 403, False, 403, None),
-            ("server_error", 500, False, 500, "Planhat returned HTTP 500"),
+            ("ok", 200, (True, None)),
+            ("unauthorized", 401, (False, "Invalid Planhat API token")),
+            ("forbidden", 403, (False, "Invalid Planhat API token")),
+            ("server_error", 500, (False, "Planhat returned HTTP 500")),
         ]
     )
-    def test_status_mapping(
-        self, _name: str, status: int, ok: bool, expected_status: int, expected_message: str | None
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = ok
-        with self._patch_session(self._session(response)):
-            assert check_access("ph-token") == (expected_status, expected_message)
+    @mock.patch(PLANHAT_SESSION_PATCH)
+    def test_status_mapping(self, _name: str, status: int, expected: tuple[bool, str | None], mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=status)
+        assert validate_credentials("tok") == expected
 
-    def test_probe_uses_limit_one(self) -> None:
-        response = MagicMock()
-        response.status_code = 200
-        response.ok = True
-        session = self._session(response)
-        with self._patch_session(session):
-            check_access("ph-token")
-        _, kwargs = session.get.call_args
-        assert kwargs["params"] == {"limit": 1, "offset": 0}
+    @mock.patch(PLANHAT_SESSION_PATCH)
+    def test_connection_error_is_not_validated(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("tok") == (False, "Could not validate Planhat API token")
 
-    def test_connection_error_maps_to_zero(self) -> None:
-        with self._patch_session(self._session(requests.ConnectionError("boom"))):
-            status, message = check_access("ph-token")
-        assert status == 0
-        assert message is not None and "boom" in message
-
-    @parameterized.expand(
-        [
-            ("ok", 200, True, None),
-            ("unauthorized", 401, False, "Invalid Planhat API token"),
-            ("forbidden", 403, False, "Invalid Planhat API token"),
-            ("server_error", 500, False, "Planhat returned HTTP 500"),
-        ]
-    )
-    def test_validate_credentials(
-        self, _name: str, status: int, expected_valid: bool, expected_message: str | None
-    ) -> None:
-        response = MagicMock()
-        response.status_code = status
-        response.ok = status < 400
-        with self._patch_session(self._session(response)):
-            assert validate_credentials("ph-token") == (expected_valid, expected_message)
+    @mock.patch(PLANHAT_SESSION_PATCH)
+    def test_probe_uses_limit_one(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = mock.MagicMock(status_code=200)
+        validate_credentials("tok")
+        url = mock_session.return_value.get.call_args.args[0]
+        assert url == "https://api.planhat.com/companies?limit=1&offset=0"
 
 
 class TestPlanhatSourceResponse:
     @parameterized.expand([(e,) for e in ENDPOINTS])
-    def test_source_response_shape(self, endpoint: str) -> None:
-        response = planhat_source(
-            api_token="ph-token",
-            endpoint=endpoint,
-            logger=MagicMock(),
-            resumable_source_manager=MagicMock(),
-        )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, MockSession) -> None:
+        response = planhat_source("tok", endpoint, team_id=1, job_id="j", resumable_source_manager=_make_manager())
         assert response.name == endpoint
         assert response.primary_keys == ["_id"]
         # No stable creation timestamp is guaranteed across every object, so we don't partition.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/pretix.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/pretix.py
@@ -7,31 +7,48 @@ is scoped to a single organizer, and every resource lives under
 ``/api/v1/organizers/{organizer}/...``.
 
 List endpoints are page-number paginated with a ``count``/``next``/``previous``/``results``
-envelope (page size defaults to the maximum of 50), where ``next`` is the full URL of the following
-page. Orders and invoices use the organizer-level list endpoints spanning all events; the remaining
-event-scoped resources fan out over the organizer's events.
+envelope where ``next`` is the full URL of the following page. Orders and invoices use the
+organizer-level list endpoints spanning all events; the remaining event-scoped resources fan out
+over the organizer's events.
 
 Only ``orders`` documents a server-side timestamp filter (``modified_since``) together with a
 ``last_modified`` ordering key, so it is the only incremental stream. Everything else is full
 refresh — pretix's other list endpoints only support ``If-Modified-Since`` conditional fetching
 (all-or-nothing 304s), which is not a per-row cursor.
+
+Built on the shared ``rest_source`` framework: a ``JSONResponsePaginator`` follows the ``next``
+link, framework ``api_key`` auth carries the token (and redacts it from errors/logs), ``allowed_hosts``
+pins every page/resume URL to the configured host, and ``allow_redirects=False`` rejects 3xx — the
+SSRF guards the hand-rolled transport enforced by hand. Event-scoped resources are single-hop
+dependent resources fanning out from the organizer's events list.
 """
 
 import re
 import dataclasses
-from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import quote, urlencode, urlparse
-
-import requests
-from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from urllib.parse import quote, urlparse
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _is_host_safe
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponsePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.resource import Resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+    EndpointResource,
+    IncrementalConfig,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.pretix.settings import (
     EVENT_SLUG_KEY,
     EVENTS_PATH,
@@ -43,20 +60,16 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pretix.set
 DEFAULT_API_HOST = "https://pretix.eu"
 API_VERSION_PATH = "/api/v1"
 
-REQUEST_TIMEOUT_SECONDS = 60
-MAX_RETRIES = 5
-# pretix Hosted enforces 360 requests/minute per organizer token and returns 429 + Retry-After.
-MAX_RETRY_AFTER_SECONDS = 60
-
 HOST_NOT_ALLOWED_ERROR = "pretix API URL is not allowed"
 HTTP_NOT_ALLOWED_ERROR = "pretix API URL must use HTTPS"
 INVALID_ORGANIZER_ERROR = "Invalid pretix organizer short name"
 
-
-class PretixRetryableError(Exception):
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
+# The parent event slug, percent-encoded, stashed on each event row so the child fan-out URL quotes
+# the slug exactly like the hand-rolled ``quote(slug, safe="")`` did — while the raw slug is stamped
+# into child rows unchanged (see ``EVENT_SLUG_KEY``).
+_EVENT_SLUG_ENCODED_KEY = "event_slug_encoded"
+# ``include_from_parent=["slug"]`` copies the parent's raw slug under this framework-derived name.
+_PARENT_SLUG_KEY = "_events_slug"
 
 
 class PretixHostNotAllowedError(Exception):
@@ -66,10 +79,13 @@ class PretixHostNotAllowedError(Exception):
 @dataclasses.dataclass
 class PretixResumeConfig:
     # Full URL of the next page to fetch, taken verbatim from the API's ``next`` link (query params,
-    # including any `modified_since` filter, are baked into it). Only persisted for organizer-level
-    # endpoints — event fan-out endpoints restart from the first event on resume and rely on merge
-    # dedupe, since event ordering is not guaranteed stable across runs.
+    # including any ``modified_since`` filter, are baked into it). Persisted for organizer-level
+    # (simple) endpoints.
     next_url: str | None = None
+    # Framework dependent-resource checkpoint for event fan-out endpoints (``{"completed": [...],
+    # "current": ..., "child_state": ...}``). Defaults to None so an old ``{"next_url": ...}`` state
+    # still parses after this change.
+    fanout_state: Optional[dict[str, Any]] = None
 
 
 def normalize_base_url(base_url: Optional[str]) -> str:
@@ -136,184 +152,64 @@ def _check_host(base_url: str, team_id: int) -> None:
         raise PretixHostNotAllowedError(HTTP_NOT_ALLOWED_ERROR)
 
 
-def _parse_retry_after(response: requests.Response) -> float | None:
-    """Honor a whole-second ``Retry-After`` on 429. HTTP-date forms are ignored."""
-    raw = response.headers.get("Retry-After")
-    if raw and raw.strip().isdigit():
-        return min(float(raw.strip()), MAX_RETRY_AFTER_SECONDS)
-    return None
+def _client_config(api_token: str, base_url: str) -> ClientConfig:
+    # Auth is supplied via the framework `api_key` config (header `Authorization: Token <token>`) so
+    # the value is redacted from logs and raised error messages; only the non-secret Accept header is
+    # set on the client. `allowed_hosts=[]` pins every page/resume URL to the base host (the base host
+    # is always implicitly allowed), and `allow_redirects=False` rejects 3xx — a tampered `next` link
+    # or a redirect can't hand the token to another origin.
+    return {
+        "base_url": base_url,
+        "auth": {
+            "type": "api_key",
+            "api_key": f"Token {api_token}",
+            "name": "Authorization",
+            "location": "header",
+        },
+        "headers": {"Accept": "application/json"},
+        "paginator": JSONResponsePaginator(next_url_path="next"),
+        "allowed_hosts": [],
+        "allow_redirects": False,
+    }
 
 
-def _retry_wait(retry_state: RetryCallState) -> float:
-    """Use a server-provided Retry-After when present, else exponential backoff."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, PretixRetryableError) and exc.retry_after is not None:
-        return exc.retry_after
-    return wait_exponential_jitter(initial=1, max=30)(retry_state)
+def _modified_since_incremental() -> IncrementalConfig:
+    return {
+        "cursor_path": "last_modified",
+        "start_param": "modified_since",
+        "convert": _format_modified_since,
+    }
 
 
-def _origin_of(url: str) -> tuple[str, str, int]:
-    # Same backslash normalization as `_host_of`, so the origin we compare is the one requests
-    # actually connects to.
-    normalized = url.replace("\\", "/").replace("%5c", "/").replace("%5C", "/")
-    parsed = urlparse(normalized)
-    scheme = parsed.scheme.lower()
-    port = parsed.port or (443 if scheme == "https" else 80)
-    return scheme, (parsed.hostname or "").lower(), port
-
-
-def _ensure_same_origin(url: str, base_url: str) -> None:
-    """Refuse pagination/resume URLs that leave the validated pretix origin.
-
-    ``next`` links come from the (possibly self-hosted, customer-controlled) server and resume URLs
-    from persisted state, while the session attaches the API token to every request — following an
-    off-origin URL would hand the token to an arbitrary host (or reach internal addresses)."""
-    if _origin_of(url) != _origin_of(base_url):
-        raise PretixHostNotAllowedError(f"pretix pagination URL is not on the configured pretix host: {url}")
-
-
-def _fetch_page_impl(
-    session: requests.Session,
-    url: str,
-    logger: FilteringBoundLogger,
-) -> tuple[list[dict[str, Any]], Optional[str]]:
-    """Fetch one list page. ``url`` is absolute — the initial endpoint URL (params baked in via
-    urlencode) or a verbatim ``next`` link, so page params are never re-sent."""
-    # Don't follow redirects: an attacker-controlled self-hosted URL could 3xx to an internal
-    # address, bypassing the host validation done before the request (SSRF).
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        retry_after = _parse_retry_after(response) if response.status_code == 429 else None
-        raise PretixRetryableError(
-            f"pretix API error (retryable): status={response.status_code}, url={url}", retry_after=retry_after
-        )
-
-    # A 3xx isn't an error status (`response.ok` is True), so reject it explicitly rather than
-    # silently parsing the redirect body as data.
-    if response.is_redirect or response.is_permanent_redirect:
-        raise PretixHostNotAllowedError(
-            f"pretix API returned an unexpected redirect (status={response.status_code}); refusing to follow it"
-        )
-
-    if not response.ok:
-        logger.error(f"pretix API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    data = response.json()
-    if not isinstance(data, dict) or not isinstance(data.get("results"), list):
-        raise PretixRetryableError(f"pretix returned an unexpected payload for {url}: {type(data).__name__}")
-
-    next_url = data.get("next")
-    return data["results"], next_url if isinstance(next_url, str) and next_url else None
-
-
-_fetch_page = retry(
-    retry=retry_if_exception_type((PretixRetryableError, requests.ReadTimeout, requests.ConnectionError)),
-    stop=stop_after_attempt(MAX_RETRIES),
-    wait=_retry_wait,
-    reraise=True,
-)(_fetch_page_impl)
-
-
-def _iter_pages(
-    session: requests.Session,
-    first_url: str,
-    base_url: str,
-    logger: FilteringBoundLogger,
-) -> Iterator[tuple[list[dict[str, Any]], Optional[str]]]:
-    """Yield ``(page_items, next_url)`` across every page starting at ``first_url``.
-
-    Every fetched URL — including a resumed ``first_url`` — and every ``next`` link is pinned to the
-    validated base origin before it is fetched or yielded (and thus before it can be persisted)."""
-    url: Optional[str] = first_url
-    while url:
-        _ensure_same_origin(url, base_url)
-        items, next_url = _fetch_page(session, url, logger)
-        if next_url:
-            _ensure_same_origin(next_url, base_url)
-        yield items, next_url
-        url = next_url
-
-
-def _build_url(base_url: str, path: str, params: dict[str, Any]) -> str:
-    return f"{base_url}{path}?{urlencode(params)}" if params else f"{base_url}{path}"
-
-
-def _iter_event_slugs(
-    session: requests.Session, base_url: str, organizer: str, logger: FilteringBoundLogger
-) -> Iterator[str]:
-    url = _build_url(base_url, EVENTS_PATH.format(organizer=organizer), {})
-    for page, _ in _iter_pages(session, url, base_url, logger):
-        for event in page:
-            # Fail fast on a malformed response rather than silently dropping an event's children.
-            yield str(event["slug"])
-
-
-def get_rows(
-    api_token: str,
-    organizer: str,
-    base_url: Optional[str],
-    endpoint: str,
-    team_id: int,
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[PretixResumeConfig],
-    should_use_incremental_field: bool = False,
-    db_incremental_field_last_value: Optional[Any] = None,
-    incremental_field: str | None = None,
-) -> Iterator[list[dict[str, Any]]]:
-    config: PretixEndpointConfig = PRETIX_ENDPOINTS[endpoint]
-    resolved_base_url = normalize_base_url(base_url)
-    # Re-check at run time (not just at source-create) in case the URL was edited or now resolves
-    # to an internal address (SSRF / DNS rebinding). Only enforced on cloud.
-    _check_host(resolved_base_url, team_id)
-    quoted_organizer = _quote_organizer(organizer)
-
-    # `redact_values` masks the token from captured HTTP samples — it rides in the Authorization
-    # header with the non-standard `Token` scheme.
-    session = make_tracked_session(headers=_get_headers(api_token), redact_values=(api_token,))
-
-    params: dict[str, Any] = {}
-    if config.ordering:
-        # An explicit stable sort keeps page boundaries deterministic, and for `orders` it makes the
-        # response order match SourceResponse.sort_mode="asc" so the incremental watermark advances
-        # correctly (DRF-style `ordering=<field>` is ascending).
-        params["ordering"] = config.ordering
-    # Only narrow with the server-side `modified_since` filter when the endpoint supports it and the
-    # user's chosen cursor is the field that filter targets. Honors inputs.incremental_field rather
-    # than assuming it.
-    if (
+def _should_apply_incremental(
+    config: PretixEndpointConfig,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+    incremental_field: Optional[str],
+) -> bool:
+    # Mirror the hand-rolled gate: only narrow with the server-side `modified_since` filter when the
+    # endpoint supports it and the user's chosen cursor is the field that filter targets
+    # (`last_modified`). Honors the selected incremental_field rather than assuming it.
+    return (
         should_use_incremental_field
-        and config.modified_since_field
-        and db_incremental_field_last_value
+        and config.modified_since_field is not None
+        and db_incremental_field_last_value is not None
         and incremental_field in (None, config.modified_since_field)
-    ):
-        params["modified_since"] = _format_modified_since(db_incremental_field_last_value)
+    )
 
-    if config.scope == EndpointScope.ORGANIZER:
-        resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-        if resume and resume.next_url:
-            logger.debug(f"pretix: resuming {endpoint} from saved page URL")
-            first_url = resume.next_url
-        else:
-            first_url = _build_url(resolved_base_url, config.path.format(organizer=quoted_organizer), params)
 
-        for page, next_url in _iter_pages(session, first_url, resolved_base_url, logger):
-            if page:
-                yield page
-            # Save AFTER yielding so a crash re-fetches from the last unpersisted page (merge
-            # dedupes the re-pulled page on the primary key).
-            if next_url:
-                resumable_source_manager.save_state(PretixResumeConfig(next_url=next_url))
-        return
+def _encode_event_slug(row: dict[str, Any]) -> dict[str, Any]:
+    # Percent-encode the slug for the child fan-out path (matches the old `quote(slug, safe="")`),
+    # keeping the raw `slug` for the row stamp. Fail fast on a malformed event with no slug.
+    row[_EVENT_SLUG_ENCODED_KEY] = quote(str(row["slug"]), safe="")
+    return row
 
-    # Event fan-out: paginate the child endpoint per event, stamping each row with its parent event
-    # slug so composite primary keys stay unique table-wide. No resume state is persisted here.
-    for event_slug in _iter_event_slugs(session, resolved_base_url, quoted_organizer, logger):
-        path = config.path.format(organizer=quoted_organizer, event=quote(event_slug, safe=""))
-        for page, _ in _iter_pages(session, _build_url(resolved_base_url, path, params), resolved_base_url, logger):
-            if page:
-                yield [{**row, EVENT_SLUG_KEY: event_slug} for row in page]
+
+def _stamp_event_slug(row: dict[str, Any]) -> dict[str, Any]:
+    # `include_from_parent=["slug"]` copies the raw parent slug under `_events_slug`; rename it to the
+    # stable `event_slug` column so composite primary keys (event_slug, id) stay table-wide unique.
+    row[EVENT_SLUG_KEY] = row.pop(_PARENT_SLUG_KEY)
+    return row
 
 
 def pretix_source(
@@ -322,34 +218,124 @@ def pretix_source(
     base_url: Optional[str],
     endpoint: str,
     team_id: int,
-    logger: FilteringBoundLogger,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[PretixResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
 ) -> SourceResponse:
-    config = PRETIX_ENDPOINTS[endpoint]
+    config: PretixEndpointConfig = PRETIX_ENDPOINTS[endpoint]
+    resolved_base_url = normalize_base_url(base_url)
+    # Re-check at run time (not just at source-create) in case the URL was edited or now resolves to
+    # an internal address (SSRF / DNS rebinding). Only enforced on cloud.
+    _check_host(resolved_base_url, team_id)
+    quoted_organizer = _quote_organizer(organizer)
+
+    incremental: Optional[IncrementalConfig] = None
+    if _should_apply_incremental(
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+    ):
+        incremental = _modified_since_incremental()
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resume is not None:
+        if resume.fanout_state:
+            initial_paginator_state = resume.fanout_state
+        elif resume.next_url:
+            initial_paginator_state = {"next_url": resume.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Save AFTER a page is yielded so a crash re-fetches the last page (merge dedupes on PK).
+        if not state:
+            return
+        if "next_url" in state:
+            if state.get("next_url"):
+                resumable_source_manager.save_state(PretixResumeConfig(next_url=state["next_url"]))
+        else:
+            resumable_source_manager.save_state(PretixResumeConfig(fanout_state=state))
+
+    client = _client_config(api_token, resolved_base_url)
+    # An explicit stable sort keeps page boundaries deterministic, and for `orders` makes the response
+    # order match `sort_mode="asc"` so the incremental watermark advances correctly.
+    static_params: dict[str, Any] = {"ordering": config.ordering} if config.ordering else {}
+
+    resource: Resource
+    if config.scope == EndpointScope.ORGANIZER:
+        organizer_endpoint: Endpoint = {
+            "path": config.path.format(organizer=quoted_organizer),
+            "data_selector": "results",
+            # An unexpected 200 body shape (not the `{results: [...]}` envelope) is treated as
+            # transient and reissued, as the hand-rolled fetch did.
+            "data_selector_malformed_retryable": True,
+        }
+        if static_params:
+            organizer_endpoint["params"] = static_params
+        if incremental is not None:
+            organizer_endpoint["incremental"] = incremental
+
+        rest_config: RESTAPIConfig = {
+            "client": client,
+            "resources": [{"name": endpoint, "endpoint": organizer_endpoint}],
+        }
+        resource = rest_api_resource(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+    else:
+        # Event fan-out: discover the organizer's events, then paginate the child endpoint per event,
+        # stamping each row with its parent event slug (single-hop dependent resource, resume enabled).
+        events_endpoint: Endpoint = {
+            "path": EVENTS_PATH.format(organizer=quoted_organizer),
+            "data_selector": "results",
+            "data_selector_malformed_retryable": True,
+        }
+        events_resource: EndpointResource = {
+            "name": "events",
+            "endpoint": events_endpoint,
+            "data_map": _encode_event_slug,
+        }
+
+        leaf_endpoint: Endpoint = {
+            "path": config.path.format(organizer=quoted_organizer, event="{event}"),
+            "data_selector": "results",
+            "params": {
+                "event": {"type": "resolve", "resource": "events", "field": _EVENT_SLUG_ENCODED_KEY},
+                **static_params,
+            },
+        }
+        leaf_resource: EndpointResource = {
+            "name": endpoint,
+            "endpoint": leaf_endpoint,
+            "include_from_parent": ["slug"],
+            "data_map": _stamp_event_slug,
+        }
+
+        rest_config = {"client": client, "resources": [events_resource, leaf_resource]}
+        built = rest_api_resources(
+            rest_config,
+            team_id,
+            job_id,
+            db_incremental_field_last_value,
+            resume_hook=save_checkpoint,
+            initial_paginator_state=initial_paginator_state,
+        )
+        resource = next(r for r in built if r.name == endpoint)
 
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            api_token=api_token,
-            organizer=organizer,
-            base_url=base_url,
-            endpoint=endpoint,
-            team_id=team_id,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-            should_use_incremental_field=should_use_incremental_field,
-            db_incremental_field_last_value=db_incremental_field_last_value,
-            incremental_field=incremental_field,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
+        column_hints=resource.column_hints,
     )
 
 
@@ -376,27 +362,26 @@ def validate_credentials(
     if not _is_https(resolved_base_url):
         return False, HTTP_NOT_ALLOWED_ERROR
 
-    url = _build_url(resolved_base_url, EVENTS_PATH.format(organizer=quoted_organizer), {"page_size": 1})
-    session = make_tracked_session(headers=_get_headers(api_token), redact_values=(api_token,))
-    try:
-        response = session.get(url, timeout=15, allow_redirects=False)
-    except Exception as e:
-        return False, f"Could not connect to pretix: {e}"
+    url = f"{resolved_base_url}{EVENTS_PATH.format(organizer=quoted_organizer)}?page_size=1"
+    # allow_redirects=False so a 3xx surfaces as its own status rather than being followed off-host.
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_token,), allow_redirects=False),
+        url,
+        headers=_get_headers(api_token),
+    )
 
-    if response.is_redirect or response.is_permanent_redirect:
-        return False, HOST_NOT_ALLOWED_ERROR
-
-    if response.status_code == 200:
+    if status is None:
+        return False, "Could not connect to pretix"
+    if status == 200:
         return True, None
-
-    if response.status_code == 401:
+    if 300 <= status < 400:
+        return False, HOST_NOT_ALLOWED_ERROR
+    if status == 401:
         return False, "Invalid pretix API token"
-
-    if response.status_code == 403:
+    if status == 403:
         # pretix returns 403 both for an unknown organizer and for a token without access to it.
         return False, (
             "Your pretix API token does not have access to this organizer. "
             "Check the organizer short name and the token's team permissions."
         )
-
-    return False, f"pretix returned HTTP {response.status_code}"
+    return False, f"pretix returned HTTP {status}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/source.py
@@ -156,7 +156,7 @@ Self-hosted users should set the API URL to their own pretix host (for example `
             base_url=config.base_url,
             endpoint=inputs.schema_name,
             team_id=inputs.team_id,
-            logger=inputs.logger,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/tests/test_pretix.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/tests/test_pretix.py
@@ -1,11 +1,13 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from unittest import mock
 
 from parameterized import parameterized
+from requests import Response
+from requests.structures import CaseInsensitiveDict
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.pretix import pretix as px
 from products.warehouse_sources.backend.temporal.data_imports.sources.pretix.pretix import (
@@ -13,44 +15,90 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.pretix.pre
     INVALID_ORGANIZER_ERROR,
     PretixHostNotAllowedError,
     PretixResumeConfig,
-    PretixRetryableError,
-    _fetch_page_impl,
     _format_modified_since,
-    _parse_retry_after,
     _quote_organizer,
-    get_rows,
     normalize_base_url,
     pretix_source,
     validate_credentials,
 )
 
-LOGGER = mock.MagicMock()
+# RESTClient builds its session via make_tracked_session in the rest_client module.
+CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+# tenacity sleeps between the client's own retries — patch it so retry tests don't actually wait.
+SLEEP_PATCH = "tenacity.nap.time.sleep"
 
 
-def _no_resume_manager() -> mock.MagicMock:
+def _envelope(items: list[dict[str, Any]], next_url: Optional[str]) -> Response:
+    body = {"count": len(items), "next": next_url, "previous": None, "results": items}
+    return _json_response(body)
+
+
+def _json_response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    return resp
+
+
+def _status_response(status_code: int, headers: Optional[dict[str, str]] = None) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = b"{}"
+    if headers:
+        resp.headers = CaseInsensitiveDict(headers)
+    return resp
+
+
+def _make_manager(resume_state: PretixResumeConfig | None = None) -> mock.MagicMock:
     manager = mock.MagicMock()
-    manager.can_resume.return_value = False
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
     return manager
 
 
-def _response(
-    status_code: int = 200,
-    json_data: Any = None,
-    headers: dict[str, str] | None = None,
-    is_redirect: bool = False,
-) -> mock.MagicMock:
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.headers = headers or {}
-    response.is_redirect = is_redirect
-    response.is_permanent_redirect = False
-    response.ok = status_code < 400
-    response.json.return_value = json_data
-    return response
+def _wire(session: mock.MagicMock, responses: list[Response]) -> tuple[list[str], list[dict[str, Any]]]:
+    """Wire a mock session and capture each request's URL and params AT SEND TIME.
+
+    ``request.url``/``request.params`` are mutated in place across pages (the paginator rewrites the
+    URL to the next-page link), so snapshot a copy when each request is prepared. ``prepared.url`` must
+    be the real string so the client's ``allowed_hosts`` check can parse a host from it.
+    """
+    session.headers = {}
+    url_snapshots: list[str] = []
+    param_snapshots: list[dict[str, Any]] = []
+
+    def _prepare(request: Any) -> mock.MagicMock:
+        url_snapshots.append(request.url)
+        param_snapshots.append(dict(request.params or {}))
+        prepared = mock.MagicMock()
+        prepared.url = request.url
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return url_snapshots, param_snapshots
 
 
-def _page(items: list[dict[str, Any]], next_url: Optional[str]) -> dict[str, Any]:
-    return {"count": len(items), "next": next_url, "previous": None, "results": items}
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _pages(source_response):
+    """Yield pages (not flattened) so a test can drive pagination one page at a time."""
+    yield from source_response.items()
+
+
+def _source(endpoint: str, manager: mock.MagicMock | None = None, base_url: str | None = None, **kwargs: Any):
+    return pretix_source(
+        api_token="tok",
+        organizer="acme",
+        base_url=base_url,
+        endpoint=endpoint,
+        team_id=1,
+        job_id="j",
+        resumable_source_manager=manager or _make_manager(),
+        **kwargs,
+    )
 
 
 class TestNormalizeBaseUrl:
@@ -101,98 +149,41 @@ class TestQuoteOrganizer:
             _quote_organizer(raw)
 
 
-class TestFetchPage:
-    # `_fetch_page_impl` is the undecorated fetch, so failures don't sleep through tenacity retries.
-
-    def test_returns_items_and_next_url(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response(json_data=_page([{"id": 1}], "https://pretix.eu/api/v1/x/?page=2"))
-
-        items, next_url = _fetch_page_impl(session, "https://pretix.eu/api/v1/x/", LOGGER)
-
-        assert items == [{"id": 1}]
-        assert next_url == "https://pretix.eu/api/v1/x/?page=2"
-
-    def test_null_next_terminates(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response(json_data=_page([{"id": 1}], None))
-
-        _, next_url = _fetch_page_impl(session, "https://pretix.eu/api/v1/x/", LOGGER)
-
-        assert next_url is None
-
-    def test_429_raises_retryable_with_retry_after(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response(status_code=429, headers={"Retry-After": "7"})
-
-        with pytest.raises(PretixRetryableError) as exc_info:
-            _fetch_page_impl(session, "https://pretix.eu/api/v1/x/", LOGGER)
-
-        assert exc_info.value.retry_after == 7.0
-
-    def test_5xx_raises_retryable(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response(status_code=503)
-
-        with pytest.raises(PretixRetryableError):
-            _fetch_page_impl(session, "https://pretix.eu/api/v1/x/", LOGGER)
-
-    def test_redirect_is_rejected(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response(status_code=302, is_redirect=True)
-
-        with pytest.raises(PretixHostNotAllowedError):
-            _fetch_page_impl(session, "https://pretix.eu/api/v1/x/", LOGGER)
-
-    def test_unexpected_payload_raises_retryable(self) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response(json_data=[{"id": 1}])
-
-        with pytest.raises(PretixRetryableError):
-            _fetch_page_impl(session, "https://pretix.eu/api/v1/x/", LOGGER)
-
-    @parameterized.expand(
-        [
-            ({"Retry-After": "7"}, 7.0),
-            ({"Retry-After": "999"}, 60.0),
-            ({"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}, None),
-            ({}, None),
-        ]
-    )
-    def test_parse_retry_after(self, headers: dict[str, str], expected: float | None) -> None:
-        assert _parse_retry_after(_response(status_code=429, headers=headers)) == expected
-
-
 @mock.patch.object(px, "_is_host_safe", return_value=(True, None))
-@mock.patch.object(px, "make_tracked_session", return_value=mock.MagicMock())
-class TestGetRowsOrganizerScope:
-    @mock.patch.object(px, "_fetch_page")
-    def test_orders_incremental_url_has_filter_and_stable_ordering(
-        self, mock_fetch: mock.MagicMock, _session: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
-        mock_fetch.return_value = ([{"code": "A1", "event": "conf"}], None)
+class TestOrganizerScopePagination:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_follows_next_link_and_terminates_on_null(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        page2 = "https://pretix.eu/api/v1/organizers/acme/orders/?page=2"
+        urls, _params = _wire(
+            session,
+            [_envelope([{"code": "A1"}], page2), _envelope([{"code": "A2"}], None)],
+        )
 
-        list(
-            get_rows(
-                api_token="tok",
-                organizer="acme",
-                base_url=None,
-                endpoint="orders",
-                team_id=1,
-                logger=LOGGER,
-                resumable_source_manager=_no_resume_manager(),
+        rows = _rows(_source("orders"))
+
+        assert [r["code"] for r in rows] == ["A1", "A2"]
+        # The self-contained next link is followed verbatim; a null next ends pagination.
+        assert urls[0].endswith("/organizers/acme/orders/")
+        assert urls[1] == page2
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_orders_incremental_url_has_filter_and_stable_ordering(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        _urls, params = _wire(session, [_envelope([{"code": "A1", "event": "conf"}], None)])
+
+        _rows(
+            _source(
+                "orders",
                 should_use_incremental_field=True,
                 db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
                 incremental_field="last_modified",
             )
         )
 
-        url = mock_fetch.call_args[0][1]
-        parsed = urlparse(url)
-        assert parsed.path == "/api/v1/organizers/acme/orders/"
-        query = parse_qs(parsed.query)
-        assert query["modified_since"] == ["2026-01-01T00:00:00Z"]
-        assert query["ordering"] == ["last_modified"]
+        assert params[0]["modified_since"] == "2026-01-01T00:00:00Z"
+        assert params[0]["ordering"] == "last_modified"
 
     @parameterized.expand(
         [
@@ -202,237 +193,188 @@ class TestGetRowsOrganizerScope:
             (True, "datetime"),
         ]
     )
-    @mock.patch.object(px, "_fetch_page")
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_no_modified_since_when_not_applicable(
-        self,
-        should_use: bool,
-        incremental_field: str,
-        mock_fetch: mock.MagicMock,
-        _session: mock.MagicMock,
-        _host: mock.MagicMock,
+        self, should_use: bool, incremental_field: str, MockSession, _host
     ) -> None:
-        mock_fetch.return_value = ([], None)
+        session = MockSession.return_value
+        _urls, params = _wire(session, [_envelope([], None)])
 
-        list(
-            get_rows(
-                api_token="tok",
-                organizer="acme",
-                base_url=None,
-                endpoint="orders",
-                team_id=1,
-                logger=LOGGER,
-                resumable_source_manager=_no_resume_manager(),
+        _rows(
+            _source(
+                "orders",
                 should_use_incremental_field=should_use,
                 db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
                 incremental_field=incremental_field,
             )
         )
 
-        url = mock_fetch.call_args[0][1]
-        assert "modified_since" not in url
+        assert "modified_since" not in params[0]
+        # `ordering` is always requested for orders regardless of the incremental filter.
+        assert params[0]["ordering"] == "last_modified"
 
-    @mock.patch.object(px, "_fetch_page")
-    def test_state_saved_only_after_page_is_yielded(
-        self, mock_fetch: mock.MagicMock, _session: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
-        next_url = "https://pretix.eu/api/v1/organizers/acme/orders/?page=2"
-        mock_fetch.side_effect = [
-            ([{"code": "A1"}], next_url),
-            ([{"code": "A2"}], None),
-        ]
-        manager = _no_resume_manager()
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_state_saved_only_after_page_is_yielded(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        page2 = "https://pretix.eu/api/v1/organizers/acme/orders/?page=2"
+        _wire(session, [_envelope([{"code": "A1"}], page2), _envelope([{"code": "A2"}], None)])
+        manager = _make_manager()
 
-        rows = get_rows(
-            api_token="tok",
-            organizer="acme",
-            base_url=None,
-            endpoint="orders",
-            team_id=1,
-            logger=LOGGER,
-            resumable_source_manager=manager,
-        )
+        rows = iter(_pages(_source("orders", manager)))
 
         assert next(rows) == [{"code": "A1"}]
         # A crash here must re-fetch page 1 (nothing persisted yet), not skip it.
         manager.save_state.assert_not_called()
 
         assert next(rows) == [{"code": "A2"}]
-        manager.save_state.assert_called_once_with(PretixResumeConfig(next_url=next_url))
+        # After page 1 is yielded the checkpoint points at page 2 (the verbatim next link).
+        manager.save_state.assert_called_once_with(PretixResumeConfig(next_url=page2))
 
-    @mock.patch.object(px, "_fetch_page")
-    def test_off_origin_next_url_is_rejected_before_yield(
-        self, mock_fetch: mock.MagicMock, _session: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
-        # The session sends the API token on every request, so a malicious server handing out an
-        # off-origin `next` link must not be followed — or persisted for a later resume.
-        mock_fetch.return_value = ([{"code": "A1"}], "https://evil.example.com/steal?page=2")
-        manager = _no_resume_manager()
-
-        with pytest.raises(PretixHostNotAllowedError):
-            list(
-                get_rows(
-                    api_token="tok",
-                    organizer="acme",
-                    base_url=None,
-                    endpoint="orders",
-                    team_id=1,
-                    logger=LOGGER,
-                    resumable_source_manager=manager,
-                )
-            )
-
-        assert mock_fetch.call_count == 1
-        manager.save_state.assert_not_called()
-
-    @mock.patch.object(px, "_fetch_page")
-    def test_off_origin_resume_url_is_rejected_before_fetch(
-        self, mock_fetch: mock.MagicMock, _session: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = PretixResumeConfig(next_url="https://evil.example.com/steal?page=5")
-
-        with pytest.raises(PretixHostNotAllowedError):
-            list(
-                get_rows(
-                    api_token="tok",
-                    organizer="acme",
-                    base_url=None,
-                    endpoint="orders",
-                    team_id=1,
-                    logger=LOGGER,
-                    resumable_source_manager=manager,
-                )
-            )
-
-        mock_fetch.assert_not_called()
-
-    @mock.patch.object(px, "_fetch_page")
-    def test_resumes_from_saved_next_url(
-        self, mock_fetch: mock.MagicMock, _session: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_resumes_from_saved_next_url(self, MockSession, _host) -> None:
+        session = MockSession.return_value
         saved_url = "https://pretix.eu/api/v1/organizers/acme/orders/?page=5"
-        manager = mock.MagicMock()
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = PretixResumeConfig(next_url=saved_url)
-        mock_fetch.return_value = ([{"code": "A9"}], None)
+        urls, _params = _wire(session, [_envelope([{"code": "A9"}], None)])
 
-        list(
-            get_rows(
-                api_token="tok",
-                organizer="acme",
-                base_url=None,
-                endpoint="orders",
-                team_id=1,
-                logger=LOGGER,
-                resumable_source_manager=manager,
-            )
-        )
+        _rows(_source("orders", _make_manager(PretixResumeConfig(next_url=saved_url))))
 
-        assert mock_fetch.call_args[0][1] == saved_url
+        assert urls[0] == saved_url
 
-    def test_unsafe_host_raises_before_any_request(
-        self, session_factory: mock.MagicMock, mock_host: mock.MagicMock
-    ) -> None:
-        mock_host.return_value = (False, HOST_NOT_ALLOWED_ERROR)
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_retries_then_succeeds_on_429(self, MockSession, _sleep, _host) -> None:
+        session = MockSession.return_value
+        _wire(session, [_status_response(429, {"Retry-After": "1"}), _envelope([{"code": "A1"}], None)])
 
-        with pytest.raises(PretixHostNotAllowedError):
-            list(
-                get_rows(
-                    api_token="tok",
-                    organizer="acme",
-                    base_url="https://internal.example.com",
-                    endpoint="orders",
-                    team_id=1,
-                    logger=LOGGER,
-                    resumable_source_manager=_no_resume_manager(),
-                )
-            )
+        rows = _rows(_source("orders"))
 
-        session_factory.return_value.get.assert_not_called()
+        assert [r["code"] for r in rows] == ["A1"]
+        assert session.send.call_count == 2
 
-    def test_http_base_url_raises(self, session_factory: mock.MagicMock, _host: mock.MagicMock) -> None:
-        with pytest.raises(PretixHostNotAllowedError):
-            list(
-                get_rows(
-                    api_token="tok",
-                    organizer="acme",
-                    base_url="http://tickets.example.com",
-                    endpoint="orders",
-                    team_id=1,
-                    logger=LOGGER,
-                    resumable_source_manager=_no_resume_manager(),
-                )
-            )
+    @mock.patch(SLEEP_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unexpected_payload_shape_is_retried(self, MockSession, _sleep, _host) -> None:
+        session = MockSession.return_value
+        # A 200 whose body isn't the `{results: [...]}` envelope is treated as transient and reissued,
+        # not failed loud or ingested as a garbage row.
+        _wire(session, [_json_response([{"code": "A1"}]), _envelope([{"code": "A2"}], None)])
 
-        session_factory.return_value.get.assert_not_called()
+        rows = _rows(_source("orders"))
+
+        assert [r["code"] for r in rows] == ["A2"]
+        assert session.send.call_count == 2
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_redirect_is_rejected(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        _wire(session, [_status_response(302, {"Location": "https://pretix.eu/login"})])
+
+        # A 3xx is not followed (allow_redirects=False) — it must not be silently parsed as data.
+        with pytest.raises(ValueError, match="[Rr]edirect"):
+            _rows(_source("orders"))
 
 
 @mock.patch.object(px, "_is_host_safe", return_value=(True, None))
-@mock.patch.object(px, "make_tracked_session", return_value=mock.MagicMock())
-class TestGetRowsEventFanOut:
-    @mock.patch.object(px, "_fetch_page")
-    def test_fans_out_per_event_and_stamps_event_slug(
-        self, mock_fetch: mock.MagicMock, _session: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
-        def router(_session: Any, url: str, _logger: Any) -> tuple[list[dict[str, Any]], Optional[str]]:
-            path = urlparse(url).path
-            if path == "/api/v1/organizers/acme/events/":
-                return [{"slug": "conf-a"}, {"slug": "conf-b"}], None
-            if path == "/api/v1/organizers/acme/events/conf-a/items/":
-                return [{"id": 1}], None
-            if path == "/api/v1/organizers/acme/events/conf-b/items/":
-                return [{"id": 1}, {"id": 2}], None
-            raise AssertionError(f"unexpected url {url}")
+class TestHostPinning:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_off_host_next_url_is_not_fetched(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        # A malicious server handing out an off-host `next` link must never be fetched — the
+        # Authorization header would otherwise be sent to an attacker-controlled origin.
+        _wire(session, [_envelope([{"code": "A1"}], "https://evil.example.com/steal?page=2")])
 
-        mock_fetch.side_effect = router
-        manager = _no_resume_manager()
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("orders"))
 
-        pages = list(
-            get_rows(
+        # Only the first (on-host) page was ever sent.
+        assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_off_host_resume_url_is_rejected_before_any_request(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        _wire(session, [])
+        manager = _make_manager(PretixResumeConfig(next_url="https://evil.example.com/steal?page=5"))
+
+        with pytest.raises(ValueError, match="disallowed host"):
+            _rows(_source("orders", manager))
+
+        session.send.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_unsafe_host_raises_before_building_the_source(self, MockSession, mock_host) -> None:
+        mock_host.return_value = (False, HOST_NOT_ALLOWED_ERROR)
+
+        with pytest.raises(PretixHostNotAllowedError):
+            _source("orders", base_url="https://internal.example.com")
+
+        MockSession.return_value.send.assert_not_called()
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_http_base_url_raises_before_building_the_source(self, MockSession, _host) -> None:
+        with pytest.raises(PretixHostNotAllowedError):
+            pretix_source(
                 api_token="tok",
                 organizer="acme",
-                base_url=None,
-                endpoint="items",
+                base_url="http://tickets.example.com",
+                endpoint="orders",
                 team_id=1,
-                logger=LOGGER,
-                resumable_source_manager=manager,
+                job_id="j",
+                resumable_source_manager=_make_manager(),
             )
+
+        MockSession.return_value.send.assert_not_called()
+
+
+@mock.patch.object(px, "_is_host_safe", return_value=(True, None))
+class TestEventFanOut:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_fans_out_per_event_and_stamps_event_slug(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _envelope([{"slug": "conf-a"}, {"slug": "conf-b"}], None),  # events discovery
+                _envelope([{"id": 1}], None),  # conf-a items
+                _envelope([{"id": 1}, {"id": 2}], None),  # conf-b items
+            ],
+        )
+        manager = _make_manager()
+
+        rows = _rows(_source("items", manager))
+
+        # The composite primary key (event_slug, id) stays unique even though both events reuse id=1.
+        assert [(r["event_slug"], r["id"]) for r in rows] == [("conf-a", 1), ("conf-b", 1), ("conf-b", 2)]
+        # The single-hop fan-out is resumable — a per-event checkpoint is persisted.
+        assert manager.save_state.called
+        assert manager.save_state.call_args.args[0].fanout_state is not None
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_event_slug_is_url_quoted_in_child_path(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        urls, _params = _wire(
+            session,
+            [_envelope([{"slug": "a/b"}], None), _envelope([], None)],
         )
 
-        rows = [row for page in pages for row in page]
-        # The composite primary key (event_slug, id) must stay unique even though both events reuse id=1.
-        assert [(row["event_slug"], row["id"]) for row in rows] == [("conf-a", 1), ("conf-b", 1), ("conf-b", 2)]
-        # Fan-out endpoints restart from the first event on resume; no partial state may be persisted.
-        manager.save_state.assert_not_called()
+        rows = _rows(_source("items", _make_manager()))
 
-    @mock.patch.object(px, "_fetch_page")
-    def test_event_slug_is_url_quoted_in_child_path(
-        self, mock_fetch: mock.MagicMock, _session: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
-        seen_urls: list[str] = []
+        # The slug is percent-encoded in the child URL so it can't inject an extra path segment...
+        assert any("/events/a%2Fb/items/" in url for url in urls)
+        # ...while the raw slug is stamped into rows unchanged (there are no rows here, so just the URL).
+        assert rows == []
 
-        def router(_session: Any, url: str, _logger: Any) -> tuple[list[dict[str, Any]], Optional[str]]:
-            seen_urls.append(url)
-            if urlparse(url).path == "/api/v1/organizers/acme/events/":
-                return [{"slug": "a/b"}], None
-            return [], None
-
-        mock_fetch.side_effect = router
-
-        list(
-            get_rows(
-                api_token="tok",
-                organizer="acme",
-                base_url=None,
-                endpoint="items",
-                team_id=1,
-                logger=LOGGER,
-                resumable_source_manager=_no_resume_manager(),
-            )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_ordering_param_sent_for_sortable_child_endpoint(self, MockSession, _host) -> None:
+        session = MockSession.return_value
+        _urls, params = _wire(
+            session,
+            [_envelope([{"slug": "conf-a"}], None), _envelope([{"id": 1}], None)],
         )
 
-        assert any("/events/a%2Fb/items/" in url for url in seen_urls)
+        _rows(_source("items", _make_manager()))
+
+        # `items` requests an explicit stable `ordering=id`; the child (leaf) request carries it.
+        assert params[-1].get("ordering") == "id"
 
 
 @mock.patch.object(px, "_is_host_safe", return_value=(True, None))
@@ -442,20 +384,16 @@ class TestValidateCredentials:
             (200, True, None),
             (401, False, "Invalid pretix API token"),
             (403, False, "does not have access to this organizer"),
+            (302, False, HOST_NOT_ALLOWED_ERROR),
             (500, False, "HTTP 500"),
         ]
     )
     @mock.patch.object(px, "make_tracked_session")
     def test_status_mapping(
-        self,
-        status_code: int,
-        expected_valid: bool,
-        message_fragment: str | None,
-        session_factory: mock.MagicMock,
-        _host: mock.MagicMock,
+        self, status_code: int, expected_valid: bool, message_fragment: str | None, session_factory, _host
     ) -> None:
         session = mock.MagicMock()
-        session.get.return_value = _response(status_code=status_code)
+        session.get.return_value = mock.MagicMock(status_code=status_code)
         session_factory.return_value = session
 
         is_valid, message = validate_credentials("tok", "acme", None, team_id=1)
@@ -467,18 +405,7 @@ class TestValidateCredentials:
             assert message is not None and message_fragment in message
 
     @mock.patch.object(px, "make_tracked_session")
-    def test_redirect_is_rejected(self, session_factory: mock.MagicMock, _host: mock.MagicMock) -> None:
-        session = mock.MagicMock()
-        session.get.return_value = _response(status_code=302, is_redirect=True)
-        session_factory.return_value = session
-
-        is_valid, message = validate_credentials("tok", "acme", None, team_id=1)
-
-        assert is_valid is False
-        assert message == HOST_NOT_ALLOWED_ERROR
-
-    @mock.patch.object(px, "make_tracked_session")
-    def test_connection_error_returns_message(self, session_factory: mock.MagicMock, _host: mock.MagicMock) -> None:
+    def test_connection_error_returns_message(self, session_factory, _host) -> None:
         session = mock.MagicMock()
         session.get.side_effect = Exception("network down")
         session_factory.return_value = session
@@ -489,9 +416,7 @@ class TestValidateCredentials:
         assert message is not None and "Could not connect to pretix" in message
 
     @mock.patch.object(px, "make_tracked_session")
-    def test_invalid_organizer_rejected_without_request(
-        self, session_factory: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
+    def test_invalid_organizer_rejected_without_request(self, session_factory, _host) -> None:
         is_valid, message = validate_credentials("tok", "  ", None, team_id=1)
 
         assert is_valid is False
@@ -499,9 +424,7 @@ class TestValidateCredentials:
         session_factory.assert_not_called()
 
     @mock.patch.object(px, "make_tracked_session")
-    def test_http_base_url_rejected_without_request(
-        self, session_factory: mock.MagicMock, _host: mock.MagicMock
-    ) -> None:
+    def test_http_base_url_rejected_without_request(self, session_factory, _host) -> None:
         is_valid, message = validate_credentials("tok", "acme", "http://tickets.example.com", team_id=1)
 
         assert is_valid is False
@@ -510,19 +433,9 @@ class TestValidateCredentials:
 
 
 class TestPretixSourceResponse:
-    def _source(self, endpoint: str):
-        return pretix_source(
-            api_token="tok",
-            organizer="acme",
-            base_url=None,
-            endpoint=endpoint,
-            team_id=1,
-            logger=LOGGER,
-            resumable_source_manager=mock.MagicMock(),
-        )
-
+    # No host patch needed — `is_cloud()` is False in tests, so `_check_host` short-circuits to safe.
     def test_orders_partitioned_on_stable_creation_datetime(self) -> None:
-        response = self._source("orders")
+        response = _source("orders")
 
         assert response.name == "orders"
         assert response.primary_keys == ["event", "code"]
@@ -542,7 +455,7 @@ class TestPretixSourceResponse:
         ]
     )
     def test_primary_keys_per_endpoint(self, endpoint: str, primary_keys: list[str]) -> None:
-        response = self._source(endpoint)
+        response = _source(endpoint)
 
         assert response.primary_keys == primary_keys
         assert response.partition_mode is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/tests/test_pretix_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pretix/tests/test_pretix_source.py
@@ -124,7 +124,7 @@ class TestPretixSource:
         inputs = mock.MagicMock()
         inputs.schema_name = "orders"
         inputs.team_id = self.team_id
-        inputs.logger = mock.MagicMock()
+        inputs.job_id = "job-123"
         inputs.should_use_incremental_field = True
         inputs.db_incremental_field_last_value = "2026-01-01T00:00:00Z"
         inputs.incremental_field = "last_modified"
@@ -137,7 +137,7 @@ class TestPretixSource:
             base_url=self.config.base_url,
             endpoint="orders",
             team_id=self.team_id,
-            logger=inputs.logger,
+            job_id="job-123",
             resumable_source_manager=manager,
             should_use_incremental_field=True,
             db_incremental_field_last_value="2026-01-01T00:00:00Z",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/raygun/raygun.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/raygun/raygun.py
@@ -1,55 +1,44 @@
 import dataclasses
-from collections.abc import Callable, Iterator
-from typing import Any
-from urllib.parse import urlencode
-
-from structlog.types import FilteringBoundLogger
+from typing import Any, Optional
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+    rest_api_resources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    OffsetPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.raygun.settings import (
     PAGE_SIZE,
     RAYGUN_BASE_URL,
     RAYGUN_ENDPOINTS,
-    RaygunEndpointConfig,
 )
 
-# Per-request timeout. Raygun list endpoints return at most `count` (<=500) rows, so pages
-# stay small; a generous ceiling covers a slow response without wedging the worker.
-REQUEST_TIMEOUT = 60
-
-# Fields dropped from ingested rows before they reach the warehouse table, keyed by endpoint path.
 # The `applications` response carries `apiKey` — the ingestion key for that application — which
 # anyone with warehouse viewer access could otherwise read and use to submit forged crash/APM/RUM
-# data. It is never needed downstream, so strip it at the source; disabling HTTP sample capture
-# does not protect the imported table.
-_SENSITIVE_FIELDS: dict[str, frozenset[str]] = {
-    RAYGUN_ENDPOINTS["applications"].path: frozenset({"apiKey"}),
-}
-
-
-def _scrub(path: str, data: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    sensitive = _SENSITIVE_FIELDS.get(path)
-    if not sensitive:
-        return data
-    return [{key: value for key, value in row.items() if key not in sensitive} for row in data]
+# data. It is never needed downstream, so strip it at the source.
+_APPLICATIONS_SENSITIVE_FIELDS = frozenset({"apiKey"})
 
 
 @dataclasses.dataclass
 class RaygunResumeConfig:
-    # Offset (rows to skip) for the next page of the endpoint/application currently in progress.
+    # Offset (rows to skip) for the next page of a top-level list endpoint.
     offset: int = 0
-    # For fan-out endpoints, the application whose child list we were paging when state was saved.
-    # None for the top-level `applications` endpoint.
+    # Retained so resume state saved before the rest_source migration still parses; the fan-out
+    # bookmark now lives in `fanout_state`. Never written by the current code.
     application_identifier: str | None = None
+    # Framework dependent-resource resume state for fan-out endpoints, of the shape
+    # ``{"completed": [child_path, ...], "current": child_path | None, "child_state": {...} | None}``.
+    fanout_state: dict[str, Any] | None = None
 
 
-def _get_headers(personal_access_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {personal_access_token}",
-        "Accept": "application/json",
-    }
+def _strip_application_api_key(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in row.items() if key not in _APPLICATIONS_SENSITIVE_FIELDS}
 
 
 def _make_session(personal_access_token: str) -> Any:
@@ -57,8 +46,22 @@ def _make_session(personal_access_token: str) -> Any:
     # IP addresses) and application rows carry ingestion API keys — fields the name-based sample
     # scrubbers can't recognise, so keep response bodies out of HTTP sample storage entirely.
     # Requests are still metered and logged (status + url). `redact_values` masks the token as
-    # defense in depth.
+    # defense in depth (the framework auth also scrubs it from raised errors).
     return make_tracked_session(redact_values=(personal_access_token,), capture=False)
+
+
+def _client_config(personal_access_token: str) -> dict[str, Any]:
+    return {
+        "base_url": RAYGUN_BASE_URL,
+        # Auth (Bearer) goes through the framework auth config so its value is redacted from raised
+        # errors; only the non-secret Accept header is set here.
+        "headers": {"Accept": "application/json"},
+        "auth": {"type": "bearer", "token": personal_access_token},
+        "session": _make_session(personal_access_token),
+        # Raygun list endpoints return a bare JSON array with no `total`; termination is the
+        # short/empty page (OffsetPaginator default). `count` is Raygun's page-size param.
+        "paginator": OffsetPaginator(limit=PAGE_SIZE, limit_param="count", total_path=None),
+    }
 
 
 def validate_token(personal_access_token: str) -> tuple[bool, int | None]:
@@ -66,163 +69,155 @@ def validate_token(personal_access_token: str) -> tuple[bool, int | None]:
 
     A 200 confirms the token is genuine and carries `applications:read`. The status code lets the
     caller distinguish a bad token (401) from a valid token missing a scope (403)."""
-    url = f"{RAYGUN_BASE_URL}/applications?{urlencode({'count': 1})}"
-    try:
-        response = _make_session(personal_access_token).get(
-            url, headers=_get_headers(personal_access_token), timeout=REQUEST_TIMEOUT
-        )
-    except Exception:
-        return False, None
-    return response.status_code == 200, response.status_code
+    return validate_via_probe(
+        lambda: _make_session(personal_access_token),
+        f"{RAYGUN_BASE_URL}/applications?count=1",
+        headers={"Authorization": f"Bearer {personal_access_token}", "Accept": "application/json"},
+    )
 
 
-def _fetch_page(
-    session: Any, path: str, params: dict[str, Any], headers: dict[str, str], logger: FilteringBoundLogger
-) -> list[dict[str, Any]]:
-    """Fetch one offset/count page. Raygun list endpoints return a bare JSON array."""
-    url = f"{RAYGUN_BASE_URL}{path}?{urlencode(params)}"
-    # The tracked session's DEFAULT_RETRY already backs off on 429/5xx (honoring Retry-After);
-    # anything still non-2xx here is terminal for this request.
-    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
-    if not response.ok:
-        logger.error(f"Raygun API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-    data = response.json()
-    if not isinstance(data, list):
-        return []
-    return _scrub(path, data)
-
-
-def _iter_application_identifiers(session: Any, headers: dict[str, str], logger: FilteringBoundLogger) -> list[str]:
-    """Enumerate every application identifier, following offset pagination to completion."""
-    identifiers: list[str] = []
-    offset = 0
-    while True:
-        page = _fetch_page(
-            session,
-            RAYGUN_ENDPOINTS["applications"].path,
-            {"count": PAGE_SIZE, "offset": offset, "orderby": RAYGUN_ENDPOINTS["applications"].orderby},
-            headers,
-            logger,
-        )
-        identifiers.extend(item["identifier"] for item in page if item.get("identifier"))
-        if len(page) < PAGE_SIZE:
-            break
-        offset += PAGE_SIZE
-    return identifiers
-
-
-def _paginate(
-    session: Any,
-    path: str,
-    orderby: str,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    start_offset: int,
-    on_page: Callable[[int], None],
-) -> Iterator[list[dict[str, Any]]]:
-    """Yield successive offset/count pages for a single list, starting at `start_offset`.
-
-    `on_page(next_offset)` is invoked after each yielded page (only when another page remains) so
-    the caller can persist resume state pointing at the page we have not yet fetched."""
-    offset = start_offset
-    while True:
-        page = _fetch_page(session, path, {"count": PAGE_SIZE, "offset": offset, "orderby": orderby}, headers, logger)
-        if page:
-            yield page
-        # A short page (fewer than a full `count`) is the last one.
-        if len(page) < PAGE_SIZE:
-            break
-        offset += PAGE_SIZE
-        on_page(offset)
-
-
-def _get_top_level_rows(
-    session: Any,
-    config: RaygunEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[RaygunResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_offset = resume.offset if resume is not None else 0
-
-    def save(next_offset: int) -> None:
-        resumable_source_manager.save_state(RaygunResumeConfig(offset=next_offset))
-
-    yield from _paginate(session, config.path, config.orderby, headers, logger, start_offset, save)
-
-
-def _get_fan_out_rows(
-    session: Any,
-    config: RaygunEndpointConfig,
-    headers: dict[str, str],
-    logger: FilteringBoundLogger,
-    resumable_source_manager: ResumableSourceManager[RaygunResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
-    application_identifiers = _iter_application_identifiers(session, headers, logger)
-
-    # Resolve the saved bookmark to the slice of applications still to process. If the bookmarked
-    # application no longer exists, start over from the first — merge dedupes re-pulled rows on the
-    # primary key.
-    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    remaining = application_identifiers
-    resume_offset = 0
-    if resume is not None and resume.application_identifier in application_identifiers:
-        remaining = application_identifiers[application_identifiers.index(resume.application_identifier) :]
-        resume_offset = resume.offset
-        logger.debug(f"Raygun: resuming {config.name} from application={resume.application_identifier}")
-
-    for index, application_identifier in enumerate(remaining):
-        path = config.path.format(application_identifier=application_identifier)
-        start_offset = resume_offset if index == 0 else 0
-
-        def save(next_offset: int, app: str = application_identifier) -> None:
-            resumable_source_manager.save_state(RaygunResumeConfig(offset=next_offset, application_identifier=app))
-
-        yield from _paginate(session, path, config.orderby, headers, logger, start_offset, save)
-
-        # Advance the bookmark to the next application so a crash between applications resumes at
-        # its first page rather than re-walking the one just completed.
-        if index + 1 < len(remaining):
-            resumable_source_manager.save_state(
-                RaygunResumeConfig(offset=0, application_identifier=remaining[index + 1])
-            )
-
-
-def get_rows(
+def _top_level_source(
     personal_access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[RaygunResumeConfig],
-) -> Iterator[list[dict[str, Any]]]:
+    db_incremental_field_last_value: Optional[Any],
+):
     config = RAYGUN_ENDPOINTS[endpoint]
-    headers = _get_headers(personal_access_token)
-    # One session reused across every page so urllib3 keeps the connection alive.
-    session = _make_session(personal_access_token)
 
-    if config.fan_out_over_applications:
-        yield from _get_fan_out_rows(session, config, headers, logger, resumable_source_manager)
-    else:
-        yield from _get_top_level_rows(session, config, headers, logger, resumable_source_manager)
+    resource_config: dict[str, Any] = {
+        "name": endpoint,
+        "endpoint": {
+            "path": config.path,
+            "params": {"orderby": config.orderby},
+        },
+    }
+    if endpoint == "applications":
+        resource_config["data_map"] = _strip_application_api_key
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(personal_access_token),
+        "resources": [resource_config],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        # Only seed from a top-level (offset) checkpoint; a fan-out checkpoint has no meaning here.
+        if resume is not None and resume.fanout_state is None:
+            initial_paginator_state = {"offset": resume.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when a next page remains; save AFTER a page is yielded so a crash re-yields
+        # the last page (merge dedupes) rather than skipping it.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(RaygunResumeConfig(offset=int(state["offset"])))
+
+    return rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+
+def _fan_out_source(
+    personal_access_token: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[RaygunResumeConfig],
+    db_incremental_field_last_value: Optional[Any],
+):
+    config = RAYGUN_ENDPOINTS[endpoint]
+    parent_config = RAYGUN_ENDPOINTS["applications"]
+
+    rest_config: RESTAPIConfig = {
+        "client": _client_config(personal_access_token),
+        "resources": [
+            {
+                "name": "applications",
+                "endpoint": {
+                    "path": parent_config.path,
+                    "params": {"orderby": parent_config.orderby},
+                },
+            },
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": config.path,
+                    "params": {
+                        # Resolve the per-application child path from each application's identifier.
+                        "application_identifier": {
+                            "type": "resolve",
+                            "resource": "applications",
+                            "field": "identifier",
+                        },
+                        "orderby": config.orderby,
+                    },
+                },
+            },
+        ],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume = resumable_source_manager.load_state()
+        # Only seed from a fan-out checkpoint. State saved before the migration (old-shape offset/
+        # application_identifier, no fanout_state) can't drive the framework's per-parent resume, so
+        # that part starts fresh — the parent list is re-enumerated and merge dedupes re-pulled rows.
+        if resume is not None and resume.fanout_state is not None:
+            initial_paginator_state = resume.fanout_state
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        resumable_source_manager.save_state(RaygunResumeConfig(fanout_state=state))
+
+    resources = rest_api_resources(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+    return next(resource for resource in resources if resource.name == endpoint)
 
 
 def raygun_source(
     personal_access_token: str,
     endpoint: str,
-    logger: FilteringBoundLogger,
+    team_id: int,
+    job_id: str,
     resumable_source_manager: ResumableSourceManager[RaygunResumeConfig],
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = RAYGUN_ENDPOINTS[endpoint]
 
+    if config.fan_out_over_applications:
+        resource = _fan_out_source(
+            personal_access_token,
+            endpoint,
+            team_id,
+            job_id,
+            resumable_source_manager,
+            db_incremental_field_last_value,
+        )
+    else:
+        resource = _top_level_source(
+            personal_access_token,
+            endpoint,
+            team_id,
+            job_id,
+            resumable_source_manager,
+            db_incremental_field_last_value,
+        )
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: get_rows(
-            personal_access_token=personal_access_token,
-            endpoint=endpoint,
-            logger=logger,
-            resumable_source_manager=resumable_source_manager,
-        ),
+        items=lambda: resource,
         primary_keys=config.primary_keys,
         partition_mode="datetime" if config.partition_key else None,
         partition_format="month" if config.partition_key else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/raygun/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/raygun/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import RaygunSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.raygun.raygun import (
     RaygunResumeConfig,
@@ -73,22 +76,9 @@ class RaygunSource(ResumableSource[RaygunSourceConfig, RaygunResumeConfig]):
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        # Raygun exposes no server-side "updated since" filter, so every endpoint is full refresh.
-        schemas = [
-            SourceSchema(
-                name=endpoint,
-                supports_incremental=False,
-                supports_append=False,
-                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
-            )
-            for endpoint in ENDPOINTS
-        ]
-
-        if names is not None:
-            names_set = set(names)
-            schemas = [s for s in schemas if s.name in names_set]
-
-        return schemas
+        # Raygun exposes no server-side "updated since" filter, so every endpoint is full refresh —
+        # no endpoint declares incremental fields, so none support incremental/append sync.
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
 
     def validate_credentials(
         self, config: RaygunSourceConfig, team_id: int, schema_name: Optional[str] = None
@@ -121,8 +111,10 @@ class RaygunSource(ResumableSource[RaygunSourceConfig, RaygunResumeConfig]):
         return raygun_source(
             personal_access_token=config.personal_access_token,
             endpoint=inputs.schema_name,
-            logger=inputs.logger,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
             resumable_source_manager=resumable_source_manager,
+            db_incremental_field_last_value=None,  # every Raygun endpoint is full refresh
         )
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/raygun/tests/test_raygun.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/raygun/tests/test_raygun.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +9,6 @@ from requests import Response
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.raygun.raygun import (
     RaygunResumeConfig,
-    get_rows,
     raygun_source,
     validate_token,
 )
@@ -34,17 +33,44 @@ def _path_of(url: str) -> str:
     return urlparse(url).path
 
 
-class _FakeSession:
-    """Session stub returning responses from a URL handler; records requested URLs."""
+def _wire_handler(session: MagicMock, handler: Any) -> list[str]:
+    """Route a mock session through a URL handler, recording each request's fully-qualified URL.
 
-    def __init__(self, handler) -> None:
-        self.handler = handler
-        self.urls: list[str] = []
-        self.headers: dict[str, str] = {}
+    ``paginate`` builds a ``requests.Request`` whose ``params`` dict is mutated in place across
+    pages, so the paginator's ``offset`` only shows on the URL if we fold params in at prepare time
+    (mirroring real ``prepare_request``). Returns the list of URLs actually sent, in order.
+    """
+    session.headers = {}
+    requested: list[str] = []
 
-    def get(self, url: str, headers: dict[str, str] | None = None, timeout: int | None = None) -> Response:
-        self.urls.append(url)
-        return self.handler(url)
+    def _prepare(request: Any) -> MagicMock:
+        params = {key: value for key, value in (request.params or {}).items() if value is not None}
+        url = request.url
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        prepared = MagicMock()
+        prepared.url = url
+        prepared.is_redirect = False
+        return prepared
+
+    def _send(prepared: Any, **_kwargs: Any) -> Response:
+        requested.append(prepared.url)
+        return handler(prepared.url)
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = _send
+    return requested
+
+
+def _rows(source_response: Any) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+def _make_manager(resume_state: RaygunResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
 
 
 class TestValidateToken:
@@ -66,78 +92,69 @@ class TestValidateToken:
 class TestTopLevelPagination:
     @patch(f"{MODULE}.PAGE_SIZE", 2)
     @patch(f"{MODULE}.make_tracked_session")
-    def test_offset_advances_and_saves_between_pages(self, mock_session: MagicMock) -> None:
+    def test_offset_advances_and_saves_between_pages(self, mock_make_session: MagicMock) -> None:
         # Two full pages then a short terminal page for /applications.
         pages = {
             0: [{"identifier": "app-1"}, {"identifier": "app-2"}],
             2: [{"identifier": "app-3"}, {"identifier": "app-4"}],
             4: [{"identifier": "app-5"}],
         }
+        session = mock_make_session.return_value
+        requested = _wire_handler(session, lambda url: _response(pages[_offset_of(url) or 0]))
 
-        def handler(url: str) -> Response:
-            return _response(pages[_offset_of(url) or 0])
+        manager = _make_manager()
 
-        session = _FakeSession(handler)
-        mock_session.return_value = session
+        yielded = _rows(raygun_source("tok", "applications", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
-
-        yielded = list(get_rows("tok", "applications", MagicMock(), manager))
-
-        assert [_offset_of(u) for u in session.urls] == [0, 2, 4]
-        assert sum(len(page) for page in yielded) == 5
+        assert [_offset_of(u) for u in requested] == [0, 2, 4]
+        assert len(yielded) == 5
         # Sync sessions carry PII-bearing bodies, so sample capture must stay off.
-        assert mock_session.call_args.kwargs["capture"] is False
-        assert "tok" in mock_session.call_args.kwargs["redact_values"]
+        assert mock_make_session.call_args.kwargs["capture"] is False
+        assert "tok" in mock_make_session.call_args.kwargs["redact_values"]
         # State is saved pointing at the next unfetched offset after each non-terminal page only.
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [RaygunResumeConfig(offset=2), RaygunResumeConfig(offset=4)]
 
     @patch(f"{MODULE}.PAGE_SIZE", 2)
     @patch(f"{MODULE}.make_tracked_session")
-    def test_single_short_page_saves_no_state(self, mock_session: MagicMock) -> None:
-        session = _FakeSession(lambda url: _response([{"identifier": "app-1"}]))
-        mock_session.return_value = session
+    def test_single_short_page_saves_no_state(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+        _wire_handler(session, lambda url: _response([{"identifier": "app-1"}]))
 
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+        manager = _make_manager()
 
-        list(get_rows("tok", "applications", MagicMock(), manager))
+        _rows(raygun_source("tok", "applications", team_id=1, job_id="j", resumable_source_manager=manager))
 
         manager.save_state.assert_not_called()
 
     @patch(f"{MODULE}.PAGE_SIZE", 2)
     @patch(f"{MODULE}.make_tracked_session")
-    def test_application_api_key_is_stripped(self, mock_session: MagicMock) -> None:
+    def test_application_api_key_is_stripped(self, mock_make_session: MagicMock) -> None:
         # `apiKey` is an ingestion credential and must never reach the warehouse table.
-        session = _FakeSession(lambda url: _response([{"identifier": "app-1", "name": "App", "apiKey": "secret"}]))
-        mock_session.return_value = session
+        session = mock_make_session.return_value
+        _wire_handler(session, lambda url: _response([{"identifier": "app-1", "name": "App", "apiKey": "secret"}]))
 
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+        manager = _make_manager()
 
-        rows = [row for page in get_rows("tok", "applications", MagicMock(), manager) for row in page]
+        rows = _rows(raygun_source("tok", "applications", team_id=1, job_id="j", resumable_source_manager=manager))
 
         assert rows == [{"identifier": "app-1", "name": "App"}]
 
     @patch(f"{MODULE}.PAGE_SIZE", 2)
     @patch(f"{MODULE}.make_tracked_session")
-    def test_resume_starts_from_saved_offset(self, mock_session: MagicMock) -> None:
-        session = _FakeSession(lambda url: _response([{"identifier": "app-9"}]))
-        mock_session.return_value = session
+    def test_resume_starts_from_saved_offset(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+        requested = _wire_handler(session, lambda url: _response([{"identifier": "app-9"}]))
 
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = RaygunResumeConfig(offset=4)
+        manager = _make_manager(RaygunResumeConfig(offset=4))
 
-        list(get_rows("tok", "applications", MagicMock(), manager))
+        _rows(raygun_source("tok", "applications", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        assert _offset_of(session.urls[0]) == 4
+        assert _offset_of(requested[0]) == 4
 
 
 class TestFanOutPagination:
-    def _fan_out_handler(self, apps: list[str], child_rows: dict[str, list[dict[str, Any]]]):
+    def _fan_out_handler(self, apps: list[str], child_rows: dict[str, list[dict[str, Any]]]) -> Any:
         def handler(url: str) -> Response:
             path = _path_of(url)
             offset = _offset_of(url) or 0
@@ -153,63 +170,73 @@ class TestFanOutPagination:
 
     @patch(f"{MODULE}.PAGE_SIZE", 2)
     @patch(f"{MODULE}.make_tracked_session")
-    def test_fans_out_over_apps_and_bookmarks_next_app(self, mock_session: MagicMock) -> None:
+    def test_fans_out_over_apps_and_marks_finished_app_complete(self, mock_make_session: MagicMock) -> None:
         apps = ["app-1", "app-2"]
         child_rows = {
             "app-1": [{"identifier": "eg-1", "applicationIdentifier": "app-1"}],
             "app-2": [{"identifier": "eg-2", "applicationIdentifier": "app-2"}],
         }
-        session = _FakeSession(self._fan_out_handler(apps, child_rows))
-        mock_session.return_value = session
+        session = mock_make_session.return_value
+        _wire_handler(session, self._fan_out_handler(apps, child_rows))
 
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = False
+        manager = _make_manager()
 
-        yielded = list(get_rows("tok", "error_groups", MagicMock(), manager))
+        rows = _rows(raygun_source("tok", "error_groups", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        rows = [row for page in yielded for row in page]
         assert {r["applicationIdentifier"] for r in rows} == {"app-1", "app-2"}
-        # After finishing app-1 the bookmark advances to app-2 at offset 0.
-        saved = [call.args[0] for call in manager.save_state.call_args_list]
-        assert RaygunResumeConfig(offset=0, application_identifier="app-2") in saved
+        # After finishing app-1 its child path is checkpointed as completed so a restart skips it
+        # (the fan-out equivalent of the old per-application bookmark advancing to the next app).
+        completed = [
+            call.args[0].fanout_state.get("completed")
+            for call in manager.save_state.call_args_list
+            if call.args[0].fanout_state
+        ]
+        assert any("/applications/app-1/error-groups" in (c or []) for c in completed)
 
     @patch(f"{MODULE}.PAGE_SIZE", 2)
     @patch(f"{MODULE}.make_tracked_session")
-    def test_resume_skips_to_bookmarked_app_and_offset(self, mock_session: MagicMock) -> None:
+    def test_resume_skips_completed_app_and_starts_bookmarked_app_at_offset(self, mock_make_session: MagicMock) -> None:
         apps = ["app-1", "app-2"]
         child_rows = {"app-2": [{"identifier": "eg-2", "applicationIdentifier": "app-2"}]}
-        session = _FakeSession(self._fan_out_handler(apps, child_rows))
-        mock_session.return_value = session
+        session = mock_make_session.return_value
+        requested = _wire_handler(session, self._fan_out_handler(apps, child_rows))
 
-        manager = MagicMock(spec=ResumableSourceManager)
-        manager.can_resume.return_value = True
-        manager.load_state.return_value = RaygunResumeConfig(offset=6, application_identifier="app-2")
+        manager = _make_manager(
+            RaygunResumeConfig(
+                fanout_state={
+                    "completed": ["/applications/app-1/error-groups"],
+                    "current": "/applications/app-2/error-groups",
+                    "child_state": {"offset": 6},
+                }
+            )
+        )
 
-        list(get_rows("tok", "error_groups", MagicMock(), manager))
+        _rows(raygun_source("tok", "error_groups", team_id=1, job_id="j", resumable_source_manager=manager))
 
-        child_urls = [u for u in session.urls if "/applications/app-1/" in u or "/applications/app-2/" in u]
+        child_urls = [u for u in requested if "/applications/app-1/" in u or "/applications/app-2/" in u]
         # app-1 is skipped entirely; the first child fetch targets app-2 at the saved offset.
         assert all("/applications/app-2/" in u for u in child_urls)
         assert _offset_of(child_urls[0]) == 6
 
 
 class TestRaygunSource:
-    def test_primary_keys_and_partitioning_per_endpoint(self) -> None:
-        manager = MagicMock(spec=ResumableSourceManager)
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_primary_keys_and_partitioning_per_endpoint(self, _mock_make_session: MagicMock) -> None:
+        manager = _make_manager()
 
-        applications = raygun_source("tok", "applications", MagicMock(), manager)
+        applications = raygun_source("tok", "applications", team_id=1, job_id="j", resumable_source_manager=manager)
         assert applications.primary_keys == ["identifier"]
         assert applications.partition_mode is None
 
-        error_groups = raygun_source("tok", "error_groups", MagicMock(), manager)
+        error_groups = raygun_source("tok", "error_groups", team_id=1, job_id="j", resumable_source_manager=manager)
         assert error_groups.primary_keys == ["applicationIdentifier", "identifier"]
         assert error_groups.partition_mode == "datetime"
         assert error_groups.partition_keys == ["createdAt"]
 
-        sessions = raygun_source("tok", "sessions", MagicMock(), manager)
+        sessions = raygun_source("tok", "sessions", team_id=1, job_id="j", resumable_source_manager=manager)
         assert sessions.partition_keys == ["startedAt"]
 
         # A fan-out endpoint without a guaranteed create-time field is left unpartitioned.
-        deployments = raygun_source("tok", "deployments", MagicMock(), manager)
+        deployments = raygun_source("tok", "deployments", team_id=1, job_id="j", resumable_source_manager=manager)
         assert deployments.primary_keys == ["applicationIdentifier", "identifier"]
         assert deployments.partition_mode is None


### PR DESCRIPTION
## Problem

Batch 30 of the ongoing effort to migrate hand-rolled data-warehouse source connectors onto the shared `rest_source` framework, removing duplicated pagination, auth, resume, and schema-building code.

This batch also lands a generic framework capability — **`data_selector_malformed_retryable`** — so sources that defensively treat an unexpected HTTP-200 body shape as a transient error no longer need bespoke transport code.

## Changes

Framework:
- New endpoint key `data_selector_malformed_retryable: True` in `common/rest_source`. When set, a 200 whose parsed body isn't the expected list shape (the `data_selector` matches nothing, or the matched value / selector-less body isn't a list) raises a retryable error and the request is reissued — the check runs inside the retry-wrapped send. This is the retryable counterpart of `data_selector_required` (which fails loud permanently). Wired for simple resources.

Migrated sources (behavior-preserving, coverage-first — each keeps its full test suite green, reusing `validate_via_probe`, `build_endpoint_schemas`, resumable built-in paginators, and framework `auth` for secret redaction):

- **groq** — now expressible: non-dict body / non-list `data` classified retryable via the new capability
- **planhat** — non-list 200-body classified retryable via the new capability
- **pretix**
- **raygun**

Not migrated this batch (left hand-rolled, valid blockers):
- **printify** — its malformed-body-retryable classification lives on the per-shop fan-out endpoints; `data_selector_malformed_retryable` is currently wired for simple resources only, not the dependent/fan-out path.
- **pylon** — multiple transport modes (date-windowed `/issues` backfill + paged lists + static object_type fan-out) with client-side window/watermark filtering.
- **pypi** — config-list fan-out with no parent API resource, deriving three differently-reshaped streams (including a version-keyed dict-of-lists explode) from one JSON document.

## How did you test this code?

- New framework capability: 5 cases in `test_malformed_body_retryable.py` — malformed-then-valid recovers, three persistent-malformed shapes (bare string / dict-without-key / key-present-but-not-a-list) reraise retryable, and a valid list body is not retried.
- Each migrated source's own `tests/` suite passes in isolation, asserting the same pagination progression, resume round-trips, termination, fail-loud paths, and `validate_credentials` mapping as before.
- Merged run of all 4 migrated dirs + `common/rest_source/tests/` — 322 passed. Additive framework change: all existing `rest_source` tests plus `data_selector_required` consumer smoke (apify_dataset, alguna, coingecko, aviationstack, greenhouse) stay green.
- `hogli ci:preflight --fix` clean (0 failures).

## 🤖 Agent context

Part of the stacked rest_source migration program. Base branch is the batch-29 PR (#71963); merge in order.
