### PR TITLE
fix(mysql): retry connect reset by peer instead of giving up

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -411,6 +411,28 @@ def _is_transient_connect_dns_failure(e: BaseException) -> bool:
     return _DNS_TEMPORARY_FAILURE_TOKEN in " ".join(str(arg) for arg in e.args)
 
 
+# ECONNRESET at connect time: the peer sent a RST while the connection was being established, so
+# pymysql wraps the underlying `ConnectionResetError` as the 2003 "Can't connect to MySQL server
+# on '<host>' ([Errno 104] Connection reset by peer)" failure. Unlike a refused connection
+# (ECONNREFUSED, "Connection refused") or a failed DNS lookup — deterministic host/port misconfig
+# that stay non-retryable via the "Can't connect to MySQL server on" classifier — a reset means
+# something *was* reachable (an overloaded server, or a TCP proxy/load balancer in front of the DB
+# that accepts then resets while its backend is cycling or briefly down) and dropped us mid-connect,
+# so a fresh attempt usually recovers. Match the stable strerror phrase, not the volatile host or
+# the platform-specific [Errno NNN] prefix.
+_CONNECTION_RESET_TOKEN = "Connection reset by peer"
+
+
+def _is_transient_connect_reset(e: BaseException) -> bool:
+    """Return True if the peer reset the connection during connect — a transient blip."""
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    code = e.args[0] if e.args else None
+    if code != _CANT_CONNECT_CODE:
+        return False
+    return _CONNECTION_RESET_TOKEN in " ".join(str(arg) for arg in e.args)
+
+
 # pymysql raises this `InternalError` from `_read_packet` when an incoming packet's
 # sequence number doesn't match the expected one (it `_force_close()`s the socket first).
 _PACKET_SEQUENCE_ERROR_PHRASE = "Packet sequence number wrong"
@@ -470,6 +492,7 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
                 _is_transient_connect_drop(e)
                 or _is_transient_connect_timeout(e)
                 or _is_transient_connect_dns_failure(e)
+                or _is_transient_connect_reset(e)
                 or _is_transient_packet_sequence_error(e)
                 or _is_transient_vitess_dial_timeout(e)
             ):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -27,6 +27,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _is_bad_plan_error,
     _is_transient_connect_dns_failure,
     _is_transient_connect_drop,
+    _is_transient_connect_reset,
     _is_transient_connect_timeout,
     _is_transient_packet_sequence_error,
     _is_transient_tablet_unavailable,
@@ -994,6 +995,43 @@ class TestIsTransientConnectDnsFailure:
         assert not _is_transient_connect_dns_failure(pymysql.err.OperationalError())
 
 
