### PR TITLE
fix(data-imports): treat non-JSON REST responses as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -30,6 +30,25 @@ class RESTClientRetryableError(Exception):
         self.retry_after = retry_after
 
 
+class RESTClientNonRetryableError(Exception):
+    """A response that retrying can never turn into usable data.
+
+    Not a subclass of RESTClientRetryableError so the tenacity retry — which only
+    reissues RESTClientRetryableError — stops immediately instead of re-fetching a
+    deterministic failure.
+    """
+
+
+# Bytes that can legally begin a JSON document: an object/array, a string, a
+# number, or one of the literals true/false/null.
+_JSON_START_BYTES = frozenset(b'{["-tfn0123456789')
+
+
+def _looks_like_json(content: bytes) -> bool:
+    stripped = content.lstrip()
+    return bool(stripped) and stripped[0] in _JSON_START_BYTES
+
+
 # Upper bound on how long we'll honor a server-provided retry delay, so a
 # misreported header can't stall a worker for an unbounded amount of time.
 MAX_RETRY_AFTER_SECONDS = 300.0
@@ -215,10 +234,17 @@ class RESTClient:
             # An empty body on an otherwise-successful response is a complete "no data"
             # answer (e.g. an endpoint with nothing to return), not a truncated page —
             # retrying can't conjure rows, so treat it as an empty page and let the
-            # paginator stop. A non-empty body that fails to parse is a partial/truncated
-            # read, which stays retryable.
+            # paginator stop.
             if not response.content or not response.content.strip():
                 return response, None
+            # A body that doesn't even begin with a JSON value is not a truncated page:
+            # the endpoint returned non-JSON content (an HTML or plain-text error page, a
+            # login redirect) on an otherwise-successful response. Re-fetching returns the
+            # same non-JSON body, so fail fast and non-retryably instead of burning the
+            # retry budget. A body that starts as JSON but fails to parse is a partial /
+            # truncated read, which stays retryable.
+            if not _looks_like_json(response.content):
+                raise RESTClientNonRetryableError(f"Non-JSON response from {response.url}") from e
             raise RESTClientRetryableError(f"Malformed JSON response from {response.url}: {e}") from e
 
         return response, body

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 from requests import Request, Response, Session
 from requests.auth import AuthBase
@@ -47,6 +48,22 @@ _JSON_START_BYTES = frozenset(b'{["-tfn0123456789')
 def _looks_like_json(content: bytes) -> bool:
     stripped = content.lstrip()
     return bool(stripped) and stripped[0] in _JSON_START_BYTES
+
+
+def _safe_url(url: str) -> str:
+    """Scheme, host, and path only — never the query string, fragment, or userinfo.
+
+    An error message built from a URL can flow into non-retryable-error analytics
+    and error tracking, where tracked-session value redaction doesn't reach. An
+    ``api_key`` auth with ``location: "query"`` carries the secret in the query
+    string, so keep only the parts that are safe to surface."""
+    parts = urlsplit(url)
+    if not parts.scheme:
+        return url
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return f"{parts.scheme}://{host}{parts.path}"
 
 
 # Upper bound on how long we'll honor a server-provided retry delay, so a
@@ -215,7 +232,7 @@ class RESTClient:
 
         if response.status_code == 429 or response.status_code >= 500:
             raise RESTClientRetryableError(
-                f"HTTP {response.status_code} for {response.url}",
+                f"HTTP {response.status_code} for {_safe_url(response.url)}",
                 retry_after=_parse_retry_after(response),
             )
 
@@ -244,8 +261,8 @@ class RESTClient:
             # retry budget. A body that starts as JSON but fails to parse is a partial /
             # truncated read, which stays retryable.
             if not _looks_like_json(response.content):
-                raise RESTClientNonRetryableError(f"Non-JSON response from {response.url}") from e
-            raise RESTClientRetryableError(f"Malformed JSON response from {response.url}: {e}") from e
+                raise RESTClientNonRetryableError(f"Non-JSON response from {_safe_url(response.url)}") from e
+            raise RESTClientRetryableError(f"Malformed JSON response from {_safe_url(response.url)}: {e}") from e
 
         return response, body
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -384,6 +384,30 @@ class TestRESTClient:
         assert mock_session.send.call_count == 1
         mock_sleep.assert_not_called()
 
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_non_json_error_message_omits_query_string_secret(self, MockSession, mock_sleep) -> None:
+        # An api_key auth with location="query" puts the secret in the URL. This message flows
+        # into non-retryable-error analytics where session-value redaction doesn't reach, so it
+        # must carry only scheme/host/path — never the query string that holds the key.
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        resp = _make_non_json_response(b"<html>nope</html>")
+        resp.url = "https://api.example.com/leads?api_key=super-secret-value&page=1"
+        mock_session.send.return_value = resp
+
+        client = RESTClient(base_url="https://api.example.com")
+        with pytest.raises(RESTClientNonRetryableError) as ctx:
+            list(client.paginate(path="/leads", paginator=SinglePagePaginator()))
+
+        message = str(ctx.value)
+        assert "super-secret-value" not in message
+        assert "api_key" not in message
+        assert "https://api.example.com/leads" in message
+
     @pytest.mark.parametrize("content", [b"", b"   \n\t"], ids=["empty", "whitespace_only"])
     @patch("tenacity.nap.time.sleep")
     @patch(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
     MAX_RETRY_AFTER_SECONDS,
     RESTClient,
+    RESTClientNonRetryableError,
     RESTClientRetryableError,
     _parse_retry_after,
 )
