### PR TITLE
fix(gitlab): surface actionable error when token scope is rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
@@ -233,11 +233,26 @@ def validate_credentials(
     if response.status_code == 404:
         return False, f"Project '{project}' not found or not accessible with this token"
 
+    if response.status_code == 403:
+        # GitLab returns a raw OAuth-style JSON body (e.g. {"error":"insufficient_scope",...}) here,
+        # which has no "message" field and is meaningless to the user. Guide them to the scope needed.
+        return False, (
+            "Your GitLab personal access token doesn't have the required scope. Create a token with "
+            "the 'read_api' scope (or 'api') and access to this project, then try again."
+        )
+
+    # Surface GitLab's own error text only when it's a plain string; otherwise a generic message, so
+    # we never echo a raw JSON body (which can embed the request context) back to the user.
     try:
-        body = response.json()
-        return False, body.get("message", response.text)
+        message = response.json().get("message")
     except Exception:
-        return False, response.text
+        message = None
+    if isinstance(message, str) and message.strip():
+        return False, message
+    return False, (
+        f"GitLab rejected the connection (HTTP {response.status_code}). "
+        "Please check your GitLab host, token, and project, then try again."
+    )
 
 
 def _parse_retry_after(response: requests.Response) -> float | None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
@@ -251,6 +251,23 @@ class TestValidateCredentials:
             else:
                 assert expected_msg_substr in (msg or "")
 
+    def test_403_maps_to_scope_guidance_without_echoing_raw_body(self):
+        # GitLab answers an under-scoped token with a raw OAuth JSON body that has no "message" field;
+        # it must be replaced with actionable scope guidance, never echoed back verbatim.
+        body = {"error": "insufficient_scope", "error_description": "requires higher privileges"}
+        with self._patch_session(_response(status_code=403, json_data=body, text=str(body))):
+            valid, msg = validate_credentials("https://gitlab.com", "tok", "group/project")
+            assert valid is False
+            assert "read_api" in (msg or "")
+            assert "insufficient_scope" not in (msg or "")
+
+    def test_unmapped_error_does_not_echo_raw_response_body(self):
+        with self._patch_session(_response(status_code=500, json_data={}, text="<html>internal details</html>")):
+            valid, msg = validate_credentials("https://gitlab.com", "tok", "group/project")
+            assert valid is False
+            assert "internal details" not in (msg or "")
+            assert "HTTP 500" in (msg or "")
+
     @pytest.mark.parametrize(
         "host, token, project, expected_msg",
         [


### PR DESCRIPTION
## Problem

When creating a GitLab data warehouse source, if the personal access token is valid but lacks the API scope the probe needs, GitLab returns a 403 with a raw OAuth-style JSON body (shaped like `{"error":"insufficient_scope","error_description":"...","scope":"..."}`). That body has no `message` field, so our validation fell through to returning `response.text` verbatim - the user saw raw JSON instead of anything they could act on. The same fallback could also echo an arbitrary raw response body for other unmapped statuses.

## Changes

- Handle 403 explicitly with a clear message telling the user to create a token with the `read_api` (or `api`) scope and access to the project.
- Replace the raw-body fallback: surface GitLab's own error text only when it's a plain string, otherwise a generic "GitLab rejected the connection (HTTP <status>)" message. We never echo a raw JSON/HTML body back.

## How did you test this code?

Added two unit tests in `test_gitlab.py`:
- a 403 with an `insufficient_scope` body maps to the scope-guidance message and does not leak the raw body,
- an unmapped 500 with an opaque body returns a generic message and does not echo the raw text.

Both catch a regression no existing test did: the old code path returned `response.text` for these cases. Ran the GitLab source test suite locally - green. No manual UI testing performed by me.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged warehouse source-creation validation failures and found the GitLab 403 path leaking a raw response body to users. Fix scoped to `validate_credentials` error handling only - no change to sync behavior or schemas. Authored by Claude (Opus) via PostHog Code; invoked the `/writing-tests` skill for the test additions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
