### PR TITLE
fix(data-warehouse): stop v3 no_job_row takeover stealing live locks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/sync_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/sync_lock.py
@@ -1,5 +1,8 @@
+import json
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any
 
 from django.conf import settings
 
@@ -12,13 +15,19 @@ from posthog.redis import get_client
 logger = structlog.get_logger(__name__)
 
 LOCK_KEY_PREFIX = "v3_pipeline_lock"
+# Holder metadata lives in a second key because the lock value must stay a bare
+# run-id token — every release path compares it byte-for-byte.
+LOCK_META_KEY_PREFIX = "v3_pipeline_lock_meta"
 LOCK_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days, matching max workflow duration
 
 # Atomic check-and-delete: prevents a race where workflow A's expired lock is
 # acquired by workflow B, then A's delayed consumer releases B's lock.
 # Replaceable with DELEX once we upgrade to Redis >= 8.4.
+# Meta is deleted in the same script so it can't outlive its lock; readers must
+# still ignore mismatched-run_id meta (old pods release without deleting it).
 _RELEASE_LOCK_SCRIPT = """
 if redis.call("get", KEYS[1]) == ARGV[1] then
+    redis.call("del", KEYS[2])
     return redis.call("del", KEYS[1])
 end
 return 0
@@ -27,6 +36,10 @@ return 0
 
 def _lock_key(team_id: int, schema_id: str) -> str:
     return f"{LOCK_KEY_PREFIX}:{team_id}:{schema_id}"
+
+
+def _lock_meta_key(team_id: int, schema_id: str) -> str:
+    return f"{LOCK_META_KEY_PREFIX}:{team_id}:{schema_id}"
 
 
 @contextmanager
@@ -76,6 +89,47 @@ def acquire_v3_pipeline_lock(team_id: int, schema_id: str, token: str) -> bool:
             return False
 
 
+def write_v3_pipeline_lock_meta(team_id: int, schema_id: str, run_id: str, workflow_id: str) -> None:
+    """Write the companion metadata for the current lock holder. Best-effort: never raises."""
+    with _get_redis_client() as client:
+        if client is None:
+            return
+
+        try:
+            payload = json.dumps(
+                {
+                    "run_id": run_id,
+                    "workflow_id": workflow_id,
+                    "acquired_at": datetime.now(UTC).isoformat(),
+                }
+            )
+            client.set(_lock_meta_key(team_id, schema_id), payload, ex=LOCK_TTL_SECONDS)
+        except Exception as e:
+            logger.warning("v3_pipeline_lock_meta_write_error", error=str(e), team_id=team_id, schema_id=schema_id)
+            capture_exception(e)
+
+
+def get_v3_pipeline_lock_meta(team_id: int, schema_id: str) -> dict[str, Any] | None:
+    """Read the companion lock metadata; None when absent, unparseable, or Redis is down.
+    Can be stale (not atomic with the lock) — callers must check run_id matches the holder."""
+    with _get_redis_client() as client:
+        if client is None:
+            return None
+
+        try:
+            raw = client.get(_lock_meta_key(team_id, schema_id))
+            if raw is None:
+                return None
+            parsed = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+            if not isinstance(parsed, dict):
+                return None
+            return parsed
+        except Exception as e:
+            logger.warning("v3_pipeline_lock_meta_read_error", error=str(e), team_id=team_id, schema_id=schema_id)
+            capture_exception(e)
+            return None
+
+
 def get_v3_pipeline_lock_holder(team_id: int, schema_id: str) -> str | None:
     """Return the token currently holding the lock, or None if unheld or Redis is unavailable."""
     with _get_redis_client() as client:
@@ -100,7 +154,9 @@ def release_v3_pipeline_lock(team_id: int, schema_id: str, token: str) -> bool:
             return False
 
         try:
-            result = client.eval(_RELEASE_LOCK_SCRIPT, 1, _lock_key(team_id, schema_id), token)
+            result = client.eval(
+                _RELEASE_LOCK_SCRIPT, 2, _lock_key(team_id, schema_id), _lock_meta_key(team_id, schema_id), token
+            )
             return bool(result)
         except Exception as e:
             logger.warning("v3_pipeline_lock_release_error", error=str(e), team_id=team_id, schema_id=schema_id)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/acquire_v3_lock.py
@@ -30,7 +30,9 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.sync_lock import (
     acquire_v3_pipeline_lock,
     get_v3_pipeline_lock_holder,
+    get_v3_pipeline_lock_meta,
     release_v3_pipeline_lock,
+    write_v3_pipeline_lock_meta,
 )
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.create_job_model import (
     is_pipeline_v3_enabled,
@@ -41,6 +43,10 @@ LOGGER = get_logger(__name__)
 # Hard cap on how long a terminal-workflow holder can block takeover on queue
 # activity alone — the backstop when the staleness heuristic is being fooled.
 TAKEOVER_MAX_HOLD_SECONDS = 24 * 60 * 60
+
+# Must outlast the healthy startup tail (SET NX → job-row commit, minutes under
+# backlog); real no-job-row cleanups are hours old, so a generous grace delays nothing.
+NO_JOB_ROW_TAKEOVER_GRACE_SECONDS = 900
 
 
 @dataclasses.dataclass
@@ -102,6 +108,16 @@ def acquire_v3_pipeline_lock_activity(inputs: AcquireV3LockActivityInputs) -> Ac
     if not acquired:
         acquired = _take_over_lock_if_holder_finished(inputs, token, logger)
 
+    if acquired:
+        # Best-effort: lets a later contender describe this workflow even before
+        # the job row exists. Missing meta degrades to the age-grace fallback.
+        write_v3_pipeline_lock_meta(
+            inputs.team_id,
+            str(inputs.schema_id),
+            run_id=token,
+            workflow_id=activity.info().workflow_id or "",
+        )
+
     logger.info(
         "v3_pipeline_lock_acquire_result",
         schema_id=str(inputs.schema_id),
@@ -117,7 +133,8 @@ def _take_over_lock_if_holder_finished(inputs: AcquireV3LockActivityInputs, toke
 
     Decision matrix (fail closed on any ambiguity):
     1. Holder workflow still RUNNING per Temporal describe -> fail closed.
-    2. Holder workflow terminal + no job row -> take over.
+    2. Holder workflow terminal + no job row -> take over; if terminal was only
+       assumed (no workflow_id anywhere), a young holder fails closed instead.
     3. Holder workflow terminal + job terminal -> take over.
     4. Holder workflow terminal + job RUNNING -> consult queue DB:
        - no batches, all-terminal, no recent loader progress, or the job has
@@ -132,8 +149,20 @@ def _take_over_lock_if_holder_finished(inputs: AcquireV3LockActivityInputs, toke
 
     close_old_connections()
 
+    # Meta is only trustworthy if it describes the current holder — a failed
+    # cleanup can leave meta from a previous run behind.
+    meta = get_v3_pipeline_lock_meta(inputs.team_id, str(inputs.schema_id))
+    meta_found = meta is not None and meta.get("run_id") == holder
+    meta_workflow_id: str | None = None
+    if meta_found and meta is not None:
+        raw_workflow_id = meta.get("workflow_id")
+        if isinstance(raw_workflow_id, str) and raw_workflow_id:
+            meta_workflow_id = raw_workflow_id
+
+    holder_age_seconds = _holder_token_age_seconds(holder)
+
     # Step 1: check if the holder's Temporal workflow is still running
-    workflow_status, holder_job = _describe_holder_workflow(inputs, holder, logger)
+    workflow_status, holder_job, status_is_assumed = _describe_holder_workflow(inputs, holder, meta_workflow_id, logger)
     if workflow_status is None:
         # Describe failed - fail closed (ambiguous)
         logger.warning(
@@ -141,20 +170,52 @@ def _take_over_lock_if_holder_finished(inputs: AcquireV3LockActivityInputs, toke
             schema_id=str(inputs.schema_id),
             holder_token=holder,
             reason="temporal_describe_failed",
+            holder_age_seconds=holder_age_seconds,
+            meta_found=meta_found,
         )
         return False
 
     if workflow_status == WorkflowExecutionStatus.RUNNING:
+        if holder_job is None:
+            # Near-miss race: a healthy holder still pre-job-row — log so these
+            # show up in prod.
+            logger.info(
+                "v3_pipeline_lock_takeover_skipped",
+                schema_id=str(inputs.schema_id),
+                holder_token=holder,
+                reason="holder_running_no_job_row",
+                holder_age_seconds=holder_age_seconds,
+                meta_found=meta_found,
+            )
         return False
 
     # Step 2/3: workflow is terminal, check the job row
     if holder_job is None:
+        if (
+            status_is_assumed
+            and holder_age_seconds is not None
+            and holder_age_seconds < NO_JOB_ROW_TAKEOVER_GRACE_SECONDS
+        ):
+            logger.warning(
+                "v3_pipeline_lock_takeover_ambiguous",
+                schema_id=str(inputs.schema_id),
+                holder_token=holder,
+                reason="no_job_row_holder_too_young",
+                holder_age_seconds=holder_age_seconds,
+                meta_found=meta_found,
+            )
+            return False
+
         # Worker crashed before creating the job row - safe to take over
+        # (holder_age_seconds=None: token wasn't UUIDv7, grace not applicable).
         logger.warning(
             "v3_pipeline_lock_taking_over",
             schema_id=str(inputs.schema_id),
             holder_token=holder,
             reason="no_job_row",
+            holder_age_seconds=holder_age_seconds,
+            meta_found=meta_found,
+            holder_status_assumed=status_is_assumed,
         )
         return _release_and_acquire(inputs, holder, token)
 
@@ -165,6 +226,8 @@ def _take_over_lock_if_holder_finished(inputs: AcquireV3LockActivityInputs, toke
             holder_token=holder,
             reason="job_terminal",
             holder_job_status=holder_job.status,
+            holder_age_seconds=holder_age_seconds,
+            meta_found=meta_found,
         )
         return _release_and_acquire(inputs, holder, token)
 
@@ -172,12 +235,28 @@ def _take_over_lock_if_holder_finished(inputs: AcquireV3LockActivityInputs, toke
     return _take_over_stale_running_job(inputs, holder, token, holder_job, logger)
 
 
+def _holder_token_age_seconds(token: str) -> float | None:
+    """Age of the holder token derived from its UUIDv7 timestamp, or None if not a UUIDv7."""
+    try:
+        holder_uuid = uuid.UUID(token)
+    except (ValueError, AttributeError, TypeError):
+        return None
+    if holder_uuid.version != 7:
+        return None
+    # UUIDv7: top 48 bits are unix milliseconds
+    created_at_ms = holder_uuid.int >> 80
+    age = (datetime.now(UTC) - datetime.fromtimestamp(created_at_ms / 1000, tz=UTC)).total_seconds()
+    return round(age, 1)
+
+
 def _describe_holder_workflow(
     inputs: AcquireV3LockActivityInputs,
     holder_run_id: str,
+    meta_workflow_id: str | None,
     logger: Any,
-) -> tuple[WorkflowExecutionStatus | None, ExternalDataJob | None]:
-    """Describe the holder's Temporal workflow and return (status, job), or (None, None) on error."""
+) -> tuple[WorkflowExecutionStatus | None, ExternalDataJob | None, bool]:
+    """Return (status, job, status_is_assumed): assumed=True when no workflow_id
+    exists anywhere so TERMINATED is a guess; (None, None, False) on describe error."""
     try:
         holder_job = (
             ExternalDataJob.objects.filter(
@@ -189,13 +268,14 @@ def _describe_holder_workflow(
             .only("id", "status", "workflow_id", "created_at")
             .first()
         )
-        if holder_job is None or not holder_job.workflow_id:
-            return WorkflowExecutionStatus.TERMINATED, holder_job
+        workflow_id = (holder_job.workflow_id if holder_job is not None else None) or meta_workflow_id
+        if not workflow_id:
+            return WorkflowExecutionStatus.TERMINATED, holder_job, True
 
         temporal: Client = sync_connect()
-        handle = temporal.get_workflow_handle(holder_job.workflow_id, run_id=holder_run_id)
+        handle = temporal.get_workflow_handle(workflow_id, run_id=holder_run_id)
         desc = async_to_sync(handle.describe)()
-        return desc.status, holder_job
+        return desc.status, holder_job, False
     except Exception as e:
         logger.warning(
             "v3_pipeline_lock_describe_failed",
@@ -204,7 +284,7 @@ def _describe_holder_workflow(
             error=str(e),
         )
         capture_exception(e)
-        return None, None
+        return None, None, False
 
 
 def _take_over_stale_running_job(

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/create_job_model.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/create_job_model.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 import posthoganalytics
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models.team.team import Team
@@ -25,6 +26,9 @@ from products.warehouse_sources.backend.models.table import HIDDEN_COLUMNS, Data
 from products.warehouse_sources.backend.temporal.data_imports.external_product_hooks import (
     emit_signals_enabled_for,
     person_property_sync_enabled_for,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.sync_lock import (
+    get_v3_pipeline_lock_holder,
 )
 
 WAREHOUSE_PIPELINES_V3_FLAG = "warehouse-pipelines-v3"
@@ -101,6 +105,22 @@ def _enrichment_pending(team_id: int, table: DataWarehouseTable | None, schema: 
     # "" is the table-level annotation; absent description on both schema and annotations means work.
     table_needs_description = not bool(schema.description) and "" not in annotated
     return bool(new_columns or table_needs_description)
+
+
+def _verify_v3_lock_still_held(team_id: int, schema_id: uuid.UUID) -> None:
+    """Fail fast if another run stole the v3 lock during this run's startup window,
+    instead of double-writing the Delta table. Best-effort: skipped when Redis is down."""
+    run_id = activity.info().workflow_run_id
+    if not run_id:
+        return
+    holder = get_v3_pipeline_lock_holder(team_id, str(schema_id))
+    if holder is None:
+        return
+    if holder != run_id:
+        raise ApplicationError(
+            "v3 pipeline lock lost to another run before job creation",
+            non_retryable=True,
+        )
 
 
 def _build_schema_snapshot(schema: ExternalDataSchema) -> dict[str, Any]:
@@ -190,6 +210,7 @@ def create_external_data_job_model_activity(
         pipeline_version = ExternalDataJob.PipelineVersion.V2
         if inputs.is_v3:
             pipeline_version = ExternalDataJob.PipelineVersion.V3
+            _verify_v3_lock_still_held(inputs.team_id, inputs.schema_id)
 
         job = ExternalDataJob.objects.create(
             team_id=inputs.team_id,

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/test_acquire_v3_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/test_acquire_v3_lock.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from temporalio.client import WorkflowExecutionStatus
 
@@ -25,6 +25,11 @@ SOURCE_ID = uuid.uuid4()
 WORKFLOW_RUN_ID = "run-abc-123"
 
 MODULE = "products.warehouse_sources.backend.temporal.data_imports.workflow_activities.acquire_v3_lock"
+
+
+def _uuid7_token(age_seconds: float) -> str:
+    ms = int((datetime.now(UTC) - timedelta(seconds=age_seconds)).timestamp() * 1000)
+    return str(uuid.UUID(int=(ms << 80) | (0x7 << 76) | (0x2 << 62)))
 
 
 class TestCheckPipelineVersionActivity:
@@ -86,6 +91,7 @@ class TestAcquireV3PipelineLockActivity:
         [True, False],
         ids=["lock_free", "lock_held"],
     )
+    @patch(f"{MODULE}.write_v3_pipeline_lock_meta")
     @patch(f"{MODULE}._take_over_lock_if_holder_finished", return_value=False)
     @patch(f"{MODULE}.acquire_v3_pipeline_lock")
     @patch(f"{MODULE}.activity")
@@ -96,9 +102,11 @@ class TestAcquireV3PipelineLockActivity:
         mock_activity: MagicMock,
         mock_acquire: MagicMock,
         mock_take_over: MagicMock,
+        mock_write_meta: MagicMock,
         lock_acquired: bool,
     ) -> None:
         mock_activity.info.return_value.workflow_run_id = WORKFLOW_RUN_ID
+        mock_activity.info.return_value.workflow_id = "wf-abc-123"
         mock_acquire.return_value = lock_acquired
 
         result = acquire_v3_pipeline_lock_activity(AcquireV3LockActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID))
@@ -108,9 +116,16 @@ class TestAcquireV3PipelineLockActivity:
         mock_acquire.assert_called_once_with(TEAM_ID, str(SCHEMA_ID), WORKFLOW_RUN_ID)
         if lock_acquired:
             mock_take_over.assert_not_called()
+            # Without meta, a later contender can't describe this workflow pre-job-row
+            # and the takeover race guard degrades to the age grace.
+            mock_write_meta.assert_called_once_with(
+                TEAM_ID, str(SCHEMA_ID), run_id=WORKFLOW_RUN_ID, workflow_id="wf-abc-123"
+            )
         else:
             mock_take_over.assert_called_once()
+            mock_write_meta.assert_not_called()
 
+    @patch(f"{MODULE}.write_v3_pipeline_lock_meta")
     @patch(f"{MODULE}._take_over_lock_if_holder_finished", return_value=True)
     @patch(f"{MODULE}.acquire_v3_pipeline_lock", return_value=False)
     @patch(f"{MODULE}.activity")
@@ -121,6 +136,7 @@ class TestAcquireV3PipelineLockActivity:
         mock_activity: MagicMock,
         _mock_acquire: MagicMock,
         _mock_take_over: MagicMock,
+        _mock_write_meta: MagicMock,
     ) -> None:
         mock_activity.info.return_value.workflow_run_id = WORKFLOW_RUN_ID
 
@@ -160,43 +176,124 @@ class TestTakeOverStaleLock:
         assert self._run() is True
         mock_acquire.assert_called_once_with(TEAM_ID, str(SCHEMA_ID), WORKFLOW_RUN_ID)
 
-    @patch(f"{MODULE}._describe_holder_workflow", return_value=(WorkflowExecutionStatus.RUNNING, None))
+    @patch(f"{MODULE}.get_v3_pipeline_lock_meta", return_value=None)
+    @patch(f"{MODULE}._describe_holder_workflow", return_value=(WorkflowExecutionStatus.RUNNING, None, False))
     @patch(f"{MODULE}.close_old_connections")
     @patch(f"{MODULE}.get_v3_pipeline_lock_holder", return_value=HOLDER_TOKEN)
     def test_fails_closed_when_holder_workflow_running(
-        self, _holder: MagicMock, _close: MagicMock, _describe: MagicMock
+        self, _holder: MagicMock, _close: MagicMock, _describe: MagicMock, _meta: MagicMock
     ) -> None:
         assert self._run() is False
 
-    @patch(f"{MODULE}._describe_holder_workflow", return_value=(None, None))
+    @patch(f"{MODULE}.get_v3_pipeline_lock_meta", return_value=None)
+    @patch(f"{MODULE}._describe_holder_workflow", return_value=(None, None, False))
     @patch(f"{MODULE}.close_old_connections")
     @patch(f"{MODULE}.get_v3_pipeline_lock_holder", return_value=HOLDER_TOKEN)
     def test_fails_closed_when_describe_fails(
-        self, _holder: MagicMock, _close: MagicMock, _describe: MagicMock
+        self, _holder: MagicMock, _close: MagicMock, _describe: MagicMock, _meta: MagicMock
     ) -> None:
         assert self._run() is False
 
+    @pytest.mark.parametrize(
+        "holder_status, expected_takeover",
+        [
+            (WorkflowExecutionStatus.RUNNING, False),
+            (WorkflowExecutionStatus.COMPLETED, True),
+            (WorkflowExecutionStatus.TERMINATED, True),
+        ],
+        ids=["running_fails_closed", "completed_takes_over", "terminated_takes_over"],
+    )
     @patch(f"{MODULE}.acquire_v3_pipeline_lock", return_value=True)
     @patch(f"{MODULE}.release_v3_pipeline_lock")
-    @patch(f"{MODULE}._describe_holder_workflow", return_value=(WorkflowExecutionStatus.COMPLETED, None))
+    @patch(f"{MODULE}.sync_connect")
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.get_v3_pipeline_lock_meta")
     @patch(f"{MODULE}.close_old_connections")
-    @patch(f"{MODULE}.get_v3_pipeline_lock_holder", return_value=HOLDER_TOKEN)
-    def test_takes_over_when_no_job_row(
+    @patch(f"{MODULE}.get_v3_pipeline_lock_holder")
+    def test_no_job_row_with_meta_asks_temporal(
         self,
-        _holder: MagicMock,
+        mock_holder: MagicMock,
         _close: MagicMock,
-        _describe: MagicMock,
+        mock_meta: MagicMock,
+        mock_job_model: MagicMock,
+        mock_sync_connect: MagicMock,
         mock_release: MagicMock,
         mock_acquire: MagicMock,
+        holder_status: WorkflowExecutionStatus,
+        expected_takeover: bool,
     ) -> None:
-        assert self._run() is True
-        mock_release.assert_called_once_with(TEAM_ID, str(SCHEMA_ID), self.HOLDER_TOKEN)
+        # Core race: meta lets us ask Temporal instead of assuming a pre-job-row
+        # holder crashed; a young token proves Temporal's answer beats the age grace.
+        holder_token = _uuid7_token(age_seconds=2)
+        mock_holder.return_value = holder_token
+        mock_meta.return_value = {"run_id": holder_token, "workflow_id": "wf-holder-1"}
+        mock_job_model.objects.filter.return_value.order_by.return_value.only.return_value.first.return_value = None
+        handle = MagicMock()
+        handle.describe = AsyncMock(return_value=MagicMock(status=holder_status))
+        mock_sync_connect.return_value.get_workflow_handle.return_value = handle
+
+        assert self._run() is expected_takeover
+        mock_sync_connect.return_value.get_workflow_handle.assert_called_once_with("wf-holder-1", run_id=holder_token)
+        if expected_takeover:
+            mock_release.assert_called_once_with(TEAM_ID, str(SCHEMA_ID), holder_token)
+        else:
+            mock_release.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "holder_age_seconds, meta, expected_takeover",
+        [
+            (60, None, False),
+            (7200, None, True),
+            (60, {"run_id": "some-other-run", "workflow_id": "wf-stale"}, False),
+            (None, None, True),
+        ],
+        ids=[
+            "young_holder_fails_closed",
+            "old_holder_takes_over",
+            "stale_meta_ignored_grace_applies",
+            "undecodable_token_takes_over",
+        ],
+    )
+    @patch(f"{MODULE}.acquire_v3_pipeline_lock", return_value=True)
+    @patch(f"{MODULE}.release_v3_pipeline_lock")
+    @patch(f"{MODULE}.sync_connect")
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.get_v3_pipeline_lock_meta")
+    @patch(f"{MODULE}.close_old_connections")
+    @patch(f"{MODULE}.get_v3_pipeline_lock_holder")
+    def test_no_job_row_without_meta_applies_age_grace(
+        self,
+        mock_holder: MagicMock,
+        _close: MagicMock,
+        mock_meta: MagicMock,
+        mock_job_model: MagicMock,
+        mock_sync_connect: MagicMock,
+        mock_release: MagicMock,
+        mock_acquire: MagicMock,
+        holder_age_seconds: float | None,
+        meta: dict | None,
+        expected_takeover: bool,
+    ) -> None:
+        # Legacy/crash path (no usable meta): without a workflow_id the token's
+        # UUIDv7 age decides; undecodable tokens keep today's take-over behavior.
+        holder_token = _uuid7_token(holder_age_seconds) if holder_age_seconds is not None else self.HOLDER_TOKEN
+        mock_holder.return_value = holder_token
+        mock_meta.return_value = meta
+        mock_job_model.objects.filter.return_value.order_by.return_value.only.return_value.first.return_value = None
+
+        assert self._run() is expected_takeover
+        mock_sync_connect.assert_not_called()
+        if expected_takeover:
+            mock_release.assert_called_once_with(TEAM_ID, str(SCHEMA_ID), holder_token)
+        else:
+            mock_release.assert_not_called()
 
     @pytest.mark.parametrize(
         "holder_status",
         ["Completed", "Failed"],
         ids=["holder_completed", "holder_failed"],
     )
+    @patch(f"{MODULE}.get_v3_pipeline_lock_meta", return_value=None)
     @patch(f"{MODULE}.acquire_v3_pipeline_lock", return_value=True)
     @patch(f"{MODULE}.release_v3_pipeline_lock")
     @patch(f"{MODULE}.close_old_connections")
@@ -207,17 +304,19 @@ class TestTakeOverStaleLock:
         _close: MagicMock,
         mock_release: MagicMock,
         mock_acquire: MagicMock,
+        _meta: MagicMock,
         holder_status: str,
     ) -> None:
         holder_job = MagicMock()
         holder_job.status = holder_status
         with patch(
             f"{MODULE}._describe_holder_workflow",
-            return_value=(WorkflowExecutionStatus.COMPLETED, holder_job),
+            return_value=(WorkflowExecutionStatus.COMPLETED, holder_job, False),
         ):
             assert self._run() is True
         mock_release.assert_called_once_with(TEAM_ID, str(SCHEMA_ID), self.HOLDER_TOKEN)
 
+    @patch(f"{MODULE}.get_v3_pipeline_lock_meta", return_value=None)
     @patch(f"{MODULE}._take_over_stale_running_job", return_value=False)
     @patch(f"{MODULE}.close_old_connections")
     @patch(f"{MODULE}.get_v3_pipeline_lock_holder", return_value=HOLDER_TOKEN)
@@ -226,12 +325,13 @@ class TestTakeOverStaleLock:
         _holder: MagicMock,
         _close: MagicMock,
         mock_stale: MagicMock,
+        _meta: MagicMock,
     ) -> None:
         holder_job = MagicMock()
         holder_job.status = "Running"
         with patch(
             f"{MODULE}._describe_holder_workflow",
-            return_value=(WorkflowExecutionStatus.COMPLETED, holder_job),
+            return_value=(WorkflowExecutionStatus.COMPLETED, holder_job, False),
         ):
             assert self._run() is False
         mock_stale.assert_called_once()

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_create_job_model.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_create_job_model.py
@@ -1,10 +1,13 @@
+import uuid
 import datetime as dt
 
 import pytest
+from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
 from parameterized import parameterized
+from temporalio.exceptions import ApplicationError
 
 from posthog.models import Organization, Team
 
@@ -17,7 +20,10 @@ from products.warehouse_sources.backend.models.table import DataWarehouseTable
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.create_job_model import (
     _enrichment_pending,
     _statistics_stale,
+    _verify_v3_lock_still_held,
 )
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.workflow_activities.create_job_model"
 
 
 def _team() -> Team:
@@ -42,6 +48,42 @@ def _schema(team: Team, table: DataWarehouseTable | None, *, description: str | 
     return ExternalDataSchema.objects.create(
         name="Charge", team=team, source=source, table=table, description=description
     )
+
+
+class TestVerifyV3LockStillHeld:
+    RUN_ID = "run-abc-123"
+    SCHEMA_ID = uuid.uuid4()
+
+    @parameterized.expand(
+        [
+            # Own token still on the lock: the normal healthy path must proceed.
+            ("holder_matches", "run-abc-123", False),
+            # Redis down (or lock vanished): the guard is best-effort — availability must not regress.
+            ("redis_unavailable", None, False),
+            # Another run took the lock during this run's startup window: fail fast
+            # instead of double-writing the Delta table alongside the new holder.
+            ("lock_lost_to_other_run", "run-thief-999", True),
+        ]
+    )
+    @patch(f"{MODULE}.get_v3_pipeline_lock_holder")
+    @patch(f"{MODULE}.activity")
+    def test_lock_guard(
+        self,
+        _name: str,
+        holder: str | None,
+        expect_raise: bool,
+        mock_activity: MagicMock,
+        mock_get_holder: MagicMock,
+    ) -> None:
+        mock_activity.info.return_value.workflow_run_id = self.RUN_ID
+        mock_get_holder.return_value = holder
+
+        if expect_raise:
+            with pytest.raises(ApplicationError) as exc_info:
+                _verify_v3_lock_still_held(1, self.SCHEMA_ID)
+            assert exc_info.value.non_retryable is True
+        else:
+            _verify_v3_lock_still_held(1, self.SCHEMA_ID)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

The v3 pipeline's `no_job_row` lock-takeover branch assumes a holder with no `ExternalDataJob` row crashed before creating it, and takes over without asking Temporal (the `workflow_id` needed to describe the holder lives only on the job row).

That assumption is wrong. Every healthy run has a startup window between the Redis `SET NX` and the create-job activity committing the row, normally a couple of seconds but stretching to minutes under task-queue backlog. A second workflow starting inside that window (manual "sync now", resync, re-snapshot) steals the lock, both runs extract and enqueue batches concurrently, and the schema's Delta table ends up an interleaved mix of two extractions with both jobs reporting success. `supersede_other_runs` doesn't protect across the two runs because it filters on a single job id.

The branch can't just be removed, since the legitimate variant (holder genuinely crashed pre-job-row) does real cleanup work.

## Changes

**Before** - a no-job-row holder is always presumed dead:

```mermaid
flowchart TD
    A{{Lock held by another run?}} --> B[Look up holder's job row]
    B --> C{Job row exists?}
    C -- yes --> D[Describe workflow in Temporal]
    C -- no --> E[Assume TERMINATED]
    E --> F[Take over lock]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class D phBlue;
    class E,F phRed;
```

**After** - three layers, all safe under a mixed-version fleet:

```mermaid
flowchart TD
    A{{Lock held by another run?}} --> B[Read lock meta key]
    B --> C{Meta matches holder,<br/>has workflow_id?}
    C -- yes --> D[Describe workflow in Temporal]
    D -- RUNNING --> E[Fail closed]
    D -- terminal --> F[Existing decision matrix]
    C -- no --> G{Holder token UUIDv7<br/>younger than 15 min?}
    G -- yes --> E
    G -- no / undecodable --> F
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class D phBlue;
    class B,C,G phGray;
    class E,F phYellow;
```

1. **Self-describing lock.** On acquire, the activity writes a best-effort companion key `v3_pipeline_lock_meta:{team_id}:{schema_id}` with the holder's `run_id`, `workflow_id`, and `acquired_at`, same TTL as the lock. A contender can now describe the holder in Temporal even before the job row exists. The lock value itself is unchanged, so the byte-for-byte Lua compare-and-delete in every release path keeps working while old and new pods coexist. Readers only trust meta whose `run_id` matches the current holder. The release Lua script deletes the meta key atomically with the lock, and meta left behind by old-pod releases is neutralized by the `run_id` check plus TTL.
2. **UUIDv7 age grace.** With no usable meta and no job row (legacy locks from pre-deploy pods, or a crash between the `SET NX` and the meta write), the holder token's UUIDv7 timestamp decides. Holders younger than `NO_JOB_ROW_TAKEOVER_GRACE_SECONDS` (15 min, sized to dominate the healthy startup tail) fail closed. Undecodable tokens keep today's take-over behavior, logged with unknown age.
3. **Victim-side guard.** For v3 runs, `create_external_data_job_model_activity` re-reads the lock right before inserting the job row and raises a non-retryable `ApplicationError` if another run now holds it, so a victim of an old-pod takeover fails fast instead of double-writing. Skipped when Redis is unavailable. The workflow finalizer already tolerates a missing job row, and the token-guarded release can't touch the thief's lock.

> [!NOTE]
> Observability: `v3_pipeline_lock_taking_over` and takeover-ambiguous log lines now carry `holder_age_seconds` and `meta_found`, and a skipped takeover against a running pre-job-row holder logs `holder_running_no_job_row`, so benign cleanups and near-miss races are distinguishable in prod.

## How did you test this code?

Automated tests only, all run locally via `hogli test` (55 passed), plus `ruff check`/`ruff format` and repo-wide `uv run mypy --cache-fine-grained .` (only failure is a pre-existing error in `posthog/personhog_client/converters.py`, untouched here).

- `test_no_job_row_with_meta_asks_temporal` catches the core race no existing test did: meta present + Temporal says RUNNING + no job row must not take over (the old `test_takes_over_when_no_job_row` enshrined the buggy behavior and was replaced). The terminal cases prove cleanup is preserved and that Temporal's answer beats the age grace.
- `test_no_job_row_without_meta_applies_age_grace` catches regressions in the legacy-compat path: young holder fails closed, old holder takes over, stale meta (mismatched `run_id`) is ignored, undecodable tokens keep today's behavior.
- `TestVerifyV3LockStillHeld` catches the victim guard regressing: non-retryable raise on lock loss, proceed when the holder matches or Redis is down.
- Acquire-activity tests now also assert the meta key is written exactly when the lock is acquired, since silently dropping that write would revive the race.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal pipeline locking behavior, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5) in an interactive session, directed by the assignee. Skills invoked: `/writing-tests`.
- The main design constraint was mixed-version rollout safety: the Redis lock value format is compared byte-for-byte by release paths across several services, so holder metadata went into a companion key instead of changing the lock value. The meta write is best-effort by design (a failed write must not fail the acquire), with the age grace as fallback.
- Comment-only follow-up during the session trimmed explanatory comments down to short why-only notes.