@@ -50,6 +51,18 @@ def _make_truncated_response(status_code: int = 200) -> Response:
     resp = Response()
     resp.status_code = status_code
     resp._content = b'{"results": [{"id": 1, "name": "unterminated'
+    resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://api.example.com/items"
+    return resp
+
+
+def _make_non_json_response(content: bytes, status_code: int = 200) -> Response:
+    # A successful response whose body never begins as JSON — an HTML/plain-text error
+    # page or login redirect returned with a 2xx. `response.json()` raises "Expecting
+    # value: line 1 column 1 (char 0)", identical to a truncated body cut off at the start.
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = content
     resp.headers["Content-Type"] = "application/json"
     resp.url = "https://api.example.com/items"
     return resp
@@ -342,6 +355,34 @@ class TestRESTClient:
             list(client.paginate(path="/items", paginator=SinglePagePaginator()))
 
         assert mock_session.send.call_count == 5
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(b"<!DOCTYPE html><html><body>Service unavailable</body></html>", id="html"),
+            pytest.param(b"  <html>login required</html>", id="html_leading_whitespace"),
+            pytest.param(b"Not Found", id="plain_text"),
+        ],
+    )
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_non_json_response_body_is_non_retryable(self, MockSession, mock_sleep, content) -> None:
+        # A 2xx whose body never begins as JSON is a deterministic non-JSON response, not a
+        # truncated page: fail fast and non-retryably rather than re-fetching the same body
+        # to the retry cap (contrast the truncated-JSON case, which stays retryable).
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_non_json_response(content)
+
+        client = RESTClient(base_url="https://api.example.com")
+        with pytest.raises(RESTClientNonRetryableError, match="Non-JSON response from"):
+            list(client.paginate(path="/items", paginator=SinglePagePaginator()))
+
+        assert mock_session.send.call_count == 1
+        mock_sleep.assert_not_called()
 
     @pytest.mark.parametrize("content", [b"", b"   \n\t"], ids=["empty", "whitespace_only"])
     @patch("tenacity.nap.time.sleep")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -777,6 +777,12 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             "invalid_client": "The OAuth2 token endpoint rejected the client credentials (invalid_client). Check the configured client_id, client secret, and token URL.",
             "invalid_grant": "The OAuth2 token endpoint rejected the grant (invalid_grant) — a refresh token may have expired or been revoked. Re-enter the OAuth2 credentials.",
             OAUTH2_PERMANENT_ERROR_MARKER: "The OAuth2 token endpoint rejected the request and the configuration must change before the sync can succeed. Check the configured OAuth2 credentials, token URL, grant type, and scopes.",
