### PR TITLE
fix(mcp): count auth failures separately in mcp_init_total

### DIFF
--- a/services/mcp/src/hono/dispatcher.ts
+++ b/services/mcp/src/hono/dispatcher.ts
@@ -20,6 +20,7 @@ import type {
 import GUIDELINES from '@shared/guidelines.md'
 import { randomUUID } from 'node:crypto'
 
+import { mapErrorToAuthResponse } from '@/lib/auth-errors'
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import type { RequestProperties } from '@/lib/request-properties'
 
@@ -149,9 +150,12 @@ class McpDispatcher {
         } catch (error) {
             // A failed resolution still fails the handshake for the client, so count
             // it in mcp_init_total — otherwise MCPServerHighInitErrorRate only sees
-            // failures past this point. The rethrow surfaces as a 500 upstream.
+            // failures past this point. Auth failures (expired tokens, missing scopes)
+            // are client-side and dominate resolution errors, so they get their own
+            // status to keep the alert on `status="error"` meaningful. The rethrow
+            // surfaces as a 401/403/500 upstream via handleCatchError.
             if (hasInit) {
-                initTotal.inc({ status: 'error' })
+                initTotal.inc({ status: mapErrorToAuthResponse(error) ? 'auth_error' : 'error' })
             }
             throw error
         }
@@ -234,7 +238,7 @@ class McpDispatcher {
                 ...(instructions ? { instructions } : {}),
             }
         } catch (error) {
-            initTotal.inc({ status: 'error' })
+            initTotal.inc({ status: mapErrorToAuthResponse(error) ? 'auth_error' : 'error' })
             throw error
         }
     }

--- a/services/mcp/tests/hono/dispatcher-init-errors.test.ts
+++ b/services/mcp/tests/hono/dispatcher-init-errors.test.ts
@@ -135,6 +135,20 @@ describe('McpDispatcher init error accounting', () => {
         expect(mockInitTotalInc).toHaveBeenCalledWith({ status: 'error' })
     })
 
+    it.each([
+        ['invalid API key', 'Failed to get user: INVALID_API_KEY'],
+        ['inactive OAuth token', 'Failed to get user: INACTIVE_OAUTH_TOKEN'],
+        ['missing scope', "Failed to get user: Missing PostHog API scope: 'user:read'"],
+    ])('counts a %s resolution failure as auth_error, not error', async (_label, message) => {
+        mockResolveState.mockRejectedValueOnce(new Error(message))
+
+        const dispatcher = new McpDispatcher({} as any, createMockRedis())
+
+        await expect(dispatcher.handleRequest(makeRequest('initialize'), makeProps())).rejects.toThrow()
+        expect(mockInitTotalInc).toHaveBeenCalledTimes(1)
+        expect(mockInitTotalInc).toHaveBeenCalledWith({ status: 'auth_error' })
+    })
+
     it('does not count non-initialize requests when state resolution fails', async () => {
         mockResolveState.mockRejectedValueOnce(new Error('django auth is down'))
 


### PR DESCRIPTION
## Problem

The new `MCPServerHighInitErrorRate` alert (added earlier today) fires almost continuously on prod-us. Investigation showed `mcp_init_total{status="error"}` sits at ~9% of inits, but effectively 100% of those "errors" are client-side auth failures, not server breakage:

- the difference `rate(mcp_init_total{status="error"}) - rate(mcp_auth_failures_total{reason=~"invalid_token|insufficient_scope"})` hovers at ~0 across an 8h window
- server logs for these failures are almost entirely `Failed to get user: INVALID_API_KEY` (expired/revoked tokens, 401) and `Failed to get user: Missing PostHog API scope: 'user:read'` (under-scoped keys, 403)

The root cause is that the auth middleware only validates the bearer token's format. A well-formed but expired or under-scoped token passes through and only fails inside `RequestStateResolver.resolve()` when the PostHog API rejects it. The dispatcher counted that as `status="error"` before the rethrow got mapped to a proper 401/403 in `handleCatchError`, so a steady stream of stale-token clients keeps the error rate permanently above the 5% alert threshold.

## Changes

At both `initTotal` error sites in the dispatcher, classify the thrown error with `mapErrorToAuthResponse` (the same helper `handleCatchError` uses to produce the 401/403), and count auth-mappable errors as `status="auth_error"` instead of `status="error"`.

The alert expression keeps watching `status="error"` untouched and now only sees genuine server-side init failures. Auth failure volume remains observable via the existing `mcp_auth_failures_total` counter and the new `auth_error` status.

> [!NOTE]
> After this deploys, `sum(rate(mcp_init_total{status="error"}))` should drop to ~0 and the alert should stop flapping. If we also want visibility into auth failure spikes, that's a separate (lower-severity) alert on `mcp_auth_failures_total`.

## How did you test this code?

Extended `services/mcp/tests/hono/dispatcher-init-errors.test.ts` with a parameterized case covering the three real-world auth failure shapes (invalid API key, inactive OAuth token, missing scope) asserting they increment `status="auth_error"` and not `status="error"`. This catches a regression where auth failures get reclassified back into `status="error"`, which would put the alert back into permanent firing. The existing generic-failure case still asserts `status="error"` for non-auth errors.

Ran locally: `vitest run --config vitest.hono.config.mts tests/hono/dispatcher-init-errors.test.ts` (6 passed), `pnpm --filter=@posthog/mcp run typecheck`, `pnpm --filter=@posthog/mcp run fix`, `hogli ci:preflight --fix` (clean). No manual testing against a live server.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference this metric in-repo. The alert rule and runbook live outside this repo and keep working unchanged (the runbook entry for `MCPServerHighInitErrorRate` may deserve a note that auth failures are excluded).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (well, Claude Code) root-caused the alert by correlating `mcp_init_total` against `mcp_auth_failures_total` in VictoriaMetrics and reading mcp-server logs in Loki, then made the change in an isolated worktree. Skills invoked: /writing-tests. Considered adding a lightweight `isAuthError` predicate instead of calling `mapErrorToAuthResponse` for classification, but reusing the exact helper that later maps the rethrown error to a 401/403 guarantees the counter and the HTTP response can never disagree.
