### PR TITLE
fix(exports): pass relevant_events in the plan-freeze test

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -489,10 +489,15 @@ def test_plan_to_freeze_requires_no_failures(total_steps: int, failed_count: int
         freshly_planned=True,
         failed_count=failed_count,
         total_steps=total_steps,
+        relevant_events=["export created"],
         trace_correlation_id=None,
     )
     if should_freeze:
-        assert result == {"version": AI_QUERY_PLAN_VERSION, "plan": plan.model_dump()}
+        assert result == {
+            "version": AI_QUERY_PLAN_VERSION,
+            "plan": plan.model_dump(),
+            "relevant_events": ["export created"],
+        }
     else:
         assert result is None
 


### PR DESCRIPTION
## Problem

Master's Python code quality check is red: #71837 added a required `relevant_events` parameter (and envelope key) to `_plan_to_freeze` but missed one parameterized test call site. mypy fails on the missing named argument, which currently fails the quality check on every open PR that merges master, and the test's `should_freeze` equality assertion no longer matches the envelope at runtime either.

## Changes

Pass `relevant_events` at the missed call site and extend the expected envelope, mirroring the sibling test's fixture value.

## How did you test this code?

`hogli test products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py` — 36 passed (was failing on the assertion at runtime and on mypy). No new coverage claimed; this restores an existing test to match the changed signature.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code in a session driven by @webjunkie while chasing a red Python code quality check on an unrelated PR — bisected to master, where the signature and its test drifted in #71837. Mechanical two-line repair; no behavior change to the pipeline itself.