+            # The endpoint returned non-JSON content (an HTML or plain-text error page, a
+            # login redirect) on an otherwise-successful response. The request shape is
+            # manifest-driven and deterministic, so retrying re-fetches the same body —
+            # stop and point at the config the user can change. Matches the stable prefix
+            # RESTClientNonRetryableError uses, not the variable URL that follows.
+            "Non-JSON response from": "The upstream API returned a non-JSON response (for example an HTML or plain-text error page) instead of data. Check that the resource's URL and path in the manifest point at a JSON API endpoint and that any required authentication is configured, then try again.",
         }
 
     def _assemble_manifest(self, config: CustomSourceConfig) -> dict[str, Any]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -30,6 +30,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     OAuth2AuthRequestError,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.config_setup import create_auth
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientNonRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.custom.source import (
     MAX_MANIFEST_RESOURCES,
     PREVIEW_MAX_FANOUT_PARENTS,
@@ -1749,6 +1752,16 @@ class TestCustomSourceNonRetryableErrors(SimpleTestCase):
 
         non_retryable = CustomSource().get_non_retryable_errors()
         assert any(key in str(ctx.exception) for key in non_retryable)
+
+    def test_non_json_response_message_is_classified_non_retryable(self):
+        # The REST client raises RESTClientNonRetryableError when a configured endpoint
+        # returns non-JSON (an HTML/plain-text error page) on a 2xx. Build the real error the
+        # client raises so this breaks if its stable prefix drifts from the classifier's key.
+        # The URL is a placeholder, never a real customer host.
+        error = RESTClientNonRetryableError("Non-JSON response from https://api.example.com/leads")
+
+        non_retryable = CustomSource().get_non_retryable_errors()
+        assert any(key in str(error) for key in non_retryable)
 
     @parameterized.expand(["invalid_client", "invalid_grant"])
     def test_oauth2_permanent_errors_are_classified_non_retryable(self, error_code):


### PR DESCRIPTION
## Problem

Error tracking flagged a captured `RESTClientRetryableError` from the data-warehouse import pipeline: `Malformed JSON response from <endpoint>: Expecting value: line 1 column 1 (char 0)`. It originates in the shared REST client (`rest_source/rest_client.py`, `_send_request`) that most API sources and every custom REST source are built on, so it isn't tied to one source.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019f7529-bdbe-7473-aded-97cba255281b)

The client already parses the response body inside its retry loop so a truncated page gets reissued like a 429/5xx. The catch: it treated *every* non-empty body that failed to parse as a truncated page. A parse failure at the very first character (`char 0`) isn't a truncation - it means the endpoint returned non-JSON content (an HTML or plain-text error page, a login redirect) on an otherwise-successful 2xx response. A truncated JSON body starts with `{` or `[` and fails deeper in, never at position 0.

So a deterministically non-JSON endpoint got retried to the cap at the HTTP layer, then re-raised as a retryable error that Temporal retried again - wasted work, and a confusing "malformed JSON" message that reads like our bug rather than the upstream response it is.

## Changes

The root cause is upstream (the endpoint returns non-JSON), but the fix has to live in shared code: by the time the error reaches the per-source non-retryable classifier, a truncation and a non-JSON body carry the identical `Malformed JSON response from ...` message, so a substring match alone can't tell them apart without also swallowing genuinely retryable truncations. Only `_send_request` has the response body to distinguish them.

- In `_send_request`, split the two cases. A body that never begins with a JSON value (`{`, `[`, `"`, a number, or a literal) raises a new `RESTClientNonRetryableError` - not a subclass of `RESTClientRetryableError`, so the tenacity retry stops immediately. A body that starts as JSON but fails to parse stays a `RESTClientRetryableError` (still retried).
- Register the stable `Non-JSON response from` prefix in the custom source's `get_non_retryable_errors()` with an actionable message, so the job stops after minimal retries and tells the user to point the manifest at a JSON endpoint and check auth, instead of exhausting the retry budget.

Empty/whitespace bodies keep their existing "yield an empty page" behavior, and truncated-JSON pages stay retryable - both are covered by existing tests that still pass.

## How did you test this code?

Automated only (I'm Claude; I did not run a live sync).

- `test_non_json_response_body_is_non_retryable` (parameterized over HTML, HTML-with-leading-whitespace, and plain text) in `test_rest_client.py`: asserts a non-JSON 2xx raises `RESTClientNonRetryableError` and is sent exactly once with no sleep. Catches a regression where a non-JSON response is retried again. No existing test covered this - the closest asserts a *truncated* body stays retryable, which this must not change.
- `test_non_json_response_message_is_classified_non_retryable` in `test_custom_source.py`: builds the real `RESTClientNonRetryableError` and asserts the custom source's classifier matches it. Guards the message-prefix ↔ dict-key contract so it breaks if either drifts.
- Ran the full `test_rest_client.py` suite and the custom source `TestCustomSourceNonRetryableErrors` class - all pass. Ruff lint and format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. Pulled the full stack trace via the PostHog error-tracking tools, traced the raise site to `_send_request`, and confirmed the two-layer retry (tenacity in the client, then Temporal via `non_retryable_error_types`).

Decision: this is a fragile-code fix, not purely a non-retryable-list addition. I rejected matching `Malformed JSON response` in `get_non_retryable_errors()` alone because it would also mark genuinely retryable truncated reads as non-retryable - the client is the only layer that can tell "not JSON at all" from "truncated JSON." The distinction keys off whether the body begins with a JSON value rather than the exception's internal `pos`, so it also handles non-JSON bodies with leading whitespace and doesn't depend on json vs simplejson internals.

Invoked `/writing-tests` before adding tests. Checked open PRs (including the maintainer's) for duplicates - the nearest, non-JSON LLM enrichment replies and a Postgres setup-auth capture fix, are different code paths.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
