### PR TITLE
fix(admin): allow saving personal API keys with blank scoped fields

### DIFF
--- a/posthog/admin/admins/personal_api_key_admin.py
+++ b/posthog/admin/admins/personal_api_key_admin.py
@@ -1,5 +1,8 @@
+from typing import Any
+
+from django import forms
 from django.contrib import admin
-from django.http import HttpResponseNotAllowed
+from django.http import HttpRequest, HttpResponseNotAllowed
 from django.shortcuts import redirect
 from django.urls import path, reverse
 from django.utils.html import format_html
@@ -38,6 +41,20 @@ class PersonalAPIKeyAdmin(admin.ModelAdmin):
     search_fields = ("id", "user__email", "scopes")
     autocomplete_fields = ("user", "team")
     ordering = ("-created_at",)
+
+    def get_form(
+        self, request: HttpRequest, obj: PersonalAPIKey | None = None, change: bool = False, **kwargs: Any
+    ) -> type[forms.ModelForm]:
+        form = super().get_form(request, obj, change=change, **kwargs)
+        # `scoped_teams` / `scoped_organizations` are nullable in the DB (null/[] = unscoped,
+        # the normal state of every UI-minted key) but lack `blank=True` on the model, so
+        # Django's default form marks them required - which made the change form unsaveable
+        # for unscoped keys (e.g. adding an OAuth-hidden support scope to a staff key).
+        # Blank input saves as [], which every scoping check treats the same as null.
+        for field_name in ("scoped_teams", "scoped_organizations"):
+            if field_name in form.base_fields:
+                form.base_fields[field_name].required = False
+        return form
 
     @admin.display(description="User")
     def user_link(self, key: PersonalAPIKey):

--- a/posthog/admin/test_admin.py
+++ b/posthog/admin/test_admin.py
@@ -8,10 +8,12 @@ from django.test import RequestFactory
 
 from posthog.admin import _OAUTH_ADMIN_MODEL_NAMES, install_admin_app_list_overrides, register_all_admin
 from posthog.admin.admins.event_ingestion_restriction_config import EventIngestionRestrictionConfigAdmin
+from posthog.admin.admins.personal_api_key_admin import PersonalAPIKeyAdmin
 from posthog.admin.admins.user_admin import UserAdmin, UserChangeForm
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberForUserInline, OrganizationMemberInline
-from posthog.models import User
+from posthog.models import PersonalAPIKey, User
 from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
+from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 from products.alerts.backend.models.alert import AlertConfiguration
 from products.cdp.backend.admin.plugin_attachment_inline import PluginAttachmentInline
@@ -231,3 +233,36 @@ class TestOrganizationMemberInlineConfig(BaseTest):
         assert "invited_by" in OrganizationMemberInline.readonly_fields
         assert "invited_by" in OrganizationMemberForUserInline.fields
         assert "invited_by" in OrganizationMemberForUserInline.readonly_fields
+
+
+class TestPersonalAPIKeyAdminForm(BaseTest):
+    def test_change_form_saves_unscoped_key_with_blank_scoped_fields(self):
+        # scoped_teams/scoped_organizations are nullable but not `blank`, so without the
+        # admin's get_form override the change form demands values for them - making it
+        # impossible to edit an unscoped key at all (the flow for granting OAuth-hidden
+        # scopes like batch_import_support:read to a staff key).
+        key = PersonalAPIKey.objects.create(
+            user=self.user, label="support", secure_value=hash_key_value(generate_random_token_personal())
+        )
+        key_admin = PersonalAPIKeyAdmin(PersonalAPIKey, admin.site)
+        request = RequestFactory().get("/admin/")
+
+        form_class = key_admin.get_form(request, key, change=True)
+        form = form_class(
+            data={
+                "label": "support",
+                # Admin renders DateTimeField with a split date/time widget.
+                "created_at_0": "2026-01-01",
+                "created_at_1": "00:00:00",
+                "scopes": "user:read,batch_import_support:read",
+                "scoped_teams": "",
+                "scoped_organizations": "",
+            },
+            instance=key,
+        )
+
+        assert form.is_valid(), form.errors
+        saved = form.save()
+        assert saved.scopes == ["user:read", "batch_import_support:read"]
+        assert not saved.scoped_teams
+        assert not saved.scoped_organizations

