### PR TITLE
feat(signals): expose fix verification on the report API

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -551,6 +551,7 @@ SPECTACULAR_SETTINGS = {
         "SignalReportRefundReasonEnum": "products.signals.backend.models.SignalReportRefund.Reason",
         "ScoutConfigStatusEnum": "products.signals.backend.models.SignalScoutConfig.Status",
         "ScoutConfigPauseReasonEnum": "products.signals.backend.models.SignalScoutConfig.PauseReason",
+        "SignalFixVerificationStatusEnum": "products.signals.backend.models.SignalFixVerification.Status",
         "EngineeringAnalyticsPRStateEnum": "products.engineering_analytics.backend.facade.contracts.PRState",
         "QuarantineModeEnum": "products.engineering_analytics.backend.facade.contracts.QuarantineMode",
         "CITestRunnerEnum": "products.engineering_analytics.backend.facade.contracts.CITestRunner",

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -22,6 +22,7 @@ from products.signals.backend.enums import SignalSourceProduct, SignalSourceType
 from .artefact_schemas import NON_WRITABLE_ARTEFACT_TYPES
 from .models import (
     AutonomyPriority,
+    SignalFixVerification,
     SignalReport,
     SignalReportArtefact,
     SignalReportRefund,
@@ -401,6 +402,38 @@ class ReportChartSerializer(serializers.Serializer):
     )
 
 
+class SignalFixVerificationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SignalFixVerification
+        fields = [
+            "id",
+            "status",
+            "pr_url",
+            "verify_after",
+            "checked_at",
+            "regressed_report",
+            "created_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "status": {
+                "help_text": (
+                    "Post-merge outcome of the fix PR: 'pending' (still inside the soak window), "
+                    "'verified' (stayed quiet through the soak window), 'regressed' (the issue "
+                    "recurred and a new report was opened), or 'inconclusive' (the report left "
+                    "resolved through another door, so no outcome can be attributed)."
+                )
+            },
+            "pr_url": {"help_text": "The merged implementation PR whose fix is being verified."},
+            "verify_after": {"help_text": "When the soak window ends; quiet until here counts as verified."},
+            "checked_at": {"help_text": "When the outcome was settled; null while pending."},
+            "regressed_report": {
+                "help_text": "The recurrence report that proved the fix did not hold; set only when regressed."
+            },
+            "created_at": {"help_text": "When the verification was scheduled (the PR merge)."},
+        }
+
+
 class SignalReportSerializer(serializers.ModelSerializer):
     artefact_count = serializers.IntegerField(read_only=True)
     charts = ReportChartSerializer(
@@ -456,6 +489,12 @@ class SignalReportSerializer(serializers.ModelSerializer):
     refund = serializers.SerializerMethodField(
         help_text="The report's PR refund, when one exists. One refund per report, ever.",
     )
+    fix_verification = serializers.SerializerMethodField(
+        help_text=(
+            "Post-merge verification of the fix PR that resolved this report, when one exists. "
+            "Distinguishes 'resolved (unverified)' from 'verified fixed' and 'fix regressed'."
+        ),
+    )
 
     class Meta:
         model = SignalReport
@@ -482,6 +521,7 @@ class SignalReportSerializer(serializers.ModelSerializer):
             "implementation_pr_url",
             "implementation_pr_merged",
             "refund",
+            "fix_verification",
             "refund_ineligibility_reason",
             "billing_exempt_reason",
         ]
@@ -613,6 +653,14 @@ class SignalReportSerializer(serializers.ModelSerializer):
         if refund is None:
             return None
         return SignalReportRefundSerializer(refund).data
