### PR TITLE
fix(replay-vision): retire gemini-2.5-flash scanner model

### DIFF
--- a/products/replay_vision/backend/billing.py
+++ b/products/replay_vision/backend/billing.py
@@ -23,11 +23,11 @@ CREDITS_PER_DOLLAR = 100  # 1 credit = $0.01, matching ai_credits
 # Keyed on the raw model-id string (not the enum) because frozen `scanner_snapshot`s and
 # receipts outlive enum members; retired ids must keep pricing in-flight observations.
 OBSERVATION_CREDITS_BY_MODEL: dict[str, int] = {
-    ScannerModel.GEMINI_2_5_FLASH: 2,
     ScannerModel.GEMINI_3_FLASH: 5,
     ScannerModel.GEMINI_3_5_FLASH: 15,
     # Retired ids, kept for observations frozen before the lineup change.
     "gemini-3.1-flash-lite-preview": 2,
+    "gemini-2.5-flash": 2,
 }
 
 # Unknown models bill at the highest known price: never underbill on a mapping gap.

--- a/products/replay_vision/backend/migrations/0049_retire_gemini_2_5_flash_scanner_model.py
+++ b/products/replay_vision/backend/migrations/0049_retire_gemini_2_5_flash_scanner_model.py
@@ -1,19 +1,5 @@
 from django.db import migrations, models
 
-# Google retired gemini-2.5-flash: it 404s ("no longer available"), so every scanner still pinned
-# to it fails its sweep. Move them to the current Flash tier — the same successor and default new
-# scanners already get. The retired id stays priced in billing.OBSERVATION_CREDITS_BY_MODEL so
-# frozen snapshots and in-flight receipts still bill correctly.
-_MODEL_REMAP = {
-    "gemini-2.5-flash": "gemini-3-flash-preview",
-}
-
-
-def remap_scanner_models(apps, schema_editor):
-    ReplayScanner = apps.get_model("replay_vision", "ReplayScanner")
-    for old, new in _MODEL_REMAP.items():
-        ReplayScanner.objects.filter(model=old).update(model=new)
-
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -32,5 +18,4 @@ class Migration(migrations.Migration):
                 max_length=64,
             ),
         ),
-        migrations.RunPython(remap_scanner_models, migrations.RunPython.noop, elidable=True),
     ]

