### PR TITLE
fix(postgres): stop capturing unreachable-source noise on CDC status

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -4091,7 +4091,11 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         try:
             live_status = adapter.get_status(instance)
         except Exception as e:
-            capture_exception(e, {"source_id": str(instance.id), "team_id": self.team_id})
+            # An unreachable source DB is the degraded state this endpoint exists to report, so
+            # don't capture expected connection failures as error-tracking noise. Capture only
+            # unexpected errors, which point at a bug in our status read.
+            if not adapter.is_connection_error(e):
+                capture_exception(e, {"source_id": str(instance.id), "team_id": self.team_id})
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": f"Could not connect to source to read CDC status: {e}"},

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/adapters.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/adapters.py
@@ -70,6 +70,13 @@ class CDCSourceAdapter(Protocol[CDCConfigT_co]):
         such that it cannot be resumed and must be recreated."""
         ...
 
+    def is_connection_error(self, exc: BaseException) -> bool:
+        """Whether the exception is an expected failure to reach the source DB (unreachable
+        host, connect timeout, refused, dropped, or a tunnel that can't be established) rather
+        than a bug in PostHog's own code. Callers use it to avoid capturing expected
+        customer/upstream connection failures as error-tracking noise."""
+        ...
+
     def classify_error(self, exc: BaseException) -> CDCErrorInfo | None:
         """Interpret a single engine-specific exception as a CDC error category, or None
         when unrecognized (the caller falls back to the engine-agnostic default). Mirrors

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import psycopg
 import structlog
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import cdc_error_info
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.config import PostgresCDCConfig
@@ -144,6 +145,13 @@ class PostgresCDCAdapter:
 
     def is_slot_invalidation_error(self, exc: BaseException) -> bool:
         return is_slot_invalidation_error(exc)
+
+    def is_connection_error(self, exc: BaseException) -> bool:
+        # psycopg raises OperationalError for every failure to reach the source DB
+        # (connect timeout, refused, unreachable host, DNS, dropped, auth); sshtunnel
+        # raises BaseSSHTunnelForwarderError when the tunnel itself can't be established.
+        # Neither points at a bug in our code.
+        return isinstance(exc, psycopg.OperationalError | BaseSSHTunnelForwarderError)
 
     def classify_error(self, exc: BaseException) -> CDCErrorInfo | None:
         category = classify_postgres_cdc_error(exc)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
@@ -4,6 +4,8 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 import psycopg.errors
+from parameterized import parameterized
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.adapter import (
     PostgresCDCAdapter,
@@ -361,3 +363,18 @@ class TestGetStatus:
         status = PostgresCDCAdapter().get_status(source)
         assert status["published_tables"] == []
         mock_tables.assert_not_called()
+
+
+class TestIsConnectionError:
+    # A connect-time timeout to an unreachable source DB is the failure `cdc_status` reports as a
+    # degraded state; it must classify as a connection error so the endpoint doesn't capture it.
+    @parameterized.expand(
+        [
+            ("connect_timeout", psycopg.errors.ConnectionTimeout("connection timeout expired"), True),
+            ("operational", psycopg.OperationalError("connection refused"), True),
+            ("ssh_tunnel", BaseSSHTunnelForwarderError("could not open tunnel"), True),
+            ("programming_bug", ValueError("unexpected status shape"), False),
+        ]
+    )
+    def test_classifies_connection_errors(self, _name: str, exc: BaseException, expected: bool) -> None:
+        assert PostgresCDCAdapter().is_connection_error(exc) is expected


### PR DESCRIPTION
## Problem

The `cdc_status` endpoint (`products/data_warehouse/backend/presentation/views/external_data_source.py`) opens a short connection to the customer's source Postgres to read live CDC health (slot/publication existence, WAL lag). When the source DB is unreachable, psycopg raises `ConnectionTimeout` ("connection timeout expired"). The endpoint already handles this - it returns a 400 so the UI can show a degraded/unreachable state, exactly as its docstring says it should.

But it also called `capture_exception` on every such failure. So each time someone opens the CDC status page while their database is unreachable, an expected customer/upstream condition gets recorded as an error. This is the error-tracking issue this PR addresses: a handled `ConnectionTimeout` originating from the `cdc_status` poll ([issue](https://us.posthog.com/project/2/error_tracking/019f70af-a60f-7590-b507-04ce45ffc9c3)).

## Changes

Add an engine-level `is_connection_error` classifier to the CDC adapter protocol, implemented for Postgres as "is this a psycopg `OperationalError` or an sshtunnel `BaseSSHTunnelForwarderError`" - i.e. any failure to reach the source DB rather than a bug in our status-reading code. The `cdc_status` handler now gates `capture_exception` on it: expected connection failures (timeout, refused, unreachable host, dropped, tunnel failures) still return the degraded 400 but are no longer captured. Genuinely unexpected errors are still captured.

Keeping the classifier on the adapter (next to `is_slot_invalidation_error` / `classify_error`) keeps psycopg specifics out of the shared DRF layer.

This is not the Temporal import path, so `get_non_retryable_errors` is not involved - the endpoint is a synchronous status poll, not a retried activity.

## How did you test this code?

Added `TestIsConnectionError` in the CDC adapter tests - a parameterized unit test asserting the reported `ConnectionTimeout("connection timeout expired")`, a generic `OperationalError`, and an sshtunnel error all classify as connection errors, while a plain `ValueError` (a real bug) does not. This catches the regression that no existing test did: if the classifier stops recognizing a connect timeout, the endpoint goes back to capturing expected unreachable-source failures. Ran the full adapter suite (26 passed) and repo-wide mypy (clean apart from one pre-existing unrelated error in `personhog_client/converters.py`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude Opus 4.8) while triaging the error-tracking issue above. Traced the stack from the `cdc_status` poll URL through `adapter.get_status` down to the psycopg connect. Decided this is a fixable "expected condition captured as noise" bug rather than a `NonRetryableErrors` case (wrong path - this is a sync API endpoint, not a Temporal activity) and rather than a code crash (the endpoint already degrades gracefully). Invoked `/writing-tests` (placed the regression test at the cheapest unit layer, on the classifier) and `/improving-drf-endpoints` (the touched action is an internal one-line guard with no schema-surface change, so no annotation work was in scope). Considered classifying only `ConnectionTimeout` but chose the broader "couldn't reach the DB" boundary so sibling connection failures (refused, unreachable, tunnel) don't resurface the same noise.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
