### PR TITLE
fix(rbac): handle non-user principals in direct-connection access check

### DIFF
--- a/posthog/hogql/direct_connection.py
+++ b/posthog/hogql/direct_connection.py
@@ -7,12 +7,15 @@ from posthog.schema import HogQLQueryModifiers
 from posthog.hogql.database.database import Database
 from posthog.hogql.timings import HogQLTimings
 
+from posthog.models import User
 from posthog.rbac.user_access_control import UserAccessControl
 
 from products.warehouse_sources.backend.facade.models import ExternalDataSource
 
 if TYPE_CHECKING:
-    from posthog.models import Team, User
+    from posthog.models import Team
+    from posthog.shared_link_user import SharedLinkUser
+    from posthog.synthetic_user import SyntheticUser
 
 
 INVALID_CONNECTION_ID_ERROR = (
@@ -22,7 +25,11 @@ INVALID_CONNECTION_ID_ERROR = (
 
 
 def get_direct_connection_source(
-    team: "Team", connection_id: str | None, *, user: Optional["User"] = None, require_pure_direct: bool = False
+    team: "Team",
+    connection_id: str | None,
+    *,
+    user: Optional["User | SyntheticUser | SharedLinkUser"] = None,
+    require_pure_direct: bool = False,
 ) -> ExternalDataSource | None:
     if not connection_id:
         return None
@@ -53,7 +60,11 @@ def get_direct_connection_source(
     if require_pure_direct and source.access_method != ExternalDataSource.AccessMethod.DIRECT:
         return None
 
-    if user is not None and not UserAccessControl(user=user, team=team).check_access_level_for_object(
+    # Only real users carry an RBAC identity. Non-user principals (shared-link viewers, service
+    # tokens) have no organization membership to query by - filtering AccessControl by their
+    # non-integer id raises a TypeError - and they bypass warehouse access control by design
+    # (see Database.create_for), so the direct-connection source is available to them.
+    if isinstance(user, User) and not UserAccessControl(user=user, team=team).check_access_level_for_object(
         source, required_level="viewer"
     ):
         return None
@@ -65,7 +76,7 @@ def get_direct_connection_source_none_or_raise(
     team: "Team",
     connection_id: str | None,
     *,
-    user: Optional["User"] = None,
+    user: Optional["User | SyntheticUser | SharedLinkUser"] = None,
     error_factory: Callable[[str], Exception],
     require_pure_direct: bool = False,
 ) -> ExternalDataSource | None:
@@ -79,7 +90,7 @@ def resolve_database_for_connection(
     team: "Team",
     connection_id: str | None,
     *,
-    user: Optional["User"] = None,
+    user: Optional["User | SyntheticUser | SharedLinkUser"] = None,
     modifiers: HogQLQueryModifiers | None = None,
     timings: HogQLTimings | None = None,
     error_factory: Callable[[str], Exception],

--- a/posthog/hogql/direct_connection.py
+++ b/posthog/hogql/direct_connection.py
@@ -9,6 +9,7 @@ from posthog.schema import HogQLQueryModifiers
 from posthog.hogql.database.database import Database
 from posthog.hogql.timings import HogQLTimings
 
+from posthog.models import User
 from posthog.ph_client import feature_enabled_or_false
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.shared_link_user import SharedLinkUser
@@ -21,7 +22,7 @@ from products.warehouse_sources.backend.facade.models import (
 )
 
 if TYPE_CHECKING:
-    from posthog.models import Team, User
+    from posthog.models import Team
 
 
 INVALID_CONNECTION_ID_ERROR = (
@@ -84,7 +85,11 @@ def raw_query_denied_by_table_access(
 
 
 def get_direct_connection_source(
-    team: "Team", connection_id: str | None, *, user: Optional["User"] = None, require_pure_direct: bool = False
+    team: "Team",
+    connection_id: str | None,
+    *,
+    user: Optional["User | SyntheticUser | SharedLinkUser"] = None,
+    require_pure_direct: bool = False,
 ) -> ExternalDataSource | None:
     if not connection_id:
         return None
@@ -122,8 +127,12 @@ def get_direct_connection_source(
     if require_pure_direct and source.access_method != ExternalDataSource.AccessMethod.DIRECT:
         return None
 
+    # Only real users carry an RBAC identity. Non-user principals (shared-link viewers, service
+    # tokens) have no organization membership to query by - filtering AccessControl by their
+    # non-integer id raises a TypeError - and they bypass warehouse access control by design
+    # (see Database.create_for), so the direct-connection source is available to them.
     if (
-        user is not None
+        isinstance(user, User)
         and managed_warehouse_mode != ManagedWarehouseSQLMode.BUILT_IN
         and not UserAccessControl(user=user, team=team).check_access_level_for_object(source, required_level="viewer")
     ):
@@ -136,7 +145,7 @@ def get_direct_connection_source_none_or_raise(
     team: "Team",
     connection_id: str | None,
     *,
-    user: Optional["User"] = None,
+    user: Optional["User | SyntheticUser | SharedLinkUser"] = None,
     error_factory: Callable[[str], Exception],
     require_pure_direct: bool = False,
 ) -> ExternalDataSource | None:
@@ -150,7 +159,7 @@ def resolve_database_for_connection(
     team: "Team",
     connection_id: str | None,
     *,
-    user: Optional["User"] = None,
+    user: Optional["User | SyntheticUser | SharedLinkUser"] = None,
     modifiers: HogQLQueryModifiers | None = None,
     timings: HogQLTimings | None = None,
     error_factory: Callable[[str], Exception],

--- a/posthog/hogql/test/test_direct_connection.py
+++ b/posthog/hogql/test/test_direct_connection.py
@@ -1,6 +1,12 @@
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
+
 from posthog.hogql.direct_connection import get_direct_connection_source
+
+from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.shared_link_user import SharedLinkUser
+from posthog.synthetic_user import SyntheticUser
 
 from products.warehouse_sources.backend.facade.models import ExternalDataSource
 from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
@@ -41,3 +47,23 @@ class TestGetDirectConnectionSource(APIBaseTest):
 
         assert resolved is not None
         self.assertEqual(resolved.id, source.id)
+
+    @parameterized.expand(
+        [
+            ("shared_link_user", lambda self: SharedLinkUser(self._enabled_sharing_configuration())),
+            ("synthetic_user", lambda self: SyntheticUser(self.team, "svc-token")),
+        ]
+    )
+    def test_non_user_principal_resolves_source_without_error(self, _name, make_user):
+        # A non-user principal (shared-link viewer, service token) has no RBAC identity; filtering
+        # AccessControl by its non-integer id used to raise TypeError and fail the query closed.
+        # These principals bypass warehouse access control by design, so the source must resolve.
+        source = self._create_source(access_method=ExternalDataSource.AccessMethod.DIRECT)
+
+        resolved = get_direct_connection_source(self.team, str(source.id), user=make_user(self))
+
+        assert resolved is not None
+        self.assertEqual(resolved.id, source.id)
+
+    def _enabled_sharing_configuration(self) -> SharingConfiguration:
+        return SharingConfiguration.objects.create(team=self.team, enabled=True)

--- a/posthog/hogql/test/test_direct_connection.py
+++ b/posthog/hogql/test/test_direct_connection.py
@@ -13,6 +13,9 @@ from posthog.hogql.query import HogQLQueryExecutor
 
 from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership, Team
+from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.shared_link_user import SharedLinkUser
+from posthog.synthetic_user import SyntheticUser
 
 from products.warehouse_sources.backend.facade.models import (
     MANAGED_WAREHOUSE_SOURCE_PREFIX,
@@ -263,6 +266,26 @@ class TestGetDirectConnectionSource(APIBaseTest):
         for source in (deleted_source, cross_team_source):
             self.assertIsNone(get_direct_connection_source(self.team, str(source.id)))
             self.assertIsNone(get_direct_external_data_source_for_connection(self.team.id, str(source.id)))
+
+    @parameterized.expand(
+        [
+            ("shared_link_user", lambda self: SharedLinkUser(self._enabled_sharing_configuration())),
+            ("synthetic_user", lambda self: SyntheticUser(self.team, "svc-token")),
+        ]
+    )
+    def test_non_user_principal_resolves_source_without_error(self, _name, make_user):
+        # A non-user principal (shared-link viewer, service token) has no RBAC identity; filtering
+        # AccessControl by its non-integer id used to raise TypeError and fail the query closed.
+        # These principals bypass warehouse access control by design, so the source must resolve.
+        source = self._create_source(access_method=ExternalDataSource.AccessMethod.DIRECT)
+
+        resolved = get_direct_connection_source(self.team, str(source.id), user=make_user(self))
+
+        assert resolved is not None
+        self.assertEqual(resolved.id, source.id)
+
+    def _enabled_sharing_configuration(self) -> SharingConfiguration:
+        return SharingConfiguration.objects.create(team=self.team, enabled=True)
 
 
 class TestRawQueryTableAccess(APIBaseTest):


### PR DESCRIPTION
## Problem

A new `TypeError` started firing in the RBAC access-control path on 2026-07-10, growing week over week (37 → 60 → 79 occurrences over 7 days). It breaks permission checks for publicly shared, warehouse-backed queries.

```
TypeError: Field 'id' expected a number but got <posthog.shared_link_user.SharedLinkUser object ...>
  posthog/rbac/user_access_control.py:377  _organization_membership
```

The regression traces to the shared-link execution work that started routing a `SharedLinkUser` (an `AnonymousUser` subclass representing an anonymous shared-link viewer, with no integer id) through the access-control layer. When a `/shared/` insight is backed by a direct-connection warehouse source, `get_direct_connection_source` runs an object-level access check:

```python
if user is not None and not UserAccessControl(user=user, team=team).check_access_level_for_object(...):
    return None
```

`user is not None` is true for a `SharedLinkUser`, so it builds a `UserAccessControl` for that principal. Resolving org membership then filters `AccessControl` by `user=<SharedLinkUser>`, and Django tries to coerce the object to an integer FK id, raising the `TypeError`. The check fails closed, so shared warehouse-backed queries error out rather than rendering (no 5xx surge, which is why it stayed quiet).

Confirmed live from the error tracking issue: 79 occurrences / 16 sessions / 3 users over 7 days, first seen 2026-07-10, last seen the day this was written. The captured request URL is a shared-token insight refresh (`.../insights/<id>/?...&sharing_access_token=...`), and the full stack ends exactly at `get_direct_connection_source` → `check_access_level_for_object` → `_organization_membership`.

## Changes

Gate the object-level access check on `isinstance(user, User)` instead of `user is not None`. Only real `User` principals carry an RBAC identity. Non-user principals (shared-link viewers via `SharedLinkUser`, service tokens via `SyntheticUser`) have no organization membership to query by, and they already bypass warehouse access control by design in `Database.create_for` - so the direct-connection source resolves for them too, consistent with that decision.

Also widened the `user` parameter type hints on the three functions in `direct_connection.py` from `Optional[User]` to `Optional[User | SyntheticUser | SharedLinkUser]`, matching the signatures already used in `database.py`, so the real principal types flowing through are honest and `isinstance` narrows cleanly.

> [!NOTE]
> No behavior change for real users: a `User` still goes through the full object-level access check exactly as before.

## How did you test this code?

Added 2 parameterized cases to `TestGetDirectConnectionSource` in `posthog/hogql/test/test_direct_connection.py`, covering a `SharedLinkUser` and a `SyntheticUser` resolving a direct-connection source. No existing test in that file passed a `user`, so none exercised the non-user-principal path.

I verified the test reproduces the exact production error before the fix (temporarily reverting the guard to `user is not None` makes the `shared_link_user` case fail with `TypeError: Field 'id' expected a number but got <SharedLinkUser object ...>`), and passes after.

```
posthog/hogql/test/test_direct_connection.py .....
============================== 5 passed in 14.94s ==============================
```

Ran `ruff check --fix`, `ruff format`, and mypy on the changed module (no new errors introduced by this change). I did not perform manual browser testing of a live shared link.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) confirmed the signal end to end before touching code: pulled the error tracking issue and a sampled `$exception` event via the PostHog MCP to get the real stack trace and request URL, which pinned the failure to `get_direct_connection_source` rather than the `database.py` / query-runner paths (both of which already handle `SharedLinkUser`).

Root-cause options considered: (1) short-circuit inside `UserAccessControl` for anonymous users, (2) skip the check in `get_direct_connection_source` for non-user principals. Chose (2) because it keeps the fix at the layer that already owns the "does this principal bypass warehouse access control" decision, and mirrors the `isinstance(user, SyntheticUser | SharedLinkUser)` handling in `Database.create_for`. Using `isinstance(user, User)` (rather than enumerating the bypass types) means any future non-user principal is also handled correctly.

Skills invoked: `/writing-tests` (gated the regression test - parameterized the two principal types into the existing test class rather than adding a new DB-round-trip test).
