### PR TITLE
fix(mixpanel): treat retryable rate-limit errors as recoverable noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/README.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/README.md
@@ -228,3 +228,16 @@ Common errors to handle:
 - **401 Unauthorized**: Invalid or expired API keys
 - **403 Forbidden**: Missing required scopes or permissions
 - **Invalid/Expired tokens**: OAuth tokens that need re-authentication
+
+## Retryable Errors
+
+Sources that retry transient failures internally (rate limits, transient 5xx) can re-raise once their own retries are exhausted.
+Temporal then retries the whole activity, so the failure is self-recovering — but by default it is logged as an exception and shows up as error-tracking noise.
+
+Override `get_retryable_errors()` to return a set of partial error messages the source already retries.
+Matching errors are logged at `warning` instead of `exception` before being re-raised for Temporal's retry:
+
+```python
+def get_retryable_errors(self) -> set[str]:
+    return {"Example API error (retryable)"}
+```

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
@@ -196,6 +196,19 @@ class _BaseSource(ABC, Generic[ConfigType]):
 
         return {}
 
+    def get_retryable_errors(self) -> set[str]:
+        """Returns partial error messages the source already retries internally.
+
+        A source that exhausts its own retries (rate limits, transient 5xx) and re-raises still
+        lets Temporal retry the whole activity, so the failure is transient and self-recovering.
+        Matching errors are logged at `warning` rather than `exception`, keeping benign,
+        recoverable failures out of error tracking as noise.
+
+        Each entry is a partial error message matched against `str(error)`.
+        """
+
+        return set()
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         """Curated, documentation-sourced descriptions for this source's well-known tables/endpoints.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/source.py
@@ -164,6 +164,12 @@ Authenticate with a [Mixpanel Service Account](https://developer.mixpanel.com/re
             ),
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A 429 (rate limit) or 5xx is retried internally honoring Retry-After; if those retries
+        # still exhaust, the failure is transient and self-recovering, so let Temporal retry the
+        # activity without surfacing it as tracked exception noise.
+        return {"Mixpanel API error (retryable)"}
+
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[MixpanelResumeConfig]:
         return ResumableSourceManager[MixpanelResumeConfig](inputs, MixpanelResumeConfig)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
@@ -27,6 +27,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mixpanel.m
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.mixpanel.settings import MIXPANEL_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.mixpanel.source import MixpanelSource
 
 LOGGER = structlog.get_logger()
 
@@ -171,6 +172,18 @@ class TestCheckResponse:
         with pytest.raises(MixpanelRetryableError) as exc_info:
             _check_response(response, "http://x", LOGGER)  # type: ignore[arg-type]
         assert exc_info.value.retry_after is None
+
+
+class TestRetryableErrors:
+    def test_retryable_marker_matches_raised_message(self) -> None:
+        # The source keeps a self-recovering 429/5xx out of error tracking by matching
+        # get_retryable_errors() against what _check_response raises; this guards the two in sync,
+        # so a change to either the raised message or the marker can't silently revive the noise.
+        with pytest.raises(MixpanelRetryableError) as exc_info:
+            _check_response(FakeResponse(status_code=429), "https://data.mixpanel.com/api/2.0/export", LOGGER)  # type: ignore[arg-type]
+        markers = MixpanelSource().get_retryable_errors()
+        assert markers
+        assert any(marker in str(exc_info.value) for marker in markers)
 
 
 class TestParseRetryAfter:

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -314,21 +314,31 @@ async def _handle_import_error(
     Errors the source classifies as non-retryable (bad credentials, a deleted or
     misconfigured remote — e.g. a MongoDB ``mongodb+srv://`` hostname whose DNS record no
     longer resolves) are handed to ``handle_non_retryable_error``, which stops the job after
-    a few attempts instead of retrying up to the activity's maximum. Everything else is
-    re-raised so Temporal retries it as usual.
+    a few attempts instead of retrying up to the activity's maximum.
+
+    Errors the source classifies as retryable (rate limits, transient 5xx) reach us only after
+    the source's own retries are exhausted. Temporal retries the whole activity and the error is
+    transient and self-recovering, so we log at ``warning`` rather than ``exception`` to keep
+    this benign, recoverable failure out of error tracking.
+
+    Everything else is logged as an exception and re-raised so Temporal retries it as usual.
     """
     source_cls = SourceRegistry.get_source(job_inputs.job_type)
-    non_retryable_errors = source_cls.get_non_retryable_errors()
     error_msg = str(error)
-    is_non_retryable_error = any(
-        non_retryable_error in error_msg for non_retryable_error in non_retryable_errors.keys()
-    )
-    if is_non_retryable_error:
+
+    non_retryable_errors = source_cls.get_non_retryable_errors()
+    if any(match in error_msg for match in non_retryable_errors):
         await handle_non_retryable_error(job_inputs, error_msg, logger, error)
