### PR TITLE
fix(mcp): count state-resolution failures on initialize in mcp_init_total

### DIFF
--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -143,7 +143,18 @@ class McpDispatcher {
         }
 
         const needsState = requests.some((r) => TRACKED_METHODS.has(r.method))
-        const state = needsState ? await this.stateResolver.resolve(props) : undefined
+        let state: ResolvedState | undefined
+        try {
+            state = needsState ? await this.stateResolver.resolve(props) : undefined
+        } catch (error) {
+            // A failed resolution still fails the handshake for the client, so count
+            // it in mcp_init_total — otherwise MCPServerHighInitErrorRate only sees
+            // failures past this point. The rethrow surfaces as a 500 upstream.
+            if (hasInit) {
+                initTotal.inc({ status: 'error' })
+            }
+            throw error
+        }
 
         const headers: Record<string, string> = { 'Content-Type': 'application/json' }
         if (props.mcpSessionId) {

--- a/services/mcp/tests/hono/dispatcher-init-errors.test.ts
+++ b/services/mcp/tests/hono/dispatcher-init-errors.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+    mockBuildInstructions,
+    mockInitDurationObserve,
+    mockInitTotalInc,
+    mockRevalidateContextMillResources,
+    mockResolveState,
+    mockTrackInitEvent,
+} = vi.hoisted(() => ({
+    mockBuildInstructions: vi.fn(),
+    mockInitDurationObserve: vi.fn(),
+    mockInitTotalInc: vi.fn(),
+    mockRevalidateContextMillResources: vi.fn(),
+    mockResolveState: vi.fn(),
+    mockTrackInitEvent: vi.fn(),
+}))
+
+vi.mock('@/hono/analytics', () => ({
+    trackInitEvent: mockTrackInitEvent,
+}))
+
+vi.mock('@/hono/instructions', () => ({
+    InstructionsBuilder: vi.fn().mockImplementation(function () {
+        return {
+            build: mockBuildInstructions,
+        }
+    }),
+}))
+
+vi.mock('@/hono/metrics', () => ({
+    initDurationSeconds: { observe: mockInitDurationObserve },
+    initTotal: { inc: mockInitTotalInc },
+}))
+
+vi.mock('@/hono/request-state-resolver', () => ({
+    RequestStateResolver: vi.fn().mockImplementation(function () {
+        return {
+            resolve: mockResolveState,
+        }
+    }),
+}))
+
+vi.mock('@/hono/resource-catalog', () => ({
+    ResourceCatalog: vi.fn().mockImplementation(function () {
+        return {
+            getPrompt: vi.fn(() => ({ messages: [] })),
+            getPromptsList: vi.fn(() => ({ prompts: [] })),
+            getResourcesList: vi.fn(() => ({ resources: [] })),
+            readResource: vi.fn(async () => ({ contents: [] })),
+            revalidateContextMillResources: mockRevalidateContextMillResources,
+            warmup: vi.fn(async () => {}),
+        }
+    }),
+}))
+
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js'
+
+import type { RedisLike } from '@/hono/cache/RedisCache'
+import { McpDispatcher } from '@/hono/dispatcher'
+import type { RequestProperties } from '@/lib/request-properties'
+
+import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
+
+function createMockRedis(): RedisLike {
+    const store = new Map<string, string>()
+    return {
+        get: vi.fn(async (key: string) => store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: string) => {
+            store.set(key, value)
+            return 'OK'
+        }),
+        del: vi.fn(async (...keys: string[]) => {
+            let count = 0
+            for (const key of keys) {
+                if (store.delete(key)) {
+                    count++
+                }
+            }
+            return count
+        }),
+        scan: vi.fn(async () => ['0', []] as [string, string[]]),
+        ...makeRedisRateLimitStubs(),
+    }
+}
+
+function makeProps(): RequestProperties {
+    return {
+        apiToken: 'phx_test',
+        mcpClientName: 'test-client',
+        mcpClientVersion: '1.0.0',
+        mcpProtocolVersion: LATEST_PROTOCOL_VERSION,
+        requestStartTime: Date.now(),
+        transport: 'streamable-http',
+        userHash: 'test-user',
+    }
+}
+
+function makeRequest(method: string): Request {
+    return new Request('https://mcp.test/mcp', {
+        body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            method,
+            params:
+                method === 'initialize'
+                    ? {
+                          capabilities: {},
+                          clientInfo: { name: 'test-client', version: '1.0.0' },
+                          protocolVersion: LATEST_PROTOCOL_VERSION,
+                      }
+                    : {},
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+    })
+}
+
+describe('McpDispatcher init error accounting', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockBuildInstructions.mockResolvedValue('')
+        mockResolveState.mockResolvedValue({ distinctId: 'test-distinct-id' })
+        mockTrackInitEvent.mockResolvedValue(undefined)
+        mockRevalidateContextMillResources.mockResolvedValue(undefined)
+    })
+
+    it('counts an initialize handshake as errored when state resolution fails', async () => {
+        const resolutionError = new Error('django auth is down')
+        mockResolveState.mockRejectedValueOnce(resolutionError)
+
+        const dispatcher = new McpDispatcher({} as any, createMockRedis())
+
+        await expect(dispatcher.handleRequest(makeRequest('initialize'), makeProps())).rejects.toBe(resolutionError)
+        expect(mockInitTotalInc).toHaveBeenCalledWith({ status: 'error' })
+    })
+
+    it('does not count non-initialize requests when state resolution fails', async () => {
+        mockResolveState.mockRejectedValueOnce(new Error('django auth is down'))
+
+        const dispatcher = new McpDispatcher({} as any, createMockRedis())
+
+        await expect(dispatcher.handleRequest(makeRequest('tools/list'), makeProps())).rejects.toThrow()
+        expect(mockInitTotalInc).not.toHaveBeenCalled()
+    })
+
+    it('counts a successful initialize handshake once', async () => {
+        const dispatcher = new McpDispatcher({} as any, createMockRedis())
+
+        const response = await dispatcher.handleRequest(makeRequest('initialize'), makeProps())
+
+        expect(response.status).toBe(200)
+        expect(mockInitTotalInc).toHaveBeenCalledTimes(1)
+        expect(mockInitTotalInc).toHaveBeenCalledWith({ status: 'success' })
+    })
+})


