### PR TITLE
fix(feature-flags): normalize flag dependency keys to strings

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1575,7 +1575,22 @@ class FeatureFlagSerializer(
                 f"Please simplify conditions or reduce payload sizes."
             )
 
+        self._normalize_flag_dependency_property_keys(filters)
+
         return filters
+
+    def _normalize_flag_dependency_property_keys(self, filters: dict) -> None:
+        """Store flag-dependency property keys as strings (flag IDs) for Rust eval."""
+        from posthog.utils import safe_int
+
+        for flag_prop in _get_flag_properties_from_filters(filters):
+            flag_reference = flag_prop.get("key")
+            if flag_reference is None:
+                continue
+            self._validate_flag_reference(flag_reference)
+            flag_id = safe_int(flag_reference)
+            if flag_id is not None:
+                flag_prop["key"] = str(flag_id)
 
     def _validate_flag_reference(self, flag_reference):
         """Validate and convert flag reference to flag key."""

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -419,6 +419,43 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_numeric_flag_dependency_key_is_stored_as_string(self) -> None:
+        base_flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="base-flag-numeric-dep",
+            filters={"groups": [{"rollout_percentage": 100, "properties": []}]},
+        )
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags",
+            {
+                "name": "Dependent flag numeric key",
+                "key": "dependent-flag-numeric-dep",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [
+                                {
+                                    "key": base_flag.id,
+                                    "type": "flag",
+                                    "value": "true",
+                                    "operator": "flag_evaluates_to",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        flag = FeatureFlag.objects.get(key="dependent-flag-numeric-dep", team=self.team)
+        flag_property = flag.filters["groups"][0]["properties"][0]
+        self.assertEqual(flag_property["key"], str(base_flag.id))
+        self.assertIsInstance(flag_property["key"], str)
+
     @parameterized.expand(
         [
             ("in",),

--- a/products/feature_flags/backend/flags_cache.py
+++ b/products/feature_flags/backend/flags_cache.py
@@ -73,6 +73,23 @@ logger = structlog.get_logger(__name__)
 FLAGS_CACHE_EXPIRY_SORTED_SET = "flags_cache_expiry"
 
 
+def _normalize_flag_dependency_keys_in_flags_data(flags_data: list[dict[str, Any]]) -> None:
+    """Coerce flag-dependency property keys to strings for Rust hypercache deserialization."""
+    for flag_data in flags_data:
+        filters = flag_data.get("filters", {})
+        for group in filters.get("groups") or []:
+            for prop in group.get("properties") or []:
+                if prop.get("type") != "flag":
+                    continue
+                key = prop.get("key")
+                if key is None or isinstance(key, str):
+                    continue
+                try:
+                    prop["key"] = str(int(key))
+                except (ValueError, TypeError):
+                    continue
+
+
 def _extract_direct_dependency_ids(flag_data: dict[str, Any]) -> set[int]:
     """
     Extract direct flag dependency IDs from a serialized flag's filters.
@@ -343,6 +360,7 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     """
     flags = get_feature_flags(team=team, exclude_encrypted_payloads=True)
     flags_data = serialize_feature_flags(flags)
+    _normalize_flag_dependency_keys_in_flags_data(flags_data)
     evaluation_metadata = _compute_flag_dependencies(flags_data)
 
     cohorts = _get_referenced_cohorts(team.id, flags_data)
@@ -416,6 +434,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     for team in teams:
         team_flags = flags_by_team_id.get(team.id, [])
         flags_data = serialize_feature_flags(team_flags)
+        _normalize_flag_dependency_keys_in_flags_data(flags_data)
         flags_data_by_team[team.id] = flags_data
         all_cohort_ids.update(_extract_cohort_ids_from_flag_filters(flags_data))
 

--- a/products/feature_flags/backend/test/test_flags_cache.py
+++ b/products/feature_flags/backend/test/test_flags_cache.py
@@ -39,6 +39,7 @@ from products.feature_flags.backend.flags_cache import (
     _get_feature_flags_for_service,
     _get_feature_flags_for_teams_batch,
     _get_referenced_cohorts,
+    _normalize_flag_dependency_keys_in_flags_data,
     _serialize_cohort,
     _strip_null_values,
     clear_flags_cache,
@@ -3064,6 +3065,31 @@ def _make_flag(id: int, key: str, deps: list[int] | None = None, active: bool = 
         "deleted": deleted,
         "filters": {"groups": [{"properties": properties, "rollout_percentage": 100}]},
     }
+
+
+class TestNormalizeFlagDependencyKeys:
+    def test_numeric_dependency_key_coerced_to_string(self):
+        flags_data = [
+            {
+                "id": 1,
+                "key": "flag_a",
+                "active": True,
+                "deleted": False,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {"type": "flag", "key": 226357, "value": True, "operator": "flag_evaluates_to"},
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+
+        _normalize_flag_dependency_keys_in_flags_data(flags_data)
+
+        assert flags_data[0]["filters"]["groups"][0]["properties"][0]["key"] == "226357"
 
 
 class TestExtractDirectDependencyIds:

--- a/rust/feature-flags/src/properties/property_models.rs
+++ b/rust/feature-flags/src/properties/property_models.rs
@@ -1,4 +1,22 @@
-use serde::{Deserialize, Serialize};
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+fn deserialize_property_filter_key<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::String(s) => Ok(s),
+        Value::Number(n) => n
+            .as_i64()
+            .map(|id| id.to_string())
+            .ok_or_else(|| DeError::custom("property filter key number must be an integer")),
+        _ => Err(DeError::custom(
+            "property filter key must be a string or integer",
+        )),
+    }
+}
 
 // Keep in sync with FEATURE_FLAG_SUPPORTED_OPERATORS in posthog/api/feature_flag.py
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
@@ -75,6 +93,7 @@ impl std::fmt::Debug for CompiledRegex {
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct PropertyFilter {
+    #[serde(deserialize_with = "deserialize_property_filter_key")]
     pub key: String,
     // NB: if a property filter is of type is_set or is_not_set, the value isn't used, and if it's a filter made by the API, the value is None.
     pub value: Option<serde_json::Value>,
@@ -99,6 +118,24 @@ pub struct PropertyFilter {
     /// See plans/verify-flags-cache-loose-comparison.md.
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_deserialize_property_filter_key_from_number() {
+        let filter: PropertyFilter = serde_json::from_value(json!({
+            "key": 226357,
+            "type": "flag",
+            "operator": "flag_evaluates_to",
+            "value": true
+        }))
+        .unwrap();
+        assert_eq!(filter.key, "226357");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Flag dependency filters can be saved with a numeric `key` (e.g. `226357`) via the REST API. Rust flag evaluation expects `PropertyFilter.key` to be a string, so hypercache deserialization fails and `/flags` returns 500 for the whole project. Re-saving the flag in the UI fixes it because the frontend writes string keys.

Closes #71795

## Changes

- Normalize flag-dependency property keys to stringified flag IDs in `FeatureFlagSerializer.validate_filters` on create/update
- Heal existing bad rows when building the flags cache (`_get_feature_flags_for_service` and batch path)
- Accept string or integer keys in Rust `PropertyFilter` deserialization as defense-in-depth for stale Redis cache entries
- Add regression tests for API save path and cache normalization

## How did you test this code?

- `hogli test products/feature_flags/backend/test/test_flags_cache.py::TestNormalizeFlagDependencyKeys` 
- `cargo test -p feature-flags test_deserialize_property_filter_key_from_number` 
- API test `test_numeric_flag_dependency_key_is_stored_as_string` 



## Docs update

No docs change — internal serialization fix, no user-facing API contract change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Cursor agent assisted with root-cause analysis and implementation. Skills considered: `/improving-drf-endpoints`, `/writing-tests`. Chose stringified flag ID as canonical form (matches existing validation via `safe_int`) rather than resolving to flag name. Rust deserializer kept for rollout safety against stale cache; Python normalization is the primary fix.