### PR TITLE
fix(flags): retry last-called sync on ClickHouseAtCapacity

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -23,6 +23,7 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_conc
 from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.errors import CH_TRANSIENT_ERRORS, CHQueryErrorTooManySimultaneousQueries
+from posthog.exceptions import ClickHouseAtCapacity
 from posthog.exceptions_capture import capture_exception
 from posthog.metrics import pushed_metrics_registry
 from posthog.models.event.new_events_schema import events_read_table, use_new_events_schema
@@ -1177,7 +1178,9 @@ def _queue_delete_team_recordings(team_ids: list[int], deleted_by: str) -> None:
     base=PushGatewayTask,
     ignore_result=True,
     queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
-    autoretry_for=CH_TRANSIENT_ERRORS,
+    # sync_execute wraps TOO_MANY_SIMULTANEOUS_QUERIES/CANNOT_SCHEDULE_TASK into
+    # ClickHouseAtCapacity, so it must be listed alongside the raw CH error classes.
+    autoretry_for=(*CH_TRANSIENT_ERRORS, ClickHouseAtCapacity),
     retry_backoff=30,
     retry_backoff_max=120,
     max_retries=3,

--- a/products/feature_flags/backend/test/test_feature_flag_sync.py
+++ b/products/feature_flags/backend/test/test_feature_flag_sync.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 from django.utils import timezone as tz
 
 from posthog.errors import CH_TRANSIENT_ERRORS, CHQueryErrorTooManyBytes
+from posthog.exceptions import ClickHouseAtCapacity
 from posthog.tasks.tasks import sync_feature_flag_last_called
 
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -557,3 +558,6 @@ class TestSyncFeatureFlagLastCalledChunking(BaseTest):
         # Transient errors should still be retried
         for error_cls in CH_TRANSIENT_ERRORS:
             assert error_cls in autoretry_for
+        # sync_execute wraps capacity errors (code 202) into ClickHouseAtCapacity,
+        # so the wrapped form must be retryable too
+        assert ClickHouseAtCapacity in autoretry_for

--- a/products/feature_flags/backend/test/test_feature_flag_sync.py
+++ b/products/feature_flags/backend/test/test_feature_flag_sync.py
@@ -551,7 +551,7 @@ class TestSyncFeatureFlagLastCalledChunking(BaseTest):
         self.flag1.refresh_from_db()
         assert self.flag1.last_called_at is None
 
-    def test_no_retry_on_too_many_bytes(self) -> None:
+    def test_autoretry_for_membership(self) -> None:
         """CHQueryErrorTooManyBytes should not be in the autoretry_for tuple"""
         autoretry_for = sync_feature_flag_last_called.autoretry_for
         assert CHQueryErrorTooManyBytes not in autoretry_for


### PR DESCRIPTION
## Problem

The scheduled `sync_feature_flag_last_called` Celery task fails outright whenever ClickHouse is at its concurrent-query cap, instead of retrying like it's configured to.

The task declares `autoretry_for=CH_TRANSIENT_ERRORS`, which includes `CHQueryErrorTooManySimultaneousQueries` (ClickHouse code 202). But `sync_execute` never raises that class for capacity errors: `wrap_clickhouse_query_error` maps code 202 (and `CANNOT_SCHEDULE_TASK`) to `ClickHouseAtCapacity`, a separate `APIException`-based class. So the retry config never matches, `max_retries=3` is never used, and every capacity blip fails the whole sync run.

Production logs from the `feature-flags-long-running` workers confirm all recent failures are `ClickHouseAtCapacity` raised from the chunked query in this task.

## Changes

- Add `ClickHouseAtCapacity` to the task's `autoretry_for`, alongside the raw `CH_TRANSIENT_ERRORS` classes. This matches the pattern already used by the cohort calculation task in `posthog/tasks/calculate_cohort.py`, which lists both forms.
- Extend the existing retry-config test to assert `ClickHouseAtCapacity` is retryable. The prior test only checked `CH_TRANSIENT_ERRORS` membership, which passed while the actually-raised exception class wasn't retried.

## How did you test this code?

Ran the full `products/feature_flags/backend/test/test_feature_flag_sync.py` suite locally (21 passed). The added assertion catches the regression the existing test missed: `sync_execute` raising the wrapped `ClickHouseAtCapacity` form while `autoretry_for` only lists the unwrapped CH error classes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal task retry behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I had Claude (PostHog Code) investigate the production failures. It pulled the worker logs from Loki, found every failure was `ClickHouseAtCapacity` from the chunked ClickHouse query, and traced the class mismatch between `wrap_clickhouse_query_error` and the task's `autoretry_for`. Skills invoked: /writing-tests. Considered adding `ClickHouseAtCapacity` to `CH_TRANSIENT_ERRORS` itself, but rejected that since it would silently change retry behavior for every other consumer of the tuple; the targeted per-task fix matches the existing `calculate_cohort` precedent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
