### PR TITLE
fix(postgres): handle unrecognized wal_level in CDC prerequisite check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
@@ -72,7 +72,20 @@ def _check_pg_version(conn: psycopg.Connection) -> list[str]:
 def _check_wal_level(conn: psycopg.Connection) -> list[str]:
     """wal_level must be 'logical'."""
     with conn.cursor() as cur:
-        cur.execute("SHOW wal_level")
+        try:
+            cur.execute("SHOW wal_level")
+        except psycopg.errors.UndefinedObject:
+            # A database that doesn't expose wal_level can't support logical replication CDC.
+            # Usually a connection pooler (e.g. PgBouncer in transaction mode) or a
+            # non-logical-replication-capable, wire-compatible database.
+            conn.rollback()
+            return [
+                "This database doesn't expose the wal_level setting, so it can't support logical "
+                "replication CDC. This usually means the connection goes through a pooler (such as "
+                "PgBouncer in transaction mode) or to a database that isn't a logical-replication-capable "
+                "PostgreSQL. Connect directly to the primary PostgreSQL server, or switch these tables "
+                "to Incremental sync."
+            ]
         row = cur.fetchone()
         if row is None:
             return ["Could not determine wal_level."]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_prerequisite_validator.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_prerequisite_validator.py
@@ -1,16 +1,21 @@
 from unittest.mock import MagicMock
 
+import psycopg
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.prerequisite_validator import (
     validate_cdc_prerequisites,
 )
 
 
-def _mock_conn(query_results: list[tuple[str, list[tuple]]]):
+def _mock_conn(query_results: list[tuple[str, list[tuple]]], raise_on: dict[str, Exception] | None = None):
     """Create a mock connection whose cursor returns results matched by query pattern.
 
     query_results: ordered list of (pattern, rows) tuples. Each time execute() is
     called, the FIRST matching pattern is used and its rows become the fetchone() results.
     Patterns are matched as substrings of the SQL query string.
+
+    raise_on: optional {pattern: exception}. When a query matches, that exception is
+    raised from execute() (mimicking a server-side error mid-validation).
     """
     conn = MagicMock()
     cursor = MagicMock()
@@ -21,6 +26,9 @@ def _mock_conn(query_results: list[tuple[str, list[tuple]]]):
 
     def mock_execute(query, *args, **kwargs):
         query_str = str(query)
+        for pattern, exc in (raise_on or {}).items():
+            if pattern in query_str:
+                raise exc
         for pattern, rows in query_results:
             if pattern in query_str:
                 cursor._current_results = list(rows)
@@ -87,6 +95,18 @@ class TestValidateCDCPrerequisites:
         conn = _mock_conn([_PG_15, _WAL_REPLICA, _HAS_PK, _HAS_REPL_ROLE, _MAX_SLOTS_10, _SLOT_COUNT_2])
         errors = validate_cdc_prerequisites(conn=conn, management_mode="posthog", tables=["users"])
         assert any("wal_level" in e for e in errors)
+
+    def test_wal_level_unrecognized_parameter(self):
+        # Poolers (e.g. PgBouncer in transaction mode) and some wire-compatible databases
+        # reject `SHOW wal_level` with UndefinedObject. That must surface as a graceful
+        # prerequisite error, not crash the whole validation.
+        conn = _mock_conn(
+            [_PG_15, _HAS_PK, _HAS_REPL_ROLE, _MAX_SLOTS_10, _SLOT_COUNT_2],
+            raise_on={"wal_level": psycopg.errors.UndefinedObject('unrecognized configuration parameter "wal_level"')},
+        )
+        errors = validate_cdc_prerequisites(conn=conn, management_mode="posthog", tables=["users"])
+        assert any("logical replication CDC" in e for e in errors)
+        conn.rollback.assert_called()
 
     def test_table_missing_primary_key(self):
         conn = _mock_conn([_PG_15, _WAL_LOGICAL, _NO_PK, _HAS_REPL_ROLE, _MAX_SLOTS_10, _SLOT_COUNT_2])


### PR DESCRIPTION
## Problem

Error tracking surfaced an unhandled `UndefinedObject` — `unrecognized configuration parameter "wal_level"` — raised from the Postgres CDC prerequisite check ([issue](https://us.posthog.com/project/2/error_tracking/019f74e5-b4b3-7601-9dd5-de98b047db67)).

`_check_wal_level` runs `SHOW wal_level` unguarded. Some databases don't expose that setting — connection poolers such as PgBouncer in transaction mode, and wire-compatible databases that aren't logical-replication-capable Postgres. On those, `SHOW wal_level` raises `UndefinedObject`, which propagated up and crashed the entire prerequisite validation instead of returning a friendly, actionable error.

The whole point of the validator is to return user-facing messages telling someone why their database isn't CDC-ready. A parameter it can't read is exactly that kind of prerequisite failure, not a crash.

## Changes

Catch `psycopg.errors.UndefinedObject` in `_check_wal_level`, roll back the aborted transaction (so later checks in the same connection still run), and return a graceful prerequisite error explaining the likely cause (a pooler or a non-logical-replication-capable database) and the fix (connect directly to the primary, or switch those tables to Incremental sync).

> [!NOTE]
> This is a synchronous prerequisite-check endpoint, not the Temporal retry loop, so `NonRetryableErrors` doesn't apply here — the right fix is graceful handling in the validator.

## How did you test this code?

Added `test_wal_level_unrecognized_parameter` to `test_prerequisite_validator.py`. It drives the validator with a connection whose `SHOW wal_level` raises `UndefinedObject` and asserts a graceful prerequisite error is returned (not an exception) and that the transaction is rolled back. No existing test exercised a mid-validation server error — they all mocked clean query results — so this locks in the new behavior. If the guard is removed the validation crashes again and the test fails.

Ran the full file locally: `uv run pytest .../cdc/tests/test_prerequisite_validator.py` — 13 passed. Ruff check and format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (PostHog Code). Confirmed the issue's top in-app frame was `prerequisite_validator.py:_check_wal_level` and traced the call path from the `check_cdc_prerequisites_for_source` endpoint. Considered `NonRetryableErrors` but ruled it out — the failure is on a synchronous validation endpoint, and the validator is designed to return messages rather than throw. Invoked `/writing-tests` before adding the regression test. Checked open PRs (including the maintainer's) for duplicates of this root cause and found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
