### PR TITLE
fix(llm-gateway): use global fable profile in eu

### DIFF
--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -68,7 +68,7 @@ ANTHROPIC_TO_BEDROCK_MODEL_MAP: Final[dict[str, dict[str, str]]] = {
     },
     "claude-fable-5": {
         "us": "us.anthropic.claude-fable-5",
-        "eu": "eu.anthropic.claude-fable-5",
+        "eu": "global.anthropic.claude-fable-5",
     },
     "claude-sonnet-4-5": {
         "us": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -879,10 +879,17 @@ class TestModelMapping:
 
         assert map_to_bedrock_model("us.anthropic.claude-sonnet-4-6") == "us.anthropic.claude-sonnet-4-6"
 
-    def test_maps_to_eu_profile_for_eu_regions(self) -> None:
+    @pytest.mark.parametrize(
+        "anthropic_model,expected_bedrock_model",
+        [
+            pytest.param("claude-opus-4-6", "eu.anthropic.claude-opus-4-6-v1", id="opus_4_6"),
+            pytest.param("claude-fable-5", "global.anthropic.claude-fable-5", id="fable_5"),
+        ],
+    )
+    def test_maps_to_available_profile_for_eu_regions(self, anthropic_model: str, expected_bedrock_model: str) -> None:
         from llm_gateway.api.anthropic import map_to_bedrock_model
 
-        assert map_to_bedrock_model("claude-opus-4-6", region_name="eu-west-1") == "eu.anthropic.claude-opus-4-6-v1"
+        assert map_to_bedrock_model(anthropic_model, region_name="eu-west-1") == expected_bedrock_model
 
     def test_raises_for_unknown_model(self) -> None:
         from llm_gateway.api.anthropic import map_to_bedrock_model


### PR DESCRIPTION
## Problem

EU Bedrock fallback mapped Fable 5 to a regional inference profile that does not exist.

## Changes

I route EU Fable 5 requests through its available global inference profile.

## How did you test this code?

Ran `uv run --project services/llm-gateway pytest -q services/llm-gateway/tests/test_bedrock.py` (47 passed). AWS profile metadata confirmed the global EU profile; local credentials could not complete live inference.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A. This corrects an internal provider mapping.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code (Codex). I used `/writing-tests`, `/rs-ship`, `/rs-update-pr`, and `/rs-tone`. I verified the Bedrock profile catalog directly and kept fallback enabled rather than disabling the model family.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
