### PR TITLE
fix(experiments): stuck loading indicator on draft experiments

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -104,11 +104,7 @@ export function MetricsTable({
         )
     }
 
-    /**
-     * Show this section's loader while any of its own metrics is loading: recalculating in place, or cold
-     * (no result and no error yet). Exposures load globally, so they count for whichever section has metrics.
-     */
-    const hasColdMetric = metrics.some((_, index) => !results[index] && !errors[index])
+    const hasColdMetric = isLaunched(experiment) && metrics.some((_, index) => !results[index] && !errors[index])
     const sectionLoading =
         sectionHasRecalculatingMetric(metrics)(recalculatingMetricUuids) || hasColdMetric || exposuresLoading
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

On a draft experiment the metrics table header shows the loading indicator forever. `sectionLoading` treats any metric with no result and no error as "cold, still loading", but a draft has no results or errors by definition, so the loader never settles. The rows themselves already handle this correctly (they gate on `isLaunched` and render "Waiting for experiment to start…"), which made the spinning header read as a hang.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Gate the `hasColdMetric` check on `isLaunched(experiment)`, matching the gate the row-level `isLoading` already uses a few lines below. Drafts now render a settled header with the waiting state in the rows; launched experiments keep the loader for genuinely cold metrics.

- `frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm --filter=@posthog/frontend typescript:check
```

Verified in the browser against a local draft experiment: table header renders without the loader, rows show "Waiting for experiment to start…", and launched experiments still show the loader while metrics compute.

![cat-type-small](https://github.com/user-attachments/assets/278a5d2d-10ca-4d74-bc6e-0f1190c49330)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

Model: Fable 5
Manually refactored: **yes**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Fixed at the section-loader gate rather than inside `TableHeader`, so the cold-metric semantics stay in one place next to the row-level `isLoading` that already carries the same `isLaunched` condition.