### PR TITLE
feat(ci): emit backend test-selection duration signals

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -564,6 +564,8 @@ jobs:
             changed_file_count: ${{ steps.classify.outputs.changed_file_count }}
             selected_test_count: ${{ steps.classify.outputs.selected_test_count }}
             full_run_reasons_count: ${{ steps.classify.outputs.full_run_reasons_count }}
+            selected_test_seconds: ${{ steps.classify.outputs.selected_test_seconds }}
+            skipped_test_seconds: ${{ steps.classify.outputs.skipped_test_seconds }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -624,11 +626,13 @@ jobs:
                   # Selection telemetry, kept apples-to-apples with canonical (the shadow
                   # strips the capture job that consumes these, per the header).
                   emit_metrics() {
-                      local changed="" selected="" reasons=""
+                      local changed="" selected="" reasons="" selected_seconds="" skipped_seconds=""
                       if [[ -s /tmp/selection.json ]]; then
                           changed=$(jq -r '.changed_file_count // empty' /tmp/selection.json)
                           selected=$(jq -r '.combined.count // empty' /tmp/selection.json)
                           reasons=$(jq -r '.ast.full_run_reasons | length' /tmp/selection.json)
+                          selected_seconds=$(jq -r '.durations.selected_seconds // empty' /tmp/selection.json)
+                          skipped_seconds=$(jq -r '.durations.skipped_seconds // empty' /tmp/selection.json)
                       fi
                       {
                           echo "narrowed=$1"
@@ -636,6 +640,8 @@ jobs:
                           echo "changed_file_count=$changed"
                           echo "selected_test_count=$selected"
                           echo "full_run_reasons_count=$reasons"
+                          echo "selected_test_seconds=$selected_seconds"
+                          echo "skipped_test_seconds=$skipped_seconds"
                       } >> "$GITHUB_OUTPUT"
                   }
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -491,6 +491,8 @@ jobs:
             changed_file_count: ${{ steps.classify.outputs.changed_file_count }}
             selected_test_count: ${{ steps.classify.outputs.selected_test_count }}
             full_run_reasons_count: ${{ steps.classify.outputs.full_run_reasons_count }}
+            selected_test_seconds: ${{ steps.classify.outputs.selected_test_seconds }}
+            skipped_test_seconds: ${{ steps.classify.outputs.skipped_test_seconds }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -551,11 +553,13 @@ jobs:
                   # Selection telemetry (see the capture-test-selection job). Best-effort
                   # from the selector JSON when it exists; narrowed=false marks a fallback.
                   emit_metrics() {
-                      local changed="" selected="" reasons=""
+                      local changed="" selected="" reasons="" selected_seconds="" skipped_seconds=""
                       if [[ -s /tmp/selection.json ]]; then
                           changed=$(jq -r '.changed_file_count // empty' /tmp/selection.json)
                           selected=$(jq -r '.combined.count // empty' /tmp/selection.json)
                           reasons=$(jq -r '.ast.full_run_reasons | length' /tmp/selection.json)
+                          selected_seconds=$(jq -r '.durations.selected_seconds // empty' /tmp/selection.json)
+                          skipped_seconds=$(jq -r '.durations.skipped_seconds // empty' /tmp/selection.json)
                       fi
                       {
                           echo "narrowed=$1"
@@ -563,6 +567,8 @@ jobs:
                           echo "changed_file_count=$changed"
                           echo "selected_test_count=$selected"
                           echo "full_run_reasons_count=$reasons"
+                          echo "selected_test_seconds=$selected_seconds"
+                          echo "skipped_test_seconds=$skipped_seconds"
                       } >> "$GITHUB_OUTPUT"
                   }
 
@@ -3457,6 +3463,10 @@ jobs:
                         "changed_file_count": ${{ needs.select-tests.outputs.changed_file_count || 'null' }},
                         "selected_test_count": ${{ needs.select-tests.outputs.selected_test_count || 'null' }},
                         "full_run_reasons_count": ${{ needs.select-tests.outputs.full_run_reasons_count || 'null' }},
+                        "selected_test_seconds": ${{ needs.select-tests.outputs.selected_test_seconds || 'null' }},
+                        "skipped_test_seconds": ${{ needs.select-tests.outputs.skipped_test_seconds || 'null' }},
+                        "run_poe": ${{ needs.select-tests.outputs.run_poe || 'false' }},
+                        "run_temporal": ${{ needs.select-tests.outputs.run_temporal || 'false' }},
                         "event_type": ${{ toJSON(github.event_name) }},
                         "branch": ${{ toJSON(github.head_ref || github.ref_name) }},
                         "sha": ${{ toJSON(github.sha) }},

--- a/tools/snob_backend_test_selection_shadow.py
+++ b/tools/snob_backend_test_selection_shadow.py
@@ -583,6 +583,56 @@ def estimate_duration(test_files: list[str], durations: dict[str, float]) -> flo
     return total
 
 
+_TEMPORAL_PREFIXES = (
+    "posthog/temporal/",
+    "products/batch_exports/backend/tests/temporal/",
+    "products/tasks/backend/temporal/",
+    "products/signals/backend/emission/",
+)
+_POE_PREFIXES = (
+    "posthog/clickhouse/",
+    "posthog/queries/",
+    "ee/clickhouse/",
+    "products/product_analytics/backend/api/test/",
+)
+_CORE_IGNORED_PREFIXES = ("posthog/dags/", "common/hogvm/python/test/")
+
+
+def segments_for_test_file(path: str) -> frozenset[str]:
+    """Which Django matrix segments run a given test file. Mirrors the Core/POE/Temporal
+    partition in ci-backend.yml's select-tests `classify` step — POE files run in both the
+    Core matrix and the person-on-events matrix, so they belong to both segments. An empty
+    result means no draft-narrowable matrix runs the file (a product/turbo test, or an
+    explicitly ignored path)."""
+    if path.startswith(_TEMPORAL_PREFIXES):
+        return frozenset({"temporal"})
+    if path.startswith(_CORE_IGNORED_PREFIXES):
+        return frozenset()
+    is_poe = (
+        path.startswith(_POE_PREFIXES)
+        or path.startswith("posthog/api/test/test_insight")
+        or path == "posthog/api/test/dashboards/test_dashboard.py"
+    )
+    if is_poe:
+        return frozenset({"core", "poe"})
+    if path.startswith(("posthog/", "ee/")):
+        return frozenset({"core"})
+    return frozenset()
+
+
+def narrowable_baseline_seconds(durations: dict[str, float]) -> float:
+    """Total test-execution seconds across the Core/POE/Temporal universe that draft
+    selection can narrow. Excludes product/turbo tests, which run regardless of selection,
+    so this is the honest denominator for how much a draft skipped. This is raw pytest
+    execution time from the sharding-balance file — it is not real CI minutes (no per-job
+    overhead, setup, or concurrency); the minutes model lives downstream in the dashboard."""
+    total = 0.0
+    for test_id, duration in durations.items():
+        if segments_for_test_file(test_id.split("::", 1)[0]):
+            total += duration
+    return total
+
+
 def build_result(base_ref: str) -> dict[str, object]:
     os.chdir(REPO_ROOT)
     changed_files = changed_files_from_git(base_ref)
@@ -594,6 +644,8 @@ def build_result(base_ref: str) -> dict[str, object]:
     combined_tests = sorted(set(snob_tests) | set(ast_selection.tests))
 
     durations = load_durations()
+    selected_seconds = estimate_duration(combined_tests, durations)
+    baseline_seconds = narrowable_baseline_seconds(durations)
     return {
         "mode": "shadow",
         "base_ref": base_ref,
@@ -604,12 +656,17 @@ def build_result(base_ref: str) -> dict[str, object]:
         "combined": {
             "tests": combined_tests,
             "count": len(combined_tests),
-            "duration_seconds": round(estimate_duration(combined_tests, durations)),
+            "duration_seconds": round(selected_seconds),
         },
         "durations": {
             "snob_seconds": round(estimate_duration(snob_tests, durations)),
             "ast_seconds": round(estimate_duration(ast_selection.tests, durations)),
             "total_seconds": round(sum(durations.values())),
+            # Draft-narrowable universe: the raw pytest execution seconds the selective run
+            # spends vs. skips. Not CI minutes — the dashboard models overhead/concurrency.
+            "narrowable_baseline_seconds": round(baseline_seconds),
+            "selected_seconds": round(selected_seconds),
+            "skipped_seconds": round(max(baseline_seconds - selected_seconds, 0.0)),
         },
     }
 
@@ -632,6 +689,8 @@ def format_summary(result: dict[str, object]) -> str:
         f"| AST-selected tests | {len(ast_data['tests'])} | {durations['ast_seconds']}s |",
         f"| Combined unique tests | {combined['count']} | {combined['duration_seconds']}s |",
         f"| Full duration data | - | {durations['total_seconds']}s |",
+        f"| Narrowable baseline | - | {durations['narrowable_baseline_seconds']}s |",
+        f"| Skipped (test exec) | - | {durations['skipped_seconds']}s |",
         "",
         "| AST group | Test files |",
         "|---|---:|",

--- a/tools/test_snob_backend_test_selection_shadow.py
+++ b/tools/test_snob_backend_test_selection_shadow.py
@@ -261,6 +261,33 @@ class TestSnobBackendTestSelectionShadow(unittest.TestCase):
         self.assertEqual([], result.full_run_reasons)
         self.assertEqual({"changed_tests": ["posthog/test/test_version_requirement.py"]}, result.groups)
 
+    def test_segments_for_test_file_mirrors_matrix_partition(self) -> None:
+        selection = _load_selection_module()
+
+        self.assertEqual(selection.segments_for_test_file("posthog/models/test_a.py"), frozenset({"core"}))
+        # POE patterns run in both the Core matrix and the person-on-events matrix.
+        self.assertEqual(selection.segments_for_test_file("posthog/clickhouse/test_b.py"), frozenset({"core", "poe"}))
+        self.assertEqual(selection.segments_for_test_file("posthog/temporal/tests/test_c.py"), frozenset({"temporal"}))
+        # Explicitly ignored by the Core invocation, and not a draft-narrowable matrix.
+        self.assertEqual(selection.segments_for_test_file("posthog/dags/test_e.py"), frozenset())
+        # Product/turbo tests are not part of any draft-narrowable Django matrix.
+        self.assertEqual(selection.segments_for_test_file("products/warehouse_sources/backend/test_d.py"), frozenset())
+
+    def test_narrowable_baseline_excludes_turbo_product_tests(self) -> None:
+        selection = _load_selection_module()
+
+        durations = {
+            "posthog/models/test_a.py::t1": 100.0,
+            "posthog/clickhouse/test_b.py::t2": 70.0,
+            "posthog/temporal/tests/test_c.py::t3": 210.0,
+            "posthog/dags/test_e.py::t5": 42.0,  # ignored path
+            "products/warehouse_sources/backend/test_d.py::t4": 100_000.0,  # turbo-tests
+        }
+
+        # Only the Core/POE/Temporal universe counts; the huge product test and the ignored
+        # path are excluded, so a draft can never be credited with skipping them.
+        self.assertEqual(selection.narrowable_baseline_seconds(durations), 380.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

[#71304](https://github.com/PostHog/posthog/pull/71304) shipped the backend `posthog-ci-test-selection` event without a savings dimension, unlike storybook. The stated reason: a draft never runs the full matrix, so there's no per-run baseline.

The real saving on skipped shard *jobs* — going 38→1 Core shards avoids ~37 full runner startups, each several minutes of fixed overhead before a test runs.

## Changes

So this PR emits the raw signals the selector can measure honestly and leaves the minutes model to the dashboard, where per-shard overhead can be calibrated against the `posthog-ci-running-time` job durations we already collect, and tuned without a CI deploy.

The shadow selector now computes, restricted to the Core/POE/Temporal universe a draft can narrow:

- `narrowable_baseline_seconds` — test-execution seconds across that universe. Product/turbo tests run regardless of selection, so they're excluded. That's the honest denominator — about 6.6k of the 29.3k total suite-seconds are `products/*` tests the Django matrices never run.
- `selected_seconds` — what the selective run will spend.
- `skipped_seconds` — the difference.

The `posthog-ci-test-selection` capture event carries `selected_test_seconds`, `skipped_test_seconds`, and `run_poe` / `run_temporal` (which heavy segments the draft still ran, so the dashboard can weight avoided shard-jobs per segment). Mirrored into the `.depot` shadow to keep it apples-to-apples — depot strips the capture job but keeps the telemetry outputs, and the drift check wants both files to move together.

> [!NOTE]
> The dashboard is where minutes get modeled: `avoided_shards × per_shard_overhead + skipped_seconds` weighting, with the overhead constant calibrated from real backend job durations. The CI event stays honest about what it can actually measure. Storybook's own single `estimated_minutes_saved` uses a fixed 3-min-per-shard constant; backend has more segment structure, so pushing the model downstream keeps it tunable.

## How did you test this code?

I (Claude, via Claude Code) did not run these workflows in CI. Locally:

- Two pure-function tests in `tools/test_snob_backend_test_selection_shadow.py`. One locks the segment partition (POE files count toward both core and poe; `posthog/dags/*` and product tests map to no segment). The other locks the anti-inflation property: a huge `products/*` duration does not enter `narrowable_baseline_seconds`. Neither regression was covered before. Full file: 13 passed.
- Ran the selector against the real `.test_durations`: narrowable baseline 21,810s vs 29,268s total (product/ignored tests excluded), and a 2-file selection yields selected 86s / skipped 21,724s as expected.
- `ruff`, `hogli lint:workflows` (6/6), lint-staged `ty check`, both workflow YAMLs parse.

`tools/` is excluded from the repo mypy config, so the standalone `uv run` script isn't type-checked in CI.

## Docs update

CI-internal, no user-facing behavior. `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @gantoine is the DRI.

Authored by Claude (Claude Code). This started as a single shard-adjusted `estimated_minutes_saved` computed in CI. @gantoine pushed back that `.test_durations` is a sharding heuristic, not a runtime baseline — it omits job overhead, setup, and concurrency — so any minutes number derived from it alone would be misleading. Reworked to emit raw duration signals plus per-segment run flags and move the minutes modeling into the dashboard, calibrated against real job-duration data.

Invoked the `/writing-tests` skill before adding the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
