### PR TITLE
chore(error-tracking): remove experimental tag from per-issue rate limit

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/IssueRateLimitSettings.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/IssueRateLimitSettings.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
 import { IconRefresh } from '@posthog/icons'
-import { LemonSegmentedButton, LemonSelect, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, LemonSelect, Link } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -32,12 +32,7 @@ export function IssueRateLimitSettings(): JSX.Element {
     return (
         <div className="space-y-4">
             <div>
-                <div className="flex items-center gap-2 mb-1">
-                    <h3 className="font-semibold text-base mb-0">Per-issue rate limit</h3>
-                    <LemonTag type="warning" size="small">
-                        Experimental
-                    </LemonTag>
-                </div>
+                <h3 className="font-semibold text-base mb-1">Per-issue rate limit</h3>
                 <p className="text-muted-foreground">
                     This limit applies to each issue per window. Once an issue exceeds the configured rate, further
                     exceptions for it are dropped at ingestion.


### PR DESCRIPTION
## Problem

The per-issue rate limit in error tracking configuration still carried an "Experimental" tag. Per-project (project-wide) and per-issue rate limiting are now generally available, so the tag is stale and undersells the feature to customers.

## Changes

Removed the "Experimental" `LemonTag` next to the "Per-issue rate limit" heading in the error tracking configuration scene, and dropped the now-unused `LemonTag` import. The "Project-wide rate limit" section never had an experimental tag, so no change was needed there.

## How did you test this code?

No manual testing performed by the agent. This is a copy/tag removal with no logic change. TypeScript check recommended in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread. The ask referred to "per-project rate limiting", but the only "Experimental" tag in the error tracking rate limit config was on the per-issue section; the project-wide section already shipped without one. I removed that single tag and its unused import.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C090RCG671C/p1784322232709319?thread_ts=1784322232.709319&cid=C090RCG671C)*
