### PR TITLE
fix(batch-exports): group schedule fields in config form

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5187,9 +5187,9 @@ snapshots:
     scenes-app-batchexports--backfills-with-estimates--light:
         hash: v1.k794b7964.bdb71e856369ccdaacaf893d0e9427b9bfeb6513333c4af98ca37cb9fb687896.kQuW_-2hLUIZa0vOFnn_FuNuy3d7ALzGXm5P7zamdVc
     scenes-app-batchexports--existing-big-query-export--dark:
-        hash: v1.k794b7964.476c627995630d76be1aa21f786e3fd67ab18a9e8e338aa23934632d13c5ae77.a-XFPIi9aR_XPAZkhfH4BjPKcp_L_Y24nWFXWr8S_04
+        hash: v1.k794b7964.158bb2510d66c6fe81f144c86fd612bac8c95cc95f56186e4465e8995a1e38b8.YJ_6q5QuNZQJsomF5fYIADEUdgz670SCVgfQtUCRL6Y
     scenes-app-batchexports--existing-big-query-export--light:
-        hash: v1.k794b7964.cee320a4307eda367b7544a65396643607bb07ea59c91809321e5bef695f7a83.JcX_Hi3xxov7Ew4uJtaR_AdZcV08HSQDo_RgVjqD4Mk
+        hash: v1.k794b7964.169c050ced77823af76847e5b432e37172733b51a52fa3e4046ab9ef586d40eb.QA_BL0dNaL6VSVaB5YMB03s3-F4U4WQjVKyOY_xGux4
     scenes-app-batchexports--history-empty--dark:
         hash: v1.k794b7964.335f845cb9d44cd636e806a58ea6942a65277de47be270e81adc77b2c66b541f.oqVugKoKPU5zE-sTuwHvXl5gZW4bpcx7X-f9Gf1Ckzw
     scenes-app-batchexports--history-empty--light:
@@ -5207,45 +5207,45 @@ snapshots:
     scenes-app-batchexports--metrics--light:
         hash: v1.k794b7964.560bb6c07c0293fd4c55c4628430209e079c540e5736f3cd22cfdd7bf992fb10.0nghDktvux7dpEKBMRnkGLJs_Sq8J4aq7gcWuPilFss
     scenes-app-batchexports--new-aws-s-3-export--dark:
-        hash: v1.k794b7964.577ca5298744ac2abff8c27de25415a71ab8233997b0ac499fdb7613f987fb45.eaM8-_P1uzBwGci15Mj4yn-NZ_O0j122h1pjoFfAzUY
+        hash: v1.k794b7964.ba28787f570fe963d52c523cedd8e8326324ecd81137a075bc4b4a1c32f22352.pvXD43-IPlixu51pmi5Yb9_skwmXwS8GFPImeRVoJRc
     scenes-app-batchexports--new-aws-s-3-export--light:
-        hash: v1.k794b7964.8d63132ddafc840dcf13df625e0d29e110cd256732b21558dd23338704020fde.WW21kokf8wVLfoBQR0yYbLhJLoSIBJ3KVh6pcVZXpV4
+        hash: v1.k794b7964.c66a1b24331da1daa163f120fcc09c1d5ed8ac8dd78e0aa0d8a4fc05abb4d474.3V0dKBx0AanEoxGf-xa-8gldLnsFagThPGTbO1hQQs0
     scenes-app-batchexports--new-azure-blob-export--dark:
-        hash: v1.k794b7964.667ae0d3678dc3b26e3c51087784a22379ab856a6ae998de8cfc7e087d362ceb.6Lx7U13UmvUs0X6w1B4XK4rZGeO1UgKmdGz3geyQLqc
+        hash: v1.k794b7964.d227776ee0ae44c93af0fce2fce0fc9da5c8931d2be3a782dd7adb2f3760bc02.VmK6ILHB7NaCkWWthKz5_pk9P2E0nyReyDf9p0u6JpE
     scenes-app-batchexports--new-azure-blob-export--light:
