### PR TITLE
chore(insights): cover retry button side action rendering

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/InsightErrorStates.test.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/InsightErrorStates.test.tsx
@@ -50,4 +50,20 @@ describe('insight error states', () => {
             query_id: 'test-query-id',
         })
     })
+
+    // The retry button only offers a side action (query debugger link) when it has a query. Without
+    // one, `sideAction` must stay undefined so LemonButton doesn't render a stray empty side action.
+    it.each([
+        { name: 'without a query', query: undefined, expectsSideAction: false },
+        {
+            name: 'with a query',
+            query: { kind: 'InsightVizNode', source: { kind: 'TrendsQuery' } },
+            expectsSideAction: true,
+        },
+    ])('retry button side action $name', ({ query, expectsSideAction }) => {
+        const { container } = render(<InsightErrorState onRetry={() => {}} query={query} />)
+
+        expect(container.querySelector('[data-attr="insight-retry-button"]')).not.toBeNull()
+        expect(container.querySelector('.LemonButtonWithSideAction') !== null).toBe(expectsSideAction)
+    })
 })


### PR DESCRIPTION
## Problem

The `RetryButton` fix in [#71997](https://github.com/PostHog/posthog/pull/71997) shipped without test coverage. That PR made `sideAction` `undefined` (instead of the always-truthy `{}`) when the retry button has no `query`, so `LemonButton` stops rendering a stray empty side action next to "Try again". The button is never exercised in the existing tests (neither passes `onRetry`), so reintroducing the old default would regress silently.

## Changes

Add a parameterized case to `InsightErrorStates.test.tsx` that renders `InsightErrorState` with `onRetry` so `RetryButton` actually mounts, then asserts the `.LemonButtonWithSideAction` wrapper is absent without a `query` and present with one.

## How did you test this code?

- Ran the suite: `InsightErrorStates.test.tsx` — all 4 cases pass.
- Confirmed the guard bites: temporarily restored the old `sideAction = {}` default and the no-query case failed as expected, then reverted.

Regression caught that no existing test did: a truthy `sideAction` default on the retry button rendering a side action when there is no query to link to.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Backfills coverage requested in review of #71997. Claude Code added the test, verified it fails when the pre-fix `sideAction = {}` default is reintroduced, and reverted that probe. Invoked the `/writing-tests` skill to gate the addition against the value bar.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
