### PR TITLE
feat(ingestion): add ai pipeline to event restrictions

### DIFF
--- a/posthog/models/event_ingestion_restriction_config.py
+++ b/posthog/models/event_ingestion_restriction_config.py
@@ -17,6 +17,7 @@ INGESTION_PIPELINES = [
     {"value": "session_recordings", "label": "Session Recordings Pipeline"},
     {"value": "errortracking", "label": "Error Tracking Pipeline"},
     {"value": "clientwarnings", "label": "Client Warnings Pipeline"},
+    {"value": "ai", "label": "AI Pipeline"},
 ]
 
 
@@ -37,6 +38,7 @@ class IngestionPipeline(models.TextChoices):
     SESSION_RECORDINGS = "session_recordings"
     ERRORTRACKING = "errortracking"
     CLIENTWARNINGS = "clientwarnings"
+    AI = "ai"
 
 
 class EventIngestionRestrictionConfig(UUIDTModel):


### PR DESCRIPTION
## Problem

The capture service (`Pipeline::Ai` in `rust/capture`) and the Node.js AI ingestion consumer (`pipeline: 'ai'` in its restriction manager) both support restriction lookups scoped to the AI pipeline, but Django only offers `analytics`, `session_recordings`, `errortracking`, and `clientwarnings` as pipeline choices. Since Django is what writes restriction configs to Redis, there is currently no way to configure a restriction that targets the AI pipeline, so those lookups can never match.

## Changes

Adds `ai` to `INGESTION_PIPELINES` and the `IngestionPipeline` choices in `posthog/models/event_ingestion_restriction_config.py`, mirroring the earlier `clientwarnings` addition. The admin form derives its choices from the same list, so no other changes are needed. No migration required (pipeline validation happens in `clean()`, not at the DB level).

## How did you test this code?

Existing `posthog/models/test/test_event_ingestion_restriction_config.py` covers pipeline validation and Redis serialization generically from the choices list. I could not run it locally (no local Postgres up), relying on CI. No new tests: a list entry with no new behavior has no regression of its own to catch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal operational tooling, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The gap was found while reviewing AI event routing on the capture side: consumers already look up `ai`-scoped restrictions, only the Django config surface was missing the option.
