### PR TITLE
fix(cymbal): reclassify java in_app after proguard resolution

### DIFF
--- a/rust/cymbal/src/core/types/langs/java.rs
+++ b/rust/cymbal/src/core/types/langs/java.rs
@@ -146,6 +146,30 @@ impl RawJavaFrame {
         let map: Arc<FetchedMapping> = catalog.lookup(team_id, r.clone()).await?;
         Ok(map.remap_class(class)?)
     }
+
+    // Android SDKs derive the proguard chunk id from build metadata as
+    // `<applicationId>@<versionName>+<versionCode>`.
+    fn application_id(&self) -> Option<&str> {
+        let (app_id, _) = self.map_id.as_deref()?.split_once('@')?;
+        (!app_id.is_empty()).then_some(app_id)
+    }
+
+    // The SDK classifies in_app at capture time by matching *runtime* class
+    // names against its inAppIncludes, so on a minified build (obfuscated
+    // names) nothing matches and every frame arrives as in_app: false. Once
+    // proguard resolution recovers the real class name, reclassify frames
+    // under the app's own package. We never demote: unminified builds (and
+    // user-configured inAppIncludes) already classify correctly client-side.
+    fn resolved_in_app(&self, resolved_class: &str) -> bool {
+        if self.meta.in_app {
+            return true;
+        }
+        self.application_id().is_some_and(|app_id| {
+            resolved_class
+                .strip_prefix(app_id)
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with('.'))
+        })
+    }
 }
 
 impl<'a> From<(&'a RawJavaFrame, StackFrame<'a>)> for Frame {
@@ -156,7 +180,7 @@ impl<'a> From<(&'a RawJavaFrame, StackFrame<'a>)> for Frame {
             line: Some(remapped.line() as u32),
             column: None,
             source: remapped.file().map(ToString::to_string),
-            in_app: raw.meta.in_app,
+            in_app: raw.resolved_in_app(remapped.class()),
             resolved_name: Some(remapped.method().to_string()),
             lang: "java".to_string(),
             resolved: true,
@@ -206,5 +230,114 @@ impl From<(&RawJavaFrame, ProguardError)> for Frame {
         add_raw_to_junk(&mut f, raw);
 
         f
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROGUARD_MAP: &str =
+        include_str!("../../../../tests/static/proguard/mapping_example.txt");
+
+    fn raw_frame(module: &str, in_app: bool, map_id: Option<&str>) -> RawJavaFrame {
+        RawJavaFrame {
+            filename: Some("SourceFile".to_string()),
+            function: "onClick".to_string(),
+            lineno: Some(14),
+            module: module.to_string(),
+            map_id: map_id.map(ToString::to_string),
+            method_synthetic: false,
+            meta: CommonFrameMetadata {
+                in_app,
+                synthetic: false,
+            },
+        }
+    }
+
+    #[test]
+    fn resolved_frames_under_application_id_promote_to_in_app() {
+        let mapping = proguard::ProguardMapping::new(PROGUARD_MAP.as_bytes());
+        let mut cache_bytes = Vec::new();
+        proguard::ProguardCache::write(&mapping, &mut cache_bytes).unwrap();
+        let cache = proguard::ProguardCache::parse(&cache_bytes).unwrap();
+
+        let raw = raw_frame("a1.d", false, Some("com.posthog.android.sample@3.0+3"));
+        let frame = StackFrame::with_file("a1.d", "onClick", 14, "SourceFile");
+        let frames: Vec<Frame> = cache
+            .remap_frame(&frame)
+            .map(|re| (&raw, re).into())
+            .collect();
+
+        assert!(!frames.is_empty());
+        assert!(frames.iter().all(|f| f.in_app
+            && f.module
+                .as_deref()
+                .unwrap()
+                .starts_with("com.posthog.android.sample.")));
+    }
+
+    #[test]
+    fn resolved_in_app_classification() {
+        let map_id = Some("com.posthog.android.sample@3.0+3");
+        let cases = [
+            // (raw in_app, map_id, resolved class, expected)
+            (
+                false,
+                map_id,
+                "com.posthog.android.sample.ErrorTrackingActivityKt",
+                true,
+            ),
+            (
+                false,
+                map_id,
+                "androidx.appcompat.app.AppCompatActivity",
+                false,
+            ),
+            (false, map_id, "kotlin.jvm.internal.Intrinsics", false),
+            (false, map_id, "okhttp3.RealCall", false),
+            // prefix must end on a package boundary
+            (false, map_id, "com.posthog.android.sampleother.Foo", false),
+            // raw true is never downgraded, even outside the applicationId
+            (
+                true,
+                map_id,
+                "androidx.appcompat.app.AppCompatActivity",
+                true,
+            ),
+            (true, None, "androidx.appcompat.app.AppCompatActivity", true),
+            // map_id absent or not in <applicationId>@<version> form: keep raw flag
+            (
+                false,
+                None,
+                "com.posthog.android.sample.ErrorTrackingActivityKt",
+                false,
+            ),
+            (
+                false,
+                Some("somechunkid"),
+                "com.posthog.android.sample.ErrorTrackingActivityKt",
+                false,
+            ),
+        ];
+
+        for (raw_in_app, map_id, class, expected) in cases {
+            let raw = raw_frame("a1.d", raw_in_app, map_id);
+            assert_eq!(
+                raw.resolved_in_app(class),
+                expected,
+                "raw={raw_in_app} map_id={map_id:?} class={class}"
+            );
+        }
+    }
+
+    #[test]
+    fn unresolved_frames_keep_raw_in_app() {
+        for raw_in_app in [false, true] {
+            let raw = raw_frame("a1.d", raw_in_app, Some("com.posthog.android.sample@3.0+3"));
+            let frame: Frame = (&raw, ProguardError::NoMapId).into();
+            assert!(!frame.resolved);
+            assert_eq!(frame.in_app, raw_in_app);
+        }
     }
 }


