### PR TITLE
fix(clickhouse): gate goldens on bytes, not semantics

### DIFF
--- a/posthog/clickhouse/hcl/check.sh
+++ b/posthog/clickhouse/hcl/check.sh
@@ -81,16 +81,31 @@ for env in $envs; do
       continue
     fi
 
-    echo "== $env/$role: diff vs golden =="
-    stack="$(manifest_stack "$env" "$role")"
-    err="$(mktemp)"
-    out="$("$HCLEXP" diff -left "$stack" -right "$golden" 2>"$err")"
-    if [ "$out" != "no differences" ]; then
-      echo "FAIL: drift in $env/$role"; echo "$out"; cat "$err"; rc=1
+    echo "== $env/$role: golden freshness =="
+    # Compose exactly the way gen-golden.sh does -- same command, same -out-name --
+    # and require the committed file to be byte-identical to it. `hclexp diff` is
+    # still run, but only to explain a failure, never to decide it: a semantic
+    # compare passes a golden whose formatting has rotted away from what the
+    # generator emits, which is how golden/local-multi/data.hcl kept "(is_deleted)"
+    # index exprs that any regen rewrites. sql/ below has always been byte-compared;
+    # golden/ now holds to the same standard.
+    tmp_g="$(mktemp -d)"
+    "$HCLEXP" load -manifest "$MANIFEST" -env "$env" -layer-root "$HCL" -role "$role" \
+      -out-name '{env}/{role}' -out "$tmp_g" >/dev/null
+    composed="$tmp_g/$env/$role.hcl"
+    if ! cmp -s "$golden" "$composed"; then
+      echo "FAIL: golden stale for $env/$role — run gen-golden.sh and commit"
+      out="$("$HCLEXP" diff -left "$composed" -right "$golden" 2>&1 || true)"
+      if [ "$out" = "no differences" ]; then
+        echo "  formatting only: semantically identical, but not what gen-golden.sh emits"
+      else
+        echo "$out"
+      fi
+      rc=1
     else
-      echo "no differences"
+      echo "golden fresh"
     fi
-    rm -f "$err"
+    rm -rf "$tmp_g"
   done
 done
 


### PR DESCRIPTION
`check.sh` asserted golden freshness with `hclexp diff` — a **semantic** compare. So a golden whose formatting had drifted from what `gen-golden.sh` emits still passed.

It rotted quietly. `golden/local-multi/data.hcl` carried:

```
expr         = "(is_deleted)"                 # regen emits "is_deleted"
materialized = "(bitShiftLeft(...) + ...)"    # regen emits it unparenthesised
```

…and the gate was green the whole time (#71918 regenerated it). Anyone running `gen-golden.sh` got an instantly dirty tree with changes unrelated to their work — so the natural move was to `git checkout` them, and the rot persisted.

## The gate was comparing the wrong thing

`golden/` is **generated**. The invariant that matters is *"the committed file is what the generator emits"* — byte-identity. Semantic equality is a weaker claim that lets the artifact drift away from its own generator.

Two things already agreed:

- **`sql/` freshness in this same script has always been byte-compared** against a fresh regen (`diff -r`). `golden/` was the odd one out.
- **posthog-cloud-infra byte-compares its goldens** (`cmp`). The two repos disagreeing on what "fresh" means is how this stayed invisible.

## What changed

The old gate composed via `diff -left <layer stack>` — a *different codepath* from `gen-golden.sh`, which uses `load -manifest -env -role -out-name {env}/{role}`. It never asserted the generator’s own output. Now it composes with that exact command and `cmp`s.

`hclexp diff` is still run, but only to **explain** a failure, never to decide it:

```
FAIL: golden stale for local-multi/data — run gen-golden.sh and commit
  formatting only: semantically identical, but not what gen-golden.sh emits
```

or, for real drift:

```
FAIL: golden stale for local-multi/data — run gen-golden.sh and commit
database "posthog"
  ~ table distributed_events_recent
      ~ column historical_migration: Bool -> UInt8
```

## Verification

- Green on master: **44 goldens fresh**, exit 0.
- Re-introducing `"(is_deleted)"` → **exit 1** with the formatting-only label. The old gate passed this.
- `Bool` → `UInt8` → **exit 1** with the per-object diff above.
- `manifest_stack` is still used by `diff.sh` / `gen-sql.sh`, so nothing orphaned.

Stacked on #71918 (merged), which left the tree byte-clean — so this gate goes green without further regeneration.