### PR TITLE
fix(batch-exports): treat S3 SSL handshake errors as non-retryable

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -78,6 +78,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "NoSuchBucket",
     # Couldn't connect to custom S3 endpoint
     "EndpointConnectionError",
+    # TLS handshake failed against a custom S3 endpoint
+    "SSLError",
     # User provided an invalid S3 key
     "InvalidS3Key",
     # Invalid S3 endpoint URL


### PR DESCRIPTION
## Problem

An S3 batch export to a custom S3-compatible endpoint can fail its TLS handshake. This can also occur if the host of the `endpoint_url` is invalid (example error message: `SSL validation failed for https://my_host Cannot connect to host my_host:443 ssl:default [[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:1032)]`). botocore surfaces this as an `SSLError`, which was not listed in `NON_RETRYABLE_ERROR_TYPES`, so the activity re-raised and Temporal retried it forever (the schedule uses `MaximumAttempts: 0`).

## Changes

Added `"SSLError"` to `NON_RETRYABLE_ERROR_TYPES` in the S3 destination

## How did you test this code?

I (Claude) did not test this manually. I confirmed botocore's `SSLError` class name is `SSLError` and its constructor signature via a quick local `python -c` check. I initially added a full workflow-environment regression test and it passed, but we dropped it: booting a `WorkflowEnvironment` (~35s) to assert one string is in a tuple isn't worth the CI cost for a change this small.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ross pointed me (Claude, via PostHog Code) at a stuck Temporal Cloud workflow and asked me to fix the error. I used the `debugging-temporal-cloud-workflows` skill to pull the failure off the prod-us run with the `temporal` CLI (`workflow describe`), which showed the `SSLError` retrying under `MaximumAttempts: 0`. I traced it to the string-based classification in `NON_RETRYABLE_ERROR_TYPES` + `handle_non_retryable_errors`.

I invoked `/writing-tests` and initially added a regression test raising a real `botocore.exceptions.SSLError`, reasoning it would guard against the classification string drifting from the real class name. Ross flagged it as too slow/expensive for the payoff, so I removed it and kept the change to the one-line fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*