### PR TITLE
fix(data-imports): skip Render services that can't have custom domains

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/render/render.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/render/render.py
@@ -90,8 +90,10 @@ def _fetch_page(
         raise RenderRetryableError(f"Render API error (retryable): status={response.status_code}, url={url}")
 
     if not response.ok:
-        # 404 is expected during fan-out (a service deleted mid-sync) and handled by the caller.
-        log = logger.warning if response.status_code == 404 else logger.error
+        # 404 (a service deleted mid-sync) and 400 (a service type that can't own the child
+        # resource, e.g. custom domains on a cron job) are expected during fan-out and handled
+        # by the caller — log them as warnings. Anything else is a genuine error.
+        log = logger.warning if response.status_code in (400, 404) else logger.error
         log(f"Render API error: status={response.status_code}, body={response.text}, url={url}")
         response.raise_for_status()
 
@@ -303,10 +305,15 @@ def _get_fan_out_rows(
                 if next_cursor:
                     resumable_source_manager.save_state(RenderResumeConfig(cursor=next_cursor, parent_id=parent_id))
         except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else None
             # A parent deleted between enumeration and this fetch 404s. Skip it rather than
             # failing the whole sync — the resource is genuinely gone.
-            if exc.response is not None and exc.response.status_code == 404:
+            if status == 404:
                 logger.warning(f"Render: {config.parent} {parent_id} not found while fetching {config.name}, skipping")
+            # Render 400s the child endpoint for parents that can't own the resource (custom
+            # domains on non-web/static services). Skip them instead of failing the sync.
+            elif status == 400 and config.skip_parent_on_bad_request:
+                logger.warning(f"Render: {config.parent} {parent_id} cannot have {config.name}, skipping")
             else:
                 raise
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/render/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/render/settings.py
@@ -52,6 +52,10 @@ class RenderEndpointConfig:
     # Hard cap on pages fetched per parent in a fan-out, to bound runaway pagination.
     # A structured warning is logged if the cap is reached.
     max_pages_per_parent: int = 500
+    # Fan-out children where Render 400s parents that can't own the resource (custom domains
+    # only exist for web services and static sites, not cron jobs, workers or private
+    # services). Skip those parents rather than failing the whole sync.
+    skip_parent_on_bad_request: bool = False
     # Some endpoints return secrets the API key is only meant to *use* for sync (env var
     # values, secret-file contents), not data worth warehousing. Maps a list column to the
     # item keys whose values are redacted before a row is yielded, keeping the safe metadata
@@ -167,6 +171,7 @@ RENDER_ENDPOINTS: dict[str, RenderEndpointConfig] = {
         # creation — a createdAt cursor would freeze it. Tiny table: full refresh only.
         parent="services",
         inject_parent_key="serviceId",
+        skip_parent_on_bad_request=True,
     ),
     "env_groups": RenderEndpointConfig(
         name="env_groups",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/render/tests/test_render.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/render/tests/test_render.py
@@ -280,6 +280,30 @@ class TestFanOut:
 
         assert batches == [[{"serviceId": "srv-2", "id": "dep-2"}]]
 
+    def test_custom_domains_400_for_unsupported_service_is_skipped(self) -> None:
+        # Render 400s /custom-domains for service types that can't have them (cron jobs, etc.);
+        # skip that parent instead of failing the whole sync.
+        batches, _, _ = _rows(
+            "custom_domains",
+            [
+                self.SERVICES_PAGE,
+                _response({"message": "Bad Request"}, status=400),
+                [{"customDomain": {"id": "dom-2"}}],
+            ],
+        )
+
+        assert batches == [[{"serviceId": "srv-2", "id": "dom-2"}]]
+
+    def test_400_still_fails_for_endpoints_without_skip_flag(self) -> None:
+        with pytest.raises(requests.HTTPError):
+            _rows(
+                "deploys",
+                [
+                    self.SERVICES_PAGE,
+                    _response({"message": "Bad Request"}, status=400),
+                ],
+            )
+
     def test_resume_skips_parents_before_bookmark_and_seeds_cursor(self) -> None:
         batches, session, _ = _rows(
             "deploys",


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` from the data warehouse import pipeline:

```
400 Client Error: Bad Request for url: https://api.render.com/v1/services/<service-id>/custom-domains?limit=100
```

Issue: [019f7ff6-97cb-7e20-806f-4d057dd94c1a](https://us.posthog.com/project/2/error_tracking/019f7ff6-97cb-7e20-806f-4d057dd94c1a)

The Render `custom_domains` table is a fan-out child of `services`: for each service we call `/services/{id}/custom-domains`. Custom domains only exist for web services and static sites. When a service is a cron job, background worker, or private service, Render rejects that request with a 400. The fan-out handler in `render.py` only skips 404s (a parent deleted mid-sync) and re-raises everything else, so one unsupported service failed the entire sync. It hit several teams because any workspace with a non-web service trips it.

## Changes

`_get_fan_out_rows` now skips a parent on a 400 the same way it already skips deleted parents on 404, but only for endpoints that opt in via a new `skip_parent_on_bad_request` flag on `RenderEndpointConfig`. Only `custom_domains` sets it, so a 400 on `deploys`, `jobs`, `events` etc. still fails loudly and reaches error tracking. `_fetch_page` also logs the expected 400 as a warning instead of an error, matching the existing 404 handling.

> [!NOTE]
> This is a graceful-skip fix, not a `NonRetryableErrors` entry. The 400 is expected for specific parents within an otherwise healthy sync, so the right behavior is to skip that parent and keep going, not to abort the run.

## How did you test this code?

Automated tests only (no manual run against the live Render API). I (Claude) added two regression tests to `TestFanOut`:

- `test_custom_domains_400_for_unsupported_service_is_skipped` - a 400 on one service is skipped and the sibling service still yields rows.
- `test_400_still_fails_for_endpoints_without_skip_flag` - a 400 on `deploys` (no opt-in flag) still raises, proving the skip isn't broadened across endpoints.

`.venv/bin/python -m pytest .../render/tests/` - 52 passed. `ruff check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I read the stack trace (`render.py:_fetch_page`), traced the fan-out call path, and confirmed the 400 comes from requesting custom domains on service types that can't have them. Considered pre-filtering parents by service type but chose to react to Render's own 400 instead, which stays correct if Render's service-type taxonomy changes. Scoped the skip behind a per-endpoint flag to avoid swallowing genuine 400s elsewhere. No customer service ids or credentials are referenced in code, tests, or this description.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
