### PR TITLE
feat(experiments): metric config change won't trigger full recalculation

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1049,6 +1049,7 @@ export interface eventUsageLogicActions {
             is_existing?: boolean
             poll_count?: number
             recalculation_id: string | null
+            reused_window?: boolean
             succeeded?: number
             total_metrics?: number
             trigger?:
@@ -1069,6 +1070,7 @@ export interface eventUsageLogicActions {
             is_existing?: boolean | undefined
             poll_count?: number | undefined
             recalculation_id: string | null
+            reused_window?: boolean | undefined
             succeeded?: number | undefined
             total_metrics?: number | undefined
             trigger?:
@@ -2413,6 +2415,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                     | 'experiment_stop'
                     | 'experiment_update'
                 is_existing?: boolean
+                reused_window?: boolean
                 total_metrics?: number
                 succeeded?: number
                 failed?: number

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -531,6 +531,35 @@ describe('experimentMetricsLogic', () => {
             }).toDispatchActions(['setCurrentRecalculation'])
             expect(createMock).toHaveBeenCalled()
         })
+
+        it.each([
+            ['config_change', { trigger: 'config_change', query_to: completedRecalculation.query_to }],
+            ['manual', { trigger: 'manual' }],
+        ] as const)('with a completed run loaded, %s sends the expected create body', async (trigger, expectedBody) => {
+            let capturedBody: any
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                        200,
+                        completedRecalculation,
+                    ],
+                },
+                post: {
+                    // Return a terminal run so triggerRecalculation finishes without arming a poll timer.
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/': async ({ request }) => {
+                        capturedBody = await request.json()
+                        return [201, completedRecalculation2]
+                    },
+                },
+            })
+            mountLogic()
+            await expectLogic(logic).toDispatchActions(['setCurrentRecalculation'])
+
+            await expectLogic(logic, () => {
+                logic.actions.triggerRecalculation(trigger)
+            }).toFinishAllListeners()
+            expect(capturedBody).toEqual(expectedBody)
+        })
     })
 
     describe('loading + progress selectors', () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -175,6 +175,7 @@ export interface experimentMetricsLogicActions {
             is_existing?: boolean
             poll_count?: number
             recalculation_id: string | null
+            reused_window?: boolean
             succeeded?: number
             total_metrics?: number
             trigger?:
@@ -195,6 +196,7 @@ export interface experimentMetricsLogicActions {
             is_existing?: boolean | undefined
             poll_count?: number | undefined
             recalculation_id: string | null
+            reused_window?: boolean | undefined
             succeeded?: number | undefined
             total_metrics?: number | undefined
             trigger?:
@@ -659,12 +661,21 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 try {
                     const { projectId, experimentId } = resolvedIds
 
+                    // Reusing the last completed window lets the backend skip unchanged metrics via the
+                    // fingerprint check, so a config change only recomputes the edited metric.
+                    const reusedQueryTo =
+                        trigger === 'config_change' &&
+                        values.currentRecalculation?.status === RECALCULATION_STATUSES.completed
+                            ? values.currentRecalculation.query_to
+                            : undefined
+
                     /**
                      * 201 with a new pending run, or 200 with the already-active one. No results yet.
                      * Create a recalculation workflow. 201: a new run. 200: one is already running, poll it.
                      */
                     const recalculation = await experimentsMetricsRecalculationCreate(String(projectId), experimentId, {
                         trigger,
+                        ...(reusedQueryTo ? { query_to: reusedQueryTo } : {}),
                     })
 
                     /**
@@ -686,6 +697,7 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                         recalculation_id: recalculation.id,
                         trigger,
                         is_existing: recalculation.is_existing,
+                        reused_window: !!reusedQueryTo,
                     })
 
                     if (

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -1196,6 +1196,16 @@ class RecalculateMetricsRequestSerializer(serializers.Serializer):
         default="manual",
         help_text="What triggered this recalculation (manual is the default for user-initiated runs)",
     )
+    query_to = serializers.DateTimeField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "Data-window end to reuse from the latest completed recalculation. When it matches that run's "
+            "query_to, metrics whose configuration is unchanged skip recomputation; on mismatch a fresh "
+            "window is pinned and all metrics recompute."
+        ),
+    )
 
 
 class ExperimentMetricsRecalculationSerializer(serializers.Serializer):

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -1072,9 +1072,10 @@ class EnterpriseExperimentsViewSet(
         request_serializer = RecalculateMetricsRequestSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)
         trigger = request_serializer.validated_data["trigger"]
+        query_to = request_serializer.validated_data["query_to"]
 
         # request.user is User | AnonymousUser at the DRF level; the viewset enforces auth so it's a User here.
-        result = request_recalculation(experiment, cast(User, request.user), trigger)
+        result = request_recalculation(experiment, cast(User, request.user), trigger, query_to=query_to)
         # Read without mutating — the serializer surfaces is_existing on the response so clients can detect
         # the idempotent-reuse path without inspecting the HTTP status code.
         is_existing = result.get("is_existing", False)

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -10,7 +10,7 @@ Module-level free functions (not methods on ExperimentService) so the API view c
 """
 
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from django.db import transaction
@@ -220,12 +220,18 @@ def _cancel_superseded_workflows(recalculation_ids: list[str]) -> None:
             pass
 
 
-def request_recalculation(experiment: Experiment, user: User, trigger: str = "manual") -> dict:
+def request_recalculation(
+    experiment: Experiment, user: User, trigger: str = "manual", query_to: datetime | None = None
+) -> dict:
     """Create an idempotent batch recalculation request for all experiment metrics.
 
     If an active (pending or in_progress) run already exists for this experiment, returns the existing run's
     serialized payload with ``is_existing=True`` — the caller should NOT start a new workflow in that case.
     Otherwise creates a fresh pending row.
+
+    ``query_to`` requests reuse of the latest completed run's data window so unchanged metrics skip
+    recomputation. It is honored only when it exactly matches that run's ``query_to`` — a stale or arbitrary
+    client value falls back to a fresh window pinned by the workflow's start activity.
     """
     if not experiment.is_launched:
         raise ValidationError("Cannot recalculate metrics for experiment that hasn't started")
@@ -276,6 +282,23 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
             _recalculation_stale_cleanup_counter.inc(len(stale_ids))
             transaction.on_commit(lambda: _cancel_superseded_workflows([str(stale_id) for stale_id in stale_ids]))
 
+        # Honor a requested window reuse only when it matches the latest completed run, so clients can't pin
+        # arbitrary timestamps. The stamped query_to is preserved by the workflow's start activity.
+        reused_query_to = None
+        if query_to is not None:
+            latest_completed_query_to = (
+                ExperimentMetricsRecalculation.objects.filter(
+                    team=experiment.team,
+                    experiment=experiment,
+                    status=ExperimentMetricsRecalculation.Status.COMPLETED,
+                )
+                .order_by("-created_at")
+                .values_list("query_to", flat=True)
+                .first()
+            )
+            if latest_completed_query_to is not None and query_to == latest_completed_query_to:
+                reused_query_to = query_to
+
         # Set total_metrics up front from the experiment definition so the client can show progress
         # ("N of M") immediately, before the workflow's discovery activity confirms the same count.
         metrics = discover_experiment_metrics(experiment)
@@ -287,6 +310,7 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
             created_by=user,
             total_metrics=len(metrics),
             metric_uuids=[m.metric_uuid for m in metrics],
+            query_to=reused_query_to,
         )
         return build_job_payload(recalc, is_existing=False)
 
@@ -349,6 +373,7 @@ def _recalc_fingerprints_for_run(experiment: Experiment, recalc: ExperimentMetri
             stats_method,
             experiment.exposure_criteria,
             only_count_matured_users=experiment.only_count_matured_users,
+            excluded_variants=experiment.excluded_variants,
         )
         fingerprints[metric_uuid] = compute_recalc_fingerprint(config_fp)
     return fingerprints

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -10,6 +10,8 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from django.db import close_old_connections, transaction
+from django.db.models import F, Value
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 import structlog
@@ -183,7 +185,8 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
     with team_scope(state.team_id, canonical=True):
         # Start: write the data-window end + started_at + initial state under a first-write-wins guard so a
         # Temporal retry of this activity can't move query_to forward (which would orphan any rows persisted by
-        # calc activities still in flight from the prior attempt).
+        # calc activities still in flight from the prior attempt). Coalesce preserves a query_to pre-stamped at
+        # request time (window reuse), so the guard anchors on started_at rather than query_to.
         if update.mark_started:
             # query_to is the run's data-window end, not bare "now": for a stopped experiment
             # experiment_window_end resolves it to end_date (a fixed value), so repeated recalcs reuse the
@@ -191,24 +194,19 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
             # timeseries point on every run. A running experiment still advances with now.
             experiment = Experiment.objects.get(id=state.experiment_id)
             proposed_query_to = experiment_window_end(experiment, timezone.now())
-            won = (
-                ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id, query_to__isnull=True).update(
-                    query_to=proposed_query_to,
-                    started_at=timezone.now(),
-                    status=update.status or ExperimentMetricsRecalculation.Status.IN_PROGRESS,
-                    total_metrics=update.total_metrics if update.total_metrics is not None else 0,
-                    metric_uuids=update.metric_uuids if update.metric_uuids is not None else [],
-                )
-                == 1
+            ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id, started_at__isnull=True).update(
+                query_to=Coalesce(F("query_to"), Value(proposed_query_to)),
+                started_at=timezone.now(),
+                status=update.status or ExperimentMetricsRecalculation.Status.IN_PROGRESS,
+                total_metrics=update.total_metrics if update.total_metrics is not None else 0,
+                metric_uuids=update.metric_uuids if update.metric_uuids is not None else [],
             )
-            if won:
-                return proposed_query_to.isoformat()
-            existing_query_to = (
+            final_query_to = (
                 ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id)
                 .values_list("query_to", flat=True)
                 .first()
             )
-            return existing_query_to.isoformat() if existing_query_to is not None else None
+            return final_query_to.isoformat() if final_query_to is not None else None
 
         # Finish: same first-write-wins guard so a retried mark_completed activity doesn't re-stamp the
         # completion timestamp (and, by symmetry with mark_started, doesn't reopen a closed run).
@@ -509,6 +507,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
             get_experiment_stats_method(experiment),
             experiment.exposure_criteria,
             only_count_matured_users=experiment.only_count_matured_users,
+            excluded_variants=experiment.excluded_variants,
         )
         recalc_fp = compute_recalc_fingerprint(config_fp)
 

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -263,6 +263,29 @@ class TestRecalculationActivities(BaseTest):
         else:
             assert recalc.query_to == now
 
+    def test_mark_started_preserves_prestamped_query_to(self):
+        # Window reuse pre-stamps query_to at request time; mark_started must keep it (rather than pin a
+        # fresh window) while still flipping status/started_at, and return it for the calc activities.
+        exp = self._experiment(flag_key="progress-prestamped")
+        prestamped = timezone.now() - timedelta(hours=1)
+        recalc = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, query_to=prestamped)
+
+        returned = _update(
+            RecalculationProgressUpdate(
+                recalculation_id=str(recalc.id),
+                status="in_progress",
+                total_metrics=1,
+                metric_uuids=["m1"],
+                mark_started=True,
+            )
+        )
+
+        recalc.refresh_from_db()
+        assert recalc.query_to == prestamped
+        assert recalc.started_at is not None
+        assert recalc.status == "in_progress"
+        assert returned == prestamped.isoformat()
+
     def test_mark_completed_is_first_write_wins_on_retry(self):
         # Symmetric to mark_started: a retried finish activity must not re-stamp completed_at.
         recalc = self._recalc(self._experiment(flag_key="progress-retry-finish"))
@@ -641,6 +664,40 @@ class TestCalculateActivity(BaseTest):
             status=ExperimentMetricResult.Status.COMPLETED,
             result={"stale": True},
         )
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        with patch("products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner") as mock_runner:
+            mock_runner.return_value.run.return_value.model_dump.return_value = {}
+            _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO)
+
+        mock_runner.assert_called_once()
+
+    def test_excluded_variants_change_recomputes(self):
+        # A cached row computed before a variant was excluded must not satisfy the skip check: the exclusion
+        # set feeds the fingerprint, so the stale row's fingerprint no longer matches and the query re-runs.
+        metric = _mean_metric("m1")
+        exp = self._experiment(flag_key="calc-excluded", metrics=[metric])
+        query_to = datetime.fromisoformat(_QUERY_TO)
+        recalc_fp = compute_recalc_fingerprint(
+            compute_metric_fingerprint(
+                metric,
+                exp.start_date,
+                get_experiment_stats_method(exp),
+                exp.exposure_criteria,
+                only_count_matured_users=exp.only_count_matured_users,
+            )
+        )
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=query_to,
+            query_to=query_to,
+            status=ExperimentMetricResult.Status.COMPLETED,
+            result={"stale": True},
+        )
+        exp.excluded_variants = ["test"]
+        exp.save(update_fields=["excluded_variants"])
         recalc = self._recalc(exp, metric_uuids=["m1"])
 
         with patch("products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner") as mock_runner:

--- a/products/experiments/backend/test/test_metrics_recalculation_api.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_api.py
@@ -83,6 +83,29 @@ class TestMetricsRecalculationAPI(APIBaseTest):
 
     @mock.patch("products.experiments.backend.presentation.views.sync_connect")
     @mock.patch("products.experiments.backend.presentation.views.asyncio.run")
+    def test_post_query_to_reaches_created_row(self, mock_run, mock_connect):
+        # Wiring guard: the validated query_to must flow from the request body into request_recalculation;
+        # the match/mismatch matrix lives in the service tests.
+        exp = self._launched_experiment()
+        completed_query_to = datetime(2026, 1, 10, tzinfo=UTC)
+        ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            status=ExperimentMetricsRecalculation.Status.COMPLETED,
+            query_to=completed_query_to,
+            completed_at=completed_query_to,
+        )
+        resp = self.client.post(
+            self._post_url(exp.id),
+            {"trigger": "config_change", "query_to": completed_query_to.isoformat()},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        row = ExperimentMetricsRecalculation.objects.get(id=resp.json()["id"])
+        assert row.query_to == completed_query_to
+
+    @mock.patch("products.experiments.backend.presentation.views.sync_connect")
+    @mock.patch("products.experiments.backend.presentation.views.asyncio.run")
     def test_post_is_idempotent_returns_200(self, mock_run, mock_connect):
         exp = self._launched_experiment()
         first = self.client.post(self._post_url(exp.id), {"trigger": "manual"}, format="json")

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -174,6 +174,69 @@ class TestRecalculationService(BaseTest):
         row = ExperimentMetricsRecalculation.objects.get(id=result["id"])
         assert row.trigger == trigger
 
+    @parameterized.expand(
+        [
+            # (name, has_completed_run, offset_from_latest, expect_stamped) — only an exact match with the
+            # latest completed run's query_to is honored; anything else falls back to a fresh window.
+            ("matching_window_is_stamped", True, timedelta(0), True),
+            ("mismatched_window_is_ignored", True, timedelta(hours=1), False),
+            ("no_completed_run_is_ignored", False, timedelta(0), False),
+        ]
+    )
+    def test_request_recalculation_query_to_reuse(
+        self, name: str, has_completed_run: bool, offset_from_latest: timedelta, expect_stamped: bool
+    ):
+        exp = self._launched_experiment(flag_key=f"reuse-{name}")
+        completed_query_to = datetime(2026, 1, 10, tzinfo=UTC)
+        if has_completed_run:
+            ExperimentMetricsRecalculation.objects.create(
+                team=self.team,
+                experiment=exp,
+                status=ExperimentMetricsRecalculation.Status.COMPLETED,
+                query_to=completed_query_to,
+                completed_at=timezone.now(),
+            )
+
+        result = request_recalculation(
+            exp, self.user, "config_change", query_to=completed_query_to + offset_from_latest
+        )
+
+        row = ExperimentMetricsRecalculation.objects.get(id=result["id"])
+        assert row.query_to == (completed_query_to if expect_stamped else None)
+
+    def test_changing_excluded_variants_invalidates_run_results(self):
+        exp = self._launched_experiment(flag_key="reuse-excluded")
+        query_to = datetime(2026, 1, 10, tzinfo=UTC)
+        recalc_fp = compute_recalc_fingerprint(
+            compute_metric_fingerprint(
+                _mean_metric("m1"),
+                exp.start_date,
+                get_experiment_stats_method(exp),
+                exp.exposure_criteria,
+                only_count_matured_users=exp.only_count_matured_users,
+                excluded_variants=exp.excluded_variants,
+            )
+        )
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=exp.start_date,
+            query_to=query_to,
+            status=ExperimentMetricResult.Status.COMPLETED,
+            result={"some": "result"},
+        )
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team, experiment=exp, metric_uuids=["m1"], query_to=query_to
+        )
+        assert [r["metric_uuid"] for r in get_run_results(recalc)] == ["m1"]
+
+        # Excluding a variant alters what the metric computes, so the cached row must stop matching.
+        exp.excluded_variants = ["test"]
+        exp.save(update_fields=["excluded_variants"])
+        recalc.refresh_from_db()
+        assert get_run_results(recalc) == []
+
     def test_get_latest_recalculation_returns_most_recent_completed(self):
         # get_latest_recalculation filters to status='completed' (powers GET /metrics_recalculation/latest).
         exp = self._launched_experiment()

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1806,6 +1806,11 @@ export interface RecalculateMetricsRequestApi {
      * * `experiment_stop` - Experiment Stop
      * * `experiment_update` - Experiment Update */
     trigger?: TriggerEnumApi
+    /**
+     * Data-window end to reuse from the latest completed recalculation. When it matches that run's query_to, metrics whose configuration is unchanged skip recomputation; on mismatch a fresh window is pinned and all metrics recompute.
+     * @nullable
+     */
+    query_to?: string | null
 }
 
 /**

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -1020,6 +1020,12 @@ export const ExperimentsMetricsRecalculationCreateBody = /* @__PURE__ */ zod
             .describe(
                 'What triggered this recalculation (manual is the default for user-initiated runs)\n\n\* `manual` - Manual\n\* `cold_run` - Cold Run\n\* `stale_refresh` - Stale Refresh\n\* `auto_refresh` - Auto Refresh\n\* `config_change` - Config Change\n\* `experiment_launch` - Experiment Launch\n\* `experiment_stop` - Experiment Stop\n\* `experiment_update` - Experiment Update'
             ),
+        query_to: zod.iso
+            .datetime({ offset: true })
+            .nullish()
+            .describe(
+                "Data-window end to reuse from the latest completed recalculation. When it matches that run's query_to, metrics whose configuration is unchanged skip recomputation; on mismatch a fresh window is pinned and all metrics recompute."
+            ),
     })
     .describe('Request body for triggering a metrics recalculation.')
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -54797,6 +54797,11 @@ export namespace Schemas {
        * * `experiment_stop` - Experiment Stop
        * * `experiment_update` - Experiment Update */
       trigger?: TriggerEnum;
+      /**
+         * Data-window end to reuse from the latest completed recalculation. When it matches that run's query_to, metrics whose configuration is unchanged skip recomputation; on mismatch a fresh window is pinned and all metrics recompute.
+         * @nullable
+         */
+      query_to?: string | null;
     }
 
     export interface RecapHighlight {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Editing a single metric (adding a breakdown, changing its configuration) triggers a full recalculation of every metric on the experiment. The calc activity already knows how to skip: a metric with a COMPLETED result row for the same `(experiment, metric_uuid, query_to, fingerprint)` returns without querying ClickHouse. But the start activity always pins a fresh `query_to = now()` for running experiments, so no cached row can ever match and the skip never fires. One metric edit costs minutes of ClickHouse work to recompute results that haven't changed.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

On config changes the client sends the latest completed run's `query_to`; the backend validates it and pre-stamps it on the new run, so unchanged metrics hit the existing fingerprint skip and only the edited metric actually queries ClickHouse. The edited metric computes against the same window as everything else, so all rows keep describing the same moment; the existing >24h stale-refresh path still forces fresh windows independently.

### Reuse the last window on config changes

`triggerRecalculation` attaches `query_to` only when the trigger is `config_change` and a completed run is loaded. Manual, auto, and stale refreshes exist to fetch fresh data, so they keep pinning fresh windows. The `triggered` analytics event carries `reused_window` so we can measure the win in production.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`
- `frontend/src/scenes/experiments/experimentMetricsLogic.test.ts`
- `frontend/src/lib/utils/eventUsageLogic.ts`

### Validate and pre-stamp the window

`RecalculateMetricsRequestSerializer` gains an optional `query_to`. `request_recalculation` honors it only when it exactly equals the latest completed run's `query_to`, so clients can't pin arbitrary timestamps; anything else falls back to a fresh window and a normal full recalculation. On match it's stamped on the new row at create time.

- `products/experiments/backend/presentation/serializers.py`
- `products/experiments/backend/presentation/views.py`
- `products/experiments/backend/recalculation.py`
- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `products/experiments/frontend/generated/api.zod.ts` (generated)
- `services/mcp/src/api/generated.ts` (generated)

### Preserve the window in the workflow

The `mark_started` first-write-wins guard anchored on `query_to__isnull`, which a pre-stamped row would never satisfy, leaving it stuck PENDING. The guard now anchors on `started_at__isnull` with `Coalesce(F("query_to"), Value(proposed))`, and the return value is read back from the row, so Temporal retries and pre-stamped runs both thread the same canonical window into the calc activities. No workflow body changes, so no versioning concerns for in-flight runs.

- `products/experiments/backend/temporal/recalculation_logic.py`
- `products/experiments/backend/temporal/test_recalculation_activities.py`

### Close the excluded_variants fingerprint gap

`compute_metric_fingerprint` supports `excluded_variants`, but the recalc write site (calc activity) and read site (`_recalc_fingerprints_for_run`) didn't pass it. Harmless while every run pinned a fresh window; with window reuse, toggling a variant exclusion (a `config_change`) would fingerprint-match every metric and silently show stale results. Both sites now include it. One-time side effect: experiments that already have exclusions recompute all metrics on their next run, since their fingerprints change.

- `products/experiments/backend/recalculation.py`
- `products/experiments/backend/temporal/recalculation_logic.py`
- `products/experiments/backend/test/test_recalculation_service.py`
- `products/experiments/backend/test/test_metrics_recalculation_api.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/3c8991d6-24b6-4d3f-ad97-335cfe60a4a1)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

Model: Fable 5
Manually refactored: **yes**

Skills used:

- /writing-kea-logics (local)
- /improving-drf-endpoints (local)
- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Considered signaling the running workflow or cancel-and-restart to handle metric edits; rejected both in favor of riding the existing per-metric fingerprint skip keyed by `(fingerprint, query_to)`. No workflow body changes means no Temporal patching, and a superseded run's completed work is never thrown away.
- The server resolves trust: `query_to` is honored only on exact equality with the latest completed run, so the failure mode of a stale or malicious client value is a fresh full recalculation, never a poisoned window.
- The `excluded_variants` gap ships in the same PR because window reuse is what makes it dangerous: an exclusion toggle would otherwise skip every metric and present stale results as fresh.