### PR TITLE
fix(hogli): bound flox log dir by size, not just age

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -501,7 +501,8 @@ ${C_DIM}  ${C_BOLD}q${C_RESET}${C_DIM} / ${C_BOLD}r${C_RESET}${C_DIM} in phrocs$
 fi
 
 # ── Silent background cleanup ──────────────────────────────────────
-# Clean old flox log files (>7 days). Fire-and-forget after activation.
+# Trim flox logs: drop >7-day-old files and cap total size (see doctor:disk).
+# Fire-and-forget after activation. The find fallback (no venv) is age-only.
 (
   if [[ -x "$UV_PROJECT_ENVIRONMENT/bin/python" && -f "$FLOX_ENV_PROJECT/bin/hogli" ]]; then
     POSTHOG_TELEMETRY_OPT_OUT=1 "$UV_PROJECT_ENVIRONMENT/bin/python" \

--- a/tools/hogli-commands/hogli_commands/doctor.py
+++ b/tools/hogli-commands/hogli_commands/doctor.py
@@ -25,6 +25,15 @@ from hogli.manifest import REPO_ROOT, get_manifest
 from . import hints
 
 MAX_SAMPLE_PATHS = 8
+
+# Flox writes a fresh log per shell activation, and direnv re-activates on every
+# `cd` into the tree (plus every agent/non-interactive shell), so the log dir can
+# reach tens of GB well inside any age window. We bound it two ways: drop anything
+# older than the age cutoff, then trim the oldest survivors past a total-size
+# budget so churn alone can't balloon the directory.
+FLOX_LOG_MAX_AGE_DAYS = 7
+FLOX_LOG_MAX_TOTAL_BYTES = 512 * 1024 * 1024  # 512 MiB of recent logs is plenty for debugging
+
 PYTHON_CACHE_PATTERNS = ("__pycache__", ".mypy_cache", ".pytest_cache", ".ruff_cache")
 NODE_ARTIFACT_PATTERNS = (
     ".parcel-cache",
@@ -156,13 +165,17 @@ def doctor_disk(
             id="flox_logs",
             title="📁 Flox logs (.flox/log)",
             description=[
-                "Remove Flox CLI logs older than 7 days from the dev environment manager.",
-                "These logs can grow to 32GB+ after repeated 'flox' operations.",
+                f"Remove Flox CLI logs older than {FLOX_LOG_MAX_AGE_DAYS} days, then trim the",
+                f"remainder past {_format_size(FLOX_LOG_MAX_TOTAL_BYTES)} (oldest first).",
+                "Every shell activation writes a log, so these grow to tens of GB otherwise.",
             ],
             estimate=_estimate_flox_logs,
-            cleanup=_cleanup_flox_logs,
-            confirmation_prompt="Clean up Flox logs older than 7 days?",
-            dry_run_message="Would run: find .flox/log -name '*.log' -mtime +7 -delete",
+            cleanup=_cleanup_items,
+            confirmation_prompt="Clean up old and oversized Flox logs?",
+            dry_run_message=(
+                f"Would remove Flox logs older than {FLOX_LOG_MAX_AGE_DAYS} days "
+                f"and trim the rest past {_format_size(FLOX_LOG_MAX_TOTAL_BYTES)}"
+            ),
         ),
         CleanupCategory(
             id="docker",
@@ -367,7 +380,11 @@ def _run_category(
 
 
 def _estimate_flox_logs(repo_root: Path) -> CleanupEstimate:
-    """Check Flox log directory - cleanup happens via find command."""
+    """Select Flox logs to remove: everything past the age cutoff, plus the
+    oldest survivors past the total-size budget.
+
+    The returned items are deleted by the generic ``_cleanup_items`` handler.
+    """
 
     flox_log_dir = repo_root / ".flox" / "log"
     if not flox_log_dir.exists():
@@ -377,16 +394,58 @@ def _estimate_flox_logs(repo_root: Path) -> CleanupEstimate:
             items=[],
         )
 
-    # Just check if directory exists and has logs - don't calculate sizes
-    # Cleanup is done via find command for simplicity
-    log_count = len(list(flox_log_dir.glob("*.log")))
+    logs: list[tuple[Path, int, float]] = []  # (path, size, mtime)
+    for log in flox_log_dir.rglob("*.log"):
+        try:
+            stat = log.stat()
+        except (FileNotFoundError, PermissionError, OSError):
+            continue
+        if not log.is_file():
+            continue
+        logs.append((log, stat.st_size, stat.st_mtime))
+
+    if not logs:
+        return CleanupEstimate(total_size=0.0, items=[], details=["   No Flox log files found."])
+
+    doomed, retained_size = _select_flox_logs_to_remove(logs)
 
     details = [
-        "   Runs: find .flox/log -name '*.log' -mtime +7 -delete",
-        f"   Found {log_count} log file(s) in directory.",
+        f"   Removes logs older than {FLOX_LOG_MAX_AGE_DAYS} days, then trims the rest "
+        f"past {_format_size(FLOX_LOG_MAX_TOTAL_BYTES)}.",
+        f"   Found {len(logs)} log file(s); {len(doomed)} to remove, keeping {_format_size(retained_size)}.",
     ]
+    if doomed:
+        details.extend(_describe_items(doomed, repo_root, "   Sample files:"))
 
-    return CleanupEstimate(total_size=0.0, items=[], details=details)
+    total = sum(item.size for item in doomed)
+    return CleanupEstimate(total_size=total, items=doomed, details=details)
+
+
+def _select_flox_logs_to_remove(logs: Sequence[tuple[Path, int, float]]) -> tuple[list[CleanupItem], float]:
+    """Return the logs to delete and the retained size, applying age then budget.
+
+    Deletes anything older than the age cutoff, then — oldest first — trims the
+    survivors until the retained set fits within the size budget.
+    """
+
+    cutoff = time.time() - (FLOX_LOG_MAX_AGE_DAYS * 24 * 60 * 60)
+    doomed: list[CleanupItem] = []
+    survivors: list[tuple[Path, int, float]] = []
+    for path, size, mtime in logs:
+        if mtime < cutoff:
+            doomed.append(CleanupItem(path, size, is_dir=False))
+        else:
+            survivors.append((path, size, mtime))
+
+    survivors.sort(key=lambda entry: entry[2])  # oldest first
+    retained_size = float(sum(size for _, size, _ in survivors))
+    for path, size, _ in survivors:
+        if retained_size <= FLOX_LOG_MAX_TOTAL_BYTES:
+            break
+        doomed.append(CleanupItem(path, size, is_dir=False))
+        retained_size -= size
+
+    return doomed, retained_size
 
 
 def _estimate_python_caches(repo_root: Path) -> CleanupEstimate:
@@ -584,24 +643,6 @@ def _cleanup_items(estimate: CleanupEstimate, _: Path) -> CleanupStats:
 
     freed = _delete_items(estimate.items)
     return CleanupStats(freed=freed, deleted_anything=freed > 0)
-
-
-def _cleanup_flox_logs(_: CleanupEstimate, repo_root: Path) -> CleanupStats:
-    """Execute find command to clean up old Flox logs."""
-
-    flox_log_dir = repo_root / ".flox" / "log"
-    if not flox_log_dir.exists():
-        return CleanupStats(deleted_anything=False)
-
-    result = subprocess.run(
-        ["find", str(flox_log_dir), "-name", "*.log", "-type", "f", "-mtime", "+7", "-delete"],
-        capture_output=True,
-        check=False,
-    )
-    if result.returncode == 0:
-        return CleanupStats(deleted_anything=True)
-
-    return CleanupStats(deleted_anything=False)
 
 
 def _cleanup_git(_: CleanupEstimate, repo_root: Path) -> CleanupStats:

--- a/tools/hogli-commands/hogli_commands/tests/test_doctor.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_doctor.py
@@ -1,4 +1,5 @@
 import os
+import time
 import hashlib
 from pathlib import Path
 from types import SimpleNamespace
@@ -6,6 +7,8 @@ from types import SimpleNamespace
 import pytest
 
 from hogli_commands.doctor import (
+    FLOX_LOG_MAX_AGE_DAYS,
+    FLOX_LOG_MAX_TOTAL_BYTES,
     _binary_arches,
     _collect_import_targets,
     _config_procs,
@@ -18,8 +21,51 @@ from hogli_commands.doctor import (
     _phrocs_runtime_pairs,
     _phrocs_socket_path,
     _probe_command_imports,
+    _select_flox_logs_to_remove,
     _tail,
 )
+
+_QUARTER_BUDGET = FLOX_LOG_MAX_TOTAL_BYTES // 4
+_TWO_FIFTHS_BUDGET = int(FLOX_LOG_MAX_TOTAL_BYTES * 0.4)
+
+
+@pytest.mark.parametrize(
+    "specs, expected_doomed, expected_retained",
+    [
+        pytest.param(
+            [("old.log", 1, FLOX_LOG_MAX_AGE_DAYS + 1), ("recent.log", FLOX_LOG_MAX_TOTAL_BYTES // 2, 0)],
+            ["old.log"],
+            float(FLOX_LOG_MAX_TOTAL_BYTES // 2),
+            id="age-cutoff-removes-old-keeps-large-recent",
+        ),
+        pytest.param(
+            [
+                ("newest.log", _TWO_FIFTHS_BUDGET, 1),
+                ("middle.log", _TWO_FIFTHS_BUDGET, 2),
+                ("oldest.log", _TWO_FIFTHS_BUDGET, 3),
+            ],
+            ["oldest.log"],
+            float(2 * _TWO_FIFTHS_BUDGET),
+            id="budget-trims-oldest-survivor-first",
+        ),
+        pytest.param(
+            [("a.log", _QUARTER_BUDGET, 1), ("b.log", _QUARTER_BUDGET, 2)],
+            [],
+            float(2 * _QUARTER_BUDGET),
+            id="within-age-and-budget-keeps-all",
+        ),
+    ],
+)
+def test_select_flox_logs_to_remove(
+    specs: list[tuple[str, int, int]],
+    expected_doomed: list[str],
+    expected_retained: float,
+) -> None:
+    now = time.time()
+    logs = [(Path(name), size, now - age_days * 86400) for name, size, age_days in specs]
+    doomed, retained = _select_flox_logs_to_remove(logs)
+    assert sorted(item.path.name for item in doomed) == sorted(expected_doomed)
+    assert retained == expected_retained
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Flox writes a fresh log on every shell activation, and direnv re-activates on every `cd` into the tree (plus every non-interactive/agent shell), so `.flox/log` grows fast. The existing `hogli doctor:disk --area=flox-logs` cleanup — which also runs automatically in the background on every activation — only pruned logs older than 7 days. That age rule alone doesn't bound total size: a busy machine can accumulate tens of GB well inside the 7-day window.

## Changes

Add a total-size budget to the flox-logs cleanup. After dropping aged-out logs (unchanged, 7 days), it now trims the oldest survivors until the retained set fits under a cap (512 MiB). This runs through the generic cleanup handler, so both the manual `hogli doctor:disk` command and the silent on-activation prune stay bounded regardless of churn.

## How did you test this code?

Added a parameterized unit test for the new `_select_flox_logs_to_remove` selection logic covering the three behaviors: age cutoff removes old files regardless of size, the size budget trims the oldest survivors first, and everything within both age and budget is kept. This guards against a regression breaking the oldest-first ordering (which would over-delete recent logs) or the budget comparison (which would let the dir grow unbounded) — no prior test exercised this path. Ran the full `test_doctor.py` suite (55 passed) plus ruff check/format.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread about flox generating tens of GB of logs. Invoked the `/writing-tests` skill before adding the test. Considered lowering log verbosity instead, but `RUST_LOG=flox=error,…` is already set in `.envrc`/manifest and flox writes a per-activation log file regardless of level — so retention/size bounding is the effective lever. Chose to keep the existing age rule and layer a size budget on top, reusing `_cleanup_items` rather than a bespoke cleanup path.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1784540725430899?thread_ts=1784540725.430899&cid=C0113360FFV)*
