### PR TITLE
fix(snowflake): treat persistent HTTP 403 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -290,6 +290,14 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # matches the columns its query produces, so the view itself fails to compile. This is
             # a broken object on the source side that retrying can't repair.
             "but view query produces": "A Snowflake view in your source is invalid — the columns it declares no longer match the columns its query returns. Please recreate the view in Snowflake so the two agree, then resync.",
+            # Snowflake connector error 290403 (ER_HTTP_GENERAL_ERROR + 403): a request to Snowflake
+            # returned HTTP 403 Forbidden and kept doing so through the connector's own retry budget.
+            # The connector treats 403 as retryable and retries within the request timeout, so a
+            # ForbiddenError reaching us means the 403 is persistent — an access-denied condition
+            # (a network policy/firewall/proxy blocking PostHog, or the role's access to the data
+            # being revoked), not a transient blip. Retrying the whole sync can't fix it. The errno
+            # prefix and host are volatile, so we match the stable status text.
+            "HTTP 403: Forbidden": "Snowflake refused the request with an HTTP 403 (forbidden). This usually means a network policy or firewall on your account is blocking PostHog's access, or your role's access to the data was revoked. Check your Snowflake network access rules and role grants, then resync.",
         }
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -775,6 +775,20 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "HTTP 403: Forbidden",
+            # The real shape from production: the errno prefix and host vary, but the status
+            # text is stable. Newlines are normalized to spaces upstream.
+            "290403: 290403: HTTP 403: Forbidden",
+        ],
+    )
+    def test_forbidden_403_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Persistent HTTP 403 should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "JWT token is invalid",
             # The real shape from production: codes, host, and request id vary, but the substring is stable.
             "250001 (08001): None: Failed to connect to DB: novjltn-acme.snowflakecomputing.com:443. "


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `ForbiddenError` — `290403: 290403: HTTP 403: Forbidden` — raised from the Snowflake import source at `snowflake.py:653` inside `get_rows` (the streaming `fetch_arrow_batches` call). See the [error tracking issue](https://us.posthog.com/project/2/error_tracking/019f7722-2ea5-7880-b327-572e147b2ea1).

The Snowflake connector treats HTTP 403 as a retryable code and retries it internally within the request timeout. When a `ForbiddenError` still bubbles out to us, the 403 has persisted through that whole retry budget. That is an access-denied condition, not a transient network blip:

- a network policy, firewall, or proxy on the account is blocking PostHog's access, or
- the role's access to the query result data was revoked.

Nothing our code can do fixes it, and re-running the whole sync just repeats the failure until the customer changes something on the Snowflake side. Today it stays classified as retryable, so the schema keeps retrying instead of stopping with an actionable message.

## Changes

Add `HTTP 403: Forbidden` to `SnowflakeSource.get_non_retryable_errors()`, mirroring the existing Stripe/Snowflake pattern. The match is on the stable status text — the errno prefix (`290403` = `ER_HTTP_GENERAL_ERROR + 403`) and host in the raw message are volatile, so they're deliberately not matched. When it fires, the schema stops syncing and the customer sees guidance to check their Snowflake network access rules and role grants.

> [!NOTE]
> This is scoped strictly to the persistent-403 case. Transient errors (read timeouts, connection resets) are untouched and stay retryable.

## How did you test this code?

Automated only — I (Claude) can't reproduce a live Snowflake 403 here. Added a parameterized case `test_forbidden_403_is_non_retryable` to `TestSnowflakeSourceNonRetryableErrors`, covering both the bare `HTTP 403: Forbidden` substring and the production-shaped `290403: 290403: HTTP 403: Forbidden` message (host redacted). It guards the regression where dropping this entry would let a persistent Snowflake 403 retry forever instead of failing fast — no existing test exercised the 403 path.

Ran the source's test file locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py` — 104 passed. Ruff check and format both clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the Snowflake data-warehouse source. I confirmed the stack frame genuinely originates in the source (`get_rows` → `fetch_arrow_batches`), then read the vendored `snowflake-connector-python` network layer to establish that errno `290403` is the non-login retryable-403 path and that a `ForbiddenError` escaping to us means the connector's own retries were exhausted. That ruled out both "transient blip" (would stay retryable) and "our bug" (we only run `SELECT ... FROM IDENTIFIER(%s)` and stream the result), leaving user/upstream — so the fix extends `get_non_retryable_errors` rather than changing code.

Invoked `/writing-tests` before adding the test. Checked for duplicate open PRs (including the maintainer's own) and found none covering this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
