### PR TITLE
fix(onboarding): stop redirect loop after completing onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/billing/OnboardingUpgradeStep.tsx
+++ b/frontend/src/scenes/onboarding/legacy/billing/OnboardingUpgradeStep.tsx
@@ -65,7 +65,7 @@ export const OnboardingUpgradeStep: OnboardingStepComponentType<OnboardingUpgrad
             showContinue={!!product.subscribed && !showPlatformPackages}
         >
             {!product.subscribed && <PlanCards product={product} />}
-            {product.subscribed && !showPlatformPackages && <SubscribedCelebration product={product} />}
+            {product.subscribed && !showPlatformPackages && <SubscribedCelebration />}
             {showPlatformPackages && platformProduct && (
                 <PlatformPackagesUpsell
                     platformProduct={platformProduct}
@@ -80,7 +80,7 @@ export const OnboardingUpgradeStep: OnboardingStepComponentType<OnboardingUpgrad
 }
 OnboardingUpgradeStep.stepKey = OnboardingStepKey.PLANS
 
-const SubscribedCelebration = ({ product }: { product: BillingProductV2Type }): JSX.Element => {
+const SubscribedCelebration = (): JSX.Element => {
     const { trigger, HogfettiComponent } = useHogfetti({ count: 100, duration: 3000 })
 
     useEffect(() => {
@@ -105,9 +105,8 @@ const SubscribedCelebration = ({ product }: { product: BillingProductV2Type }): 
             </div>
 
             <h3 className="text-2xl font-bold mt-6">Go forth and build amazing products!</h3>
-            <p className="text-gray-700 dark:text-gray-400">
-                You've unlocked all features for <strong>{product.name}</strong>.
-            </p>
+            {/* Subscribing unlocks every product, so don't scope this to the product being onboarded. */}
+            <p className="text-gray-700 dark:text-gray-400">You're all signed up. You've unlocked all features.</p>
         </div>
     )
 }

--- a/frontend/src/scenes/onboarding/legacy/billing/OnboardingUpgradeStep.tsx
+++ b/frontend/src/scenes/onboarding/legacy/billing/OnboardingUpgradeStep.tsx
@@ -58,9 +58,10 @@ export const OnboardingUpgradeStep: OnboardingStepComponentType<OnboardingUpgrad
         <OnboardingStep
             title="Select a plan"
             stepKey={OnboardingStepKey.PLANS}
-            // The packages screen carries its own heading and its own Skip/Next nav (below the cards),
-            // so the "Select a plan" title (misleading once subscribed) and the bottom Next are dropped there.
-            hideTitle={showPlatformPackages}
+            // Once subscribed there's no plan left to select — both the celebration screen and the
+            // packages screen (which carries its own heading) contradict the "Select a plan" title,
+            // so drop it. The packages screen also brings its own Skip/Next nav below the cards.
+            hideTitle={!!product.subscribed}
             showContinue={!!product.subscribed && !showPlatformPackages}
         >
             {!product.subscribed && <PlanCards product={product} />}

--- a/frontend/src/scenes/teamLogic.test.ts
+++ b/frontend/src/scenes/teamLogic.test.ts
@@ -112,6 +112,30 @@ describe('teamLogic', () => {
                 { product_type: 'session_replay' },
             ])
         })
+
+        it('ignores a response for a different team (team switched mid-flight)', async () => {
+            await expectLogic(logic).toDispatchActions(['loadCurrentTeamSuccess'])
+            useMocks({
+                patch: {
+                    '/api/environments/:id/complete_product_onboarding': () => [
+                        200,
+                        {
+                            ...MOCK_DEFAULT_TEAM,
+                            id: MOCK_TEAM_ID + 1,
+                            product_intents: [{ product_type: 'surveys' }],
+                        },
+                    ],
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.recordProductIntentOnboardingComplete({ product_type: ProductKey.SURVEYS })
+            }).toDispatchActions(['recordProductIntentOnboardingCompleteSuccess'])
+
+            // The stale team's intents must not be grafted onto the team that is now active.
+            expect(logic.values.currentTeam?.id).toBe(MOCK_TEAM_ID)
+            expect((logic.values.currentTeam as TeamType)?.product_intents).toBeUndefined()
+        })
     })
 
     describe('before team is loaded', () => {

--- a/frontend/src/scenes/teamLogic.test.ts
+++ b/frontend/src/scenes/teamLogic.test.ts
@@ -3,8 +3,9 @@ import { MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.m
 import { expectLogic } from 'kea-test-utils'
 
 import { useMocks } from '~/mocks/jest'
+import { ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { AppContext } from '~/types'
+import { AppContext, TeamType } from '~/types'
 
 import { projectLogic } from './projectLogic'
 import { teamLogic } from './teamLogic'
@@ -65,6 +66,51 @@ describe('teamLogic', () => {
 
             expect(logic.values.currentTeam?.name).toBe('Renamed project')
             expect(projectLogic.values.currentProject?.name).toBe('Renamed project')
+        })
+    })
+
+    describe('product intent loaders', () => {
+        beforeEach(() => {
+            initKeaTests()
+            useMocks({
+                get: {
+                    '/api/environments/:id/user_product_list': () => [200, { results: [], count: 0 }],
+                },
+                patch: {
+                    // Simulates the race hit in production: `complete_product_onboarding` serializes
+                    // the team from a snapshot taken before the concurrent onboarding-completion
+                    // PATCH committed, so its response arrives without the completion fields.
+                    '/api/environments/:id/complete_product_onboarding': () => [
+                        200,
+                        {
+                            ...MOCK_DEFAULT_TEAM,
+                            completed_snippet_onboarding: false,
+                            has_completed_onboarding_for: {},
+                            product_intents: [{ product_type: 'session_replay' }],
+                        },
+                    ],
+                },
+            })
+            logic = teamLogic()
+            logic.mount()
+        })
+
+        it('keeps onboarding-completion fields when a stale team snapshot comes back', async () => {
+            await expectLogic(logic).toDispatchActions(['loadCurrentTeamSuccess'])
+
+            await expectLogic(logic, () => {
+                logic.actions.recordProductIntentOnboardingComplete({ product_type: ProductKey.SESSION_REPLAY })
+            }).toDispatchActions(['recordProductIntentOnboardingCompleteSuccess'])
+
+            // Fresh local fields survive; only product_intents is taken from the response.
+            // A wholesale replace here would flip hasOnboardedAnyProduct back to false and
+            // send the user into the /onboarding redirect loop.
+            expect(logic.values.currentTeam?.completed_snippet_onboarding).toBe(true)
+            expect(logic.values.currentTeam?.has_completed_onboarding_for).toEqual({ product_analytics: true })
+            expect(logic.values.hasOnboardedAnyProduct).toBe(true)
+            expect((logic.values.currentTeam as TeamType)?.product_intents).toEqual([
+                { product_type: 'session_replay' },
+            ])
         })
     })
 

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -50,6 +50,24 @@ export function isAuthenticatedTeam(team: TeamType | TeamPublicType | undefined 
     return !!team && 'api_token' in team
 }
 
+/**
+ * Product-intent endpoints echo a full team serialized from a snapshot taken when their request
+ * started. Replacing `currentTeam` wholesale with that snapshot can clobber fields committed by a
+ * concurrent team PATCH — e.g. the onboarding-completion PATCH racing `complete_product_onboarding`
+ * loses `has_completed_onboarding_for`, so `hasOnboardedAnyProduct` flips back to false and
+ * sceneLogic bounces the user into /onboarding on every navigation. Keep the local team and take
+ * only `product_intents`, the one field these endpoints actually change.
+ */
+function withProductIntentsFrom(
+    currentTeam: TeamType | TeamPublicType | null,
+    response: TeamType | null
+): TeamType | TeamPublicType | null {
+    if (!currentTeam || !response) {
+        return response ?? currentTeam
+    }
+    return { ...currentTeam, product_intents: response.product_intents }
+}
+
 export interface FrequentMistakeAdvice {
     key: string
     type: 'event' | 'person'
@@ -450,13 +468,13 @@ export const teamLogic = kea<teamLogicType>([
                     const result = await addProductIntent(properties)
                     actions.loadCustomProducts()
 
-                    return result
+                    return withProductIntentsFrom(values.currentTeam, result)
                 },
                 addProductIntentForCrossSell: async (properties: ProductCrossSellProperties) => {
                     const result = await addProductIntentForCrossSell(properties)
                     actions.loadCustomProducts()
 
-                    return result
+                    return withProductIntentsFrom(values.currentTeam, result)
                 },
                 recordProductIntentOnboardingComplete: async ({ product_type }: { product_type: ProductKey }) => {
                     const result = await api.update(
@@ -467,7 +485,7 @@ export const teamLogic = kea<teamLogicType>([
                     )
                     actions.loadCustomProducts()
 
-                    return result
+                    return withProductIntentsFrom(values.currentTeam, result)
                 },
             },
         ],

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -139,17 +139,17 @@ export interface teamLogicActions {
         errorObject?: any
     }
     addProductIntentForCrossSellSuccess: (
-        currentTeam: TeamType | null,
+        currentTeam: TeamPublicType | TeamType | null,
         payload?: ProductCrossSellProperties
     ) => {
-        currentTeam: TeamType | null
+        currentTeam: TeamPublicType | TeamType | null
         payload?: ProductCrossSellProperties
     }
     addProductIntentSuccess: (
-        currentTeam: TeamType | null,
+        currentTeam: TeamPublicType | TeamType | null,
         payload?: ProductIntentProperties
     ) => {
-        currentTeam: TeamType | null
+        currentTeam: TeamPublicType | TeamType | null
         payload?: ProductIntentProperties
     }
     createTeam: ({ name, is_demo }: { is_demo: boolean; name: string }) => {

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -65,6 +65,11 @@ function withProductIntentsFrom(
     if (!currentTeam || !response) {
         return response ?? currentTeam
     }
+    if (response.id !== currentTeam.id) {
+        // The response is for a different team than the one now active (the team switched while
+        // the request was in flight) — don't graft the old team's intents onto the current one.
+        return currentTeam
+    }
     return { ...currentTeam, product_intents: response.product_intents }
 }
 


### PR DESCRIPTION
## Problem

Reported in #team-growth ([Slack thread](https://posthog.slack.com/archives/C043VJ93L3B/p1784531930175779)): going through onboarding on a fresh account surfaced two bugs.

1. After finishing onboarding, navigating to any product page kept bouncing the user back to the "What do you want to do with PostHog?" product-selection screen, until they ran through onboarding a second time.
2. The post-subscribe celebration screen read "You've unlocked all features for **Product analytics**", implying only that product's features were unlocked (a paid signup unlocks everything) — under a leftover "Select a plan" heading, though there is no plan left to select.

The loop is a race. `completeOnboarding` fires several `complete_product_onboarding` calls concurrently with the completion team PATCH. Those endpoints echo a full team serialized from a snapshot taken when their request started, and since they are `currentTeam` loaders, whichever response lands last replaces `currentTeam` wholesale. A straggling intent response arriving after the PATCH response reverts `completed_snippet_onboarding` and `has_completed_onboarding_for` in kea state, `hasOnboardedAnyProduct` flips back to false, and sceneLogic redirects every product-page navigation into `/onboarding`. I confirmed this ordering in the reporter's session data: the last intent response landed just after the completion PATCH response, and the loop stopped only after a second full completion where the PATCH happened to land last.

**Why:** a new user who just finished onboarding was trapped back in it on every navigation, and the contradictory plans heading added to the confusion.

## Changes

- `teamLogic`: the product-intent loaders (`addProductIntent`, `addProductIntentForCrossSell`, `recordProductIntentOnboardingComplete`) no longer replace `currentTeam` with the server's snapshot. They merge only `product_intents` (the one field those endpoints change) into the latest local team, so a stale echo can't clobber concurrently-committed fields.
- `OnboardingUpgradeStep`: hide the "Select a plan" title whenever the product is subscribed (matching the platform-packages variant), and replace the product-scoped celebration copy with a plan-wide "You're all signed up. You've unlocked all features."

## How did you test this code?

- Added a jest regression test: `recordProductIntentOnboardingComplete` resolving with a stale team (completion fields missing) must not clobber `currentTeam` — it catches exactly the wholesale-replace regression, which no existing test covered. Mutation-checked: reverting the loader to `return result` makes it fail.
- Ran `jest src/scenes/teamLogic.test.ts` (7 passed) and the full `src/scenes/onboarding` suite (261 passed).
- oxlint/oxfmt clean; `tsgo` reports no errors in the changed files (the sandbox has unrelated pre-existing `@posthog/quill` resolution errors).
- I (Claude) could not manually click through onboarding in a browser in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe this internal behavior; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) directed by the assignee, from a #team-growth bug thread with two screenshots. Since the thread text wasn't accessible from the sandbox, I (Claude) reconstructed the reporter's onboarding session from PostHog analytics (pageview/step/billing event ordering) to root-cause the redirect loop, then verified the clobber mechanism in `teamLogic` loaders and the `complete_product_onboarding` viewset. Considered fixing by sequencing the intent calls before the PATCH in `completeOnboarding`, but rejected it: ordering fixes only that call site, while merging in the loader kills the clobber for every caller and keeps loading semantics. Skills invoked: /writing-tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