--- a/products/managed_migrations/docs/support-mcp-tools.md
+++ b/products/managed_migrations/docs/support-mcp-tools.md
@@ -20,7 +20,10 @@ The `batch_import_support:read` scope is **hidden from the key-creation UI** and
 so minting takes two steps — create the key normally, then add the hidden scope via Django admin:
 
 1. In the PostHog UI on the region you want to inspect, go to **Settings → Personal API keys** and create a key with the **User: Read** scope and **no organization/project restriction** (the endpoint rejects scoped keys). Copy the `phx_...` value — it is shown only once.
-2. In Django admin (`/admin/posthog/personalapikey/`), open your new key and add `batch_import_support:read` to its `scopes` list, then save. Do this **before** first using the key with MCP — the MCP server caches a token's scopes on first use.
+2. In Django admin (`/admin/posthog/personalapikey/`), open your new key and add `batch_import_support:read` to its `scopes` list (comma-separated, no spaces), then save.
+   Leave `Scoped teams` / `Scoped organizations` **blank** — the key must stay unscoped.
+   Do this **before** first using the key with MCP — the MCP server caches a token's scopes on first use.
+   Note: admin bypasses scope validation, so a typo in the scope string saves fine and just silently never matches — double-check the spelling.
 
 <details>
 <summary>Alternative: one-shot mint from the browser console</summary>
@@ -34,8 +37,16 @@ await fetch('/api/personal_api_keys/', {
     'Content-Type': 'application/json',
     'X-Csrftoken': document.cookie.match(/posthog_csrftoken=([^;]+)/)[1],
   },
-  body: JSON.stringify({ label: 'migrations support', scopes: ['batch_import_support:read', 'user:read'] }),
-}).then((r) => r.json())
+  body: JSON.stringify({
+    label: 'migrations support',
+    scopes: ['batch_import_support:read', 'user:read'],
+    // Required keys (the serializer demands them even when empty); [] = unscoped.
+    scoped_teams: [],
+    scoped_organizations: [],
+  }),
+})
+  .then((r) => r.json())
+  .then((k) => k.value)
 ```
 
 The CSRF header is required — session-authenticated POSTs are CSRF-protected.


### PR DESCRIPTION
## Problem

Editing a personal API key in Django admin is currently impossible for unscoped keys: `scoped_teams` and `scoped_organizations` are nullable in the DB (null = unscoped, the normal state of every UI-minted key) but lack `blank=True` on the model, so Django's default model form marks them required. Saving the change form fails with "This field is required" on both, and there is no valid value to enter, since any value would tenant-scope the key.

This blocks the documented staff flow for minting support keys (#70120): create a key in the UI, then add the OAuth-hidden `batch_import_support:read` scope via Django admin. The doc's fallback console snippet was also broken, because the serializer requires `scoped_teams`/`scoped_organizations` to be present in the request body (the `required=False` in the serializer sits on the list children, not the fields), and the snippet omitted them.

## Changes

- `PersonalAPIKeyAdmin.get_form` now marks `scoped_teams`/`scoped_organizations` as not required. Blank input saves as `[]`, which every scoping check already treats the same as null. Admin-level override instead of model `blank=True` so no migration is needed and the DRF surface is untouched.
- Fixed the console-mint snippet in the managed-migrations support docs to include the two required-but-empty fields, and noted in the admin step that the scoped fields must stay blank and that admin bypasses scope-string validation (typos save silently).

## How did you test this code?

- New test `TestPersonalAPIKeyAdminForm::test_change_form_saves_unscoped_key_with_blank_scoped_fields` builds the admin change form and saves an unscoped key with blank scoped fields while adding a hidden scope - this fails without the `get_form` override (both fields error as required), which no existing test caught.
- Ran `posthog/admin/test_admin.py` locally: 30 passed.
- I have not manually exercised the admin page in a browser for this change; the form-level test drives the same form class the admin view uses.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `products/managed_migrations/docs/support-mcp-tools.md` in this PR (snippet fix + admin-step notes).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, driven by @nickbest-ph after field-testing the support-key mint flow from #70120 and hitting both breakages. Skills invoked: /writing-tests. Decisions: chose an admin `get_form` override over model `blank=True` (same effect, avoids a no-op migration on a high-traffic app) and left the serializer's accidental field-requiredness as is to keep this PR admin-scoped - moving `required=False` from the list children to the fields themselves is a possible follow-up that would also let API callers omit the two fields.
