### PR TITLE
fix(data-imports): skip OpenAI projects that 400 on sub-resource listing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/openai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/openai.py
@@ -350,14 +350,24 @@ def _iter_project_fan_out_rows(
         after = resume_after
         resume_after = None  # only the resumed-into project uses the saved cursor
 
-        for items, last_id in _iter_cursor_pages(session, headers, logger, path, {}, after):
-            for item in items:
-                row = {**_normalize_entity(config.name, item), "project_id": project_id}
-                batcher.batch(row)
-                while batcher.should_yield():
-                    yield batcher.get_table()
-                    if last_id:
-                        resumable_source_manager.save_state(OpenAIResumeConfig(cursor=last_id, project_id=project_id))
+        try:
+            for items, last_id in _iter_cursor_pages(session, headers, logger, path, {}, after):
+                for item in items:
+                    row = {**_normalize_entity(config.name, item), "project_id": project_id}
+                    batcher.batch(row)
+                    while batcher.should_yield():
+                        yield batcher.get_table()
+                        if last_id:
+                            resumable_source_manager.save_state(
+                                OpenAIResumeConfig(cursor=last_id, project_id=project_id)
+                            )
+        except requests.HTTPError as e:
+            # Some projects reject listing their project-scoped sub-resources with a 400 even for a
+            # valid admin key (e.g. the org's default project). Skip just that project so the rest of
+            # the endpoint still syncs, rather than failing the whole run on one bad project.
+            if e.response is None or e.response.status_code != 400:
+                raise
+            logger.warning(f"OpenAI: skipping {config.name} for project {project_id} after a 400 from the API")
 
         # Flush any incomplete batch before checkpointing to the next project, otherwise a crash
         # between the state save and the final flush would drop this project's buffered rows.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/tests/test_openai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/tests/test_openai.py
@@ -336,6 +336,47 @@ class TestProjectFanOut:
         rows = _collect(_FakeResumableManager(), monkeypatch, responses, "project_users")
         assert [(r["project_id"], r["id"]) for r in rows] == [("proj_1", "user_1"), ("proj_2", "user_1")]
 
+    def test_400_on_one_project_is_skipped_and_others_still_import(self, monkeypatch: Any) -> None:
+        # A single project can reject listing its sub-resources with a 400 even for a valid admin
+        # key (e.g. the org's default project). That must skip only that project, not fail the whole
+        # endpoint's sync — a 400 on proj_1 here still lets proj_2 import.
+        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
+            if "/projects/proj_1/" in url:
+                raise requests.HTTPError("400 Client Error", response=MagicMock(status_code=400))
+            if "/projects/proj_2/" in url:
+                return {"data": [{"id": "user_1"}], "has_more": False, "last_id": "user_1"}
+            return {"data": [{"id": "proj_1"}, {"id": "proj_2"}], "has_more": False, "last_id": "proj_2"}
+
+        monkeypatch.setattr(openai, "_fetch_page", fake_fetch)
+        rows: list[dict] = []
+        for table in get_rows(
+            api_key="sk-admin-test",
+            endpoint="project_users",
+            logger=MagicMock(),
+            resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+        ):
+            rows.extend(table.to_pylist())
+        assert [(r["project_id"], r["id"]) for r in rows] == [("proj_2", "user_1")]
+
+    def test_non_400_http_error_still_propagates(self, monkeypatch: Any) -> None:
+        # Only a 400 is a per-project skip; other client errors must surface so real failures aren't
+        # silently swallowed.
+        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
+            if "/projects/proj_1/" in url:
+                raise requests.HTTPError("404 Client Error", response=MagicMock(status_code=404))
+            return {"data": [{"id": "proj_1"}], "has_more": False, "last_id": "proj_1"}
+
+        monkeypatch.setattr(openai, "_fetch_page", fake_fetch)
+        with pytest.raises(requests.HTTPError):
+            list(
+                get_rows(
+                    api_key="sk-admin-test",
+                    endpoint="project_users",
+                    logger=MagicMock(),
+                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+                )
+            )
+
     def test_flushes_each_projects_rows_before_checkpointing_next(self, monkeypatch: Any) -> None:
         # A project's buffered rows must be yielded before the resume cursor advances to the next
         # project; otherwise a crash before the final flush would lose them (they'd never be re-read


### PR DESCRIPTION
## Problem

The OpenAI data warehouse source imports project-scoped resources (`project_api_keys`, `project_users`, `project_service_accounts`, `project_rate_limits`) by fanning out one request per project. Some projects reject listing those sub-resources with a `400 Bad Request` even for a valid org admin key (an org's default project is a common example). Because the fan-out let that error propagate, a single bad project failed the whole endpoint's sync for every other project.

This surfaced in error tracking as `HTTPError: 400 Client Error: Bad Request` from `openai.py:_fetch_page`, hitting `.../v1/organization/projects/<project_id>/api_keys` (and the sibling `/users` and `/service_accounts` paths under the same fingerprint).

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f7b27-e6ce-7951-95af-5a36f667b7a5

## Changes

This is a fixable bug, not a credential/upstream problem, so it's not a `NonRetryableErrors` case:

- The admin key is valid. Most projects sync fine. Only specific projects reject the sub-resource listing, so marking the whole source non-retryable would wrongly stop syncing everything.
- A blanket `400` match is too broad. A 400 can also mean a genuinely bad request (the code already documents one such case where `api_key_id` grouping on the costs endpoint 400s). We only want to tolerate a per-project rejection inside the fan-out.

The fix wraps the per-project cursor loop in `_iter_project_fan_out_rows`: on a `400` it logs and skips just that project, then continues with the rest. Any non-400 HTTP error still propagates.

> [!NOTE]
> Scoped strictly to the project fan-out path. Org-level entity endpoints are untouched, so a systematic 400 there still fails loudly rather than being silently swallowed.

## How did you test this code?

Added two cases to `TestProjectFanOut` in `test_openai.py`:

- `test_400_on_one_project_is_skipped_and_others_still_import` — a 400 on one project's listing skips only that project; the remaining project still imports. This is the regression the fix addresses; no existing fan-out test exercised the failure path.
- `test_non_400_http_error_still_propagates` — a non-400 client error surfaces instead of being swallowed, guarding against over-broad catching.

Ran locally with `uv run pytest`:

- `test_openai.py` — 37 passed
- `test_openai_source.py` — 30 passed
- `ruff check` and `ruff format --check` clean on both changed files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the issue and pulled representative events via the PostHog error-tracking MCP tools, traced the stack frame to `openai.py:_fetch_page` and the project fan-out in `_iter_project_fan_out_rows`, then decided fix-vs-non-retryable. Invoked the `/writing-tests` skill before adding the regression tests. Considered adding `400` to `get_non_retryable_errors` and rejected it as both too broad and wrong for a per-project failure that shouldn't stop the whole sync.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
