### PR TITLE
feat(insights): virtualize SQL insight table rows

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -164,6 +164,21 @@
                 border-top: 1px solid var(--color-border-primary);
             }
 
+            // Zero-content row that stands in for the off-screen rows above/below the virtualized window
+            &.LemonTable__virtual-spacer {
+                border: none;
+
+                > td {
+                    padding: 0;
+                    border: none;
+                }
+            }
+
+            // The row after the top spacer is the first visible row — keep it borderless like a real first row
+            &.LemonTable__virtual-spacer:first-child + tr {
+                border-top: none;
+            }
+
             &.LemonTable__expansion {
                 position: relative;
                 background: var(--color-bg-primary);

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+
+import { LemonTable } from './LemonTable'
+import { LemonTableColumn } from './types'
+
+interface TestRow {
+    id: number
+    name: string
+}
+
+const ROW_HEIGHT = 40
+const VIEWPORT_HEIGHT = 600 // fits 15 rows of 40px
+// Window (~15 rows) + overscan + partially visible rows — far below the 500-row dataset
+const MAX_MOUNTED_ROWS = 40
+
+const rows: TestRow[] = Array.from({ length: 500 }, (_, index) => ({ id: index, name: `row-marker-${index}` }))
+const columns: LemonTableColumn<TestRow, keyof TestRow | undefined>[] = [
+    { title: 'Name', key: 'name', render: (_, record) => record.name },
+]
+
+function mountedRowMarkers(container: HTMLElement): string[] {
+    return Array.from(container.querySelectorAll('tbody tr:not(.LemonTable__virtual-spacer)')).map(
+        (row) => row.textContent ?? ''
+    )
+}
+
+function renderTable(virtualized: boolean): HTMLElement {
+    const { container } = render(
+        <Provider>
+            <LemonTable
+                columns={columns}
+                dataSource={rows}
+                virtualized={virtualized}
+                rowHeight={virtualized ? ROW_HEIGHT : undefined}
+            />
+        </Provider>
+    )
+    return container
+}
+
+describe('LemonTable', () => {
+    beforeEach(() => {
+        initKeaTests()
+        // jsdom has no layout — the virtualizer sizes its window from the scroll container's offset dimensions
+        jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(VIEWPORT_HEIGHT)
+        jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(800)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('renders all rows by default', () => {
+        const container = renderTable(false)
+
+        expect(mountedRowMarkers(container)).toHaveLength(500)
+    })
+
+    it('mounts only the visible window of rows when virtualized', () => {
+        const container = renderTable(true)
+
+        const markers = mountedRowMarkers(container)
+        expect(markers.length).toBeGreaterThan(0)
+        expect(markers.length).toBeLessThan(MAX_MOUNTED_ROWS)
+        expect(markers).toContain('row-marker-0')
+        expect(markers).toContain('row-marker-10')
+        expect(markers).not.toContain('row-marker-499')
+    })
+
+    it('moves the mounted window when the container scrolls', () => {
+        const container = renderTable(true)
+        const scroller = container.querySelector('.ScrollableShadows__inner')
+        expect(scroller).not.toBeNull()
+
+        fireEvent.scroll(scroller!, { target: { scrollTop: 300 * ROW_HEIGHT } })
+
+        const markers = mountedRowMarkers(container)
+        expect(markers.length).toBeLessThan(MAX_MOUNTED_ROWS)
+        expect(markers).toContain('row-marker-300')
+        expect(markers).toContain('row-marker-310')
+        expect(markers).not.toContain('row-marker-0')
+        expect(markers).not.toContain('row-marker-499')
+    })
+})

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -1,5 +1,6 @@
 import './LemonTable.scss'
 
+import { useVirtualizer } from '@tanstack/react-virtual'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
@@ -28,6 +29,9 @@ import { BulkSelectionConfig, BulkSelectionKey, useBulkSelection } from './useBu
 /** Sentinel passed to `useBulkSelection` when `bulkSelection` is undefined — the hook still runs
  *  unconditionally so hook order is stable, but its result is never read. */
 const UNUSED_ROW_KEY = (): string | number => 0
+
+/** Rows rendered beyond the visible window on each side, so scrolling doesn't flash blank rows. */
+const VIRTUALIZED_OVERSCAN_ROWS = 5
 
 export interface LemonTableProps<T extends Record<string, any>, K extends BulkSelectionKey = BulkSelectionKey> {
     /** Table ID that will also be used in pagination to add uniqueness to search params (page + order). */
@@ -104,6 +108,14 @@ export interface LemonTableProps<T extends Record<string, any>, K extends BulkSe
      * Whether the table content is allowed to scroll inside its container.
      */
     allowContentScroll?: boolean
+    /**
+     * Opt-in row windowing for large datasets: only the rows near the visible viewport are mounted.
+     * Requires `rowHeight`, implies `allowContentScroll`, and needs a height-bounded container so the
+     * table scrolls its own content. Not compatible with `expandable` (expanded rows break the fixed height).
+     */
+    virtualized?: boolean
+    /** Fixed row height in px, used to size and position virtualized rows. */
+    rowHeight?: number
     /** Row actions to display at the end of each row. Return null to hide actions for specific rows. */
     rowActions?: (record: T, recordIndex: number) => React.ReactNode | null
     /** Whether to hide the sorting indicator when no sort is active. Defaults to false. */
@@ -150,6 +162,8 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
     maxHeaderWidth,
     hideScrollbar,
     allowContentScroll = false,
+    virtualized = false,
+    rowHeight,
     rowActions,
     hideSortingIndicatorWhenInactive = false,
     bulkSelection,
@@ -240,6 +254,14 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
     }, [dataSource, currentSorting, baseColumns])
 
     const paginationState = usePagination(sortedDataSource, pagination, id)
+
+    const rowVirtualizer = useVirtualizer({
+        count: paginationState.dataSourcePage.length,
+        getScrollElement: () => scrollRef.current,
+        estimateSize: () => rowHeight ?? 0,
+        overscan: VIRTUALIZED_OVERSCAN_ROWS,
+        enabled: virtualized,
+    })
 
     const resolveRowKey = useMemo<(record: T) => K>(() => {
         if (bulkSelection?.getKey) {
@@ -354,15 +376,86 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
         // Due to CSS, for firstColumnSticky to work the first column needs to be a content column
         throw new Error('LemonTable `firstColumnSticky` prop cannot be used with `expandable`')
     }
+    if (virtualized && !rowHeight) {
+        throw new Error('LemonTable `virtualized` requires a fixed `rowHeight`')
+    }
+    if (virtualized && expandable) {
+        throw new Error('LemonTable `virtualized` cannot be used with `expandable`')
+    }
+
+    // Virtualization needs the table to scroll its own content — the virtualizer listens to this container
+    const contentScrollEnabled = allowContentScroll || virtualized
 
     const isRowExpansionToggleShown = expandable ? (expandable?.showRowExpansionToggle ?? true) : false
 
     const visibleDataColumnCount = useMemo(() => columns.filter((column) => !column.isHidden).length, [columns])
-    // Matches the main header row cell count so the loader row does not add an extra table column (which shifts headers while loading)
-    const headerLoaderColSpan = Math.max(
+    // Matches the main header row cell count so full-width rows (loader, virtual spacers) do not add
+    // an extra table column (which shifts headers)
+    const fullRowColSpan = Math.max(
         1,
         Number(isRowExpansionToggleShown) + visibleDataColumnCount + Number(!!rowActions)
     )
+
+    const renderTableRow = (record: T, rowIndex: number): JSX.Element => {
+        const rowKeyDetermined = rowKey
+            ? typeof rowKey === 'function'
+                ? rowKey(record, rowIndex)
+                : (record[rowKey] ?? rowIndex)
+            : paginationState.currentStartIndex + rowIndex
+        const rowClassNameDetermined =
+            typeof rowClassName === 'function' ? rowClassName(record, rowIndex) : rowClassName
+        const rowRibbonColorDetermined =
+            typeof rowRibbonColor === 'function'
+                ? rowRibbonColor(record, rowIndex) || 'var(--color-border-primary)'
+                : rowRibbonColor
+        const rowStatusDetermined = typeof rowStatus === 'function' ? rowStatus(record, rowIndex) : rowStatus
+
+        return (
+            <TableRow
+                key={`LemonTable-tr-${rowKeyDetermined}`}
+                record={record}
+                recordIndex={paginationState.currentStartIndex + rowIndex}
+                rowKeyDetermined={rowKeyDetermined}
+                rowClassNameDetermined={rowClassNameDetermined}
+                rowRibbonColorDetermined={rowRibbonColorDetermined}
+                rowStatusDetermined={rowStatusDetermined}
+                columnGroups={columnGroups}
+                onRow={onRow}
+                expandable={expandable}
+                rowCount={paginationState.dataSourcePage.length}
+                firstColumnSticky={firstColumnSticky}
+                pinnedColumns={pinnedColumns}
+                pinnedColumnWidths={pinnedColumnWidths}
+                columns={columns}
+                rowActions={rowActions}
+            />
+        )
+    }
+
+    const renderSpacerRow = (key: string, height: number): JSX.Element => (
+        <tr key={key} className="LemonTable__virtual-spacer" aria-hidden="true">
+            {/* eslint-disable-next-line react/forbid-dom-props */}
+            <td colSpan={fullRowColSpan} style={{ height }} />
+        </tr>
+    )
+
+    const renderVirtualizedRows = (): JSX.Element => {
+        const virtualRows = rowVirtualizer.getVirtualItems()
+        if (!virtualRows.length) {
+            return <></>
+        }
+        const paddingTop = virtualRows[0].start
+        const paddingBottom = rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+        return (
+            <>
+                {paddingTop > 0 && renderSpacerRow('LemonTable-virtual-spacer-top', paddingTop)}
+                {virtualRows.map((virtualRow) =>
+                    renderTableRow(paginationState.dataSourcePage[virtualRow.index], virtualRow.index)
+                )}
+                {paddingBottom > 0 && renderSpacerRow('LemonTable-virtual-spacer-bottom', paddingBottom)}
+            </>
+        )
+    }
 
     return (
         <>
@@ -378,7 +471,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                     rowRibbonColor !== undefined && `LemonTable--with-ribbon`,
                     stealth && 'LemonTable--stealth',
                     !uppercaseHeader && 'LemonTable--lowercase-header',
-                    allowContentScroll && 'h-full min-h-0 overflow-hidden',
+                    contentScrollEnabled && 'h-full min-h-0 overflow-hidden',
                     className
                 )}
                 // eslint-disable-next-line react/forbid-dom-props
@@ -387,7 +480,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
             >
                 <ScrollableShadows
                     innerClassName={hideScrollbar ? 'hide-scrollbar' : undefined}
-                    direction={allowContentScroll ? undefined : 'horizontal'}
+                    direction={contentScrollEnabled ? undefined : 'horizontal'}
                     scrollRef={scrollRef}
                 >
                     <div className="LemonTable__content">
@@ -647,7 +740,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                                         {rowActions && <th className="w-0" />}
                                     </tr>
                                     <tr className="LemonTable__loader-row">
-                                        <th colSpan={headerLoaderColSpan} className="LemonTable__loader-host">
+                                        <th colSpan={fullRowColSpan} className="LemonTable__loader-host">
                                             <LemonTableLoader loading={loading} tag="div" />
                                         </th>
                                     </tr>
@@ -655,44 +748,13 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                             )}
                             <tbody>
                                 {paginationState.dataSourcePage.length ? (
-                                    paginationState.dataSourcePage.map((record, rowIndex) => {
-                                        const rowKeyDetermined = rowKey
-                                            ? typeof rowKey === 'function'
-                                                ? rowKey(record, rowIndex)
-                                                : (record[rowKey] ?? rowIndex)
-                                            : paginationState.currentStartIndex + rowIndex
-                                        const rowClassNameDetermined =
-                                            typeof rowClassName === 'function'
-                                                ? rowClassName(record, rowIndex)
-                                                : rowClassName
-                                        const rowRibbonColorDetermined =
-                                            typeof rowRibbonColor === 'function'
-                                                ? rowRibbonColor(record, rowIndex) || 'var(--color-border-primary)'
-                                                : rowRibbonColor
-                                        const rowStatusDetermined =
-                                            typeof rowStatus === 'function' ? rowStatus(record, rowIndex) : rowStatus
-
-                                        return (
-                                            <TableRow
-                                                key={`LemonTable-tr-${rowKeyDetermined}`}
-                                                record={record}
-                                                recordIndex={paginationState.currentStartIndex + rowIndex}
-                                                rowKeyDetermined={rowKeyDetermined}
-                                                rowClassNameDetermined={rowClassNameDetermined}
-                                                rowRibbonColorDetermined={rowRibbonColorDetermined}
-                                                rowStatusDetermined={rowStatusDetermined}
-                                                columnGroups={columnGroups}
-                                                onRow={onRow}
-                                                expandable={expandable}
-                                                rowCount={paginationState.dataSourcePage.length}
-                                                firstColumnSticky={firstColumnSticky}
-                                                pinnedColumns={pinnedColumns}
-                                                pinnedColumnWidths={pinnedColumnWidths}
-                                                columns={columns}
-                                                rowActions={rowActions}
-                                            />
+                                    virtualized ? (
+                                        renderVirtualizedRows()
+                                    ) : (
+                                        paginationState.dataSourcePage.map((record, rowIndex) =>
+                                            renderTableRow(record, rowIndex)
                                         )
-                                    })
+                                    )
                                 ) : loading ? (
                                     Array(loadingSkeletonRows)
                                         .fill(null)

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.test.tsx
@@ -1,0 +1,92 @@
+import { render } from '@testing-library/react'
+import { BindLogic, Provider } from 'kea'
+
+import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { ChartDisplayType } from '~/types'
+
+import { dataNodeLogic } from '../../DataNode/dataNodeLogic'
+import { DataVisualizationLogicProps, dataVisualizationLogic } from '../dataVisualizationLogic'
+import { Table } from './Table'
+
+// Prevent loadData from completing so the response set via setResponse is not overwritten
+jest.mock('~/queries/query', () => ({
+    ...jest.requireActual('~/queries/query'),
+    performQuery: jest.fn().mockImplementation(() => new Promise(() => {})),
+}))
+
+const dataNodeCollectionId = 'test-dataviz-table'
+let logicCounter = 0
+
+const query: DataVisualizationNode = {
+    kind: NodeKind.DataVisualizationNode,
+    source: {
+        kind: NodeKind.HogQLQuery,
+        query: `SELECT number AS n, tuple('__hx_tag', 'Sparkline', 'data', arrayMap(x -> (number + x) % 10, range(14))) AS trend FROM numbers(500)`,
+    },
+    display: ChartDisplayType.ActionsTable,
+}
+
+function sparklineResponse(rowCount: number): Record<string, any> {
+    return {
+        columns: ['n', 'trend'],
+        types: [
+            ['n', 'UInt64'],
+            ['trend', 'Tuple(String, String, String, Array(UInt16))'],
+        ] as [string, string][],
+        results: Array.from({ length: rowCount }, (_, index) => [
+            index,
+            ['__hx_tag', 'Sparkline', 'data', Array.from({ length: 14 }, (_, x) => (index + x) % 10)],
+        ]),
+    }
+}
+
+function setup(rowCount: number): HTMLElement {
+    logicCounter += 1
+    const key = `test-dataviz-table-${logicCounter}`
+    const props: DataVisualizationLogicProps = { key, query, dataNodeCollectionId }
+    const dataNodeProps = { key, query: query.source, dataNodeCollectionId }
+
+    const logic = dataVisualizationLogic(props)
+    logic.mount()
+    dataNodeLogic(dataNodeProps).actions.setResponse(sparklineResponse(rowCount))
+
+    const { container } = render(
+        <Provider>
+            <BindLogic logic={dataNodeLogic} props={dataNodeProps}>
+                <BindLogic logic={dataVisualizationLogic} props={props}>
+                    <Table uniqueKey={key} query={query} context={undefined} cachedResults={undefined} embedded />
+                </BindLogic>
+            </BindLogic>
+        </Provider>
+    )
+    return container
+}
+
+describe('DataVisualization Table', () => {
+    beforeEach(() => {
+        initKeaTests()
+        // jsdom has no layout — the virtualizer sizes its window from the scroll container's offset dimensions
+        jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(600)
+        jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(800)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('bounds mounted sparkline charts to the visible window for large results', () => {
+        const container = setup(500)
+
+        const sparklineCanvases = container.querySelectorAll('tbody canvas')
+        expect(sparklineCanvases.length).toBeGreaterThan(0)
+        expect(sparklineCanvases.length).toBeLessThan(40)
+    })
+
+    it('renders every row for small results without virtualization', () => {
+        const container = setup(20)
+
+        expect(container.querySelectorAll('tbody canvas')).toHaveLength(20)
+        expect(container.querySelectorAll('.LemonTable__virtual-spacer')).toHaveLength(0)
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -33,6 +33,12 @@ interface TableProps {
 
 export const DEFAULT_PAGE_SIZE = 500
 
+// Tallest common row: a sparkline cell (h-8, 32px) plus the standard 5px vertical cell padding
+const VIRTUALIZED_ROW_HEIGHT_PX = 42
+// Bounds the standalone insight scene's table so it scrolls internally — virtualization needs a
+// height-constrained scroll container (embedded surfaces get one from their tile/pane)
+const STANDALONE_VIRTUALIZED_TABLE_HEIGHT = '70vh'
+
 function formatColumnTitle(title: string): React.ReactNode {
     const parts = title.split(/([_-])/)
     if (parts.length === 1) {
@@ -125,6 +131,7 @@ export const Table = (props: TableProps): JSX.Element => {
         isTransposed,
         hasSortedTable,
         hasMoreData,
+        isTableVirtualized,
     } = useValues(dataVisualizationLogic)
     const { toggleColumnPin, setTableSorted } = useActions(dataVisualizationLogic)
 
@@ -339,6 +346,11 @@ export const Table = (props: TableProps): JSX.Element => {
                 rowClassName="DataVizRow"
                 embedded={props.embedded}
                 allowContentScroll={!!props.embedded}
+                virtualized={isTableVirtualized}
+                rowHeight={VIRTUALIZED_ROW_HEIGHT_PX}
+                style={
+                    isTableVirtualized && !props.embedded ? { height: STANDALONE_VIRTUALIZED_TABLE_HEIGHT } : undefined
+                }
             />
         </>
     )

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -149,6 +149,9 @@ const cloneOrDefaultSettings = (settings?: AxisSeriesSettings): AxisSeriesSettin
 const TRANSPOSED_FIELD_COLUMN_NAME = '__transpose_field__'
 const TRANSPOSED_ROW_COLUMN_PREFIX = '__transpose_row__'
 
+// Above this row count the table windows its rows; below it plain rendering is cheaper than the virtualization overhead
+export const TABLE_VIRTUALIZATION_THRESHOLD_ROWS = 50
+
 export const formatDataWithSettings = (
     data: number | string | null | object,
     settings?: AxisSeriesSettings
@@ -448,6 +451,7 @@ export interface dataVisualizationLogicValues {
     isColumnPinned: (columnName: string) => boolean
     isPinningEnabled: boolean
     isShowingCachedResults: boolean
+    isTableVirtualized: boolean
     isTableVisualization: boolean
     isTransposed: boolean
     numericalColumns: Column[]
@@ -741,6 +745,7 @@ export interface dataVisualizationLogicMeta {
                 | null
         ) => ChartDisplayType
         isTableVisualization: (effectiveVisualizationType: ChartDisplayType) => boolean
+        isTableVirtualized: (tabularData: TableDataCell<any>[][]) => boolean
         showTableSettings: (effectiveVisualizationType: ChartDisplayType) => boolean
         isColumnPinned: (pinnedColumns: string[]) => (columnName: string) => boolean
         isPinningEnabled: (activeSceneId: string | null, isTransposed: boolean) => boolean
@@ -1663,6 +1668,10 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 // BoldNumber relies on yAxis formatting so it's considered a table visualization
                 visualizationType === ChartDisplayType.ActionsTable ||
                 visualizationType === ChartDisplayType.BoldNumber,
+        ],
+        isTableVirtualized: [
+            (s) => [s.tabularData],
+            (tabularData: TableDataCell<any>[][]): boolean => tabularData.length > TABLE_VIRTUALIZATION_THRESHOLD_ROWS,
         ],
         showTableSettings: [
             (s) => [s.effectiveVisualizationType],


### PR DESCRIPTION
## Problem

SQL insights (DataVisualizationNode) render their table through LemonTable with a 500-row page size and no windowing, so every row of a page mounts at once. That is tolerable for text cells, but HogQL's `sparkline()` returns an hx-tagged value that renders as a full chart instance per cell (canvas, annotation plugin, hover popover, event listeners). A dashboard with a few such tiles mounts thousands of chart instances and interaction latency collapses. We saw this on a dashboard of SQL tiles using `sparkline()` and had to cut the SQL LIMIT as a stopgap.

Reproduction (SQL insight, table display):

```sql
SELECT
    number AS n,
    tuple('__hx_tag', 'Sparkline', 'data',
          arrayMap(x -> (number + x) % 10, range(14))) AS trend
FROM numbers(500)
```

## Changes

- `LemonTable` gains opt-in row virtualization: `virtualized` plus a fixed `rowHeight`, built on `@tanstack/react-virtual` (already a dependency, no new packages). Only the rows near the viewport mount; two spacer `<tr>`s stand in for the off-screen rows above and below the window.
- Integration point: I went with the preferred option, virtualization on LemonTable itself rather than a DataViz-local table fork. The headless virtualizer plus spacer rows works inside the existing `<table>` markup, so the `<colgroup>`, pinned-column sticky cells, per-cell `style`/`className` callbacks, and native text selection all keep working, and no consumer-visible markup changes. A fork of the DataViz table was the fallback but was not needed. Default rendering is byte-for-byte unchanged, `virtualized` is strictly opt-in, and the disabled virtualizer attaches no observers or listeners.
- `virtualized` implies `allowContentScroll` (the virtualizer needs the table to scroll its own content) and is rejected in combination with `expandable` (expanded rows break the fixed row height).
- `dataVisualizationLogic` gains an `isTableVirtualized` selector: virtualize when the result exceeds 50 rows.
- The DataViz `Table` passes `virtualized` and `rowHeight={42}` (sparkline cell height 32px plus cell padding). Embedded surfaces (dashboard tiles, the SQL editor output pane) already have a height-bounded scroll container. The standalone insight scene gets a 70vh table height when virtualized so it scrolls internally instead of growing a 500-row-tall page.
- Preserved behavior: column pinning, sticky pinned headers, per-cell conditional formatting, transposed tables, client-side sorting, the LoadNext footer, pagination beyond 500 rows, `embedded` mode and dashboard tile scroll containment, and text selection within visible rows.

> [!NOTE]
> With table-layout auto, column widths are computed from mounted rows only, so widths can adjust slightly while scrolling a virtualized table. Row heights that deviate from the fixed `rowHeight` estimate only make the scrollbar slightly inaccurate (spacer rows keep the visible window geometry exact).

Follow-up: insights that were capped to `LIMIT 100` as a mitigation can be raised back to 500 once this deploys.

## How did you test this code?

Jest, red then green (verified before implementing that the new virtualization tests fail on master, where all 500 rows mount):

- `LemonTable.test.tsx`: with 500 rows and a ~15-row viewport, mounted `<tr>` count is bounded (< 40) and contains the right rows; after programmatically scrolling the container, the window contains the scrolled-to rows and the initial rows are unmounted; a non-virtualized LemonTable still mounts all 500 rows. These catch: windowing silently removed or broken, scroll wiring lost, and virtualization accidentally becoming the default for the ~hundreds of non-opt-in consumers.
- `Table.test.tsx` (DataViz): with the 500-row sparkline fixture, mounted canvas count is bounded by the window (< 40, actual 20), and a 20-row result renders all rows unvirtualized. These catch: the DataViz table dropping its opt-in (LemonTable tests alone would stay green), and the threshold being removed.

Full `LemonTable` + `DataVisualization` suites pass (374 tests), plus `pnpm --filter=@posthog/frontend fix` and a clean full `typescript:check`.

Measurements: I could not run a browser measurement locally (the local dev environment's Postgres/docker daemon was unresponsive, so the app would not load), so as the fallback these are React Profiler numbers from jest with the fixture above, 5 iterations each, median reported:

| metric (500 sparkline rows) | master | this branch |
| --- | --- | --- |
| mounted rows / chart instances | 500 / 500 | 20 / 20 (25 after scroll) |
| initial render, React commit time | 151.2 ms (118–231) | 37.1 ms (32–45) |
| initial render, wall clock | 549 ms (465–683) | 91.8 ms (83–102) |
| scroll interaction, React commit time | ~2 ms (no re-render happens) | ~29 ms (window re-render) |

Two caveats stated plainly: jsdom has no layout or paint and `jest-canvas-mock` makes chart painting free, so these numbers understate the real-browser win; the dominant real cost (the INP regression) scales with mounted chart instances, which is the number that drops 500 → 20-25. And master's ~2 ms scroll commit is not "master is faster at scrolling": master does no React work on scroll, its scroll cost is browser-side layout/paint/hit-testing across 500 mounted charts, which jsdom cannot measure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover the SQL insight table's rendering internals; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) from a task brief by the assignee; the DataViz table was the motivating surface. Skills invoked: `/writing-tests`. Decisions along the way: reused `@tanstack/react-virtual` (already used elsewhere in the repo) over `react-window`, since the headless API lets the existing table markup stay intact; spacer rows over absolutely-positioned rows, because absolute positioning breaks table column alignment while spacers preserve it and also make the window geometry immune to row-height misestimates; virtualization threshold and row height live as a kea selector and constants rather than component state per frontend conventions. The red-then-green order on the jest tests was verified explicitly (three tests fail on master with 500 rows/canvases mounted). Browser profiling was attempted first via a headless Chrome against the local dev stack but the dev database was down, hence the jest Profiler fallback the task brief allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
