### PR TITLE
fix(dockerhub): give actionable errors for rejected sign-in

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/dockerhub/dockerhub.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/dockerhub/dockerhub.py
@@ -306,6 +306,24 @@ def dockerhub_source(
     )
 
 
+def _unexpected_status_message(status_code: int) -> str:
+    """User-facing message for a Docker Hub status we don't handle specifically.
+
+    Login/probe failures other than auth (401/403) and the known namespace cases land here; echoing
+    the bare status left the user nothing to act on."""
+    if status_code == 400:
+        return (
+            "Docker Hub rejected the request (HTTP 400). Check that the Username field is your Docker Hub "
+            "username (not your email address) and that the personal access token is valid, then try again."
+        )
+    if status_code >= 500:
+        return f"Docker Hub is temporarily unavailable (HTTP {status_code}). Please try again in a few minutes."
+    return (
+        f"Docker Hub returned an unexpected response (HTTP {status_code}). "
+        "Please check your username, personal access token, and namespace, then try again."
+    )
+
+
 def check_access(username: str, personal_access_token: str, namespace: str) -> tuple[int, Optional[str]]:
     """Login with the PAT and probe the configured namespace.
 
@@ -337,7 +355,7 @@ def check_access(username: str, personal_access_token: str, namespace: str) -> t
         return response.status_code, None
 
     if not response.ok:
-        return response.status_code, f"Docker Hub returned HTTP {response.status_code}"
+        return response.status_code, _unexpected_status_message(response.status_code)
 
     data = response.json()
     token = data.get("token") if isinstance(data, dict) else None
@@ -364,7 +382,7 @@ def check_access(username: str, personal_access_token: str, namespace: str) -> t
         return 401, None
 
     if not probe.ok:
-        return probe.status_code, f"Docker Hub returned HTTP {probe.status_code}"
+        return probe.status_code, _unexpected_status_message(probe.status_code)
 
     return 200, None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/dockerhub/tests/test_dockerhub.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/dockerhub/tests/test_dockerhub.py
@@ -386,10 +386,25 @@ class TestCheckAccess:
         with patch.object(dockerhub, "make_tracked_session", return_value=session):
             assert check_access("tom", "bad-token", "acme") == (status, None)
 
-    def test_login_server_error_returns_status_and_message(self) -> None:
-        session = self._session(self._response(500))
+    @parameterized.expand(
+        [
+            # A bare status echo left the user nothing to act on; a 400 (Docker Hub rejects e.g. an
+            # email in the username field) now points at the username/token, a 5xx reads as transient.
+            ("bad_request", 400, "username"),
+            ("server_error", 500, "temporarily unavailable"),
+            ("unexpected", 418, "unexpected response"),
+        ]
+    )
+    def test_login_unexpected_status_returns_actionable_message(
+        self, _name: str, status: int, expected_substr: str
+    ) -> None:
+        session = self._session(self._response(status))
         with patch.object(dockerhub, "make_tracked_session", return_value=session):
-            assert check_access("tom", "token", "acme") == (500, "Docker Hub returned HTTP 500")
+            result_status, message = check_access("tom", "token", "acme")
+        assert result_status == status
+        assert message is not None
+        assert expected_substr in message
+        assert message != f"Docker Hub returned HTTP {status}"
 
     def test_login_connection_error_maps_to_zero(self) -> None:
         session = self._session(requests.ConnectionError("boom"))
@@ -436,7 +451,13 @@ class TestCheckAccess:
                 False,
                 "Your personal access token does not have access to the 'acme' namespace",
             ),
-            ("server_error", 500, None, False, "Docker Hub returned HTTP 500"),
+            (
+                "server_error",
+                500,
+                None,
+                False,
+                "Docker Hub is temporarily unavailable (HTTP 500). Please try again in a few minutes.",
+            ),
         ]
     )
     def test_validate_credentials(


### PR DESCRIPTION
## Problem

When a user adds a Docker Hub source, we validate the credentials by signing in and probing the configured namespace. Any failure other than 401/403 (auth) or the known namespace cases fell through to a generic `Docker Hub returned HTTP <status>` message. That's a bare status echo with no guidance. The common one in the wizard was a 400 on sign-in, which Docker Hub returns when the Username field holds something it rejects (for example an email address rather than the account username).

## Changes

Replace the bare echo in `check_access` with `_unexpected_status_message`, used on both the login and namespace-probe branches:

- `400` → check the Username is your Docker Hub username (not an email) and the token is valid
- `5xx` → Docker Hub is temporarily unavailable, try again shortly
- anything else → generic "unexpected response" with a check-your-details prompt

The 401/403 auth paths and the namespace 404/403 messages are unchanged. No sync behavior or schemas change.

## How did you test this code?

Updated `TestCheckAccess` and `test_validate_credentials`: parameterized the unexpected-status case over 400/500/418, asserting the actionable substring is present and the old bare echo is gone, and updated the validate-credentials 5xx expectation. Ran `uv run pytest ...::TestCheckAccess` locally — 15 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged failed data-warehouse source-creation errors and classified the bare `HTTP <status>` echo as an internal error leaking to users. Fix authored by Claude (Claude Code). Invoked the `/writing-tests` skill to gate the test changes. The 400-means-email hint is framed as a check rather than a definitive cause, since Docker Hub can return 400 for other malformed sign-ins too.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
