### PR TITLE
fix(data-imports): treat llama_cloud usage-metrics 400 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/llama_cloud/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/llama_cloud/source.py
@@ -87,9 +87,22 @@ You can create an API key in [LlamaCloud](https://cloud.llamaindex.ai) under **S
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         # Both regional hosts share the https://api.cloud. prefix, so one key per status
         # covers NA and EU without matching unrelated hosts.
+        usage_metrics_400 = (
+            "LlamaCloud rejected the request for the usage metrics table with a 400 error. This beta "
+            "endpoint isn't available for every LlamaCloud organization, so we've stopped syncing "
+            "usage_metrics; your other LlamaCloud tables keep syncing. If you need usage metrics, check "
+            "with LlamaCloud that your organization has access to the beta usage-metrics API."
+        )
         return {
             "401 Client Error: Unauthorized for url: https://api.cloud.": "Your LlamaCloud API key is invalid, revoked, or from a different region. Create a new API key in LlamaCloud, check the region, and reconnect.",
             "403 Client Error: Forbidden for url: https://api.cloud.": "Your LlamaCloud API key does not have access to this data. Check the key's project in LlamaCloud and reconnect.",
+            # The beta usage-metrics endpoint deterministically returns 400 for organizations it isn't
+            # available to; our request is otherwise valid (organization_id resolved, page_size in range),
+            # so retrying can't help. Scope the key to this endpoint's path — status and path, not the
+            # variable query string — so genuine 400s on other endpoints still surface. The host differs
+            # per region, so one key each keeps the match off unrelated 401/403 responses.
+            "400 Client Error: Bad Request for url: https://api.cloud.llamaindex.ai/api/v1/beta/usage-metrics": usage_metrics_400,
+            "400 Client Error: Bad Request for url: https://api.cloud.eu.llamaindex.ai/api/v1/beta/usage-metrics": usage_metrics_400,
         }
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/llama_cloud/tests/test_llama_cloud_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/llama_cloud/tests/test_llama_cloud_source.py
@@ -139,6 +139,14 @@ class TestLlamaCloudSource:
             ("401 Client Error: Unauthorized for url: https://api.cloud.llamaindex.ai/api/v2/parse?page_size=100",),
             ("401 Client Error: Unauthorized for url: https://api.cloud.eu.llamaindex.ai/api/v2/projects",),
             ("403 Client Error: Forbidden for url: https://api.cloud.llamaindex.ai/api/v1/beta/files",),
+            # The beta usage-metrics endpoint 400s for organizations it isn't available to; the
+            # request is otherwise valid, so retrying can't help. Both regional hosts must match.
+            (
+                "400 Client Error: Bad Request for url: https://api.cloud.llamaindex.ai/api/v1/beta/usage-metrics?page_size=100&organization_id=00000000-0000-0000-0000-000000000000",
+            ),
+            (
+                "400 Client Error: Bad Request for url: https://api.cloud.eu.llamaindex.ai/api/v1/beta/usage-metrics?page_size=100&organization_id=00000000-0000-0000-0000-000000000000",
+            ),
         ]
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error: str) -> None:
@@ -149,6 +157,9 @@ class TestLlamaCloudSource:
         [
             ("500 Server Error: Internal Server Error for url: https://api.cloud.llamaindex.ai/api/v2/parse",),
             ("401 Client Error: Unauthorized for url: https://api.example.com/api/v2/parse",),
+            # A 400 on a different endpoint may be a fixable bug in our request, so it must stay
+            # retryable and keep surfacing rather than being swallowed by the usage-metrics key.
+            ("400 Client Error: Bad Request for url: https://api.cloud.llamaindex.ai/api/v2/parse?page_size=100",),
         ]
     )
     def test_non_retryable_errors_ignore_unrelated(self, unrelated_error: str) -> None:


### PR DESCRIPTION
## Problem

The data-warehouse import pipeline is throwing `HTTPError: 400 Client Error: Bad Request` from the LlamaCloud source, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f764a-261f-77d0-a9b3-50df5b49aafd)). It fires from `_fetch_page` in `llama_cloud.py` when syncing the `usage_metrics` table, and it hit several teams in a short window, all on that one endpoint.

The `usage_metrics` schema maps to LlamaCloud's beta `GET /api/v1/beta/usage-metrics` endpoint. That endpoint returns a 400 for organizations it isn't available to. I confirmed against LlamaCloud's live OpenAPI spec that our request is otherwise valid: `organization_id` is the only required query param and we resolve and send it, and `page_size` is optional and in range. FastAPI returns 422 for parameter-validation problems, so a 400 here is a deliberate business-rule rejection from the handler, not a malformed request we can correct.

Because the request is already valid, retrying the identical call can never succeed. Today it stays on the retry path, wastes attempts, and keeps surfacing as an error. There is nothing sensible for us to do but stop retrying, so this is a non-retryable upstream condition rather than a fixable bug.

## Changes

Extend `LlamaCloudSource.get_non_retryable_errors` to classify the usage-metrics 400 as non-retryable, mapping it to a friendly message that explains the beta endpoint isn't available for every organization and that the other tables keep syncing.

The match is scoped tightly on purpose:

- **Status + path, not the query string.** The key matches `400 Client Error: Bad Request for url: .../api/v1/beta/usage-metrics` and stops before the variable `page_size` / `organization_id` query params, so no customer values are baked into the match.
- **Per region host.** NA and EU use different hosts, so there's one key each. This keeps the match off unrelated responses and off the existing 401/403 keys.
- **Endpoint-scoped.** A 400 on any *other* llama_cloud endpoint stays retryable and keeps surfacing, so a future request bug elsewhere won't be silently swallowed.

When matched, the pipeline stops syncing just that schema and shows the friendly message; the source's other tables are unaffected.

> [!NOTE]
> This is scoped strictly to the usage-metrics 400. Retry policy for the rest of the pipeline is unchanged, and transient errors (timeouts, connection resets, 429/5xx) remain retryable as before.

## How did you test this code?

Automated only (I'm an agent and did not run a live sync against LlamaCloud):

- Extended `test_non_retryable_errors_match_auth_failures` to assert the usage-metrics 400 is recognised for both the NA and EU hosts, including the real query-string shape from the reported error.
- Extended `test_non_retryable_errors_ignore_unrelated` to assert a 400 on a *different* endpoint (`/api/v2/parse`) is **not** matched, so we don't swallow bugs elsewhere.
- Ran the full source test dir: `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/llama_cloud/tests/` → 67 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I pulled the issue and a representative event via the PostHog error-tracking tools, traced the failure to `_fetch_page` raising on `raise_for_status()` for the `usage_metrics` schema, and checked LlamaCloud's live OpenAPI to confirm our request was spec-valid (ruling out a wrong-param / pagination bug). I considered a silent graceful-skip instead, but rejected it: disabling the schema with a clear message keeps the user informed and stops the retry waste, and it mirrors the existing Stripe/llama_cloud non-retryable pattern. Given the request is valid and the 400 is deterministic and account-specific, non-retryable is the safe and correct call. Searched open PRs (including the maintainer's own) and found no existing fix for this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