-        hash: v1.k794b7964.0315a94af62dea4d6046ba1371238df983d0dc9b6d6b01b478c261d05be2039d.fteT23pAxMRM484_21ctOrn03qAQ_tY30DhPAkErtig
+        hash: v1.k794b7964.74e4fdc93efb6446e31fc8f42506b2c124c2b597e74976ad46fe63d5605f67c9.VSCo8j_5XCX0yQGlUMA-jWi19OpE2gh2iLCR01V6z3w
     scenes-app-batchexports--new-big-query-export--dark:
-        hash: v1.k794b7964.595a19e14378db884b1c57cdc448cb4c3238c8a3cffd8cd6bcf1218d7b8f13e2.bEhz4vmd3xcDvZp0KMJZVwjSLrrRw3PbUaPHpIy5ImM
+        hash: v1.k794b7964.4e98a854cfb3f9ea6775654e96c5c0daf63286b5f086b7913ccc84a9a51d6c6c.DM73bXvKBX6-sPVMAvDKLV2FnUFuu_DIpIoBEXXC5I0
     scenes-app-batchexports--new-big-query-export--light:
-        hash: v1.k794b7964.df6eb27911c56f61d0878231e4b93c0c84fe22581e77b9fd8508fdd64e503277.QnOaYX2vvjgsl3is1JzSws-viDlA543EclTNZx9s_jg
+        hash: v1.k794b7964.25ad001cadbcdb033ee83c394a4bdf255c31f9b505256df7c0ba978246e8bfef.NmigLvuhgu-IGaPD6vkYk5fj3TJHrnlSPx7CgvPni58
     scenes-app-batchexports--new-databricks-export--dark:
-        hash: v1.k794b7964.62a0d75925b126f7763d2bba306173d6d6659deee86b05521884c39cedd8ee09.4pcDnnf9XHITH0eRgrY_M7nc1Hnsea1sSzqVP--np0U
+        hash: v1.k794b7964.52c632dfccfce8311e7e07775cae97e5b8dbd0e8c164f4d910578b36f6057bf3.e9262YQSR9G2kdUIjpB7HxKhZ3neg33Rs6LDun6Urf8
     scenes-app-batchexports--new-databricks-export--light:
-        hash: v1.k794b7964.175b2360ed977ddba553e068d34901f4df186455c24df0dfbde5e5aee5d12a30.zOJvB7pyaDkNAFjRXZAydwYkJPruShcymEB9KJFvpHE
+        hash: v1.k794b7964.568ea6e09ad255c6ab35fe9f8bd2080da52e3f347ac0d2d94179ff7ae961a7ea.yrv5bUcnRY1pEQQEfo3wRskxeyfsEFmry1nDncQvjZs
     scenes-app-batchexports--new-http-export--dark:
-        hash: v1.k794b7964.4b469d69d17e7ffbd90713714e5e3e04c6444e60ea56cab136ff7a0d3dd048eb.dNlHM79EIHUJoayGZrzThOWjrB9hWB1C0a7aXj8n1cA
+        hash: v1.k794b7964.9872d07f9404c34e657202e561faa6ed9793f8739a7eb8924eb9c80f8a3ec4a0.YUz7AOQ_zd71UZuzmz8c8gsoQHhB6qMpoWKsbpW7A7k
     scenes-app-batchexports--new-http-export--light:
-        hash: v1.k794b7964.ede20e92290fccc0c914ea95bdb5982f2285466d9928268ce7604c4f71024835.azXFSmTl75nh3Y3zRg0IobQENzgd6PcS1c3n6sXrP38
+        hash: v1.k794b7964.bb6fd5df7b39fe1f2d725670240deabac6018f2294df4adff0cf7b59658c4301.goEA8ZB1CU_cQDKRlbg2a8kj7_hqREz_Em39RGzduXo
     scenes-app-batchexports--new-postgres-export--dark:
-        hash: v1.k794b7964.3311e6476d597ae25389700de81bdd5083dad4f07ee30dbd15341b61b75ac40f.mUpjOQGx59YVI9LVpxXYJJ7BMa0BAHkPcfpqI66Ba6w
+        hash: v1.k794b7964.0f37ca574b71d528642d63c705f47a508d514413b2fdbc11e3e4bf2f62582990.IeLS4jkdO76AcA7f6uCnpx9m0Ha77i-BL6cNKUYOxdo
     scenes-app-batchexports--new-postgres-export--light:
