### PR TITLE
fix(data-imports): retry Langfuse resource-limit 422s as transient

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/langfuse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/langfuse.py
@@ -328,7 +328,11 @@ def get_rows(
             url, params=params, auth=auth, timeout=REQUEST_TIMEOUT_SECONDS, allow_redirects=False, stream=True
         )
 
-        if response.status_code == 429 or response.status_code >= 500:
+        # Langfuse maps a ClickHouse resource limit (memory/timeout) to 422 with an "Request timed
+        # out" body; genuine request-validation failures come back as 400. Deep offset pagination on
+        # the traces endpoint can trip that resource limit, so 422 is a transient upstream error —
+        # retry it through the backoff/resume machinery rather than crashing the sync.
+        if response.status_code in (422, 429) or response.status_code >= 500:
             retry_after = _parse_retry_after(response) if response.status_code == 429 else None
             raise LangfuseRetryableError(
                 f"Langfuse API error (retryable): status={response.status_code}, endpoint={endpoint}",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/tests/test_langfuse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/tests/test_langfuse.py
@@ -470,6 +470,22 @@ class TestGetRows:
         # Only the first page's (legitimate) continuation was saved.
         assert manager.save_state.call_count == 1
 
+    def test_resource_limit_422_is_retried_then_recovers(self):
+        # Langfuse maps a transient ClickHouse resource/timeout to 422 (validation errors are 400).
+        # A 422 must flow through the backoff and recover, not surface as a fatal HTTPError that
+        # fails the sync. Patch the wait so the retry doesn't sleep.
+        manager = self._manager()
+        with mock.patch.object(langfuse_module, "_retry_wait", return_value=0):
+            rows, session = self._run(
+                manager,
+                [
+                    _response(status_code=422, json_data={"error": "Request timed out"}),
+                    _page([{"id": "t1"}], page=1, total_pages=1),
+                ],
+            )
+        assert [r["id"] for r in rows] == ["t1"]
+        assert session.get.call_count == 2
+
     def test_page_limit_raises_after_checkpointing_next_page(self):
         # A hostile host reporting ever-more totalPages would otherwise keep the loop alive until
         # the activity timeout. The run must abort at the cap — retryably, with the next page


### PR DESCRIPTION
## Problem

Error tracking surfaced an uncaught `HTTPError` from the data warehouse import pipeline, in the Langfuse source:

```
422 Client Error: Unprocessable Entity for url:
https://<langfuse-host>/api/public/traces?limit=50&fromTimestamp=<redacted>&orderBy=timestamp.asc&page=<deep-page>
```

Issue: [019f70df-ab1b-7ab1-830c-b70904cf4781](https://us.posthog.com/project/2/error_tracking/019f70df-ab1b-7ab1-830c-b70904cf4781). Raised in `fetch_page` at `products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/langfuse.py` via `raise_for_status()`, reached from `get_rows` while paginating the v1 traces endpoint.

The 422 looks like a client error but isn't one here. Langfuse's public API maps a ClickHouse resource limit (memory limit / overcommit / query timeout) to HTTP **422** with a `{"error": "Request timed out"}` body. Genuine request-validation failures return **400**, not 422. The v1 traces endpoint uses offset-based pagination, and deep offset pages (with the full trace field groups joined) get progressively heavier, so ClickHouse eventually hits a resource/time limit and the request comes back as a 422.

That makes it a **transient upstream error**, not a credentials/config problem and not a bug in how we build the request (the parameters are valid). But `fetch_page` only retried `429` and `5xx`, so a 422 raised a fatal `HTTPError` and failed the whole sync instead of being retried.

## Changes

Treat a Langfuse `422` as retryable, alongside `429`/`5xx`. It now raises `LangfuseRetryableError` and flows through the existing tenacity backoff and the resume checkpoint, giving a load- or time-limited request a chance to recover instead of crashing the sync. This is safe because on the Langfuse public API a 422 is exclusively a ClickHouse resource/timeout error — validation errors come back as 400.

I did not widen `NonRetryableErrors`: this is a transient timeout, so per the pipeline's error-handling policy it stays retryable.

```diff
-        if response.status_code == 429 or response.status_code >= 500:
+        if response.status_code in (422, 429) or response.status_code >= 500:
```

## How did you test this code?

Automated only (I'm an agent — no manual sync run). Added `test_resource_limit_422_is_retried_then_recovers` to `TestGetRows`: it queues a `422` followed by a valid page and asserts the rows come back and `session.get` was called twice, proving the 422 was retried rather than surfaced as a fatal error. It catches a regression where 422 handling is dropped and a transient Langfuse timeout again crashes the sync — no existing test exercised the retry-on-status path through `get_rows`.

Ran the Langfuse source suite locally:

```
uv run pytest .../sources/langfuse/tests/ -q
72 passed
```

Invoked the `/writing-tests` skill while adding the test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude. I confirmed the issue in PostHog error tracking (single occurrence, one team), read the stack trace end to end into `fetch_page`/`get_rows`, then traced the 422 into Langfuse's own source: `withMiddlewares` returns 422 only for `ClickHouseResourceError` (types `MEMORY_LIMIT` / `OVERCOMMIT` / `TIMEOUT`), while zod validation errors return 400. That's what pinned the decision to "transient, keep retryable" rather than adding it to `NonRetryableErrors`. I considered tuning `page_size`, but smaller pages mean deeper offsets for the same data, which doesn't reduce the offset-pagination cost — so the scoped fix is to retry. Checked open PRs (including the maintainer's) for a duplicate; none addresses this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
