### PR TITLE
perf(error-tracking): raise issue cache capacity and make it configurable

### DIFF
--- a/rust/cymbal/src/modes/processing/app_context.rs
+++ b/rust/cymbal/src/modes/processing/app_context.rs
@@ -178,7 +178,7 @@ impl AppContext {
         let process_request_limiter =
             Arc::new(Semaphore::new(config.process_max_in_flight_requests.max(1)));
 
-        let issue_cache = CacheBuilder::new(1000)
+        let issue_cache = CacheBuilder::new(config.issue_cache_capacity)
             .time_to_live(Duration::from_secs(config.issue_cache_ttl_seconds))
             .build();
 

--- a/rust/cymbal/src/modes/processing/config.rs
+++ b/rust/cymbal/src/modes/processing/config.rs
@@ -73,6 +73,12 @@ pub struct ProcessingConfig {
     #[envconfig(default = "600")]
     pub issue_cache_ttl_seconds: u64,
 
+    // Sized generously on purpose: entries are ~100 bytes, and versioned fingerprinting
+    // probes this cache once per registered fingerprint version per event, so the working
+    // set is several multiples of the distinct-issue count at current event volume.
+    #[envconfig(default = "100000")]
+    pub issue_cache_capacity: u64,
+
     // Maximum number of in-flight futures for a single `Batch::apply_func` call.
     // This is a per-call-site limit, not a global pipeline-wide concurrency cap.
     #[envconfig(default = "64")]


### PR DESCRIPTION
## Problem

cymbal's cross-batch issue cache (`AppContext.issue_cache`, a `(TeamId, fingerprint) -> issue Uuid` moka cache) was hard-coded to 1000 entries. Since versioned fingerprinting landed, this cache is probed much harder: `select_automatic_fingerprint` computes a fingerprint for every registered fingerprint version per event and probes the cache once per version, falling back to a batched Postgres lookup (`IssueFingerprintOverride::load_many`) on any miss.

At current production event volume, across many thousands of teams and multiple fingerprint versions per event, a 1000-entry cache thrashes. Profiling showed this grouping path near the top of cymbal's CPU, with a meaningful slice in sqlx streaming from the fallback lookups.

## Changes

- Add `issue_cache_capacity` (u64, envconfig, default 100000) to `ProcessingConfig`, matching the style of the neighboring `issue_cache_ttl_seconds` field.
- Use it in `AppContext::new` (`CacheBuilder::new(config.issue_cache_capacity)`) instead of the hard-coded `1000`.
- TTL behavior is unchanged.

The default is sized generously on purpose. Entries are ~100 bytes, and versioned fingerprinting multiplies the working set by the number of registered fingerprint versions per event, so 100k entries is roughly 10 MB of headroom to keep the hit rate high without meaningful memory cost. The value is now an env knob, so it can be tuned per deployment without a rebuild.

> [!NOTE]
> Behavior change: the default in-memory footprint of this cache grows from ~1000 to up to 100000 entries (~10 MB at ~100 bytes/entry). No API or on-disk change.

## How did you test this code?

This is config plumbing of an existing cache, so no new tests. The cache's behavior (population, TTL, fallback to the batched Postgres lookup) is already covered by the DB-backed grouping tests, and only the capacity constant changed.

Automated checks I (Claude) ran locally in a fresh worktree:

- `cargo fmt --check -p cymbal` - clean
- `cargo check -p cymbal` - clean
- `cargo clippy -p cymbal --all-targets -- -D warnings` - clean
- `cargo test -p cymbal --no-run` - test targets compile

I did not run the full `cargo test -p cymbal` suite: the DB-backed tests need a local Postgres that isn't available in this environment. Compiling the test targets is sufficient to confirm this change (a capacity constant becoming a config field) doesn't break them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected. `issue_cache_capacity` is an internal service env var with a sensible default.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) made this change end to end under human direction. The task was a focused perf fix identified from production profiling of the error-tracking grouping path.

No repo skills were needed for a two-file Rust config change. I confirmed moka's `CacheBuilder::new` takes `u64` before typing the field as `u64` so the types line up cleanly with no cast. Ran `$autoreview` (Codex engine) against the diff; it came back clean ("patch is correct", 0.98) with no actionable findings.