--- a/products/replay_vision/backend/migrations/0049_retire_gemini_2_5_flash_scanner_model.py
+++ b/products/replay_vision/backend/migrations/0049_retire_gemini_2_5_flash_scanner_model.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+# Google retired gemini-2.5-flash: it 404s ("no longer available"), so every scanner still pinned
+# to it fails its sweep. Move them to the current Flash tier — the same successor and default new
+# scanners already get. The retired id stays priced in billing.OBSERVATION_CREDITS_BY_MODEL so
+# frozen snapshots and in-flight receipts still bill correctly.
+_MODEL_REMAP = {
+    "gemini-2.5-flash": "gemini-3-flash-preview",
+}
+
+
+def remap_scanner_models(apps, schema_editor):
+    ReplayScanner = apps.get_model("replay_vision", "ReplayScanner")
+    for old, new in _MODEL_REMAP.items():
+        ReplayScanner.objects.filter(model=old).update(model=new)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("replay_vision", "0048_alter_visionaction_alert_config"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="replayscanner",
+            name="model",
+            field=models.CharField(
+                choices=[
+                    ("gemini-3-flash-preview", "Gemini 3 Flash"),
+                    ("gemini-3.5-flash", "Gemini 3.5 Flash"),
+                ],
+                max_length=64,
+            ),
+        ),
+        migrations.RunPython(remap_scanner_models, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/replay_vision/backend/migrations/0050_remap_retired_gemini_2_5_flash_scanners.py
+++ b/products/replay_vision/backend/migrations/0050_remap_retired_gemini_2_5_flash_scanners.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+# Google retired gemini-2.5-flash: it 404s ("no longer available"), so every scanner still pinned
+# to it fails its sweep. Move them to the current Flash tier — the same successor and default new
+# scanners already get. The retired id stays priced in billing.OBSERVATION_CREDITS_BY_MODEL so
+# frozen snapshots and in-flight receipts still bill correctly.
+_MODEL_REMAP = {
+    "gemini-2.5-flash": "gemini-3-flash-preview",
+}
+
+
+def remap_scanner_models(apps, schema_editor):
+    ReplayScanner = apps.get_model("replay_vision", "ReplayScanner")
+    for old, new in _MODEL_REMAP.items():
+        ReplayScanner.objects.filter(model=old).update(model=new)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("replay_vision", "0049_retire_gemini_2_5_flash_scanner_model"),
+    ]
+
+    operations = [
+        migrations.RunPython(remap_scanner_models, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/replay_vision/backend/migrations/max_migration.txt
+++ b/products/replay_vision/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0048_alter_visionaction_alert_config
+0049_retire_gemini_2_5_flash_scanner_model

--- a/products/replay_vision/backend/migrations/max_migration.txt
+++ b/products/replay_vision/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0049_retire_gemini_2_5_flash_scanner_model
+0050_remap_retired_gemini_2_5_flash_scanners

--- a/products/replay_vision/backend/models/replay_scanner.py
+++ b/products/replay_vision/backend/models/replay_scanner.py
@@ -34,7 +34,6 @@ class ScannerProvider(models.TextChoices):
 class ScannerModel(models.TextChoices):
     """Priced per observation in `billing.OBSERVATION_CREDITS_BY_MODEL`; new members need a price there."""
 
-    GEMINI_2_5_FLASH = "gemini-2.5-flash", "Gemini 2.5 Flash"
     GEMINI_3_FLASH = "gemini-3-flash-preview", "Gemini 3 Flash"
     GEMINI_3_5_FLASH = "gemini-3.5-flash", "Gemini 3.5 Flash"
 

--- a/products/replay_vision/backend/tests/test_billing.py
+++ b/products/replay_vision/backend/tests/test_billing.py
@@ -43,7 +43,8 @@ class TestReplayVisionBillingUsage(APIBaseTest):
         self._receipt(team_id=self.team.id, created_at=now, model=ScannerModel.GEMINI_3_FLASH)
         self._receipt(team_id=self.team.id, created_at=now, model=ScannerModel.GEMINI_3_5_FLASH)
         self._receipt(team_id=self.team.id, created_at=now - timedelta(days=3))
-        self._receipt(team_id=self.team.id + 1, created_at=now, model=ScannerModel.GEMINI_2_5_FLASH)
+        # A frozen receipt for the retired gemini-2.5-flash id still bills at its kept price.
+        self._receipt(team_id=self.team.id + 1, created_at=now, model="gemini-2.5-flash")
 
         result = dict(get_replay_vision_credits_by_team(begin, end))
         assert result == {self.team.id: 5 + 15, self.team.id + 1: 2}

--- a/products/replay_vision/backend/tests/test_models.py
+++ b/products/replay_vision/backend/tests/test_models.py
@@ -85,7 +85,7 @@ class TestReplayScanner(BaseTest):
             ("scanner_config", {"prompt": "different prompt"}),
             ("query", {"properties": [{"key": "foo"}]}),
             ("sampling_rate", 0.25),
-            ("model", ScannerModel.GEMINI_2_5_FLASH),
+            ("model", ScannerModel.GEMINI_3_5_FLASH),
             ("emits_signals", True),
         ]
     )

