### PR TITLE
feat(visual-review): emit processing telemetry

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1215,21 +1215,15 @@ def finish_processing(run_id: UUID, error_message: str = "") -> Run:
     return run
 
 
-def capture_run_processing_metrics(
-    run_id: UUID,
-    *,
-    outcome: str,
-    timings: Mapping[str, float],
-    total_seconds: float,
-) -> None:
+def capture_run_processing_metrics(run_id: UUID, *, outcome: str) -> None:
     """Emit a product-analytics event for a finished diff-processing run.
 
-    Records run volume, how many snapshots actually needed a pixel comparison
-    (changed / new / removed vs. unchanged / tolerated), and where the task
-    spent its time. That's the signal to tell a snapshot-determinism regression
-    — where the changed rate climbs because images stop being byte-stable, so
-    the content-hash dedup and tolerance cache stop absorbing work — apart from
-    plain run-volume growth, and to see which phase dominates a slow run.
+    Records run volume and how many snapshots actually needed a pixel
+    comparison (changed / new / removed vs. unchanged / tolerated). That's the
+    signal to tell a snapshot-determinism regression — where the changed rate
+    climbs because images stop being byte-stable, so the content-hash dedup and
+    tolerance cache stop absorbing work — apart from plain run-volume growth.
+    Where the time goes is captured separately as OTel spans in the task.
 
     Best-effort: instrumentation must never fail or slow the task, so every
     error is swallowed — including so it can't mask a real exception when
@@ -1260,8 +1254,6 @@ def capture_run_processing_metrics(
             # content-hash dedup and tolerance cache are meant to keep near zero.
             "diffed_count": run.changed_count,
             "reviewable_count": run.changed_count + run.new_count + run.removed_count,
-            "processing_seconds": round(total_seconds, 3),
-            **{key: round(value, 3) for key, value in timings.items()},
         }
 
         with ph_scoped_capture() as capture_ph_event:

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -41,6 +41,7 @@ from posthog.helpers.trigram_search import (
     normalize_search_term,
 )
 from posthog.models.github_integration_base import GitHubIntegrationError
+from posthog.ph_client import ph_scoped_capture
 
 from .classifier import SnapshotClassifier
 from .db import READER_DB, WRITER_DB
@@ -1212,6 +1213,65 @@ def finish_processing(run_id: UUID, error_message: str = "") -> Run:
     _update_counts_and_post_status(run)
 
     return run
+
+
+def capture_run_processing_metrics(
+    run_id: UUID,
+    *,
+    outcome: str,
+    timings: Mapping[str, float],
+    total_seconds: float,
+) -> None:
+    """Emit a product-analytics event for a finished diff-processing run.
+
+    Records run volume, how many snapshots actually needed a pixel comparison
+    (changed / new / removed vs. unchanged / tolerated), and where the task
+    spent its time. That's the signal to tell a snapshot-determinism regression
+    — where the changed rate climbs because images stop being byte-stable, so
+    the content-hash dedup and tolerance cache stop absorbing work — apart from
+    plain run-volume growth, and to see which phase dominates a slow run.
+
+    Best-effort: instrumentation must never fail or slow the task, so every
+    error is swallowed — including so it can't mask a real exception when
+    called from the task's ``finally``.
+    """
+    try:
+        try:
+            run = Run.objects.select_related("repo").get(id=run_id)
+        except Run.DoesNotExist:
+            return
+
+        properties = {
+            "run_id": str(run.id),
+            "run_type": run.run_type,
+            "outcome": outcome,
+            "status": run.status,
+            "repo": run.repo.repo_full_name,
+            "branch": run.branch,
+            "pr_number": run.pr_number,
+            "team_id": run.team_id,
+            "is_partial": run.is_partial,
+            "total_snapshots": run.total_snapshots,
+            "changed_count": run.changed_count,
+            "new_count": run.new_count,
+            "removed_count": run.removed_count,
+            "tolerated_match_count": run.tolerated_match_count,
+            # Snapshots that actually ran a pixel comparison — the cost the
+            # content-hash dedup and tolerance cache are meant to keep near zero.
+            "diffed_count": run.changed_count,
+            "reviewable_count": run.changed_count + run.new_count + run.removed_count,
+            "processing_seconds": round(total_seconds, 3),
+            **{key: round(value, 3) for key, value in timings.items()},
+        }
+
+        with ph_scoped_capture() as capture_ph_event:
+            capture_ph_event(
+                distinct_id=run.repo.repo_full_name or str(run.repo_id),
+                event="vr_run_processed",
+                properties=properties,
+            )
+    except Exception:
+        logger.warning("visual_review.metrics_capture_failed", run_id=str(run_id), exc_info=True)
 
 
 @transaction.atomic(using=WRITER_DB)

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -8,17 +8,19 @@ NOTE: Imports are done inside functions to avoid circular imports
 when Celery loads this module at startup.
 """
 
