### PR TITLE
chore(ci): add stamphog temporal worker deploy target

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -720,6 +720,16 @@ jobs:
                         - 'posthog/clickhouse/migrations/**'
                         - pyproject.toml
                         - bin/temporal-django-worker
+                      # posthog/egress is included because the stamphog worker routes its
+                      # GitHub calls through the egress transport.
+                      stamphog:
+                        - 'products/stamphog/backend/**'
+                        - 'posthog/egress/**'
+                        - 'posthog/temporal/common/**'
+                        - 'posthog/management/commands/start_temporal_worker.py'
+                        - 'posthog/clickhouse/migrations/**'
+                        - pyproject.toml
+                        - bin/temporal-django-worker
 
             - name: Trigger Health Check Temporal Worker Cloud deployment
               if: steps.check_temporal_worker_changes.outputs.healthCheck == 'true'
@@ -832,6 +842,27 @@ jobs:
                           }
                         },
                         "release": "temporal-worker-logs-alerting",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": ${{ steps.labels.outputs.labels }},
+                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                      }
+
+            - name: Trigger Stamphog Temporal Worker Cloud deployment
+              if: steps.check_temporal_worker_changes.outputs.stamphog == 'true'
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                          }
+                        },
+                        "release": "temporal-worker-stamphog",
                         "commit": ${{ toJson(github.event.head_commit) }},
                         "repository": ${{ toJson(github.repository) }},
                         "labels": ${{ steps.labels.outputs.labels }},


### PR DESCRIPTION
## Problem

The stamphog review worker gets its own deploy target in charts (PostHog/charts#13243). Charts-side workflows only promote already-ingested digests between environments; nothing there ever ingests a new build. Without a release entry in `container-images-cd.yml`, the new worker stays pinned at its hand-seeded digest forever (see the signup-enrichment incident that motivated charts' new-app-image-releases doc).

## Changes

- `stamphog` paths filter in the temporal-worker change check: the stamphog product backend, `posthog/egress/**` (the worker routes GitHub calls through the egress transport), plus the shared temporal plumbing every worker entry lists
- repository-dispatch step sending `release: temporal-worker-stamphog` to PostHog/charts, copied from the logs-alerting pair

## How did you test this code?

Agent-prepared PR; checks actually run: `actionlint` passes (exit 0, only pre-existing shellcheck infos on untouched lines). The step is a copy of the adjacent logs-alerting entry with only the filter key and release name changed.

## Automatic notifications

Not applicable.

## Docs update

Not applicable — the charts-side docs already describe this requirement.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prepared by Claude Code (background session, directed by @webjunkie) as the required companion to PostHog/charts#13243, per charts docs/claude/new-app-image-releases.md rule 1 (land the release entry before or with the app's first real use, not as a follow-up). Merge order: this can merge any time; it only dispatches once the filter paths change and is inert until the charts state file exists.
