### PR TITLE
fix(organizations): stop infinite redirect loop on org lockout pages

### DIFF
--- a/frontend/src/lib/utils/kea-router.test.ts
+++ b/frontend/src/lib/utils/kea-router.test.ts
@@ -30,6 +30,20 @@ describe('router-utils', () => {
         expect(altered).toEqual('/project/123/feature_flags/123')
     })
 
+    describe('organization lockout pages', () => {
+        // These org-level pages must stay at the bare path: the backend middleware compares
+        // request.path against it exactly, and a /project/<id> prefix used to defeat the
+        // "already there" check in organizationLogic, causing an infinite redirect loop.
+        it.each([
+            ['/organization-pending-deletion', '/organization-pending-deletion'],
+            ['/project/123/organization-pending-deletion', '/organization-pending-deletion'],
+            ['/organization-deactivated', '/organization-deactivated'],
+            ['/project/123/organization-deactivated', '/organization-deactivated'],
+        ])('normalizes %s to %s', (input, expected) => {
+            expect(addProjectIdIfMissing(input, 123)).toEqual(expected)
+        })
+    })
+
     describe('relative path normalization', () => {
         it('normalizes ../ prefix to absolute path with project id', () => {
             expect(addProjectIdIfMissing('../dashboard/1663553', 112509)).toEqual('/project/112509/dashboard/1663553')

--- a/frontend/src/lib/utils/kea-router.ts
+++ b/frontend/src/lib/utils/kea-router.ts
@@ -7,6 +7,8 @@ const pathsWithoutProjectId = [
     'me',
     'instance',
     'organization',
+    'organization-deactivated',
+    'organization-pending-deletion',
     'preflight',
     'login',
     'signup',

--- a/frontend/src/scenes/organizationLogic.test.ts
+++ b/frontend/src/scenes/organizationLogic.test.ts
@@ -1,11 +1,14 @@
-import { MOCK_DEFAULT_ORGANIZATION } from 'lib/api.mock'
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM } from 'lib/api.mock'
 
+import { router } from 'kea-router'
+import type { LocationChangedPayload } from 'kea-router/lib/types'
 import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
 
-import { AppContext } from '../types'
+import { AppContext, OrganizationType } from '../types'
 import { organizationLogic } from './organizationLogic'
+import { urls } from './urls'
 
 describe('organizationLogic', () => {
     let logic: ReturnType<typeof organizationLogic.build>
@@ -58,6 +61,63 @@ describe('organizationLogic', () => {
             await expectLogic(logic).toMatchValues({
                 currentOrganization: { ...MOCK_DEFAULT_ORGANIZATION },
             })
+        })
+    })
+
+    describe('lockout redirects on locationChanged', () => {
+        const mountWithOrganization = async (organization: Partial<OrganizationType>): Promise<void> => {
+            initKeaTests(true, MOCK_DEFAULT_TEAM, MOCK_DEFAULT_PROJECT, {
+                ...MOCK_DEFAULT_ORGANIZATION,
+                ...organization,
+            })
+            logic = organizationLogic()
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadCurrentOrganizationSuccess'])
+        }
+
+        // Regression guard: the redirect used to recurse infinitely ("Maximum call stack size
+        // exceeded") because the replaced pathname came back with a /project/<id> prefix and
+        // never matched the bare lockout URL.
+        it.each<[string, Partial<OrganizationType>, string]>([
+            ['pending deletion', { is_pending_deletion: true }, urls.organizationPendingDeletion()],
+            ['deactivated', { is_active: false }, urls.organizationDeactivated()],
+        ])(
+            'navigation while the organization is %s settles on its bare lockout page',
+            async (_label, organization, lockoutPath) => {
+                await mountWithOrganization(organization)
+
+                router.actions.push('/dashboard')
+
+                expect(router.values.location.pathname).toEqual(lockoutPath)
+            }
+        )
+
+        it('does not redirect again when already on the lockout page', async () => {
+            await mountWithOrganization({ is_pending_deletion: true })
+
+            router.actions.push(urls.organizationPendingDeletion())
+
+            expect(router.values.location.pathname).toEqual(urls.organizationPendingDeletion())
+            await expectLogic(router).toNotHaveDispatchedActions(['replace'])
+        })
+
+        it('does not rewrite history on a POP to a legacy project-prefixed lockout URL', async () => {
+            await mountWithOrganization({ is_pending_deletion: true })
+            const prefixedLockoutUrl = `/project/${MOCK_DEFAULT_TEAM.id}${urls.organizationPendingDeletion()}`
+
+            // POP events (browser back/forward) bypass the router's path transforms, so the
+            // pathname can still carry a prefix recorded by an older client.
+            router.actions.locationChanged({
+                method: 'POP',
+                pathname: prefixedLockoutUrl,
+                search: '',
+                searchParams: {},
+                hash: '',
+                hashParams: {},
+                url: prefixedLockoutUrl,
+            } as LocationChangedPayload)
+
+            await expectLogic(router).toNotHaveDispatchedActions(['replace'])
         })
     })
 

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -11,6 +11,7 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { isUserLoggedIn } from 'lib/utils/getAppContext'
 import { getAppContext } from 'lib/utils/getAppContext'
+import { removeProjectIdIfPresent } from 'lib/utils/kea-router'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { AvailableFeature, OrganizationType } from '~/types'
@@ -333,13 +334,17 @@ export const organizationLogic = kea<organizationLogicType>([
             }
         },
         locationChanged: ({ pathname }) => {
+            // The pathname may carry a /project/<id> prefix, so strip it before comparing —
+            // otherwise the "already there" checks below never match and each replace
+            // re-triggers this listener in an infinite synchronous loop.
+            const path = removeProjectIdIfPresent(pathname)
             // Redirect to pending deletion page if organization deletion is in progress
-            if (values.currentOrganization?.is_pending_deletion && pathname !== urls.organizationPendingDeletion()) {
+            if (values.currentOrganization?.is_pending_deletion && path !== urls.organizationPendingDeletion()) {
                 router.actions.replace(urls.organizationPendingDeletion())
                 return
             }
             // Redirect to deactivated page if organization is inactive (client-side navigation)
-            if (values.currentOrganization?.is_active === false && pathname !== urls.organizationDeactivated()) {
+            if (values.currentOrganization?.is_active === false && path !== urls.organizationDeactivated()) {
                 router.actions.replace(urls.organizationDeactivated())
             }
         },

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -1,3 +1,5 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
 import { kea, path } from 'kea'
 import { router } from 'kea-router'
 import { expectLogic, partial, truth } from 'kea-test-utils'
@@ -5,6 +7,7 @@ import { expectLogic, partial, truth } from 'kea-test-utils'
 import api from 'lib/api'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { removeProjectIdIfPresent } from 'lib/utils/kea-router'
+import { organizationLogic } from 'scenes/organizationLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -102,6 +105,40 @@ describe('sceneLogic', () => {
         expect(logic.values.exportedScenes).toMatchObject({
             [Scene.DataManagement]: expectedAnnotation,
             [Scene.Settings]: expectedSettings,
+        })
+    })
+
+    describe('organization lockout', () => {
+        // Regression guard: openScene used to see a pending-deletion org (which loads without a
+        // membership level) as "unavailable" and redirect to /create-organization, while
+        // organizationLogic's locationChanged redirected straight back — an infinite synchronous
+        // replace loop ("Maximum call stack size exceeded").
+        it('loads the pending-deletion scene instead of redirecting to organization creation', async () => {
+            logic.unmount()
+            const priorAppContext = window.POSTHOG_APP_CONTEXT
+            try {
+                initKeaTests(true, MOCK_DEFAULT_TEAM, MOCK_DEFAULT_PROJECT, {
+                    ...MOCK_DEFAULT_ORGANIZATION,
+                    is_pending_deletion: true,
+                    membership_level: null,
+                })
+                ;(api.get as jest.Mock).mockResolvedValue({ tabs: [], homepage: null })
+                ;(api.update as jest.Mock).mockResolvedValue({ tabs: [], homepage: null })
+                await expectLogic(organizationLogic).toDispatchActions(['loadCurrentOrganizationSuccess'])
+                featureFlagLogic.mount()
+                const lockoutLogic = sceneLogic.build({
+                    scenes: { ...testScenes, [Scene.OrganizationPendingDeletion]: sceneImport },
+                })
+                lockoutLogic.mount()
+
+                router.actions.push(urls.organizationPendingDeletion())
+                await expectLogic(lockoutLogic).delay(1)
+
+                expect(lockoutLogic.values.sceneId).toEqual(Scene.OrganizationPendingDeletion)
+                expect(router.values.location.pathname).toEqual(urls.organizationPendingDeletion())
+            } finally {
+                window.POSTHOG_APP_CONTEXT = priorAppContext
+            }
         })
     })
 

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -798,7 +798,16 @@ export const sceneLogic = kea<sceneLogicType>([
                     return
                 }
 
-                if (sceneId !== Scene.InviteSignup) {
+                // While the org is pending deletion or deactivated, organizationLogic's
+                // locationChanged listener steers all navigation to the matching lockout
+                // scene. Redirecting to org/project creation or onboarding here would fight
+                // it in an infinite synchronous replace loop (kea-router has no same-URL
+                // short-circuit), so these redirects only apply to healthy orgs.
+                const { currentOrganization } = organizationLogic.values
+                const orgInLockoutState =
+                    currentOrganization?.is_pending_deletion || currentOrganization?.is_active === false
+
+                if (sceneId !== Scene.InviteSignup && !orgInLockoutState) {
                     // Redirect to org/project creation if there's no org/project respectively, unless using invite
                     if (organizationLogic.values.isCurrentOrganizationUnavailable) {
                         if (


### PR DESCRIPTION
## Problem

When an organization is pending deletion (or deactivated), the app can enter an infinite client-side redirect loop that crashes the tab with `InternalError: too much recursion` (Firefox) or `RangeError: Maximum call stack size exceeded` (Chrome). This shows up as recurring issues in our own error tracking ([Firefox variant](https://us.posthog.com/project/2/error_tracking/019f7fc7-4708-7e10-979e-5aef99afbaeb), [Chrome variant](https://us.posthog.com/project/2/error_tracking/019b387c-4b1b-73d1-bb30-6100255f0b3c)), hitting users right after they delete their organization from the danger zone.

Two loop variants, same root: kea-router dispatches `locationChanged` synchronously on every `push`/`replace` with no same-URL short-circuit, so any pair of competing redirects recurses in one call stack.

1. **Ping-pong**: `sceneLogic.openScene` sees a pending-deletion org (which loads without a `membership_level`) as "unavailable" and redirects to `/create-organization`, while `organizationLogic.locationChanged` redirects straight back to `/organization-pending-deletion`.
2. **Self-loop**: `organizationLogic` compared the raw pathname against the bare lockout URL, but the router prefixes pathnames with `/project/<id>` (neither lockout page was in `pathsWithoutProjectId`), so the "already there" guard never matched and the replace looped onto itself.

Before:

```mermaid
flowchart LR
    A["locationChanged"] --> B{{"organizationLogic sees org pending deletion"}}
    B -->|"replace /organization-pending-deletion"| C{{"openScene sees org unavailable"}}
    C -->|"replace /create-organization"| A
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class B,C phBlue;
    class A phRed;
```

After:

```mermaid
flowchart LR
    A["locationChanged"] --> B{{"organizationLogic compares normalized path"}}
    B -->|"already on lockout page, no-op"| D["stays on /organization-pending-deletion"]
    C{{"openScene, org in lockout state"}} -->|"skips create-org and onboarding redirects"| D
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class B,C phBlue;
    class D phYellow;
```

## Changes

- `sceneLogic.tsx`: `openScene` no longer runs its create-org / create-project / onboarding redirects while the current org is pending deletion or deactivated. In those states `organizationLogic.locationChanged` is the single authority steering to the lockout page. Once the org is fully deleted (`currentOrganization` becomes null) the existing create-org redirect resumes, so org-less users are not stranded.
- `organizationLogic.tsx`: normalize the pathname with `removeProjectIdIfPresent` before comparing against the lockout URLs, so the "already there" guard also holds for project-prefixed URLs (e.g. from history entries recorded by older clients).
- `lib/utils/kea-router.ts`: add `organization-pending-deletion` and `organization-deactivated` to `pathsWithoutProjectId`. These are org-level pages and the backend `ActiveOrganizationMiddleware` matches them by exact path, so they must stay bare.

## How did you test this code?

Automated tests only (no manual browser testing):

- `organizationLogic.test.ts`: navigating anywhere while the org is pending deletion / deactivated settles on the bare lockout path with a single replace, and no further replace fires when already on the page (including a POP to a legacy `/project/<id>`-prefixed lockout URL). Catches the self-loop regression: without the fix these tests fail with the production `RangeError: Maximum call stack size exceeded`.
- `sceneLogic.test.tsx`: with a pending-deletion org that has no membership level, opening the lockout page loads `Scene.OrganizationPendingDeletion` instead of redirecting to `/create-organization`. Catches the ping-pong regression, same stack-overflow failure without the fix.
- `kea-router.test.ts`: `addProjectIdIfMissing` leaves both lockout paths bare and strips a stale project prefix. Pins the bare-path contract the backend middleware relies on; no existing test covered these paths.

I verified all seven new tests fail against the unfixed code (reproducing the exact production crash) and pass with the fix. Existing tests in the three touched files still pass (49 total).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal navigation behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude via PostHog Code. The session started from an error tracking issue investigation (`posthog:investigating-error-issue` skill) which traced the production stack frames line-for-line to the redirect war described above, then confirmed the Chrome-variant issue shares the same `organizationLogic.locationChanged` frame with a project-prefixed URL.
- Skills invoked: `posthog:investigating-error-issue`, `/writing-tests`.
- Design decision: the `openScene` guard is state-based (`is_pending_deletion` / `is_active === false`) rather than a scene-id exemption. A scene-id exemption would strand users on the lockout screen after deletion completes (org gone means the create-org redirect is the only exit) and would still allow redirect churn on other scenes while the org is blocked.
- Deliberately not included: the analogous project-deletion vector (`projectLogic.guardPendingDeletion` vs the onboarding redirect) is narrower (only fires for a fresh project deleted before ingesting events) and its guard is already prefix-safe, so it is left for a follow-up if it shows up in error tracking.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
