### PR TITLE
fix(data-imports): honor non-retryable REST errors by type

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -44,6 +44,9 @@ from products.warehouse_sources.backend.temporal.data_imports.row_tracking impor
 from products.warehouse_sources.backend.temporal.data_imports.sources import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import ResumableSource, SimpleSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.job_context import bind_job_context
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientNonRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.predicates import (
     RowFilterValidationError,
@@ -325,6 +328,13 @@ async def _handle_import_error(
     """
     source_cls = SourceRegistry.get_source(job_inputs.job_type)
     error_msg = str(error)
+
+    # The shared REST engine raises RESTClientNonRetryableError only for responses retrying can
+    # never turn into data (a non-JSON body on an otherwise-successful response). Honor that
+    # contract by type so every REST-based source stops immediately, rather than depending on each
+    # source listing the message in get_non_retryable_errors.
+    if isinstance(error, RESTClientNonRetryableError):
+        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
 
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -6,6 +6,9 @@ import pytest
 from unittest import mock
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientNonRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.util import NonRetryableException
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities import import_data_sync as module
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.import_data_sync import (
@@ -150,6 +153,35 @@ async def test_source_classified_retryable_error_logged_as_warning_not_exception
             await module._handle_import_error(mock.MagicMock(), logger, error)
 
     logger.awarning.assert_awaited_once()
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rest_client_non_retryable_error_routes_through_handler_without_source_opt_in():
+    # RESTClientNonRetryableError is the REST engine's "retrying can never help" signal (a non-JSON
+    # body on an otherwise-successful response). It must be honored by type even when the source's
+    # get_non_retryable_errors doesn't list the message, so any REST-based source stops instead of
+    # retrying the deterministic failure to the activity max and minting error-tracking noise.
+    error = RESTClientNonRetryableError("Non-JSON response from https://api.example.com/v1/data/leads")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+    ):
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args.args[3] is error
     logger.aexception.assert_not_awaited()
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -181,6 +181,7 @@ async def test_rest_client_non_retryable_error_routes_through_handler_without_so
             await module._handle_import_error(mock.MagicMock(), logger, error)
 
     handle_mock.assert_awaited_once()
+    assert handle_mock.await_args is not None
     assert handle_mock.await_args.args[3] is error
     logger.aexception.assert_not_awaited()
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `RESTClientNonRetryableError: Non-JSON response from <redacted upstream URL>` coming out of the shared data-import REST engine (`sources/common/rest_source/rest_client.py`). Issue: https://us.posthog.com/project/2/error_tracking/019f7ef0-9118-7dd3-92cb-3a2f912e0045

The REST client already does the right thing at the transport layer. When an otherwise-successful response carries a body that isn't JSON (an HTML or plain-text error page, a login redirect), re-fetching returns the same bytes, so it raises `RESTClientNonRetryableError` - a class documented as "retrying can never turn this into usable data" and deliberately not a subclass of the retryable error so the tenacity retry stops immediately.

The problem is one layer up. The pipeline's error classifier `_handle_import_error` ignores the exception *type* and only treats this as non-retryable when the source lists the message substring in `get_non_retryable_errors()`. Just one source (the arbitrary-URL custom REST source) does that. Every other REST-based source - and the shared framework now backs a large fleet of them - would fall through, log the failure as an unhandled exception (minting error-tracking noise), and let Temporal retry the deterministic failure up to the activity maximum before giving up.

So the engine's non-retryable contract held at the transport layer but was silently dropped at the classifier.

## Changes

Honor `RESTClientNonRetryableError` by type in `_handle_import_error`, before the per-source string matching. Any REST-based source now routes it through `handle_non_retryable_error` (which still allows a few guard attempts against a one-off blip, then fails terminally) instead of depending on each source enumerating the message.

Scope is deliberately narrow: this only changes how the one, purpose-built non-retryable REST exception is classified. It does not touch global retry policy, and it does not widen anything that could mask a real bug - the class is raised only for a non-JSON body on a 200, which the client already distinguishes from a truncated/partial read (that stays retryable) and from an empty body (treated as an empty page).

> [!NOTE]
> This is an upstream/config condition, not a bug in the request we send. The right behavior is to stop retrying, which the fix now guarantees uniformly.

## How did you test this code?

Added one unit test at the classifier layer (`test_rest_client_non_retryable_error_routes_through_handler_without_source_opt_in`): a real `RESTClientNonRetryableError` from a source whose `get_non_retryable_errors()` is empty must still route through `handle_non_retryable_error` and must not be logged via `aexception`. This catches a regression that no existing test did - the existing cases all match on source-provided strings, so a revert to pure string matching would leave this path unprotected.

Ran locally (agent-run, not manual QA):

- `pytest .../workflow_activities/tests/test_import_data_sync.py` - 10 passed
- `pytest .../sources/common/rest_source/tests/test_rest_client.py` - 30 passed
- `ruff check` + `ruff format --check` on both changed files - clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). I confirmed the issue in error tracking, traced the raise site in the shared `rest_client`, and read the classifier and finalization paths that consume `get_non_retryable_errors()`. Invoked the `/writing-tests` skill before adding the regression test.

Decision: this is a fixable fragility in shared pipeline code, not a per-source config item. I considered just extending the one source's `NonRetryableErrors` (rejected - it leaves every other REST source exposed and doesn't address the root cause) and a base-class default string (rejected - most sources override `get_non_retryable_errors` without calling `super()`, so it wouldn't propagate). Honoring the exception type in the shared classifier is the smallest change that makes the engine's documented contract hold for all REST sources.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
