### PR TITLE
chore(clickhouse): bump hclexp pin to sha-a305c27

### DIFF
--- a/posthog/clickhouse/hcl/bin/image.txt
+++ b/posthog/clickhouse/hcl/bin/image.txt
@@ -1,1 +1,1 @@
-ghcr.io/posthog/chschema:sha-5eadb87
+ghcr.io/posthog/chschema:sha-a305c27


### PR DESCRIPTION
Picks up [chschema#153](https://github.com/PostHog/chschema/pull/153) (issue [#152](https://github.com/PostHog/chschema/issues/152)): **`patch_table` now merges `settings`** into the target instead of rejecting them at parse time.

## Why it matters

`patch_table` accepted `column` blocks only, so a table whose envs differ by a single *setting* had no additive way to express that — it had to be redeclared in full, per env. That is exactly what migration.md’s "each table shall be defined once" forbids, and the tool left no alternative.

In posthog-cloud-infra, **15 data objects differ by nothing but `default_compression_codec = "lz4"`**. `adhoc_events_deletion` is 30 lines; the entire env difference is one. They can now be declared once in a shared layer and patched:

```hcl
# shared, declared once
table "adhoc_events_deletion" { ...; settings = { index_granularity = "8192" } }

# prod-us — the whole difference
patch_table "adhoc_events_deletion" {
  settings = { default_compression_codec = "lz4" }
}
```

Verified the merge semantics are additive (patch wins on collision, inherited keys survive): base `index_granularity` + patch `default_compression_codec` composes to **both**. An earlier build replaced the map — this one merges.

## Verification

- `gen-golden.sh && gen-sql.sh` → **zero churn**; canonicalization-neutral.
- `check.sh` green.