### PR TITLE
chore(web-analytics): backfill AI assistant channel definitions

### DIFF
--- a/posthog/clickhouse/migrations/0291_add_ai_assistant_channel_types.py
+++ b/posthog/clickhouse/migrations/0291_add_ai_assistant_channel_types.py
@@ -1,0 +1,30 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.channel_type.sql import CHANNEL_DEFINITION_DATA_SQL
+
+AI_ASSISTANT_CHANNEL_DEFINITIONS = [
+    ("ai.perplexity.app", "source", "AI", None, "AI Assistant"),
+    ("chatgpt.com", "source", "AI", None, "AI Assistant"),
+    ("claude.ai", "source", "AI", None, "AI Assistant"),
+    ("copilot.microsoft.com", "source", "AI", None, "AI Assistant"),
+    ("gemini.google.com", "source", "AI", None, "AI Assistant"),
+    ("meta.ai", "source", "AI", None, "AI Assistant"),
+    ("perplexity.ai", "source", "AI", None, "AI Assistant"),
+    ("pi.ai", "source", "AI", None, "AI Assistant"),
+    ("poe.com", "source", "AI", None, "AI Assistant"),
+    ("you.com", "source", "AI", None, "AI Assistant"),
+]
+
+operations = [
+    # ai.perplexity.app, perplexity.ai and you.com already have rows from migration 0069
+    # (classified under Organic Search). Remove them first so the dictionary's
+    # (domain, kind) key stays unique before re-inserting with the new classification.
+    run_sql_with_exceptions(
+        "ALTER TABLE channel_definition DELETE WHERE kind = 'source' AND domain IN "
+        "('ai.perplexity.app', 'chatgpt.com', 'claude.ai', 'copilot.microsoft.com', "
+        "'gemini.google.com', 'meta.ai', 'perplexity.ai', 'pi.ai', 'poe.com', 'you.com') "
+        "SETTINGS mutations_sync = 2",
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(CHANNEL_DEFINITION_DATA_SQL(channel_definitions=AI_ASSISTANT_CHANNEL_DEFINITIONS)),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0290_trace_spans_and_attributes
+0291_add_ai_assistant_channel_types


### PR DESCRIPTION
## Problem
People increasingly find sites through AI assistants like ChatGPT and Perplexity instead of classic search, but right now PostHog's channel classification lumps that traffic in with Organic Search. This is the data half of fixing that: it updates the ClickHouse dictionary PostHog's channel classifier reads from, so the domains are ready to be recognized once the follow-up PR ships the code that actually uses them.

Part of #71889, not closing it here since the feature only lands with the next PR.

## Changes

New migration 0291_add_ai_assistant_channel_types that removes the old rows for perplexity.ai, you.com and ai.perplexity.app (currently sitting under Organic Search) and re-inserts all 10 AI assistant domains under a new AI Assistant classification
Bumped max_migration.txt to point at 0291
Per this repo's migration rule, this PR only touches migration files on purpose
## How did you test this code?

Ran the migration lint suite (posthog/clickhouse/test/test_migrations.py), all 4 checks pass
Manually ran the migration's SQL against a local ClickHouse instance, including a simulated version of the current prod state (a stale Organic Search row sitting next to a newer one), to confirm it ends up as one row per domain, not a duplicate
Along the way found that the delete step needs SETTINGS mutations_sync = 2 — without it, ClickHouse runs the delete in the background and the following insert can land before the old row is actually gone, leaving two conflicting rows for the same domain. Reproduced that race, added the setting, reproduced again to confirm it's fixed
Didn't test against a real multi-node cluster, don't have one locally, but the migration follows the same pattern as the rest of this file and passes the same lint that gates it in CI
## Automatic notifications
Leave both unchecked, this is an internal data migration, nothing changelog-worthy on its own.

## Docs update
Nothing to update here, no documented behavior changes yet.
## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used Gemini to help bounce architectural ideas around and map out the PostHog query pipeline. 

* **Skills invoked:** ClickHouse data migrations and HogQL schema analysis.