-        hash: v1.k794b7964.50794892d91d3ba16f6a40199cae0c2fbcdb88f68225bd51d8fcffe84ead7d0d.gchCTMj0N1sj5WSMfcRkVrkuL5oyeeEc5xhyxuI2-I0
+        hash: v1.k794b7964.07ab832542a34e8d6cf32435896fa8db80e75bd5f6ff30a84af2460d866b2e27.e3DOY3ZdXD5wz0IaB9IWUuTrvof0z_QX5uKAevqP0W8
     scenes-app-batchexports--new-redshift-export--dark:
-        hash: v1.k794b7964.dd9c374e731b24f2357abaa0ff4a984d2c339493ce9f1d9210212ece4be0a1e0.CI7kWjUymzD2ho9e9gPuKv1GxXaUDn-4frKwWA2viLw
+        hash: v1.k794b7964.8f0388fbdd4a8d00212684d736e614f2344aad1cfe39367f3b816b20dd763c15.YHxV-ye4sDuyCfkAEScg1Cu1fJNySEqpEd9vHiCqEA4
     scenes-app-batchexports--new-redshift-export--light:
-        hash: v1.k794b7964.eb2083ae118743188351fea0ef1848225bc6067676700e94d64f4c3dd3ee3a44.njvJ_I9LmuMUiLEz7EYuogOGRP48mdzNjnhq7uzJ-i4
+        hash: v1.k794b7964.fa2185c87dad9181ffdec1888102174d0ec3acc2a11411ef597177a9d0d570b1.2wW_Q7snJas3pAN8GKb0XGnS2QMeI_CUZkMwiQ7Wkuc
     scenes-app-batchexports--new-s-3-compatible-export--dark:
-        hash: v1.k794b7964.7233d56bebab07dbd59f97c4ff94f4c6a5a253bff231ae0e729b684c5ea0039a.L4Z1PblDrhQ3IXvOksTrWpynp9U_V7k84FYBhtvq-qs
+        hash: v1.k794b7964.bd6c771412a0a94b18f4ccf9e1d49b5618dd5832f213db69668f4669ec7368fb.wYOVOvzHJarYOR5JuHFQcyRL5SXIUqTU2X5RITySkng
     scenes-app-batchexports--new-s-3-compatible-export--light:
-        hash: v1.k794b7964.f09b548a76ee89747687677a05862dba146ea81f965ad8d6b1beb987beb89f71.V-5PaMjAjFUBpfD0yWM2B2ssGKx7oUYaCJruQZCX8Hs
+        hash: v1.k794b7964.67df45858aeb4fcf46af4f7afabc683cec81be3442b2c561b6af13401b3200a2._8_wr0216yWo9Rn0UqS88sGH35FBPLD-jFMdhw5z_Mk
     scenes-app-batchexports--new-s-3-export--dark:
-        hash: v1.k794b7964.f55931dbb7ab700f5dfe2098ff32e5f14c704cc206dbd02e8d27036dd05edabb.Fd81msCYodqRsep3BNLj51_VIvmROLQsOrqmiQVdphY
+        hash: v1.k794b7964.f46d394738974eb3d02b849560277a19768798eb28f4d0db8ace2b7ed995f6c0.vtSRWfK4ELlej9rcHE2Gu4p_YqNwmszdSKA-ENaoROQ
     scenes-app-batchexports--new-s-3-export--light:
-        hash: v1.k794b7964.1778817ba915c967ed248359a721bb7359f6370dbca5b1e6fb34e8769b78cdba.yEseQ8plqcP182L5sJ8gnS3mPfFvpHzKjNTTsT8h23c
+        hash: v1.k794b7964.0b39adf828caa2776a8a90f798157511d7db9162c7f371f2805af11c646eafa0.pfiWERvy7Xz3-xZHmshfXGWOqGwynxM8mDkFB2Moslk
     scenes-app-batchexports--new-snowflake-export--dark:
