### PR TITLE
fix(data-warehouse): clarify BigQuery source is for imports, not exports

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -291,6 +291,10 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             category=DataWarehouseSourceCategory.DATABASES,
             featured=True,
             iconPath="/static/services/bigquery.png",
+            caption=(
+                "Enter your BigQuery credentials to automatically pull your BigQuery data into the PostHog Data "
+                "warehouse. To send PostHog data to BigQuery instead, set up a batch export."
+            ),
             docsUrl="https://posthog.com/docs/cdp/sources/bigquery",
             fields=cast(
                 list[FieldType],


### PR DESCRIPTION
## Problem

Replay Vision scanned real users going through data-warehouse new-source onboarding. In several sessions users who intended to *export* PostHog data to BigQuery instead ended up in the *import* (Sources) flow and stalled on the BigQuery configuration screen. Separately, BigQuery is the only database source whose config is missing the short descriptive caption that every peer database source shows.

## Changes

Add the top-level caption to the BigQuery source config, matching the wording used by its peers (Postgres, MySQL, MSSQL, Snowflake, Redshift), and add one sentence clarifying direction: this connector pulls data *from* BigQuery *into* PostHog, and anyone wanting to send PostHog data *to* BigQuery should set up a batch export instead.

This is a copy-only change to `get_source_config`; no sync behaviour or schemas are touched.

## How did you test this code?

No manual UI testing was performed by the agent. Ran `ruff check` and `ruff format` on the changed file (both clean). The caption renders through the existing `LemonMarkdown` path already used for every other source caption, so no new rendering code is involved. No tests assert source-config caption text.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent analysing anonymised onboarding session summaries for friction themes. Most observed friction (Supabase IPv6, Postgres connection errors, S3 file-path errors, coming-soon connectors, connector search) was already well handled in the codebase, so no change was made there. The one clear, self-contained gap was BigQuery lacking the caption its peers have, combined with a recurring import-vs-export mix-up. Chose a copy-only fix consistent with existing sources rather than a larger navigational/UX change, which would need product input. No repo skills were required (no DRF/serializer/migration changes).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
