### PR TITLE
fix(warehouse): reopen mysql streaming connection dropped during pre-stream setup

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -1329,6 +1329,20 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
                     # state for the streaming execute() below.
                     self.explain_query(ss_cursor, query, args, logger)
 
+                    # The best-effort preamble above (the session-timeout SET and the diagnostic
+                    # EXPLAIN) runs on this streaming connection. A transient drop during either
+                    # force-closes the socket silently, which would leave the streaming execute
+                    # below raising an opaque `InterfaceError(0, '')` — pymysql's signal that the
+                    # socket is already gone — that masks the recoverable lost connection. Reopen
+                    # once so the real query runs on a live socket instead of failing the attempt
+                    # on a blip a fresh connection recovers from.
+                    if not streaming_connection.open:
+                        logger.warning(
+                            "MySQL connection dropped during pre-stream setup; reopening before streaming query"
+                        )
+                        streaming_connection.connect()
+                        ss_cursor = streaming_connection.cursor(SSCursor)
+
                     ss_cursor.execute(query, args)
 
                     column_names = [column[0] for column in ss_cursor.description or []]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -1340,6 +1340,9 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
                         logger.warning(
                             "MySQL connection dropped during pre-stream setup; reopening before streaming query"
                         )
+                        # Detach the cursor bound to the dead socket first so its later teardown
+                        # can't drain the freshly reopened connection (see _release_streaming_cursor).
+                        _release_streaming_cursor(ss_cursor)
                         streaming_connection.connect()
                         ss_cursor = streaming_connection.cursor(SSCursor)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -841,6 +841,33 @@ class TestStreamingCursorTeardown:
         assert ss_cursor.connection is None
 
 
+class TestStreamingReopensDroppedConnection:
+    """A transient drop during the best-effort pre-stream setup (SET SESSION / EXPLAIN)
+    force-closes the socket. The streaming query must reopen it, otherwise the execute
+    runs on a dead socket and surfaces pymysql's opaque, unactionable
+    `InterfaceError(0, '')` instead of recovering from the blip."""
+
+    def test_reopens_when_preamble_dropped_the_connection(self, build_pipeline_mocks):
+        mock_connect, _, ss_cursor = build_pipeline_mocks
+        mock_connection = mock_connect.return_value
+        mock_connection.open = False
+
+        _drain_source()
+
+        mock_connection.connect.assert_called_once()
+        assert ss_cursor.execute.called
+
+    def test_does_not_reopen_a_live_connection(self, build_pipeline_mocks):
+        mock_connect, _, ss_cursor = build_pipeline_mocks
+        mock_connection = mock_connect.return_value
+        mock_connection.open = True
+
+        _drain_source()
+
+        mock_connection.connect.assert_not_called()
+        assert ss_cursor.execute.called
+
+
 class TestIsBadPlanError:
     def test_matches_error_2013(self):
         assert _is_bad_plan_error(pymysql.err.OperationalError(2013, "Lost connection to MySQL server during query"))


### PR DESCRIPTION
## Problem

Error tracking surfaced a `pymysql.err.InterfaceError: (0, '')` raised from the MySQL data-warehouse source at [`mysql.py` `_stream_with_optional_force_index`](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py#L1332) (issue [019f73d5-2435-7f40-859a-312ada45fe58](https://us.posthog.com/project/2/error_tracking/019f73d5-2435-7f40-859a-312ada45fe58)).

`InterfaceError(0, '')` is pymysql's internal signal for "the socket is already `None`" — the connection was force-closed by an earlier operation, before the streaming query ran. The only things that run on the freshly opened streaming connection before that query are two best-effort steps: the `SET SESSION net_write_timeout/net_read_timeout` bump and the diagnostic `EXPLAIN`. Both swallow their own exceptions (by design — they are non-essential). When a transient drop hits either of them, pymysql force-closes the socket silently, and the real streaming `execute()` then raises the empty, unactionable `(0, '')` — which masks the recoverable lost connection and shows up as error-tracking noise with no diagnostic value.

This is a transient blip, so it should stay retryable (it already does — the error propagates and Temporal retries the activity). The bug is that a best-effort diagnostic can poison the real query's connection. The `explain_query` docstring even claims its failure "never affects the sync" — this incident shows that isn't true when the failure is a connection drop.

## Changes

Before the streaming `execute()`, check whether the pre-stream preamble left the connection closed (`not streaming_connection.open`, i.e. the socket is gone). If so, reopen the connection once and re-arm the streaming cursor, so the real query runs on a live socket instead of failing the attempt on a blip a fresh connection recovers from. The check only fires when the socket is actually dead, so benign EXPLAIN failures that don't touch the connection (e.g. MySQL 1345 on a view) are unaffected.

This follows the file's existing philosophy of recovering transient connection blips in-process rather than surfacing them as captured error-tracking noise (see `_connect_with_transient_retry`, `_retry_on_transient_tablet_unavailable`).

> [!NOTE]
> Deliberately not added to `get_non_retryable_errors`: a dropped connection is transient and must remain retryable. This change removes the masking, it does not change retry classification.

## How did you test this code?

Automated only (I, Claude, could not exercise a real MySQL server). Added two unit tests in `TestStreamingReopensDroppedConnection` that drive `build_pipeline` end-to-end through the existing mocks:

- `test_reopens_when_preamble_dropped_the_connection` — when the streaming connection reports closed after setup, the streaming path reopens it and still runs the query. This is the regression: without the guard the execute would run on a dead socket and raise `InterfaceError(0, '')`.
- `test_does_not_reopen_a_live_connection` — a healthy connection is never needlessly reopened.

Ran the full source test file locally: `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py` → 209 passed. Ruff check + format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I confirmed the issue in PostHog error tracking (full stack trace, single occurrence, one affected team), traced the raise site into pymysql's `_execute_command` socket-None guard, and read the MySQL source's connection lifecycle to locate the pre-stream preamble as the only place the socket could be force-closed before the streaming query.

Decision: this is a fixable fragility bug, not a non-retryable user/upstream error and not a "no change needed" transient. I rejected adding it to `NonRetryableErrors` (the drop is transient and must keep retrying) and rejected relabeling the error into a 2013 (that would route it through the FORCE INDEX bad-plan fallback, which is semantically wrong). Reopening the dead connection removes the masking and opportunistically recovers the attempt. Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