-        hash: v1.k794b7964.e843d4755dc71856b6a979dc92ff55bf5b96aad73ae92fc84e75b4928db6a881.l71DgdgJKxvGClNwzNogGnHBQbp2KJLj0oMLs8-Htf4
+        hash: v1.k794b7964.075b8aa4181551b8bee5dceb4982f9b97877b50ead700a111e2667dc3812bdb7.M8WKd7N1oqgqtdmMI9zCDmHrgDdfnDof2FWsg1r3LlY
     scenes-app-batchexports--new-snowflake-export--light:
-        hash: v1.k794b7964.1025c42527dc2156f4a19a8472783095203ac62a2b4dd8081c246a4d5a5b445b.ggdjfWosV1awfLqx-6Y3fw8u4Sogs1W3bnlOAn8q3VI
+        hash: v1.k794b7964.a5e73f672e4c9bd8560cbb4072ed56f74943d530d3c6d7d37f7faa0b62d5f42a.Ym3v_JtQ0zKBQ-oahLRlJYHiNwiQHnbeeUsplE5Awug
     scenes-app-batchexports--runs-empty--dark:
         hash: v1.k794b7964.8177c005d63cababb9abc801ea81b65535c143566c46768b5de465a9d0d53beb.Z_iUGxGBuja1U4pMXOJ99dvgsMUdovOKv-xiIZdsV-U
     scenes-app-batchexports--runs-empty--light:

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -69,6 +69,13 @@ export function BatchExportConfiguration(): JSX.Element {
             <div className="flex flex-wrap gap-4 items-start">
                 <div className="flex flex-col flex-1 max-w-200 min-w-100 gap-y-3">
                     <div className="flex flex-col p-3 rounded border bg-surface-primary gap-y-2">
+                        <div className="flex flex-col gap-y-1">
+                            <h3 className="mb-0">Schedule</h3>
+                            <p className="text-secondary text-xs mb-0">
+                                Controls when batch export runs happen. The timezone here only affects the run schedule,
+                                not the timezone of the exported data.
+                            </p>
+                        </div>
                         <LemonField
                             label="Status"
                             name="paused"
@@ -124,7 +131,7 @@ export function BatchExportConfiguration(): JSX.Element {
                                         name="timezone"
                                         label="Timezone"
                                         className="flex-1"
-                                        info={`Timezone used for determining ${configuration.interval} boundaries for batch export runs`}
+                                        info={`Timezone used for determining ${configuration.interval} boundaries when scheduling batch export runs. This does not change the timezone of the exported data.`}
                                     >
                                         {({ value, onChange }) => {
                                             const currentTimezone = value || teamTimezone || 'UTC'
@@ -209,6 +216,12 @@ export function BatchExportConfiguration(): JSX.Element {
                         )}
                     </div>
                     <div className="flex flex-col p-3 rounded border bg-surface-primary gap-y-2">
+                        <div className="flex flex-col gap-y-1">
+                            <h3 className="mb-0">Data</h3>
+                            <p className="text-secondary text-xs mb-0">
+                                Controls which data is exported and how it's filtered.
+                            </p>
+                        </div>
                         <div className="flex gap-2 min-h-16">
                             <LemonField
                                 name="model"

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -69,12 +69,9 @@ export function BatchExportConfiguration(): JSX.Element {
             <div className="flex flex-wrap gap-4 items-start">
                 <div className="flex flex-col flex-1 max-w-200 min-w-100 gap-y-3">
                     <div className="flex flex-col p-3 rounded border bg-surface-primary gap-y-2">
-                        <div className="flex flex-col gap-y-1">
+                        <div className="flex flex-col gap-y-1 mb-2">
                             <h3 className="mb-0">Schedule</h3>
-                            <p className="text-secondary text-xs mb-0">
-                                Controls when batch export runs happen. The timezone here only affects the run schedule,
-                                not the timezone of the exported data.
-                            </p>
+                            <p className="text-secondary text-xs mb-0">Controls when this batch export runs</p>
                         </div>
                         <LemonField
                             label="Status"
@@ -126,31 +123,6 @@ export function BatchExportConfiguration(): JSX.Element {
 
                         {showTimezoneAndOffsetSelector && (
                             <>
-                                <div className="flex gap-2 min-h-16">
-                                    <LemonField
-                                        name="timezone"
-                                        label="Timezone"
-                                        className="flex-1"
-                                        info={`Timezone used for determining ${configuration.interval} boundaries when scheduling batch export runs. This does not change the timezone of the exported data.`}
-                                    >
-                                        {({ value, onChange }) => {
-                                            const currentTimezone = value || teamTimezone || 'UTC'
-                                            return (
-                                                <LemonInputSelect
-                                                    mode="single"
-                                                    placeholder="Select a time zone"
-                                                    value={[currentTimezone]}
-                                                    onChange={(newValue) => {
-                                                        onChange(newValue[0] || teamTimezone || 'UTC')
-                                                    }}
-                                                    options={timezoneOptions || []}
-                                                    popoverClassName="z-[1000]"
-                                                    virtualized
-                                                />
-                                            )
-                                        }}
-                                    </LemonField>
-                                </div>
                                 {configuration.interval === 'day' && (
                                     <div className="flex gap-2 min-h-16">
                                         <LemonField
@@ -212,15 +184,38 @@ export function BatchExportConfiguration(): JSX.Element {
                                         </LemonField>
                                     </div>
                                 )}
+                                <div className="flex gap-2 min-h-16">
+                                    <LemonField
+                                        name="timezone"
+                                        label="Timezone"
+                                        className="flex-1"
+                                        info={`Timezone used for determining ${configuration.interval} boundaries when scheduling batch export runs. This does not change the timezone of the exported data.`}
+                                    >
+                                        {({ value, onChange }) => {
+                                            const currentTimezone = value || teamTimezone || 'UTC'
+                                            return (
+                                                <LemonInputSelect
+                                                    mode="single"
+                                                    placeholder="Select a time zone"
+                                                    value={[currentTimezone]}
+                                                    onChange={(newValue) => {
+                                                        onChange(newValue[0] || teamTimezone || 'UTC')
+                                                    }}
+                                                    options={timezoneOptions || []}
+                                                    popoverClassName="z-[1000]"
+                                                    virtualized
+                                                />
+                                            )
+                                        }}
+                                    </LemonField>
+                                </div>
                             </>
                         )}
                     </div>
                     <div className="flex flex-col p-3 rounded border bg-surface-primary gap-y-2">
-                        <div className="flex flex-col gap-y-1">
+                        <div className="flex flex-col gap-y-1 mb-2">
                             <h3 className="mb-0">Data</h3>
-                            <p className="text-secondary text-xs mb-0">
-                                Controls which data is exported and how it's filtered.
-                            </p>
+                            <p className="text-secondary text-xs mb-0">Controls which data is exported</p>
                         </div>
                         <div className="flex gap-2 min-h-16">
                             <LemonField


### PR DESCRIPTION
## Problem

The `timezone` field in the batch export config form is potentially confusing — it could be interpreted as controlling the timezone of the data written to the destination (e.g. BigQuery), when it only affects when scheduled runs fire. The schedule-related fields (interval, start time, timezone) weren't visually grouped, so it wasn't obvious they all describe the run schedule.

## Changes

- Added a "Schedule" section heading and short description to the card that already holds the interval, timezone, and start-time fields, so they read together as scheduling settings.
- Added a matching "Data" heading to the adjacent model/filters card for consistency.
- Sharpened the timezone field tooltip to make clear it only affects run scheduling, not the timezone of the exported data.
- Moved the timezone field below the start time, so it's slightly more obvious what the timezone is associated with.

## How did you test this code?

Ran the stack locally

## Screenshot

<img width="928" height="1008" alt="image" src="https://github.com/user-attachments/assets/b2235042-bff7-4c37-9a37-9bd602e440f9" />

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Small copy/layout change scoped to `frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx`. No skills required (pure `.tsx` change, no serializer/API types touched). The schedule fields were already in a single bordered card but lacked a header; the fix makes that grouping explicit and disambiguates the timezone field via its tooltip.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
