### PR TITLE
feat(ci): emit reason detail for playwright spec-selection fallbacks

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -335,6 +335,7 @@ jobs:
             skipped_count: ${{ steps.classify.outputs.skipped_count }}
             changed_file_count: ${{ steps.classify.outputs.changed_file_count }}
             full_run_reason_category: ${{ steps.classify.outputs.full_run_reason_category }}
+            full_run_reason_detail: ${{ steps.classify.outputs.full_run_reason_detail }}
         steps:
             # Full checkout at PR head so the selector can glob specs on disk and read
             # the map/script from the branch under test. Bounded depth + blob:none keeps
@@ -385,6 +386,7 @@ jobs:
                   SKIPPED_COUNT=""
                   CHANGED_COUNT=""
                   REASON_CATEGORY=""
+                  REASON_DETAIL=""
 
                   if [[ "$SELECT_OUTCOME" != "success" ]] || [[ ! -s /tmp/spec-selection.json ]]; then
                       echo "::warning::spec selector produced no output — running the FULL suite"
@@ -396,6 +398,7 @@ jobs:
                       TOTAL_COUNT=$(jq -r '.total_spec_count' /tmp/spec-selection.json)
                       CHANGED_COUNT=$(jq -r '.changed_file_count' /tmp/spec-selection.json)
                       REASON_CATEGORY=$(jq -r '.full_run_reason_category' /tmp/spec-selection.json)
+                      REASON_DETAIL=$(jq -r '.full_run_reason_detail // ""' /tmp/spec-selection.json)
                       SKIPPED_COUNT=$((TOTAL_COUNT - SELECTED_COUNT))
                       if [[ "$MODE" == "selected" ]]; then
                           SPECS=$(jq -r '.spec_files | join(" ")' /tmp/spec-selection.json)
@@ -423,6 +426,7 @@ jobs:
                       echo "skipped_count=$SKIPPED_COUNT"
                       echo "changed_file_count=$CHANGED_COUNT"
                       echo "full_run_reason_category=$REASON_CATEGORY"
+                      echo "full_run_reason_detail=$REASON_DETAIL"
                   } >> "$GITHUB_OUTPUT"
                   echo "mode=$MODE category=${REASON_CATEGORY:-none} selected=${SELECTED_COUNT:-?}/${TOTAL_COUNT:-?}"
 
@@ -1090,6 +1094,7 @@ jobs:
                         "skipped_count": ${{ needs.select-specs.outputs.skipped_count || 'null' }},
                         "changed_file_count": ${{ needs.select-specs.outputs.changed_file_count || 'null' }},
                         "full_run_reason_category": ${{ toJSON(needs.select-specs.outputs.full_run_reason_category || '') }},
+                        "full_run_reason_detail": ${{ toJSON(needs.select-specs.outputs.full_run_reason_detail || '') }},
                         "playwright_test_seconds": ${{ needs.playwright.outputs.test_seconds || 'null' }},
                         "playwright_result": ${{ toJSON(needs.playwright.result) }},
                         "runner_billing_multiplier": 4,

--- a/tools/playwright_spec_selection.py
+++ b/tools/playwright_spec_selection.py
@@ -21,13 +21,20 @@ Emits a single JSON object to stdout:
 
     {
       "mode": "selected" | "full",
-      "spec_files": [...],          # [] when mode == "full"
-      "full_run_reasons": [...],    # why a full run was chosen (empty when selected)
+      "spec_files": [...],              # [] when mode == "full"
+      "full_run_reasons": [...],        # why a full run was chosen (empty when selected)
+      "full_run_reason_category": "",   # low-cardinality category (empty when selected)
+      "full_run_reason_detail": "",     # low-cardinality trigger (the pattern/scene/product/dir)
       "changed_files": [...],
       "changed_file_count": N,
       "selected_count": M,
       "total_spec_count": T
     }
