### PR TITLE
fix(flags): tolerate behavioral cohort filters instead of failing eval

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_models.rs
+++ b/rust/feature-flags/src/cohorts/cohort_models.rs
@@ -171,11 +171,21 @@ pub struct CohortValues {
 /// `PropertyFilter` requires `key`, so a group (no `key`) falls through to `Group`,
 /// while an ambiguous object carrying both `key` and `values` is kept as the filter
 /// it most likely is rather than silently dropping its `key`/`value`/`operator`.
+///
+/// `Unsupported` is the catch-all last variant: a leaf whose `type` this evaluator
+/// can't resolve from person/group properties — most commonly a `behavioral` filter,
+/// which needs event history over time. Keeping it as raw JSON means one unsupported
+/// leaf no longer aborts parsing of the whole cohort (which previously failed every
+/// referencing flag with `CohortFiltersParsingError`). It contributes no cohort
+/// dependency and is treated as a non-match during evaluation, so the cohort's
+/// person-property leaves still evaluate correctly. Because it deserializes any JSON,
+/// it must stay last so real filters and groups are tried first.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum CohortValuesItem {
     Filter(PropertyFilter),
     Group(CohortValues),
+    Unsupported(serde_json::Value),
 }
 
 #[cfg(test)]
@@ -601,6 +611,30 @@ mod tests {
             size > 1000,
             "Large JSON should have significant estimated size"
         );
+    }
+
+    #[test]
+    fn test_cohort_values_item_untagged_variant_ordering() {
+        // The untagged variant order must keep real filters and groups ahead of the
+        // catch-all: a leaf property filter stays a `Filter`, a group stays a `Group`,
+        // and only a leaf whose `type` we can't parse (e.g. `behavioral`) falls through
+        // to `Unsupported` instead of aborting the whole cohort parse.
+        let filter: CohortValuesItem = serde_json::from_value(serde_json::json!(
+            {"key": "email", "type": "person", "value": "@posthog.com", "operator": "icontains"}
+        ))
+        .unwrap();
+        assert!(matches!(filter, CohortValuesItem::Filter(_)));
+
+        let group: CohortValuesItem =
+            serde_json::from_value(serde_json::json!({"type": "AND", "values": []})).unwrap();
+        assert!(matches!(group, CohortValuesItem::Group(_)));
+
+        let behavioral: CohortValuesItem = serde_json::from_value(serde_json::json!(
+            {"key": "$pageview", "type": "behavioral", "value": "performed_event",
+             "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"}
+        ))
+        .unwrap();
+        assert!(matches!(behavioral, CohortValuesItem::Unsupported(_)));
     }
 }
 

--- a/rust/feature-flags/src/cohorts/cohort_models.rs
+++ b/rust/feature-flags/src/cohorts/cohort_models.rs
@@ -1,4 +1,4 @@
-use crate::properties::property_models::PropertyFilter;
+use crate::properties::property_models::{PropertyFilter, PropertyType};
 use crate::utils::json_size::estimate_json_size;
 use chrono::{DateTime, Utc};
 use serde::de::IgnoredAny;
