### PR TITLE
feat(users): add UserPersonalization side table with avatar_url

### DIFF
--- a/.semgrep/rules/security/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/security/idor-team-scoped-models.yaml
@@ -868,6 +868,7 @@ rules:
                               |PersonalAPIKey
                               |ScoreDefinitionVersion
                               |SignalUserAutonomyConfig
+                              |UserPersonalization
                               |UserPushToken
                               |WebauthnCredential
                           )$
@@ -922,6 +923,7 @@ rules:
                         |PersonalAPIKey
                         |ScoreDefinitionVersion
                         |SignalUserAutonomyConfig
+                        |UserPersonalization
                         |UserPushToken
                         |WebauthnCredential
                     )$

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -3512,6 +3512,12 @@ export interface UserApi {
     readonly scene_personalisation: readonly ScenePersonalisationBasicApi[]
     theme_mode?: ThemeModeEnumApi | BlankEnumApi | null
     hedgehog_config?: unknown
+    /**
+     * Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.
+     * @maxLength 800
+     * @nullable
+     */
+    avatar_url?: string | null
     /** @nullable */
     allow_sidebar_suggestions?: boolean | null
     shortcut_position?: ShortcutPositionEnumApi | BlankEnumApi | null
@@ -3619,6 +3625,12 @@ export interface PatchedUserApi {
     readonly scene_personalisation?: readonly ScenePersonalisationBasicApi[]
     theme_mode?: ThemeModeEnumApi | BlankEnumApi | null
     hedgehog_config?: unknown
+    /**
+     * Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.
+     * @maxLength 800
+     * @nullable
+     */
+    avatar_url?: string | null
     /** @nullable */
     allow_sidebar_suggestions?: boolean | null
     shortcut_position?: ShortcutPositionEnumApi | BlankEnumApi | null

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -9688,6 +9688,8 @@ export const usersUpdateBodyEmailMax = 254
 
 export const usersUpdateBodyPasswordMax = 128
 
+export const usersUpdateBodyAvatarUrlMax = 800
+
 export const UsersUpdateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersUpdateBodyFirstNameMax).optional(),
     last_name: zod.string().max(usersUpdateBodyLastNameMax).optional(),
@@ -9732,6 +9734,11 @@ export const UsersUpdateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersUpdateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -9772,6 +9779,8 @@ export const usersPartialUpdateBodyLastNameMax = 150
 export const usersPartialUpdateBodyEmailMax = 254
 
 export const usersPartialUpdateBodyPasswordMax = 128
+
+export const usersPartialUpdateBodyAvatarUrlMax = 800
 
 export const UsersPartialUpdateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersPartialUpdateBodyFirstNameMax).optional(),
@@ -9817,6 +9826,11 @@ export const UsersPartialUpdateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersPartialUpdateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -9854,6 +9868,8 @@ export const usersHedgehogConfigPartialUpdateBodyLastNameMax = 150
 export const usersHedgehogConfigPartialUpdateBodyEmailMax = 254
 
 export const usersHedgehogConfigPartialUpdateBodyPasswordMax = 128
+
+export const usersHedgehogConfigPartialUpdateBodyAvatarUrlMax = 800
 
 export const UsersHedgehogConfigPartialUpdateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersHedgehogConfigPartialUpdateBodyFirstNameMax).optional(),
@@ -9899,6 +9915,11 @@ export const UsersHedgehogConfigPartialUpdateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersHedgehogConfigPartialUpdateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10071,6 +10092,8 @@ export const usersScenePersonalisationCreateBodyEmailMax = 254
 
 export const usersScenePersonalisationCreateBodyPasswordMax = 128
 
+export const usersScenePersonalisationCreateBodyAvatarUrlMax = 800
+
 export const UsersScenePersonalisationCreateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersScenePersonalisationCreateBodyFirstNameMax).optional(),
     last_name: zod.string().max(usersScenePersonalisationCreateBodyLastNameMax).optional(),
