### PR TITLE
chore(ci): fix stale warehouse-sources-load deploy path filter

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -953,7 +953,7 @@ jobs:
             - name: Check for changes that affect warehouse-sources-load
               id: check_changes_warehouse_sources_load
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/|^products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/|^posthog/management/commands/run_warehouse_sources_load\.py$|^posthog/warehouse/|^products/data_warehouse/backend/|^pyproject\.toml$|^Dockerfile$|^posthog/clickhouse/migrations/'; then
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/|^products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/|^posthog/warehouse/|^products/data_warehouse/backend/|^products/warehouse_sources/backend/|^pyproject\.toml$|^Dockerfile$|^posthog/clickhouse/migrations/'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The `warehouse-sources-load` Cloud deploy trigger in `container-images-cd.yml` decides whether to dispatch a deploy by running `git diff | grep -qE '<regex>'` over the changed files.
One pattern in that regex still pointed at `posthog/management/commands/run_warehouse_sources_load.py`, but that command moved to `products/warehouse_sources/backend/management/commands/run_warehouse_sources_load.py` in #66020.
The filter also lacked a broad `^products/warehouse_sources/backend/` catch-all (it only listed two narrow `pipelines/pipeline_v3/` and `pipelines/pipeline/` subpaths), so a commit touching only the command file would silently fail to trigger a deploy.

## Changes

- Add the broad `^products/warehouse_sources/backend/` catch-all, matching the sibling `warehouse-sources-duckgres-load` step.
- Remove the dead `^posthog/management/commands/run_warehouse_sources_load\.py$` term.
- Keep the two existing pipeline subpaths so this step mirrors the duckgres sibling exactly (they are now subpaths of the catch-all, kept for consistency rather than necessity).

The `warehouse-sources-duckgres-load` step already had the catch-all and is left untouched.

```diff
- ...pipeline/|^posthog/management/commands/run_warehouse_sources_load\.py$|^posthog/warehouse/|^products/data_warehouse/backend/|^pyproject\.toml$...
+ ...pipeline/|^posthog/warehouse/|^products/data_warehouse/backend/|^products/warehouse_sources/backend/|^pyproject\.toml$...
```

## How did you test this code?

No app runtime is involved — this is a CI trigger regex. I (Claude, via PostHog Code) verified:

- The old command file is gone; the real file now lives under `products/warehouse_sources/backend/management/commands/`.
- The new regex matches the moved command path and other `products/warehouse_sources/backend/` files via `grep -qE`, and does not over-match unrelated paths (e.g. `frontend/src/index.tsx`).
- The dead term is fully removed and the duckgres sibling step is unchanged.
- The workflow YAML still parses (`yaml.safe_load`).

`hogli lint:workflows` and `actionlint` were not installed in my environment, but the change only alters the content of a grep pattern string inside a `run: |` block, so no workflow structure changed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Estefania flagged that the warehouse-sources-load deploy filter references a command file that no longer exists after #66020, and asked me (Claude) to bring it in line with the duckgres sibling.
I invoked the `/authoring-ci-workflows` skill for the conventions, confirmed the old and new file locations, made the minimal regex change, and verified it with `grep` and a YAML parse.

One decision worth noting: the two `pipelines/pipeline_v3/` and `pipelines/pipeline/` subpaths become redundant once the catch-all is added.
I kept them so this step mirrors the duckgres sibling exactly, favoring consistency between the two adjacent steps over a marginally shorter regex.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
