### PR TITLE
feat(tasks): send slack dms for channel thread @-mentions

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1511,6 +1511,34 @@ class SlackIntegration:
     def missing_scopes(self, required: Iterable[str]) -> frozenset[str]:
         return frozenset(required) - self.granted_scopes()
 
+    def lookup_user_id_by_email(self, email: str) -> str | None:
+        """The workspace member id for an email, or None when no member matches.
+
+        Swallows the expected ``users_not_found`` error; other Slack errors are
+        logged and treated as no-match so callers stay best-effort. Requires the
+        ``users:read.email`` scope.
+        """
+        normalized_email = email.strip().lower()
+        if not normalized_email:
+            return None
+
+        try:
+            response = self.client.users_lookupByEmail(email=normalized_email)
+        except SlackApiError as exc:
+            error_code = exc.response.get("error") if exc.response else None
+            if error_code != "users_not_found":
+                logger.warning("slack_user_email_lookup_failed", email=normalized_email, error=error_code)
+            return None
+
+        data = response.data if isinstance(getattr(response, "data", None), dict) else response
+        if not isinstance(data, dict) or not data.get("ok"):
+            return None
+
+        slack_user = data.get("user")
+        if not isinstance(slack_user, dict) or not slack_user.get("id"):
+            return None
+        return str(slack_user["id"])
+
     def list_channels(self, should_include_private_channels: bool, authed_user: str) -> list[dict]:
         # NOTE: Annoyingly the Slack API has no search so we have to load all channels...
         # We load public and private channels separately as when mixed, the Slack API pagination is buggy

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -55,6 +55,7 @@ from products.tasks.backend.models import (
     ChannelFeedMessage,
     CodeInvite,
     CodeInviteRedemption,
+    CodeUserNotificationSettings,
     CodeWorkflowConfig,
     CodeWorkstream,
     SandboxCustomImage,
@@ -5037,6 +5038,8 @@ def _index_thread_message_mentions(message: TaskThreadMessage) -> None:
     mentioned_user_ids = resolve_mentioned_user_ids(
         User, message.content, team_id=message.team_id, author_id=message.author_id
     )
+    if not mentioned_user_ids:
+        return
     TaskThreadMessageMention.objects.for_team(message.team_id).bulk_create(
         [
             TaskThreadMessageMention(
@@ -5050,6 +5053,15 @@ def _index_thread_message_mentions(message: TaskThreadMessage) -> None:
         ],
         ignore_conflicts=True,
     )
+
+    from products.tasks.backend.tasks import (
+        send_thread_message_mention_dms,  # noqa: PLC0415 - keep celery task import lazy
+    )
+
+    # After commit so the task reads the mention rows it just indexed; Slack
+    # delivery stays off the request path and can never fail message creation.
+    message_id, team_id = str(message.id), message.team_id
+    transaction.on_commit(lambda: send_thread_message_mention_dms.delay(message_id, team_id))
 
 
 def list_mentions(
@@ -5081,6 +5093,24 @@ def list_mentions(
         )
         for mention in mentions
     ]
+
+
+def get_code_user_notification_settings(user_id: int) -> contracts.CodeUserNotificationSettingsDTO:
+    """The user's PostHog Code notification settings; all-defaults when never saved."""
+    config = CodeUserNotificationSettings.objects.filter(user_id=user_id).first()
+    return contracts.CodeUserNotificationSettingsDTO(
+        slack_mention_notifications=bool(config and config.slack_mention_notifications)
+    )
+
+
+def update_code_user_notification_settings(
+    user_id: int, *, slack_mention_notifications: bool
+) -> contracts.CodeUserNotificationSettingsDTO:
+    """Upsert the user's PostHog Code notification settings."""
+    CodeUserNotificationSettings.objects.update_or_create(
+        user_id=user_id, defaults={"slack_mention_notifications": slack_mention_notifications}
+    )
+    return contracts.CodeUserNotificationSettingsDTO(slack_mention_notifications=slack_mention_notifications)
 
 
 def delete_thread_message(message_id: str | UUID, task_id: str | UUID, team_id: int, user_id: int | None) -> str:

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -209,6 +209,13 @@ class TaskMentionDTO:
 
 
 @dataclass(frozen=True)
+class CodeUserNotificationSettingsDTO:
+    """The requester's PostHog Code notification preferences."""
+
+    slack_mention_notifications: bool
+
+
+@dataclass(frozen=True)
 class TaskLatestRunSummaryDTO:
     """The latest-run status/environment pair nested in a task summary response."""
 

--- a/products/tasks/backend/mentions.py
+++ b/products/tasks/backend/mentions.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from django.db.models.functions import Lower
 
-MENTION_TOKEN_PATTERN = re.compile(r"@\[[^\][\n]+\]\(([^\s()]+@[^\s()]+)\)")
+MENTION_TOKEN_PATTERN = re.compile(r"@\[(?P<name>[^\][\n]+)\]\((?P<email>[^\s()]+@[^\s()]+)\)")
 
 # Content length is unbounded, so cap how many distinct emails one message may
 # resolve to keep the lookup's IN list from growing with attacker-sized input.
@@ -19,7 +19,12 @@ MAX_RESOLVED_MENTIONS_PER_MESSAGE = 50
 
 def extract_mention_emails(content: str) -> set[str]:
     """Emails mentioned in the content, lowercased and deduped."""
-    return {match.group(1).lower() for match in MENTION_TOKEN_PATTERN.finditer(content)}
+    return {match.group("email").lower() for match in MENTION_TOKEN_PATTERN.finditer(content)}
+
+
+def render_mention_tokens(content: str) -> str:
+    """Content with mention tokens flattened to ``@Display Name`` for plain-text surfaces."""
+    return MENTION_TOKEN_PATTERN.sub(lambda match: f"@{match.group('name')}", content)
 
 
 def format_mention_token(name: str, email: str) -> str:

--- a/products/tasks/backend/migrations/0063_codeusernotificationsettings.py
+++ b/products/tasks/backend/migrations/0063_codeusernotificationsettings.py
@@ -1,0 +1,39 @@
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0062_sandbox_custom_image_base_reference"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CodeUserNotificationSettings",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False),
+                ),
+                ("slack_mention_notifications", models.BooleanField(default=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="code_notification_settings",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_code_user_notification_settings",
+            },
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0062_sandbox_custom_image_base_reference
+0063_codeusernotificationsettings

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -903,6 +903,31 @@ class TaskThreadMessageMention(TeamScopedRootMixin):
         return f"Mention of user {self.mentioned_user_id} in message {self.message_id}"
 
 
+class CodeUserNotificationSettings(models.Model):
+    """Per-user PostHog Code notification preferences. User-scoped, not team-scoped:
+    the settings follow the user across projects (the Slack integration is resolved
+    per-team at send time). A missing row means every opt-in notification is off."""
+
+    # nosemgrep: prefer-uuid7-django-pk -- mirrors sibling task models in this app
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # db_constraint=False on the user FK: posthog_user is written on virtually every
+    # request, and adding an FK constraint takes a lock that stalls deploys; Django
+    # still enforces the relation and on_delete at the app level (see safe-django-migrations.md).
+    user = models.OneToOneField(
+        "posthog.User", on_delete=models.CASCADE, related_name="code_notification_settings", db_constraint=False
+    )
+    # Slack DM when someone @-mentions the user in a channel thread. Opt-in.
+    slack_mention_notifications = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "posthog_code_user_notification_settings"
+
+    def __str__(self):
+        return f"Code notification settings for user {self.user_id}"
+
+
 class ChannelFeedMessage(TeamScopedRootMixin):
     """A durable, team-visible announcement in a channel's feed — rendered alongside
     task cards as a "PostHog agent" system row (e.g. "Adam created this context").

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -25,6 +25,7 @@ from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.contracts import (
     ChannelDTO,
     ChannelFeedMessageDTO,
+    CodeUserNotificationSettingsDTO,
     SandboxCustomImageDTO,
     SandboxEnvironmentDTO,
     TaskAutomationDTO,
@@ -1442,6 +1443,27 @@ class TaskMentionSerializer(DataclassSerializer):
             "content",
             "created_at",
         ]
+
+
+class CodeUserNotificationSettingsSerializer(DataclassSerializer):
+    """Response shape for the requester's PostHog Code notification settings."""
+
+    slack_mention_notifications = serializers.BooleanField(
+        help_text="Send a Slack DM when someone @-mentions the requester in a channel thread."
+    )
+
+    class Meta:
+        dataclass = CodeUserNotificationSettingsDTO
+        fields = ["slack_mention_notifications"]
+
+
+class CodeUserNotificationSettingsWriteSerializer(serializers.Serializer):
+    """Write shape for updating the requester's PostHog Code notification settings."""
+
+    slack_mention_notifications = serializers.BooleanField(
+        required=True,
+        help_text="Send a Slack DM when someone @-mentions the requester in a channel thread.",
+    )
 
 
 class TaskRepositoriesResponseSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/views/user_settings_api.py
+++ b/products/tasks/backend/presentation/views/user_settings_api.py
@@ -1,0 +1,54 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.permissions import APIScopePermission
+
+from products.tasks.backend.facade import api as tasks_facade
+from products.tasks.backend.presentation.serializers import (
+    CodeUserNotificationSettingsSerializer,
+    CodeUserNotificationSettingsWriteSerializer,
+)
+
+
+class CodeUserSettingsViewSet(viewsets.ViewSet):
+    """
+    API for the requester's PostHog Code notification settings — a singleton per
+    user (all-defaults when the user never saved any). User-scoped, not
+    team-scoped: the settings follow the user across projects.
+    """
+
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "user"
+    http_method_names = ["get", "post", "head", "options"]
+
+    @extend_schema(
+        responses={200: CodeUserNotificationSettingsSerializer},
+        summary="Get the requester's PostHog Code notification settings",
+        description="Defaults (everything off) when the requester never saved settings.",
+    )
+    def list(self, request, **kwargs):
+        settings_dto = tasks_facade.get_code_user_notification_settings(request.user.id)
+        return Response(CodeUserNotificationSettingsSerializer(settings_dto).data)
+
+    @extend_schema(
+        request=CodeUserNotificationSettingsWriteSerializer,
+        responses={200: CodeUserNotificationSettingsSerializer},
+        summary="Update the requester's PostHog Code notification settings",
+    )
+    def create(self, request, **kwargs):
+        serializer = CodeUserNotificationSettingsWriteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        settings_dto = tasks_facade.update_code_user_notification_settings(
+            request.user.id,
+            slack_mention_notifications=serializer.validated_data["slack_mention_notifications"],
+        )
+        return Response(CodeUserNotificationSettingsSerializer(settings_dto).data)

--- a/products/tasks/backend/routes.py
+++ b/products/tasks/backend/routes.py
@@ -4,6 +4,7 @@ import products.tasks.backend.presentation.views.api as tasks
 import products.tasks.backend.presentation.views.seat_api as seats
 import products.tasks.backend.presentation.views.channels_api as channels
 import products.tasks.backend.presentation.views.code_home_api as code_home
+import products.tasks.backend.presentation.views.user_settings_api as user_settings
 
 
 def register_routes(routers: RouterRegistry) -> None:
@@ -40,4 +41,5 @@ def register_routes(routers: RouterRegistry) -> None:
     routers.projects.register(r"code_workflow", code_home.CodeWorkflowViewSet, "project_code_workflow", ["team_id"])
     routers.projects.register(r"code_home", code_home.CodeHomeViewSet, "project_code_home", ["team_id"])
     routers.root.register(r"code/invites", tasks.CodeInviteViewSet, "code_invites")
+    routers.root.register(r"code/user_settings", user_settings.CodeUserSettingsViewSet, "code_user_settings")
     routers.root.register(r"seats", seats.SeatViewSet, "seats")

--- a/products/tasks/backend/slack_mention_notifications.py
+++ b/products/tasks/backend/slack_mention_notifications.py
@@ -1,0 +1,139 @@
+"""Slack DMs for @-mentions in task thread messages.
+
+When a thread message @-mentions org members, each mentioned user who opted in
+(``CodeUserNotificationSettings.slack_mention_notifications``) gets a DM via the
+team's Slack integration. All sends are best-effort: one recipient's failure
+never blocks the others, and nothing here can fail message creation (dispatch
+happens from a Celery task, after the mention rows commit).
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+
+import structlog
+from slack_sdk.errors import SlackApiError
+
+from posthog.models.integration import Integration, SlackIntegration
+
+from products.tasks.backend.mentions import render_mention_tokens
+from products.tasks.backend.models import CodeUserNotificationSettings, TaskThreadMessage, TaskThreadMessageMention
+
+logger = structlog.get_logger(__name__)
+
+_CONTENT_EXCERPT_MAX_LEN = 300
+
+
+def _escape_mrkdwn(text: str) -> str:
+    """Neutralize Slack control syntax (`&`, `<`, `>`) so message content can't inject mentions/links."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _author_display_name(message: TaskThreadMessage) -> str:
+    if message.author_id and message.author:
+        name = f"{message.author.first_name or ''} {message.author.last_name or ''}".strip()
+        if name:
+            return name
+        email = (message.author.email or "").strip()
+        if email:
+            return email.split("@", 1)[0] if "@" in email else email
+    return "PostHog agent"
+
+
+def _content_excerpt(content: str) -> str:
+    text = _escape_mrkdwn(render_mention_tokens(content)).strip()
+    if len(text) > _CONTENT_EXCERPT_MAX_LEN:
+        text = text[:_CONTENT_EXCERPT_MAX_LEN].rstrip() + "…"
+    return text
+
+
+def _build_dm_blocks(message: TaskThreadMessage) -> tuple[str, list[dict]]:
+    """The DM payload: plain-text fallback and Block Kit blocks."""
+    author = _escape_mrkdwn(_author_display_name(message))
+    channel = message.task.channel
+    where = f" in *#{_escape_mrkdwn(channel.name)}*" if channel else ""
+    body = f"*{author}* mentioned you{where}\n*{_escape_mrkdwn(message.task.title)}*"
+    excerpt = _content_excerpt(message.content)
+    if excerpt:
+        quoted = "\n".join(f"> {line}" for line in excerpt.splitlines())
+        body = f"{body}\n{quoted}"
+
+    # The cloud task page (works on mobile) rather than a desktop-only
+    # ``posthog-code://`` deep link, matching post_slack_update.py.
+    task_url = f"{settings.SITE_URL}/project/{message.team_id}/tasks/{message.task_id}"
+    blocks = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": body}},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Open in PostHog"},
+                    "url": task_url,
+                }
+            ],
+        },
+    ]
+    fallback = f"{_author_display_name(message)} mentioned you in a task thread"
+    return fallback, blocks
+
+
+def send_mention_dms_for_message(message_id: str, team_id: int) -> int:
+    """DM each opted-in user mentioned in the message. Returns how many DMs were sent.
+
+    Mention rows are unique per (message, user), so a user mentioned twice in
+    one message gets one DM. Recipients without a Slack account matching their
+    PostHog email are skipped silently.
+    """
+    message = (
+        TaskThreadMessage.objects.for_team(team_id)
+        .filter(id=message_id)
+        .select_related("author", "task__channel")
+        .first()
+    )
+    if message is None:
+        return 0
+
+    mentioned_user_ids = list(
+        TaskThreadMessageMention.objects.for_team(team_id)
+        .filter(message_id=message.id)
+        .values_list("mentioned_user_id", flat=True)
+    )
+    if not mentioned_user_ids:
+        return 0
+
+    recipients = [
+        config.user
+        for config in CodeUserNotificationSettings.objects.filter(
+            user_id__in=mentioned_user_ids, slack_mention_notifications=True
+        ).select_related("user")
+    ]
+    if not recipients:
+        return 0
+
+    integration = Integration.objects.filter(team_id=team_id, kind="slack").first()
+    if integration is None:
+        return 0
+
+    slack = SlackIntegration(integration)
+    fallback, blocks = _build_dm_blocks(message)
+
+    sent = 0
+    for recipient in recipients:
+        try:
+            slack_user_id = slack.lookup_user_id_by_email(recipient.email)
+            if not slack_user_id:
+                continue
+            # chat_postMessage to a user id opens the IM if it doesn't already exist.
+            slack.client.chat_postMessage(channel=slack_user_id, text=fallback, blocks=blocks)
+            sent += 1
+        except SlackApiError as exc:
+            logger.warning(
+                "task_mention_slack_dm_failed",
+                message_id=str(message.id),
+                user_id=recipient.id,
+                error=exc.response.get("error") if exc.response else None,
+            )
+        except Exception:
+            logger.exception("task_mention_slack_dm_failed", message_id=str(message.id), user_id=recipient.id)
+    return sent