@@ -173,6 +173,15 @@ pub struct CohortValues {
 /// while an ambiguous object carrying both `key` and `values` is kept as the filter
 /// it most likely is rather than silently dropping its `key`/`value`/`operator`.
 ///
+/// `MalformedKnownType` catches a leaf whose `type` names one of the supported
+/// `PropertyType`s (so it isn't genuinely unsupported) but is otherwise malformed for
+/// that type, e.g. a `cohort` filter missing the required `key` — a shape that could
+/// exist in storage from before cohort filters were validated on write. It's tried
+/// after `Filter`/`Group` (a well-formed leaf of a known type already matched one of
+/// those) and before `Unsupported`, so a malformed-but-known-type leaf still surfaces
+/// as a parsing error instead of silently degrading like a genuinely unrecognized type
+/// does.
+///
 /// `Unsupported` is the catch-all last variant: a leaf whose `type` this evaluator
 /// can't resolve from person/group properties — most commonly a `behavioral` filter,
 /// which needs event history over time. An unsupported leaf contributes no cohort
@@ -189,7 +198,17 @@ pub struct CohortValues {
 pub enum CohortValuesItem {
     Filter(PropertyFilter),
     Group(CohortValues),
+    MalformedKnownType(KnownTypeMarker),
     Unsupported(IgnoredAny),
+}
+
+/// Matches only the `type` field of a leaf, so it succeeds whenever `type` names a
+/// supported `PropertyType` even if the rest of the leaf is malformed for that type.
+/// See `CohortValuesItem::MalformedKnownType`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct KnownTypeMarker {
+    #[serde(rename = "type")]
+    pub prop_type: PropertyType,
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/cohorts/cohort_models.rs
+++ b/rust/feature-flags/src/cohorts/cohort_models.rs
@@ -1,6 +1,7 @@
 use crate::properties::property_models::PropertyFilter;
 use crate::utils::json_size::estimate_json_size;
 use chrono::{DateTime, Utc};
+use serde::de::IgnoredAny;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::FromRow;
@@ -143,19 +144,19 @@ pub enum CohortPropertyType {
     OR,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CohortProperty {
     pub properties: InnerCohortProperty,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct InnerCohortProperty {
     #[serde(rename = "type")]
     pub prop_type: CohortPropertyType,
     pub values: Vec<CohortValuesItem>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CohortValues {
     #[serde(rename = "type")]
     pub prop_type: String,
@@ -174,18 +175,23 @@ pub struct CohortValues {
 ///
 /// `Unsupported` is the catch-all last variant: a leaf whose `type` this evaluator
 /// can't resolve from person/group properties — most commonly a `behavioral` filter,
-/// which needs event history over time. Keeping it as raw JSON means one unsupported
-/// leaf no longer aborts parsing of the whole cohort (which previously failed every
-/// referencing flag with `CohortFiltersParsingError`). It contributes no cohort
-/// dependency and is treated as a non-match during evaluation, so the cohort's
-/// person-property leaves still evaluate correctly. Because it deserializes any JSON,
-/// it must stay last so real filters and groups are tried first.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// which needs event history over time. One unsupported leaf no longer aborts parsing
+/// of the whole cohort (which previously failed every referencing flag with
+/// `CohortFiltersParsingError`); it contributes no cohort dependency and is treated as
+/// a non-match during evaluation, so the cohort's evaluable leaves still decide
+/// membership. The payload is discarded via `IgnoredAny` rather than kept as
+/// `serde_json::Value` since nothing reads it, avoiding materializing every
+/// unsupported leaf on each cohort parse. Because it deserializes any JSON, it must
+/// stay last so real filters and groups are tried first; this also means the whole
+/// type tree can no longer derive `Serialize` (`IgnoredAny` doesn't implement it) —
+/// nothing in the codebase serializes cohort filters back out, only the raw JSON on
+/// `Cohort::filters`.
+#[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum CohortValuesItem {
     Filter(PropertyFilter),
     Group(CohortValues),
-    Unsupported(serde_json::Value),
+    Unsupported(IgnoredAny),
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/cohorts/cohort_models.rs
+++ b/rust/feature-flags/src/cohorts/cohort_models.rs
@@ -175,12 +175,10 @@ pub struct CohortValues {
 ///
 /// `Unsupported` is the catch-all last variant: a leaf whose `type` this evaluator
 /// can't resolve from person/group properties — most commonly a `behavioral` filter,
-/// which needs event history over time. One unsupported leaf no longer aborts parsing
-/// of the whole cohort (which previously failed every referencing flag with
-/// `CohortFiltersParsingError`); it contributes no cohort dependency and is treated as
-/// a non-match during evaluation, so the cohort's evaluable leaves still decide
-/// membership. The payload is discarded via `IgnoredAny` rather than kept as
-/// `serde_json::Value` since nothing reads it, avoiding materializing every
+/// which needs event history over time. An unsupported leaf contributes no cohort
+/// dependency and is a non-match during evaluation, so the cohort's evaluable leaves
+/// still decide membership. The payload is discarded via `IgnoredAny` rather than kept
+/// as `serde_json::Value` since nothing reads it, avoiding materializing every
 /// unsupported leaf on each cohort parse. Because it deserializes any JSON, it must
 /// stay last so real filters and groups are tried first; this also means the whole
 /// type tree can no longer derive `Serialize` (`IgnoredAny` doesn't implement it) —

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -10,6 +10,7 @@ use crate::cohorts::cohort_models::{
     Cohort, CohortId, CohortProperty, CohortValuesItem, InnerCohortProperty,
 };
 use crate::database::get_connection_with_metrics;
+use crate::metrics::consts::COHORT_UNSUPPORTED_FILTER_COUNTER;
 use crate::properties::property_matching::match_property;
 use crate::properties::property_models::OperatorType;
 use crate::utils::graph_utils::{DependencyGraph, DependencyProvider, DependencyType};
@@ -213,6 +214,12 @@ impl Cohort {
                     }
                 }
             }
+            // A leaf we can't resolve here (e.g. a `behavioral` filter) has no cohort
+            // dependency to contribute — count it and move on rather than failing the
+            // whole cohort parse.
+            CohortValuesItem::Unsupported(_) => {
+                common_metrics::inc(COHORT_UNSUPPORTED_FILTER_COUNTER, &[], 1);
+            }
         }
         Ok(())
     }
@@ -284,6 +291,10 @@ fn evaluate_cohort_item(
         CohortValuesItem::Filter(filter) => {
             evaluate_cohort_filter(filter, target_properties, cohort_matches, team_timezone)
         }
+        // A leaf this evaluator can't resolve from person/group properties (e.g. a
+        // `behavioral` filter) is treated as a non-match, so the cohort's evaluable
+        // leaves still decide membership via their AND/OR combination.
+        CohortValuesItem::Unsupported(_) => Ok(false),
     }
 }
 
@@ -1371,6 +1382,105 @@ mod tests {
         assert!(matches!(
             evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &HashMap::new(), Tz::UTC),
             Err(FlagError::CohortFiltersParsingError)
+        ));
+    }
+
+    #[test]
+    fn test_extract_dependencies_tolerates_behavioral_leaf() {
+        // A `behavioral` leaf can't be resolved from person properties here, but it
+        // must not abort dependency extraction — the sibling cohort reference should
+        // still be discovered. Before the fix this returned CohortFiltersParsingError.
+        let cohort = create_dynamic_cohort_with_filters(
+            1,
+            json!({
+                "properties": {
+                    "type": "AND",
+                    "values": [{
+                        "type": "OR",
+                        "values": [
+                            {"key": "$pageview", "type": "behavioral", "value": "performed_event",
+                             "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"},
+                            {"key": "id", "type": "cohort", "value": 7, "negation": false}
+                        ]
+                    }]
+                }
+            }),
+        );
+
+        let dependencies = cohort
+            .extract_dependencies()
+            .expect("a behavioral leaf must not fail cohort dependency extraction");
+        assert_eq!(dependencies, [7].into_iter().collect());
+    }
+
+    #[test]
+    fn test_evaluate_dynamic_cohorts_with_behavioral_leaf_in_or_group() {
+        // In an OR group, an unresolvable behavioral leaf is a non-match, so an
+        // evaluable person-property sibling still decides membership.
+        let cohort = create_dynamic_cohort_with_filters(
+            1,
+            json!({
+                "properties": {
+                    "type": "OR",
+                    "values": [{
+                        "type": "OR",
+                        "values": [
+                            {"key": "$pageview", "type": "behavioral", "value": "performed_event",
+                             "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"},
+                            {"key": "plan", "type": "person", "value": "pro", "operator": "exact"}
+                        ]
+                    }]
+                }
+            }),
+        );
+
+        let cohorts = vec![cohort];
+        let static_cohort_matches = HashMap::new();
+
+        let test_cases = [
+            (json!("pro"), true),   // person-property sibling matches -> cohort matches
+            (json!("free"), false), // sibling misses, behavioral leaf non-matches -> no match
+        ];
+        for (plan, expected) in test_cases {
+            let target_properties = HashMap::from([("plan".to_string(), plan.clone())]);
+            let result = evaluate_dynamic_cohorts(
+                1,
+                &target_properties,
+                &cohorts,
+                &static_cohort_matches,
+                Tz::UTC,
+            )
+            .unwrap();
+            assert_eq!(result, expected, "plan={plan} should evaluate to {expected}");
+        }
+    }
+
+    #[test]
+    fn test_evaluate_dynamic_cohorts_with_behavioral_leaf_in_and_group_never_matches() {
+        // In an AND group, the unresolvable behavioral leaf (treated as a non-match)
+        // prevents the group from matching even when the person-property leaf is satisfied.
+        let cohort = create_dynamic_cohort_with_filters(
+            1,
+            json!({
+                "properties": {
+                    "type": "AND",
+                    "values": [{
+                        "type": "AND",
+                        "values": [
+                            {"key": "plan", "type": "person", "value": "pro", "operator": "exact"},
+                            {"key": "$pageview", "type": "behavioral", "value": "performed_event",
+                             "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"}
+                        ]
+                    }]
+                }
+            }),
+        );
+
+        let cohorts = vec![cohort];
+        let target_properties = HashMap::from([("plan".to_string(), json!("pro"))]);
+        assert!(matches!(
+            evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &HashMap::new(), Tz::UTC),
+            Ok(false)
         ));
     }
 }

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -1451,7 +1451,10 @@ mod tests {
                 Tz::UTC,
             )
             .unwrap();