@@ -10115,6 +10138,11 @@ export const UsersScenePersonalisationCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersScenePersonalisationCreateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10155,6 +10183,8 @@ export const usersTwoFactorBackupCodesCreateBodyLastNameMax = 150
 export const usersTwoFactorBackupCodesCreateBodyEmailMax = 254
 
 export const usersTwoFactorBackupCodesCreateBodyPasswordMax = 128
+
+export const usersTwoFactorBackupCodesCreateBodyAvatarUrlMax = 800
 
 export const UsersTwoFactorBackupCodesCreateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersTwoFactorBackupCodesCreateBodyFirstNameMax).optional(),
@@ -10200,6 +10230,11 @@ export const UsersTwoFactorBackupCodesCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersTwoFactorBackupCodesCreateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10240,6 +10275,8 @@ export const usersTwoFactorDisableCreateBodyLastNameMax = 150
 export const usersTwoFactorDisableCreateBodyEmailMax = 254
 
 export const usersTwoFactorDisableCreateBodyPasswordMax = 128
+
+export const usersTwoFactorDisableCreateBodyAvatarUrlMax = 800
 
 export const UsersTwoFactorDisableCreateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersTwoFactorDisableCreateBodyFirstNameMax).optional(),
@@ -10285,6 +10322,11 @@ export const UsersTwoFactorDisableCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersTwoFactorDisableCreateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10322,6 +10364,8 @@ export const usersTwoFactorValidateCreateBodyLastNameMax = 150
 export const usersTwoFactorValidateCreateBodyEmailMax = 254
 
 export const usersTwoFactorValidateCreateBodyPasswordMax = 128
+
+export const usersTwoFactorValidateCreateBodyAvatarUrlMax = 800
 
 export const UsersTwoFactorValidateCreateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersTwoFactorValidateCreateBodyFirstNameMax).optional(),
@@ -10367,6 +10411,11 @@ export const UsersTwoFactorValidateCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersTwoFactorValidateCreateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10404,6 +10453,8 @@ export const usersValidate2faCreateBodyLastNameMax = 150
 export const usersValidate2faCreateBodyEmailMax = 254
 
 export const usersValidate2faCreateBodyPasswordMax = 128
+
+export const usersValidate2faCreateBodyAvatarUrlMax = 800
 
 export const UsersValidate2faCreateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersValidate2faCreateBodyFirstNameMax).optional(),
@@ -10449,6 +10500,11 @@ export const UsersValidate2faCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersValidate2faCreateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10486,6 +10542,8 @@ export const usersCancelEmailChangeRequestPartialUpdateBodyLastNameMax = 150
 export const usersCancelEmailChangeRequestPartialUpdateBodyEmailMax = 254
 
 export const usersCancelEmailChangeRequestPartialUpdateBodyPasswordMax = 128
+
+export const usersCancelEmailChangeRequestPartialUpdateBodyAvatarUrlMax = 800
 
 export const UsersCancelEmailChangeRequestPartialUpdateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersCancelEmailChangeRequestPartialUpdateBodyFirstNameMax).optional(),
@@ -10531,6 +10589,11 @@ export const UsersCancelEmailChangeRequestPartialUpdateBody = /* @__PURE__ */ zo
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersCancelEmailChangeRequestPartialUpdateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10568,6 +10631,8 @@ export const usersRequestEmailVerificationCreateBodyLastNameMax = 150
 export const usersRequestEmailVerificationCreateBodyEmailMax = 254
 
 export const usersRequestEmailVerificationCreateBodyPasswordMax = 128
+
+export const usersRequestEmailVerificationCreateBodyAvatarUrlMax = 800
 
 export const UsersRequestEmailVerificationCreateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersRequestEmailVerificationCreateBodyFirstNameMax).optional(),
