### PR TITLE
feat(conversations): hoist current user to top of ticket assignee filter

### DIFF
--- a/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
+++ b/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
@@ -151,6 +151,34 @@ function TriggerLabel({ value }: { value: AssigneeFilterEntry[] }): JSX.Element 
     )
 }
 
+const AssigneeFilterItem = ({
+    item,
+    isSelected,
+    onToggle,
+    selectionCapReason,
+}: {
+    item: NonNullable<Assignee>
+    isSelected: (entry: AssigneeFilterEntry) => boolean
+    onToggle: (entry: AssigneeFilterEntry) => void
+    selectionCapReason?: string
+}): JSX.Element => {
+    return (
+        <LemonButton
+            fullWidth
+            role="menuitem"
+            size="small"
+            icon={<LemonCheckbox checked={isSelected(item)} className="pointer-events-none" />}
+            disabledReason={isSelected(item) ? undefined : selectionCapReason}
+            onClick={() => onToggle({ type: item.type, id: item.id })}
+        >
+            <span className="flex items-center gap-1">
+                <AssigneeIconDisplay assignee={item} size="small" />
+                <AssigneeLabelDisplay assignee={item} />
+            </span>
+        </LemonButton>
+    )
+}
+
 const Section = ({
     title,
     loading,
@@ -176,19 +204,12 @@ const Section = ({
                 <h5 className="mx-2 my-0.5">{title}</h5>
                 {items.map((item) => (
                     <li key={item.id}>
-                        <LemonButton
-                            fullWidth
-                            role="menuitem"
-                            size="small"
-                            icon={<LemonCheckbox checked={isSelected(item)} className="pointer-events-none" />}
-                            disabledReason={isSelected(item) ? undefined : selectionCapReason}
-                            onClick={() => onToggle({ type: item.type, id: item.id })}
-                        >
-                            <span className="flex items-center gap-1">
-                                <AssigneeIconDisplay assignee={item} size="small" />
-                                <AssigneeLabelDisplay assignee={item} />
-                            </span>
-                        </LemonButton>
+                        <AssigneeFilterItem
+                            item={item}
+                            isSelected={isSelected}
+                            onToggle={onToggle}
+                            selectionCapReason={selectionCapReason}
+                        />
                     </li>
                 ))}
 

--- a/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
+++ b/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
@@ -24,7 +24,8 @@ export function AssigneeMultiSelect({
     value: AssigneeFilterEntry[]
     onChange: (value: AssigneeFilterEntry[]) => void
 }): JSX.Element {
-    const { search, filteredRoles, filteredMembers, rolesLoading, membersLoading } = useValues(assigneeSelectLogic)
+    const { search, filteredRoles, otherFilteredMembers, currentUserMember, rolesLoading, membersLoading } =
+        useValues(assigneeSelectLogic)
     const { setSearch, ensureAssigneeTypesLoaded } = useActions(assigneeSelectLogic)
     const [showPopover, setShowPopover] = useState(false)
 
@@ -80,6 +81,21 @@ export function AssigneeMultiSelect({
                                 </span>
                             </LemonButton>
                         </li>
+                        {currentUserMember && (
+                            <li>
+                                <AssigneeFilterItem
+                                    item={{
+                                        id: currentUserMember.user.id,
+                                        type: 'user',
+                                        user: currentUserMember.user,
+                                    }}
+                                    isSelected={isSelected}
+                                    onToggle={toggleEntry}
+                                    selectionCapReason={selectionCapReason}
+                                    labelSuffix={<span className="text-secondary">(you)</span>}
+                                />
+                            </li>
+                        )}
                         <Section
                             title="Roles"
                             loading={rolesLoading}
@@ -99,19 +115,21 @@ export function AssigneeMultiSelect({
                                 </LemonButton>
                             }
                         />
-                        <Section
-                            title="Users"
-                            loading={membersLoading}
-                            search={!!search}
-                            items={filteredMembers.map((member) => ({
-                                id: member.user.id,
-                                type: 'user' as const,
-                                user: member.user,
-                            }))}
-                            isSelected={isSelected}
-                            onToggle={toggleEntry}
-                            selectionCapReason={selectionCapReason}
-                        />
+                        {(!!search || membersLoading || otherFilteredMembers.length > 0) && (
+                            <Section
+                                title="Users"
+                                loading={membersLoading}
+                                search={!!search}
+                                items={otherFilteredMembers.map((member) => ({
+                                    id: member.user.id,
+                                    type: 'user' as const,
+                                    user: member.user,
+                                }))}
+                                isSelected={isSelected}
+                                onToggle={toggleEntry}
+                                selectionCapReason={selectionCapReason}
+                            />
+                        )}
                     </ul>
                 </div>
             }
@@ -156,11 +174,13 @@ const AssigneeFilterItem = ({
     isSelected,
     onToggle,
     selectionCapReason,
+    labelSuffix,
 }: {
     item: NonNullable<Assignee>
     isSelected: (entry: AssigneeFilterEntry) => boolean
     onToggle: (entry: AssigneeFilterEntry) => void
     selectionCapReason?: string
+    labelSuffix?: JSX.Element
 }): JSX.Element => {
     return (
         <LemonButton
@@ -174,6 +194,7 @@ const AssigneeFilterItem = ({
             <span className="flex items-center gap-1">
                 <AssigneeIconDisplay assignee={item} size="small" />
                 <AssigneeLabelDisplay assignee={item} />
+                {labelSuffix}
             </span>
         </LemonButton>
     )


### PR DESCRIPTION
## Problem

Follow-up to #72248, which hoisted the current user in the single-select assignee dropdown on the ticket view. The multi-select assignee filter on the tickets list still buries the current user inside the alphabetical Users section, below Roles, even though filtering to your own tickets is the most common use.

## Changes

Hoists the current user in the assignee filter dropdown: below the "Unassigned" entry, above the Roles section, labeled with a muted "(you)", and deduplicated out of the Users section. Reuses the `currentUserMember` / `otherFilteredMembers` selectors that #72248 added to `assigneeSelectLogic`, so the hoisted row is hidden while searching, same as the single-select. The Users section also hides entirely when there is nobody else to show.

Filter open, nothing selected:

![open-unselected](https://raw.githubusercontent.com/PostHog/pr-assets/99c9fc39264252ece14847225b0ec811160b0e59/2026/07/c7dbc17c-07da-4763-8e40-eed33e3194b6.png)

Multi-selection in use (current user + a teammate checked, trigger shows the count):

![multi-selected](https://raw.githubusercontent.com/PostHog/pr-assets/fdab77737deab33cef4aebce48a7c549d814cb8e/2026/07/97de3ebc-feda-456e-9b0a-cf344524d624.png)

## How did you test this code?

Verified live in local dev (screenshots above): hoisted row position, "(you)" label, checkbox toggling through the hoisted row, trigger count updating, and no duplicate in Users. Frontend typecheck passes with no errors in the changed file and the tickets scene jest suite passes. No new tests, per the same reasoning as #72248: presentation ordering over already-tested selectors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), directed by @xljones as a follow-up to #72248. Skills invoked: /run-posthog for live verification. Two commits: a pure extraction of the checkbox row into `AssigneeFilterItem` (mirroring #72248's `AssigneeItem`), then the hoist itself. No logic changes were needed since the selectors already exist; this PR only touches `AssigneeMultiSelect.tsx`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
