### PR TITLE
fix(cdp): hide native webhook from destination chooser

### DIFF
--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -247,6 +247,9 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
                 }
                 return templates
                     .filter((x) => shouldShowHogFunctionTemplate(x, user))
+                    // The native webhook is an internal building block; the public HTTP Webhook
+                    // destination covers this use case, so keep it out of the chooser entirely.
+                    .filter((x) => x.id !== 'native-webhook')
                     .filter((x) => !x.flag || !!featureFlags[x.flag as FeatureFlagKey])
                     .filter((x) => x.type !== 'source_webhook' || !!featureFlags[FEATURE_FLAGS.CDP_HOG_SOURCES])
                     .filter(


### PR DESCRIPTION
## Problem

Staff users see the internal **Native HTTP Webhook** template in the destinations chooser and can create destinations from it. That template is a `hidden` internal building block, not a supported standalone destination, so any later edit that keeps the function enabled (e.g. tweaking its filters) is rejected with:

> This function was created from an internal template and can only be disabled or deleted, not kept enabled.

The public **HTTP Webhook** destination has been available for a long time and covers this use case, so the native webhook shouldn't be offered as a choice.

## Changes

Filter the `native-webhook` template out of the destinations chooser for all users (it was previously stripped from the anonymous catalog but still shown to staff, since the chooser surfaces `hidden` templates to `is_staff` users). The template stays registered, so existing native-webhook functions keep executing at runtime — this only removes it from the picker.

## How did you test this code?

No automated tests added — this is a one-line list filter matching the existing per-id exclusions already in `hogFunctionTemplateListLogic`. I (the agent) did not run the app manually. Reviewer can verify the native webhook no longer appears in the destinations chooser as a staff user.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread: a staff user hit the "internal template" error editing a native-webhook destination's filters. Traced the error to `_validate_hidden_template_not_enabled` in `products/cdp/backend/api/hog_function.py`, then found the chooser (`hogFunctionTemplateListLogic`) shows `hidden` templates to staff via `shouldShowHogFunctionTemplate`. Chose a targeted frontend id-exclusion (the pattern the file already uses for other templates) over unregistering the template, since the runtime executor resolves existing native functions from the template registry and removing it would break them.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784320790705409?thread_ts=1784320790.705409&cid=C0ACRAMJUAG)*