### PR DESCRIPTION
## Problem

The `MCPServerHighInitErrorRate` alert measures failed `initialize` handshakes via `mcp_init_total{status="error"}`, but the counter is only incremented inside `handleInitialize` — after `stateResolver.resolve()` has already succeeded. A handshake that dies in state resolution (e.g. Django auth down, Redis session lookup failing) returns a 500 without ever touching the counter, so the alert is blind to a whole class of failed inits. This surfaced while auditing the mcp-server runbooks against the service code (charts-side fixes: PostHog/charts#13312, stacked on PostHog/charts#13302).

## Changes

- `McpDispatcher.handleRequest` now wraps the state-resolution await: if it throws and the batch contains an `initialize` request, `mcp_init_total{status="error"}` is incremented before the error is rethrown. The rethrow still surfaces as a 500 via `handleCatchError`, so `MCPServerHigh5xxRate` behavior is unchanged.
- Non-init requests failing state resolution are unaffected (no counter increment), as before.

## How did you test this code?

Automated tests only (agent-authored):

- New `tests/hono/dispatcher-init-errors.test.ts` — catches the regression no existing test did: a state-resolution failure on an `initialize` batch must increment `mcp_init_total{status="error"}` (and must not for non-init requests, and must count success exactly once).
- `pnpm exec vitest run --config vitest.hono.config.mts dispatcher-init` — 4 tests pass (3 new + existing revalidation test).
- `pnpm --filter=@posthog/mcp run fix` — clean. `typecheck` in the agent's worktree fails only on pre-existing missing-workspace-dep noise (`react`, `@posthog/quill*`) from a scripts-skipped install; no errors in the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The runbook update describing this behavior ships in PostHog/charts#13312.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) during a runbook-accuracy audit of the mcp-server alerts: the session traced every alert claim through `src/hono/{dispatcher,tool-executor,request-utils,metrics,public-routes}.ts` and found the init counter's blind spot as the one code-side gap (everything else was fixed docs-side in the charts PRs above). Chose to increment-and-rethrow at the resolve site rather than moving resolution inside `handleInitialize`, to keep batch semantics and the existing 500 path untouched. No repo skills were invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)