### PR TITLE
fix(error-tracking): avoid kea store crash when mini breakdowns unmount mid-query

### DIFF
--- a/products/error_tracking/frontend/components/Breakdowns/miniBreakdownsLogic.ts
+++ b/products/error_tracking/frontend/components/Breakdowns/miniBreakdownsLogic.ts
@@ -87,12 +87,16 @@ export const miniBreakdownsLogic = kea<miniBreakdownsLogicType>([
             {
                 loadResponse: async () => {
                     const startTime = Date.now()
+                    // Read connected values up front: the logic (and its connected breakdownFiltersLogic)
+                    // may unmount while the query is in flight, and accessing values afterwards would throw.
+                    const { dateRange, filterTestAccounts } = values
+                    const breakdownProperties = BREAKDOWN_PRESETS.map((preset) => preset.property)
                     const result = await api.query(
                         errorTrackingBreakdownsQuery({
                             issueId: props.issueId,
-                            dateRange: values.dateRange,
-                            filterTestAccounts: values.filterTestAccounts,
-                            breakdownProperties: BREAKDOWN_PRESETS.map((preset) => preset.property),
+                            dateRange,
+                            filterTestAccounts,
+                            breakdownProperties,
                             maxValuesPerProperty: LIMIT_ITEMS,
                         }),
                         { refresh: 'blocking' }
@@ -100,9 +104,9 @@ export const miniBreakdownsLogic = kea<miniBreakdownsLogicType>([
 
                     posthog.capture(BreakdownsEvents.MiniBreakdownsLoaded, {
                         issueId: props.issueId,
-                        dateRange: values.dateRange,
-                        filterTestAccounts: values.filterTestAccounts,
-                        breakdownProperties: BREAKDOWN_PRESETS.map((preset) => preset.property),
+                        dateRange,
+                        filterTestAccounts,
+                        breakdownProperties,
                         duration: Date.now() - startTime,
                         cached: (result as CachedErrorTrackingBreakdownsQueryResponse).is_cached ?? false,
                     })


### PR DESCRIPTION
## Problem

Error tracking's mini breakdowns panel crashes with `[KEA] Can not find path "products.error_tracking.components.Breakdowns.breakdownFiltersLogic" in the store`.

`miniBreakdownsLogic`'s `loadResponse` loader reads `values.dateRange` / `values.filterTestAccounts` (which come from the connected `breakdownFiltersLogic`) *after* awaiting the query. If the component unmounts while the query is in flight, the connected logic is torn down, so the post-await access to those values throws.

PostHog issue: https://us.posthog.com/error_tracking/019aef36-a3af-7e12-83a2-75f6764c50de

## Changes

Read the connected values synchronously into locals before the `await`, and reuse them afterwards (in the query args and the `posthog.capture` call). No behavior change beyond not touching the store after a possible unmount.

## How did you test this code?

No new automated tests. The change is a small, mechanical hoist of value reads to before the await; the crash path (unmount during in-flight query) is timing-dependent and awkward to reproduce deterministically in a unit test.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from the stack trace: the failing frame was the `posthog.capture` call in `loadResponse` accessing `values.dateRange` after the query resolved. Root cause is use-after-unmount of a connected kea logic. Fix hoists the value reads before the await. No skills required.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
