### PR TITLE
fix: stripped text

### DIFF
--- a/products/conversations/backend/api/email_events.py
+++ b/products/conversations/backend/api/email_events.py
@@ -368,15 +368,22 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
         sender_email=sender_email,
     )
 
-    # 7. Get content. Mailgun's stripped-text removes quoted replies, but its signature
-    # detection also cuts real content (e.g. a trailing list of bare emails/links), so we
-    # reattach stripped-signature to keep quote-stripping without losing customer text.
+    # 7. Get content. Mailgun's stripped-text removes quoted parts, which is right for
+    # replies (the quoted trail is the thread we already store) but wrong for a first
+    # message: a forwarded email's original content lives in the "quoted" block, so
+    # stripping would drop the very context the customer forwarded in. Keep the full
+    # plain body for new tickets; strip quotes only on replies to existing tickets.
+    # Mailgun's signature detection also cuts real content (e.g. a trailing list of
+    # bare emails/links), so reattach stripped-signature after stripped-text.
+    body_plain = request.POST.get("body-plain", "")
     stripped_text = request.POST.get("stripped-text", "")
     stripped_signature = request.POST.get("stripped-signature", "")
-    if stripped_text:
-        content = f"{stripped_text}\n\n{stripped_signature}" if stripped_signature else stripped_text
+    if stripped_signature and stripped_text:
+        stripped_text = f"{stripped_text}\n\n{stripped_signature}"
+    if existing_ticket:
+        content = stripped_text or body_plain
     else:
-        content = request.POST.get("body-plain", "")
+        content = body_plain or stripped_text
     content = content[:MAX_EMAIL_BODY_LENGTH]
     subject = request.POST.get("subject", "")[:500]
 

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -863,6 +863,16 @@ class TestEmailInboundContent(BaseTest):
                 {"body-plain": "Full body text"},
                 "Full body text",
             ),
+            # A forwarded email's original content is inside the "quoted" block that
+            # Mailgun strips — on a new ticket the full body must be kept.
+            (
+                "new_ticket_keeps_forwarded_context",
+                {
+                    "stripped-text": "FYI, see below",
+                    "body-plain": "FYI, see below\n\n---------- Forwarded message ---------\nOriginal content",
+                },
+                "FYI, see below\n\n---------- Forwarded message ---------\nOriginal content",
+            ),
         ]
     )
     @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
@@ -883,6 +893,32 @@ class TestEmailInboundContent(BaseTest):
 
         comment = Comment.objects.get(team=self.team, scope="conversations_ticket")
         assert comment.content == expected_content
+
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_reply_strips_quoted_thread(self, _mock_sig: MagicMock):
+        base = {
+            "recipient": "team-cc00dd11ee2233ff@mg.posthog.com",
+            "from": "customer@test.com",
+            "subject": "Help",
+        }
+        self.client.post(
+            "/api/conversations/v1/email/inbound",
+            {**base, "Message-Id": "<thread-init@test.com>", "stripped-text": "Initial question"},
+        )
+        response = self.client.post(
+            "/api/conversations/v1/email/inbound",
+            {
+                **base,
+                "Message-Id": "<thread-reply@test.com>",
+                "In-Reply-To": "<thread-init@test.com>",
+                "stripped-text": "Thanks, that worked",
+                "body-plain": "Thanks, that worked\n\nOn Mon, Support wrote:\n> Initial question",
+            },
+        )
+        assert response.status_code == 200
+
+        reply = Comment.objects.filter(team=self.team, scope="conversations_ticket").order_by("created_at")[1]
+        assert reply.content == "Thanks, that worked"
 
 
 class TestSendEmailReplyMultiConfig(BaseTest):


### PR DESCRIPTION
do not drop stripped in forwarded emails