### PR TITLE
feat(error-tracking): adopt single source assignee on issue merge

### DIFF
--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -102,6 +102,10 @@ class ErrorTrackingIssue(UUIDTModel):
             ErrorTrackingSpikeEvent.objects.filter(team_id=team_id, issue_id__in=existing_source_issue_ids).update(
                 issue_id=target_issue_id
             )
+            # Read source assignees before the delete cascades their assignment rows away
+            _adopt_source_assignee_on_merge(
+                team_id=team_id, target_issue_id=target_issue_id, source_issue_ids=existing_source_issue_ids
+            )
             ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=existing_source_issue_ids).delete()
 
             _sync_error_tracking_issue_changes_on_commit(
@@ -233,6 +237,32 @@ def _lock_merge_issues(*, team_id: int, target_issue_id: UUID, source_issue_ids:
         return []
 
     return source_issue_ids
+
+
+def _adopt_source_assignee_on_merge(*, team_id: int, target_issue_id: UUID, source_issue_ids: list[UUID]) -> None:
+    """Carry a single shared assignee from merged issues onto an unassigned target.
+
+    Only fires when the target has no assignee and the sources resolve to exactly one
+    distinct assignee — ambiguous (2+) or empty assignee sets leave the target untouched.
+    Source issue ids are already team-scoped and row-locked by the caller.
+    """
+    if ErrorTrackingIssueAssignment.objects.filter(issue_id=target_issue_id).exists():
+        return
+
+    distinct_assignees = {
+        (assignment.user_id, assignment.role_id)
+        for assignment in ErrorTrackingIssueAssignment.objects.filter(issue_id__in=source_issue_ids)
+    }
+    if len(distinct_assignees) != 1:
+        return
+
+    user_id, role_id = next(iter(distinct_assignees))
+    if user_id is None and role_id is None:
+        return
+
+    ErrorTrackingIssueAssignment.objects.create(
+        team_id=team_id, issue_id=target_issue_id, user_id=user_id, role_id=role_id
+    )
 
 
 def _lock_expected_fingerprint_issue_ids(*, team_id: int, expected_fingerprint_issue_ids: dict[str, UUID]) -> bool:

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -249,9 +249,11 @@ def _adopt_source_assignee_on_merge(*, team_id: int, target_issue_id: UUID, sour
     if ErrorTrackingIssueAssignment.objects.filter(issue_id=target_issue_id).exists():
         return
 
+    # Lock the source assignments so a concurrent assign can't commit a new assignee that we then
+    # read as stale and delete via cascade — matches the fingerprint locking in merge().
     distinct_assignees = {
         (assignment.user_id, assignment.role_id)
-        for assignment in ErrorTrackingIssueAssignment.objects.filter(issue_id__in=source_issue_ids)
+        for assignment in ErrorTrackingIssueAssignment.objects.select_for_update().filter(issue_id__in=source_issue_ids)
     }
     if len(distinct_assignees) != 1:
         return

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -266,7 +266,9 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
             # (source assignees, target assignee, expected target assignee after merge)
             ("single_source_assignee_adopted", ["a"], None, "a"),
             ("repeated_same_source_assignee_adopted", ["a", "a"], None, "a"),
+            ("single_assignee_with_unassigned_sources_adopted", ["a", None, None], None, "a"),
             ("ambiguous_distinct_assignees_left_unassigned", ["a", "b"], None, None),
+            ("ambiguous_distinct_assignees_with_unassigned_left_unassigned", ["a", "b", None], None, None),
             ("no_source_assignees_left_unassigned", [None, None], None, None),
             ("target_assignee_takes_precedence", ["a"], "b", "b"),
         ]

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -11,7 +11,9 @@ from unittest.mock import patch
 from django.db import close_old_connections, connection, transaction
 from django.db.utils import IntegrityError
 
-from posthog.models import Team
+from parameterized import parameterized
+
+from posthog.models import Team, User
 
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
@@ -258,6 +260,41 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         with pytest.raises(IntegrityError):
             ErrorTrackingIssueAssignment.objects.create(issue=issue, user=self.user)
             ErrorTrackingIssueAssignment.objects.create(issue=issue, user=self.user)
+
+    @parameterized.expand(
+        [
+            # (source assignees, target assignee, expected target assignee after merge)
+            ("single_source_assignee_adopted", ["a"], None, "a"),
+            ("repeated_same_source_assignee_adopted", ["a", "a"], None, "a"),
+            ("ambiguous_distinct_assignees_left_unassigned", ["a", "b"], None, None),
+            ("no_source_assignees_left_unassigned", [None, None], None, None),
+            ("target_assignee_takes_precedence", ["a"], "b", "b"),
+        ]
+    )
+    def test_merge_adopts_single_source_assignee(self, _name, source_keys, target_key, expected_key):
+        users = {"a": self.user, "b": User.objects.create(email="merge_assignee_b@posthog.com")}
+
+        def assign(issue: ErrorTrackingIssue, key: str | None) -> None:
+            if key is not None:
+                ErrorTrackingIssueAssignment.objects.create(issue=issue, team=self.team, user=users[key])
+
+        target = self.create_issue(["target_fingerprint"])
+        assign(target, target_key)
+
+        source_ids = []
+        for index, key in enumerate(source_keys):
+            source = self.create_issue([f"source_fingerprint_{index}"])
+            assign(source, key)
+            source_ids.append(source.id)
+
+        target.merge(issue_ids=source_ids)
+
+        assignment = ErrorTrackingIssueAssignment.objects.filter(issue_id=target.id).first()
+        if expected_key is None:
+            assert assignment is None
+        else:
+            assert assignment is not None
+            assert assignment.user_id == users[expected_key].id
 
     @freeze_time("2025-01-01")
     def test_error_tracking_issue_first_seen_earliest_fingerprint(self):


### PR DESCRIPTION
## Problem

When you merge error tracking issues, the target issue keeps whatever assignee it had and the merged-in issues' assignees are just dropped. If the target was unassigned and the issues being merged in were clearly owned by one person, that ownership is lost for no good reason. You then have to reassign by hand.

## Changes

On merge, if the target issue has no assignee and the merged (source) issues resolve to exactly one distinct assignee, the target adopts that assignee. Guardrails:

- Target already has an assignee → it wins, nothing changes.
- Sources have 2+ distinct assignees → ambiguous, target stays unassigned.
- Sources have no assignee → nothing to adopt.

The adoption happens inside `ErrorTrackingIssue.merge()`, in the same transaction, right before the source issues are deleted. That ordering matters: `ErrorTrackingIssueAssignment.issue` is a `OneToOneField(on_delete=CASCADE)`, so the source assignments are gone the moment the source issues are deleted. We read them first, then create the target assignment. The existing on-commit ClickHouse sync already reads `issue.assignment`, so the new assignee flows through to ClickHouse without extra wiring.

An assignee is a `(user_id, role_id)` pair, so a role assignee is carried over the same way a user assignee is.

## How did you test this code?

Added a parameterized model-level test (`test_merge_adopts_single_source_assignee`) covering the four branches: single-source adoption, repeated-same-assignee adoption, 2+ distinct assignees left unassigned, no-source-assignee noop, and target-assignee-precedence. No existing merge test exercised assignee carry-over, so this catches a regression in the adoption guard logic.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Aleksander asked for this; I (Claude, via Claude Code) implemented it. I put the logic in the model's `merge()` rather than the logic/facade layer because the source assignments must be read inside the merge transaction before the cascade delete removes them. Doing it a layer up would mean reading source assignees before the call and writing the target after, outside the transaction boundary, which is racy. The model layer keeps it atomic and lets the existing ClickHouse sync pick up the change for free.

Skills invoked: `/writing-tests` (to gate the test to model-level parameterized cases rather than an endpoint round-trip). I kept the merge path's existing behavior of not emitting an activity-log entry or assignment email for the adoption, matching how `merge()` already works (it is not user-attributed at the model layer).
