### PR TITLE
fix(ci): cancel superseded backend jobs promptly

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -721,7 +721,7 @@ jobs:
         name: Build product test matrix
         needs: [turbo-discover]
         if: >-
-            always() && needs.turbo-discover.result == 'success' && needs.turbo-discover.outputs.matrix != '[]' && needs.turbo-discover.outputs.matrix != ''
+            !cancelled() && needs.turbo-discover.result == 'success' && needs.turbo-discover.outputs.matrix != '[]' && needs.turbo-discover.outputs.matrix != ''
         runs-on: depot-ubuntu-latest
         timeout-minutes: 5
         outputs:
@@ -745,10 +745,12 @@ jobs:
     # Runs product tests in parallel — one matrix job per group
     # Each job gets its own runner + Docker stack, so no shared DB conflicts
     # Small products (< 50 tests) are grouped into a single job to avoid setup overhead
+    # A status function is required to inspect dependency results after failures.
+    # Use !cancelled(), not always(), so superseded matrix jobs still receive cancellation.
     turbo-tests:
         needs: [changes, turbo-discover, detect-snapshot-mode, build-product-test-matrix, get_clickhouse_versions]
         if: >-
-            always() && (github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'run-ci-backend')) && needs.turbo-discover.result == 'success' && needs.build-product-test-matrix.result == 'success' && needs.build-product-test-matrix.outputs.include != '[]' && needs.build-product-test-matrix.outputs.include != ''
+            !cancelled() && (github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'run-ci-backend')) && needs.turbo-discover.result == 'success' && needs.build-product-test-matrix.result == 'success' && needs.build-product-test-matrix.outputs.include != '[]' && needs.build-product-test-matrix.outputs.include != ''
         runs-on: depot-ubuntu-latest
         timeout-minutes: 40
         name: Product tests (${{ matrix.group }}, events schema ${{ matrix.new-events-schema && 'json' || 'legacy' }})
@@ -1233,7 +1235,7 @@ jobs:
         name: Build Django matrix
         needs: [changes, get_clickhouse_versions, turbo-discover, select-tests]
         if: |
-            always() &&
+            !cancelled() &&
             needs.changes.outputs.backend == 'true' &&
             needs.get_clickhouse_versions.result == 'success'
         runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
@@ -1499,8 +1501,10 @@ jobs:
         # 3. OR turbo-discover itself failed (conservative: run Django on detection failure)
         # The non-empty include guard covers drafts in skip mode and selected runs
         # that chose zero files — an empty matrix would otherwise fail the job.
+        # A status function is required to inspect dependency results after failures.
+        # Use !cancelled(), not always(), so superseded matrix jobs still receive cancellation.
         if: |
-            always() &&
+            !cancelled() &&
             needs.changes.outputs.backend == 'true' &&
             needs.build_django_matrix.result == 'success' &&
             needs.build_django_matrix.outputs.include != '[]' &&

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -689,6 +689,7 @@ jobs:
     # Runs product tests in parallel — one matrix job per group
     # Each job gets its own runner + Docker stack, so no shared DB conflicts
     # Small products (< 50 tests) are grouped into a single job to avoid setup overhead
+    # Keep this cancellation-aware: always() prevents superseded matrix jobs from receiving runner cancellation.
     turbo-tests:
         needs: [changes, turbo-discover, detect-snapshot-mode, build-product-test-matrix, get_clickhouse_versions]
         if: >-
@@ -2355,6 +2356,7 @@ jobs:
         # 3. OR turbo-discover itself failed (conservative: run Django on detection failure)
         # The non-empty include guard covers drafts in skip mode and selected runs
         # that chose zero files — an empty matrix would otherwise fail the job.
+        # Keep this cancellation-aware: always() prevents superseded matrix jobs from receiving runner cancellation.
         if: |
             !cancelled() &&
             needs.changes.outputs.backend == 'true' &&
@@ -3164,6 +3166,7 @@ jobs:
         runs-on: ubuntu-latest
         # Headroom for downloading every shard's JUnit for the failure rollup.
         timeout-minutes: 8
