### PR TITLE
fix(data-warehouse): ride out temporalio rpc timeout expired errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
@@ -70,7 +70,13 @@ _RETRYABLE_RPC_STATUSES = frozenset({RPCStatusCode.RESOURCE_EXHAUSTED, RPCStatus
 # rather than one of the transient statuses above. It's a connection blip, not the server
 # rejecting the request, so ride it out the same way. Match the stable transport phrase, not the
 # whole UNKNOWN status, so genuine server-side UNKNOWN failures still surface.
-_RETRYABLE_RPC_MESSAGES = ("h2 protocol error",)
+#
+# tonic's timeout layer cancels a call that outruns the core client's per-request RPC deadline and
+# surfaces it as status CANCELLED with the message "Timeout expired" — a client-side timeout on a
+# single read (ListWorkflowExecutions / GetWorkflowExecutionHistory), not the server rejecting the
+# request. It's the client-side analog of the DEADLINE_EXCEEDED case above, so ride it out too.
+# Match the phrase rather than the whole CANCELLED status so a genuine cancellation still surfaces.
+_RETRYABLE_RPC_MESSAGES = ("h2 protocol error", "Timeout expired")
 
 
 def _is_retryable_rpc_error(error: RPCError) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -114,6 +114,9 @@ class TestTransientRPCRetry:
             # A mid-stream HTTP/2 transport interruption surfaces as UNKNOWN, not one of the
             # transient statuses above — it must still be ridden out in-process.
             ("h2 protocol error: error reading a body from connection", RPCStatusCode.UNKNOWN),
+            # tonic cancels a call that outruns the client's RPC deadline with status CANCELLED and
+            # message "Timeout expired" — a client-side timeout that must be ridden out, not raised.
+            ("Timeout expired", RPCStatusCode.CANCELLED),
         ],
     )
     @patch(
@@ -163,6 +166,8 @@ class TestTransientRPCRetry:
             ("workflow execution not found for", RPCStatusCode.NOT_FOUND),
             # UNKNOWN alone must not be retried — only UNKNOWN carrying a transport signature is.
             ("internal server error", RPCStatusCode.UNKNOWN),
+            # CANCELLED alone must not be retried — only the "Timeout expired" phrase qualifies.
+            ("Cancelled by caller", RPCStatusCode.CANCELLED),
         ],
     )
     @patch(


### PR DESCRIPTION
## Problem

The Temporal.io warehouse import wraps its `list_workflows` / `fetch_next_page` / `fetch_history` calls in `_with_transient_rpc_retry` so a brief server blip doesn't fail the whole import activity. That helper retried `RESOURCE_EXHAUSTED`, `DEADLINE_EXCEEDED`, and an `h2 protocol error` transport message.

It missed one case. tonic's timeout layer cancels a call that outruns the core client's per-request RPC deadline and surfaces it as gRPC status `CANCELLED` with the message `Timeout expired`. That is a client-side timeout on a single read, not the server rejecting the request, but it wasn't in the retryable set, so the helper re-raised immediately. A single such timeout failed the import activity attempt and leaked through as an error-tracking issue.

Reported by error tracking: [RPCError: Timeout expired](https://us.posthog.com/project/2/error_tracking/019f7f7f-f33a-7f80-bb08-93c1af121bb5). The top in-app frame is `_with_transient_rpc_retry` in `temporalio.py`, reached from `_get_workflows` → `fetch_next_page`.

## Changes

Add the stable `Timeout expired` phrase to `_RETRYABLE_RPC_MESSAGES`. It is the client-side analog of the `DEADLINE_EXCEEDED` case the helper already rides out, so it now gets the same in-process backoff. Persistent failures still re-raise so Temporal's activity-level retry applies.

> [!NOTE]
> Matched on the message phrase, not the whole `CANCELLED` status. `CANCELLED` is otherwise too broad to blanket-retry, and a genuine cancellation should still surface — same reasoning as the existing `h2 protocol error` / `UNKNOWN` match.

This is a transient timeout, so it is deliberately not added to `NonRetryableErrors` — that set is reserved for credential and config problems where retrying can never recover.

## How did you test this code?

Extended the existing parametrized tests in `test_temporalio.py`:

- Added a `CANCELLED` / `Timeout expired` row to `test_rides_out_transient_error` — locks in that a client-side RPC timeout now backs off and retries rather than failing immediately (the regression this PR fixes).
- Added a generic `CANCELLED` row to `test_non_transient_rpc_error_is_not_retried` — guards against someone blanket-adding the `CANCELLED` status to the retryable set and wrongly retrying real cancellations.

Ran `uv run pytest ...::TestTransientRPCRetry ...::TestTemporalIONonRetryableErrors` (23 passed) plus ruff check / format.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) triaging an error-tracking issue where a single transient RPC timeout on the Temporal.io source failed an import activity. Root cause traced to `_with_transient_rpc_retry` in `temporalio.py` not covering tonic's client-side `Timeout expired` (`CANCELLED`) timeout.

Considered adding `CANCELLED` to the retryable status set but rejected it as too broad — `CANCELLED` also covers genuine cancellations. Chose a narrow message match on the stable `Timeout expired` phrase, consistent with the existing `h2 protocol error` handling. Distinct root cause from the open #71792 (which covers `h2 protocol error` / `UNAVAILABLE`). Invoked the `/writing-tests` skill before extending test coverage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
