### PR TITLE
fix(data-warehouse): surface file-storage connectors when searching a file format

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
@@ -46,6 +46,11 @@ const MANUAL_SOURCE_KEYWORDS: Record<string, string[]> = {
     azure: ['azure', 'microsoft azure', 'azure blob', 'blob storage'],
 }
 
+// Every self-managed connector links files from a bucket, so a user searching for a file
+// format ("csv", "parquet") should land on them rather than an empty result that pushes
+// them to request a source we already support. Matches the formats the link form accepts.
+const FILE_STORAGE_FORMAT_KEYWORDS = ['csv', 'parquet', 'delta', 'file', 'files', 'flat file']
+
 // "Request a data warehouse source" survey. We render our own modal and submit the answer
 // directly as a `survey sent` event rather than using the posthog-js survey popover.
 export const SOURCE_REQUEST_SURVEY_ID = '0190ff15-5032-0000-722a-e13933c140ac'
@@ -1984,7 +1989,7 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                         label: source.name,
                         iconType: source.type,
                         category: MANUAL_SOURCE_CATEGORY,
-                        keywords: MANUAL_SOURCE_KEYWORDS[source.type] ?? [],
+                        keywords: [...(MANUAL_SOURCE_KEYWORDS[source.type] ?? []), ...FILE_STORAGE_FORMAT_KEYWORDS],
                         status: 'stable',
                         url: urls.dataWarehouseSourceNew(source.type),
                         selfManaged: true,

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
@@ -71,6 +71,16 @@ describe('sourceCatalogLogic', () => {
         expect(names.indexOf('Zebra')).toBeLessThan(names.indexOf('Apple'))
     })
 
+    it('surfaces self-managed file-storage connectors when searching for a file format', () => {
+        const logic = sourceCatalogLogic()
+        logic.actions.setSearch('csv')
+
+        // CSV files are imported via the self-managed bucket connectors, so a "csv" search must
+        // find them instead of dead-ending on "no sources match".
+        const names = logic.values.filteredItems.map((item) => item.name)
+        expect(names).toContain('aws')
+    })
+
     it('clears the request text when the modal is closed', () => {
         const logic = sourceCatalogLogic()
         logic.actions.setSearch('Podium')


### PR DESCRIPTION
## Problem

In the data-warehouse new-source catalog, a user who searches for a file format ("csv", "parquet") gets zero matches and is nudged to request a source. But PostHog already supports importing those files: CSV, Parquet, and Delta all come in through the self-managed bucket connectors (S3, GCS, Cloudflare R2, Azure). The capability exists, it just isn't discoverable by the name people actually type.

Session scans of real onboarding runs showed users searching a format name, finding nothing, and submitting a "request a source" for something we can already do.

## Changes

The self-managed connector tiles only carried provider-name keywords (`amazon`, `aws`, `gcs`, `r2`, ...). This adds the file-format terms the link form accepts (`csv`, `parquet`, `delta`, plus generic `file`/`files`/`flat file`) as search keywords on every self-managed connector, so a format search surfaces them.

No behavior change beyond search discoverability - the connectors, categories, and link flow are untouched.

## How did you test this code?

Added a unit test in `sourceCatalogLogic.test.ts` asserting that searching "csv" surfaces the self-managed connectors instead of returning nothing. I (Claude) could not run the frontend jest suite in this environment (no `node_modules` installed), so I verified the logic by inspection: the Fuse index already searches the `keywords` key at threshold 0.3, and an exact keyword match scores 0, well within range.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) while synthesizing friction themes from Replay Vision scans of the data-warehouse onboarding flow. One recurring theme: users search connectors by an alternate name or file format and can't find a capability we already ship. This is the narrow, self-contained slice of that theme - the search-keyword gap for self-managed file storage. Broader themes (credential-error clarity, IP allow-list hints) were left as recommendations rather than PRs, since the connector-error area is under active hand-tuning by the maintainer.

No skills were required for this change (frontend kea logic + test only).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
