### PR TITLE
chore(clickhouse): bump hclexp pin to sha-6db99e9

### DIFF
--- a/posthog/clickhouse/hcl/bin/image.txt
+++ b/posthog/clickhouse/hcl/bin/image.txt
@@ -1,1 +1,1 @@
-ghcr.io/posthog/chschema:sha-5eadb87
+ghcr.io/posthog/chschema:sha-6db99e9


### PR DESCRIPTION
## Problem

The pinned hclexp (`sha-5eadb87`) predates the completed patch vocabulary (PostHog/chschema#153, PostHog/chschema#156, PostHog/chschema#159). posthog-cloud-infra's data-override dedup declares each shared table once and expresses env deltas as `patch_table` / `patch_view` / `patch_dictionary` blocks, which need the newer engine.

## Changes

Bump `posthog/clickhouse/hcl/bin/image.txt` `sha-5eadb87` → `sha-6db99e9`, picking up:

- `patch_table` full vocabulary: engine, order_by, ttl, partition_by, columns (add/modify/drop), indexes, settings-merge (#153, #156)
- positioned column adds — `after = "..."` / `first = true` (#159) and positioned index adds (#161)
- `patch_view` / `patch_dictionary` (#156)
- `locate -layer` mode and node attribution (#147), `load -out-name` templates (#148), `load` object filters (#150), Distributed-over-system-tables diff tolerance (#151)

## How did you test this code?

`gen-golden.sh`, `gen-sql.sh`, `check.sh` — green; `git diff --exit-code -- golden sql` — goldens and sql regenerate **byte-identically** under the new pin (no canonicalization shift), so this is a pure toolchain bump.