--- a/products/replay_vision/backend/tests/test_quota.py
+++ b/products/replay_vision/backend/tests/test_quota.py
@@ -109,7 +109,7 @@ class _VisionQuotaTestCase(APIBaseTest):
 class TestComputeQuotaSnapshot(_VisionQuotaTestCase):
     @parameterized.expand(
         [
-            (ObservationStatus.SUCCEEDED, ScannerModel.GEMINI_2_5_FLASH, 2),
+            (ObservationStatus.SUCCEEDED, "gemini-2.5-flash", 2),
             (ObservationStatus.SUCCEEDED, ScannerModel.GEMINI_3_FLASH, 5),
             (ObservationStatus.SUCCEEDED, ScannerModel.GEMINI_3_5_FLASH, 15),
             (ObservationStatus.PENDING, ScannerModel.GEMINI_3_5_FLASH, 15),

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -693,14 +693,12 @@ export const ScannerProviderEnumApi = {
 } as const
 
 /**
- * * `gemini-2.5-flash` - Gemini 2.5 Flash
  * * `gemini-3-flash-preview` - Gemini 3 Flash
  * * `gemini-3.5-flash` - Gemini 3.5 Flash
  */
 export type ScannerModelEnumApi = (typeof ScannerModelEnumApi)[keyof typeof ScannerModelEnumApi]
 
 export const ScannerModelEnumApi = {
-    Gemini25Flash: 'gemini-2.5-flash',
     Gemini3FlashPreview: 'gemini-3-flash-preview',
     Gemini35Flash: 'gemini-3.5-flash',
 } as const
@@ -773,7 +771,6 @@ export interface ReplayScannerApi {
     provider?: ScannerProviderEnumApi
     /** Concrete model to use for this scanner.
      *
-     * * `gemini-2.5-flash` - Gemini 2.5 Flash
      * * `gemini-3-flash-preview` - Gemini 3 Flash
      * * `gemini-3.5-flash` - Gemini 3.5 Flash */
     model: ScannerModelEnumApi
@@ -855,7 +852,6 @@ export interface PatchedReplayScannerApi {
     provider?: ScannerProviderEnumApi
     /** Concrete model to use for this scanner.
      *
-     * * `gemini-2.5-flash` - Gemini 2.5 Flash
      * * `gemini-3-flash-preview` - Gemini 3 Flash
      * * `gemini-3.5-flash` - Gemini 3.5 Flash */
     model?: ScannerModelEnumApi
@@ -1215,7 +1211,6 @@ export interface EstimateRequestApi {
     scanner_id?: string | null
     /** Proposed model; determines `credits_per_observation` in the response.
      *
-     * * `gemini-2.5-flash` - Gemini 2.5 Flash
      * * `gemini-3-flash-preview` - Gemini 3 Flash
      * * `gemini-3.5-flash` - Gemini 3.5 Flash */
     model?: ScannerModelEnumApi

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -410,12 +410,10 @@ export const VisionScannersCreateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe('LLM provider. v1 is Google-only.\n\n\* `google` - Google'),
     model: zod
-        .enum(['gemini-2.5-flash', 'gemini-3-flash-preview', 'gemini-3.5-flash'])
+        .enum(['gemini-3-flash-preview', 'gemini-3.5-flash'])
+        .describe('\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash')
         .describe(
-            '\* `gemini-2.5-flash` - Gemini 2.5 Flash\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
-        )
-        .describe(
-            'Concrete model to use for this scanner.\n\n\* `gemini-2.5-flash` - Gemini 2.5 Flash\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
+            'Concrete model to use for this scanner.\n\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
         ),
     enabled: zod
         .boolean()
@@ -492,13 +490,11 @@ export const VisionScannersPartialUpdateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe('LLM provider. v1 is Google-only.\n\n\* `google` - Google'),
     model: zod
-        .enum(['gemini-2.5-flash', 'gemini-3-flash-preview', 'gemini-3.5-flash'])
-        .describe(
-            '\* `gemini-2.5-flash` - Gemini 2.5 Flash\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
-        )
+        .enum(['gemini-3-flash-preview', 'gemini-3.5-flash'])
+        .describe('\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash')
         .optional()
         .describe(
-            'Concrete model to use for this scanner.\n\n\* `gemini-2.5-flash` - Gemini 2.5 Flash\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
+            'Concrete model to use for this scanner.\n\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
         ),
     enabled: zod
         .boolean()
@@ -600,13 +596,11 @@ export const VisionScannersEstimateCreateBody = /* @__PURE__ */ zod
                 "The scanner being edited, excluded from `other_enabled_scanners_monthly_credits` so its stored estimate isn't double-counted in the forecast. Omit (or null) when estimating a brand-new scanner."
             ),
         model: zod
-            .enum(['gemini-2.5-flash', 'gemini-3-flash-preview', 'gemini-3.5-flash'])
-            .describe(
-                '\* `gemini-2.5-flash` - Gemini 2.5 Flash\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
-            )
+            .enum(['gemini-3-flash-preview', 'gemini-3.5-flash'])
+            .describe('\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash')
             .default(visionScannersEstimateCreateBodyModelDefault)
             .describe(
-                'Proposed model; determines `credits_per_observation` in the response.\n\n\* `gemini-2.5-flash` - Gemini 2.5 Flash\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
+                'Proposed model; determines `credits_per_observation` in the response.\n\n\* `gemini-3-flash-preview` - Gemini 3 Flash\n\* `gemini-3.5-flash` - Gemini 3.5 Flash'
             ),
     })
     .describe('Body of POST \/vision\/scanners\/estimate\/ — a proposed, unsaved scanner config.')

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -143,13 +143,11 @@ export const ENABLED_OPTIONS: { value: EnabledFilter; label: string }[] = [
 // Mirrors the backend `OBSERVATION_CREDITS_BY_MODEL` table (the scanner/estimate API responses are authoritative);
 // the picker needs a price per model before anything is saved, so it can't come from a per-instance response.
 export const OBSERVATION_CREDITS_BY_MODEL: Record<ScannerModelEnumApi, number> = {
-    [ScannerModelEnumApi.Gemini25Flash]: 2,
     [ScannerModelEnumApi.Gemini3FlashPreview]: 5,
     [ScannerModelEnumApi.Gemini35Flash]: 15,
 }
 
 const MODEL_NAMES: Record<ScannerModelEnumApi, string> = {
-    [ScannerModelEnumApi.Gemini25Flash]: 'Gemini 2.5 Flash',
     [ScannerModelEnumApi.Gemini3FlashPreview]: 'Gemini 3 Flash',
     [ScannerModelEnumApi.Gemini35Flash]: 'Gemini 3.5 Flash',
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -23048,7 +23048,6 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `gemini-2.5-flash` - Gemini 2.5 Flash
      * * `gemini-3-flash-preview` - Gemini 3 Flash
      * * `gemini-3.5-flash` - Gemini 3.5 Flash
      */
@@ -23056,7 +23055,6 @@ export namespace Schemas {
 
 
     export const ScannerModelEnum = {
-      Gemini25Flash: 'gemini-2.5-flash',
       Gemini3FlashPreview: 'gemini-3-flash-preview',
       Gemini35Flash: 'gemini-3.5-flash',
     } as const;
@@ -23086,7 +23084,6 @@ export namespace Schemas {
       scanner_id?: string | null;
       /** Proposed model; determines `credits_per_observation` in the response.
        *
-       * * `gemini-2.5-flash` - Gemini 2.5 Flash
        * * `gemini-3-flash-preview` - Gemini 3 Flash
        * * `gemini-3.5-flash` - Gemini 3.5 Flash */
       model?: ScannerModelEnum;
@@ -38526,7 +38523,6 @@ export namespace Schemas {
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
        *
-       * * `gemini-2.5-flash` - Gemini 2.5 Flash
        * * `gemini-3-flash-preview` - Gemini 3 Flash
        * * `gemini-3.5-flash` - Gemini 3.5 Flash */
       model: ScannerModelEnum;
@@ -46900,7 +46896,6 @@ export namespace Schemas {
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
        *
-       * * `gemini-2.5-flash` - Gemini 2.5 Flash
        * * `gemini-3-flash-preview` - Gemini 3 Flash
        * * `gemini-3.5-flash` - Gemini 3.5 Flash */
       model?: ScannerModelEnum;

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -233,12 +233,10 @@ export const VisionScannersCreateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe('LLM provider. v1 is Google-only.\n\n* `google` - Google'),
     model: zod
-        .enum(['gemini-2.5-flash', 'gemini-3-flash-preview', 'gemini-3.5-flash'])
+        .enum(['gemini-3-flash-preview', 'gemini-3.5-flash'])
+        .describe('* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash')
         .describe(
-            '* `gemini-2.5-flash` - Gemini 2.5 Flash\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
-        )
-        .describe(
-            'Concrete model to use for this scanner.\n\n* `gemini-2.5-flash` - Gemini 2.5 Flash\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
+            'Concrete model to use for this scanner.\n\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
         ),
     enabled: zod
         .boolean()
@@ -336,13 +334,11 @@ export const VisionScannersPartialUpdateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe('LLM provider. v1 is Google-only.\n\n* `google` - Google'),
     model: zod
-        .enum(['gemini-2.5-flash', 'gemini-3-flash-preview', 'gemini-3.5-flash'])
-        .describe(
-            '* `gemini-2.5-flash` - Gemini 2.5 Flash\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
-        )
+        .enum(['gemini-3-flash-preview', 'gemini-3.5-flash'])
+        .describe('* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash')
         .optional()
         .describe(
-            'Concrete model to use for this scanner.\n\n* `gemini-2.5-flash` - Gemini 2.5 Flash\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
+            'Concrete model to use for this scanner.\n\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
         ),
     enabled: zod
         .boolean()
@@ -640,13 +636,11 @@ export const VisionScannersEstimateCreateBody = /* @__PURE__ */ zod
                 "The scanner being edited, excluded from `other_enabled_scanners_monthly_credits` so its stored estimate isn't double-counted in the forecast. Omit (or null) when estimating a brand-new scanner."
             ),
         model: zod
-            .enum(['gemini-2.5-flash', 'gemini-3-flash-preview', 'gemini-3.5-flash'])
-            .describe(
-                '* `gemini-2.5-flash` - Gemini 2.5 Flash\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
-            )
+            .enum(['gemini-3-flash-preview', 'gemini-3.5-flash'])
+            .describe('* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash')
             .default(visionScannersEstimateCreateBodyModelDefault)
             .describe(
-                'Proposed model; determines `credits_per_observation` in the response.\n\n* `gemini-2.5-flash` - Gemini 2.5 Flash\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
+                'Proposed model; determines `credits_per_observation` in the response.\n\n* `gemini-3-flash-preview` - Gemini 3 Flash\n* `gemini-3.5-flash` - Gemini 3.5 Flash'
             ),
     })
     .describe('Body of POST /vision/scanners/estimate/ — a proposed, unsaved scanner config.')


### PR DESCRIPTION
## Problem

Replay Vision scanners store a hardcoded model id. Google retired `gemini-2.5-flash` ("no longer available"), so every scanner still pinned to that id `404`s on each scheduled sweep with no graceful handling — surfacing opaque errors to users and flooding error tracking. Error-tracking traces point at the live scanner path (`products/replay_vision/backend/temporal/conversation.py`), where the id is bound from the scanner's stored `model` field, and `gemini-2.5-flash` was still an offered enum option.

Raised in a PostHog Signals inbox item (P1, Error tracking / Replay Vision).

## Changes

- Remove `GEMINI_2_5_FLASH` from the `ScannerModel` choices so it can no longer be selected for new or edited scanners.
- Data migration repoints existing scanners from `gemini-2.5-flash` to `gemini-3-flash-preview` — the same Flash-tier successor that new scanners already default to (a nearer capability/cost match than the pricier `gemini-3.5-flash`).
- Keep the retired id priced in `OBSERVATION_CREDITS_BY_MODEL` so frozen `scanner_snapshot`s and in-flight receipts still bill correctly.

Mirrors the existing retire-and-remap precedent (migrations 0034/0035).

## How did you test this code?

Automated tests only — the agent did not run the app or a live migration (no Django environment in this session). Updated the affected unit tests (`test_models`, `test_billing`, `test_quota`) so the billing/quota cases now assert the retired id still prices at its kept value via the raw `"gemini-2.5-flash"` string. `ruff check`/`format` pass on the touched files; the migration matches Django's generated `AlterField` form. Reviewer should confirm `makemigrations --check` reports no drift in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1784271179134089?thread_ts=1784271179.134089&cid=C0B8ZE81ZT7). Callsite was pinned by cross-referencing error-tracking traces (not just a code grep — the grep candidates in `support_sidebar_max` / `llm_traces_summaries` did not appear in the traces). Chose `gemini-3-flash-preview` over `gemini-3.5-flash` because it's the current new-scanner default and the closer Flash-tier match; repointing to 3.5-flash would have raised per-observation credits sharply. Invoked the repo `/django-migrations` skill while shaping the migration.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1784271179134089?thread_ts=1784271179.134089&cid=C0B8ZE81ZT7)*