-import time
 from uuid import UUID
 
 import structlog
 from celery import shared_task
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 
 from posthog.models.scoping import with_team_scope
 
 from ..logic import HashIntegrityError
 
 logger = structlog.get_logger(__name__)
+TRACER = trace.get_tracer(__name__)
 
 
 @shared_task(
@@ -44,61 +46,57 @@ def process_run_diffs(self, team_id: int, run_id: str) -> None:
     from ..diffing import process_diffs
 
     run_uuid = UUID(run_id)
-    started = time.monotonic()
-    timings: dict[str, float] = {}
     outcome = "completed"
     retrying = False
 
-    try:
-        logger.info("visual_review.diff_processing_started", run_id=run_id, team_id=team_id)
-
-        phase_start = time.monotonic()
-        logic.verify_uploads_and_create_artifacts(run_uuid)
-        timings["verify_seconds"] = time.monotonic() - phase_start
-
-        phase_start = time.monotonic()
-        process_diffs(run_uuid)
-        timings["diff_seconds"] = time.monotonic() - phase_start
-
-        phase_start = time.monotonic()
-        logic.finish_processing(run_uuid)
-        timings["finish_seconds"] = time.monotonic() - phase_start
-
-        logger.info("visual_review.diff_processing_completed", run_id=run_id, team_id=team_id)
-    except HashIntegrityError as e:
-        outcome = "hash_integrity_failed"
-        logger.warning("visual_review.hash_integrity_failed", run_id=run_id, error=str(e))
-        logic.finish_processing(run_uuid, error_message=str(e))
-    except GitHubRateLimitError as e:
-        outcome = "rate_limited"
-        logger.warning(
-            "visual_review.diff_processing_rate_limited",
-            run_id=run_id,
-            retry=self.request.retries,
-            max_retries=self.max_retries,
-        )
+    # Phase timings go to OTel spans (where is time spent); counts go to the
+    # vr_run_processed event (how many runs, how many diffs).
+    with TRACER.start_as_current_span("visual_review.process_run_diffs") as span:
+        span.set_attribute("visual_review.run_id", run_id)
+        span.set_attribute("visual_review.team_id", team_id)
         try:
-            retrying = True
-            countdown = e.retry_after or 60
-            self.retry(countdown=min(countdown, 600), exc=e)
-        except self.MaxRetriesExceededError:
-            retrying = False
-            outcome = "rate_limit_exhausted"
-            logic.finish_processing(run_uuid, error_message="GitHub API rate limit exceeded after retries")
-    except Exception as e:
-        outcome = "failed"
-        logger.exception("visual_review.diff_processing_failed", run_id=run_id, team_id=team_id, error=str(e))
-        logic.finish_processing(run_uuid, error_message=str(e))
-        raise
-    finally:
-        # Skip on retry: the run isn't terminal yet and will emit on its next attempt.
-        if not retrying:
-            logic.capture_run_processing_metrics(
-                run_uuid,
-                outcome=outcome,
-                timings=timings,
-                total_seconds=time.monotonic() - started,
+            logger.info("visual_review.diff_processing_started", run_id=run_id, team_id=team_id)
+
+            with TRACER.start_as_current_span("visual_review.verify_uploads"):
+                logic.verify_uploads_and_create_artifacts(run_uuid)
+            with TRACER.start_as_current_span("visual_review.process_diffs"):
+                process_diffs(run_uuid)
+            with TRACER.start_as_current_span("visual_review.finish_processing"):
+                logic.finish_processing(run_uuid)
+
+            logger.info("visual_review.diff_processing_completed", run_id=run_id, team_id=team_id)
+        except HashIntegrityError as e:
+            outcome = "hash_integrity_failed"
+            logger.warning("visual_review.hash_integrity_failed", run_id=run_id, error=str(e))
+            logic.finish_processing(run_uuid, error_message=str(e))
+        except GitHubRateLimitError as e:
+            outcome = "rate_limited"
+            logger.warning(
+                "visual_review.diff_processing_rate_limited",
+                run_id=run_id,
+                retry=self.request.retries,
+                max_retries=self.max_retries,
             )
+            try:
+                retrying = True
+                countdown = e.retry_after or 60
+                self.retry(countdown=min(countdown, 600), exc=e)
+            except self.MaxRetriesExceededError:
+                retrying = False
+                outcome = "rate_limit_exhausted"
+                logic.finish_processing(run_uuid, error_message="GitHub API rate limit exceeded after retries")
+        except Exception as e:
+            outcome = "failed"
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.record_exception(e)
+            logger.exception("visual_review.diff_processing_failed", run_id=run_id, team_id=team_id, error=str(e))
+            logic.finish_processing(run_uuid, error_message=str(e))
+            raise
+        finally:
+            span.set_attribute("visual_review.outcome", outcome)
+            # Skip on retry: the run isn't terminal yet and will emit on its next attempt.
+            if not retrying:
+                logic.capture_run_processing_metrics(run_uuid, outcome=outcome)
 
 
 @shared_task(

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -8,6 +8,7 @@ NOTE: Imports are done inside functions to avoid circular imports
 when Celery loads this module at startup.
 """
 
+import time
 from uuid import UUID
 
 import structlog
@@ -43,17 +44,33 @@ def process_run_diffs(self, team_id: int, run_id: str) -> None:
     from ..diffing import process_diffs
 
     run_uuid = UUID(run_id)
+    started = time.monotonic()
+    timings: dict[str, float] = {}
+    outcome = "completed"
+    retrying = False
 
     try:
         logger.info("visual_review.diff_processing_started", run_id=run_id, team_id=team_id)
+
+        phase_start = time.monotonic()
         logic.verify_uploads_and_create_artifacts(run_uuid)
+        timings["verify_seconds"] = time.monotonic() - phase_start
+
+        phase_start = time.monotonic()
         process_diffs(run_uuid)
+        timings["diff_seconds"] = time.monotonic() - phase_start
+
+        phase_start = time.monotonic()
         logic.finish_processing(run_uuid)
+        timings["finish_seconds"] = time.monotonic() - phase_start
+
         logger.info("visual_review.diff_processing_completed", run_id=run_id, team_id=team_id)
     except HashIntegrityError as e:
+        outcome = "hash_integrity_failed"
         logger.warning("visual_review.hash_integrity_failed", run_id=run_id, error=str(e))
         logic.finish_processing(run_uuid, error_message=str(e))
     except GitHubRateLimitError as e:
+        outcome = "rate_limited"
         logger.warning(
             "visual_review.diff_processing_rate_limited",
             run_id=run_id,
@@ -61,14 +78,27 @@ def process_run_diffs(self, team_id: int, run_id: str) -> None:
             max_retries=self.max_retries,
         )
         try:
+            retrying = True
             countdown = e.retry_after or 60
             self.retry(countdown=min(countdown, 600), exc=e)
         except self.MaxRetriesExceededError:
+            retrying = False
+            outcome = "rate_limit_exhausted"
             logic.finish_processing(run_uuid, error_message="GitHub API rate limit exceeded after retries")
     except Exception as e:
+        outcome = "failed"
         logger.exception("visual_review.diff_processing_failed", run_id=run_id, team_id=team_id, error=str(e))
         logic.finish_processing(run_uuid, error_message=str(e))
         raise
+    finally:
+        # Skip on retry: the run isn't terminal yet and will emit on its next attempt.
+        if not retrying:
+            logic.capture_run_processing_metrics(
+                run_uuid,
+                outcome=outcome,
+                timings=timings,
+                total_seconds=time.monotonic() - started,
+            )
 
 
 @shared_task(

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -62,6 +62,49 @@ class TestProcessRunDiffs:
         assert run.status == RunStatus.FAILED
         assert "Something went wrong" in (run.error_message or "")
 
+    def test_emits_metrics_event_on_success(self, repo):
+        create_result = api.create_run(
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                snapshots=[SnapshotManifestItem(identifier="Button", content_hash="hash1")],
+            ),
+            team_id=repo.team_id,
+        )
+
+        with patch("products.visual_review.backend.logic.capture_run_processing_metrics") as capture:
+            process_run_diffs(repo.team_id, str(create_result.run_id))
+
+        capture.assert_called_once()
+        assert capture.call_args.kwargs["outcome"] == "completed"
+        # All three phases ran, so all three timings are recorded.
+        assert set(capture.call_args.kwargs["timings"]) == {"verify_seconds", "diff_seconds", "finish_seconds"}
+
+    def test_emits_metrics_event_on_failure(self, repo):
+        create_result = api.create_run(
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                snapshots=[],
+            ),
+            team_id=repo.team_id,
+        )
+
+        with (
+            patch("products.visual_review.backend.diffing.process_diffs", side_effect=Exception("boom")),
+            patch("products.visual_review.backend.logic.capture_run_processing_metrics") as capture,
+        ):
+            with pytest.raises(Exception, match="boom"):
+                process_run_diffs(repo.team_id, str(create_result.run_id))
+
+        # Metrics still emitted on the failure path, and the real error is not masked.
+        capture.assert_called_once()
+        assert capture.call_args.kwargs["outcome"] == "failed"
+
     def testprocess_diffs_skips_unchanged(self, repo):
         # Create artifact that exists for both baseline and current
         logic.get_or_create_artifact(

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -79,8 +79,6 @@ class TestProcessRunDiffs:
 
         capture.assert_called_once()
         assert capture.call_args.kwargs["outcome"] == "completed"
-        # All three phases ran, so all three timings are recorded.
-        assert set(capture.call_args.kwargs["timings"]) == {"verify_seconds", "diff_seconds", "finish_seconds"}
 
     def test_emits_metrics_event_on_failure(self, repo):
         create_result = api.create_run(


### PR DESCRIPTION
## Problem

The Visual Review diff-processing task had no product analytics or tracing, which made it difficult to distinguish run-volume growth from runs doing more image comparisons or to see which processing phase was slow.

**Why:** We need run-level counts and phase timings before deciding where reliability and performance work will have the most impact.

## Changes

- Emit a `vr_run_processed` event for every terminal processing outcome with snapshot and reviewable counts.
- Add OpenTelemetry spans for upload verification, image diffing, and finalization.
- Keep telemetry best-effort and skip event capture while a rate-limit retry is still pending.

## How did you test this code?

- Added task tests covering event capture on successful and failed terminal outcomes, including preservation of the original task exception.
- The original author ran Ruff lint, formatting checks, and Python compilation. The Django suite was left to CI because the required product databases were unavailable locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code. The instrumentation separates counts into product analytics and timings into OpenTelemetry spans, while keeping capture failures isolated from task behavior.

Origin: [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1784219129993479?thread_ts=1784219129.993479&cid=C09ADEV3AJD)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*