### PR TITLE
fix(hogql): date-bound the events query examples we ship

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
@@ -399,7 +399,10 @@ export function buildInsertCommands(
                 insertComponent(targetNodeId, 'Query', {
                     query: {
                         kind: 'DataTableNode',
-                        source: { kind: 'HogQLQuery', query: 'select event, count() from events group by event' },
+                        source: {
+                            kind: 'HogQLQuery',
+                            query: 'select event, count() from events where timestamp >= now() - interval 7 day group by event',
+                        },
                     },
                 }),
         },

--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -685,7 +685,7 @@ class DataWarehouseSavedQuerySerializer(
                 detail=(
                     'Query must be a JSON object with a "query" key, '
                     f"got {type(query).__name__}. "
-                    'Example: {"kind": "HogQLQuery", "query": "SELECT * FROM events LIMIT 100"}'
+                    'Example: {"kind": "HogQLQuery", "query": "SELECT * FROM events WHERE timestamp >= now() - INTERVAL 7 DAY LIMIT 100"}'
                 )
             )
         if not isinstance(query.get("query"), str) or not query["query"].strip():


### PR DESCRIPTION
@andyzzhao is this over the top?
occurred to me that the examples we give people don't have a time bound 🙈 

-----

## Problem

Several of the example and default HogQL queries PostHog ships read the `events` table with no `timestamp` filter, so they scan the whole history of the table. Because these are the queries users copy, insert, or see in messages, they normalize the exact unbounded pattern that drives disproportionate query cost on shared/embedded dashboards — the same shape the execution-time detector in #72231 flags.

This is the companion cleanup to #72231: stop modelling the bad pattern in our own examples.

## Changes

- **Notebook SQL block** (`InsertMenu.tsx`): the query inserted by the "SQL" command changes from `select event, count() from events group by event` (a full-history aggregation) to the same query bounded to the last 7 days.
- **Saved-query validation error** (`saved_query.py`): the example in the "query must be a JSON object" error message now carries a `WHERE timestamp >= now() - INTERVAL 7 DAY` bound.

Both are the codegen-free half of the cleanup. Two more shipped examples carry the same unbounded shape but feed generated artifacts, so they're deferred to a follow-up that can run codegen:

| Example | File | Regenerates via |
|---|---|---|
| `query` field `help_text` | `products/data_warehouse/backend/presentation/views/saved_query.py` | `hogli build:openapi` (→ `api.schemas.ts`, `api.zod.ts`, MCP client + scopes) |
| `QueryRequest.query` JSDoc `@example` | `frontend/src/queries/schema/schema-general.ts` | `hogli build:schema` (→ `schema.json`) |

(There's also the generic warehouse table-preview default in `products/data_warehouse/frontend/utils.ts` — `SELECT … FROM <table> LIMIT 100` — but it spans arbitrary tables, so a uniform `events` timestamp bound doesn't fit; left out deliberately.)

## How did you test this code?

No manual/behavioural testing was performed by the agent. Verification was limited to:

- `ruff check` / `ruff format` on the changed Python file — clean.
- Confirmed the notebook query string is an **independent fixture** in `MarkdownNotebook.test.ts` / `markdownNotebookV2.test.ts` (each has its own copy, not derived from `InsertMenu`), so changing the insert default neither breaks them nor requires updating them.
- The frontend file could **not** be run through oxlint/oxfmt or jest here (no `node_modules`); the multi-line object formatting was matched by hand against the existing `data-people` entry in the same file.

No automated tests were added — the change is to example/default query strings, and there's no realistic regression a new test would catch beyond what existing rendering tests already cover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs hardcode these example queries; no docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Paul D'Ambra as a follow-up to the unbounded-events-query detector (#72231): if we flag timestamp-less events reads at execution time, our own shipped examples shouldn't model that pattern.

- Considered dropping in a `{filters}` placeholder instead of a literal bound, but rejected it: with no date-range context (the raw SQL-editor / notebook path), `{filters}` expands to `WHERE true` and doesn't bound the scan — it only injects a `timestamp` bound when a `dateRange.date_from` is supplied. An explicit bound is the reliable choice for a standalone example.
- Scoped to the two codegen-free examples because `hogli build:openapi` / `build:schema` (Orval, ts-json-schema-generator) couldn't run in this environment (`node_modules` absent, hogli venv paths stale). Shipping the serializer `help_text` / JSDoc edits without regenerating would leave generated types out of sync, so they're deferred (see table above).
- Skills invoked: `/improving-drf-endpoints` (before touching the saved-query serializer file) and `/writing-tests` (consulted on whether the notebook test fixtures needed updating — concluded they did not).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
