### PR TITLE
fix(experiments): allow sorting experiments list by conclusion

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -596,6 +596,8 @@ class ExperimentService:
         "-duration",
         "status",
         "-status",
+        "conclusion",
+        "-conclusion",
     }
 
     ELIGIBLE_FLAGS_ORDER_ALLOWLIST = {
@@ -3701,6 +3703,23 @@ class ExperimentService:
                     queryset = queryset.order_by(F("status_sort_key").desc())
                 else:
                     queryset = queryset.order_by(F("status_sort_key").asc())
+            elif order_value in ["conclusion", "-conclusion"]:
+                # Match the frontend Result column's sorter: won, lost, inconclusive,
+                # stopped early, invalid, then experiments without a conclusion.
+                queryset = queryset.annotate(
+                    conclusion_sort_key=Case(
+                        When(conclusion="won", then=Value(1)),
+                        When(conclusion="lost", then=Value(2)),
+                        When(conclusion="inconclusive", then=Value(3)),
+                        When(conclusion="stopped_early", then=Value(4)),
+                        When(conclusion="invalid", then=Value(5)),
+                        default=Value(6),
+                    )
+                )
+                if order_value.startswith("-"):
+                    queryset = queryset.order_by(F("conclusion_sort_key").desc())
+                else:
+                    queryset = queryset.order_by(F("conclusion_sort_key").asc())
             elif order_value in ["created_by", "-created_by"]:
                 # Match the frontend column's `first_name || email` sorter — treat an
                 # empty `first_name` as missing and fall back to `email`, so users with

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -282,7 +282,7 @@ def _slugify_feature_flag_key(name: str, *, team_id: int) -> str:
                 type=str,
                 description=(
                     "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, "
-                    "created_at, updated_at, start_date, end_date, duration, and status."
+                    "created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion."
                 ),
                 required=False,
             ),

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -5173,6 +5173,39 @@ class TestExperimentService(APIBaseTest):
 
         assert list(queryset.values_list("name", flat=True)[:3]) == expected_order
 
+    @parameterized.expand(
+        [
+            ("ascending", "conclusion", ["Won", "Lost", "Invalid", "No conclusion"]),
+            ("descending", "-conclusion", ["No conclusion", "Invalid", "Lost", "Won"]),
+        ]
+    )
+    def test_filter_experiments_queryset_orders_by_conclusion(
+        self, _: str, order: str, expected_order: list[str]
+    ) -> None:
+        service = self._service()
+        conclusions: dict[str, str | None] = {
+            "Won": "won",
+            "Lost": "lost",
+            "Invalid": "invalid",
+            "No conclusion": None,
+        }
+        for name, conclusion in conclusions.items():
+            experiment = service.create_experiment(
+                name=name,
+                feature_flag_key=f"order-conclusion-{name.lower().replace(' ', '-')}",
+            )
+            if conclusion:
+                experiment.conclusion = conclusion
+                experiment.save()
+
+        queryset = service.filter_experiments_queryset(
+            Experiment.objects.filter(team=self.team),
+            action="list",
+            query_params={"order": order},
+        )
+
+        assert list(queryset.values_list("name", flat=True)[:4]) == expected_order
+
     def test_filter_experiments_queryset_validates_feature_flag_id(self) -> None:
         with self.assertRaises(ValidationError) as ctx:
             self._service().filter_experiments_queryset(
@@ -5921,6 +5954,8 @@ class TestExperimentService(APIBaseTest):
             ("-duration",),
             ("status",),
             ("-status",),
+            ("conclusion",),
+            ("-conclusion",),
         ]
     )
     def test_order_by_valid_fields_works(self, order: str):

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -2211,7 +2211,7 @@ export type ExperimentsListParams = {
      */
     offset?: number
     /**
-     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.
+     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion.
      */
     order?: string
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -74091,7 +74091,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.
+     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion.
      */
     order?: string;
     /**

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -710,7 +710,7 @@ export const ExperimentsListQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status."
+            "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion."
         ),
     prompt_name: zod
         .string()


### PR DESCRIPTION
## Problem

Sorting the experiments list by the Result column breaks the page. The column's sort key is `conclusion`, so clicking it makes the frontend request `order=conclusion`, but the list endpoint's order allowlist never included that field. The API responds with `Invalid order field: 'conclusion'` and the list fails to load.

The issue also reports a 500 when sorting by Created By. That looks like the bug already fixed in #60532 (`created_by` ordering now goes through a display-name annotation), and I could not reproduce it on master, so this PR only fixes the conclusion half.

Closes #63621

## Changes

- Add `conclusion` / `-conclusion` to `EXPERIMENT_ORDER_ALLOWLIST` in `ExperimentService`
- Order by a `Case`/`When` rank that matches the frontend Result column's client-side sorter (won, lost, inconclusive, stopped early, invalid, then experiments without a conclusion), the same pattern the existing `status` ordering uses
- Update the `order` parameter description on the list endpoint (it was also missing `created_by`) and regenerate the OpenAPI-derived types, which only changes that description string in 3 generated files

## How did you test this code?

- New parameterized test `test_filter_experiments_queryset_orders_by_conclusion` (ascending + descending). The fixture set (won, lost, invalid, no conclusion) is picked so plain alphabetical ordering would fail the assertion, and it checks that experiments without a conclusion sort last ascending. That's the regression no existing test catches: dropping the allowlist entry or the rank mapping breaks Result sorting again.
- Added `conclusion` / `-conclusion` to the existing parameterized `test_order_by_valid_fields_works`.
- Verified both new tests fail on master without the service change (rejected with `ValidationError`) and pass with it.
- Full `products/experiments/backend/test/test_experiment_service.py` passes locally (471 tests).
- `hogli ci:preflight --fix` green, repo-wide `mypy --cache-fine-grained .` clean.
- I did not click through the UI against a live stack; verification is automated at the service layer, which is where the failure originates.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` describe experiments list ordering; the API parameter description is updated in code and flows into the generated docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: `/writing-tests` and `/improving-drf-endpoints`. Main decision: sort by a rank that mirrors the frontend column's own comparator instead of ordering alphabetically on the raw column, mirroring how `status` ordering is implemented. I also considered removing the column's sorter on the frontend instead, but the column is clearly meant to be sortable. The OpenAPI regen was needed because the `order` parameter description is embedded in the generated types.

---

small disclaimer: i'm a freshman in college trying to contribute properly to projects i use. claude code did a lot of the heavy lifting here and i went through the logic and the tests myself, so if anything looks off i would honestly love to hear what i missed :)
