### PR TITLE
fix(data-warehouse): treat temporalio RPC "Timeout expired" as transient

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
@@ -70,7 +70,13 @@ _RETRYABLE_RPC_STATUSES = frozenset({RPCStatusCode.RESOURCE_EXHAUSTED, RPCStatus
 # rather than one of the transient statuses above. It's a connection blip, not the server
 # rejecting the request, so ride it out the same way. Match the stable transport phrase, not the
 # whole UNKNOWN status, so genuine server-side UNKNOWN failures still surface.
-_RETRYABLE_RPC_MESSAGES = ("h2 protocol error",)
+#
+# The Temporal core enforces a per-call gRPC deadline and, when it lapses, surfaces the aborted
+# call as an RPCError with status CANCELLED and the message "Timeout expired" — a client-side
+# timeout rather than the server-side DEADLINE_EXCEEDED above. It's the same transient blip, so
+# ride it out too. Match the stable message, not the whole CANCELLED status, so a genuine call
+# cancellation still surfaces.
+_RETRYABLE_RPC_MESSAGES = ("h2 protocol error", "Timeout expired")
 
 
 def _is_retryable_rpc_error(error: RPCError) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -114,6 +114,9 @@ class TestTransientRPCRetry:
             # A mid-stream HTTP/2 transport interruption surfaces as UNKNOWN, not one of the
             # transient statuses above — it must still be ridden out in-process.
             ("h2 protocol error: error reading a body from connection", RPCStatusCode.UNKNOWN),
+            # A lapsed client-side per-call deadline surfaces as CANCELLED with "Timeout expired" —
+            # a transient blip, matched by message rather than the broad CANCELLED status.
+            ("Timeout expired", RPCStatusCode.CANCELLED),
         ],
     )
     @patch(
@@ -163,6 +166,9 @@ class TestTransientRPCRetry:
             ("workflow execution not found for", RPCStatusCode.NOT_FOUND),
             # UNKNOWN alone must not be retried — only UNKNOWN carrying a transport signature is.
             ("internal server error", RPCStatusCode.UNKNOWN),
+            # CANCELLED alone must not be retried — only CANCELLED carrying the "Timeout expired"
+            # deadline message is, so a genuine call cancellation still surfaces.
+            ("call cancelled by caller", RPCStatusCode.CANCELLED),
         ],
     )
     @patch(


### PR DESCRIPTION
## Problem

The Temporal.io warehouse import wraps its `list_workflows` / `fetch_next_page` / `fetch_history` calls in `_with_transient_rpc_retry` so brief server blips don't fail the whole import activity or spam error tracking. The helper already rides out `RESOURCE_EXHAUSTED`, `DEADLINE_EXCEEDED`, and connection-level `UNKNOWN`/`h2 protocol error` blips.

It had a gap. The Temporal core enforces a per-call gRPC deadline, and when that lapses it surfaces the aborted call as an `RPCError` with status `CANCELLED` and the message `"Timeout expired"`. That is the client-side counterpart of the server-side `DEADLINE_EXCEEDED` the helper already handles, but `CANCELLED` isn't in the retryable status set and the message wasn't matched. So the helper re-raised it immediately, failing the import activity attempt and leaking through as an avoidable error-tracking issue.

Observed as an [error-tracking issue](https://us.posthog.com/project/2/error_tracking/019f7f7f-9d8d-7770-a57e-570787461661): `RPCError: Timeout expired`, raised inside `_with_transient_rpc_retry`, with the raw gRPC status `(1, 'Timeout expired', b'')` (status code 1 is `CANCELLED`).

## Changes

Add `"Timeout expired"` to `_RETRYABLE_RPC_MESSAGES` so a lapsed client-side deadline gets the same bounded in-process backoff as the existing transient cases. Persistent failures still re-raise after the attempt cap so Temporal's activity-level retry applies.

I match the stable message rather than adding the broad `CANCELLED` status to the retryable set. `CANCELLED` also covers a genuine call cancellation, which should still surface. This mirrors the existing `h2 protocol error` handling, which matches a message fragment instead of blanket-retrying `UNKNOWN`.

This is a transient infrastructure timeout, not a credential or config problem, so it stays retryable and is deliberately not added to `get_non_retryable_errors`.

## How did you test this code?

Extended the existing parametrized tests in `test_temporalio.py`:

- Added a `("Timeout expired", CANCELLED)` row to `test_rides_out_transient_error` — locks in that a lapsed per-call deadline now backs off and retries instead of failing immediately (the regression this PR fixes).
- Added a `("call cancelled by caller", CANCELLED)` row to `test_non_transient_rpc_error_is_not_retried` — guards that we match the stable message, not the broad `CANCELLED` status, so a genuine cancellation still surfaces.

Ran `uv run pytest ...::TestTransientRPCRetry` (9 passed) plus ruff check/format.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude, Opus 4.8) triaging the error-tracking issue linked above. I confirmed the failure originates in this source (top in-app frame `_with_transient_rpc_retry`), read the helper, and checked the raw gRPC status against `temporalio.service.RPCStatusCode` (1 = `CANCELLED`) to establish this is a client-side per-call timeout.

I considered adding `CANCELLED` to the retryable status set but rejected it as too broad — `CANCELLED` also covers genuine cancellations that should surface. Matching the stable `"Timeout expired"` substring is narrow and follows the precedent set for `h2 protocol error`. I ruled out `get_non_retryable_errors` since this is transient infrastructure, not a credential/config fault. Invoked `/writing-tests` before extending the parametrized tests. Checked open PRs (including #71792 for `h2`/`UNAVAILABLE` and #71788 for `CancelledError` noise) and confirmed neither addresses this error class.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
