### PR TITLE
fix(experiments): hide idle recalculation status and 0/0 rows flash

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -90,11 +90,7 @@ const MetricsTab = (): JSX.Element => {
                 <MultiVariantBiasWarning />
             </div>
 
-            {showRecalculationStatus && (
-                <div className="mb-2">
-                    <RecalculationStatus experiment={experiment} />
-                </div>
-            )}
+            {showRecalculationStatus && <RecalculationStatus experiment={experiment} />}
 
             {/* Modern metrics view */}
             {!hasMetrics ? (

--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -4,10 +4,8 @@ import { IconBell, IconCheck, IconInfo } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 import { useAnimatedNumber } from '@posthog/quill-charts'
 
-import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
-import { ExperimentLastRefreshText } from 'scenes/experiments/ExperimentView/ExperimentReloadAction'
 
 import { experimentMetricsLogic } from '~/scenes/experiments/experimentMetricsLogic'
 import { experimentResultsNotificationLogic } from '~/scenes/experiments/experimentResultsNotificationLogic'
@@ -16,80 +14,47 @@ import { Experiment } from '~/types'
 import type { ExperimentMetricsRecalculationApi } from 'products/experiments/frontend/generated/api.schemas'
 
 /**
- * Always-on status line for the recalculation flow. Renders exactly one state from
- * `recalculationDisplayState`; the in-flight states read live ClickHouse progress off the poll.
- * Only rendered behind EXPERIMENTS_METRICS_RECALCULATION (see ExperimentView).
+ * Status line for an in-flight recalculation. Renders only while a run is actually executing
+ * (`cold` / `refreshing`); loading-from-latest and terminal states show nothing — the metric rows
+ * carry their own loading and error affordances. Only rendered behind
+ * EXPERIMENTS_METRICS_RECALCULATION (see ExperimentView).
  */
-export function RecalculationStatus({ experiment }: { experiment: Experiment }): JSX.Element {
-    const { recalculationDisplayState, currentRecalculation, totalMetricsCount } = useValues(
+export function RecalculationStatus({ experiment }: { experiment: Experiment }): JSX.Element | null {
+    const { recalculationDisplayState, currentRecalculation, liveRowsProgress } = useValues(
         experimentMetricsLogic({ experiment })
     )
     /**
      * Mounted here rather than inside the in-flight branch so the finish-edge subscription that
-     * fires the browser notification is still alive when the bar swaps to a terminal state.
+     * fires the browser notification is still alive when the bar disappears on the terminal state.
      */
     const notificationLogic = experimentResultsNotificationLogic({ experiment })
     const { notifyWhenResultsReady } = useValues(notificationLogic)
     const { subscribeToResultsNotification } = useActions(notificationLogic)
 
-    switch (recalculationDisplayState) {
-        case 'initial':
-            return (
-                <StatusBar>
-                    <span className="flex items-center gap-1.5 whitespace-nowrap">
-                        <Spinner textColored className="text-sm text-accent" />
-                        <span className="font-medium">Loading metrics…</span>
-                    </span>
-                </StatusBar>
-            )
-        case 'cold':
-        case 'refreshing':
-            return (
-                <InFlightStatus
-                    recalculation={currentRecalculation}
-                    notifyWhenResultsReady={notifyWhenResultsReady}
-                    onSubscribe={subscribeToResultsNotification}
-                />
-            )
-        case 'partial':
-        case 'resting':
-            return (
-                <StatusBar>
-                    <span className="flex items-center gap-1.5 whitespace-nowrap">
-                        <IconCheck className="text-success text-sm" />
-                        <span className="font-medium">
-                            {totalMetricsCount} {totalMetricsCount === 1 ? 'metric' : 'metrics'}
-                        </span>
-                        {recalculationDisplayState === 'partial' && (
-                            <span className="text-danger font-medium">
-                                · {currentRecalculation?.failed_metrics} failed
-                            </span>
-                        )}
-                    </span>
-                    {currentRecalculation?.completed_at && (
-                        <>
-                            <LemonDivider vertical className="h-3.5 self-center" />
-                            <span className="flex items-center gap-1 whitespace-nowrap text-muted text-xs [&_span]:align-baseline">
-                                <span>Results calculated </span>
-                                <ExperimentLastRefreshText lastRefresh={currentRecalculation.completed_at} />
-                            </span>
-                        </>
-                    )}
-                </StatusBar>
-            )
+    if (recalculationDisplayState !== 'cold' && recalculationDisplayState !== 'refreshing') {
+        return null
     }
+    return (
+        <InFlightStatus
+            recalculation={currentRecalculation}
+            liveRowsProgress={liveRowsProgress}
+            notifyWhenResultsReady={notifyWhenResultsReady}
+            onSubscribe={subscribeToResultsNotification}
+        />
+    )
 }
 
 function InFlightStatus({
     recalculation,
+    liveRowsProgress,
     notifyWhenResultsReady,
     onSubscribe,
 }: {
     recalculation: ExperimentMetricsRecalculationApi | null
+    liveRowsProgress: { recalculationId: string; rowsRead: number; estimatedRows: number } | null
     notifyWhenResultsReady: boolean
     onSubscribe: () => void
 }): JSX.Element {
-    const rowsRead = recalculation?.rows_read ?? undefined
     const succeeded = recalculation?.completed_metrics ?? 0
     const failed = recalculation?.failed_metrics ?? 0
     const total = recalculation?.total_metrics ?? 0
@@ -106,10 +71,10 @@ function InFlightStatus({
                 <Tooltip title="We're computing each metric against the latest data. This runs server-side so you can leave this page; results appear as each metric finishes.">
                     <IconInfo className="text-muted text-xs" />
                 </Tooltip>
-                {rowsRead !== undefined && (
+                {liveRowsProgress && liveRowsProgress.recalculationId === recalculation?.id && (
                     <ClimbingRows
-                        rowsRead={rowsRead}
-                        estimatedRows={recalculation?.estimated_rows_total ?? undefined}
+                        rowsRead={liveRowsProgress.rowsRead}
+                        estimatedRows={liveRowsProgress.estimatedRows || undefined}
                     />
                 )}
             </span>
@@ -133,7 +98,7 @@ function InFlightStatus({
 
 function StatusBar({ children }: { children: React.ReactNode }): JSX.Element {
     return (
-        <div className="flex min-h-8 w-full flex-wrap items-center gap-2.5 rounded border border-primary bg-surface-secondary px-2.5 py-1 text-sm">
+        <div className="mb-2 flex min-h-8 w-full flex-wrap items-center gap-2.5 rounded border border-primary bg-surface-secondary px-2.5 py-1 text-sm">
             {children}
         </div>
     )

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -11,6 +11,8 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { Experiment } from '~/types'
 
+import type { ExperimentMetricsRecalculationApi } from 'products/experiments/frontend/generated/api.schemas'
+
 import { experimentMetricsLogic } from './experimentMetricsLogic'
 
 jest.mock('@posthog/lemon-ui', () => ({
@@ -734,6 +736,40 @@ describe('experimentMetricsLogic', () => {
             // Still in progress, but the finished metric from the partial payload is already on screen.
             expect(logic.values.currentRecalculation).toEqual(expect.objectContaining({ status: 'in_progress' }))
             expect(logic.values.primaryMetricsResults[0]).toEqual(primaryResult)
+        })
+    })
+
+    describe('liveRowsProgress', () => {
+        const asRecalc = (obj: Record<string, unknown>): ExperimentMetricsRecalculationApi =>
+            obj as unknown as ExperimentMetricsRecalculationApi
+
+        it('retains the last nonzero sample within a run and clears on a new run', () => {
+            // Draft experiment: afterMount no-ops, so the reducer can be driven directly.
+            const draft = { ...EXPERIMENT, status: undefined, start_date: null, end_date: null } as Experiment
+            logic = experimentMetricsLogic({ experiment: draft })
+            logic.mount()
+
+            logic.actions.setCurrentRecalculation(
+                asRecalc({ ...inProgressRecalculation, rows_read: 500, estimated_rows_total: 1000 })
+            )
+            expect(logic.values.liveRowsProgress).toEqual({
+                recalculationId: 'recalc-2',
+                rowsRead: 500,
+                estimatedRows: 1000,
+            })
+
+            // A poll without a live sample (all-zeros gap) must not wipe the last value — the 0/0 flash.
+            logic.actions.setCurrentRecalculation(
+                asRecalc({ ...inProgressRecalculation, rows_read: 0, estimated_rows_total: 0 })
+            )
+            expect(logic.values.liveRowsProgress).toEqual({
+                recalculationId: 'recalc-2',
+                rowsRead: 500,
+                estimatedRows: 1000,
+            })
+
+            logic.actions.setCurrentRecalculation(asRecalc({ ...inProgressRecalculation, id: 'recalc-3' }))
+            expect(logic.values.liveRowsProgress).toBeNull()
         })
     })
 

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -145,6 +145,11 @@ export interface experimentMetricsLogicValues {
     isMetricRecalculating: (metricUuid: string | undefined) => boolean
     isRecalculating: boolean
     lastRefresh: string | null
+    liveRowsProgress: {
+        estimatedRows: number
+        recalculationId: string
+        rowsRead: number
+    } | null
     primaryMetricsResults: CachedNewExperimentQueryResponse[]
     primaryMetricsResultsErrors: (unknown | null)[]
     recalculatingMetricUuids: string[]
@@ -330,6 +335,25 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
             [] as string[],
             {
                 setRecalculatingMetricUuids: (_, { uuids }) => uuids,
+            },
+        ],
+        liveRowsProgress: [
+            null as { recalculationId: string; rowsRead: number; estimatedRows: number } | null,
+            {
+                setCurrentRecalculation: (state, { recalculation }) => {
+                    if (!recalculation) {
+                        return null
+                    }
+                    const rowsRead = recalculation.rows_read ?? 0
+                    if (rowsRead > 0) {
+                        return {
+                            recalculationId: recalculation.id,
+                            rowsRead,
+                            estimatedRows: recalculation.estimated_rows_total ?? 0,
+                        }
+                    }
+                    return state?.recalculationId === recalculation.id ? state : null
+                },
             },
         ],
     }),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The recalculation status bar renders in every state, but it only carries useful information while a run is actually executing. When loading cached results from `/latest` it shows a redundant "Loading metrics…" placeholder, and after a run completes it sits there permanently repeating what the metric rows already show.

The "rows read" counter also flashes "0 / 0 rows read". The backend's live progress read legitimately samples all-zeros (queries not started yet, or finished but not flushed to `system.query_log`), and the component rendered whatever the poll returned.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Two behavior fixes to `RecalculationStatus`, no visual redesign.

### Hide the bar unless a run is executing

`RecalculationStatus` now renders only in the `cold` and `refreshing` display states and returns null for `initial`, `partial`, and `resting`. It returns null instead of being unmounted so `experimentResultsNotificationLogic` stays alive and the finish-edge browser notification still fires. The `mb-2` wrapper in `ExperimentView` moved onto `StatusBar` itself, so hidden states leave no stray margin.

- `frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx`
- `frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx`

### Never show 0/0 rows read

New `liveRowsProgress` reducer in `experimentMetricsLogic`: it keeps the last nonzero rows-read sample for the current run and ignores all-zeros polls, clearing only when a different run starts. The component renders the counter exclusively from this value, so it either shows nothing (no sample yet) or the latest real number.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`
- `frontend/src/scenes/experiments/experimentMetricsLogic.test.ts`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/a45048fb-55a3-48b8-add9-86fb29184889)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

Model: Fable 5
Manually refactored: **yes**

Skills used:

- /writing-kea-logics (local)
- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Rows-counter retention lives in a `liveRowsProgress` reducer keyed by run id, not component state, so the all-zeros-gap behavior is testable at the logic level and the component stays render-only.
- The idle states return null from inside the component rather than gating the mount in `ExperimentView`, deliberately keeping the notification logic mounted.
- The retained sample is matched against `recalculation.id` before rendering, so a new run never briefly shows the previous run's row count.