-            assert_eq!(result, expected, "plan={plan} should evaluate to {expected}");
+            assert_eq!(
+                result, expected,
+                "plan={plan} should evaluate to {expected}"
+            );
         }
     }
 

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -214,9 +214,7 @@ impl Cohort {
                     }
                 }
             }
-            // A leaf we can't resolve here (e.g. a `behavioral` filter) has no cohort
-            // dependency to contribute — count it and move on rather than failing the
-            // whole cohort parse.
+            // No cohort dependency to contribute; count it and continue.
             CohortValuesItem::Unsupported(_) => {
                 common_metrics::inc(COHORT_UNSUPPORTED_FILTER_COUNTER, &[], 1);
             }
@@ -291,9 +289,7 @@ fn evaluate_cohort_item(
         CohortValuesItem::Filter(filter) => {
             evaluate_cohort_filter(filter, target_properties, cohort_matches, team_timezone)
         }
-        // A leaf this evaluator can't resolve from person/group properties (e.g. a
-        // `behavioral` filter) is treated as a non-match, so the cohort's evaluable
-        // leaves still decide membership via their AND/OR combination.
+        // Non-match, so sibling leaves decide membership via their AND/OR combination.
         CohortValuesItem::Unsupported(_) => Ok(false),
     }
 }
@@ -1487,6 +1483,36 @@ mod tests {
         let target_properties = HashMap::from([("plan".to_string(), json!("pro"))]);
         assert!(matches!(
             evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &HashMap::new(), Tz::UTC),
+            Ok(false)
+        ));
+    }
+
+    #[test]
+    fn test_purely_behavioral_cohort_resolves_to_non_match_with_no_dependencies() {
+        // A cohort whose only criterion is behavioral has no evaluable leaves at all:
+        // dependency extraction finds nothing, and evaluation resolves to non-match
+        // instead of aborting the whole cohort parse.
+        let cohort = create_dynamic_cohort_with_filters(
+            1,
+            json!({
+                "properties": {
+                    "type": "OR",
+                    "values": [{
+                        "type": "OR",
+                        "values": [behavioral_leaf_json()]
+                    }]
+                }
+            }),
+        );
+
+        let dependencies = cohort
+            .extract_dependencies()
+            .expect("a purely behavioral cohort must not fail dependency extraction");
+        assert!(dependencies.is_empty());
+
+        let cohorts = vec![cohort];
+        assert!(matches!(
+            evaluate_dynamic_cohorts(1, &HashMap::new(), &cohorts, &HashMap::new(), Tz::UTC),
             Ok(false)
         ));
     }

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -1385,6 +1385,13 @@ mod tests {
         ));
     }
 
