### PR TITLE
chore(agent-platform): refresh project readme

### DIFF
--- a/products/agent_platform/README.md
+++ b/products/agent_platform/README.md
@@ -124,6 +124,7 @@ hogli build:openapi
 
 ## Further reading
 
+- [`docs/architecture.md`](docs/architecture.md): control plane, runtime architecture, data model, and revision lifecycle.
 - [`docs/identity-and-tools.md`](docs/identity-and-tools.md): identity, credentials, approvals, and tool dispatch.
 - [`docs/custom-tools.md`](docs/custom-tools.md): custom-tool contract and sandbox boundary.
 - [`docs/coherence-overview.md`](docs/coherence-overview.md): cross-language contract generation and validation.

--- a/products/agent_platform/README.md
+++ b/products/agent_platform/README.md
@@ -124,6 +124,7 @@ hogli build:openapi
 
 ## Further reading
 
+- [`docs/README.md`](docs/README.md): index of the agent platform documentation.
 - [`docs/architecture.md`](docs/architecture.md): control plane, runtime architecture, data model, and revision lifecycle.
 - [`docs/identity-and-tools.md`](docs/identity-and-tools.md): identity, credentials, approvals, and tool dispatch.
 - [`docs/custom-tools.md`](docs/custom-tools.md): custom-tool contract and sandbox boundary.

--- a/products/agent_platform/README.md
+++ b/products/agent_platform/README.md
@@ -1,40 +1,130 @@
-# agent_platform v2 backend
+# Agent platform
 
-This is the Django-side data layer for the v2 agent platform refactor (see
-[docs/native-refactor.md](../../../docs/native-refactor.md)).
+The agent platform is PostHog's system for authoring, publishing, and running AI agents.
+It includes the Django control plane, the Node.js runtime services, shared contracts, built-in tools, sandbox execution, and end-to-end tests.
 
-## What's here
+This directory contains the active implementation.
+The earlier v2 cutover is complete: the models use their final names, Django owns the schema, and all agent platform tables live in the dedicated `agent_platform` product database.
 
-- `models_v2.py` — new `AgentApplicationV2`, `AgentRevisionV2`, `AgentSessionV2`
-  shapes. Replaces `models.py`'s `AgentApplication` + `AgentApplicationRevision`.
+## How it works
 
-## Cutover plan (pre-prod — DB gets dropped)
+The platform has two main paths:
 
-1. Add `models_v2` to `apps.py`'s migrations target.
-2. Generate a migration that drops the v1 tables and creates the v2 tables.
-3. Wire `api.py` to read/write the v2 models. (Existing `api.py` becomes
-   reference-only and is deleted post-cutover.)
-4. Internal endpoints for `agent-ingress-v2` and `agent-runner-v2` consume the
-   v2 tables directly.
-5. After step 9 of the refactor sequence, drop `models.py`, rename
-   `models_v2.py` → `models.py`, drop the `V2` suffixes from class names.
-
-## The shape
+- **Authoring:** clients use the Django API to create an application, edit draft revisions, manage secrets and bundle files, validate the result, and promote a revision to live.
+- **Execution:** external triggers reach `agent-ingress`, while scheduled triggers are fired by `agent-janitor`. Both create sessions for the application's live revision. `agent-runner` claims each session, runs the model loop, dispatches tools, and persists the result.
 
 ```text
-AgentApplicationV2
-  team_id, slug, name, description, encrypted_env, live_revision_id, archived
-  (unique on slug while archived=false)
-
-AgentRevisionV2
-  application_id, parent_revision_id, state, bundle_uri, bundle_sha256, spec(JSONB)
-  state: draft → ready → live | archived
-
-AgentSessionV2
-  application_id, revision_id, team_id, state, external_key, conversation(JSONB), metadata
-  (unique on (application, external_key) while state in queued/running/waiting)
+Authors and API clients
+        │
+        ▼
+Django API ───────────────► agent-janitor
+        │                    bundle, memory, and operational APIs
+        │
+        ▼
+agent_platform database
+ applications, revisions, sessions, users, credentials, approvals
+        ▲
+        │
+External triggers ──► agent-ingress ──► agent-runner ──► tools and sandboxes
+Scheduled triggers ─► agent-janitor ───────▲
+                          │                 │
+                          └── sessions ─────┘
 ```
 