--- a/products/tasks/backend/tasks.py
+++ b/products/tasks/backend/tasks.py
@@ -1,0 +1,8 @@
+from celery import shared_task
+
+
+@shared_task(ignore_result=True)
+def send_thread_message_mention_dms(message_id: str, team_id: int) -> None:
+    from products.tasks.backend.slack_mention_notifications import send_mention_dms_for_message  # noqa: PLC0415
+
+    send_mention_dms_for_message(message_id, team_id)

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -9,8 +9,16 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from posthog.models import Organization, OrganizationMembership, Team, User
+from posthog.models.integration import Integration
 
-from products.tasks.backend.models import Channel, ChannelFeedMessage, Task, TaskRun, TaskThreadMessage
+from products.tasks.backend.models import (
+    Channel,
+    ChannelFeedMessage,
+    CodeUserNotificationSettings,
+    Task,
+    TaskRun,
+    TaskThreadMessage,
+)
 
 
 class ChannelsAPITestCase(TestCase):
@@ -498,3 +506,72 @@ class ChannelFeedMessageAPITestCase(TestCase):
         # Same org, wrong team in the URL — the channel must not resolve.
         response = self.client.get(f"/api/projects/{other_team.id}/task_channels/{channel_id}/feed/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class ThreadMessageMentionSlackDMTestCase(ChannelTaskAPITestCase):
+    """Posting a thread message that @-mentions an opted-in teammate dispatches a Slack DM."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        Integration.objects.create(team=self.team, kind="slack", sensitive_config={"access_token": "xoxb-test"})
+        CodeUserNotificationSettings.objects.create(user=self.peer, slack_mention_notifications=True)
+
+    def _thread_url(self) -> str:
+        return f"/api/projects/{self.team.id}/tasks/{self.task.id}/thread_messages/"
+
+    def _post_mention(self):
+        # Dispatch rides on transaction.on_commit; Celery runs eagerly in tests.
+        with self.captureOnCommitCallbacks(execute=True):
+            return self.author_client.post(self._thread_url(), {"content": "ping @[Bob](peer@example.com)"})
+
+    @patch("products.tasks.backend.slack_mention_notifications.SlackIntegration")
+    def test_mention_dispatches_slack_dm(self, slack_cls):
+        slack = slack_cls.return_value
+        slack.lookup_user_id_by_email.return_value = "U123"
+
+        response = self._post_mention()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        slack.client.chat_postMessage.assert_called_once()
+        self.assertEqual(slack.client.chat_postMessage.call_args.kwargs["channel"], "U123")
+
+    @patch("products.tasks.backend.slack_mention_notifications.SlackIntegration")
+    def test_slack_failure_does_not_fail_message_creation(self, slack_cls):
+        slack_cls.return_value.lookup_user_id_by_email.side_effect = Exception("slack down")
+
+        response = self._post_mention()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+    @patch("products.tasks.backend.slack_mention_notifications.SlackIntegration")
+    def test_no_dm_when_recipient_not_opted_in(self, slack_cls):
+        CodeUserNotificationSettings.objects.filter(user=self.peer).update(slack_mention_notifications=False)
+
+        response = self._post_mention()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        slack_cls.return_value.client.chat_postMessage.assert_not_called()
+
+
+class CodeUserSettingsAPITestCase(ChannelTaskAPITestCase):
+    url = "/api/code/user_settings/"
+
+    def test_defaults_to_disabled_without_a_row(self):
+        response = self.author_client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.json(), {"slack_mention_notifications": False})
+
+    def test_post_upserts_and_is_per_user(self):
+        response = self.author_client.post(self.url, {"slack_mention_notifications": True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.json(), {"slack_mention_notifications": True})
+        self.assertEqual(self.author_client.get(self.url).json(), {"slack_mention_notifications": True})
+        # Another user's settings are unaffected.
+        self.assertEqual(self.peer_client.get(self.url).json(), {"slack_mention_notifications": False})
+        # Toggling back off updates the existing row.
+        response = self.author_client.post(self.url, {"slack_mention_notifications": False})
+        self.assertEqual(response.json(), {"slack_mention_notifications": False})
+
+    def test_requires_authentication(self):
+        response = APIClient().get(self.url)
+        self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))

--- a/products/tasks/backend/tests/test_mention_slack_notifications.py
+++ b/products/tasks/backend/tests/test_mention_slack_notifications.py
@@ -1,0 +1,170 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from slack_sdk.errors import SlackApiError
+
+from posthog.models import Organization, Team, User
+from posthog.models.integration import Integration
+
+from products.tasks.backend.models import (
+    Channel,
+    CodeUserNotificationSettings,
+    Task,
+    TaskThreadMessage,
+    TaskThreadMessageMention,
+)
+from products.tasks.backend.slack_mention_notifications import send_mention_dms_for_message
+
+
+class SlackMentionDMTestCase(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Growth Team")
+        self.author = User.objects.create_user(email="author@example.com", first_name="Ann", password="password")
+        self.peer = User.objects.create_user(email="peer@example.com", first_name="Bob", password="password")
+        for user in (self.author, self.peer):
+            self.organization.members.add(user)
+
+        # Direct instantiation sidesteps the fail-closed TeamScopedManager so
+        # setUp doesn't need a team_scope wrapper (see test_channels_api.py).
+        self.channel = Channel(team=self.team, name="growth", created_by=self.author)
+        self.channel.save()
+        self.task = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            channel=self.channel,
+            title="A Task",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        self.integration = Integration.objects.create(
+            team=self.team, kind="slack", sensitive_config={"access_token": "xoxb-test"}
+        )
+
+    def _message(self, content: str, *, mentioned: list[User], author: User | None = ...) -> TaskThreadMessage:  # type: ignore[assignment]
+        resolved_author = self.author if author is ... else author
+        message = TaskThreadMessage(
+            team=self.team,
+            task=self.task,
+            author=resolved_author,
+            author_kind=TaskThreadMessage.AuthorKind.HUMAN if resolved_author else TaskThreadMessage.AuthorKind.AGENT,
+            content=content,
+        )
+        message.save()
+        for user in mentioned:
+            mention = TaskThreadMessageMention(
+                team=self.team, message=message, task=self.task, mentioned_user=user, created_at=message.created_at
+            )
+            mention.save()
+        return message
+
+    def _opt_in(self, user: User) -> None:
+        CodeUserNotificationSettings.objects.create(user=user, slack_mention_notifications=True)
+
+    def test_opted_in_recipient_gets_one_dm_with_expected_content(self) -> None:
+        self._opt_in(self.peer)
+        message = self._message("ping @[Bob](peer@example.com), thoughts?", mentioned=[self.peer])
+
+        with patch("products.tasks.backend.slack_mention_notifications.SlackIntegration") as slack_cls:
+            slack = slack_cls.return_value
+            slack.lookup_user_id_by_email.return_value = "U123"
+            sent = send_mention_dms_for_message(str(message.id), self.team.id)
+
+        assert sent == 1
+        slack.lookup_user_id_by_email.assert_called_once_with("peer@example.com")
+        slack.client.chat_postMessage.assert_called_once()
+        kwargs = slack.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "U123"
+        body = kwargs["blocks"][0]["text"]["text"]
+        assert "*Ann*" in body
+        assert "*#growth*" in body
+        assert "*A Task*" in body
+        # Mention tokens render as plain @Name in the excerpt.
+        assert "@Bob" in body
+        assert "peer@example.com" not in body
+        button = kwargs["blocks"][1]["elements"][0]
+        assert button["url"].endswith(f"/project/{self.team.id}/tasks/{self.task.id}")
+
+    def test_users_without_opt_in_are_not_dmed(self) -> None:
+        # No settings row for peer; author has a row but disabled.
+        CodeUserNotificationSettings.objects.create(user=self.author, slack_mention_notifications=False)
+        message = self._message("ping @[Bob](peer@example.com)", mentioned=[self.peer, self.author])
+
+        with patch("products.tasks.backend.slack_mention_notifications.SlackIntegration") as slack_cls:
+            sent = send_mention_dms_for_message(str(message.id), self.team.id)
+
+        assert sent == 0
+        slack_cls.assert_not_called()
+
+    def test_no_slack_integration_is_a_noop(self) -> None:
+        self._opt_in(self.peer)
+        message = self._message("ping @[Bob](peer@example.com)", mentioned=[self.peer])
+        self.integration.delete()
+
+        with patch("products.tasks.backend.slack_mention_notifications.SlackIntegration") as slack_cls:
+            sent = send_mention_dms_for_message(str(message.id), self.team.id)
+
+        assert sent == 0
+        slack_cls.assert_not_called()
+
+    def test_recipient_without_slack_account_is_skipped(self) -> None:
+        self._opt_in(self.peer)
+        message = self._message("ping @[Bob](peer@example.com)", mentioned=[self.peer])
+
+        with patch("products.tasks.backend.slack_mention_notifications.SlackIntegration") as slack_cls:
+            slack = slack_cls.return_value
+            slack.lookup_user_id_by_email.return_value = None
+            sent = send_mention_dms_for_message(str(message.id), self.team.id)
+
+        assert sent == 0
+        slack.client.chat_postMessage.assert_not_called()
+
+    def test_one_recipient_failure_does_not_block_the_others(self) -> None:
+        carol = User.objects.create_user(email="carol@example.com", first_name="Carol", password="password")
+        self.organization.members.add(carol)
+        self._opt_in(self.peer)
+        self._opt_in(carol)
+        message = self._message("ping both", mentioned=[self.peer, carol])
+
+        with patch("products.tasks.backend.slack_mention_notifications.SlackIntegration") as slack_cls:
+            slack = slack_cls.return_value
+            slack.lookup_user_id_by_email.return_value = "U123"
+            slack.client.chat_postMessage.side_effect = [
+                SlackApiError("boom", {"error": "channel_not_found"}),
+                {"ok": True},
+            ]
+            sent = send_mention_dms_for_message(str(message.id), self.team.id)
+
+        assert sent == 1
+        assert slack.client.chat_postMessage.call_count == 2
+
+    def test_agent_author_and_channel_less_task_degrade_gracefully(self) -> None:
+        self.task.channel = None
+        self.task.save()
+        self._opt_in(self.peer)
+        message = self._message("done, @[Bob](peer@example.com)", mentioned=[self.peer], author=None)
+
+        with patch("products.tasks.backend.slack_mention_notifications.SlackIntegration") as slack_cls:
+            slack = slack_cls.return_value
+            slack.lookup_user_id_by_email.return_value = "U123"
+            sent = send_mention_dms_for_message(str(message.id), self.team.id)
+
+        assert sent == 1
+        body = slack.client.chat_postMessage.call_args.kwargs["blocks"][0]["text"]["text"]
+        assert "*PostHog agent* mentioned you\n" in body
+        assert "#" not in body
+
+    def test_content_is_escaped_and_truncated(self) -> None:
+        self._opt_in(self.peer)
+        message = self._message("@[Bob](peer@example.com) see <!channel> & this " + "x" * 400, mentioned=[self.peer])
+
+        with patch("products.tasks.backend.slack_mention_notifications.SlackIntegration") as slack_cls:
+            slack = slack_cls.return_value
+            slack.lookup_user_id_by_email.return_value = "U123"
+            send_mention_dms_for_message(str(message.id), self.team.id)
+
+        body = slack.client.chat_postMessage.call_args.kwargs["blocks"][0]["text"]["text"]
+        assert "<!channel>" not in body
+        assert "&lt;!channel&gt; &amp; this" in body
+        assert body.endswith("…")

--- a/products/tasks/backend/tests/test_mentions.py
+++ b/products/tasks/backend/tests/test_mentions.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
-from products.tasks.backend.mentions import extract_mention_emails
+from products.tasks.backend.mentions import extract_mention_emails, render_mention_tokens
 
 
 class ExtractMentionEmailsTest(SimpleTestCase):
@@ -25,3 +25,21 @@ class ExtractMentionEmailsTest(SimpleTestCase):
     )
     def test_extract_mention_emails(self, _name, content, expected):
         assert extract_mention_emails(content) == expected
+
+
+class RenderMentionTokensTest(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("single_mention", "hey @[Ann](ann@example.com), thoughts?", "hey @Ann, thoughts?"),
+            (
+                "multiple_mentions",
+                "@[Ann](ann@example.com) and @[Bob Two](bob@example.com)",
+                "@Ann and @Bob Two",
+            ),
+            ("non_token_text_untouched", "mail ann@example.com directly", "mail ann@example.com directly"),
+            ("malformed_token_untouched", "@[Ann](not-an-email)", "@[Ann](not-an-email)"),
+            ("empty_content", "", ""),
+        ]
+    )
+    def test_render_mention_tokens(self, _name, content, expected):
+        assert render_mention_tokens(content) == expected


### PR DESCRIPTION
## Problem

@-mentions in PostHog Code channel threads are pull-only today: they're indexed at write time (`TaskThreadMessageMention`) and surfaced in the client's Activity feed via a 60s poll, with no push notification of any kind. If you're not in the app, you don't find out someone needs you.

This adds an opt-in Slack DM when you're @-mentioned, reusing the team's existing Slack integration (raised in a project-bluebird channel task).

## Changes

- New `products/tasks/backend/slack_mention_notifications.py`: builds and sends the DM ("*Ann* mentioned you in *#growth*" + task title + quoted excerpt + "Open in PostHog" link to the cloud task page). Content is mrkdwn-escaped and truncated; mention tokens render as plain `@Name`.
- Dispatch: a Celery task (`products/tasks/backend/tasks.py`, autodiscovered) fired via `transaction.on_commit` from `_index_thread_message_mentions` — the single choke point both human- and agent-authored messages already flow through. Best-effort end to end: one recipient's failure never blocks the others, and nothing can fail message creation.
- Opt-in preference: new user-scoped `CodeUserNotificationSettings` model (default off), exposed at `GET`/`POST /api/code/user_settings/` for the PostHog Code client. Recipients are resolved per team at send time (`Integration` kind `slack`), so the preference itself doesn't need team scoping.
- `SlackIntegration.lookup_user_id_by_email` promoted onto the core helper (ported from the signals product's implementation) — uses `users_lookupByEmail`, which is already in the always-granted scope set along with `chat:write`, so no new Slack scopes or re-auth.
- `render_mention_tokens` added to `mentions.py` (pattern switched to named groups, behavior-preserving).

> [!NOTE]
> The preference defaults off and is only settable from the (flag-gated) PostHog Code settings UI, so there's no server-side flag check — an opt-in row is an explicit user signal. A companion PostHog Code PR adds the settings toggle.

## How did you test this code?

Automated tests added (not run in this sandbox — no Django environment; CI will run them):

- `test_mentions.py`: `render_mention_tokens` cases — catches the DM showing raw `@[Name](email)` tokens or mangling non-token text.
- `test_mention_slack_notifications.py`: opt-in filtering (no row / disabled row → no DM), missing integration and missing Slack account guards, per-recipient failure isolation, agent-author + channel-less fallbacks, escaping/truncation.
- `test_channels_api.py`: posting a mention dispatches exactly one DM through `on_commit` + eager Celery (catches the wiring being dropped); a Slack blow-up still returns 201; settings API defaults, upsert, per-user isolation, and auth.

`ruff check` and `ruff format` pass on all touched files. The migration was written by hand (mirrors sibling migrations, `db_constraint=False` on the user FK per the hot-table rule) — please verify `makemigrations --check` and `hogli build:openapi` output; I couldn't run either here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` cover the mentions feed or Code notification settings yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via a PostHog Code cloud task, directed by the assignee. Repo skills read before writing: `/django-migrations`, `/improving-drf-endpoints`, `/writing-tests`.

Decisions along the way: Celery over Temporal for the send (matches the main app's comment-mention precedent; Temporal here is the long-running-run machinery), cloud web URL over a `posthog-code://` deep link (matches `post_slack_update.py`, works on mobile), a user-scoped opt-in model rather than reusing the signals `SignalUserAutonomyConfig` (different product, and mentions DM the user directly instead of posting to a chosen channel), and promoting the email→Slack-id lookup onto `SlackIntegration` because the signals implementation sits behind a product boundary.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