+    /// A `behavioral` filter leaf — unresolvable from person/group properties, so it
+    /// always parses to `CohortValuesItem::Unsupported`.
+    fn behavioral_leaf_json() -> serde_json::Value {
+        json!({"key": "$pageview", "type": "behavioral", "value": "performed_event",
+               "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"})
+    }
+
     #[test]
     fn test_extract_dependencies_tolerates_behavioral_leaf() {
         // A `behavioral` leaf can't be resolved from person properties here, but it
@@ -1398,8 +1405,7 @@ mod tests {
                     "values": [{
                         "type": "OR",
                         "values": [
-                            {"key": "$pageview", "type": "behavioral", "value": "performed_event",
-                             "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"},
+                            behavioral_leaf_json(),
                             {"key": "id", "type": "cohort", "value": 7, "negation": false}
                         ]
                     }]
@@ -1425,8 +1431,7 @@ mod tests {
                     "values": [{
                         "type": "OR",
                         "values": [
-                            {"key": "$pageview", "type": "behavioral", "value": "performed_event",
-                             "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"},
+                            behavioral_leaf_json(),
                             {"key": "plan", "type": "person", "value": "pro", "operator": "exact"}
                         ]
                     }]
@@ -1471,8 +1476,7 @@ mod tests {
                         "type": "AND",
                         "values": [
                             {"key": "plan", "type": "person", "value": "pro", "operator": "exact"},
-                            {"key": "$pageview", "type": "behavioral", "value": "performed_event",
-                             "negation": false, "event_type": "events", "time_value": "30", "time_interval": "day"}
+                            behavioral_leaf_json()
                         ]
                     }]
                 }

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -214,6 +214,12 @@ impl Cohort {
                     }
                 }
             }