-The `spec` JSONB is the structural truth — model, triggers, tools, mcps,
-skills, secrets, limits, entrypoint. See `@posthog/agent-shared-v2`
-for the canonical TypeScript shape (`AgentSpec`).
+Agent bundles and agent memory are stored in S3-compatible object storage.
+The services authenticate internal requests with audience-bound JWTs signed by `AGENT_INTERNAL_SIGNING_KEY`.
+
+## Repository layout
+
+### Django control plane
+
+[`backend/`](backend/) owns the database schema and the project-scoped REST API.
+
+- [`backend/models.py`](backend/models.py) defines the authoring and runtime models.
+- [`backend/presentation/`](backend/presentation/) contains serializers and viewsets for applications, revisions, sessions, users, approvals, memory, and fleet operations.
+- [`backend/routes.py`](backend/routes.py) registers routes under `/api/projects/<project_id>/`.
+- [`backend/logic/`](backend/logic/) contains the janitor and ingress clients, spec helpers, skill resolution, and generated cross-language contracts.
+- [`backend/migrations/`](backend/migrations/) is the only source of database migrations for the platform. The Node.js services consume the schema but do not manage it.
+- [`frontend/generated/`](frontend/generated/) contains generated TypeScript API clients and schemas. Do not edit these files by hand.
+
+The primary authoring resources are:
+
+- `agent_applications`: application CRUD, invocation, session history, users, approvals, and statistics.
+- `agent_applications/<application_id>/revisions`: draft editing, bundle operations, validation, promotion, archiving, secrets, and skill references.
+- `agent_applications/<application_id>/memory`: application-scoped memory management.
+- `agent_native_tools`: the built-in tool catalog.
+- `agent_fleet`: cross-application operational views for a project.
+
+### Runtime services
+
+[`services/`](services/) contains the Node.js packages that run agents:
+
+- [`agent-ingress/`](services/agent-ingress/) accepts chat, webhook, Slack, and MCP traffic; authenticates callers; resolves live revisions; creates sessions; and streams lifecycle events.
+- [`agent-runner/`](services/agent-runner/) claims queued sessions, builds the model context, runs the model loop, dispatches native, MCP, and custom tools, and records results.
+- [`agent-janitor/`](services/agent-janitor/) exposes internal bundle, revision, memory, session, and maintenance APIs used by Django; fires cron triggers; and periodically recovers stale runtime state.
+- [`agent-sandbox-host/`](services/agent-sandbox-host/) is the process inside isolated custom-tool sandboxes.
+- [`agent-shared/`](services/agent-shared/) is the canonical home for the agent spec, persistence clients, identity and credential contracts, bundle storage, memory, transports, sandbox adapters, and runtime utilities.
+- [`agent-tools/`](services/agent-tools/) contains PostHog-provided native tools and their authorization rules.
+- [`agent-tests/`](services/agent-tests/) is the end-to-end harness for full authoring and execution flows.
+- [`agents/`](services/agents/) builds the unified production image for ingress, runner, janitor, and migrations.
+
+## Core data model
+
+All models are team-scoped and stored in the dedicated product database.
+The central records are:
+
+- **Application:** the stable agent identity, globally unique routing slug, metadata, and pointer to the live revision.
+- **Revision:** a versioned agent definition containing the structural spec, bundle location, encrypted environment, skill references, and revision lineage. Draft content is editable; promotion freezes the spec and bundle, while environment keys remain rotatable.
+- **Session:** one execution, including trigger metadata, conversation state, status, output, usage, errors, and timing.
+- **Agent user and transport binding:** the caller's transport identity and its verified canonical identity for an application.
+- **Credentials and identity links:** short-lived session credentials, reusable linked credentials, and pending identity-link state.
+- **Tool approval request:** a durable approval gate for tool calls that require human confirmation.
+- **Sandbox instance:** lifecycle state for isolated custom-tool execution.
+
+Revision state moves through:
+
+```text
+draft → ready → live
+          │       │
+          └───────┴──► archived
+```
+
+The canonical agent spec is [`AgentSpecSchema`](services/agent-shared/src/spec/spec.ts).
+It defines the model, triggers, tools, MCP connections, skills, secrets, limits, identity policy, and runtime behavior.
+Keep Python helpers and generated contracts synchronized with this schema.
+
+## Development
+
+Read [`docs/local-dev.md`](docs/local-dev.md) for stack setup, local MCP usage, smoke tests, and debugging recipes.
+The `agent_runtime` development capability starts the database and the main runtime services through `hogli start`.
+
+Common checks:
+
+```bash
+# Django tests and lint
+hogli test products/agent_platform/backend
+pnpm --filter @posthog/products-agent-platform backend:lint
+
+# Runtime package tests
+pnpm --filter @posthog/agent-ingress test
+pnpm --filter @posthog/agent-runner test
+pnpm --filter @posthog/agent-janitor test
+pnpm --filter @posthog/agent-shared test
+pnpm --filter @posthog/agent-tools test
+
+# Full platform flow
+pnpm --filter @posthog/agent-tests test
+```
+
+After changing a serializer or viewset, regenerate OpenAPI clients and MCP schemas:
+
+```bash
+hogli build:openapi
+```
+
+## Further reading
+
+- [`docs/identity-and-tools.md`](docs/identity-and-tools.md): identity, credentials, approvals, and tool dispatch.
+- [`docs/custom-tools.md`](docs/custom-tools.md): custom-tool contract and sandbox boundary.
+- [`docs/coherence-overview.md`](docs/coherence-overview.md): cross-language contract generation and validation.
+- [`AGENTS.md`](AGENTS.md): implementation rules and pointers for contributors working in this product.


### PR DESCRIPTION
## Problem

**Why:** The agent platform README still described an unfinished v2 migration, so it no longer helped contributors understand the product that exists today.

## Changes

- Replace the cutover checklist with a current overview of the control plane, runtime services, data model, execution flow, and development commands.
- Link contributors to the canonical spec and focused implementation guides.