### PR TITLE
fix(bugsnag): cap releases endpoint page size at 10

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/bugsnag.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/bugsnag.py
@@ -21,7 +21,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 # BugSnag uses a single global host for its Data Access API. On-prem / Enterprise installs use a
 # custom host, which this source does not yet support.
 BUGSNAG_BASE_URL = "https://api.bugsnag.com"
-# BugSnag's documented per_page maximum for list endpoints.
+# Default per_page for list endpoints. Endpoints that cap lower override it via
+# BugsnagEndpointConfig.page_size (e.g. releases, which 400s on anything above 10).
 PAGE_SIZE = 100
 # The Data Access API is versioned via the X-Version header. v2 is current; v1 is decommissioned.
 BUGSNAG_API_VERSION = "2"
@@ -184,7 +185,7 @@ def _iter_top_level(
         url = resume.next_url
         logger.debug(f"BugSnag: resuming {config.name} from URL: {url}")
     else:
-        url = _build_url(f"{BUGSNAG_BASE_URL}{config.path}", {"per_page": PAGE_SIZE})
+        url = _build_url(f"{BUGSNAG_BASE_URL}{config.path}", {"per_page": config.page_size})
 
     while True:
         items, next_url = _fetch_list_page(session, url, headers, logger)
@@ -234,7 +235,7 @@ def _iter_fan_out(
     for index in range(start_index, len(parents)):
         parent = parents[index]
         path = config.path.format(**parent.path_kwargs)
-        url = resume_url or _build_url(f"{BUGSNAG_BASE_URL}{path}", {"per_page": PAGE_SIZE})
+        url = resume_url or _build_url(f"{BUGSNAG_BASE_URL}{path}", {"per_page": config.page_size})
         resume_url = None  # only the resumed-into parent uses the saved URL; the rest start fresh
 
         while True:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/settings.py
@@ -36,6 +36,10 @@ class BugsnagEndpointConfig:
     # Stable, creation-time datetime column to partition by. Never a `last_seen`/`updated_at`
     # style field — those move and would rewrite partitions every sync. None disables partitioning.
     partition_key: Optional[str] = None
+    # per_page value used when paginating this endpoint. Most list endpoints accept up to 100, but
+    # a few cap lower and hard-reject an over-max value with a 400 instead of clamping, so those
+    # need their own limit.
+    page_size: int = 100
     # The menu of incremental cursor candidates advertised to the user. Empty = full refresh only.
     incremental_fields: list[IncrementalField] = field(default_factory=list)
     # Whether the table is selected for sync by default in the connection wizard.
@@ -96,6 +100,8 @@ BUGSNAG_ENDPOINTS: dict[str, BugsnagEndpointConfig] = {
         path="/projects/{project_id}/releases",
         primary_keys=["id", "project_id"],
         partition_key="released_at",
+        # This endpoint caps per_page at 10 and returns 400 for anything higher.
+        page_size=10,
     ),
     "pivots": BugsnagEndpointConfig(
         name="pivots",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/tests/test_bugsnag.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/tests/test_bugsnag.py
@@ -251,6 +251,18 @@ class TestPerProjectFanOut:
             {"id": "e2", "organization_id": "o1", "project_id": "p2"},
         ]
 
+    def test_releases_caps_page_size_at_ten(self, monkeypatch: Any) -> None:
+        # The releases endpoint rejects per_page above 10 with a 400, so it must request per_page=10
+        # while the parent enumeration keeps the default 100. A per_page=100 releases URL is absent
+        # from `pages`, so a regression would raise on the unexpected URL.
+        pages = {
+            "https://api.bugsnag.com/user/organizations?per_page=100": ([{"id": "o1"}], None),
+            "https://api.bugsnag.com/organizations/o1/projects?per_page=100": ([{"id": "p1"}], None),
+            "https://api.bugsnag.com/projects/p1/releases?per_page=10": ([{"id": "r1"}], None),
+        }
+        rows = _collect("releases", pages, _FakeResumableManager(), monkeypatch)
+        assert rows == [{"id": "r1", "organization_id": "o1", "project_id": "p1"}]
+
 
 class TestValidateCredentials:
     @parameterized.expand(


### PR DESCRIPTION
## Problem

The Bugsnag data warehouse source fails on the `releases` table with an `HTTPError`:

`400 Client Error: Bad Request for url: https://api.bugsnag.com/projects/<redacted>/releases?per_page=100`

The source hardcodes `per_page=100` for every list endpoint. That works for most of the Data Access API, where exceeding a resource's `per_page` maximum just clamps to the max. But the [List Releases on a Project](https://bugsnagapiv2.docs.apiary.io/#reference/projects/releases/list-releases-on-a-project) endpoint documents `per_page` as "between 1 and 10" (default 5), and the live API hard-rejects anything higher with a 400 instead of clamping. So every releases sync 400s.

Surfaced by error tracking issue `019f7625-24bc-7710-819b-49a4f9e4c527`. The failing frame is `_fetch_page` calling `raise_for_status()` in `bugsnag.py`.

This is our bug, not a user or upstream problem: we send an unsupported query value. A bad or revoked token would surface as 401/403, which is already handled in `get_non_retryable_errors`.

## Changes

- Add a per-endpoint `page_size` to `BugsnagEndpointConfig`, defaulting to 100.
- Set the `releases` endpoint's `page_size` to 10 (its documented max).
- Build each endpoint's page URLs from `config.page_size` instead of the shared `PAGE_SIZE` constant. Parent enumeration (organizations, projects) keeps the 100 default since those endpoints don't have the lower cap.

No change to retry policy or any other endpoint's behavior.

## How did you test this code?

Added `test_releases_caps_page_size_at_ten` to the existing `TestPerProjectFanOut` suite. It collects the `releases` endpoint and asserts the request URL uses `per_page=10` while parent enumeration stays at `per_page=100`. No existing test exercised the releases endpoint or per-endpoint page sizing (the fan-out tests all use `errors` at 100), so this catches a regression that would otherwise reintroduce the 400.

Verified the test fails without the fix (it requests `per_page=100`, the exact live-API 400 cause) and passes with it. Full suite: `29 passed`. Ran `ruff check` and `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue. I (Claude) confirmed the failure originates in the bugsnag source's `_fetch_page`, then checked the official Bugsnag Data Access API blueprint to find that the releases endpoint caps `per_page` at 10 while other endpoints allow 100. Ruled out a missing `release_stage` param (it's optional for this endpoint; `release_stage_name` is required only for the separate release_groups endpoint) and confirmed this is a fixable bug rather than a non-retryable user error. Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