+
+`full_run_reason_detail` names the specific thing that forced the full run, normalized
+to stay low-cardinality so it groups cleanly in analytics: the matched `force_full`
+pattern, the unmapped scene/product name, or the offending file's directory prefix
+(for `unmapped_path`). It's what tells you which map gap to close next.
 """
 
 from __future__ import annotations
@@ -50,6 +57,18 @@ SPEC_GLOBS = ("playwright/e2e/**/*.spec.ts", "products/*/frontend/e2e/**/*.spec.
 
 _PRODUCT_FRONTEND_RE = re.compile(r"^products/([^/]+)/frontend/")
 _SCENE_RE = re.compile(r"^frontend/src/scenes/([^/]+)/")
+
+# How many leading path segments to keep when normalizing an unmapped file to a
+# directory prefix — enough to point at the area to map, bounded so cardinality stays low.
+_DETAIL_PREFIX_SEGMENTS = 3
+
+
+def _dir_prefix(path: str) -> str:
+    """The file's directory, capped to the first few segments, as a low-cardinality label."""
+    parts = path.split("/")[:-1]
+    if not parts:
+        return path
+    return "/".join(parts[:_DETAIL_PREFIX_SEGMENTS]) + "/"
 
 
 class MapError(Exception):
@@ -112,13 +131,15 @@ def _result(
     changed_files: list[str],
     total_spec_count: int,
     reason_category: str = "",
+    reason_detail: str = "",
 ) -> dict:
     return {
         "mode": mode,
         "spec_files": spec_files,
         "full_run_reasons": reasons,
-        # Low-cardinality label for analytics grouping (the reasons carry file paths).
+        # Low-cardinality labels for analytics grouping (the reasons carry file paths).
         "full_run_reason_category": reason_category,
+        "full_run_reason_detail": reason_detail,
         "changed_files": changed_files,
         "changed_file_count": len(changed_files),
         "selected_count": len(spec_files),
@@ -130,8 +151,8 @@ def select(changed_files: list[str], area_map: dict, all_specs: set[str]) -> dic
     """Pure selection: changed files + map + on-disk specs -> a full/selected decision."""
     total = len(all_specs)
 
-    def full(reason: str, category: str) -> dict:
-        return _result("full", [], [reason], changed_files, total, category)
+    def full(reason: str, category: str, detail: str = "") -> dict:
+        return _result("full", [], [reason], changed_files, total, category, detail)
 
     if not changed_files:
         return full("empty diff (defensive full run)", "empty_diff")
@@ -156,7 +177,7 @@ def select(changed_files: list[str], area_map: dict, all_specs: set[str]) -> dic
         # 1. Shared infra / backend / unattributable code -> full (highest priority).
         for pat, rx in force_full:
             if rx.match(f):
-                return full(f"{f} matches force-full pattern '{pat}'", "force_full")
+                return full(f"{f} matches force-full pattern '{pat}'", "force_full", pat)
 
         # 2. Product-owned frontend -> that product's specs (or an explicit rule for
         #    products whose behavior is exercised by top-level specs).
@@ -169,7 +190,7 @@ def select(changed_files: list[str], area_map: dict, all_specs: set[str]) -> dic
                 continue
             if explicit_match(f, selected):
                 continue
-            return full(f"{f}: product '{name}' has no spec mapping", "unmapped_product")
+            return full(f"{f}: product '{name}' has no spec mapping", "unmapped_product", name)
 
         # 3. Frontend scene -> mapped specs.
         sm = _SCENE_RE.match(f)
@@ -179,7 +200,7 @@ def select(changed_files: list[str], area_map: dict, all_specs: set[str]) -> dic
                 for t in scenes[area]:
                     selected |= expand_target(t, all_specs)
                 continue
-            return full(f"{f}: scene '{area}' has no spec mapping", "unmapped_scene")
+            return full(f"{f}: scene '{area}' has no spec mapping", "unmapped_scene", area)
 
         # 4. Explicit path rules.
         if explicit_match(f, selected):
@@ -191,7 +212,7 @@ def select(changed_files: list[str], area_map: dict, all_specs: set[str]) -> dic
             continue
 
         # 6. Anything unrecognized -> full (fail closed).
-        return full(f"{f}: unmapped path", "unmapped_path")
+        return full(f"{f}: unmapped path", "unmapped_path", _dir_prefix(f))
 
     # Belt-and-suspenders: a directly-edited spec always runs even if its area also mapped.
     selected |= {f for f in changed_files if f in all_specs}

--- a/tools/playwright_spec_selection.py
+++ b/tools/playwright_spec_selection.py
@@ -67,7 +67,7 @@ def _dir_prefix(path: str) -> str:
     """The file's directory, capped to the first few segments, as a low-cardinality label."""
     parts = path.split("/")[:-1]
     if not parts:
-        return path
+        return "./"
     return "/".join(parts[:_DETAIL_PREFIX_SEGMENTS]) + "/"
 
 

--- a/tools/test_playwright_spec_selection.py
+++ b/tools/test_playwright_spec_selection.py
@@ -45,8 +45,9 @@ class TestPlaywrightSpecSelection(unittest.TestCase):
         return selection.select(changed, FAKE_MAP, FAKE_SPECS)
 
     def test_select_behavior_matrix(self) -> None:
-        # (name, changed files, expected mode, expected specs (selected) or reason category (full))
-        cases: list[tuple[str, list[str], str, set[str] | str]] = [
+        # (name, changed files, expected mode,
+        #  selected -> expected specs; full -> (reason category, reason detail))
+        cases: list[tuple[str, list[str], str, set[str] | tuple[str, str]]] = [
             (
                 "mapped product frontend narrows to that product's specs",
                 ["products/surveys/frontend/logic.ts"],
@@ -75,16 +76,29 @@ class TestPlaywrightSpecSelection(unittest.TestCase):
                 {"playwright/e2e/auth.spec.ts"},
             ),
             # Fail-closed: the core safety property. Any of these dropping to "selected" is a
-            # coverage hole. The category is the analytics grouping key, so lock it too.
-            ("unmapped scene forces full", ["frontend/src/scenes/settings/x.ts"], "full", "unmapped_scene"),
-            ("unmapped product forces full", ["products/messaging/frontend/x.ts"], "full", "unmapped_product"),
-            ("unrecognized path forces full", ["some/random/file.ts"], "full", "unmapped_path"),
-            # force_full wins even when another changed file would have narrowed.
+            # coverage hole. Category + detail are the analytics grouping keys (detail names the
+            # map gap to close and must stay low-cardinality), so lock both.
+            (
+                "unmapped scene forces full",
+                ["frontend/src/scenes/settings/x.ts"],
+                "full",
+                ("unmapped_scene", "settings"),
+            ),
+            (
+                "unmapped product forces full",
+                ["products/messaging/frontend/x.ts"],
+                "full",
+                ("unmapped_product", "messaging"),
+            ),
+            ("unrecognized path forces full", ["some/random/file.ts"], "full", ("unmapped_path", "some/random/")),
+            # unmapped_path detail is normalized to a bounded dir prefix, not the raw (high-cardinality) file path.
+            ("deep unmapped path caps to leading segments", ["a/b/c/d/e.ts"], "full", ("unmapped_path", "a/b/c/")),
+            # force_full wins even when another changed file would have narrowed; detail is the matched pattern.
             (
                 "force-full pattern forces full alongside a mappable file",
                 ["products/surveys/frontend/logic.ts", "posthog/models/team.py"],
                 "full",
-                "force_full",
+                ("force_full", "posthog/**"),
             ),
             # `*` must not cross `/`: a nested spec dir change must not be swallowed by `playwright/*.ts`.
             (
@@ -93,7 +107,7 @@ class TestPlaywrightSpecSelection(unittest.TestCase):
                 "selected",
                 {"playwright/e2e/billing/billing.spec.ts"},
             ),
-            ("empty diff defaults to full", [], "full", "empty_diff"),
+            ("empty diff defaults to full", [], "full", ("empty_diff", "")),
         ]
         for name, changed, mode, expected in cases:
             with self.subTest(name):
@@ -102,8 +116,10 @@ class TestPlaywrightSpecSelection(unittest.TestCase):
                 if mode == "selected":
                     self.assertEqual(set(result["spec_files"]), expected, msg=name)
                 else:
+                    category, detail = expected
                     self.assertTrue(result["full_run_reasons"], msg=f"{name}: expected a reason")
-                    self.assertEqual(result["full_run_reason_category"], expected, msg=name)
+                    self.assertEqual(result["full_run_reason_category"], category, msg=name)
+                    self.assertEqual(result["full_run_reason_detail"], detail, msg=name)
 
     def test_over_ceiling_forces_full(self) -> None:
         changed = [f"products/surveys/frontend/f{i}.ts" for i in range(selection.MAX_CHANGED_FILES + 1)]


### PR DESCRIPTION
## Problem

The `posthog-ci-e2e-spec-selection` event tells us *that* an eligible Playwright run fell back to the full suite, but not *why* in an actionable way. It carries the low-cardinality `full_run_reason_category` (`unmapped_path`, `unmapped_scene`, `force_full`, ...), which is enough to compute a fallback rate but useless for fixing it.

Looking at the last few days of data in the DevEx project, only ~3% of eligible runs actually narrow. The two biggest fallback buckets are `unmapped_path` (~33% of eligible runs) and `unmapped_scene` (~7%) — both are pure map-coverage gaps in `tools/playwright_area_map.json`. But the event doesn't say *which* paths or scenes are missing, so closing those gaps means guessing.

The selector already knows the exact trigger. It builds strings like `"frontend/src/scenes/settings/x.ts: scene 'settings' has no spec mapping"`, but that detail lives in the `full_run_reasons` list, which the workflow drops before capture (it carries raw file paths, so it can't ship as-is).

## Changes

Add a `full_run_reason_detail` dimension: a low-cardinality, normalized name for the specific thing that forced the full run. It's the analytics counterpart to the reasons list, safe to group on.

| Category | `full_run_reason_detail` |
|---|---|
| `force_full` | the matched glob pattern, e.g. `posthog/**`, `frontend/src/lib/**` |
| `unmapped_scene` | the scene name, e.g. `settings` |
| `unmapped_product` | the product name, e.g. `messaging` |
| `unmapped_path` | the file's directory, capped to 3 leading segments, e.g. `some/random/` |

The `unmapped_path` normalization matters: emitting the raw file path would put one distinct value per changed file into the dimension. Capping to a directory prefix keeps it groupable while still pointing at the area to map.

Wiring, following the existing `full_run_reason_category` path exactly:

- `tools/playwright_spec_selection.py` — `select()` passes the detail through every full-run branch; `_result` emits `full_run_reason_detail`.
- `.github/workflows/ci-e2e-playwright.yml` — the `classify` step extracts it, `select-specs` exposes it as an output, and the capture job ships it on the event (`toJSON`-wrapped, empty on `selector_error`).

This is instrumentation only. It doesn't narrow anything itself. Once events flow, a single breakdown on `full_run_reason_detail` filtered to `unmapped_path` / `unmapped_scene` gives a ranked worklist of directories and scenes to add to the area map — the empirical flywheel the map's own comment already calls for ("widen `scenes`/`explicit` as recall data comes in").

## How did you test this code?

I (Claude, via Claude Code) did not run this in CI. Locally:

- `python3 tools/test_playwright_spec_selection.py` — extended the existing parameterized matrix so every full-run case asserts `full_run_reason_detail` alongside `category`, plus one case locking the 3-segment cap on `unmapped_path`. This catches the specific regression where the detail reverts to the raw high-cardinality file path, or a `full()` branch stops passing the right trigger — no existing test asserted detail. 4 tests pass.
- Smoke-ran the selector against `origin/master`; the new field appears in the JSON output.
- `ruff check`, `ruff format`, `hogli lint:workflows` (all 6 checks), and `hogli ci:preflight --strict` all clean.

The real end-to-end check is a synchronize push on a ready PR that touches an unmapped path, which fires the event with a populated detail.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

CI-internal, no user-facing behavior. Add `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @gantoine is the DRI.

Authored by Claude (Claude Code) as a follow-on to the test-selection analytics work in #71304. It started as an investigation into how many CI minutes selection saves; the Playwright number was small because narrowing almost never fires, and the data couldn't say which map gaps to close. This PR adds the missing dimension to make that answerable.

Decisions: (1) normalize `unmapped_path` to a 3-segment directory prefix rather than shipping the raw path — keeps the dimension low-cardinality while still actionable; (2) reuse the exact category-wiring path (selector output → classify → job output → event) rather than inventing a new mechanism; (3) instrumentation only, no map or logic changes — acting on the data is a deliberate follow-up. The 37 `selector_error` runs seen in the data are a separate bug, not addressed here.

No skills shaped the production code; `/writing-tests` was invoked before extending the test to apply its value gate.
