### PR TITLE
fix(pulse): allow project members to generate briefs

### DIFF
--- a/products/pulse/backend/api/brief.py
+++ b/products/pulse/backend/api/brief.py
@@ -9,7 +9,6 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
-from rest_framework.permissions import SAFE_METHODS, BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import BaseThrottle
@@ -20,7 +19,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
 from posthog.models import User
-from posthog.permissions import PostHogFeatureFlagPermission, is_service_auth
+from posthog.permissions import PostHogFeatureFlagPermission
 from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.slo.types import SloArea, SloConfig, SloOperation
@@ -35,16 +34,6 @@ from products.pulse.backend.temporal.inputs import GENERATE_BRIEF_WORKFLOW_NAME,
 PULSE_FEATURE_FLAG = "pulse"
 
 logger = structlog.get_logger(__name__)
-
-
-class PulseProjectWritePermission(BasePermission):
-    message = "Project admin access is required to modify Pulse briefs."
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        if request.method in SAFE_METHODS or is_service_auth(request):
-            return True
-        pulse_view = cast(TeamAndOrgViewSetMixin, view)
-        return pulse_view.user_access_control.check_access_level_for_object(pulse_view.team, required_level="admin")
 
 
 def _validate_anchor_access(*, anchors: dict, team_id: int, user_access_control: UserAccessControl) -> None:
@@ -278,7 +267,7 @@ class BriefConfigViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "project"
     serializer_class = BriefConfigSerializer
     posthog_feature_flag = PULSE_FEATURE_FLAG
-    permission_classes = [PostHogFeatureFlagPermission, PulseProjectWritePermission]
+    permission_classes = [PostHogFeatureFlagPermission]
     # Fail-closed manager raises if `.all()` runs at import; the real per-request
     # scoping happens in safely_get_queryset.
     queryset = BriefConfig.objects.unscoped()
@@ -321,7 +310,7 @@ class ProductBriefViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewSet)
     scope_object_write_actions = ["generate"]
     serializer_class = ProductBriefSerializer
     posthog_feature_flag = PULSE_FEATURE_FLAG
-    permission_classes = [PostHogFeatureFlagPermission, PulseProjectWritePermission]
+    permission_classes = [PostHogFeatureFlagPermission]
     queryset = ProductBrief.objects.unscoped()
 
     def dangerously_get_required_scopes(self, request: Request, view: APIView) -> list[str] | None:

--- a/products/pulse/backend/test/test_api.py
+++ b/products/pulse/backend/test/test_api.py
@@ -204,7 +204,8 @@ class TestPulseAPI(APIBaseTest):
         assert str(other_config.id) not in [row["id"] for row in configs]
         assert str(other_brief.id) not in [row["id"] for row in briefs]
 
-    def test_project_member_cannot_mutate_or_generate(self, mock_connect: MagicMock, _mock_flag: MagicMock) -> None:
+    def test_project_member_can_mutate_and_generate(self, mock_connect: MagicMock, _mock_flag: MagicMock) -> None:
+        mock_connect.return_value = _temporal_client()
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
         self.organization.available_product_features = [
@@ -220,13 +221,13 @@ class TestPulseAPI(APIBaseTest):
         )
 
         list_response = self.client.get(f"/api/projects/{self.team.id}/pulse/brief_configs/")
-        create_response = self.client.post(f"/api/projects/{self.team.id}/pulse/brief_configs/", {"name": "blocked"})
+        create_response = self.client.post(f"/api/projects/{self.team.id}/pulse/brief_configs/", {"name": "allowed"})
         generate_response = self.client.post(f"/api/projects/{self.team.id}/pulse/briefs/generate/")
 
         assert list_response.status_code == status.HTTP_200_OK
-        assert create_response.status_code == status.HTTP_403_FORBIDDEN
-        assert generate_response.status_code == status.HTTP_403_FORBIDDEN
-        mock_connect.assert_not_called()
+        assert create_response.status_code == status.HTTP_201_CREATED
+        assert generate_response.status_code == status.HTTP_201_CREATED
+        mock_connect.assert_called_once()
 
     def test_config_crud_roundtrip(self, _mock_connect: MagicMock, _mock_flag: MagicMock) -> None:
         insight = Insight.objects.create(team=self.team, name="Pageviews")


### PR DESCRIPTION
## Problem

Pulse currently requires project administrator access for config changes and brief generation. This blocks regular project members even though Pulse data is already creator-scoped and source access is checked separately.

## Changes

- Remove the Pulse-specific project-admin permission gate.
- Keep feature flag checks, creator scoping, API token scopes, and source access validation unchanged.
- Cover project-member config creation and brief generation.

## How did you test this code?

- `ruff check products/pulse/backend/api/brief.py products/pulse/backend/test/test_api.py`
- `ruff format --check products/pulse/backend/api/brief.py products/pulse/backend/test/test_api.py`
- Python compilation for both changed files.
- The focused database-backed regression test could not run locally because this runner has no Postgres `db` service. CI will run it.

The changed regression catches the admin-only access restriction returning for ordinary project members.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed. This removes an unintended alpha access restriction and does not change the documented Pulse workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested access change using the `/improving-drf-endpoints` and `/writing-tests` skills. The change removes only the explicit admin check; existing project membership, feature flag, token scope, creator scoping, and source access boundaries remain in place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
