### PR TITLE
feat(data-warehouse): promote google analytics source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -195,7 +195,7 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
                 "devices, locations, traffic sources, and events). Requires a Google account with read access "
                 "to the GA4 property."
             ),
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             featureFlag="dwh-google-analytics",
             iconPath="/static/services/google_analytics.png",
             docsUrl="https://posthog.com/docs/cdp/sources/google-analytics",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -36,7 +36,7 @@ def test_get_source_config_fields():
     assert field_names == {"google_analytics_integration_id", "property_id"}
     assert cfg.label == "Google Analytics"
     assert cfg.featureFlag == "dwh-google-analytics"
-    assert cfg.releaseStatus == ReleaseStatus.ALPHA
+    assert cfg.releaseStatus == ReleaseStatus.BETA
     assert not cfg.unreleasedSource
 
 


### PR DESCRIPTION
## Problem

The Google Analytics (GA4) data-warehouse source has been running in alpha. Over the last 7 days it has cleared the bar we use to move a source to beta:

- Used by 34 teams (need >= 30)
- Import error rate of 0.1% over the last 7 days (need < 5%)

Time to promote it so it reads as a more trusted, established connector.

## Changes

Flip the source's `releaseStatus` from `ALPHA` to `BETA` in `get_source_config`, and update the matching test assertion.

This is a status-only promotion. No connector behavior, schemas, or sync logic change. The `dwh-google-analytics` feature flag stays in place, consistent with how other beta sources (`customer_io`, `intercom`) keep their gating flag — release status is a soft label, not a gate, and nothing in the repo conventions ties the two together.

## How did you test this code?

Ran the source-config test that asserts the release status:

```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py::test_get_source_config_fields
```

It passes. I (the agent) did not exercise the live GA4 API — this change doesn't touch transport or sync logic.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — the source doc already exists and behavior is unchanged.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code). Invoked the `/implementing-warehouse-sources` skill to confirm where source release status lives and the alpha/beta/GA conventions.

Decisions:
- Left the `dwh-google-analytics` feature flag untouched. The skill treats `releaseStatus` and `featureFlag` as independent, and existing beta sources (`customer_io`, `intercom`) keep their flags — so removing it wasn't warranted for this promotion.
- Ruled out a duplicate: searched open PRs by source name, "releaseStatus", "promote beta", and the maintainer's own open PRs. The only nearby PR promotes Cloudflare, not Google Analytics.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