+class TestIsTransientConnectReset:
+    def test_matches_connection_reset_on_connect(self):
+        # ECONNRESET at connect time — the peer sent a RST mid-connect (an overloaded server, or a
+        # TCP proxy that accepts then resets while its backend is down). A transient blip that must
+        # be retried in-process rather than surfacing as the non-retryable "Can't connect" config error.
+        assert _is_transient_connect_reset(
+            pymysql.err.OperationalError(
+                2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 104] Connection reset by peer)"
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Refused connection and failed DNS lookup are also 2003 but deterministic host/port
+            # misconfig — they must stay non-retryable, not be absorbed here.
+            "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)",
+            "Can't connect to MySQL server on 'nope.example.com' ([Errno -2] Name or service not known)",
+        ],
+    )
+    def test_does_not_match_permanent_connect_errors(self, message):
+        assert not _is_transient_connect_reset(pymysql.err.OperationalError(2003, message))
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            (2013, "Lost connection to MySQL server during query"),
+            (1045, "Access denied for user"),
+        ],
+    )
+    def test_does_not_match_other_error_codes(self, code, message):
+        assert not _is_transient_connect_reset(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_connect_reset(pymysql.err.OperationalError())
+
+
 class TestIsTransientPacketSequenceError:
     @pytest.mark.parametrize(
         "message",
@@ -1094,6 +1132,26 @@ class TestConnectTransientRetry:
         mock_connect = mocker.patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
             side_effect=[drop, conn],
+        )
+
+        with MySQLImplementation().connect(_make_config()) as yielded:
+            assert yielded is conn
+
+        assert mock_connect.call_count == 2
+        sleep.assert_called_once_with(2)
+
+    def test_retries_connection_reset_then_succeeds(self, mocker):
+        sleep = mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        conn = MagicMock()
+        conn.__enter__.return_value = conn
+        mock_connect = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=[
+                pymysql.err.OperationalError(
+                    2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 104] Connection reset by peer)"
+                ),
+                conn,
+            ],
         )
 
         with MySQLImplementation().connect(_make_config()) as yielded:


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError` from the MySQL import source: `(2003, "Can't connect to MySQL server on '<host>' ([Errno 104] Connection reset by peer)")`. The top in-app frame is `_connect_with_transient_retry` in `mysql.py` — the helper that opens a fresh pymysql connection for schema discovery and sync setup.

`ECONNRESET` at connect time means the peer sent a RST while the connection was being established. pymysql wraps the underlying `ConnectionResetError` as the code 2003 "Can't connect to MySQL server on '<host>'" failure. This is a transient infrastructure blip — an overloaded server, or a TCP proxy in front of the DB that accepts then resets while its backend is cycling or briefly down — and a fresh attempt recovers.

The problem: no transient-connect predicate matched this shape, so `_connect_with_transient_retry` re-raised on the very first attempt, and the error then hit the `"Can't connect to MySQL server on"` entry in `get_non_retryable_errors`. So a momentary reset during connect was classified **non-retryable** and gave up the sync permanently.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019f7bec-f57d-7e50-9895-b2532e273f34)

## Changes

Added `_is_transient_connect_reset` (matches pymysql code 2003 carrying "Connection reset by peer") and wired it into `_connect_with_transient_retry` alongside the existing transient-connect predicates.

This keeps the error **retryable** — a transient reset, not a user/upstream config problem, so it does not belong in `get_non_retryable_errors`. The change moves recovery in-process (bounded 5 attempts, same backoff as the other drops) so a momentary reset during connect no longer fails setup on the first blip. A refused connection (`ECONNREFUSED`, "Connection refused") and a failed DNS lookup are also 2003 but deterministic host/port misconfig, so they stay non-retryable — the predicate matches only the reset token.

> [!NOTE]
> This is the connect-establishment (2003) sibling of [#72185](https://github.com/PostHog/posthog/pull/72185), which retries the write-side "MySQL server has gone away" (2006) reset. Both share the same underlying `ConnectionResetError` but surface with different pymysql codes and message shapes, and each predicate matches only its own code — they are complementary, not overlapping.

## How did you test this code?

Automated only (I'm Claude, an agent — no manual testing).

Added:

- `TestIsTransientConnectReset` — asserts a 2003 "Connection reset by peer" connect failure is classified transient, and that refused-connection / failed-DNS 2003 errors, the 2013 drop, 1045 auth failures, and arg-less errors are **not**. Catches a regression where the predicate stops matching the reset or starts swallowing a deterministic connect/auth error.
- `test_retries_connection_reset_then_succeeds` in `TestConnectTransientRetry` — proves the predicate is actually wired into `_connect_with_transient_retry` (reset then success → one retry, one backoff sleep). Catches a regression where the classifier exists but isn't consulted.

Ran the full mysql source test file locally: `214 passed`. `ruff check` + `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) confirmed the issue in PostHog error tracking, read the stack (the top in-app frame is `_connect_with_transient_retry`, the chained cause is `ConnectionResetError [Errno 104]`), and traced the connect path. Decided this is a transient infra reset that should stay retryable rather than a non-retryable user/upstream error — so the fix recovers it in-process, matching how the source already treats the 2013 drop and the SSL/DNS/timeout connect blips. Ruled out duplicate work: [#72185](https://github.com/PostHog/posthog/pull/72185) handles the 2006 write-side "gone away" reset (a different code and error-tracking issue, and its own test asserts it does not match 2003); [#72118](https://github.com/PostHog/posthog/pull/72118) touches a drop on the streaming connection during pre-stream setup. Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
