### PR TITLE
chore(visual-review): cover below-threshold processing

### DIFF
--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -26,8 +26,16 @@ from products.visual_review.backend.tasks.tasks import post_approval_comment, pr
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES, VisualReviewTeamScopedTestMixin
 
 
-def _make_png(color: tuple[int, int, int, int]) -> bytes:
-    image = Image.new("RGBA", (10, 10), color)
+def _make_png(color: tuple[int, int, int, int], size: tuple[int, int] = (10, 10)) -> bytes:
+    image = Image.new("RGBA", size, color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _make_png_with_single_changed_pixel() -> bytes:
+    image = Image.new("RGBA", (100, 100), (255, 0, 0, 255))
+    image.putpixel((0, 0), (0, 0, 255, 255))
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
     return buffer.getvalue()
@@ -320,8 +328,11 @@ class TestProcessRunDiffs:
         assert process_diffs(create_result.run_id) == 0
         assert compare_images.call_count == 1
 
-    def testprocess_diffs_counts_below_threshold_comparisons(self, repo, mocker):
-        image_bytes = _make_png((255, 0, 0, 255))
+    def test_process_diffs_counts_below_threshold_comparisons(self, repo, mocker):
+        stored_bytes = {
+            "old_hash": _make_png((255, 0, 0, 255), size=(100, 100)),
+            "new_hash": _make_png_with_single_changed_pixel(),
+        }
         logic.get_or_create_artifact(repo.id, "old_hash", "visual_review/old_hash")
         logic.get_or_create_artifact(repo.id, "new_hash", "visual_review/new_hash")
         create_result = api.create_run(
@@ -347,7 +358,14 @@ class TestProcessRunDiffs:
         mocker.patch(
             "products.visual_review.backend.storage.ArtifactStorage.read",
             autospec=True,
-            return_value=image_bytes,
+            side_effect=lambda _storage, content_hash: stored_bytes.get(content_hash),
+        )
+        mocker.patch(
+            "products.visual_review.backend.storage.ArtifactStorage.write",
+            autospec=True,
+            side_effect=lambda _storage, content_hash, content: (
+                stored_bytes.setdefault(content_hash, content) and f"visual_review/{content_hash}"
+            ),
         )
 
         assert process_diffs(create_result.run_id) == 1
@@ -355,6 +373,10 @@ class TestProcessRunDiffs:
         snapshot = RunSnapshot.objects.get(run_id=create_result.run_id)
         assert snapshot.result == SnapshotResult.UNCHANGED
         assert snapshot.classification_reason == ClassificationReason.BELOW_THRESHOLD
+        assert snapshot.diff_pixel_count is not None
+        assert snapshot.diff_pixel_count > 0
+        assert snapshot.diff_percentage is not None
+        assert snapshot.diff_percentage > 0
         assert ToleratedHash.objects.filter(
             repo_id=repo.id,
             identifier="Button",

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -21,9 +21,16 @@ from products.visual_review.backend.facade.enums import (
     RunType,
     SnapshotResult,
 )
-from products.visual_review.backend.models import RunSnapshot
+from products.visual_review.backend.models import RunSnapshot, ToleratedHash
 from products.visual_review.backend.tasks.tasks import post_approval_comment, process_run_diffs
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES, VisualReviewTeamScopedTestMixin
+
+
+def _make_png(color: tuple[int, int, int, int]) -> bytes:
+    image = Image.new("RGBA", (10, 10), color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
@@ -269,15 +276,9 @@ class TestProcessRunDiffs:
             assert any("diff_skipped_missing_artifact" in arg for arg in call_args)
 
     def testprocess_diffs_does_not_repeat_completed_comparisons(self, repo, mocker):
-        def png(color: tuple[int, int, int, int]) -> bytes:
-            image = Image.new("RGBA", (10, 10), color)
-            buffer = io.BytesIO()
-            image.save(buffer, format="PNG")
-            return buffer.getvalue()
-
         stored_bytes = {
-            "old_hash": png((255, 0, 0, 255)),
-            "new_hash": png((0, 0, 255, 255)),
+            "old_hash": _make_png((255, 0, 0, 255)),
+            "new_hash": _make_png((0, 0, 255, 255)),
         }
         logic.get_or_create_artifact(repo.id, "old_hash", "visual_review/old_hash")
         logic.get_or_create_artifact(repo.id, "new_hash", "visual_review/new_hash")
@@ -318,6 +319,48 @@ class TestProcessRunDiffs:
         assert process_diffs(create_result.run_id) == 1
         assert process_diffs(create_result.run_id) == 0
         assert compare_images.call_count == 1
+
+    def testprocess_diffs_counts_below_threshold_comparisons(self, repo, mocker):
+        image_bytes = _make_png((255, 0, 0, 255))
+        logic.get_or_create_artifact(repo.id, "old_hash", "visual_review/old_hash")
+        logic.get_or_create_artifact(repo.id, "new_hash", "visual_review/new_hash")
+        create_result = api.create_run(
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc123",
+                branch="main",
+                snapshots=[SnapshotManifestItem(identifier="Button", content_hash="new_hash")],
+                baseline_hashes={"Button": "old_hash"},
+            ),
+            team_id=repo.team_id,
+        )
+        with (
+            patch(
+                "products.visual_review.backend.logic._resolve_baselines_with_merge_base",
+                return_value=({"Button": "old_hash"}, 0),
+            ),
+            patch("products.visual_review.backend.tasks.tasks.process_run_diffs.delay"),
+        ):
+            logic.complete_run(create_result.run_id)
+
+        mocker.patch(
+            "products.visual_review.backend.storage.ArtifactStorage.read",
+            autospec=True,
+            return_value=image_bytes,
+        )
+
+        assert process_diffs(create_result.run_id) == 1
+
+        snapshot = RunSnapshot.objects.get(run_id=create_result.run_id)
+        assert snapshot.result == SnapshotResult.UNCHANGED
+        assert snapshot.classification_reason == ClassificationReason.BELOW_THRESHOLD
+        assert ToleratedHash.objects.filter(
+            repo_id=repo.id,
+            identifier="Button",
+            baseline_hash="old_hash",
+            alternate_hash="new_hash",
+        ).exists()
 
 
 class TestCountProcessedDiffs(VisualReviewTeamScopedTestMixin, BaseTest):


### PR DESCRIPTION
## Problem

[PR #72179](https://github.com/PostHog/posthog/pull/72179) added retry-safe visual diff processing, but merged before its final below-threshold regression test was included. Without this case, a future change could stop counting successfully processed noise-level comparisons or stop seeding their tolerance cache.

## Changes

- Add a behavioral test covering below-threshold comparison persistence, processed-count reporting, and tolerance-cache creation.
- Reuse a small PNG fixture helper across the adjacent diff-processing tests.

## How did you test this code?

- `uv run ruff check products/visual_review/backend/tests/test_tasks.py --fix`
- `uv run ruff format products/visual_review/backend/tests/test_tasks.py`
- `uv run pytest --collect-only -q products/visual_review/backend/tests/test_tasks.py -k 'counts_below_threshold_comparisons'`
- `uv run mypy --cache-fine-grained .` reaches one unrelated existing error in `posthog/personhog_client/converters.py:71` and reports no error in the changed file.
- The DB-backed test could not execute locally because the configured Postgres host `db` is unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed for this test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code recovered the final test commit after the original PR merged and reapplied it cleanly on current `master`. The `/writing-tests` and `/pr-shepherd` skills were used. The one-line wrapper reported as uncovered was intentionally left without a test because it would only assert implementation delegation rather than behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
