### PR TITLE
fix(billing): refresh quota limits on plan change

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -321,7 +321,28 @@ class BillingManager:
 
         handle_billing_service_error(res)
 
+        self.refresh_org_billing_state(organization)
+
         return res.json()
+
+    def refresh_org_billing_state(self, organization: Organization) -> None:
+        """Re-sync the org's local billing state from the billing service.
+
+        Running update_org_details refreshes the org's usage limits and rewrites the
+        Redis quota-limiting sets, so a plan change clears quota limits (including AI
+        credits) right away instead of waiting for the periodic quota-limiting job.
+        Failures are swallowed: that job and the frontend's billing reload are backstops,
+        and a refresh error should not fail the plan-change request itself.
+        """
+        if not self.license or not self.license.is_v2_license:
+            return
+
+        try:
+            billing_service_response = self._get_billing(organization)
+            if cast(dict[str, Any], billing_service_response).get("customer"):
+                self.update_org_details(organization, billing_service_response)
+        except Exception as e:
+            capture_exception(e, {"organization_id": organization.id})
 
     def deactivate_products(self, organization: Organization, products: str) -> None:
         res = requests.post(
@@ -713,6 +734,7 @@ class BillingManager:
 
         handle_billing_service_error(res)
         self.update_available_product_features(organization)
+        self.refresh_org_billing_state(organization)
 
         return res.json()
 

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -224,7 +224,17 @@ def _get_previous_recordings_zset_tokens() -> set[str]:
 
 def is_team_limited(team_api_token: str, resource: QuotaResource, cache_key: QuotaLimitingCaches) -> bool:
     limited_team_attributes = list_limited_team_attributes(resource, cache_key)
-    return team_api_token in limited_team_attributes
+    if team_api_token not in limited_team_attributes:
+        return False
+
+    # The cached list can be a stale positive. `list_limited_team_attributes` is cached per
+    # process for 30s with background_refresh, which returns the OLD value on the request that
+    # triggers the refresh — so right after a team's limit clears (e.g. a plan upgrade), warm web
+    # pods keep reporting it as limited for minutes, blocking a user who already paid. Only when
+    # the cached answer says "limited" (the rare branch), confirm against live Redis before
+    # actually limiting. The extra read costs nothing on the common not-limited path.
+    fresh_limited_team_attributes = list_limited_team_attributes(resource, cache_key, use_cache=False)
+    return team_api_token in fresh_limited_team_attributes
 
 
 def dispatch_recordings_remote_config_sync(team_ids: Iterable[int]) -> None:

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -282,6 +282,55 @@ class TestBillingManager(BaseTest):
         }
 
     @patch("posthoganalytics.capture")
