### PR TITLE
fix(cohorts): work around clickhouse 26.3 union distinct dedup loss

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -196,6 +196,13 @@ class HogQLGlobalSettings(HogQLQuerySettings):
     # [minIf(..., notNullIn(...))]` (THERE_IS_NO_COLUMN). Same bug class as #64487; disabling the rewrite avoids it
     # without touching NULL semantics (unlike transform_null_in).
     optimize_min_inequality_conjunction_chain_length: Optional[int] = 4294967295
+    # A bugfix workaround for UNION/INTERSECT DISTINCT losing deduplication on ClickHouse 26.3.x when
+    # every branch carries an ORDER BY: the planner puts DistinctSortedStreamTransform (adjacent-row
+    # dedup, assumes a globally sorted input) after the Resize that merely concatenates the branches'
+    # independently sorted streams, so cross-branch duplicates survive. 26.6 plans a hash
+    # DistinctTransform instead. Only effective at the outermost statement level (branch-level settings
+    # are ignored for the distinct step), so set it on the executor's global settings, not per SELECT.
+    optimize_distinct_in_order: Optional[bool] = None
     # experimental support for nonequal joins
     allow_experimental_join_condition: Optional[bool] = True
     preferred_block_size_bytes: Optional[int] = None

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -260,7 +260,9 @@ class HogQLCohortQuery:
             modifiers=HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED),
             team=self.team,
             limit_context=LimitContext.COHORT_CALCULATION,
-            settings=HogQLGlobalSettings(),
+            # OR conditions print as UNION DISTINCT of ORDER BY-ed branches, which loses dedup on
+            # ClickHouse 26.3.x (see HogQLGlobalSettings.optimize_distinct_in_order).
+            settings=HogQLGlobalSettings(optimize_distinct_in_order=False),
         )
 
     def get_query(self) -> SelectQuery | SelectSetQuery:

--- a/products/cohorts/backend/models/sql.py
+++ b/products/cohorts/backend/models/sql.py
@@ -38,13 +38,16 @@ WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version = %(versio
 
 # Continually ensure that all previous version rows are deleted and insert persons that match the criteria
 # optimize_aggregation_in_order = 1 is necessary to avoid oom'ing for our biggest clients
+# optimize_distinct_in_order = 0 works around UNION DISTINCT returning duplicates on ClickHouse 26.3.x
+# when branches are sorted (see HogQLGlobalSettings.optimize_distinct_in_order); the embedded
+# {cohort_filter} has its own trailing SETTINGS trimmed, so the workaround must live on this INSERT.
 RECALCULATE_COHORT_BY_ID = """
 INSERT INTO cohortpeople
 SELECT id, %(cohort_id)s as cohort_id, %(team_id)s as team_id, 1 AS sign, %(new_version)s AS version
 FROM (
     {cohort_filter}
 ) as person
-SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto'
+SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto', optimize_distinct_in_order = 0
 """
 
 # NOTE: Group by version id to ensure that signs are summed between corresponding rows.


### PR DESCRIPTION
## Problem

- ClickHouse 26.3.x drops UNION DISTINCT dedup when branches carry ORDER BY (adjacent-row distinct over concatenated sorted streams): a 100k-unique union returns 150k rows on 26.3.10, correct on 26.6.1. No upstream issue found yet.
- OR cohorts print exactly this shape: recalculation writes duplicate `sign=+1` cohortpeople rows and direct cohort queries return duplicate persons. CI's oldest-supported image and prod run 26.3.10 (local moved to 26.6.1 in #69499).
- Canary: flaky `test_cohort_filter_with_extra` (both schema variants), surfaced after the resharding in #69887.

## Changes

- `optimize_distinct_in_order=0` on the cohort executor (only outermost-level settings affect the distinct step) and on `RECALCULATE_COHORT_BY_ID` (the embedded subquery's trailing SETTINGS gets trimmed).
- New optional `HogQLGlobalSettings` field, default `None`: no other query or snapshot changes.
- Revert when prod CH reaches 26.6.

## How did you test this code?

- Docker repro on 26.3.10: the setting flips 150k back to 100k at both touched levels.
- 49 cohort tests pass locally; the existing canary test validates this on CI's 26.3.10 shards.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: bisected master CI runs, proved the planner bug via `EXPLAIN PIPELINE` (26.3.10 plans `DistinctSortedStreamTransform`, 26.6.1 a hash `DistinctTransform`), and reproduced the duplicate count on prod.
- Rejected a global `False` default: the SETTINGS suffix appears in 115 `.ambr` snapshots and would drift them all.
