### PR TITLE
feat(signals): hourly sweep settles post-merge fix verifications

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -106,6 +106,7 @@ from products.replay_vision.backend.temporal.reconciler import create_replay_vis
 from products.review_hog.backend.temporal.outcomes_schedule import create_review_hog_finding_outcomes_schedule
 from products.signals.backend.emission.conversations_schedule import create_conversations_signals_coordinator_schedule
 from products.signals.backend.temporal.agentic.schedule import create_signals_scout_coordinator_schedule
+from products.signals.backend.temporal.fix_verification_sweep import create_signals_fix_verification_sweep_schedule
 from products.web_analytics.backend.temporal.digest_notification.types import WADigestNotificationInput
 from products.web_analytics.backend.temporal.weekly_digest.types import WAWeeklyDigestInput
 
@@ -836,6 +837,7 @@ schedules = [
     create_run_investigation_safety_net_schedule,
     create_cleanup_alert_checks_schedule,
     create_signals_scout_coordinator_schedule,
+    create_signals_fix_verification_sweep_schedule,
     create_support_reply_coordinator_schedule,
     create_channel_summary_coordinator_schedule,
     create_replay_vision_reconciler_schedule,

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -227,6 +227,7 @@ class TestSignalsProductModuleIntegrity:
             "SignalsScoutCoordinatorWorkflow",
             "CustomSignalAgentWorkflow",
             "SignalReportInboxNotificationWorkflow",
+            "SignalFixVerificationSweepWorkflow",
         ]
         actual_workflow_names = [w.__name__ for w in SIGNALS_PRODUCT_WORKFLOWS]
         assert len(actual_workflow_names) == len(expected_workflows), (
@@ -285,6 +286,7 @@ class TestSignalsProductModuleIntegrity:
             "stamp_dispatched_signals_scout_runs_activity",
             "run_signals_scout_activity",
             "run_custom_signal_agent_activity",
+            "sweep_fix_verifications_activity",
         ]
         actual_activity_names = [a.__name__ for a in SIGNALS_PRODUCT_ACTIVITIES]
         assert len(actual_activity_names) == len(expected_activities), (

--- a/products/signals/backend/fix_verification.py
+++ b/products/signals/backend/fix_verification.py
@@ -6,13 +6,16 @@ resolves a report; the verification sweep (temporal) settles it after the soak w
 """
 
 import uuid
-from datetime import timedelta
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 
 import structlog
 
-from products.signals.backend.models import SignalFixVerification, SignalReport
+from products.signals.backend.artefact_schemas import RelatedTo, parse_artefact_content
+from products.signals.backend.models import SignalFixVerification, SignalReport, SignalReportArtefact
 
 logger = structlog.get_logger(__name__)
 
@@ -20,6 +23,10 @@ logger = structlog.get_logger(__name__)
 # counts as verified. Recurrences flip the row to REGRESSED as soon as the sweep sees
 # them; only the VERIFIED outcome waits for this deadline.
 FIX_VERIFICATION_SOAK_WINDOW = timedelta(days=7)
+
+# Per-sweep cap so a backlog (first deploy, sweep outage) settles over a few ticks
+# instead of one unbounded pass.
+FIX_VERIFICATION_SWEEP_LIMIT = 500
 
 
 def schedule_fix_verification(report: SignalReport, *, task_id: uuid.UUID | None, pr_url: str) -> SignalFixVerification:
@@ -45,3 +52,134 @@ def schedule_fix_verification(report: SignalReport, *, task_id: uuid.UUID | None
             verify_after=verification.verify_after.isoformat(),
         )
     return verification
+
+
+@dataclass
+class FixVerificationSweepStats:
+    checked: int = 0
+    verified: int = 0
+    regressed: int = 0
+    inconclusive: int = 0
+    regressed_verification_ids: list[str] = field(default_factory=list)
+
+
+def evaluate_pending_fix_verifications(*, now: datetime | None = None) -> FixVerificationSweepStats:
+    """Settle pending fix verifications against what actually happened after the merge.
+
+    A verification is examined when its soak deadline has passed, or earlier as soon as a
+    recurrence link appears on the resolved report (regressions shouldn't wait out the
+    window). Outcomes:
+
+    - REGRESSED: a live recurrence report exists — the grouping pipeline spawned a fresh
+      report for the same issue after the fix merged (`related_to` artefact pair).
+    - VERIFIED: the deadline passed with no live recurrence. Recurrences the team
+      dismissed as noise don't count against the fix.
+    - INCONCLUSIVE: the report left RESOLVED through another door (suppressed, refunded,
+      deleted) — no outcome can be attributed to the fix.
+
+    Cross-team by design (the sweep runs unscoped); every per-row query stays pinned to
+    the verification's own team.
+    """
+    now = now or timezone.now()
+    post_merge_recurrence_link = Exists(
+        SignalReportArtefact.objects.filter(
+            report_id=OuterRef("report_id"),
+            type=SignalReportArtefact.ArtefactType.RELATED_TO,
+            created_at__gt=OuterRef("created_at"),
+        )
+    )
+    due = (
+        SignalFixVerification.all_teams.filter(status=SignalFixVerification.Status.PENDING)
+        .filter(Q(verify_after__lte=now) | post_merge_recurrence_link)
+        .select_related("report")
+        .order_by("verify_after")[:FIX_VERIFICATION_SWEEP_LIMIT]
+    )
+
+    stats = FixVerificationSweepStats()
+    for verification in due:
+        outcome = _settle_verification(verification, now=now)
+        if outcome is None:
+            continue
+        stats.checked += 1
+        match outcome:
+            case SignalFixVerification.Status.VERIFIED:
+                stats.verified += 1
+            case SignalFixVerification.Status.REGRESSED:
+                stats.regressed += 1
+                stats.regressed_verification_ids.append(str(verification.id))
+            case SignalFixVerification.Status.INCONCLUSIVE:
+                stats.inconclusive += 1
+    return stats
+
+
+def _settle_verification(
+    verification: SignalFixVerification, *, now: datetime
+) -> "SignalFixVerification.Status | None":
+    report = verification.report
+    if report.status != SignalReport.Status.RESOLVED:
+        return _record_outcome(verification, SignalFixVerification.Status.INCONCLUSIVE, now=now)
+
+    recurrence = _earliest_live_recurrence(verification, report)
+    if recurrence is not None:
+        return _record_outcome(
+            verification, SignalFixVerification.Status.REGRESSED, now=now, regressed_report=recurrence
+        )
+    if verification.verify_after <= now:
+        return _record_outcome(verification, SignalFixVerification.Status.VERIFIED, now=now)
+    # A recurrence link exists but every linked report was dismissed/deleted — stay
+    # pending until the deadline in case a real recurrence still lands.
+    return None
+
+
+def _earliest_live_recurrence(verification: SignalFixVerification, report: SignalReport) -> SignalReport | None:
+    """The first still-live report the grouping pipeline linked to `report` after the merge."""
+    link_artefacts = SignalReportArtefact.objects.filter(
+        report_id=report.id,
+        type=SignalReportArtefact.ArtefactType.RELATED_TO,
+        created_at__gt=verification.created_at,
+    ).order_by("created_at")
+
+    linked_ids: list[str] = []
+    for artefact in link_artefacts:
+        content = parse_artefact_content(artefact.type, artefact.content)
+        if isinstance(content, RelatedTo):
+            linked_ids.append(content.report_id)
+    if not linked_ids:
+        return None
+
+    live_by_id = {
+        str(r.id): r
+        for r in SignalReport.objects.filter(id__in=linked_ids, team_id=verification.team_id).exclude(
+            status__in=[SignalReport.Status.DELETED, SignalReport.Status.SUPPRESSED]
+        )
+    }
+    for linked_id in linked_ids:
+        if linked_id in live_by_id:
+            return live_by_id[linked_id]
+    return None
+
+
+def _record_outcome(
+    verification: SignalFixVerification,
+    status: "SignalFixVerification.Status",
+    *,
+    now: datetime,
+    regressed_report: SignalReport | None = None,
+) -> "SignalFixVerification.Status":
+    verification.status = status
+    verification.checked_at = now
+    update_fields = ["status", "checked_at"]
+    if regressed_report is not None:
+        verification.regressed_report = regressed_report
+        update_fields.append("regressed_report")
+    verification.save(update_fields=update_fields)
+    logger.info(
+        "signals_fix_verification_settled",
+        verification_id=str(verification.id),
+        report_id=str(verification.report_id),
+        team_id=verification.team_id,
+        outcome=status,
+        pr_url=verification.pr_url,
+        regressed_report_id=str(regressed_report.id) if regressed_report else None,
+    )
+    return status

--- a/products/signals/backend/fix_verification.py
+++ b/products/signals/backend/fix_verification.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 
 import structlog
 
-from products.signals.backend.artefact_schemas import RelatedTo, parse_artefact_content
+from products.signals.backend.artefact_schemas import ArtefactContentValidationError, RelatedTo, parse_artefact_content
 from products.signals.backend.models import SignalFixVerification, SignalReport, SignalReportArtefact
 
 logger = structlog.get_logger(__name__)
@@ -86,6 +86,11 @@ def evaluate_pending_fix_verifications(*, now: datetime | None = None) -> FixVer
             report_id=OuterRef("report_id"),
             type=SignalReportArtefact.ArtefactType.RELATED_TO,
             created_at__gt=OuterRef("created_at"),
+            # Only the grouping pipeline's system-attributed links count as recurrence
+            # evidence — `related_to` is also writable through the artefact API, and a
+            # user- or task-authored link must not pull a verification forward.
+            created_by__isnull=True,
+            task__isnull=True,
         )
     )
     due = (
@@ -97,7 +102,19 @@ def evaluate_pending_fix_verifications(*, now: datetime | None = None) -> FixVer
 
     stats = FixVerificationSweepStats()
     for verification in due:
-        outcome = _settle_verification(verification, now=now)
+        try:
+            outcome = _settle_verification(verification, now=now)
+        except Exception:
+            # The sweep is global: one team's bad row (or a transient DB error) must not
+            # stop every later team's verifications from settling. The row stays PENDING
+            # and is retried on the next tick.
+            logger.exception(
+                "signals_fix_verification_settle_failed",
+                verification_id=str(verification.id),
+                report_id=str(verification.report_id),
+                team_id=verification.team_id,
+            )
+            continue
         if outcome is None:
             continue
         stats.checked += 1
@@ -132,23 +149,31 @@ def _settle_verification(
 
 
 def _earliest_live_recurrence(verification: SignalFixVerification, report: SignalReport) -> SignalReport | None:
-    """The first still-live report the grouping pipeline linked to `report` after the merge."""
+    """The first still-live report the grouping pipeline linked to `report` after the merge.
+
+    Only system-attributed links are trusted: `related_to` is also writable through the
+    artefact API, and a user- or task-authored link must not decide a terminal outcome.
+    Stored content is still treated as untrusted — malformed rows are skipped, not raised,
+    so one bad artefact can't poison the verification.
+    """
     link_artefacts = SignalReportArtefact.objects.filter(
         report_id=report.id,
         type=SignalReportArtefact.ArtefactType.RELATED_TO,
         created_at__gt=verification.created_at,
+        created_by__isnull=True,
+        task__isnull=True,
     ).order_by("created_at")
 
-    linked_ids: list[str] = []
+    linked_ids: list[uuid.UUID] = []
     for artefact in link_artefacts:
-        content = parse_artefact_content(artefact.type, artefact.content)
-        if isinstance(content, RelatedTo):
-            linked_ids.append(content.report_id)
+        linked_id = _parse_linked_report_id(artefact)
+        if linked_id is not None:
+            linked_ids.append(linked_id)
     if not linked_ids:
         return None
 
     live_by_id = {
-        str(r.id): r
+        r.id: r
         for r in SignalReport.objects.filter(id__in=linked_ids, team_id=verification.team_id).exclude(
             status__in=[SignalReport.Status.DELETED, SignalReport.Status.SUPPRESSED]
         )
@@ -157,6 +182,31 @@ def _earliest_live_recurrence(verification: SignalFixVerification, report: Signa
         if linked_id in live_by_id:
             return live_by_id[linked_id]
     return None
+
+
+def _parse_linked_report_id(artefact: SignalReportArtefact) -> uuid.UUID | None:
+    try:
+        content = parse_artefact_content(artefact.type, artefact.content)
+    except ArtefactContentValidationError:
+        logger.warning(
+            "signals_fix_verification_malformed_link_skipped",
+            artefact_id=str(artefact.id),
+            report_id=str(artefact.report_id),
+            team_id=artefact.team_id,
+        )
+        return None
+    if not isinstance(content, RelatedTo):
+        return None
+    try:
+        return uuid.UUID(content.report_id)
+    except ValueError:
+        logger.warning(
+            "signals_fix_verification_invalid_link_target_skipped",
+            artefact_id=str(artefact.id),
+            report_id=str(artefact.report_id),
+            team_id=artefact.team_id,
+        )
+        return None
 
 
 def _record_outcome(

--- a/products/signals/backend/temporal/__init__.py
+++ b/products/signals/backend/temporal/__init__.py
@@ -26,6 +26,10 @@ from products.signals.backend.temporal.deletion import SignalReportDeletionWorkf
 from products.signals.backend.temporal.drop_telemetry import capture_signal_dropped_activity
 from products.signals.backend.temporal.emit_eval_signal import EmitEvalSignalWorkflow, emit_eval_signal_activity
 from products.signals.backend.temporal.emitter import SignalEmitterWorkflow
+from products.signals.backend.temporal.fix_verification_sweep import (
+    SignalFixVerificationSweepWorkflow,
+    sweep_fix_verifications_activity,
+)
 from products.signals.backend.temporal.grouping import (
     TeamSignalGroupingWorkflow,
     assign_and_emit_signal_activity,
@@ -87,6 +91,7 @@ WORKFLOWS = [
     RunSignalsScoutWorkflow,
     SignalsScoutCoordinatorWorkflow,
     SignalReportInboxNotificationWorkflow,
+    SignalFixVerificationSweepWorkflow,
 ]
 
 ACTIVITIES = [
@@ -132,6 +137,7 @@ ACTIVITIES = [
     safety_filter_activity,
     select_repository_activity,
     soft_delete_report_signals_activity,
+    sweep_fix_verifications_activity,
     verify_match_specificity_activity,
     wait_for_signal_in_clickhouse_activity,
 ]

--- a/products/signals/backend/temporal/fix_verification_sweep.py
+++ b/products/signals/backend/temporal/fix_verification_sweep.py
@@ -1,0 +1,128 @@
+"""Hourly sweep that settles pending post-merge fix verifications.
+
+The tasks GitHub webhook records a pending `SignalFixVerification` when a merged PR
+resolves a report (see `fix_verification.py`); this workflow is what actually settles
+those claims against reality — recurrence means REGRESSED, quiet-through-soak means
+VERIFIED. Hourly because outcomes gate memory write-back and inbox context, not
+anything latency-sensitive.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import timedelta
+
+from django.conf import settings
+
+import structlog
+from temporalio import activity, workflow
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+from temporalio.common import RetryPolicy
+
+from posthog.sync import database_sync_to_async
+from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+
+from products.signals.backend.fix_verification import evaluate_pending_fix_verifications
+
+logger = structlog.get_logger(__name__)
+
+SWEEP_INTERVAL_MINUTES = 60
+
+FIX_VERIFICATION_SWEEP_SCHEDULE_ID = "signals-fix-verification-sweep-schedule"
+FIX_VERIFICATION_SWEEP_WORKFLOW_NAME = "signals-fix-verification-sweep"
+
+
+@dataclass
+class FixVerificationSweepWorkflowInput:
+    """Placeholder input for forward-compat (e.g. future dry-run / team filters)."""
+
+    pass
+
+
+@dataclass
+class FixVerificationSweepWorkflowOutput:
+    checked: int
+    verified: int
+    regressed: int
+    inconclusive: int
+
+
+@activity.defn
+async def sweep_fix_verifications_activity(
+    _input: FixVerificationSweepWorkflowInput,
+) -> FixVerificationSweepWorkflowOutput:
+    async with Heartbeater():
+        stats = await database_sync_to_async(evaluate_pending_fix_verifications, thread_sensitive=False)()
+        logger.info(
+            "signals_fix_verification_sweep_completed",
+            checked=stats.checked,
+            verified=stats.verified,
+            regressed=stats.regressed,
+            inconclusive=stats.inconclusive,
+        )
+        return FixVerificationSweepWorkflowOutput(
+            checked=stats.checked,
+            verified=stats.verified,
+            regressed=stats.regressed,
+            inconclusive=stats.inconclusive,
+        )
+
+
+@workflow.defn(name=FIX_VERIFICATION_SWEEP_WORKFLOW_NAME)
+class SignalFixVerificationSweepWorkflow:
+    """One activity per tick; the per-sweep row cap inside it bounds the tick's work."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> FixVerificationSweepWorkflowInput:
+        if not inputs:
+            return FixVerificationSweepWorkflowInput()
+        loaded = json.loads(inputs[0])
+        return FixVerificationSweepWorkflowInput(**loaded)
+
+    @workflow.run
+    async def run(self, input: FixVerificationSweepWorkflowInput) -> FixVerificationSweepWorkflowOutput:
+        return await workflow.execute_activity(
+            sweep_fix_verifications_activity,
+            input,
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+
+async def create_signals_fix_verification_sweep_schedule(client: Client) -> None:
+    """Create or update the hourly sweep schedule.
+
+    Runs on the shared signals task queue (see `create_signals_scout_coordinator_schedule`
+    for the queue rationale). SKIP overlap: a slow sweep just defers the next tick — the
+    due-set is recomputed from the DB every tick, so nothing is lost.
+    """
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            FIX_VERIFICATION_SWEEP_WORKFLOW_NAME,
+            asdict(FixVerificationSweepWorkflowInput()),
+            id=FIX_VERIFICATION_SWEEP_SCHEDULE_ID,
+            task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=SWEEP_INTERVAL_MINUTES))]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+    )
+
+    if await a_schedule_exists(client, FIX_VERIFICATION_SWEEP_SCHEDULE_ID):
+        await a_update_schedule(client, FIX_VERIFICATION_SWEEP_SCHEDULE_ID, schedule)
+    else:
+        await a_create_schedule(
+            client,
+            FIX_VERIFICATION_SWEEP_SCHEDULE_ID,
+            schedule,
+            trigger_immediately=False,
+        )

--- a/products/signals/backend/test/test_fix_verification.py
+++ b/products/signals/backend/test/test_fix_verification.py
@@ -1,11 +1,17 @@
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import BaseTest
 
-from products.signals.backend.fix_verification import FIX_VERIFICATION_SOAK_WINDOW, schedule_fix_verification
-from products.signals.backend.models import SignalFixVerification, SignalReport
+from products.signals.backend.artefact_attribution import ArtefactAttribution
+from products.signals.backend.artefact_schemas import RelatedTo
+from products.signals.backend.fix_verification import (
+    FIX_VERIFICATION_SOAK_WINDOW,
+    evaluate_pending_fix_verifications,
+    schedule_fix_verification,
+)
+from products.signals.backend.models import SignalFixVerification, SignalReport, SignalReportArtefact
 
 
 class TestScheduleFixVerification(BaseTest):
@@ -43,3 +49,102 @@ class TestScheduleFixVerification(BaseTest):
         assert first.id == second.id
         assert SignalFixVerification.objects.for_team(self.team.id).count() == 1
         assert second.pr_url == "https://github.com/x/y/pull/1"
+
+
+class TestEvaluatePendingFixVerifications(BaseTest):
+    _MERGED_AT = datetime(2026, 7, 1, 12, tzinfo=UTC)
+
+    def _make_verification(self) -> tuple[SignalReport, SignalFixVerification]:
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.RESOLVED,
+            title="MCP tool calls failing validation",
+            summary="Schema mismatch on the execute-sql tool",
+        )
+        with freeze_time(self._MERGED_AT):
+            verification = schedule_fix_verification(
+                report, task_id=uuid.uuid4(), pr_url="https://github.com/posthog/posthog/pull/42"
+            )
+        return report, verification
+
+    def _spawn_recurrence(
+        self, resolved: SignalReport, *, at: datetime, status: str = SignalReport.Status.POTENTIAL
+    ) -> SignalReport:
+        # Mirror the grouping pipeline: a signal matching a resolved report spawns a fresh
+        # report and links it back via a symmetric related_to artefact pair.
+        with freeze_time(at):
+            recurrence = SignalReport.objects.create(
+                team=self.team, status=status, title=resolved.title, summary=resolved.summary
+            )
+            SignalReportArtefact.add_log(
+                team_id=self.team.id,
+                report_id=str(recurrence.id),
+                content=RelatedTo(report_id=str(resolved.id)),
+                attribution=ArtefactAttribution.system(),
+            )
+        return recurrence
+
+    def test_recurrence_settles_regressed_before_the_deadline(self):
+        resolved, verification = self._make_verification()
+        recurrence = self._spawn_recurrence(resolved, at=self._MERGED_AT + timedelta(days=2))
+
+        now = self._MERGED_AT + timedelta(days=3)
+        stats = evaluate_pending_fix_verifications(now=now)
+
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.REGRESSED
+        assert verification.regressed_report_id == recurrence.id
+        assert verification.checked_at == now
+        assert stats.regressed == 1
+
+    def test_quiet_report_verifies_at_the_deadline(self):
+        _, verification = self._make_verification()
+
+        stats = evaluate_pending_fix_verifications(now=self._MERGED_AT + FIX_VERIFICATION_SOAK_WINDOW)
+
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.VERIFIED
+        assert verification.checked_at is not None
+        assert stats.verified == 1
+
+    def test_not_due_stays_pending(self):
+        _, verification = self._make_verification()
+
+        stats = evaluate_pending_fix_verifications(now=self._MERGED_AT + timedelta(days=1))
+
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.PENDING
+        assert verification.checked_at is None
+        assert stats.checked == 0
+
+    def test_dismissed_recurrence_does_not_regress(self):
+        # A recurrence the team dismissed as noise must not fail the fix; quiet-through-soak wins.
+        resolved, verification = self._make_verification()
+        self._spawn_recurrence(resolved, at=self._MERGED_AT + timedelta(days=2), status=SignalReport.Status.SUPPRESSED)
+
+        evaluate_pending_fix_verifications(now=self._MERGED_AT + FIX_VERIFICATION_SOAK_WINDOW)
+
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.VERIFIED
+
+    def test_related_link_predating_the_fix_does_not_count(self):
+        # The resolved report may itself have been born as a recurrence of an older report;
+        # that pre-merge link must not read as post-merge recurrence.
+        resolved, verification = self._make_verification()
+        self._spawn_recurrence(resolved, at=self._MERGED_AT - timedelta(days=5))
+
+        evaluate_pending_fix_verifications(now=self._MERGED_AT + FIX_VERIFICATION_SOAK_WINDOW)
+
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.VERIFIED
+
+    def test_report_that_left_resolved_settles_inconclusive(self):
+        resolved, verification = self._make_verification()
+        resolved.status = SignalReport.Status.SUPPRESSED
+        resolved.save(update_fields=["status"])
+
+        stats = evaluate_pending_fix_verifications(now=self._MERGED_AT + FIX_VERIFICATION_SOAK_WINDOW)
+
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.INCONCLUSIVE
+        assert stats.inconclusive == 1

--- a/products/signals/backend/test/test_fix_verification.py
+++ b/products/signals/backend/test/test_fix_verification.py
@@ -3,7 +3,13 @@ from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
+from parameterized import parameterized
+
+from posthog.models import Team
+
+from products.signals.backend import fix_verification
 from products.signals.backend.artefact_attribution import ArtefactAttribution
 from products.signals.backend.artefact_schemas import RelatedTo
 from products.signals.backend.fix_verification import (
@@ -54,33 +60,40 @@ class TestScheduleFixVerification(BaseTest):
 class TestEvaluatePendingFixVerifications(BaseTest):
     _MERGED_AT = datetime(2026, 7, 1, 12, tzinfo=UTC)
 
-    def _make_verification(self) -> tuple[SignalReport, SignalFixVerification]:
+    def _make_verification(
+        self, *, team: Team | None = None, merged_at: datetime | None = None
+    ) -> tuple[SignalReport, SignalFixVerification]:
         report = SignalReport.objects.create(
-            team=self.team,
+            team=team or self.team,
             status=SignalReport.Status.RESOLVED,
             title="MCP tool calls failing validation",
             summary="Schema mismatch on the execute-sql tool",
         )
-        with freeze_time(self._MERGED_AT):
+        with freeze_time(merged_at or self._MERGED_AT):
             verification = schedule_fix_verification(
                 report, task_id=uuid.uuid4(), pr_url="https://github.com/posthog/posthog/pull/42"
             )
         return report, verification
 
     def _spawn_recurrence(
-        self, resolved: SignalReport, *, at: datetime, status: str = SignalReport.Status.POTENTIAL
+        self,
+        resolved: SignalReport,
+        *,
+        at: datetime,
+        status: str = SignalReport.Status.POTENTIAL,
+        attribution: ArtefactAttribution | None = None,
     ) -> SignalReport:
         # Mirror the grouping pipeline: a signal matching a resolved report spawns a fresh
         # report and links it back via a symmetric related_to artefact pair.
         with freeze_time(at):
             recurrence = SignalReport.objects.create(
-                team=self.team, status=status, title=resolved.title, summary=resolved.summary
+                team_id=resolved.team_id, status=status, title=resolved.title, summary=resolved.summary
             )
             SignalReportArtefact.add_log(
-                team_id=self.team.id,
+                team_id=resolved.team_id,
                 report_id=str(recurrence.id),
                 content=RelatedTo(report_id=str(resolved.id)),
-                attribution=ArtefactAttribution.system(),
+                attribution=attribution or ArtefactAttribution.system(),
             )
         return recurrence
 
@@ -148,3 +161,77 @@ class TestEvaluatePendingFixVerifications(BaseTest):
         verification.refresh_from_db()
         assert verification.status == SignalFixVerification.Status.INCONCLUSIVE
         assert stats.inconclusive == 1
+
+    def test_user_authored_link_is_not_recurrence_evidence(self):
+        # related_to is writable through the artefact API; a member linking a live report
+        # must neither force REGRESSED nor pull the verification forward before its deadline.
+        resolved, verification = self._make_verification()
+        self._spawn_recurrence(
+            resolved,
+            at=self._MERGED_AT + timedelta(days=2),
+            attribution=ArtefactAttribution.from_user(self.user.id),
+        )
+
+        stats = evaluate_pending_fix_verifications(now=self._MERGED_AT + timedelta(days=3))
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.PENDING
+        assert stats.checked == 0
+
+        evaluate_pending_fix_verifications(now=self._MERGED_AT + FIX_VERIFICATION_SOAK_WINDOW)
+        verification.refresh_from_db()
+        assert verification.status == SignalFixVerification.Status.VERIFIED
+
+    @parameterized.expand(
+        [
+            ("non_uuid_target", '{"report_id": "../not-a-uuid"}'),
+            ("schema_mismatch", '{"unexpected": true}'),
+        ]
+    )
+    def test_malformed_link_row_is_skipped_and_later_teams_still_settle(self, _name: str, raw_content: str):
+        # A poisoned one-sided related_to row (e.g. left behind by a failed symmetric write)
+        # must be skipped, not raise out of the cross-team sweep.
+        poisoned_report, poisoned_verification = self._make_verification()
+        with freeze_time(self._MERGED_AT + timedelta(days=1)):
+            SignalReportArtefact.objects.create(
+                team=self.team,
+                report=poisoned_report,
+                type=SignalReportArtefact.ArtefactType.RELATED_TO,
+                content=raw_content,
+            )
+
+        other_team = Team.objects.create(organization=self.organization)
+        other_report, other_verification = self._make_verification(
+            team=other_team, merged_at=self._MERGED_AT + timedelta(hours=1)
+        )
+        recurrence = self._spawn_recurrence(other_report, at=self._MERGED_AT + timedelta(days=2))
+
+        stats = evaluate_pending_fix_verifications(now=self._MERGED_AT + FIX_VERIFICATION_SOAK_WINDOW)
+
+        poisoned_verification.refresh_from_db()
+        other_verification.refresh_from_db()
+        assert poisoned_verification.status == SignalFixVerification.Status.VERIFIED
+        assert other_verification.status == SignalFixVerification.Status.REGRESSED
+        assert other_verification.regressed_report_id == recurrence.id
+        assert stats.checked == 2
+
+    def test_error_settling_one_verification_does_not_halt_the_sweep(self):
+        _, broken_verification = self._make_verification()
+        _, other_verification = self._make_verification(merged_at=self._MERGED_AT + timedelta(hours=1))
+
+        real_settle = fix_verification._settle_verification
+
+        def settle_or_boom(
+            verification: SignalFixVerification, *, now: datetime
+        ) -> "SignalFixVerification.Status | None":
+            if verification.id == broken_verification.id:
+                raise RuntimeError("boom")
+            return real_settle(verification, now=now)
+
+        with patch.object(fix_verification, "_settle_verification", side_effect=settle_or_boom):
+            stats = evaluate_pending_fix_verifications(now=self._MERGED_AT + FIX_VERIFICATION_SOAK_WINDOW)
+
+        broken_verification.refresh_from_db()
+        other_verification.refresh_from_db()
+        assert broken_verification.status == SignalFixVerification.Status.PENDING
+        assert other_verification.status == SignalFixVerification.Status.VERIFIED
+        assert stats.checked == 1

--- a/products/signals/backend/test/test_fix_verification.py
+++ b/products/signals/backend/test/test_fix_verification.py
@@ -215,8 +215,11 @@ class TestEvaluatePendingFixVerifications(BaseTest):
         assert stats.checked == 2
 
     def test_error_settling_one_verification_does_not_halt_the_sweep(self):
-        _, broken_verification = self._make_verification()
-        _, other_verification = self._make_verification(merged_at=self._MERGED_AT + timedelta(hours=1))
+        # Both have to be past their soak deadline at the swept `now`, and the raising one
+        # has to sort first (the sweep orders by verify_after) — otherwise the sweep never
+        # reaches the second row and the test passes for the wrong reason.
+        _, broken_verification = self._make_verification(merged_at=self._MERGED_AT - timedelta(hours=1))
+        _, other_verification = self._make_verification()
 
         real_settle = fix_verification._settle_verification
 


### PR DESCRIPTION
## Problem

Stacked on #72128. That PR records the pending claim "this merged PR fixed the report"; nothing settles the claim yet.

## Changes

- `evaluate_pending_fix_verifications` settles pending verifications against what actually happened after the merge:
  - `REGRESSED` as soon as a live recurrence exists: the grouping pipeline already spawns a fresh report (linked via a symmetric `related_to` artefact pair) when a signal matches a resolved report, so a post-merge `related_to` link on the resolved report is the recurrence signal. Regressions don't wait out the soak window.
  - `VERIFIED` when the soak deadline passes with no live recurrence. Recurrence reports the team dismissed or deleted don't count against the fix.
  - `INCONCLUSIVE` when the report left `RESOLVED` through another door (suppressed, refunded, deleted) - no outcome is attributable to the fix.
- `SignalFixVerificationSweepWorkflow`: an hourly Temporal schedule on the shared signals task queue running that evaluation, capped at 500 rows per tick so a backlog settles over a few ticks. Registered in the signals worker lists and the deploy-time schedule list.

## How did you test this code?

`products/signals/backend/test/test_fix_verification.py` covers each outcome path against a realistic regression: early regression settling (recurrence before the deadline), quiet-through-soak verification, not-due rows untouched, dismissed recurrences not failing the fix, pre-merge `related_to` links not counting (a report born as a recurrence of an older one must not read as post-merge recurrence), and inconclusive settling. Also import-checked the Temporal registration end to end (workflow and activity present in the signals worker lists, schedule list imports cleanly). 12 tests pass locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed at this layer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) with Daniel directing. Skills invoked: /writing-tests. The evaluation lives in plain Django code (`fix_verification.py`) with the Temporal activity as a one-line delegation, so the outcome logic is tested at the cheapest level and the workflow layer stays thin. Deliberately no agent involvement in settling: recurrence is a deterministic signal the pipeline already produces, so the sweep needs no LLM.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