-    else:
-        await logger.aexception(error_msg)
-        await logger.adebug("Error encountered during import_data_activity - re-raising")
+
+    retryable_errors = source_cls.get_retryable_errors()
+    if any(match in error_msg for match in retryable_errors):
+        await logger.awarning(error_msg)
+        await logger.adebug("Source-classified retryable error - re-raising for Temporal retry")
         raise error
+
+    await logger.aexception(error_msg)
+    await logger.adebug("Error encountered during import_data_activity - re-raising")
+    raise error
 
 
 async def _run(

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -130,6 +130,29 @@ async def test_unparseable_config_routes_through_handler():
     source.source_for_pipeline.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_source_classified_retryable_error_logged_as_warning_not_exception():
+    # A rate-limit / transient error the source retries internally reaches _handle_import_error only
+    # once those retries exhaust. Temporal retries the whole activity, so it must be logged at
+    # warning (not aexception, which mints error-tracking noise) while still being re-raised.
+    error = Exception("Mixpanel API error (retryable): status=429, url=https://data.mixpanel.com/api/2.0/export")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = {"Mixpanel API error (retryable)"}
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
+        with pytest.raises(Exception, match="retryable"):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    logger.awarning.assert_awaited_once()
+    logger.aexception.assert_not_awaited()
+
+
 def _incremental_schema(*, is_incremental: bool, lookback_seconds: int | None) -> mock.MagicMock:
     schema = mock.MagicMock()
     schema.should_use_incremental_field = True


### PR DESCRIPTION
## Problem

A Mixpanel data-warehouse import hit a `429` rate-limit that surfaced as a tracked error-tracking exception ([issue](https://us.posthog.com/project/2/error_tracking/019f75dd-ac77-77a3-9a72-47abc9979119)), even though the import recovered on its own.

```
MixpanelRetryableError: Mixpanel API error (retryable): status=429, url=<redacted>/api/2.0/export
```

The Mixpanel source raises `MixpanelRetryableError` on any `429`/`5xx` and retries internally, honoring `Retry-After` (capped). When those retries exhaust it re-raises so Temporal can retry the whole activity. But because the message wasn't classified anywhere, `_handle_import_error` logged it via `logger.aexception` first, minting an error-tracking issue for a transient, self-recovering failure. The import itself never permanently failed.

This is not a credentials/upstream problem (so it should not become non-retryable) and the recovery path is already correct. The only defect is the benign noise.

## Changes

- Add a `get_retryable_errors()` extension point on the base source, mirroring `get_non_retryable_errors()`. It returns partial error messages the source already retries internally.
- `_handle_import_error` now logs source-classified retryable errors at `warning` (not `exception`) before re-raising, so Temporal still retries but the recoverable failure stays out of error tracking.
- `MixpanelSource` classifies its `"Mixpanel API error (retryable)"` message via the new hook.
- Document the hook in the sources README.

> [!NOTE]
> This shares the same base-source/`_handle_import_error` mechanism proposed for Cloudflare in [#69537](https://github.com/PostHog/posthog/pull/69537) (still a draft). That PR only wires Cloudflare and does not fix Mixpanel. This PR is standalone so it lands on its own; if both merge, the shared hook and handler change are trivially reconcilable and only the per-source overrides differ.

## How did you test this code?

Automated tests (run locally via `uv run pytest`, all passing):

- `test_mixpanel.py::TestRetryableErrors::test_retryable_marker_matches_raised_message` — drives `_check_response` with a `429` and asserts the marker from `MixpanelSource().get_retryable_errors()` is a substring of the raised message. Catches the regression where either the raised message format or the marker drifts and silently revives the noise. No existing test tied classification to the raise site.
- `test_import_data_sync.py::test_source_classified_retryable_error_logged_as_warning_not_exception` — asserts `_handle_import_error` logs a source-classified retryable error at `warning`, not `aexception`, and still re-raises. Catches the regression where dropping the retryable branch turns a transient rate-limit back into a tracked exception. The retryable branch was previously untested.

Also ran the full `mixpanel/` and `workflow_activities/` suites (94 passed), plus `ruff check`, `ruff format --check`, and `mypy` on the changed modules.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while triaging the linked error-tracking issue. Invoked the `/writing-tests` skill to gate the added tests against the "what regression does this catch" bar, landing on two targeted tests (one tying the Mixpanel override to the actual raise site, one on the shared handler branch) rather than a full-activity round-trip.

Decisions: rejected adding the `429` to `get_non_retryable_errors()` — that would permanently fail syncs on transient rate limits, which is the opposite of what we want. Also considered concluding "no change needed" since recovery already works, but the error-tracking noise is a real, fixable defect. Chose a source-level `get_retryable_errors()` hook (matching the existing `get_non_retryable_errors()` pattern) over inline `"(retryable)"` string-matching in the handler, to keep classification with the source that owns it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
