### PR TITLE
fix(hogvm): treat replaceOne/replaceAll replacement literally

### DIFF
--- a/common/hogvm/__tests__/__snapshots__/hogqlx.js
+++ b/common/hogvm/__tests__/__snapshots__/hogqlx.js
@@ -1,4 +1,4 @@
-function replaceAll (str, searchValue, replaceValue) { return str.replaceAll(searchValue, replaceValue) }
+function replaceAll (str, searchValue, replaceValue) { return str.replaceAll(searchValue, () => replaceValue) }
 function print (...args) { console.log(...args.map(__printHogStringOutput)) }
 function jsonStringify (value, spacing) {
     function convert(x, marked) {

--- a/common/hogvm/__tests__/__snapshots__/stl.js
+++ b/common/hogvm/__tests__/__snapshots__/stl.js
@@ -75,8 +75,8 @@ function startsWith(str, prefix) {
 }
 function round(a) { return Math.round(a) }
 function reverse (value) { return value.split('').reverse().join('') }
-function replaceOne (str, searchValue, replaceValue) { return str.replace(searchValue, replaceValue) }
-function replaceAll (str, searchValue, replaceValue) { return str.replaceAll(searchValue, replaceValue) }
+function replaceOne (str, searchValue, replaceValue) { return str.replace(searchValue, () => replaceValue) }
+function replaceAll (str, searchValue, replaceValue) { return str.replaceAll(searchValue, () => replaceValue) }
 function range(...args) {
     if (args.length === 1) {
         const end = args[0];

--- a/common/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/common/hogvm/typescript/src/__tests__/execute.test.ts
@@ -111,6 +111,32 @@ describe('hogvm execute', () => {
         expect(execSync(['_h', op.NULL, op.INTEGER, 1, op.NOT_EQ], options)).toBe(true)
     })
 
+    test('replaceOne/replaceAll treat the replacement literally', () => {
+        const options = { globals: {} }
+        // Use versioned bytecode so arguments are passed in source order.
+        const replaceAll = (s: string, from: string, to: string) =>
+            execSync(['_H', 1, op.STRING, s, op.STRING, from, op.STRING, to, op.CALL_GLOBAL, 'replaceAll', 3], options)
+        const replaceOne = (s: string, from: string, to: string) =>
+            execSync(['_H', 1, op.STRING, s, op.STRING, from, op.STRING, to, op.CALL_GLOBAL, 'replaceOne', 3], options)
+
+        // Ordinary replacements are unaffected.
+        expect(replaceAll('hello world', 'l', 'L')).toBe('heLLo worLd')
+        expect(replaceOne('hello world', 'l', 'L')).toBe('heLlo world')
+
+        // Dollar sequences in the replacement must not be interpreted as
+        // JavaScript special patterns ($$, $&, $`, $'). This matches the Python
+        // interpreter and ClickHouse's replaceOne/replaceAll.
+        expect(replaceAll('price', 'price', '$$')).toBe('$$')
+        expect(replaceAll('a_b', '_', '$&')).toBe('a$&b')
+        expect(replaceAll('xYx', 'x', '($&)')).toBe('($&)Y($&)')
+        expect(replaceAll('a-b', '-', '$`')).toBe('a$`b')
+        expect(replaceAll('a-b', '-', "$'")).toBe("a$'b")
+
+        expect(replaceOne('price', 'price', '$$')).toBe('$$')
+        expect(replaceOne('a_b', '_', '$&')).toBe('a$&b')
+        expect(replaceOne('xYx', 'x', '($&)')).toBe('($&)Yx')
+    })
+
     test('error handling', async () => {
         const globals = { properties: { foo: 'bar' } }
         const options = { globals }

--- a/common/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/common/hogvm/typescript/src/__tests__/execute.test.ts
@@ -144,6 +144,32 @@ describe('hogvm execute', () => {
         }
     })
 
+    test('replaceOne/replaceAll treat the replacement literally', () => {
+        const options = { globals: {} }
+        // Use versioned bytecode so arguments are passed in source order.
+        const replaceAll = (s: string, from: string, to: string) =>
+            execSync(['_H', 1, op.STRING, s, op.STRING, from, op.STRING, to, op.CALL_GLOBAL, 'replaceAll', 3], options)
+        const replaceOne = (s: string, from: string, to: string) =>
+            execSync(['_H', 1, op.STRING, s, op.STRING, from, op.STRING, to, op.CALL_GLOBAL, 'replaceOne', 3], options)
+
+        // Ordinary replacements are unaffected.
+        expect(replaceAll('hello world', 'l', 'L')).toBe('heLLo worLd')
+        expect(replaceOne('hello world', 'l', 'L')).toBe('heLlo world')
+
+        // Dollar sequences in the replacement must not be interpreted as
+        // JavaScript special patterns ($$, $&, $`, $'). This matches the Python
+        // interpreter and ClickHouse's replaceOne/replaceAll.
+        expect(replaceAll('price', 'price', '$$')).toBe('$$')
+        expect(replaceAll('a_b', '_', '$&')).toBe('a$&b')
+        expect(replaceAll('xYx', 'x', '($&)')).toBe('($&)Y($&)')
+        expect(replaceAll('a-b', '-', '$`')).toBe('a$`b')
+        expect(replaceAll('a-b', '-', "$'")).toBe("a$'b")
+
+        expect(replaceOne('price', 'price', '$$')).toBe('$$')
+        expect(replaceOne('a_b', '_', '$&')).toBe('a$&b')
+        expect(replaceOne('xYx', 'x', '($&)')).toBe('($&)Yx')
+    })
+
     test('error handling', async () => {
         const globals = { properties: { foo: 'bar' } }
         const options = { globals }

--- a/common/hogvm/typescript/src/stl/stl.ts
+++ b/common/hogvm/typescript/src/stl/stl.ts
@@ -970,7 +970,10 @@ export const STL: Record<string, STLFunction> = {
     },
     replaceOne: {
         fn: (args) => {
-            return args[0].replace(args[1], args[2])
+            // Use a replacer function so the replacement is treated literally.
+            // Passing a plain string lets JS interpret $$, $&, $`, $' as special
+            // patterns, which diverges from the Python VM and ClickHouse.
+            return args[0].replace(args[1], () => args[2])
         },
         description: 'Replaces first occurrence of a substring',
         example: 'replaceOne($1, $2, $3)',
@@ -979,7 +982,8 @@ export const STL: Record<string, STLFunction> = {
     },
     replaceAll: {
         fn: (args) => {
-            return args[0].replaceAll(args[1], args[2])
+            // Replacer function keeps the replacement literal (see replaceOne).
+            return args[0].replaceAll(args[1], () => args[2])
         },
         description: 'Replaces all occurrences of a substring',
         example: 'replaceAll($1, $2, $3)',

--- a/posthog/hogql/compiler/javascript_stl.py
+++ b/posthog/hogql/compiler/javascript_stl.py
@@ -231,11 +231,11 @@ STL_FUNCTIONS: dict[str, list[str | list[str]]] = {
         [],
     ],
     "replaceOne": [
-        "function replaceOne (str, searchValue, replaceValue) { return str.replace(searchValue, replaceValue) }",
+        "function replaceOne (str, searchValue, replaceValue) { return str.replace(searchValue, () => replaceValue) }",
         [],
     ],
     "replaceAll": [
-        "function replaceAll (str, searchValue, replaceValue) { return str.replaceAll(searchValue, replaceValue) }",
+        "function replaceAll (str, searchValue, replaceValue) { return str.replaceAll(searchValue, () => replaceValue) }",
         [],
     ],
     "position": [


### PR DESCRIPTION
## Problem

`replaceOne` / `replaceAll` in the TypeScript HogVM (`common/hogvm/typescript/src/stl/stl.ts`) and the Hog→JS compiler (`posthog/hogql/compiler/javascript_stl.py`) pass the replacement to JS `String.replace` / `.replaceAll` as a plain string. JS then interprets `$$`, `$&`, `` $` ``, `$'` as **special replacement patterns**, so the result diverges from the Python VM, the Rust VM, and ClickHouse — all of which treat the replacement literally.

The same Hog program returns different output depending on the runtime:

- `replaceAll('price', 'price', '$$')` → `'$'` on TS (dollar silently halved), `'$$'` on Python / Rust / ClickHouse
- `replaceAll('a_b', '_', '$&')` → `'a_b'` on TS, `'a$&b'` correct

The TS VM runs in plugin-server (production ingestion) while the Python VM backs previews/tests, so a hog-function transformation can **preview correctly and run wrong** — a silent data-integrity divergence, reachable via ordinary currency/price strings.

## Changes

- `stl.ts`: `replaceOne` / `replaceAll` now use a replacer function (`() => replacement`), whose return value is never `$`-processed, so the replacement is always literal.
- `javascript_stl.py`: same fix in the two generated function bodies; regenerated the committed `stl.js` / `hogqlx.js` snapshots to match.
- Added a regression test through the real bytecode path covering `$$`, `$&`, `` $` ``, `$'` plus an ordinary-replacement guard. The full HogVM TS suite passes (97/97), and the output matches the Python VM byte-for-byte.

## 🤖 Agent context

Investigated with the help of an AI coding agent (Claude Code). I verified the cross-runtime divergence and the fix myself against the real HogVM code (Python vs TS vs Rust), ran the HogVM TypeScript jest suite (97/97), and confirmed red→green on the new regression test through the real bytecode path. I understand and own this change.