+        # Intentional exception: this required gate must evaluate cancelled dependencies and fail closed.
         if: always()
         steps:
             - name: Summarize dependency results

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -689,7 +689,8 @@ jobs:
     # Runs product tests in parallel — one matrix job per group
     # Each job gets its own runner + Docker stack, so no shared DB conflicts
     # Small products (< 50 tests) are grouped into a single job to avoid setup overhead
-    # Keep this cancellation-aware: always() prevents superseded matrix jobs from receiving runner cancellation.
+    # A status function is required to inspect dependency results after failures.
+    # Use !cancelled(), not always(), so superseded matrix jobs still receive cancellation.
     turbo-tests:
         needs: [changes, turbo-discover, detect-snapshot-mode, build-product-test-matrix, get_clickhouse_versions]
         if: >-
@@ -2356,7 +2357,8 @@ jobs:
         # 3. OR turbo-discover itself failed (conservative: run Django on detection failure)
         # The non-empty include guard covers drafts in skip mode and selected runs
         # that chose zero files — an empty matrix would otherwise fail the job.
-        # Keep this cancellation-aware: always() prevents superseded matrix jobs from receiving runner cancellation.
+        # A status function is required to inspect dependency results after failures.
+        # Use !cancelled(), not always(), so superseded matrix jobs still receive cancellation.
         if: |
             !cancelled() &&
             needs.changes.outputs.backend == 'true' &&
@@ -3166,7 +3168,8 @@ jobs:
         runs-on: ubuntu-latest
         # Headroom for downloading every shard's JUnit for the failure rollup.
         timeout-minutes: 8
-        # Intentional exception: this required gate must evaluate cancelled dependencies and fail closed.
+        # Intentional always(): this required gate must inspect failed and cancelled
+        # dependencies and fail closed.
         if: always()
         steps:
             - name: Summarize dependency results

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -651,7 +651,7 @@ jobs:
         name: Build product test matrix
         needs: [turbo-discover]
         if: >-
-            always() &&
+            !cancelled() &&
             needs.turbo-discover.result == 'success' &&
             needs.turbo-discover.outputs.matrix != '[]' &&
             needs.turbo-discover.outputs.matrix != ''
@@ -692,7 +692,7 @@ jobs:
     turbo-tests:
         needs: [changes, turbo-discover, detect-snapshot-mode, build-product-test-matrix, get_clickhouse_versions]
         if: >-
-            always() &&
+            !cancelled() &&
             (github.event.pull_request.draft != true ||
              contains(github.event.pull_request.labels.*.name, 'run-ci-backend')) &&
             needs.turbo-discover.result == 'success' &&
@@ -2069,7 +2069,7 @@ jobs:
         name: Build Django matrix
         needs: [changes, get_clickhouse_versions, turbo-discover, select-tests]
         if: |
-            always() &&
+            !cancelled() &&
             needs.changes.outputs.backend == 'true' &&
             needs.get_clickhouse_versions.result == 'success'
         runs-on: depot-ubuntu-latest
@@ -2356,7 +2356,7 @@ jobs:
         # The non-empty include guard covers drafts in skip mode and selected runs
         # that chose zero files — an empty matrix would otherwise fail the job.
         if: |
-            always() &&
+            !cancelled() &&
             needs.changes.outputs.backend == 'true' &&
             needs.build_django_matrix.result == 'success' &&
             needs.build_django_matrix.outputs.include != '[]' &&
@@ -3079,7 +3079,7 @@ jobs:
         needs: [changes, detect-snapshot-mode, django, turbo-tests]
         # Only in UPDATE mode - CHECK mode verifies snapshots match exactly
         # Run even if some matrix jobs failed (to commit snapshots from passing jobs)