+            // A known filter type (e.g. `cohort`) that's otherwise malformed, such as a
+            // cohort reference missing `key`. Fail loud rather than silently dropping
+            // what may be a real dependency.
+            CohortValuesItem::MalformedKnownType(_) => {
+                return Err(FlagError::CohortFiltersParsingError);
+            }
             // No cohort dependency to contribute; count it and continue.
             CohortValuesItem::Unsupported(_) => {
                 common_metrics::inc(COHORT_UNSUPPORTED_FILTER_COUNTER, &[], 1);
@@ -289,6 +295,9 @@ fn evaluate_cohort_item(
         CohortValuesItem::Filter(filter) => {
             evaluate_cohort_filter(filter, target_properties, cohort_matches, team_timezone)
         }
+        // A known filter type that's otherwise malformed; fail loud rather than
+        // silently resolving to non-match (see `traverse_item`).
+        CohortValuesItem::MalformedKnownType(_) => Err(FlagError::CohortFiltersParsingError),
         // Non-match, so sibling leaves decide membership via their AND/OR combination.
         CohortValuesItem::Unsupported(_) => Ok(false),
     }
@@ -1514,6 +1523,39 @@ mod tests {
         assert!(matches!(
             evaluate_dynamic_cohorts(1, &HashMap::new(), &cohorts, &HashMap::new(), Tz::UTC),
             Ok(false)
+        ));
+    }
+
+    #[test]
+    fn test_cohort_filter_of_known_type_missing_required_field_still_errors() {
+        // A `type: "cohort"` leaf missing the required `key` matches neither `Filter`
+        // (no `key`) nor `Group` (no `values`). Its `type` is still a recognized
+        // `PropertyType`, though, so this must surface as a parsing error rather than
+        // silently falling through to `Unsupported` like a genuinely unrecognized type
+        // (e.g. `behavioral`) does — losing a real cohort dependency edge silently
+        // would be worse than the loud failure this replaces.
+        let cohort = create_dynamic_cohort_with_filters(
+            1,
+            json!({
+                "properties": {
+                    "type": "AND",
+                    "values": [{
+                        "type": "OR",
+                        "values": [{"type": "cohort", "value": 7, "negation": false}]
+                    }]
+                }
+            }),
+        );
+
+        assert!(matches!(
+            cohort.extract_dependencies(),
+            Err(FlagError::CohortFiltersParsingError)
+        ));
+
+        let cohorts = vec![cohort];
+        assert!(matches!(
+            evaluate_dynamic_cohorts(1, &HashMap::new(), &cohorts, &HashMap::new(), Tz::UTC),
+            Err(FlagError::CohortFiltersParsingError)
         ));
     }
 }

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -20,6 +20,9 @@ pub const COHORT_CACHE_HIT_COUNTER: &str = "flags_cohort_cache_hit_total";
 pub const COHORT_CACHE_MISS_COUNTER: &str = "flags_cohort_cache_miss_total";
 pub const COHORT_CACHE_SIZE_BYTES_GAUGE: &str = "flags_cohort_cache_size_bytes";
 pub const COHORT_CACHE_ENTRIES_GAUGE: &str = "flags_cohort_cache_entries";
+// Incremented once per unsupported cohort filter leaf (e.g. a `behavioral` filter)
+// skipped during dependency extraction, instead of failing the whole cohort parse.
+pub const COHORT_UNSUPPORTED_FILTER_COUNTER: &str = "flags_cohort_unsupported_filter_total";
 // Realtime cohort membership cache (CachedCohortMembershipProvider, keyed on
 // (team_id, person_uuid)). hit = lookup fully served from cache; miss = a
 // behavioral cohorts DB query was issued (no cache entry, or the entry was


