### PR TITLE
fix(cdp): unshadow rerun paginator attempts alias so max_attempts filter works

### DIFF
--- a/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
@@ -81,6 +81,12 @@ describe('RerunPaginatorService integration', () => {
             invocation_id: string
             status: 'running' | 'succeeded' | 'failed'
             error?: Error
+            // Stable error_kind stamped on the row (e.g. 'janitor_poison_pill').
+            // When omitted it is derived from the error message, as before.
+            errorKind?: string
+            // Prior rerun count → the row's `attempts` column, for exercising the
+            // max_attempts filter. Defaults to 0.
+            rerunAttempts?: number
             scheduledAt?: Date
         }>
     ): Promise<void> => {
@@ -100,6 +106,7 @@ describe('RerunPaginatorService integration', () => {
                     globals: globals as any,
                     timings: [],
                     attempts: 0,
+                    rerunAttempts: r.rerunAttempts,
                 },
                 teamId: team.id,
                 functionId: hogFunction.id,
@@ -108,7 +115,7 @@ describe('RerunPaginatorService integration', () => {
                 queuePriority: 0,
                 queueScheduledAt: r.scheduledAt ? ({ toJSDate: () => r.scheduledAt } as any) : undefined,
             }
-            seedingService.queueLifecycleRow(invocation, r.status, { error: r.error })
+            seedingService.queueLifecycleRow(invocation, r.status, { error: r.error, errorKind: r.errorKind })
         }
         await seedingService.flush()
 
@@ -485,6 +492,64 @@ describe('RerunPaginatorService integration', () => {
             expect(next.progress.queued).toBe(0)
             expect(next.progress.done).toBe(true)
             expect(hogQueue.queueInvocations).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('max_attempts filter (poison-pill autodrain path)', () => {
+        // Regression guard for the aggregate-inside-aggregate ClickHouse error: with
+        // max_attempts set, fetchPage adds `argMax(attempts, version) < {max_attempts}`
+        // to HAVING. If the SELECT alias is named `attempts` it shadows the raw column,
+        // so `attempts` inside the HAVING argMax resolves to the alias (itself an
+        // aggregate) → ClickHouse rejects every page. No other test sets max_attempts
+        // (the manual-rerun UI leaves it unset), so this whole clause was dormant until
+        // the autodrain became the first caller to set it unconditionally.
+        it('runs a valid query and honours the cap when max_attempts is set', async () => {
+            await seedRows([
+                {
+                    invocation_id: 'pp-under-cap',
+                    status: 'failed',
+                    error: new Error('poison pill'),
+                    errorKind: 'janitor_poison_pill',
+                    rerunAttempts: 1,
+                },
+                {
+                    invocation_id: 'pp-over-cap',
+                    status: 'failed',
+                    error: new Error('poison pill'),
+                    errorKind: 'janitor_poison_pill',
+                    rerunAttempts: 5,
+                },
+            ])
+
+            // The exact filter the autodrain enqueues.
+            const state = buildState({
+                request: {
+                    filter: {
+                        window_start: '2026-01-01T00:00:00Z',
+                        window_end: '2027-01-01T00:00:00Z',
+                        status: ['failed'],
+                        error_kind: ['janitor_poison_pill'],
+                        max_attempts: 3,
+                    },
+                },
+            })
+
+            const { state: next } = await paginator.processPage(team.id, state, {
+                jobId: 'test-rerun-job',
+                createdAt: DateTime.now(),
+            })
+
+            // The query executed — without the alias fix this is the CH
+            // aggregate-inside-aggregate error and every page fails here.
+            expect(next.progress.last_error).toBeUndefined()
+
+            // Under the cap is re-enqueued; over the cap is filtered by the HAVING clause.
+            const enqueued = hogQueue.queueInvocations.mock.calls[0]?.[0] as
+                | CyclotronJobInvocationHogFunction[]
+                | undefined
+            expect(enqueued?.map((i) => i.id)).toEqual(['pp-under-cap'])
+            expect(next.progress.queued).toBe(1)
+            expect(next.progress.done).toBe(true)
         })
     })
 

--- a/nodejs/src/cdp/rerun/rerun-paginator.service.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.ts
@@ -67,7 +67,9 @@ const toClickhouseDateTime = (value: string): string => {
 interface InvocationRow {
     invocation_id: string
     parent_run_id: string
-    attempts: number
+    // Prior rerun count for this invocation (argMax over version). Named to avoid
+    // shadowing the raw `attempts` column in the fetch query — see fetchPage.
+    latest_attempts: number
     last_scheduled_at: string
     first_scheduled_at: string
     invocation_globals: string
@@ -467,7 +469,12 @@ export class RerunPaginatorService {
                 SELECT
                     invocation_id,
                     argMax(parent_run_id, version)         AS parent_run_id,
-                    argMax(attempts, version)              AS attempts,
+                    -- NOT aliased 'attempts': that would shadow the raw column, and the
+                    -- max_attempts HAVING below (argMax(attempts, version) < …) would then
+                    -- resolve 'attempts' to this alias — an aggregate inside an aggregate,
+                    -- which ClickHouse rejects. Any caller setting max_attempts (the poison-
+                    -- pill autodrain always does) would fail every page. Keep the names distinct.
+                    argMax(attempts, version)              AS latest_attempts,
                     argMax(invocation_globals, version)    AS invocation_globals,
                     argMax(first_scheduled_at, version)    AS first_scheduled_at,
                     max(scheduled_at)                      AS last_scheduled_at
@@ -518,7 +525,7 @@ export class RerunPaginatorService {
         // across concurrent callers, so a sequential loop would defeat that.
         const rehydrated = await Promise.all(
             rows.map(async (row): Promise<CyclotronJobInvocation | null> => {
-                if (maxAttempts !== undefined && row.attempts >= maxAttempts) {
+                if (maxAttempts !== undefined && row.latest_attempts >= maxAttempts) {
                     counterRerunInvocationsSkipped.labels(state.function_kind, 'over_max_attempts').inc()
                     return null
                 }
@@ -614,7 +621,7 @@ export class RerunPaginatorService {
                     // rerun count) drives `is_retry` and `attempts` on the
                     // lifecycle rows.
                     attempts: 0,
-                    rerunAttempts: (row.attempts || 0) + 1,
+                    rerunAttempts: (row.latest_attempts || 0) + 1,
                     // Carry the original first-scheduled time forward — the
                     // producer writes this verbatim on every retry's lifecycle
                     // rows so ReplacingMergeTree doesn't collapse it away.
@@ -676,7 +683,7 @@ export class RerunPaginatorService {
                 // Sticky rerun counter — mirror the hog function path so the
                 // lifecycle row producer can derive `attempts` / `is_retry`
                 // for flows too, and the `max_attempts` guard actually trips.
-                rerunAttempts: (row.attempts || 0) + 1,
+                rerunAttempts: (row.latest_attempts || 0) + 1,
                 firstScheduledAt: row.first_scheduled_at,
             }
             return invocation


### PR DESCRIPTION
## Problem

The rerun paginator's `fetchPage` (`nodejs/src/cdp/rerun/rerun-paginator.service.ts`) selected `argMax(attempts, version) AS attempts`, aliasing the aggregate to the same name as the raw `attempts` column. When a rerun filter sets `max_attempts`, `fetchPage` also adds to the `HAVING`:

```sql
AND argMax(attempts, version) < {max_attempts:UInt8}
```

The `attempts` inside that `argMax` resolves to the **SELECT alias** (itself an aggregate), not the raw column — an aggregate inside an aggregate, which ClickHouse rejects:

```
Aggregate function argMax(attempts, version) AS attempts is found inside another aggregate function in query.
```

So **every page of any rerun that sets `max_attempts` fails**, and the rerun worker loops on the error (~every 2s) without ever executing the rerun.

The clause is pre-existing but was **dormant**: the only prior caller (the manual rerun UI) leaves `max_attempts` unset by default, so the clause was never appended. The **poison-pill autodrain (#71538) is the first caller to set it unconditionally** — which is how this surfaced in end-to-end testing on a real local stack (janitor recorded a poison pill → autodrain enqueued a wrapper → the rerun worker then failed every page with the error above). This fix also quietly repairs the manual-rerun path for anyone who sets `max_attempts` there.

## Changes

- Rename the SELECT alias `argMax(attempts, version) AS attempts` → `AS latest_attempts`, so `attempts` inside the `HAVING` `argMax` now resolves to the raw column and the query is valid. Added a comment at the alias so it can't regress.
- Update the `InvocationRow` type field (`attempts` → `latest_attempts`) and its three readers in the same file (the over-`max_attempts` skip check and the two `rerunAttempts` derivations for hog functions and hog flows). No behavior change beyond fixing the query.
- The other `HAVING` predicates (`is_deleted`, `status`, `error_kind`) already reference raw columns with no shadowing alias — only `attempts` collided.

Purely a paginator fix; it does not touch the autodrain. #71538 depends on it (the autodrain always sets `max_attempts`), so that PR should rebase onto this once merged.

## How did you test this code?

Added a ClickHouse-backed integration test to `rerun-paginator.service.test.ts` — the existing suite exercises the real Kafka → MV → `hog_invocation_results` → paginator pipeline but **never set `max_attempts`**, which is exactly why the bug shipped dormant. The new case seeds two `janitor_poison_pill` `failed` rows (one under the cap, one over) and runs `processPage` with the exact autodrain filter (`status=['failed']`, `error_kind=['janitor_poison_pill']`, `max_attempts=3`, window). It asserts:

- `progress.last_error` is undefined — i.e. the query executed. Without the alias rename this is where the aggregate-inside-aggregate error lands and every page fails.
- The under-cap invocation is re-enqueued and the over-cap one is filtered out by the `HAVING` cap.

The regression this catches that no existing test did: any rerun with `max_attempts` set producing an invalid ClickHouse query. It must be ClickHouse-backed because the defect is in the SQL — a mocked client can't reproduce it.

**Verification.** The new regression test runs and **passes in CI** (`Node.js Tests Pass`). The fix was also independently verified on a real local stack:

- **Query level:** against real ClickHouse, the old `AS attempts` query throws the exact `argMax(...) is found inside another aggregate function` error, while the fixed `AS latest_attempts` query executes and returns the expected poison-pill rows.
- **Full drain loop, end to end:** the poison-pill autodrain (#71538) discovering → enqueuing → the rerun worker re-enqueuing, exercised at scale — a 30-real-invocation outage-recovery run and a 220-invocation group spanning both paginator pages (`RERUN_PAGE_SIZE = 200`) — with **zero query errors** (`queued: 30` / `queued: 220`) and, via #70792, **zero double-sends** on the recovered invocations. Before this fix the rerun worker looped on the query error every ~2s and drained nothing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by Daniel. Invoked the `/writing-tests` skill to gate the new test (named regression, ClickHouse-backed because the bug is in the query, single parameterized-style case rather than duplicating the by-filter tests).

Decision: shipped as a companion `fix(cdp)` PR rather than folding into #71538, because it repairs a live (if dormant) production bug in the manual-rerun path independent of the autodrain feature, so it can merge and deploy on its own timeline instead of being gated behind an off-by-default feature review. #71538 depends on it and should rebase once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WCtr8RrgwKkPbvx3RyuvnX)_
