### PR TITLE
fix(tasks): preserve custom images in warm sandboxes

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -3532,6 +3532,8 @@ def create_task(team_id: int, user_id: int | None, *, validated_data: dict) -> c
     warm_runtime_adapter = validated_data.pop("runtime_adapter", None)
     warm_model = validated_data.pop("model", None)
     warm_reasoning_effort = validated_data.pop("reasoning_effort", None)
+    warm_sandbox_environment_id = validated_data.pop("sandbox_environment_id", None)
+    warm_custom_image_id = validated_data.pop("custom_image_id", None)
     pending_user_message = (validated_data.pop("pending_user_message", None) or "").strip() or None
     pending_user_artifact_ids = validated_data.pop("pending_user_artifact_ids", None) or []
     warm_auto_publish = validated_data.pop("auto_publish", None)
@@ -3553,7 +3555,16 @@ def create_task(team_id: int, user_id: int | None, *, validated_data: dict) -> c
             runtime_adapter=warm_runtime_adapter,
             model=warm_model,
             reasoning_effort=warm_reasoning_effort,
+            sandbox_environment_id=warm_sandbox_environment_id,
+            custom_image_id=warm_custom_image_id,
         )
+        if warm_run is not None and not _warm_sandbox_selection_is_accessible(
+            team_id=team_id,
+            task_created_by_id=user_id,
+            sandbox_environment_id=warm_sandbox_environment_id,
+            custom_image_id=warm_custom_image_id,
+        ):
+            warm_run = None
         if warm_run is not None and pending_user_artifact_ids:
             from products.tasks.backend.logic.services.staged_artifacts import (  # noqa: PLC0415 — keep storage deps off the api import path
                 get_task_run_artifacts_by_id,
@@ -3843,6 +3854,8 @@ def _find_idling_warm_run(
     runtime_adapter: str | None = None,
     model: str | None = None,
     reasoning_effort: str | None = None,
+    sandbox_environment_id: str | UUID | None = None,
+    custom_image_id: str | UUID | None = None,
 ) -> TaskRun | None:
     """Most-recent idling pre-warmed Run matching this user's cloud composing selection, or ``None``.
 
@@ -3852,10 +3865,10 @@ def _find_idling_warm_run(
     live Run instead of spawning a second) and lets the normal create+run path transparently reuse a
     warm Run on submit. Team + user scoped; branch compared as ``None``-normalized exact match.
 
-    Reuse also requires the warm Run's ``runtime_adapter``/``model``/``reasoning_effort`` to match the
-    requested selection (each ``None``-normalized); a mismatch returns ``None`` so the caller cold-creates
-    on the correct runtime. The repo/branch/``await_user_message`` predicates stay in the query; the
-    runtime selection is matched in Python over the small candidate set.
+    Reuse also requires the warm Run's runtime, sandbox environment, and custom image selections to
+    match the request. A mismatch returns ``None`` so the caller cold-creates on the correct sandbox.
+    The repo/branch/``await_user_message`` predicates stay in the query; the remaining selection is
+    matched in Python over the small candidate set.
     """
     if user_id is None or not repository:
         return None
@@ -3873,13 +3886,53 @@ def _find_idling_warm_run(
         .select_related("task")
         .order_by("-created_at")[:20]
     )
-    wanted = (runtime_adapter or None, model or None, reasoning_effort or None)
+    wanted = (
+        runtime_adapter or None,
+        model or None,
+        reasoning_effort or None,
+        str(sandbox_environment_id) if sandbox_environment_id else None,
+        str(custom_image_id) if custom_image_id else None,
+    )
     for run in candidates:
         state = run.state or {}
-        have = (state.get("runtime_adapter") or None, state.get("model") or None, state.get("reasoning_effort") or None)
+        have = (
+            state.get("runtime_adapter") or None,
+            state.get("model") or None,
+            state.get("reasoning_effort") or None,
+            state.get("sandbox_environment_id") or None,
+            state.get("custom_image_id") or None,
+        )
         if have == wanted:
             return run
     return None
+
+
+def _warm_sandbox_selection_is_accessible(
+    *,
+    team_id: int,
+    task_created_by_id: int | None,
+    sandbox_environment_id: str | UUID | None,
+    custom_image_id: str | UUID | None,
+) -> bool:
+    if sandbox_environment_id is not None:
+        sandbox_environment = SandboxEnvironment.get_accessible_for_task(
+            environment_id=sandbox_environment_id,
+            team_id=team_id,
+            task_created_by_id=task_created_by_id,
+        )
+        if sandbox_environment is None:
+            return False
+
+    if custom_image_id is not None:
+        custom_image = SandboxCustomImage.get_accessible_for_task(
+            image_id=custom_image_id,
+            team_id=team_id,
+            task_created_by_id=task_created_by_id,
+        )
+        if custom_image is None or not custom_image.is_ready:
+            return False
+
+    return True
 
 
 def _idling_warm_run_for_task(task: Task) -> TaskRun | None:
@@ -3964,6 +4017,8 @@ def warm_task_sandbox(
     runtime_adapter: str | None = None,
     model: str | None = None,
     reasoning_effort: str | None = None,
+    sandbox_environment_id: str | UUID | None = None,
+    custom_image_id: str | UUID | None = None,
 ) -> contracts.WarmTaskDTO | None:
     """Warm a full idling Run for a Code-app cloud task while the user composes.
 
@@ -3997,6 +4052,31 @@ def warm_task_sandbox(
         get_provider_for_runtime_adapter,
     )
 
+    team = Team.objects.get(id=team_id)
+    github_integration = Integration.objects.filter(id=github_integration_id, team_id=team_id, kind="github").first()
+    if github_integration is None:
+        return None
+
+    sandbox_environment = None
+    if sandbox_environment_id is not None:
+        sandbox_environment = SandboxEnvironment.get_accessible_for_task(
+            environment_id=sandbox_environment_id,
+            team_id=team_id,
+            task_created_by_id=user_id,
+        )
+        if sandbox_environment is None:
+            return None
+
+    custom_image = None
+    if custom_image_id is not None:
+        custom_image = SandboxCustomImage.get_accessible_for_task(
+            image_id=custom_image_id,
+            team_id=team_id,
+            task_created_by_id=user_id,
+        )
+        if custom_image is None or not custom_image.is_ready:
+            return None
+
     existing = _find_idling_warm_run(
         team_id,
         user_id,
@@ -4005,14 +4085,11 @@ def warm_task_sandbox(
         runtime_adapter=runtime_adapter,
         model=model,
         reasoning_effort=reasoning_effort,
+        sandbox_environment_id=sandbox_environment_id,
+        custom_image_id=custom_image_id,
     )
     if existing is not None:
         return contracts.WarmTaskDTO(task_id=existing.task_id, run_id=existing.id)
-
-    team = Team.objects.get(id=team_id)
-    github_integration = Integration.objects.filter(id=github_integration_id, team_id=team_id, kind="github").first()
-    if github_integration is None:
-        return None
 
     task = Task.create_without_run(
         team=team,
@@ -4031,6 +4108,10 @@ def warm_task_sandbox(
         "initial_permission_mode": initial_permission_mode,
         "use_modal_network_allowlist": False,
     }
+    if sandbox_environment is not None:
+        extra_state["sandbox_environment_id"] = str(sandbox_environment.id)
+    if custom_image is not None:
+        extra_state["custom_image_id"] = str(custom_image.id)
     for key, value in {
         "runtime_adapter": runtime_adapter,
         "provider": provider.value if provider is not None else None,
@@ -4099,12 +4180,21 @@ def run_task(
                 warm_state.get("runtime_adapter") or None,
                 warm_state.get("model") or None,
                 warm_state.get("reasoning_effort") or None,
+                warm_state.get("sandbox_environment_id") or None,
+                warm_state.get("custom_image_id") or None,
             ) == (
                 validated_data.get("runtime_adapter") or None,
                 validated_data.get("model") or None,
                 validated_data.get("reasoning_effort") or None,
+                str(validated_data["sandbox_environment_id"]) if validated_data.get("sandbox_environment_id") else None,
+                str(validated_data["custom_image_id"]) if validated_data.get("custom_image_id") else None,
             )
-            if warm_runtime_matches:
+            if warm_runtime_matches and _warm_sandbox_selection_is_accessible(
+                team_id=team_id,
+                task_created_by_id=task.created_by_id,
+                sandbox_environment_id=warm_state.get("sandbox_environment_id"),
+                custom_image_id=warm_state.get("custom_image_id"),
+            ):
                 warm_staged_artifacts, warm_missing_artifact_ids = (
                     get_task_staged_artifacts(task, pending_user_artifact_ids)
                     if pending_user_artifact_ids

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -647,6 +647,20 @@ class TaskWriteSerializer(serializers.Serializer):
 
 
 class TaskCreateSerializer(TaskWriteSerializer):
+    sandbox_environment_id = serializers.UUIDField(
+        required=False,
+        default=None,
+        allow_null=True,
+        write_only=True,
+        help_text="Sandbox environment selected for matching a pre-warmed cloud run. Not persisted on the task.",
+    )
+    custom_image_id = serializers.UUIDField(
+        required=False,
+        default=None,
+        allow_null=True,
+        write_only=True,
+        help_text="Custom image selected for matching a pre-warmed cloud run. Not persisted on the task.",
+    )
     runtime = serializers.ChoiceField(
         choices=tasks_facade.TaskRuntime.choices,
         required=False,
@@ -2070,6 +2084,18 @@ class WarmTaskRequestSerializer(serializers.Serializer):
         default=None,
         allow_null=True,
         help_text="Reasoning effort to warm the sandbox on for models that expose an effort control.",
+    )
+    sandbox_environment_id = serializers.UUIDField(
+        required=False,
+        default=None,
+        allow_null=True,
+        help_text="Optional sandbox environment to provision before the task is submitted.",
+    )
+    custom_image_id = serializers.UUIDField(
+        required=False,
+        default=None,
+        allow_null=True,
+        help_text="Optional custom base image to provision before the task is submitted; takes precedence over the environment's image.",
     )
 
     def validate_repository(self, value: str) -> str:

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -661,6 +661,8 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             runtime_adapter=request.validated_data.get("runtime_adapter"),
             model=request.validated_data.get("model"),
             reasoning_effort=request.validated_data.get("reasoning_effort"),
+            sandbox_environment_id=request.validated_data.get("sandbox_environment_id"),
+            custom_image_id=request.validated_data.get("custom_image_id"),
         )
         if result is None:
             return Response(status=status.HTTP_200_OK)

--- a/products/tasks/backend/tests/test_warm_facade.py
+++ b/products/tasks/backend/tests/test_warm_facade.py
@@ -17,7 +17,7 @@ from products.tasks.backend.logic.services.staged_artifacts import (
     build_task_staged_artifact_cache_key,
 )
 from products.tasks.backend.logic.services.warm import WarmResult
-from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.models import SandboxCustomImage, SandboxEnvironment, Task, TaskRun
 from products.tasks.backend.redis import get_tasks_cache
 
 FACADE = "products.tasks.backend.facade.api"
@@ -61,6 +61,71 @@ class TestWarmTaskSandbox(APIBaseTest):
         }
         kwargs.update(overrides)
         return facade.warm_task_sandbox(**kwargs)
+
+    @patch("products.tasks.backend.presentation.views.api.code_access_required_response", return_value=None)
+    @patch("products.tasks.backend.presentation.views.api.TaskViewSet._warm_enabled", return_value=True)
+    @patch("products.tasks.backend.facade.api.warm_task_sandbox")
+    def test_warm_endpoint_forwards_sandbox_selection(self, mock_warm, _mock_warm_enabled, _mock_code_access):
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Custom environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+        custom_image = SandboxCustomImage.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name="Custom image",
+            status=SandboxCustomImage.Status.READY,
+            modal_image_name="custom-image:v1",
+        )
+        mock_warm.return_value = None
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/warm/",
+            {
+                "repository": "posthog/posthog",
+                "github_integration": self.integration.id,
+                "branch": "main",
+                "sandbox_environment_id": str(sandbox_environment.id),
+                "custom_image_id": str(custom_image.id),
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert mock_warm.call_args.kwargs["sandbox_environment_id"] == sandbox_environment.id
+        assert mock_warm.call_args.kwargs["custom_image_id"] == custom_image.id
+
+    def test_provisions_selected_sandbox_environment_and_custom_image(self):
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Custom environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+        custom_image = SandboxCustomImage.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name="Custom image",
+            status=SandboxCustomImage.Status.READY,
+            modal_image_name="custom-image:v1",
+        )
+
+        def fake_warm(self_warmer, **kwargs):
+            run = self_warmer.task.create_run(mode="interactive", extra_state=kwargs["extra_state"])
+            return WarmResult(run=run, just_created=True)
+
+        with patch(f"{WARM_SRC}.warm", autospec=True, side_effect=fake_warm):
+            result = self._warm(
+                sandbox_environment_id=sandbox_environment.id,
+                custom_image_id=custom_image.id,
+            )
+
+        assert result is not None
+        run = TaskRun.objects.get(id=result.run_id)
+        assert run.state["sandbox_environment_id"] == str(sandbox_environment.id)
+        assert run.state["custom_image_id"] == str(custom_image.id)
 
     def test_births_draft_task_and_returns_warm_dto(self):
         def fake_warm(self_warmer, **kwargs):
@@ -123,6 +188,58 @@ class TestWarmTaskSandbox(APIBaseTest):
         m_warm.assert_called_once()
         assert Task.objects.filter(team=self.team, deleted=False).count() == 1
 
+    def test_does_not_reuse_warm_run_after_environment_access_is_revoked(self):
+        other_user = User.objects.create_and_join(self.organization, "other-warm-owner@posthog.com", None)
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=other_user,
+            name="Shared environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+            private=False,
+        )
+
+        def fake_warm(self_warmer, **kwargs):
+            state = kwargs["extra_state"]
+            run = self_warmer.task.create_run(mode="interactive", extra_state=state, branch=state.get("branch"))
+            return WarmResult(run=run, just_created=True)
+
+        with patch(f"{WARM_SRC}.warm", autospec=True, side_effect=fake_warm) as mock_warm:
+            first = self._warm(sandbox_environment_id=sandbox_environment.id)
+            sandbox_environment.private = True
+            sandbox_environment.save(update_fields=["private", "updated_at"])
+            second = self._warm(sandbox_environment_id=sandbox_environment.id)
+
+        assert first is not None
+        assert second is None
+        mock_warm.assert_called_once()
+
+    def test_does_not_dedup_across_different_sandbox_environments(self):
+        first_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="First environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+        second_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Second environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+
+        def fake_warm(self_warmer, **kwargs):
+            state = kwargs["extra_state"]
+            run = self_warmer.task.create_run(mode="interactive", extra_state=state, branch=state.get("branch"))
+            return WarmResult(run=run, just_created=True)
+
+        with patch(f"{WARM_SRC}.warm", autospec=True, side_effect=fake_warm) as mock_warm:
+            first = self._warm(sandbox_environment_id=first_environment.id)
+            second = self._warm(sandbox_environment_id=second_environment.id)
+
+        assert first is not None and second is not None
+        assert second.run_id != first.run_id
+        assert mock_warm.call_count == 2
+
     def test_does_not_dedup_across_a_different_branch(self):
         def fake_warm(self_warmer, **kwargs):
             branch = (kwargs.get("extra_state") or {}).get("branch")
@@ -147,7 +264,9 @@ class TestCreateTaskWarmReuse(APIBaseTest):
         super().setUp()
         self.integration = Integration.objects.create(team=self.team, kind="github", config={})
 
-    def _warm_run(self, *, repository="posthog/posthog", branch="main", created_by=None) -> tuple[Task, TaskRun]:
+    def _warm_run(
+        self, *, repository="posthog/posthog", branch="main", created_by=None, extra_state: dict[str, Any] | None = None
+    ) -> tuple[Task, TaskRun]:
         task = Task.objects.create(
             team=self.team,
             title="",
@@ -158,7 +277,9 @@ class TestCreateTaskWarmReuse(APIBaseTest):
             github_integration=self.integration,
         )
         run = task.create_run(
-            mode="interactive", extra_state={"await_user_message": True, "branch": branch}, branch=branch
+            mode="interactive",
+            extra_state={"await_user_message": True, "branch": branch, **(extra_state or {})},
+            branch=branch,
         )
         return task, run
 
@@ -197,12 +318,59 @@ class TestCreateTaskWarmReuse(APIBaseTest):
         assert warm_task.description == "already there"
 
     def test_branch_mismatch_creates_a_new_cold_task(self):
-        warm_task, _ = self._warm_run(branch="main")
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Custom environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+        custom_image = SandboxCustomImage.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name="Custom image",
+            status=SandboxCustomImage.Status.READY,
+            modal_image_name="custom-image:v1",
+        )
+        warm_task, _ = self._warm_run(
+            branch="main",
+            extra_state={
+                "sandbox_environment_id": str(sandbox_environment.id),
+                "custom_image_id": str(custom_image.id),
+            },
+        )
         with patch(f"{TITLE_SRC}.generate_task_title", return_value="T"):
-            dto = self._create(branch="feature/x")
+            dto = self._create(
+                branch="feature/x",
+                sandbox_environment_id=sandbox_environment.id,
+                custom_image_id=custom_image.id,
+            )
 
         assert str(dto.id) != str(warm_task.id)
         assert Task.objects.filter(team=self.team, deleted=False).count() == 2
+
+    def test_revoked_environment_does_not_reuse_warm_task(self):
+        other_user = User.objects.create_and_join(self.organization, "other-create-owner@posthog.com", None)
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=other_user,
+            name="Shared environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+            private=False,
+        )
+        warm_task, run = self._warm_run(extra_state={"sandbox_environment_id": str(sandbox_environment.id)})
+        sandbox_environment.private = True
+        sandbox_environment.save(update_fields=["private", "updated_at"])
+
+        with (
+            patch(f"{FACADE}.signal_task_run_user_message") as mock_signal,
+            patch(f"{TITLE_SRC}.generate_task_title", return_value="T"),
+        ):
+            dto = self._create(sandbox_environment_id=sandbox_environment.id)
+
+        assert str(dto.id) != str(warm_task.id)
+        mock_signal.assert_not_called()
+        run.refresh_from_db()
+        assert run.state.get("await_user_message") is True
 
     def test_terminal_warm_run_is_not_reused(self):
         warm_task, run = self._warm_run()
@@ -271,7 +439,25 @@ class TestCreateTaskWarmReuse(APIBaseTest):
         assert run.state.get("await_user_message") is True
 
     def test_create_endpoint_passes_pending_fields_to_warm_activation(self):
-        warm_task, run = self._warm_run()
+        sandbox_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Custom environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+        custom_image = SandboxCustomImage.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name="Custom image",
+            status=SandboxCustomImage.Status.READY,
+            modal_image_name="custom-image:v1",
+        )
+        warm_task, run = self._warm_run(
+            extra_state={
+                "sandbox_environment_id": str(sandbox_environment.id),
+                "custom_image_id": str(custom_image.id),
+            }
+        )
         run.artifacts = [_artifact_entry("artifact-1")]
         run.save(update_fields=["artifacts"])
 
@@ -284,6 +470,8 @@ class TestCreateTaskWarmReuse(APIBaseTest):
                     "branch": "main",
                     "pending_user_message": "resolved skill message",
                     "pending_user_artifact_ids": ["artifact-1"],
+                    "sandbox_environment_id": str(sandbox_environment.id),
+                    "custom_image_id": str(custom_image.id),
                 },
                 format="json",
             )
@@ -302,7 +490,7 @@ class TestRunTaskWarmActivation(APIBaseTest):
         super().setUp()
         self.integration = Integration.objects.create(team=self.team, kind="github", config={})
 
-    def _warm_run(self, *, branch="main") -> tuple[Task, TaskRun]:
+    def _warm_run(self, *, branch="main", extra_state: dict[str, Any] | None = None) -> tuple[Task, TaskRun]:
         task = Task.objects.create(
             team=self.team,
             title="",
@@ -313,7 +501,9 @@ class TestRunTaskWarmActivation(APIBaseTest):
             github_integration=self.integration,
         )
         run = task.create_run(
-            mode="interactive", extra_state={"await_user_message": True, "branch": branch}, branch=branch
+            mode="interactive",
+            extra_state={"await_user_message": True, "branch": branch, **(extra_state or {})},
+            branch=branch,
         )
         return task, run
 
@@ -420,6 +610,77 @@ class TestRunTaskWarmActivation(APIBaseTest):
         assert task.runs.count() == 2
         run.refresh_from_db()
         assert run.state.get("await_user_message") is True  # warm run untouched
+
+    def test_sandbox_environment_mismatch_does_not_activate_warm_run(self):
+        warm_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Warm environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+        requested_environment = SandboxEnvironment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Requested environment",
+            network_access_level=SandboxEnvironment.NetworkAccessLevel.FULL,
+        )
+        task, run = self._warm_run(extra_state={"sandbox_environment_id": str(warm_environment.id)})
+
+        with (
+            patch(f"{FACADE}.signal_task_run_user_message") as mock_signal,
+            patch(f"{FACADE}._trigger_task_processing_workflow") as mock_trigger,
+        ):
+            facade.run_task(
+                task.id,
+                self.team.id,
+                self.user.id,
+                validated_data={
+                    "mode": "interactive",
+                    "branch": "main",
+                    "pending_user_message": "do it",
+                    "sandbox_environment_id": requested_environment.id,
+                },
+            )
+
+        mock_signal.assert_not_called()
+        mock_trigger.assert_called_once()
+        run.refresh_from_db()
+        assert run.state.get("await_user_message") is True
+
+    def test_unready_custom_image_does_not_activate_warm_run(self):
+        custom_image = SandboxCustomImage.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name="Custom image",
+            status=SandboxCustomImage.Status.READY,
+            modal_image_name="custom-image:v1",
+        )
+        task, run = self._warm_run(extra_state={"custom_image_id": str(custom_image.id)})
+        custom_image.status = SandboxCustomImage.Status.ARCHIVED
+        custom_image.save(update_fields=["status", "updated_at"])
+
+        with (
+            patch(f"{FACADE}.signal_task_run_user_message") as mock_signal,
+            patch(f"{FACADE}._trigger_task_processing_workflow") as mock_trigger,
+        ):
+            result = facade.run_task(
+                task.id,
+                self.team.id,
+                self.user.id,
+                validated_data={
+                    "mode": "interactive",
+                    "branch": "main",
+                    "pending_user_message": "do it",
+                    "custom_image_id": custom_image.id,
+                },
+            )
+
+        mock_signal.assert_not_called()
+        mock_trigger.assert_not_called()
+        assert result is not None and result.error is not None
+        assert "not ready" in result.error.detail
+        run.refresh_from_db()
+        assert run.state.get("await_user_message") is True
 
     def test_explicit_resume_does_not_trigger_warm_activation(self):
         task, run = self._warm_run()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -912,6 +912,16 @@ export interface TaskCreateApi {
      * @nullable
      */
     channel?: string | null
+    /**
+     * Sandbox environment selected for matching a pre-warmed cloud run. Not persisted on the task.
+     * @nullable
+     */
+    sandbox_environment_id?: string | null
+    /**
+     * Custom image selected for matching a pre-warmed cloud run. Not persisted on the task.
+     * @nullable
+     */
+    custom_image_id?: string | null
     /** Agent protocol and harness used for this task's runs. Defaults to ACP when omitted.
      *
      * * `acp` - ACP
@@ -2863,6 +2873,16 @@ export interface WarmTaskRequestApi {
      * * `xhigh` - xhigh
      * * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi | null
+    /**
+     * Optional sandbox environment to provision before the task is submitted.
+     * @nullable
+     */
+    sandbox_environment_id?: string | null
+    /**
+     * Optional custom base image to provision before the task is submitted; takes precedence over the environment's image.
+     * @nullable
+     */
+    custom_image_id?: string | null
 }
 
 /**

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -472,6 +472,14 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 "When true, the cloud run agent pushes its work and opens a draft pull request on completion without waiting for an explicit ask. Write-only and not persisted on the task: persisted into the reused warm Run's state when creation activates one, so resumes of that Run honor it. Ignored when no warm Run is reused — cold creation takes it via the run start endpoint instead."
             ),
         channel: zod.uuid().nullish().describe('Channel this task is owned by (the channel it was kicked off in).'),
+        sandbox_environment_id: zod
+            .uuid()
+            .nullish()
+            .describe('Sandbox environment selected for matching a pre-warmed cloud run. Not persisted on the task.'),
+        custom_image_id: zod
+            .uuid()
+            .nullish()
+            .describe('Custom image selected for matching a pre-warmed cloud run. Not persisted on the task.'),
         runtime: zod
             .enum(['acp', 'pi'])
             .describe('\* `acp` - ACP\n\* `pi` - Pi')
@@ -2174,6 +2182,16 @@ export const TasksWarmCreateBody = /* @__PURE__ */ zod
             .optional()
             .describe(
                 'Reasoning effort to warm the sandbox on for models that expose an effort control.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
+            ),
+        sandbox_environment_id: zod
+            .uuid()
+            .nullish()
+            .describe('Optional sandbox environment to provision before the task is submitted.'),
+        custom_image_id: zod
+            .uuid()
+            .nullish()
+            .describe(
+                "Optional custom base image to provision before the task is submitted; takes precedence over the environment's image."
             ),
     })
     .describe(

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -61432,6 +61432,16 @@ export namespace Schemas {
          * @nullable
          */
       channel?: string | null;
+      /**
+         * Sandbox environment selected for matching a pre-warmed cloud run. Not persisted on the task.
+         * @nullable
+         */
+      sandbox_environment_id?: string | null;
+      /**
+         * Custom image selected for matching a pre-warmed cloud run. Not persisted on the task.
+         * @nullable
+         */
+      custom_image_id?: string | null;
       /** Agent protocol and harness used for this task's runs. Defaults to ACP when omitted.
        *
        * * `acp` - ACP
@@ -63504,6 +63514,16 @@ export namespace Schemas {
        * * `xhigh` - xhigh
        * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum | null;
+      /**
+         * Optional sandbox environment to provision before the task is submitted.
+         * @nullable
+         */
+      sandbox_environment_id?: string | null;
+      /**
+         * Optional custom base image to provision before the task is submitted; takes precedence over the environment's image.
+         * @nullable
+         */
+      custom_image_id?: string | null;
     }
 
     /**


### PR DESCRIPTION
## Problem

The prewarm endpoint accepted the client request but dropped the sandbox environment and custom image identifiers before provisioning.

This made the run appear to honor the selected environment while it continued on the default sandbox runtime.

## Changes

- Carry `sandbox_environment_id` and `custom_image_id` through the warm API into the run state before sandbox provisioning
- Include the environment and image in warm-run deduplication and submit-time reuse checks, so a mismatched sandbox falls back to a fresh correctly configured run