### PR DESCRIPTION
## Problem

A flag that targets a cohort containing a `behavioral` filter fails to evaluate. In the flags service, a cohort's stored filter JSON is deserialized into `CohortProperty` during dependency extraction. `CohortValuesItem` is an untagged enum of `Filter | Group`, so a leaf whose `type` isn't a supported `PropertyType` (`person`, `person_metadata`, `cohort`, `group`, `flag`) matches neither variant and aborts parsing of the *entire* cohort. `behavioral` filters are the dominant offender: they need event history over time and can't be resolved from person properties in this path.

The effect is `CohortFiltersParsingError` on every evaluation of every flag that references such a cohort. It's caught per-flag (no request-level 5xx), but the flag silently resolves to its default even when the cohort's person-property leaves alone would have decided membership. This surfaced in the flags ops report as a persistent error pattern across multiple unrelated teams, so it's a service robustness gap, not one customer's misconfiguration.

> [!NOTE]
> This path is the sole flag evaluator (the Python matcher is gone), so there's no Python-parity constraint on the degradation behavior chosen here.

## Changes

Add an `Unsupported(serde_json::Value)` catch-all as the **last** untagged variant of `CohortValuesItem`. Because it deserializes any JSON, ordering matters: real filters and groups are still tried first, and only a genuinely unparseable leaf falls through.

- **Dependency extraction** skips an `Unsupported` leaf (it contributes no cohort dependency) instead of returning `CohortFiltersParsingError`.
- **Evaluation** treats an `Unsupported` leaf as a non-match, so the cohort's evaluable leaves still decide membership through their AND/OR combination. In an OR group an evaluable sibling can still match; in an AND group the unresolvable leaf keeps the group from matching.
- A new `flags_cohort_unsupported_filter_total` counter is incremented per skipped leaf, replacing the per-eval error log so the degradation stays observable without log spam.

> [!WARNING]
> This is a behavior change for affected flags: they now evaluate (resolving on the person-property parts of the cohort) instead of erroring to default. For a cohort that is purely behavioral, membership resolves to non-match in this path — the same practical outcome as the prior error, minus the noise.

## How did you test this code?

Added Rust unit tests covering the regression (each fails before this change, where the parse would error and `evaluate_dynamic_cohorts` would return `Err`):

- `test_cohort_values_item_untagged_variant_ordering` — pins that a person filter still parses as `Filter`, a group as `Group`, and a `behavioral` leaf as `Unsupported` (guards the catch-all from shadowing real variants).
- `test_extract_dependencies_tolerates_behavioral_leaf` — a behavioral leaf no longer aborts extraction, and a sibling cohort reference is still discovered.
- `test_evaluate_dynamic_cohorts_with_behavioral_leaf_in_or_group` — an evaluable person-property sibling still decides membership.
- `test_evaluate_dynamic_cohorts_with_behavioral_leaf_in_and_group_never_matches` — the unresolvable leaf keeps an AND group from matching.

Existing tests for unknown *group* types and depth limits are intentionally unchanged and still error (those aren't leaf-type failures).

> [!NOTE]
> I (Claude, the PostHog Slack app) could not compile or run the tests: this sandbox has no Rust toolchain (`cargo` unavailable). The changes are Rust-only; please rely on CI for `cargo test`/`fmt`/`clippy`. I matched an existing rustfmt-stable assertion style to reduce the chance of a fmt-check failure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread on the flags ops report: I traced `CohortFiltersParsingError` through the flags service logs to the underlying serde failure ("data did not match any variant of untagged enum `CohortValuesItem`") and confirmed it spanned multiple unrelated teams' cohorts, then read the cohort parse/eval path to find the root cause.

Design decision: rather than special-casing `behavioral` by name, I added a generic `Unsupported` catch-all so any current or future unsupported leaf `type` degrades gracefully. Considered treating the leaf's `negation` — rejected, since we can't parse it into a `PropertyFilter`, so a fixed non-match (pre-negation) is the honest choice. Kept observability via a counter instead of the per-eval error log that was generating the noise.

No repo skills applied (Rust flags-service change, outside the mandatory-skill areas).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07Q2U4BH4L/p1784046300403139?thread_ts=1784046300.403139&cid=C07Q2U4BH4L)*