@@ -10613,6 +10678,11 @@ export const UsersRequestEmailVerificationCreateBody = /* @__PURE__ */ zod.objec
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersRequestEmailVerificationCreateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([
@@ -10650,6 +10720,8 @@ export const usersVerifyEmailCreateBodyLastNameMax = 150
 export const usersVerifyEmailCreateBodyEmailMax = 254
 
 export const usersVerifyEmailCreateBodyPasswordMax = 128
+
+export const usersVerifyEmailCreateBodyAvatarUrlMax = 800
 
 export const UsersVerifyEmailCreateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersVerifyEmailCreateBodyFirstNameMax).optional(),
@@ -10695,6 +10767,11 @@ export const UsersVerifyEmailCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersVerifyEmailCreateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar\/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from django.db.models import F, Model, Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
@@ -59,7 +59,7 @@ def organization_members_base_queryset() -> QuerySet:
     return (
         OrganizationMembership.objects.exclude(user__email__endswith=INTERNAL_BOT_EMAIL_SUFFIX)
         .filter(user__is_active=True)
-        .select_related("user")
+        .select_related("user", "user__personalization")
     )
 
 
@@ -88,6 +88,9 @@ class OrganizationMemberSerializer(SearchMatchTypeSerializerMixin, serializers.M
     is_2fa_enabled = serializers.SerializerMethodField()
     has_social_auth = serializers.SerializerMethodField()
     last_login = serializers.DateTimeField(read_only=True)
+    avatar_url = serializers.SerializerMethodField(
+        help_text="The member's profile picture URL, when they have set one."
+    )
 
     class Meta:
         model = OrganizationMembership
@@ -100,9 +103,14 @@ class OrganizationMemberSerializer(SearchMatchTypeSerializerMixin, serializers.M
             "is_2fa_enabled",
             "has_social_auth",
             "last_login",
+            "avatar_url",
             "search_match_type",
         ]
         read_only_fields = ["id", "joined_at", "updated_at"]
+
+    def get_avatar_url(self, instance: OrganizationMembership) -> Optional[str]:
+        personalization = getattr(instance.user, "personalization", None)
+        return personalization.avatar_url if personalization else None
 
     def get_is_2fa_enabled(self, instance: OrganizationMembership) -> bool:
         # Uses prefetched relations to avoid N+1 queries

--- a/posthog/api/test/test_user_avatar_url.py
+++ b/posthog/api/test/test_user_avatar_url.py
@@ -1,0 +1,39 @@
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from posthog.models import UserPersonalization
+
+
+class TestUserAvatarUrl(APIBaseTest):
+    def test_can_set_and_remove_avatar_url(self) -> None:
+        response = self.client.patch("/api/users/@me/", {"avatar_url": "https://example.com/me.png"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["avatar_url"], "https://example.com/me.png")
+        self.assertEqual(
+            UserPersonalization.objects.get(user=self.user).avatar_url,
+            "https://example.com/me.png",
+        )
+
+        response = self.client.patch("/api/users/@me/", {"avatar_url": None})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.json()["avatar_url"])
+        self.assertIsNone(UserPersonalization.objects.get(user=self.user).avatar_url)
+
+    def test_avatar_url_defaults_to_none_without_personalization_row(self) -> None:
+        response = self.client.get("/api/users/@me/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.json()["avatar_url"])
+
+    def test_rejects_non_https_avatar_url(self) -> None:
+        for bad_url in ["http://example.com/me.png", "javascript:alert(1)", "not a url"]:
+            response = self.client.patch("/api/users/@me/", {"avatar_url": bad_url})
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, bad_url)
+        self.assertFalse(UserPersonalization.objects.filter(user=self.user).exists())
+
+    def test_organization_members_expose_avatar_url(self) -> None:
+        UserPersonalization.objects.create(user=self.user, avatar_url="https://example.com/me.png")
+        response = self.client.get("/api/organizations/@current/members/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        member = next(m for m in response.json()["results"] if m["user"]["uuid"] == str(self.user.uuid))
+        self.assertEqual(member["avatar_url"], "https://example.com/me.png")

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -83,7 +83,7 @@ from posthog.middleware import (
     get_impersonated_session_expires_at,
     is_read_only_impersonation,
 )
-from posthog.models import OrganizationInvite, Team, User, UserScenePersonalisation
+from posthog.models import OrganizationInvite, Team, User, UserPersonalization, UserScenePersonalisation
 from posthog.models.onboarding_delegation import cancel_pending_delegation, clear_delegation_state
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.organization_domain import OrganizationDomain
@@ -236,6 +236,14 @@ class UserSerializer(serializers.ModelSerializer):
         help_text="Whether PostHog should anonymize events captured for this user when identified."
     )
     role_at_organization = serializers.ChoiceField(choices=ROLE_CHOICES, required=False)
+    avatar_url = serializers.URLField(
+        source="personalization.avatar_url",
+        max_length=800,
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.",
+    )
     # Intentionally NOT declared explicitly — Meta.read_only_fields below is silently ignored
     # for explicitly declared fields (a well-known DRF gotcha that drf-spectacular replicates
     # in its generated OpenAPI), so any explicit declaration here would re-open the writable
@@ -301,6 +309,7 @@ class UserSerializer(serializers.ModelSerializer):
             "scene_personalisation",
             "theme_mode",
             "hedgehog_config",
+            "avatar_url",
             "allow_sidebar_suggestions",
             "shortcut_position",
             "role_at_organization",
@@ -354,6 +363,12 @@ class UserSerializer(serializers.ModelSerializer):
 
     def validate_first_name(self, value: str) -> str:
         return validate_display_name(value)
+
+    def validate_avatar_url(self, value: Optional[str]) -> Optional[str]:
+        # Rendered as an <img> src across PostHog apps, so only allow https.
+        if value and not value.startswith("https://"):
+            raise serializers.ValidationError("Avatar URL must use https.")
+        return value
 
     def validate_last_name(self, value: str) -> str:
         return validate_display_name(value)
@@ -675,6 +690,15 @@ class UserSerializer(serializers.ModelSerializer):
         return value
 
     def update(self, instance: "User", validated_data: Any) -> Any:
+        # The dotted avatar_url source arrives nested; it lives on a side
+        # table so posthog_user itself is never written for avatar changes.
+        personalization_data = validated_data.pop("personalization", None)
+        if personalization_data is not None and "avatar_url" in personalization_data:
+            UserPersonalization.objects.update_or_create(
+                user=instance,
+                defaults={"avatar_url": personalization_data["avatar_url"]},
+            )
+
         # Update current_organization and current_team
         current_organization = validated_data.pop("set_current_organization", None)
         current_team = validated_data.pop("set_current_team", None)

--- a/posthog/migrations/1259_userpersonalization.py
+++ b/posthog/migrations/1259_userpersonalization.py
@@ -1,0 +1,56 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+from posthog.migration_helpers import AddForeignKeyNotValid
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("posthog", "1258_duckgressinkschemastate_queue_last_applied_at"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="UserPersonalization",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "avatar_url",
+                    models.URLField(
+                        blank=True,
+                        help_text="Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.",
+                        max_length=800,
+                        null=True,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="personalization",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        AddForeignKeyNotValid(
+            model_name="userpersonalization",
+            name="posthog_userpersonalization_user_id_fk",
+            column="user_id",
+            to_table="posthog_user",
+        ),
+    ]

--- a/posthog/migrations/1260_validate_userpersonalization_fk.py
+++ b/posthog/migrations/1260_validate_userpersonalization_fk.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+from posthog.migration_helpers import ValidateForeignKey
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1259_userpersonalization"),
+    ]
+
+    operations = [
+        # Phase 2 of the NOT VALID foreign key added in 1259; the scan takes
+        # only SHARE UPDATE EXCLUSIVE and the table is brand new, so this is
+        # instant and never blocks posthog_user traffic.
+        ValidateForeignKey(
+            model_name="userpersonalization",
+            name="posthog_userpersonalization_user_id_fk",
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1258_duckgressinkschemastate_queue_last_applied_at
+1260_validate_userpersonalization_fk

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -77,6 +77,7 @@ from .repo_routing_rule import RepoRoutingRule
 from .user_repo_preference import UserRepoPreference
 from .user_scene_personalisation import UserScenePersonalisation
 from .user_home_settings import UserHomeSettings
+from .user_personalization import UserPersonalization
 from .oauth import (
     CIMDVerificationToken,
     OAuthAccessToken,
@@ -181,6 +182,7 @@ __all__ = [
     "UserRepoPreference",
     "UserScenePersonalisation",
     "UserHomeSettings",
+    "UserPersonalization",
     "UserManager",
     "UserGroup",
     "UserGroupMembership",

--- a/posthog/models/user_personalization.py
+++ b/posthog/models/user_personalization.py
@@ -1,0 +1,27 @@
+from django.db import models
+
+from posthog.models.utils import UUIDModel
+
+
+class UserPersonalization(UUIDModel):
+    """
+    Per-user appearance/profile preferences. A side table rather than columns
+    on posthog_user, which is too hot to ALTER casually.
+    """
+
+    # db_constraint=False so CreateModel takes no lock on hot posthog_user;
+    # the FK constraint is added NOT VALID + validated in the migration.
+    user = models.OneToOneField(
+        "posthog.User",
+        on_delete=models.CASCADE,
+        related_name="personalization",
+        db_constraint=False,
+    )
+    avatar_url = models.URLField(
+        max_length=800,
+        null=True,
+        blank=True,
+        help_text="Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -316,6 +316,11 @@ export interface OrganizationMemberApi {
     readonly is_2fa_enabled: boolean
     readonly has_social_auth: boolean
     readonly last_login: string
+    /**
+     * The member's profile picture URL, when they have set one.
+     * @nullable
+     */
+    readonly avatar_url: string | null
     /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
     readonly search_match_type: SearchMatchTypeEnumApi | null
 }
@@ -338,6 +343,11 @@ export interface PatchedOrganizationMemberApi {
     readonly is_2fa_enabled?: boolean
     readonly has_social_auth?: boolean
     readonly last_login?: string
+    /**
+     * The member's profile picture URL, when they have set one.
+     * @nullable
+     */
+    readonly avatar_url?: string | null
     /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
     readonly search_match_type?: SearchMatchTypeEnumApi | null
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -36714,6 +36714,11 @@ export namespace Schemas {
       readonly is_2fa_enabled: boolean;
       readonly has_social_auth: boolean;
       readonly last_login: string;
+      /**
+         * The member's profile picture URL, when they have set one.
+         * @nullable
+         */
+      readonly avatar_url: string | null;
       /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
       readonly search_match_type: SearchMatchTypeEnum | null;
     }
@@ -41883,6 +41888,12 @@ export namespace Schemas {
       readonly scene_personalisation: readonly ScenePersonalisationBasic[];
       theme_mode?: ThemeModeEnum | BlankEnum | null;
       hedgehog_config?: unknown;
+      /**
+         * Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.
+         * @maxLength 800
+         * @nullable
+         */
+      avatar_url?: string | null;
       /** @nullable */
       allow_sidebar_suggestions?: boolean | null;
       shortcut_position?: ShortcutPositionEnum | BlankEnum | null;
@@ -46046,6 +46057,11 @@ export namespace Schemas {
       readonly is_2fa_enabled?: boolean;
       readonly has_social_auth?: boolean;
       readonly last_login?: string;
+      /**
+         * The member's profile picture URL, when they have set one.
+         * @nullable
+         */
+      readonly avatar_url?: string | null;
       /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match, returned only when no exact match exists). Null when the list is not filtered by `search`. */
       readonly search_match_type?: SearchMatchTypeEnum | null;
     }
@@ -49417,6 +49433,12 @@ export namespace Schemas {
       readonly scene_personalisation?: readonly ScenePersonalisationBasic[];
       theme_mode?: ThemeModeEnum | BlankEnum | null;
       hedgehog_config?: unknown;
+      /**
+         * Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.
+         * @maxLength 800
+         * @nullable
+         */
+      avatar_url?: string | null;
       /** @nullable */
       allow_sidebar_suggestions?: boolean | null;
       shortcut_position?: ShortcutPositionEnum | BlankEnum | null;

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -789,6 +789,8 @@ export const usersPartialUpdateBodyEmailMax = 254
 
 export const usersPartialUpdateBodyPasswordMax = 128
 
+export const usersPartialUpdateBodyAvatarUrlMax = 800
+
 export const UsersPartialUpdateBody = /* @__PURE__ */ zod.object({
     first_name: zod.string().max(usersPartialUpdateBodyFirstNameMax).optional(),
     last_name: zod.string().max(usersPartialUpdateBodyLastNameMax).optional(),
@@ -830,6 +832,11 @@ export const UsersPartialUpdateBody = /* @__PURE__ */ zod.object({
         ])
         .optional(),
     hedgehog_config: zod.unknown().optional(),
+    avatar_url: zod
+        .url()
+        .max(usersPartialUpdateBodyAvatarUrlMax)
+        .nullish()
+        .describe('Profile picture URL, shown across PostHog apps in place of the Gravatar/initials fallback.'),
     allow_sidebar_suggestions: zod.boolean().nullish(),
     shortcut_position: zod
         .union([

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -568,6 +568,9 @@ const userSettingsUpdate = (): ToolBase<typeof UserSettingsUpdateSchema, Schemas
         if (params.hedgehog_config !== undefined) {
             body['hedgehog_config'] = params.hedgehog_config
         }
+        if (params.avatar_url !== undefined) {
+            body['avatar_url'] = params.avatar_url
+        }
         if (params.allow_sidebar_suggestions !== undefined) {
             body['allow_sidebar_suggestions'] = params.allow_sidebar_suggestions
         }


### PR DESCRIPTION
## Problem

PostHog apps have no real profile photos for users — every avatar surface falls back to Gravatar (which most accounts don't have) or initials. PostHog Code is adding a generic `UserAvatar` component that reads a profile photo off the API, but there's nowhere to store one. An earlier revision of this PR added a column to `posthog_user`; that's a hot table, so the field now lives on a side table instead and the core user model is untouched.

## Changes

- New `UserPersonalization` model: one row per user (`OneToOneField`), currently holding `avatar_url`, with room for future per-user appearance/profile preferences. Follows the existing user-keyed side-table pattern (`UserProductList`, `UserScenePersonalisation`, `UserHomeSettings`).
- `avatar_url` readable and writable (https-only) on `/api/users/@me/` — writes upsert the side row, `posthog_user` is never written.
- Exposed on the org members endpoint (`OrganizationMemberSerializer.avatar_url`) via a `select_related` on the shared members queryset, so clients resolve teammates' avatars from the members list. `UserBasicSerializer` is deliberately untouched — no payload changes ripple through other endpoints, and no SQL snapshots move.
- Migration is a plain `CREATE TABLE`; no hot-table acknowledgment or coordinated deploy needed.

Stacked follow-up: [#72092](https://github.com/PostHog/posthog/pull/72092) backfills staff avatars from posthog.com/people. PostHog Code consumes this in [PostHog/code#3549](https://github.com/PostHog/code/pull/3549).

## How did you test this code?

Automated tests added (not run locally — this environment has no dev stack, so CI is the arbiter): `posthog/api/test/test_user_avatar_url.py` — set/remove via PATCH `@me` (asserting the side row), default-null read without a row, https-only rejection, and exposure on the org members list. Catches the upsert path breaking, the field becoming read-only, or the members exposure regressing.

Not run locally: `hogli build:openapi` and mypy — expecting the CI bots/checks to flag anything needed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — API reference flows from serializer `help_text`.

## 🤖 Agent context

Human-driven (agent-assisted) — requested by Adam Bowker in the project-bluebird channel (PostHog Code); reworked from a `posthog_user` column to a side table at his direction.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*