### PR TITLE
fix(postgres): reconnect on transient WAL peek connection drops in CDC

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -23,6 +23,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.c
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import (
     _connect_to_postgres,
     _connect_with_dropped_retry,
+    _is_connection_dropped_error,
+    _safe_close_connection,
     get_primary_key_columns,
 )
 
@@ -109,7 +111,15 @@ class PgCDCStreamReader:
         # read paths and absorb those drops in-process instead of failing the whole
         # extraction activity; permanent errors (auth, SSL-required) are re-raised
         # immediately by the helper.
-        self._conn = _connect_with_dropped_retry(
+        self._conn = self._open_streaming_connection()
+
+    def _open_streaming_connection(self) -> psycopg.Connection:
+        """Open a streaming connection to the source through the current tunnel endpoint.
+
+        Shared by the initial ``connect()`` and the in-process reconnect ``read_changes`` runs
+        after a transient mid-peek drop, so both use identical server-side timeouts.
+        """
+        return _connect_with_dropped_retry(
             lambda: _connect_to_postgres(
                 host=self._effective_host,
                 port=self._effective_port,
@@ -204,6 +214,21 @@ class PgCDCStreamReader:
                 self._last_rows_consumed = 0
                 logger.warning("slot_read_busy_retry", slot_name=self._params.slot_name, attempt=attempt + 1)
                 time.sleep(0.5 * 2**attempt)
+            except psycopg.OperationalError as e:
+                # A transient drop on the peek fetch (pooler/firewall idle cull, failover, network
+                # blip — e.g. "consuming input failed: SSL SYSCALL error: EOF detected") is the same
+                # class connect()/confirm_position() already absorb in-process. Reconnect and
+                # re-peek: the peek is non-consuming, so re-reading from the slot's last confirmed
+                # position is safe. Only retry before the first row lands — once events have been
+                # yielded the caller has buffered them, so a re-peek would duplicate; let it surface
+                # and Temporal replays the whole run from the last confirmed LSN.
+                if slot_acquired or not _is_connection_dropped_error(e) or attempt == _SLOT_READ_MAX_ATTEMPTS - 1:
+                    raise
+                _safe_close_connection(conn)
+                self._last_rows_consumed = 0
+                logger.warning("slot_read_dropped_retry", slot_name=self._params.slot_name, attempt=attempt + 1)
+                time.sleep(0.5 * 2**attempt)
+                self._conn = conn = self._open_streaming_connection()
 
     def confirm_position(self, position: str) -> None:
         """Advance the replication slot to the given LSN.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -236,6 +236,85 @@ class TestPgCDCStreamReaderReadChangesSlotInUse:
         sleep.assert_not_called()
 
 
+class TestPgCDCStreamReaderReadChangesConnectionDropped:
+    def _reader_reading(self, params, iter_side_effect):
+        reader = PgCDCStreamReader(params)
+        fake_cursor = mock.MagicMock()
+        fake_cursor.__iter__.side_effect = iter_side_effect
+        reader._conn = mock.MagicMock()
+        reader._conn.cursor.return_value.__enter__.return_value = fake_cursor
+        reader._decoder = mock.MagicMock()
+        reader._decoder.decode_message.return_value = []
+        return reader, fake_cursor
+
+    def test_read_changes_reconnects_after_mid_peek_drop_before_first_row(self, params):
+        # A transient drop on the peek fetch before any row is yielded reconnects and re-peeks
+        # instead of failing the whole extraction — the peek is non-consuming, so re-reading is safe.
+        rows = [("0/1", 1, b"a"), ("0/2", 1, b"b")]
+        reader, fake_cursor = self._reader_reading(
+            params,
+            [
+                psycopg.OperationalError("consuming input failed: SSL SYSCALL error: EOF detected"),
+                iter(rows),
+            ],
+        )
+        new_conn = mock.MagicMock()
+        new_conn.cursor.return_value.__enter__.return_value = fake_cursor
+        reconnect = mock.MagicMock(return_value=new_conn)
+        with (
+            patch.object(reader, "_open_streaming_connection", reconnect),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+            ),
+        ):
+            list(reader.read_changes(upto_nchanges=10))
+
+        reconnect.assert_called_once()
+        assert reader._conn is new_conn
+        assert reader.last_rows_consumed == len(rows)
+
+    def test_read_changes_does_not_retry_drop_after_row_yielded(self, params):
+        # Once a row has been yielded the caller has buffered events, so a re-peek would duplicate
+        # them — the drop must surface and let Temporal replay the whole run from the last confirmed
+        # LSN rather than silently reconnecting mid-stream.
+        def rows_then_drop():
+            yield ("0/1", 1, b"a")
+            raise psycopg.OperationalError("consuming input failed: SSL SYSCALL error: EOF detected")
+
+        reader, _ = self._reader_reading(params, [rows_then_drop()])
+        reconnect = mock.MagicMock()
+        with (
+            patch.object(reader, "_open_streaming_connection", reconnect),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+            ),
+        ):
+            with pytest.raises(psycopg.OperationalError):
+                list(reader.read_changes(upto_nchanges=10))
+
+        reconnect.assert_not_called()
+
+    def test_read_changes_does_not_retry_non_dropped_operational_error(self, params):
+        # A non-drop OperationalError (not a recognized transient connection loss) is re-raised
+        # immediately, never reconnected, so a real error isn't masked as a transient blip.
+        reader, fake_cursor = self._reader_reading(
+            params,
+            psycopg.OperationalError("some unexpected operational failure"),
+        )
+        reconnect = mock.MagicMock()
+        with (
+            patch.object(reader, "_open_streaming_connection", reconnect),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader.time.sleep"
+            ),
+        ):
+            with pytest.raises(psycopg.OperationalError):
+                list(reader.read_changes(upto_nchanges=10))
+
+        assert fake_cursor.__iter__.call_count == 1
+        reconnect.assert_not_called()
+
+
 class TestPgCDCStreamReaderConfirmPosition:
     def test_confirm_position_retries_transient_dropped_connection(self, params):
         good_conn = mock.MagicMock()


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `OperationalError: consuming input failed: SSL SYSCALL error: EOF detected` originating in the Postgres CDC stream reader ([issue](https://us.posthog.com/project/2/error_tracking/019f7507-88c9-7623-8bf6-af707bf8035f)).

This is a transient mid-stream connection drop — a pooler or firewall idle cull, a failover, or a network blip severing the TLS connection while reading WAL changes. It is not a user or config error, so it should stay retryable.

The reader already knows this class of drop is transient: the exact substrings (`consuming input failed`, `ssl syscall error`) live in `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, and both `connect()` and `confirm_position()` absorb them in-process via `_connect_with_dropped_retry`. The one path that didn't was the mid-stream WAL read in `read_changes()` — a drop there raised straight out of the extraction activity. Temporal does retry the whole run correctly (the peek is non-consuming), but the drop also lands in error tracking as noise on every occurrence.

## Changes

Reconnect and re-peek in-process when the peek fetch hits a recognized transient drop, mirroring the existing slot-in-use retry that already sits in the same loop.

The retry is deliberately narrow, gated on the same safety boundary as the slot-in-use retry:

- Only **before the first row is yielded** (`slot_acquired` is `False`). Once events have been handed to the caller they're buffered, and a re-peek would re-yield them — so past that point the drop propagates and Temporal replays the whole run from the last confirmed LSN.
- Only for drops `_is_connection_dropped_error` recognizes. Any other `OperationalError` (including slot invalidation, which is `ObjectNotInPrerequisiteState`) re-raises immediately, so real failures aren't masked.

The peek is non-consuming, so re-reading from the slot's last confirmed position is safe. I pulled the streaming-connection open into `_open_streaming_connection()` so the initial connect and the reconnect share identical server-side timeouts.

I ruled out `NonRetryableErrors`: this is a transient infrastructure drop, not a credentials/config/upstream-permanent condition, so it must keep retrying.

## How did you test this code?

Unit tests in `test_stream_reader.py` (all pass locally; ran `pytest` on the file and the CDC package). Three new cases, each guarding a distinct regression no existing test covered:

- `test_read_changes_reconnects_after_mid_peek_drop_before_first_row` — the fix itself: a drop on the first fetch reconnects and re-peeks instead of failing the run.
- `test_read_changes_does_not_retry_drop_after_row_yielded` — the correctness boundary: a drop after a row was yielded must **not** reconnect (would duplicate buffered events), it re-raises.
- `test_read_changes_does_not_retry_non_dropped_operational_error` — a non-drop `OperationalError` re-raises immediately, so a real error isn't swallowed as a transient blip.

I (Claude) could not exercise a live Postgres CDC stream in this environment, so testing is the automated unit coverage above plus a targeted `mypy` run on the changed module.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue. I (Claude) confirmed the failure originates in `cdc/stream_reader.py`'s WAL peek, traced the call path from `_read_wal_loop` → `read_changes`, and confirmed the drop is already classified retryable (`CONNECTION_FAILED`) in the CDC error taxonomy.

Decision: not a `NonRetryableError` (transient), and a fixable fragility rather than a no-op — the mid-stream read was the one connection path in the reader without graceful in-process drop handling. I considered concluding "no change needed" since Temporal already recovers, but chose the scoped reconnect to match the reader's own established pattern (`connect()`/`confirm_position()`) and stop the error-tracking noise. I rejected any broader retry (mid-stream, after rows are yielded) as unsafe because it would duplicate buffered events. The MySQL sibling fix in #72118 reopens a dropped streaming connection for the same class of transient drop.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
