### PR TITLE
fix(wordpress): surface actionable errors for connection failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress.py
@@ -4,6 +4,8 @@ from typing import Any, Optional
 import pytest
 from unittest import mock
 
+import requests
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress import wordpress as wordpress_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.settings import WORDPRESS_ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.wordpress import (
@@ -279,13 +281,22 @@ class TestValidateCredentials:
         assert valid is False
         assert msg == "Invalid WordPress site URL"
 
-    def test_request_exception_returns_failure(self):
-        import requests
-
-        with self._patch_session(raises=requests.exceptions.ConnectionError("boom")):
+    @pytest.mark.parametrize(
+        "exc_factory, expected_msg_substr",
+        [
+            (lambda: requests.exceptions.SSLError("certificate verify failed"), "secure connection"),
+            (lambda: requests.exceptions.ConnectionError("boom"), "Couldn't connect"),
+            (lambda: requests.exceptions.Timeout("slow"), "took too long"),
+            (lambda: requests.exceptions.RequestException("weird"), "Couldn't reach"),
+        ],
+    )
+    def test_request_exception_returns_actionable_message(self, exc_factory, expected_msg_substr):
+        # The raw exception string (e.g. an SSL traceback) must never surface to the user.
+        with self._patch_session(raises=exc_factory()):
             valid, msg = validate_credentials("https://example.com", None, None)
             assert valid is False
-            assert "boom" in (msg or "")
+            assert expected_msg_substr in (msg or "")
+            assert "certificate verify failed" not in (msg or "")
 
     def test_rejects_redirect_response(self):
         with self._patch_session(_response(status_code=302)) as patched:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/wordpress.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/wordpress.py
@@ -247,8 +247,20 @@ def validate_credentials(
             timeout=10,
             allow_redirects=False,
         )
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
+    except requests.exceptions.SSLError:
+        return False, (
+            "Couldn't establish a secure connection to the WordPress site — its TLS certificate failed "
+            "verification. Install a publicly trusted certificate (not a self-signed one) on the site and try again."
+        )
+    except requests.exceptions.ConnectionError:
+        return False, "Couldn't connect to the WordPress site. Check the site URL is correct and the site is reachable."
+    except requests.exceptions.Timeout:
+        return False, "The WordPress site took too long to respond. Check that it's reachable and try again."
+    except requests.exceptions.RequestException:
+        return (
+            False,
+            "Couldn't reach the WordPress site. Check the site URL and that the site is online, then try again.",
+        )
 
     if response.is_redirect or response.is_permanent_redirect:
         return False, HOST_NOT_ALLOWED_ERROR


### PR DESCRIPTION
## Problem

When a user adds a WordPress source, credential validation probes the site's REST API. If that request fails at the transport layer (TLS/certificate error, DNS/connection failure, timeout), the wizard echoed the raw `requests` exception string straight back to the user. That surfaces a Python traceback like `HTTPSConnectionPool(host=<redacted>, port=443): Max retries exceeded ... SSLCertVerificationError(...)` — internal noise the user can't act on, and it leaks the site host/IP they typed.

## Changes

Map the transport-level exceptions to short, user-facing messages in `validate_credentials`:

- SSL/certificate verification failure → guidance to install a publicly trusted certificate
- connection error → check the URL and that the site is reachable
- timeout → the site took too long to respond
- any other request error → generic "couldn't reach the site" fallback

`SSLError` is a subclass of `ConnectionError` in `requests`, so it's caught first. No sync behavior or schemas change.

## How did you test this code?

Extended the existing `TestValidateCredentials` suite: the old test asserted the raw exception string leaked through. Replaced it with a parameterized test that raises each transport exception and asserts the actionable message is returned and the raw detail is not. Ran the suite locally with `uv run pytest ...::TestValidateCredentials` — 13 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged failed data-warehouse source-creation errors and classified this one as an internal error leaking to users. Fix authored by Claude (Claude Code). Invoked the `/writing-tests` skill to gate the test change (replacing a change-detector test that pinned the leak). Considered adding server-side logging of the raw error but kept the change minimal, matching the surrounding function which takes no logger.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
