### PR TITLE
fix(llm-gateway): allow larger agent requests

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -133,7 +133,7 @@ class Settings(BaseSettings):
     request_timeout: float = 300.0
     streaming_timeout: float = 300.0
 
-    max_request_body_size: int = 10_485_760  # 10MB
+    max_request_body_size: int = 26_214_400  # 25 MiB
 
     cors_origins: list[str] = ["*"]
 

--- a/services/llm-gateway/tests/test_main.py
+++ b/services/llm-gateway/tests/test_main.py
@@ -151,3 +151,7 @@ class TestExportProviderCredentials:
 
         export_provider_credentials(settings)
         assert os.environ["OPENAI_BASE_URL"] == "https://eu.api.openai.com/v1"
+
+
+def test_default_request_body_limit_supports_large_agent_contexts() -> None:
+    assert Settings().max_request_body_size == 25 * 1024 * 1024


### PR DESCRIPTION
## Problem

Image-heavy agent conversations can exceed the gateway's 10 MiB request limit before client-side history compaction can recover them.

## Changes

I raised the gateway safety limit to 25 MiB. This covers the observed 17.9 MB request while retaining a bounded request size.

## How did you test this code?

- Added a regression test for the 25 MiB default.
- Ran all 1,426 LLM gateway tests, 1,324 passed and 102 integration tests skipped.
- Ran Ruff checks and formatting for the changed files.
- Ran the repository pre-commit Python lint, format, and `ty` checks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A. This changes an internal gateway safety limit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code using Codex implemented this under my direction. It used the `rs-ship`, `rs-update-pr`, and `rs-tone` skills. I chose 25 MiB to cover the observed 17.9 MB request with headroom while retaining a hard cap.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*