### PR TITLE
feat(replay-vision): link slack group-summaries back to their run page

### DIFF
--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -3,7 +3,6 @@
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 
@@ -188,7 +187,6 @@ def _emit(inputs: EmitActionReadyInputs) -> None:
         # Nothing to deliver to; the run row (synthesized_markdown) is the in-app artifact.
         return
 
-    action_url = f"{settings.SITE_URL}/project/{team.id}/replay/vision-actions/{action.id}"
     # Private internal event (cdp_internal_events topic), NOT the public capture pipeline — an
     # internal_destination HogFunction filtered on vision_action_id delivers it. This is non-forgeable
     # with the public project token, and (unlike capture) it does NOT land in the analytics events
@@ -207,7 +205,6 @@ def _emit(inputs: EmitActionReadyInputs) -> None:
                 # Pre-split section blocks so the full report renders as ONE Slack message; None (not
                 # []) when absent so Slack falls back to slack_text rather than rejecting empty blocks.
                 "slack_blocks": run.output.get("slack_blocks") or None,
-                "action_url": action_url,
             },
         ),
     )

--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -175,6 +175,11 @@ def _synthesize(inputs: SynthesizeGroupSummaryInputs) -> SynthesizeGroupSummaryR
     markdown = strip_external_links_markdown(
         _summary_header(action, batch.window_start, len(batch.lines), batch.window_total) + markdown
     )
+    # Link the header's scanner name to this run's page. Added after the strip pass (like the citation
+    # links) so the PostHog URL survives on non-posthog.com hosts.
+    markdown = _linkify_summary_header(
+        markdown, _clean_scanner_name(action), _run_url(team.id, str(action.id), str(run.pk))
+    )
     slack_text = _markdown_to_slack(markdown, team_id=team.id, observation_ids=batch.observation_ids)
 
     run.synthesized_markdown = markdown
@@ -360,15 +365,19 @@ def _fetch_observations(team: Team, action: VisionAction, run: VisionActionRun) 
     )
 
 
+def _clean_scanner_name(action: VisionAction) -> str:
+    """Scanner name is free-text; strip markdown/mrkdwn control chars so it can't garble the bold header
+    (in-app Markdown or the Slack `**`→`*` pass) and collapse any newlines that would break the line."""
+    raw_name = action.scanner.name if action.scanner_id else ""
+    return re.sub(r"\s+", " ", re.sub(r"[*_`#]", "", raw_name)).strip() or "your scanner"
+
+
 def _summary_header(action: VisionAction, window_start: datetime | None, count: int, window_total: int = 0) -> str:
     """A trusted one-line preface stating which scanner this summary is for, how many recordings it
     covers, and the window's start — the "summary for scans since <prev run>" context the reader needs.
     When the window held more observations than the cap, it says so ("sampled N of M") so the reader
     knows the report covers only a sample of the period, not every observation."""
-    # Scanner name is free-text; strip markdown/mrkdwn control chars so it can't garble the bold header
-    # (in-app Markdown or the Slack `**`→`*` pass) and collapse any newlines that would break the line.
-    raw_name = action.scanner.name if action.scanner_id else ""
-    scanner_name = re.sub(r"\s+", " ", re.sub(r"[*_`#]", "", raw_name)).strip() or "your scanner"
+    scanner_name = _clean_scanner_name(action)
     noun = "recording" if count == 1 else "recordings"
     # When the period held more observations than the cap, only `count` were summarized — say so.
     coverage = f"sampled {count} of {window_total:,} {noun}" if window_total > count else f"{count} {noun}"
@@ -434,6 +443,21 @@ def _run_synthesis(team: Team, action: VisionAction, lines: list[str]) -> str:
 
 def _observation_url(team_id: int, observation_id: str) -> str:
     return f"{settings.SITE_URL}/project/{team_id}/replay-vision/observations/{observation_id}"
