### PR TITLE
fix(data-warehouse): don't capture expected errors on sync defaults

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -4766,12 +4766,18 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
 
         failures: dict[str, tuple[str, str]] = {}
         names = [source_schemas_by_id[schema_update["id"]].name for schema_update in needing_defaults]
+        source_impl: AnySource | None = None
         try:
             source_impl = SourceRegistry.get_source(ExternalDataSourceType(source.source_type))
             config = source_impl.parse_config(source.job_inputs)
             discovered = source_impl.get_schemas(config, self.team_id, names=names)
         except Exception as e:
-            capture_exception(e)
+            # Discovery connects to the customer's source, so an expected user/upstream failure
+            # (bad credentials, unreachable host) is theirs to fix and is already reported back to
+            # them below — don't capture it as error-tracking noise. Mirrors `refresh_schemas`.
+            _, is_expected_source_error = _classify_refresh_schemas_error(source_impl, e)
+            if not is_expected_source_error:
+                capture_exception(e)
             reason = "could not read the source to pick default sync settings; check the source credentials"
             for schema_update in needing_defaults:
                 schema = source_schemas_by_id[schema_update["id"]]

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -1342,6 +1342,68 @@ class TestExternalDataSource(APIBaseTest):
         assert configured_schema.should_sync is True
         assert mock_unpause.call_count == 1
 
+    @parameterized.expand(
+        [
+            # A bad-credentials rejection from the customer's database is theirs to fix and is
+            # already reported back in the response, so it must not be captured as error-tracking noise.
+            (
+                "expected_credential_error",
+                psycopg.OperationalError(
+                    'connection failed: FATAL:  password authentication failed for user "postgres"'
+                ),
+                False,
+            ),
+            # An unexpected error still points at a bug in our discovery code, so keep capturing it.
+            ("unexpected_error", ValueError("unexpected discovery failure"), True),
+        ]
+    )
+    @patch(
+        "products.data_warehouse.backend.presentation.views.external_data_schema.external_data_workflow_exists",
+        return_value=False,
+    )
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
+    def test_bulk_update_schemas_apply_sync_defaults_skips_capture_for_expected_errors(
+        self, _name, raised_exception, should_capture, mock_capture_exception, _mock_workflow_exists
+    ):
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            source_type="Postgres",
+            created_by=self.user,
+            prefix="pg",
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "app",
+                "user": "user",
+                "password": "pass",
+                "schema": "public",
+            },
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="Customer", team_id=self.team.pk, source=source, should_sync=False, sync_type=None
+        )
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas",
+            side_effect=raised_exception,
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.id}/bulk_update_schemas",
+                data={"schemas": [{"id": str(schema.id), "should_sync": True, "apply_sync_defaults": True}]},
+                format="json",
+            )
+
+        # Discovery failed, so the schema is reported back either way and stays unconfigured.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "could not read the source" in response.json()["detail"]
+        schema.refresh_from_db()
+        assert schema.should_sync is False
+
+        assert mock_capture_exception.called is should_capture
+
     @patch(
         "products.data_warehouse.backend.presentation.views.external_data_schema.external_data_workflow_exists",
         return_value=True,


### PR DESCRIPTION
## Problem

Error tracking flagged a Postgres `OperationalError` — a `password authentication failed` from a customer's database — surfacing as a captured (`handled: true`) exception.

The stack originates in the Postgres source (`get_schemas`), but it's captured on the setup path, not the Temporal sync path. `bulk_update_schemas` → `_fill_default_sync_settings` connects to the source to discover default sync settings for a not-yet-configured schema. When that connection fails with bad credentials, the handler reported the failure back to the caller *and* called `capture_exception` unconditionally.

That's noise: bad credentials are the customer's to fix, the message is already classified as a known user/upstream condition (it's in the Postgres source's `get_non_retryable_errors`, and in the view's expected-errors map), and every sibling handler in this view already skips capture for exactly these errors.

Error tracking issue: [019f74ee-d023-7160-8310-975fd2b10f0b](https://us.posthog.com/project/2/error_tracking/019f74ee-d023-7160-8310-975fd2b10f0b)

## Changes

Gate the `capture_exception` in `_fill_default_sync_settings` behind `_classify_refresh_schemas_error`, mirroring `refresh_schemas` and the connection-metadata fetch a few hundred lines up. Expected source errors (bad credentials, unreachable host, refused connection) are still reported to the caller but no longer captured. Genuine, unexpected errors are still captured.

> [!NOTE]
> This is a graceful-skip fix, not a retry-policy change. The error was already treated as non-retryable everywhere it mattered — this only stops the setup path from logging it as a defect.

## How did you test this code?

Added a parameterized regression test to `test_bulk_update_schemas_apply_sync_defaults_*` that drives discovery failure two ways and asserts the capture decision:

- an expected credentials rejection (`password authentication failed`) is reported back but **not** captured
- an unexpected error is still captured

The existing discovery-failure test only checked per-schema reporting, never the capture, so it wouldn't catch a regression here.

I (Claude) could not run the DB-backed test in this environment — no Postgres/docker available — so CI runs it. I verified statically: `ruff check`, `ruff format --check`, `py_compile` all pass, and confirmed the classifier's two-branch decision by running `_classify_refresh_schemas_error` against the real `PostgresSource` error map outside the DB path.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage started from an error-tracking webhook for the Postgres source. Confirmed the issue via the error-tracking MCP tools (one occurrence, `handled: true`), then read the full stack to find the capture site.

Key decision: the reported string is *already* classified as non-retryable in the Postgres source and mapped in the view's expected-errors dict, so extending `NonRetryableErrors` would have been a no-op. The real defect was the one setup-path handler that captured unconditionally while all its siblings classify first. Fixed at that layer by reusing the existing `_classify_refresh_schemas_error` helper rather than adding anything new.

Skills invoked: `/improving-drf-endpoints` (viewset change) and `/writing-tests` (regression test gate). Ruled out duplicates by reading the diffs of the nearby open PRs on this file (#71040 fixes the *create* path, #72014 the `cdc_status` endpoint) — neither touches `_fill_default_sync_settings`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
