### PR TITLE
fix(google_sheets): name service account in permission-denied error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -113,7 +113,9 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
         except PermissionError:
             return (
                 False,
-                "Permissions missing from spreadsheet. View documentation at https://posthog.com/docs/cdp/sources/google-sheets",
+                "PostHog does not have access to this spreadsheet. Share it with our service account "
+                f"({settings.GOOGLE_SHEETS_SERVICE_ACCOUNT_CLIENT_EMAIL}) as a Viewer, then try again. "
+                "See https://posthog.com/docs/cdp/sources/google-sheets for more.",
             )
         except gspread.exceptions.APIError as e:
             # gspread stringifies these as "APIError: [<code>]: <message>", which isn't actionable.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -615,6 +615,20 @@ def test_validate_credentials_maps_api_error_to_friendly_message(api_message, ex
     assert "APIError" not in (error_message or "")
 
 
+def test_validate_credentials_permission_denied_names_service_account(settings):
+    settings.GOOGLE_SHEETS_SERVICE_ACCOUNT_CLIENT_EMAIL = "svc@posthog.iam.gserviceaccount.com"
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.source.google_sheets_client"
+    ) as mock_client:
+        mock_client.return_value.open_by_url.side_effect = PermissionError()
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+        is_valid, error_message = GoogleSheetsSource().validate_credentials(config, team_id=1)
+
+    assert is_valid is False
+    # The user needs the exact address to share the sheet with — not just a docs link.
+    assert "svc@posthog.iam.gserviceaccount.com" in (error_message or "")
+
+
 @pytest.mark.parametrize(
     "auth_error,expect_retry_hint",
     [


### PR DESCRIPTION
## Problem

During data-warehouse onboarding, users repeatedly hit a 403 when linking a Google Sheet they had not yet shared with PostHog's service account. The error toast pointed to the docs but never named the exact address to share the sheet with, so users had to leave the flow to find it — and often retried the same failing action.

## Changes

Surface the service account address inline in the permission-denied error raised during connection validation, so the actionable next step (share the sheet with this address as a Viewer) is self-contained. The field caption and the sync-time error already do this; this brings the connect-time (onboarding) message in line.

## How did you test this code?

Added `test_validate_credentials_permission_denied_names_service_account`, which asserts the 403 validate-time message includes the configured service account address — guarding against a regression that drops the address and leaves users with only a docs link (no existing test covered the `PermissionError` message content). Ran the `validate_credentials` suite for this source (6 passed) and ruff check/format over the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent reviewing anonymized onboarding session summaries for the data-warehouse new-source flow. Repeated 403s on Google Sheets linking stood out as a recurring, self-contained copy gap. Invoked the `/writing-tests` skill to gate the added test. No sync behaviour or schemas were changed — copy only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