+
+
+def _run_url(team_id: int, action_id: str, run_id: str) -> str:
+    return f"{settings.SITE_URL}/project/{team_id}/replay-vision/actions/{action_id}/runs/{run_id}"
+
+
+def _linkify_summary_header(markdown: str, scanner_name: str, run_url: str) -> str:
+    """Wrap the header's scanner name in a link to this summary's run page — the full report plus every
+    cited observation. Added AFTER `strip_external_links_markdown` so the PostHog URL isn't defanged on
+    instances whose SITE_URL isn't a posthog.com host (self-hosted, dev). If the strip pass rewrote the
+    name (e.g. it carried a bare URL, now a code span), the prefix won't match — leave it unlinked."""
+    prefix = f"**Summary for {scanner_name}**"
+    if not markdown.startswith(prefix):
+        return markdown
+    return f"**Summary for [{scanner_name}]({run_url})**" + markdown[len(prefix) :]
 
 
 def _citations_to_slack_links(markdown: str, team_id: int, observation_ids: list[str]) -> str:

--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -367,9 +367,13 @@ def _fetch_observations(team: Team, action: VisionAction, run: VisionActionRun) 
 
 def _clean_scanner_name(action: VisionAction) -> str:
     """Scanner name is free-text; strip markdown/mrkdwn control chars so it can't garble the bold header
-    (in-app Markdown or the Slack `**`→`*` pass) and collapse any newlines that would break the line."""
+    (in-app Markdown or the Slack `**`→`*` pass) and collapse any newlines that would break the line.
+
+    Also strips link/autolink punctuation `[](){}<>`: `_linkify_summary_header` wraps this name in
+    `[name](run_url)` after the external-link strip pass, so a name like `x](//evil/)` would otherwise
+    break out of that link and plant a trusted-looking header link to an attacker domain."""
     raw_name = action.scanner.name if action.scanner_id else ""
-    return re.sub(r"\s+", " ", re.sub(r"[*_`#]", "", raw_name)).strip() or "your scanner"
+    return re.sub(r"\s+", " ", re.sub(r"[*_`#\[\]()<>{}]", "", raw_name)).strip() or "your scanner"
 
 
 def _summary_header(action: VisionAction, window_start: datetime | None, count: int, window_total: int = 0) -> str:

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -195,7 +195,8 @@ class TestVisionActionSynthesis(BaseTest):
 
     def test_summary_leads_with_scanner_window_and_count_header(self) -> None:
         # The report must always state which scanner it's for, how many recordings it covers, and the
-        # window start — prepended in code so it's present regardless of what the LLM returns.
+        # window start — prepended in code so it's present regardless of what the LLM returns. The
+        # scanner name links to this run's page so both the in-app report and Slack can jump back to it.
         self._observation("Users churned at checkout", title="Checkout")
         self._observation("Onboarding looked smooth", title="Onboarding", session_id="s2")
         action = self._action()
@@ -204,12 +205,13 @@ class TestVisionActionSynthesis(BaseTest):
         self._synthesize(action, run, llm_content="# Summary\nThemes.")
 
         run.refresh_from_db()
+        run_url = f"{settings.SITE_URL}/project/{self.team.id}/replay-vision/actions/{action.id}/runs/{run.id}"
         self.assertTrue(
-            run.synthesized_markdown.startswith("**Summary for summarizer** — 2 recordings since "),
+            run.synthesized_markdown.startswith(f"**Summary for [summarizer]({run_url})** — 2 recordings since "),
             run.synthesized_markdown,
         )
-        # The header rides into the Slack payload too (bold header → *bold*).
-        self.assertIn("*Summary for summarizer*", run.output["slack"])
+        # The linked header rides into the Slack payload too (**bold** → *bold*, [name](url) → <url|name>).
+        self.assertIn(f"*Summary for <{run_url}|summarizer>*", run.output["slack"])
 
     def test_header_flags_sampling_when_window_exceeds_cap(self) -> None:
         # When the period holds more observations than the cap, the header must say the summary covers
@@ -236,7 +238,7 @@ class TestVisionActionSynthesis(BaseTest):
         self._synthesize(action, run)
 
         run.refresh_from_db()
-        self.assertIn("**Summary for Checkoutflow**", run.synthesized_markdown)
+        self.assertIn("**Summary for [Checkoutflow](", run.synthesized_markdown)
 
     def test_summary_header_defangs_links_in_scanner_name(self) -> None:
         # A scanner name is free text and lands in the header; a name with link/image markdown must not

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -255,6 +255,28 @@ class TestVisionActionSynthesis(BaseTest):
         self.assertNotIn("](https://evil.example", run.synthesized_markdown)
         self.assertNotIn("](https://evil.example", run.output["slack"])
 
+    def test_summary_header_name_cannot_break_out_of_the_run_link(self) -> None:
+        # _linkify_summary_header wraps the name in [name](run_url) AFTER the external-link strip pass.
+        # A name carrying `](url)` would break out of that link and plant a header link to an attacker
+        # domain (the "]" arms the injected link once linkify supplies the opening "["). The name's
+        # bracket/paren chars must be stripped so the only link the header can point to is the run page.
+        self.scanner.name = "Checkout](//attacker.example/)"
+        self.scanner.save()
+        self._observation("churned")
+        action = self._action()
+        run = self._run_for(action)
+
+        self._synthesize(action, run)
+
+        run.refresh_from_db()
+        run_url = f"{settings.SITE_URL}/project/{self.team.id}/replay-vision/actions/{action.id}/runs/{run.id}"
+        # The header still links, but only to the run page — the attacker domain can't be a link
+        # target. It may survive as inert label text; what must not exist is a link pointing at it.
+        self.assertIn(f"]({run_url})", run.synthesized_markdown)
+        self.assertNotIn("](//attacker.example", run.synthesized_markdown)
+        self.assertNotIn("attacker.example|", run.output["slack"])
+        self.assertNotIn("<//attacker.example", run.output["slack"])
+
     def test_persists_only_included_observation_ids(self) -> None:
         # observation_ids must track the summaries actually included — a blank-summary observation is
         # skipped by _fetch_observations, so its id must not land in the persisted list.


### PR DESCRIPTION
## Problem

Group-summary reports from Replay Vision "and then… summarize" actions get posted to Slack, but the header was plain text ("Summary for <scanner>"). Nothing in the message linked back into PostHog, so a reader couldn't jump to the scanner or the run that produced the summary.

The alert path already solves this: it wraps the alert name in a link to the run page. The group-summary path just never got the same treatment.

## Changes

The Slack group-summary header now links the scanner name to that summary's run page (`/replay-vision/actions/<action>/runs/<run>`), showing the full report plus every cited observation. This mirrors the alert path exactly:

- New `_run_url` + `_linkify_summary_header` in `synthesis.py`, wired into `_synthesize` **after** `strip_external_links_markdown` so the PostHog URL isn't defanged on non-posthog.com hosts (self-hosted, dev).
- The existing `_markdown_to_slack` pass renders `[name](url)` as Slack's `<url|name>`, and the link is persisted in `synthesized_markdown` so the in-app run view shows it too.
- Extracted `_clean_scanner_name` so the header and the linkifier agree on the exact (sanitized) scanner name.

I also dropped a dead `action_url` event property in the emit activity. It used a stale path (`/replay/vision-actions/...`) and no delivery destination ever consumed it (the Slack HogFunction only wires `slack_blocks` / `slack_text`).

> [!NOTE]
> If a scanner name carries link/image markdown, the strip pass rewrites it, the header prefix no longer matches, and the name is left unlinked rather than risk smuggling a link. Same graceful degradation the alert path uses.

## How did you test this code?

Automated (run locally by me, the agent):

- `test_vision_action_synthesis.py` — 39 passed. Folded the run-link assertion into the existing header test (asserts both the Markdown `[summarizer](run_url)` and Slack `<run_url|summarizer>` forms) rather than adding a near-duplicate; updated the sanitize test to the linked form. The defang test passes unchanged, confirming a name with link markdown is left unlinked. This guards the regression where the header→run link is dropped or defanged.
- `test_vision_action_alerts.py` — 20 passed (regression guard for the shared emit-activity edit).
- `ruff check` clean; lint-staged `ty check` passed on commit.

I did not manually post to a live Slack workspace.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim asked for scheduled Slack summaries to link back to the run/scanner. I (Claude) explored the Replay Vision notification pipeline, found the alert path already had the `_run_url` + `_linkify_header` pattern, and mirrored it in the group-summary path. Kim chose to link the summary run page over the scanner overview. Invoked the `/writing-tests` skill before touching tests, and folded the assertion into the existing header test rather than adding a redundant one.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*