### PR TITLE
feat(dashboards): mirror dashboard cache counters into the metrics product

### DIFF
--- a/products/dashboards/backend/access.py
+++ b/products/dashboards/backend/access.py
@@ -6,8 +6,11 @@ from prometheus_client import Counter
 from rest_framework.request import Request
 
 from posthog.event_usage import EventSource, get_event_source
+from posthog.otel_metrics import OtelInstrumentFactory
 
 from products.dashboards.backend.models.dashboard import Dashboard
+
+_otel = OtelInstrumentFactory("dashboards")
 
 
 class DashboardAccessMethod(StrEnum):
@@ -43,6 +46,7 @@ def dashboard_access_method(
 
 def record_dashboard_access(access_method: DashboardAccessMethod) -> None:
     DASHBOARD_ACCESS_COUNTER.labels(access_method=access_method.value).inc()
+    _otel.record_counter_twin(DASHBOARD_ACCESS_COUNTER, 1, {"access_method": access_method.value})
 
 
 def record_dashboard_view(dashboard: Dashboard, access_method: DashboardAccessMethod) -> None:
@@ -52,7 +56,8 @@ def record_dashboard_view(dashboard: Dashboard, access_method: DashboardAccessMe
 
 
 def record_dashboard_cache_outcome(access_method: DashboardAccessMethod, *, is_cached: bool) -> None:
-    DASHBOARD_CACHE_OUTCOME_COUNTER.labels(
-        access_method=access_method.value,
-        result="hit" if is_cached else "miss",
-    ).inc()
+    result = "hit" if is_cached else "miss"
+    DASHBOARD_CACHE_OUTCOME_COUNTER.labels(access_method=access_method.value, result=result).inc()
+    _otel.record_counter_twin(
+        DASHBOARD_CACHE_OUTCOME_COUNTER, 1, {"access_method": access_method.value, "result": result}
+    )


### PR DESCRIPTION
## Problem

#71628 added `posthog_dashboard_access_total` and `posthog_dashboard_cache_outcome_total` as Prometheus counters, so the cache-outcome baseline for the dashboard refresh work is only visible in Grafana. We dogfood the PostHog Metrics product for other backend metrics (session replay playback, replay vision), and it would be useful to watch these counters there too, next to the related analytics.

Refs #43633 — same dual-emit goal for analytics-platform surfaces; this covers the metrics-product half for the dashboard cache counters.

## Changes

- Mirror both counters into the Metrics product using the existing `OtelInstrumentFactory` twin helpers from `posthog/otel_metrics.py`, following the `session_recording_api.py` pattern.
- Metric names and labels stay 1:1 with the scraped Prometheus series (the twin helper restores the `_total` suffix), so Grafana and PostHog dashboards translate directly.
- No-op unless `OTEL_METRICS_EXPORT_URL` and `OTEL_METRICS_EXPORT_TOKEN` are configured; twin recording swallows errors by design, so hot paths are unaffected.

## How did you test this code?

- `ruff check` and `ruff format --check` pass on the changed file; it compiles.
- The twin machinery has existing coverage in `posthog/test/test_otel_metrics.py` (name/description derivation, `_total` restoration, no-op gating), and `products/dashboards/backend/test/test_access.py` continues to cover the counter call sites. No new tests: the change adds two calls to already-tested helpers behind an env gate.
- pytest could not run in this task sandbox (no Python test environment); nothing in the diff is reachable by CI beyond Python lint and the existing suites above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal telemetry wiring, no user-facing behavior change.

## 🤖 Agent context

Human-driven (agent-assisted) — requested by @pauldambra as a follow-up to #71628 so the cache-outcome counters are queryable in the Metrics product alongside the query-cost tracking.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*