### PR TITLE
fix(postgres): give actionable error for unreachable SSH gateway

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -192,6 +192,17 @@ _FOREIGN_SERVER_UNREACHABLE_ERROR = (
     "persists, check that the foreign server is running and reachable from your source database."
 )
 
+# sshtunnel raises BaseSSHTunnelForwarderError("Could not establish session to SSH gateway") when it
+# can't open a session to the bastion — the SSH host/port is wrong or unreachable, the bastion is
+# down, or its firewall blocks PostHog's IPs. The raw message tells the user nothing actionable, so
+# replace it with concrete guidance on both the validate and sync paths.
+_SSH_GATEWAY_SESSION_ERROR = "Could not establish session to SSH gateway"
+_SSH_GATEWAY_UNREACHABLE_MESSAGE = (
+    "Could not connect to your SSH tunnel — PostHog couldn't open a session to the SSH gateway. "
+    "Check that the SSH host and port point to a reachable SSH server (not the database port), that "
+    "the bastion is running, and that PostHog's IP addresses are allowed through its firewall."
+)
+
 
 @SourceRegistry.register
 class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
@@ -490,7 +501,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             ),
             "SSLRequiredError": None,
             "SSL/TLS connection is required": None,
-            "Could not establish session to SSH gateway": None,
+            _SSH_GATEWAY_SESSION_ERROR: _SSH_GATEWAY_UNREACHABLE_MESSAGE,
             # paramiko raises a bare, message-less EOFError when the SSH gateway accepts the TCP
             # connection but drops it mid-handshake (a non-SSH service on the port, the bastion
             # refusing PostHog's IPs, a proxy resetting the stream). sshtunnel doesn't wrap it, so
@@ -937,9 +948,12 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             capture_exception(e)
             return False, f"Could not connect to {self.source_name}. Please check all connection details are valid."
         except BaseSSHTunnelForwarderError as e:
+            raw = e.value or ""
+            if _SSH_GATEWAY_SESSION_ERROR in raw:
+                return False, _SSH_GATEWAY_UNREACHABLE_MESSAGE
             return (
                 False,
-                e.value
+                raw
                 or f"Could not connect to {self.source_name} via the SSH tunnel. Please check all connection details are valid.",
             )
         except Exception as e:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -20,6 +20,7 @@ import pyarrow as pa
 import structlog
 from parameterized import parameterized
 from psycopg import sql
+from sshtunnel import BaseSSHTunnelForwarderError
 
 import products.warehouse_sources.backend.temporal.data_imports.sources.postgres.partitioned_tables as partitioned_tables_pkg
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE
@@ -2977,6 +2978,22 @@ class TestValidateCredentialsErrorMapping:
 
         assert valid is False
         assert error == expected
+
+    def test_ssh_gateway_session_error_maps_to_actionable_message(self, source, config):
+        # sshtunnel's raw "Could not establish session to SSH gateway" is meaningless to the user;
+        # it must be replaced with concrete guidance rather than surfaced verbatim.
+        err = BaseSSHTunnelForwarderError("Could not establish session to SSH gateway")
+        with (
+            mock.patch.object(source, "ssh_tunnel_is_valid", return_value=(True, None)),
+            mock.patch.object(source, "is_database_host_valid", return_value=(True, None)),
+            mock.patch.object(source, "get_schemas", side_effect=err),
+        ):
+            valid, error = source.validate_credentials(config, team_id=1)
+
+        assert valid is False
+        assert error is not None
+        assert "Could not establish session to SSH gateway" not in error
+        assert "SSH gateway" in error and "firewall" in error
 
     @pytest.mark.parametrize(
         "host",


### PR DESCRIPTION
## Problem

When a Postgres (or Supabase, which subclasses it) source is set up over an SSH tunnel and the bastion can't be reached, `sshtunnel` raises `BaseSSHTunnelForwarderError("Could not establish session to SSH gateway")`. We surfaced that raw library string verbatim - both at source-creation validation and on the sync path. It tells the user nothing about what to check.

## Changes

- Map the "Could not establish session to SSH gateway" case to a concrete message: check that the SSH host and port point to a reachable SSH server (not the database port), that the bastion is running, and that PostHog's IP addresses are allowed through its firewall.
- Applied consistently in two places that both showed the raw text: `validate_credentials` (creation) and `get_non_retryable_errors` (sync). Retryability is unchanged - only the surfaced message changes.

> [!NOTE]
> This is purely error-message handling. No change to sync behavior, retry classification, or schemas.

## How did you test this code?

Added a unit test asserting that a `BaseSSHTunnelForwarderError` carrying the raw gateway-session message maps to the actionable text and never echoes the raw string. The existing non-retryable-error test still passes (the substring key is unchanged, only its mapped value). Ran the Postgres source suite locally - green. No manual UI testing performed by me.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged warehouse source-creation validation failures and found the Postgres/Supabase SSH-tunnel path leaking a raw `sshtunnel` message to users. The sibling handshake-EOF case already had a friendly message; this closes the same gap for the gateway-session case. Fix scoped to error handling only. Authored by Claude (Opus) via PostHog Code; invoked the `/writing-tests` skill for the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
