### PR TITLE
fix(data-warehouse): clarify optional Stripe Account id field

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
@@ -191,10 +191,11 @@ class StripeSource(
                     ),
                     SourceFieldInputConfig(
                         name="stripe_account_id",
-                        label="Account id",
+                        label="Account id (optional)",
                         type=SourceFieldInputConfigType.TEXT,
                         required=False,
-                        placeholder="stripe_account_id",
+                        placeholder="acct_...",
+                        caption="Leave blank in most cases, including when connecting with OAuth. Only set this if you use a Stripe Connect platform key and want to sync a specific connected account. You can find it under Account details in your [Stripe account settings](https://dashboard.stripe.com/settings/account).",
                         secret=False,
                     ),
                 ],


### PR DESCRIPTION
## Problem

After connecting Stripe via OAuth, users land back on the source page with an "Account id" field that is blank and unexplained. It reads like a required value they have to go find, but for OAuth (and standard API key) connections it should just be left empty.

That field is the Stripe Connect `stripe_account` header. It only applies to Connect platform keys that want to sync a specific connected account. Setting it on a non-Connect / OAuth connection actually makes Stripe reject the requests ("Only Stripe Connect platforms can work with other accounts"), so auto-filling it from the OAuth response would be the wrong fix. The real gap is that the field has no guidance.

Raised in a Slack support thread (ticket #3117).

## Changes

- Add a caption to the `stripe_account_id` field explaining it should be left blank in most cases (including OAuth), and is only for Stripe Connect platform keys targeting a specific connected account, with a link to where the value lives in Stripe settings.
- Relabel to "Account id (optional)" and use a realistic `acct_...` placeholder instead of `stripe_account_id`.

This is display-only metadata. The field `name`, type, and optional flag are unchanged, so no source config or import behavior changes.

## How did you test this code?

No manual UI testing was done in this environment. The change only edits the `SourceConfig` display metadata (`label`, `placeholder`, `caption`) for one field; the `name` (`stripe_account_id`) and functional config are untouched, so existing config/import tests continue to cover behavior. I grepped for tests and snapshots asserting on this field's labels and found none.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack support thread: after Stripe OAuth, the "Account id" field was blank with no explanation of where to get it. I investigated whether it could be auto-filled from the OAuth response and found that would be incorrect: the field is the Connect `stripe_account` header, and sending it on a non-Connect/OAuth key causes Stripe to reject requests (see the non-retryable error copy in `stripe/source.py`). So the right fix is guidance, not auto-fill. Chose a caption plus an "(optional)" label and a realistic placeholder, matching the existing caption style on the `stripe_secret_key` field.

Authored by the PostHog Slack app (Claude).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784300786235469?thread_ts=1784300786.235469&cid=C0ACRAMJUAG)*