+
+    @extend_schema_field(SignalFixVerificationSerializer(allow_null=True))
+    def get_fix_verification(self, obj: SignalReport) -> dict | None:
+        # Reverse OneToOne, same degradation pattern as `refund` above.
+        verification = getattr(obj, "fix_verification", None)
+        if verification is None:
+            return None
+        return SignalFixVerificationSerializer(verification).data
 
     @extend_schema_field(
         serializers.ChoiceField(

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -26,7 +26,12 @@ from products.signals.backend.implementation_pr import (
     fetch_implementation_pr_state_for_reports,
     fetch_implementation_pr_urls_for_reports,
 )
-from products.signals.backend.models import SignalReport, SignalReportArtefact, SignalReportTask
+from products.signals.backend.models import (
+    SignalFixVerification,
+    SignalReport,
+    SignalReportArtefact,
+    SignalReportTask,
+)
 from products.signals.backend.signal_metadata import ReportSignalMeta
 from products.signals.backend.task_run_artefacts import append_task_run_artefact, record_implementation_task
 
@@ -1274,6 +1279,37 @@ class TestAssociatedTaskRunsForReports(APIBaseTest):
         assert str(report.id) in SignalReport.associated_task_runs_for_reports(
             report_ids=[str(report.id)], team_id=self.team.id
         )
+
+
+class TestSignalReportFixVerificationAPI(APIBaseTest):
+    """The inbox needs to distinguish 'resolved (unverified)' from 'verified fixed' / 'fix regressed'."""
+
+    def test_list_renders_fix_verification_when_present_and_null_otherwise(self):
+        verified = SignalReport.objects.create(
+            team=self.team, status=SignalReport.Status.RESOLVED, title="Fixed thing", summary="s"
+        )
+        unverified = SignalReport.objects.create(
+            team=self.team, status=SignalReport.Status.READY, title="Open thing", summary="s"
+        )
+        checked_at = timezone.now()
+        SignalFixVerification.all_teams.create(
+            team=self.team,
+            report=verified,
+            pr_url="https://github.com/posthog/posthog/pull/42",
+            verify_after=checked_at - timedelta(days=1),
+            status=SignalFixVerification.Status.VERIFIED,
+            checked_at=checked_at,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/")
+
+        assert response.status_code == status.HTTP_200_OK
+        by_id = {row["id"]: row for row in response.json()["results"]}
+        rendered = by_id[str(verified.id)]["fix_verification"]
+        assert rendered["status"] == "verified"
+        assert rendered["pr_url"] == "https://github.com/posthog/posthog/pull/42"
+        assert rendered["regressed_report"] is None
+        assert by_id[str(unverified.id)]["fix_verification"] is None
 
 
 class TestSignalReportSuppressionAPI(APIBaseTest):

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -26,12 +26,7 @@ from products.signals.backend.implementation_pr import (
     fetch_implementation_pr_state_for_reports,
     fetch_implementation_pr_urls_for_reports,
 )
-from products.signals.backend.models import (
-    SignalFixVerification,
-    SignalReport,
-    SignalReportArtefact,
-    SignalReportTask,
-)
+from products.signals.backend.models import SignalFixVerification, SignalReport, SignalReportArtefact, SignalReportTask
 from products.signals.backend.signal_metadata import ReportSignalMeta
 from products.signals.backend.task_run_artefacts import append_task_run_artefact, record_implementation_task
 

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -752,10 +752,11 @@ class SignalReportViewSet(
             .values("count"),
             output_field=IntegerField(),
         )
-        # select_related("refund"): the serializer renders the reverse OneToOne inline.
+        # select_related("refund", "fix_verification"): the serializer renders both reverse
+        # OneToOnes inline.
         return (
             queryset.filter(team=self.team)
-            .select_related("refund")
+            .select_related("refund", "fix_verification")
             .annotate(
                 artefact_count=Coalesce(artefact_count_subquery, Value(0), output_field=IntegerField()),
             )

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -165,6 +165,49 @@ export interface SignalReportRefundApi {
     readonly created_at: string
 }
 
+/**
+ * * `pending` - Pending
+ * * `verified` - Verified
+ * * `regressed` - Regressed
+ * * `inconclusive` - Inconclusive
+ */
+export type SignalFixVerificationStatusEnumApi =
+    (typeof SignalFixVerificationStatusEnumApi)[keyof typeof SignalFixVerificationStatusEnumApi]
+
+export const SignalFixVerificationStatusEnumApi = {
+    Pending: 'pending',
+    Verified: 'verified',
+    Regressed: 'regressed',
+    Inconclusive: 'inconclusive',
+} as const
+
+export interface SignalFixVerificationApi {
+    readonly id: string
+    /** Post-merge outcome of the fix PR: 'pending' (still inside the soak window), 'verified' (stayed quiet through the soak window), 'regressed' (the issue recurred and a new report was opened), or 'inconclusive' (the report left resolved through another door, so no outcome can be attributed).
+     *
+     * * `pending` - Pending
+     * * `verified` - Verified
+     * * `regressed` - Regressed
+     * * `inconclusive` - Inconclusive */
+    readonly status: SignalFixVerificationStatusEnumApi
+    /** The merged implementation PR whose fix is being verified. */
+    readonly pr_url: string
+    /** When the soak window ends; quiet until here counts as verified. */
+    readonly verify_after: string
+    /**
+     * When the outcome was settled; null while pending.
+     * @nullable
+     */
+    readonly checked_at: string | null
+    /**
+     * The recurrence report that proved the fix did not hold; set only when regressed.
+     * @nullable
+     */
+    readonly regressed_report: string | null
+    /** When the verification was scheduled (the PR merge). */
+    readonly created_at: string
+}
+
 export type RefundIneligibilityReasonEnumApi =
     (typeof RefundIneligibilityReasonEnumApi)[keyof typeof RefundIneligibilityReasonEnumApi]
 
@@ -245,6 +288,8 @@ export interface SignalReportApi {
     readonly implementation_pr_merged: boolean
     /** The report's PR refund, when one exists. One refund per report, ever. */
     readonly refund: SignalReportRefundApi | null
+    /** Post-merge verification of the fix PR that resolved this report, when one exists. Distinguishes 'resolved (unverified)' from 'verified fixed' and 'fix regressed'. */
+    readonly fix_verification: SignalFixVerificationApi | null
     /** Why refunding this report's PR would be rejected right now, or null when a refund would be accepted (see the field's schema for the reason values). */
     readonly refund_ineligibility_reason: RefundIneligibilityReasonEnumApi | null
     /** Non-null when this report is system-marked never-billable (PostHog-system origin, e.g. a health-check scout finding) — its implementation PRs are free and cannot be refunded because nothing was charged.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44940,6 +44940,49 @@ export namespace Schemas {
       readonly created_at: string;
     }
 
+    /**
+     * * `pending` - Pending
+     * * `verified` - Verified
+     * * `regressed` - Regressed
+     * * `inconclusive` - Inconclusive
+     */
+    export type SignalFixVerificationStatusEnum = typeof SignalFixVerificationStatusEnum[keyof typeof SignalFixVerificationStatusEnum];
+
+
+    export const SignalFixVerificationStatusEnum = {
+      Pending: 'pending',
+      Verified: 'verified',
+      Regressed: 'regressed',
+      Inconclusive: 'inconclusive',
+    } as const;
+
+    export interface SignalFixVerification {
+      readonly id: string;
+      /** Post-merge outcome of the fix PR: 'pending' (still inside the soak window), 'verified' (stayed quiet through the soak window), 'regressed' (the issue recurred and a new report was opened), or 'inconclusive' (the report left resolved through another door, so no outcome can be attributed).
+       *
+       * * `pending` - Pending
+       * * `verified` - Verified
+       * * `regressed` - Regressed
+       * * `inconclusive` - Inconclusive */
+      readonly status: SignalFixVerificationStatusEnum;
+      /** The merged implementation PR whose fix is being verified. */
+      readonly pr_url: string;
+      /** When the soak window ends; quiet until here counts as verified. */
+      readonly verify_after: string;
+      /**
+         * When the outcome was settled; null while pending.
+         * @nullable
+         */
+      readonly checked_at: string | null;
+      /**
+         * The recurrence report that proved the fix did not hold; set only when regressed.
+         * @nullable
+         */
+      readonly regressed_report: string | null;
+      /** When the verification was scheduled (the PR merge). */
+      readonly created_at: string;
+    }
+
     export type RefundIneligibilityReasonEnum = typeof RefundIneligibilityReasonEnum[keyof typeof RefundIneligibilityReasonEnum];
 
 
@@ -45007,6 +45050,8 @@ export namespace Schemas {
       readonly implementation_pr_merged: boolean;
       /** The report's PR refund, when one exists. One refund per report, ever. */
       readonly refund: SignalReportRefund | null;
+      /** Post-merge verification of the fix PR that resolved this report, when one exists. Distinguishes 'resolved (unverified)' from 'verified fixed' and 'fix regressed'. */
+      readonly fix_verification: SignalFixVerification | null;
       /** Why refunding this report's PR would be rejected right now, or null when a refund would be accepted (see the field's schema for the reason values). */
       readonly refund_ineligibility_reason: RefundIneligibilityReasonEnum | null;
       /** Non-null when this report is system-marked never-billable (PostHog-system origin, e.g. a health-check scout finding) — its implementation PRs are free and cannot be refunded because nothing was charged.


### PR DESCRIPTION
## Problem

Stacked on #72130. Verification outcomes exist in the DB but aren't visible to the inbox UI or MCP consumers, so "resolved" still looks like one state when it's really three: resolved (unverified), verified fixed, and fix regressed.

## Changes

- `SignalReportSerializer` gains a read-only `fix_verification` field (nested `SignalFixVerificationSerializer`: status, PR URL, soak deadline, checked_at, regressed report id), following the existing `refund` reverse-OneToOne pattern, with `select_related` on the reports queryset so lists stay N+1-free.
- `SignalFixVerificationStatusEnum` added to `ENUM_NAME_OVERRIDES` up front since `status` is a collision-prone enum field name.
- Regenerated OpenAPI-derived types (`products/signals/frontend/generated`, MCP generated client).

## How did you test this code?

`products/signals/backend/test/test_signal_report_api.py` (`TestSignalReportFixVerificationAPI`): one list-endpoint test asserting a report with a settled verification renders the nested payload and a report without one renders null - the wiring guard for serializer field, nested shape, and queryset `select_related`. Full report API suite passes locally (173 tests). `hogli build:openapi` ran clean and the generated `SignalFixVerificationApi` types are included.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Generated API types updated in this PR. No handbook page covers the signals report payload.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) with Daniel directing. Skills invoked: /improving-drf-endpoints, /writing-tests. Every nested field carries help_text so the generated TS types and MCP schemas are self-describing; the enum override was added preemptively rather than waiting for the CI collision warning.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