+    @patch("ee.billing.billing_manager.requests.get")
+    @patch("ee.billing.billing_manager.requests.post")
+    def test_activate_subscription_refreshes_quota_limits(self, post_mock, get_mock, patch_capture):
+        organization = self.organization
+        organization.usage = {
+            "events": {"usage": 90, "limit": 1000, "todays_usage": 10},
+            "ai_credits": {
+                "usage": 1200,
+                "limit": 20000,
+                "todays_usage": 150,
+                "quota_limited_until": 1612137599,
+            },
+            "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
+        }
+        organization.save()
+
+        license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7),
+        )
+
+        post_mock.return_value = MagicMock(status_code=200, json=MagicMock(return_value={"success": True}))
+        get_mock.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "customer": {
+                        "usage_summary": {
+                            "events": {"usage": 90, "limit": 1000},
+                            "ai_credits": {"usage": 1200, "limit": 20000},
+                        },
+                        "billing_period": {
+                            "current_period_start": "2024-01-01T00:00:00Z",
+                            "current_period_end": "2024-01-31T23:59:59Z",
+                        },
+                    }
+                }
+            ),
+        )
+
+        BillingManager(license).activate_subscription(organization, {"products": "all_products:"})
+        organization.refresh_from_db()
+
+        # Activating a subscription re-syncs billing so the stale AI-credit quota limit clears
+        # immediately, rather than waiting for the periodic quota-limiting job.
+        assert "quota_limited_until" not in organization.usage["ai_credits"]
+
+    @patch("posthoganalytics.capture")
     def test_update_org_details_applies_never_drop_data_before_recomputing_existing_quota_limits(self, patch_capture):
         organization = self.organization
         organization.usage = {

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from freezegun import freeze_time
 from posthog.test.base import BaseTest, FuzzyInt, _create_event, flush_persons_and_events
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.apps import apps
 from django.test import override_settings
@@ -29,6 +29,7 @@ from ee.billing.quota_limiting import (
     _patch_todays_usage,
     add_limited_team_tokens,
     get_team_attribute_by_quota_resource,
+    is_team_limited,
     list_limited_team_attributes,
     org_quota_limited_until,
     replace_limited_team_tokens,
@@ -72,6 +73,37 @@ class TestQuotaLimiting(BaseTest):
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/cdp_trigger_events")
         self.redis_client.delete(f"@posthog/quota-limiting-suspended/ai_credits")
         materialize("events", "$exception_values")
+
+    @patch("ee.billing.quota_limiting.list_limited_team_attributes")
+    def test_is_team_limited_confirms_stale_positive_against_live_redis(self, mock_list: MagicMock) -> None:
+        # The 30s per-process cache serves a stale "limited" value on the request that triggers
+        # its background refresh, so a just-upgraded team keeps getting blocked. When the cached
+        # list says limited, is_team_limited must re-read live Redis (uncached) before limiting.
+        token = self.team.api_token
+        mock_list.side_effect = [[token], []]  # cached: stale positive, live: cleared
+
+        limited = is_team_limited(token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY)
+
+        assert limited is False
+        assert mock_list.call_count == 2
+        assert mock_list.call_args_list[1].kwargs.get("use_cache") is False
+
+    @patch("ee.billing.quota_limiting.list_limited_team_attributes")
+    def test_is_team_limited_when_genuinely_limited(self, mock_list: MagicMock) -> None:
+        # A genuinely limited team is still limited: live Redis confirms the cached positive.
+        token = self.team.api_token
+        mock_list.side_effect = [[token], [token]]
+
+        assert is_team_limited(token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY) is True
+
+    @patch("ee.billing.quota_limiting.list_limited_team_attributes")
+    def test_is_team_limited_skips_live_read_when_not_cached_limited(self, mock_list: MagicMock) -> None:
+        # The common not-limited path stays on the cheap cached read — no extra Redis round trip.
+        token = self.team.api_token
+        mock_list.side_effect = [[]]
+
+        assert is_team_limited(token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY) is False
+        assert mock_list.call_count == 1
 
     @patch("posthoganalytics.capture")
     @patch("posthoganalytics.feature_enabled", return_value=True)


### PR DESCRIPTION
## Problem

When a user upgrades to a paid plan (or otherwise clears their AI-credit limit), PostHog AI keeps returning "Your organization reached its AI credit usage limit" (a 402 from `POST /api/environments/:team_id/conversations/`) for several minutes afterward, even though billing already reflects the upgrade.

Tracing one reported case end-to-end (linked Slack thread) made the mechanism precise. On the session in question:

- The plan was activated and billing pushed a customer sync to PostHog.
- **~1 second later** the org's `org_quota_limited_until` decision flipped from `already limited` to `suspension removed` and the team's token was removed from the Redis quota set — and it was **never re-added** for the rest of the day.
- Yet the 402s continued in a scattered tail for roughly **20+ minutes** after the Redis set was already correct.

So this is **not** a stale-Redis / missing-invalidation problem — the Redis set cleared almost immediately. The 402s outlived it because of the read path.

## Root cause

The conversation endpoints gate on `is_team_limited(..., AI_CREDITS)`, which reads `list_limited_team_attributes` — a **30s per-process in-memory cache** with `background_refresh=True`. That cache returns the *old* value on the request that triggers its refresh (`return self._cache[key][1]` after kicking the background thread). So every web pod still holding the pre-upgrade "limited" snapshot serves at least one more "limited" answer after going stale, and since a user's retries load-balance across pods, each warm pod emits a stale 402 before it refreshes. That produces a multi-minute tail of 402s that no amount of prompt Redis invalidation fixes, because the Redis set was never the stale layer.

## Changes

1. **`is_team_limited` confirms a stale positive against live Redis (the fix).** When the cached list says the team is limited, re-read the Redis set uncached before actually limiting. The common not-limited path stays on the cheap cached read, so there's no extra Redis traffic on the happy path; the extra read only happens on the rare deny branch. This removes the false 402s the moment Redis is correct, regardless of per-pod cache warmth.

2. **Refresh org billing state server-side on `activate` / `switch-plan` (hardening).** These endpoints now re-sync the org and rebuild the Redis quota set right after the plan change, instead of relying on the frontend's follow-up billing reload. In the traced case the existing customer-sync path already rebuilt Redis within ~1s, so this is defense-in-depth for activation flows that don't trigger a billing reload — not the primary fix.

The 30s cache itself is left in place (it's load-bearing for higher-frequency gates); change (1) neutralizes its user-visible downside on the AI-credit deny path.

## How did you test this code?

Added unit tests in `ee/billing/test/test_quota_limiting.py`:
- a stale-positive cached list plus a cleared live Redis read must return not-limited (the exact regression above), asserting the second read is uncached;
- a genuinely limited team stays limited (live Redis confirms);
- the not-limited path takes a single cached read (no extra round trip on the happy path).

And `test_activate_subscription_refreshes_quota_limits` covering the server-side refresh on activate.

The agent could not run the DB/Redis-backed suite in this environment (no container runtime for Postgres/Redis). Verified statically — `ruff check`, `ruff format --check`, and `py_compile` pass on the changed files. CI runs the suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started from "invalidate Redis on upgrade", but tracing a real session's event timeline (billing activation, `customer_sync_succeeded`, `org_quota_limited_until` decisions, and the per-minute 402/404 breakdown on the conversations endpoint) disproved the stale-Redis theory: the quota set cleared ~1s after activation and never re-limited, while 402s persisted 20+ minutes. That pointed at the read path — `list_limited_team_attributes`' 30s cache serving stale positives under `background_refresh` across warm web pods. The fix moved to a confirm-on-deny live read in `is_team_limited`; the original activate/switch-plan refresh is kept as hardening. Skills invoked: `/writing-tests`, `/querying-posthog-data`. Worth a look from the billing/Max owners on whether the AI-credit gate should drop the cache entirely for these low-frequency checks.

Tool used: PostHog Slack app agent.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1784196546336269?thread_ts=1784196546.336269&cid=C09SK2PAGKF)*
