### PR TITLE
chore(data-warehouse): narrow dagster path filter for warehouse_sources

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -138,7 +138,15 @@ jobs:
                         - 'products/cohorts/backend/**/*.py'
                         - 'products/data_modeling/backend/**/*.py'
                         - 'products/data_warehouse/backend/**/*.py'
-                        - 'products/warehouse_sources/backend/**/*.py'
+                        # warehouse_sources is deliberately narrower than the other product
+                        # globs: DAGs import only backend.types and the facade, and the product
+                        # holds 850+ source connector dirs no DAG can reach — a whole-backend
+                        # glob would run this suite on every new-source PR. models/** is kept
+                        # because facade.models re-exports flow through it. Mirrors the
+                        # product's turbo.json backend:contract-check surface.
+                        - 'products/warehouse_sources/backend/types.py'
+                        - 'products/warehouse_sources/backend/facade/**'
+                        - 'products/warehouse_sources/backend/models/**'
                         - 'products/error_tracking/backend/**/*.py'
                         - 'products/event_definitions/backend/**/*.py'
                         - 'products/growth/backend/**/*.py'

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -145,8 +145,8 @@ jobs:
                         # because facade.models re-exports flow through it. Mirrors the
                         # product's turbo.json backend:contract-check surface.
                         - 'products/warehouse_sources/backend/types.py'
-                        - 'products/warehouse_sources/backend/facade/**'
-                        - 'products/warehouse_sources/backend/models/**'
+                        - 'products/warehouse_sources/backend/facade/**/*.py'
+                        - 'products/warehouse_sources/backend/models/**/*.py'
                         - 'products/error_tracking/backend/**/*.py'
                         - 'products/event_definitions/backend/**/*.py'
                         - 'products/growth/backend/**/*.py'


### PR DESCRIPTION
## Problem

The Dagster CI path filter includes a whole-product glob, `products/warehouse_sources/backend/**/*.py`, so any Python change in warehouse_sources — a new source connector, a migration batch (e.g. #71540), a framework tweak, a test file — runs the full Dagster suite. Dagster DAGs actually import only three warehouse_sources modules (`backend/types.py`, `facade/types.py`, `facade/models.py`, from `managed_viewset_sync.py` and `marketing_precompute.py`), and the product holds 850+ source connector directories no DAG can reach.

## Changes

Replaces the whole-backend glob in `ci-dagster.yml`'s `changes` filter with the product's contract surface: `backend/types.py`, `backend/facade/**`, and `backend/models/**` (kept because `facade.models` re-exports flow through it). This mirrors the product's `backend:contract-check` inputs in `products/warehouse_sources/turbo.json`. Source connector, framework, migration, and test changes in warehouse_sources no longer trigger Dagster CI; facade/models/types changes still do.

The `validate-paths` job remains the loud backstop: if a DAG ever imports a warehouse_sources module outside these globs, `check-dagster-paths.py` fails the workflow and forces a filter update. The accepted gap is transitive reach through another covered product's wrappers (e.g. data_warehouse helpers importing warehouse_sources internals) — the same mediated-path trade-off the contract-check system documents.

Companion to #71908 and #71915, which fix the equivalent over-triggering in the backend Django matrix.

## How did you test this code?

- `uv run .github/scripts/check-dagster-paths.py` — all 874 internal imports across 153 dagster files remain covered by the narrowed filter.
- `bin/hogli lint:workflows` — all checks pass.
- Grep-verified the complete set of DAG imports from warehouse_sources (three modules, all inside the retained globs) and that no DAG imports `sources/**`, migrations, or temporal code from the product.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

CI-internal configuration only; no user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session continuing the warehouse_sources CI fan-out audit (#71908, #71915). Skills invoked: /authoring-ci-workflows. The alternative of keeping the broad glob with `!` negations for `temporal/**` and `migrations/**` was considered and rejected in favor of the allowlist mirroring the product's declared contract surface, since the validate-paths job enforces coverage of the allowlist form directly.