### PR DESCRIPTION
## Problem

On any R8/ProGuard-minified Android build, every stack frame of a captured exception shows as a vendor frame in Error Tracking (`in_app: false`), even after cymbal successfully resolves the frame to the app's own class via the uploaded mapping. Vendor frames don't get source context, so minified Android apps (exactly the users who upload mappings) end up with an unusable stack view. Reproduced on `posthog-android-sample` (release build, mapping uploaded): the top frame resolves to `com.posthog.android.sample.ErrorTrackingActivityKt` but stays a vendor frame.

| Before | After |
|--------|--------|
| <img width="345" height="429" alt="CleanShot 2026-07-20 at 15 38 07" src="https://github.com/user-attachments/assets/987f403f-8edd-49e1-9017-32eaad6ced2f" /> | <img width="345" height="429" alt="CleanShot 2026-07-20 at 16 00 44" src="https://github.com/user-attachments/assets/89f37542-cf19-4b66-8410-a47cf24f35e9" /> | 

## Changes

After proguard resolution succeeds, recompute `in_app` for java frames instead of trusting the raw flag:

- The app's package is derived from the frame's `map_id`, which Android SDKs build from project metadata as `<applicationId>@<versionName>+<versionCode>` (e.g. `com.posthog.android.sample@3.0+3`).
- If the resolved class sits under the applicationId (with a package-boundary check, so `com.example.app` doesn't match `com.example.appother.Foo`), the frame is promoted to `in_app: true`.
- Never downgrade: a raw `in_app: true` is always kept, so unminified builds and user-configured `inAppIncludes` (which classify correctly client-side today) are unaffected.
- Unresolved frames and map_ids not in the `applicationId@version` shape keep the raw flag, i.e. current behavior.

## How did you test this code?

Automated tests added in `rust/cymbal/src/core/types/langs/java.rs`:

- an obfuscated frame remapped through the real proguard mapping fixture flips to `in_app: true` (catches the regression this PR fixes, which no existing test did)
- table-driven classification: resolved classes outside the applicationId (androidx/kotlin/okhttp) stay `false`, raw `true` is never downgraded, missing or non-`@` map_ids keep the raw flag, and a sibling-package prefix does not false-match
- unresolved frames preserve the raw flag in both directions

Ran `cargo test -p cymbal --lib` (247 passed), `cargo clippy -p cymbal --all-targets` and `cargo fmt` clean. I have not re-run the end-to-end minified Android capture against this build.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, server-side classification fix with no user-facing config or API change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Claude Fable 5). The problem statement and requested fix came from a prior investigation session that reproduced the issue on the minified sample app. I (well, Claude) verified via git archaeology that cymbal has passed the raw flag through since java support was added, confirmed the `map_id` format against the captured fixture in `rust/cymbal/src/bin/test.json`, and mirrored the existing post-resolution normalization pattern from the python and native frame types (those demote, java promotes, but both are one-directional so client config still wins). Alternatives rejected earlier: shipping `inAppIncludes` with the event (protocol change, still can't classify pre-deobfuscation) and `-keepnames` consumer rules (defeats minification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
