### PR TITLE
feat(conversations): add "assign to me" button to ticket assignee

### DIFF
--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -400,21 +400,33 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                             </div>
                             <div className="flex justify-between items-center">
                                 <span className="text-muted-alt">Assignee</span>
-                                <AssigneeSelect assignee={assignee} onChange={setAssignee}>
-                                    {(resolvedAssignee, isOpen) => (
-                                        <LemonButton
-                                            size="small"
-                                            type="secondary"
-                                            active={isOpen}
-                                            sideIcon={<IconChevronDown />}
-                                        >
-                                            <span className="flex items-center gap-1">
-                                                <AssigneeIconDisplay assignee={resolvedAssignee} size="small" />
-                                                <AssigneeLabelDisplay assignee={resolvedAssignee} size="small" />
-                                            </span>
-                                        </LemonButton>
-                                    )}
-                                </AssigneeSelect>
+                                <div className="flex items-center gap-1">
+                                    {user?.id != null &&
+                                        !(assignee?.type === 'user' && String(assignee.id) === String(user.id)) && (
+                                            <LemonButton
+                                                size="small"
+                                                type="tertiary"
+                                                onClick={() => setAssignee({ type: 'user', id: user.id })}
+                                            >
+                                                Assign to me
+                                            </LemonButton>
+                                        )}
+                                    <AssigneeSelect assignee={assignee} onChange={setAssignee}>
+                                        {(resolvedAssignee, isOpen) => (
+                                            <LemonButton
+                                                size="small"
+                                                type="secondary"
+                                                active={isOpen}
+                                                sideIcon={<IconChevronDown />}
+                                            >
+                                                <span className="flex items-center gap-1">
+                                                    <AssigneeIconDisplay assignee={resolvedAssignee} size="small" />
+                                                    <AssigneeLabelDisplay assignee={resolvedAssignee} size="small" />
+                                                </span>
+                                            </LemonButton>
+                                        )}
+                                    </AssigneeSelect>
+                                </div>
                             </div>
                             {ticket?.sla_due_at && (
                                 <div className="flex justify-between items-center">

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -404,7 +404,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                                     {user?.id != null &&
                                         !(assignee?.type === 'user' && String(assignee.id) === String(user.id)) && (
                                             <LemonButton
-                                                size="small"
+                                                size="xxsmall"
                                                 type="tertiary"
                                                 onClick={() => setAssignee({ type: 'user', id: user.id })}
                                             >

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -398,9 +398,9 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                                     dropdownMatchSelectWidth={false}
                                 />
                             </div>
-                            <div className="flex justify-between items-center">
+                            <div className="flex justify-between items-start">
                                 <span className="text-muted-alt">Assignee</span>
-                                <div className="flex items-center gap-1">
+                                <div className="flex flex-col items-end gap-1">
                                     {user?.id != null &&
                                         !(assignee?.type === 'user' && String(assignee.id) === String(user.id)) && (
                                             <LemonButton
@@ -408,7 +408,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                                                 type="tertiary"
                                                 onClick={() => setAssignee({ type: 'user', id: user.id })}
                                             >
-                                                Assign to me
+                                                <span className="text-accent">Assign to me</span>
                                             </LemonButton>
                                         )}
                                     <AssigneeSelect assignee={assignee} onChange={setAssignee}>


### PR DESCRIPTION
## Problem

Assigning a support ticket to yourself takes three steps today: open the assignee dropdown, search your own name, click it. That is a lot of friction for one of the most common actions on the ticket page.

## Changes

Adds a tertiary "Assign to me" button next to the assignee dropdown in the ticket detail sidebar.

- Clicking it stages the current user as the assignee via the existing `setAssignee` action, exactly like picking yourself from the dropdown. Nothing persists until you hit the existing "Save changes" button, so the staged-changes flow is unchanged.
- The button is hidden when the ticket is already assigned to you (and when there is no logged-in user id).

It reuses what is already in the scene: `setAssignee`, `user` from `userLogic`, `LemonButton`, and the `{ type: 'user', id }` assignee shape the dropdown's Users section already produces, so `resolveAssignee` renders your name correctly with no extra wiring.

Single file touched: `products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx`.

<img width="561" height="530" alt="CleanShot 2026-07-20 at 14 31 45" src="https://github.com/user-attachments/assets/cd937e25-f726-4f06-9cb6-32faf7ab996a" />

<img width="556" height="554" alt="CleanShot 2026-07-20 at 14 31 22" src="https://github.com/user-attachments/assets/da9a7128-fbf5-4567-974b-1d321df9a6e4" />



## How did you test this code?

I (Claude) did not run the app. I ran the automated checks only:

- `oxlint` on the changed file: clean (one pre-existing `style` warning on an untouched line).
- `oxfmt` applied.
- Full `tsc --noEmit`: no type errors in the scene or the Assignee components.

Manual click-through on a live ticket is still to be done by the PR author.

No new tests: this is thin UI wiring of an existing action with no new logic branch worth a regression test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Luke directed the work; I (Claude, via PostHog Code) explored the conversations assignee components, planned the change, and implemented it. No repo skills were required beyond the exploration. I confirmed two UX decisions with Luke before writing code: the button stages the change rather than saving immediately (matches the dropdown), and it is hidden rather than disabled when the ticket is already yours.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