-        if: ${{ always() && needs.detect-snapshot-mode.outputs.mode == 'update' && needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+        if: ${{ !cancelled() && needs.detect-snapshot-mode.outputs.mode == 'update' && needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
         runs-on: ubuntu-latest
         timeout-minutes: 5
         permissions:
@@ -3334,7 +3334,7 @@ jobs:
     test-selection-verdict:
         needs: [django, turbo-tests, changes, select-tests]
         name: Test selection verdict
-        if: always() && github.event_name == 'pull_request'
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:
@@ -3412,8 +3412,9 @@ jobs:
         needs: [django_tests]
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks or Dependabot (no secrets access)
-            always() && github.actor != 'dependabot[bot]' && (
+        # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks or Dependabot (no secrets access)
+        if: >-
+            !cancelled() && github.actor != 'dependabot[bot]' && (
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'PostHog/posthog') ||
             (github.event_name != 'pull_request' && github.repository == 'PostHog/posthog'))
         steps:
@@ -3459,7 +3460,7 @@ jobs:
         # continue-on-error so telemetry never reds CI. Skipped on forks/Dependabot,
         # which never have the secret (and where select-tests didn't run anyway).
         if: |
-            always() && github.run_attempt == '1'
+            !cancelled() && github.run_attempt == '1'
             && github.actor != 'dependabot[bot]'
             && github.event.pull_request.head.repo.full_name == 'PostHog/posthog'
             && needs.select-tests.result == 'success'
@@ -3494,7 +3495,7 @@ jobs:
         timeout-minutes: 10
         # Master pushes and all in-repo PRs. Skip forks (no secrets access).
         if: >-
-            always() &&
+            !cancelled() &&
             github.repository == 'PostHog/posthog' &&
             (
             (github.event_name != 'pull_request' && github.ref == 'refs/heads/master') ||
@@ -3560,7 +3561,7 @@ jobs:
         # post-coverage-section.mjs) — never add secrets beyond github.token to this job
         # (report-test-timings checks out the base ref for exactly this reason).
         if: >-
-            always() &&
+            !cancelled() &&
             github.event_name == 'pull_request' &&
             github.event.pull_request.draft == false &&
             github.event.pull_request.head.repo.full_name == 'PostHog/posthog' &&


### PR DESCRIPTION
## Problem

Superseded Backend CI runs hold the concurrency slot. Job-level `always()` stays true during cancellation, so stale Django and product shards still dispatch and run to completion.

## Changes

- Swap `always()` for `!cancelled()` on matrix prep, test matrices, snapshots, and optional reporting.
- Mirror the four applicable jobs in the Depot shadow.
- Keep `always()` on the required `Django Tests Pass` gate and the deterministic-failure cancel jobs.

## How did you test this code?

Probe workflow pushed to a throwaway branch, then superseded mid-run: [run 29765284128](https://github.com/PostHog/posthog/actions/runs/29765284128). `matrix_build` succeeded before the cancel landed, so `!cancelled()` vs `always()` was the only difference between the two shard jobs.

| Job | Condition | Result |
| --- | --- | --- |
| `shard_always` | `always() && needs.matrix_build.result == 'success'` | `success`, 3 steps. Dispatched and ran to completion after the cancel. |
| `shard_nc` | `!cancelled() && needs.matrix_build.result == 'success'` | `cancelled`, 0 steps. Never dispatched. |

Gate job read: `shard_nc=cancelled`, `shard_always=success`.

Two conclusions:

- `always()` is what kept stale shards alive. Signal traps could not help, because the job never received cancellation.
- `!cancelled()` reports `cancelled`, never `skipped`, so `check_required_result` still fails closed. No green-gate-on-cancel regression.

Also ran `uv run hogli lint:workflows`, actionlint, and `hogli ci:preflight --fix`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs update is needed.

## Follow-up

`calculate-running-time` stops emitting `posthog-ci-running-time` on cancelled runs, so DevEx CI dashboards measuring run volume or mean duration will step-change on merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Native cancellation-aware conditions were chosen over signal wrappers or an API-polling watchdog, then verified against a live superseded run rather than reasoned about. The required gate deliberately keeps `always()` so it always emits an explicit verdict.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
