### PR TITLE
feat(billing): route customer archetype classification through the ai-gateway

### DIFF
--- a/ee/billing/dags/customer_archetype.py
+++ b/ee/billing/dags/customer_archetype.py
@@ -28,7 +28,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.dags.common import JobOwners
-from posthog.llm.gateway_client import get_llm_client
+from posthog.llm.gateway_client import build_openai_client
 from posthog.models import Team
 
 from ee.billing.dags.customer_archetype_prompt import SYSTEM_PROMPT
@@ -584,7 +584,7 @@ def classify_and_push_accounts_batch(
     # Classify LLM batches with global concurrency control. The semaphore is shared
     # across all accounts batches running in parallel so the total in-flight LLM
     # requests stays bounded regardless of executor parallelism.
-    client = get_llm_client("customer_archetype_classification")
+    client = build_openai_client("customer_archetype_classification", ai_product="customer_archetype_classification")
     semaphore = _get_llm_semaphore(config.llm_max_concurrent_requests)
     new_classifications: list[AccountClassification] = []
     failed_batches: list[dict[str, Any]] = []


### PR DESCRIPTION
Routes the customer archetype classification DAG's LLM calls through the internal Go ai-gateway when configured, else falls back to the Python LLM gateway unchanged. Mirrors the merged summarization and eval-report gateway migrations.

## Changes
- `customer_archetype.py`: build the classification client via `build_openai_client(..., ai_product="customer_archetype_classification")` instead of `get_llm_client(...)`.

## Rollout
Inert until the Dagster deployment gets `AI_GATEWAY_URL` + `AI_GATEWAY_API_KEY` (PostHog/charts#13286): without them `resolve_ai_gateway_config()` returns None and the DAG stays on the Python gateway. Safe to merge first. Once set, events route to the Go gateway tagged `ai_product='customer_archetype_classification'`, the same value the Python gateway already stamps, so attribution and billing don't split.

## Verification
Pre-commit (ruff, ty) pass. No test changes: `test_customer_archetype.py` doesn't exercise the client-construction path.

## Related
- PostHog/charts#13286 sets the Dagster `AI_GATEWAY_URL` that activates this PR.
- PostHog/posthog#72064 is the sibling migration (survey summarization).
