### PR TITLE
fix(cymbal): resolve Hermes maps without scope metadata

### DIFF
--- a/rust/cymbal/src/core/symbolication/symbol_store/hermesmap.rs
+++ b/rust/cymbal/src/core/symbolication/symbol_store/hermesmap.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use posthog_symbol_data::{read_symbol_data_with_byte_count, HermesMap};
+use serde::Deserialize;
 
 use crate::{
     error::{HermesError, ResolveError, UnhandledError},
@@ -10,9 +11,44 @@ use crate::{
 };
 
 pub struct ParsedHermesMap {
-    pub map: sourcemap::SourceMapHermes,
+    pub(crate) map: ParsedHermesSourceMap,
     /// Decompressed byte count from the symbol_data container, used for cache memory accounting.
     decompressed_bytes: usize,
+}
+
+pub(crate) enum ParsedHermesSourceMap {
+    WithScopes(sourcemap::SourceMapHermes),
+    LocationOnly(sourcemap::SourceMap),
+}
+
+impl ParsedHermesSourceMap {
+    pub fn lookup_token(&self, line: u32, column: u32) -> Option<sourcemap::Token<'_>> {
+        match self {
+            Self::WithScopes(map) => map.lookup_token(line, column),
+            Self::LocationOnly(map) => map.lookup_token(line, column),
+        }
+    }
+
+    pub fn get_original_function_name(&self, bytecode_offset: u32) -> Option<&str> {
+        match self {
+            Self::WithScopes(map) => map.get_original_function_name(bytecode_offset),
+            Self::LocationOnly(_) => None,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct HermesMapMetadata {
+    #[serde(default, deserialize_with = "marker_present")]
+    x_hermes_function_offsets: bool,
+}
+
+fn marker_present<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::de::IgnoredAny::deserialize(deserializer)?;
+    Ok(true)
 }
 
 impl Countable for ParsedHermesMap {
@@ -60,10 +96,84 @@ impl ParsedHermesMap {
         map: HermesMap,
         decompressed_bytes: usize,
     ) -> Result<ParsedHermesMap, HermesError> {
+        let content = map.sourcemap;
+        let decoded = sourcemap::decode_slice(content.as_bytes())
+            .map_err(|e| HermesError::InvalidMap(e.to_string()))?;
+
+        let map = match decoded {
+            sourcemap::DecodedMap::Hermes(map) => ParsedHermesSourceMap::WithScopes(map),
+            // The CLI also accepts this Hermes marker, but rust-sourcemap classifies
+            // maps without Metro's scope metadata as regular source maps.
+            sourcemap::DecodedMap::Regular(map) if has_hermes_function_offsets(&content)? => {
+                ParsedHermesSourceMap::LocationOnly(map)
+            }
+            _ => {
+                return Err(HermesError::InvalidMap(
+                    sourcemap::Error::IncompatibleSourceMap.to_string(),
+                ));
+            }
+        };
+
         Ok(ParsedHermesMap {
-            map: sourcemap::SourceMapHermes::from_reader(map.sourcemap.as_bytes())
-                .map_err(|e| HermesError::InvalidMap(e.to_string()))?,
+            map,
             decompressed_bytes,
         })
+    }
+}
+
+fn has_hermes_function_offsets(content: &str) -> Result<bool, HermesError> {
+    let content = match content.as_bytes().first() {
+        Some(b')' | b']' | b'}' | b'\'') => content
+            .split_once('\n')
+            .map(|(_, content)| content)
+            .unwrap_or_default(),
+        _ => content,
+    };
+    let metadata: HermesMapMetadata =
+        serde_json::from_str(content).map_err(|e| HermesError::InvalidMap(e.to_string()))?;
+    Ok(metadata.x_hermes_function_offsets)
+}
+
+#[cfg(test)]
+mod tests {
+    use posthog_symbol_data::HermesMap;
+
+    use super::{ParsedHermesMap, ParsedHermesSourceMap};
+
+    const OFFSETS_ONLY_MAP: &str =
+        include_str!("../../../../tests/static/hermes/hermes_example.map");
+
+    #[test]
+    fn parses_offsets_only_map_for_location_resolution() {
+        let parsed = ParsedHermesMap::parse(
+            HermesMap {
+                sourcemap: OFFSETS_ONLY_MAP.to_string(),
+            },
+            OFFSETS_ONLY_MAP.len(),
+        )
+        .unwrap();
+
+        assert!(matches!(parsed.map, ParsedHermesSourceMap::LocationOnly(_)));
+        let token = parsed.map.lookup_token(0, 1000).unwrap();
+        assert_eq!(
+            token.get_source(),
+            Some("./build/android/index.android.bundle")
+        );
+        assert_eq!(token.get_src_line(), 49);
+        assert_eq!(token.get_src_col(), 26);
+        assert_eq!(parsed.map.get_original_function_name(1000), None);
+    }
+
+    #[test]
+    fn rejects_regular_map_without_hermes_marker() {
+        let result = ParsedHermesMap::parse(
+            HermesMap {
+                sourcemap: r#"{"version":3,"sources":["index.js"],"names":[],"mappings":"AAAA"}"#
+                    .to_string(),
+            },
+            0,
+        );
+
+        assert!(result.is_err());
     }
 }

--- a/rust/cymbal/src/core/types/langs/hermes.rs
+++ b/rust/cymbal/src/core/types/langs/hermes.rs
@@ -244,28 +244,84 @@ impl From<&RawHermesFrame> for Frame {
 #[cfg(test)]
 mod test {
     use crate::core::symbolication::resolve::Resolve;
+    use async_trait::async_trait;
     use std::sync::Arc;
 
     use chrono::Utc;
     use mockall::predicate;
-    use posthog_symbol_data::write_symbol_data;
+    use posthog_symbol_data::{write_symbol_data, HermesMap};
     use regex::Regex;
     use sqlx::PgPool;
     use uuid::Uuid;
 
     use crate::{
         core::config::ResolverConfig,
+        error::ResolveError,
         frames::RawFrame,
-        langs::{hermes::RawHermesFrame, CommonFrameMetadata},
+        langs::{
+            hermes::{HermesRef, RawHermesFrame},
+            CommonFrameMetadata,
+        },
         symbolication::symbol_store::{
-            apple::AppleProvider, chunk_id::ChunkIdFetcher, hermesmap::HermesMapProvider,
-            native::NativeProvider, proguard::ProguardProvider, saving::SymbolSetRecord,
-            sourcemap::SourcemapProvider, Catalog, MockS3Client,
+            apple::AppleProvider,
+            chunk_id::{ChunkIdFetcher, OrChunkId},
+            hermesmap::{HermesMapProvider, ParsedHermesMap},
+            native::NativeProvider,
+            proguard::ProguardProvider,
+            saving::SymbolSetRecord,
+            sourcemap::SourcemapProvider,
+            Catalog, MockS3Client, SymbolCatalog,
         },
     };
 
     const HERMES_MAP: &str = include_str!("../../../../tests/static/hermes/composed_example.map");
+    const OFFSETS_ONLY_MAP: &str =
+        include_str!("../../../../tests/static/hermes/hermes_example.map");
     const RAW_STACK: &str = include_str!("../../../../tests/static/hermes/raw_stack.txt");
+
+    struct StaticHermesCatalog(Arc<ParsedHermesMap>);
+
+    #[async_trait]
+    impl SymbolCatalog<OrChunkId<HermesRef>, ParsedHermesMap> for StaticHermesCatalog {
+        async fn lookup(
+            &self,
+            _team_id: i32,
+            _r: OrChunkId<HermesRef>,
+        ) -> Result<Arc<ParsedHermesMap>, ResolveError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_offsets_only_hermes_resolution() {
+        let map = ParsedHermesMap::parse(
+            HermesMap {
+                sourcemap: OFFSETS_ONLY_MAP.to_string(),
+            },
+            OFFSETS_ONLY_MAP.len(),
+        )
+        .unwrap();
+        let catalog = StaticHermesCatalog(Arc::new(map));
+        let frame = RawHermesFrame {
+            column: Some(1000),
+            source: "index.android.bundle".to_string(),
+            fn_name: "anonymous".to_string(),
+            chunk_id: Some("test-chunk".to_string()),
+            meta: CommonFrameMetadata::default(),
+        };
+
+        let resolved = frame.resolve_frame(1, &catalog, 15).await.unwrap();
+
+        assert!(resolved.resolved);
+        assert_eq!(
+            resolved.source.as_deref(),
+            Some("./build/android/index.android.bundle")
+        );
+        assert_eq!(resolved.line, Some(49));
+        assert_eq!(resolved.column, Some(26));
+        assert_eq!(resolved.resolved_name, None);
+        assert_eq!(resolved.resolve_failure, None);
+    }
 
     #[sqlx::test(migrations = "./tests/test_migrations")]
     async fn test_hermes_resolution(db: PgPool) {


### PR DESCRIPTION
## Problem

Hermes symbol data can contain `x_hermes_function_offsets` without Metro's `x_facebook_sources` scope metadata. The CLI accepts that shape, but Cymbal always parses Hermes symbol data with `SourceMapHermes`. In `sourcemap` 9.3.2, that parser only recognizes maps containing `x_facebook_sources`, so an otherwise usable location map fails with an incompatible-format error.

Before:

```mermaid
flowchart LR
    A[Hermes symbol data] --> B[SourceMapHermes parser]
    B --> C{x_facebook_sources present?}
    C -->|Yes| D[Resolve location and function]
    C -->|No| E[Reject map]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D phGray;
    class E phRed;
```

## Changes

- Wrap parsed Hermes maps as either scoped or location-only.
- Preserve the existing scoped path and function-name enrichment when `x_facebook_sources` exists.
- Accept a regular decoded source map only when its top-level JSON contains the CLI's `x_hermes_function_offsets` marker.
- Resolve source, line, and column for the location-only variant without fabricating an enclosing function name.
- Keep ordinary source maps without either Hermes marker invalid for Hermes symbol data.

After:

```mermaid
flowchart LR
    A[Hermes symbol data] --> B[Decode source map]
    B --> C{Decoded shape}
    C -->|Hermes with scopes| D[Resolve location and function]
    C -->|Regular with Hermes offsets| E[Resolve location only]
    C -->|Anything else| F[Reject map]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D,E phGray;
    class F phRed;
```

## How did you test this code?

<img width="732" height="376" alt="CleanShot 2026-07-18 at 00 49 48" src="https://github.com/user-attachments/assets/ad4a386d-82a4-410f-be5a-f34f7a15c925" />


The new regression tests use the repository's existing offsets-only Hermes fixture. They verify location resolution to `./build/android/index.android.bundle:49:26`, no function-name enrichment, and no resolution failure. A negative test verifies that an ordinary source map without a Hermes marker remains rejected. The existing scoped-Hermes test continues to verify function-name enrichment.

- `cargo test --manifest-path rust/Cargo.toml -p cymbal hermes --lib`
- `cargo test --manifest-path rust/Cargo.toml -p cymbal`
- `cargo clippy --manifest-path rust/Cargo.toml -p cymbal --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change is required. This makes the existing Hermes symbol-data contract tolerant of missing optional scope metadata.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used Codex with the `pr-closeout` and `autoreview` skills. I chose a PostHog-owned parser wrapper instead of synthesizing scope metadata or changing the upstream source-map crate. Structured autoreview reported no accepted or actionable findings.
