### PR TITLE
feat(dashboards): use a dropdown for the test account filter override

### DIFF
--- a/frontend/src/lib/components/TestAccountFiltersSwitch.test.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
@@ -8,7 +8,7 @@ import { initKeaTests } from '~/test/init'
 
 import { TestAccountFilterSwitch } from './TestAccountFiltersSwitch'
 
-describe('TestAccountFilterSwitch', () => {
+describe('TestAccountFilterSwitch — gear icon links to internal test filtering settings', () => {
     beforeEach(() => {
         initKeaTests()
         featureFlagLogic.mount()
@@ -18,24 +18,12 @@ describe('TestAccountFilterSwitch', () => {
         cleanup()
     })
 
-    it('gear icon navigates to the project product analytics settings, scrolled to internal-user-filtering', () => {
+    it('navigates to the project product analytics settings, scrolled to internal-user-filtering', () => {
         render(<TestAccountFilterSwitch checked={false} onChange={jest.fn()} />)
 
         // The LemonSwitch itself has role="switch"; the gear is rendered as a link.
         // The router prepends a `/project/<id>` prefix to the href, so match the suffix.
         const gear = screen.getByRole('link')
         expect(gear.getAttribute('href')).toMatch(/\/settings\/project-product-analytics#internal-user-filtering$/)
-    })
-
-    it('clicking "Unset override" calls onReset without toggling the switch', () => {
-        const onChange = jest.fn()
-        const onReset = jest.fn()
-        render(<TestAccountFilterSwitch checked={true} onChange={onChange} onReset={onReset} />)
-
-        // The reset link sits inside the switch's <label> — a forwarded click would also toggle the switch
-        fireEvent.click(screen.getByText('Unset override'))
-
-        expect(onReset).toHaveBeenCalledTimes(1)
-        expect(onChange).not.toHaveBeenCalled()
     })
 })

--- a/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
@@ -1,24 +1,17 @@
 import { useValues } from 'kea'
 
 import { IconGear } from '@posthog/icons'
-import { LemonButton, LemonSwitch, LemonSwitchProps, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, LemonSwitchProps } from '@posthog/lemon-ui'
 
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 type TestAccountFilterProps = Partial<LemonSwitchProps> & {
-    checked: boolean | 'indeterminate'
+    checked: boolean
     onChange: (checked: boolean) => void
-    /** Marks the switch as an override control: shows "No override set" while indeterminate, and an "Unset override" link (calling this) once resolved. */
-    onReset?: () => void
 }
 
-export function TestAccountFilterSwitch({
-    checked,
-    onChange,
-    onReset,
-    ...props
-}: TestAccountFilterProps): JSX.Element | null {
+export function TestAccountFilterSwitch({ checked, onChange, ...props }: TestAccountFilterProps): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
     const hasFilters = (currentTeam?.test_account_filters || []).length > 0
     return (
@@ -43,22 +36,6 @@ export function TestAccountFilterSwitch({
                         className="ml-1"
                         to={urls.settings('project-product-analytics', 'internal-user-filtering')}
                     />
-                    {onReset &&
-                        (checked === 'indeterminate' ? (
-                            <span className="ml-2 text-xs text-tertiary">No override set</span>
-                        ) : (
-                            <Link
-                                className="ml-2 text-xs"
-                                onClick={(e) => {
-                                    // The label is wired to the switch button via htmlFor — don't toggle it on reset
-                                    e.preventDefault()
-                                    e.stopPropagation()
-                                    onReset()
-                                }}
-                            >
-                                Unset override
-                            </Link>
-                        ))}
                 </div>
             }
         />

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 
-import { IconCalendar, IconCollapse, IconExpand } from '@posthog/icons'
+import { IconCalendar, IconCollapse, IconExpand, IconGear } from '@posthog/icons'
 import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -9,13 +9,14 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { Scene } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
 import { VariablesForDashboard } from '~/queries/nodes/DataVisualization/Components/Variables/Variables'
@@ -59,26 +60,40 @@ export function DashboardIntervalFilter(): JSX.Element {
 export function DashboardTestAccountFilter(): JSX.Element {
     const { dashboardMode, effectiveEditBarFilters } = useValues(dashboardLogic)
     const { setFilterTestAccounts, setDashboardMode } = useActions(dashboardLogic)
-
-    const ensureEditMode = (): void => {
-        if (dashboardMode !== DashboardMode.Edit) {
-            setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
-        }
-    }
+    const { currentTeam } = useValues(teamLogic)
+    const hasFilters = (currentTeam?.test_account_filters || []).length > 0
 
     return (
-        <TestAccountFilterSwitch
-            size="small"
-            checked={effectiveEditBarFilters.filterTestAccounts ?? 'indeterminate'}
-            onChange={(checked) => {
-                ensureEditMode()
-                setFilterTestAccounts(checked)
-            }}
-            onReset={() => {
-                ensureEditMode()
-                setFilterTestAccounts(null)
-            }}
-        />
+        <span className="flex items-center gap-2">
+            <span>internal and test users</span>
+            <LemonSelect<boolean | null>
+                size="small"
+                value={effectiveEditBarFilters.filterTestAccounts ?? null}
+                dropdownMatchSelectWidth={false}
+                disabledReason={
+                    !hasFilters
+                        ? "You haven't set any internal test filters. Click the gear icon to configure."
+                        : undefined
+                }
+                onChange={(filterTestAccounts) => {
+                    if (dashboardMode !== DashboardMode.Edit) {
+                        setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
+                    }
+                    setFilterTestAccounts(filterTestAccounts)
+                }}
+                options={[
+                    { value: null, label: "each insight's setting" },
+                    { value: true, label: 'excluded' },
+                    { value: false, label: 'included' },
+                ]}
+            />
+            <LemonButton
+                icon={<IconGear />}
+                size="small"
+                noPadding
+                to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+            />
+        </span>
     )
 }
 


### PR DESCRIPTION
> Stacked on #71957 (`posthog-code/dashboard-test-account-filter-override`).

## Problem

#71957 built the dashboard test account override as a customized `TestAccountFilterSwitch`: an indeterminate switch state plus an "Unset override" link. That meant teaching a shared lib component two new concepts (tri-state `checked`, `onReset`) for a single call site, and the resulting control reads differently from the interval override sitting next to it.

## Changes

- `DashboardTestAccountFilter` is now a `LemonSelect<boolean | null>` labeled "internal and test users" with three options: **each insight's setting** (inherit), **excluded** (force on), **included** (force off). This mirrors `DashboardIntervalFilter` exactly, including the null option copy, and makes "unset the override" just another option instead of a separate link.
- Keeps the gear link to the internal-user-filtering settings and the disabled state (with reason) when the project has no test account filters configured, matching the switch's behavior.
- Reverts `TestAccountFilterSwitch` (and its test) to the master version — the `boolean | 'indeterminate'` checked type and `onReset` prop are unused once the dashboard uses the dropdown, so the shared component goes back untouched.

`dashboardLogic` is unchanged: the select dispatches the same `setFilterTestAccounts(boolean | null)` action, so URL sync, auto-preview, analytics, and the card details mention from the base PR all work as before.

No screenshots — I (Claude) couldn't run the UI in this environment.

## How did you test this code?

Automated only, no manual testing:

- Re-ran the base PR's suites: `TestAccountFiltersSwitch.test.tsx` (reverted alongside the component, so the gear-link test again covers the master version), `dashboardFilterEmpty.test.ts`, and `InsightDetails.test.tsx` — all pass. No new tests: the dropdown is declarative wiring onto the already-tested `setFilterTestAccounts` action, and a test asserting the option list would be a change detector.
- Frontend typecheck reports no errors in changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None in this repo; dashboard filter docs live on posthog.com.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) on request to try a dropdown instead of the customized switch. Decisions: used `LemonSelect` rather than a quill menu to match the sibling `DashboardIntervalFilter` in the same row; option copy ("excluded"/"included") matches the card details popover added in the base PR; reverted the shared switch component to master rather than leaving dead tri-state props behind.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
