### PR TITLE
feat(conversations): link tickets table channel tag to slack thread

### DIFF
--- a/products/conversations/frontend/components/Channels/ChannelsTag.tsx
+++ b/products/conversations/frontend/components/Channels/ChannelsTag.tsx
@@ -60,7 +60,8 @@ export function ChannelsTag({ channel, detail, to }: ChannelsTagProps): JSX.Elem
         const tooltip = channelOpenLabel[channel] ?? `${channel}${detailText ? ` · ${detailText}` : ''}`
         return (
             <Tooltip title={tooltip}>
-                <Link to={to} target="_blank">
+                {/* Stop propagation so clicking the tag opens Slack without triggering a row/parent click. */}
+                <Link to={to} target="_blank" onClick={(e) => e.stopPropagation()}>
                     {tag}
                 </Link>
             </Tooltip>

--- a/products/conversations/frontend/components/Channels/ChannelsTag.tsx
+++ b/products/conversations/frontend/components/Channels/ChannelsTag.tsx
@@ -3,7 +3,15 @@ import { LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { IconMicrosoftTeams, IconSlack } from 'lib/lemon-ui/icons'
 
-import type { TicketChannel, TicketChannelDetail } from '../../types'
+import type { Ticket, TicketChannel, TicketChannelDetail } from '../../types'
+
+// Builds a deep link to the originating Slack thread so the Channel tag can be clickable.
+export function getChannelThreadUrl(ticket: Ticket | null): string | undefined {
+    if (ticket?.channel_source === 'slack' && ticket.slack_channel_id && ticket.slack_thread_ts) {
+        return `https://app.slack.com/archives/${ticket.slack_channel_id}/p${ticket.slack_thread_ts.replace('.', '')}`
+    }
+    return undefined
+}
 
 const channelIcon: Record<TicketChannel, JSX.Element> = {
     widget: <IconComment />,

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -21,18 +21,12 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { AssigneeIconDisplay, AssigneeLabelDisplay, AssigneeSelect } from '../../components/Assignee'
-import { ChannelsTag } from '../../components/Channels/ChannelsTag'
+import { ChannelsTag, getChannelThreadUrl } from '../../components/Channels/ChannelsTag'
 import { ChatView } from '../../components/Chat/ChatView'
 import { IdentityBadge } from '../../components/IdentityBadge/IdentityBadge'
 import { SlaDisplay } from '../../components/SlaDisplay'
 import { TicketTags } from '../../components/TicketTags'
-import {
-    type Ticket,
-    type TicketPriority,
-    type TicketStatus,
-    priorityOptions,
-    statusOptionsWithoutAll,
-} from '../../types'
+import { type TicketPriority, type TicketStatus, priorityOptions, statusOptionsWithoutAll } from '../../types'
 import { AIPanel } from './AIPanel'
 import { ExceptionsPanel } from './ExceptionsPanel'
 import { PreviousTicketsPanel } from './PreviousTicketsPanel'
@@ -48,14 +42,6 @@ export const scene: SceneExport<{ ticketId: string; id: string }> = {
     logic: supportTicketSceneLogic,
     productKey: ProductKey.CONVERSATIONS,
     paramsToProps: ({ params: { ticketId } }) => ({ ticketId, id: ticketId || 'new' }),
-}
-
-// Builds a deep link to the originating Slack thread so the Channel tag can be clickable.
-function getChannelThreadUrl(ticket: Ticket | null): string | undefined {
-    if (ticket?.channel_source === 'slack' && ticket.slack_channel_id && ticket.slack_thread_ts) {
-        return `https://app.slack.com/archives/${ticket.slack_channel_id}/p${ticket.slack_thread_ts.replace('.', '')}`
-    }
-    return undefined
 }
 
 // The rendered label is "<Send|Attach> and set <statusLabel>", depending on the private note checkbox

--- a/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
+++ b/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
@@ -9,7 +9,7 @@ import { stripMarkdown } from 'lib/utils/markdown'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
 import { AssigneeDisplay, AssigneeResolver } from '../../components/Assignee'
-import { ChannelsTag } from '../../components/Channels/ChannelsTag'
+import { ChannelsTag, getChannelThreadUrl } from '../../components/Channels/ChannelsTag'
 import { IdentityBadge } from '../../components/IdentityBadge/IdentityBadge'
 import { SlaDisplay } from '../../components/SlaDisplay'
 import { TicketPreviewPopover } from '../../components/TicketPreview/TicketPreviewPopover'
@@ -238,7 +238,13 @@ const TICKET_COLUMNS: Record<TicketColumnKey, TicketColumnDefinition> = {
         column: {
             title: 'Channel',
             key: 'channel',
-            render: (_, ticket) => <ChannelsTag channel={ticket.channel_source} detail={ticket.channel_detail} />,
+            render: (_, ticket) => (
+                <ChannelsTag
+                    channel={ticket.channel_source}
+                    detail={ticket.channel_detail}
+                    to={getChannelThreadUrl(ticket)}
+                />
+            ),
         },
     },
     tags: {


### PR DESCRIPTION
## Problem

In the support tickets table, the Channel column shows a Slack tag but it is not clickable. The single-ticket detail view already makes its Channel tag link out to the originating Slack thread. This closes that gap so you can jump from the list straight into Slack without opening each ticket first.

## Changes

The `ChannelsTag` component already supported a `to` prop that renders an external-link glyph, an "Open in Slack" tooltip, and wraps the tag in a link. The table column just never passed it.

- Moved the `getChannelThreadUrl` helper out of `SupportTicketScene` (where it was private) and into `ChannelsTag`, next to the component that consumes its output, and exported it.
- The detail view now imports the shared helper instead of defining its own. Behavior there is unchanged.
- The table's Channel column now passes `to={getChannelThreadUrl(ticket)}`.

Only Slack rows that have both `slack_channel_id` and `slack_thread_ts` become clickable. Other channels (email, widget, teams, github) and Slack rows missing those IDs fall back to the existing non-clickable tag, so there is no regression. The table rows already carry those fields, so no API or serializer changes were needed.

<img width="309" height="865" alt="CleanShot 2026-07-20 at 10 58 34" src="https://github.com/user-attachments/assets/7f3df191-e44a-472d-98d0-ab52d540a9a3" />

## How did you test this code?

I (Claude) ran `pnpm --filter=@posthog/frontend typescript:check`. The three changed files report no type errors. I did not run the app or manually click through the UI, so the visual and click behavior in the tickets list has not been verified by a human yet.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Luke asked whether it would be much work to make the tickets-table Slack tag open the ticket in Slack, the same way the Customer panel in the ticket detail view does. It turned out to be a few lines: the shared `ChannelsTag` component already handled the clickable case, so the work was sharing the URL builder (`getChannelThreadUrl`) rather than duplicating it, then passing `to` from the table column. No new component or logic was introduced.

Tools: Claude Code (Explore agents for codebase search, then direct edits). No repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
