### PR TITLE
chore(ci): port trunk quarantine entries

### DIFF
--- a/.test_quarantine.json
+++ b/.test_quarantine.json
@@ -1,4 +1,77 @@
 {
     "version": 1,
-    "entries": []
+    "entries": [
+        {
+            "id": "ee/hogai/chat_agent/query_planner/test/test_toolkit.py::TestTaxonomyAgentToolkit::test_retrieve_event_or_action_property_values",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "@team-self-driving",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/hogql/transforms/test/test_property_types.py::TestPropertyTypes::test_exception_array_property_extracted_for_array_membership_functions_0_has",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "@team-data-tools",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/hogql/transforms/test/test_property_types.py::TestPropertyTypes::test_exception_array_property_extracted_for_array_membership_functions_1_hasAny",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "@team-data-tools",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/hogql/transforms/test/test_property_types.py::TestPropertyTypes::test_exception_array_property_extracted_for_array_membership_functions_2_hasAll",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "@team-data-tools",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/temporal/tests/data_modeling/test_run_workflow.py::test_run_workflow_timeout_does_not_pause_schedule_without_consecutive_failures",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "(unowned)",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/temporal/tests/data_modeling/test_run_workflow.py::test_run_workflow_timeout_pauses_schedule_after_5_consecutive_failures",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "(unowned)",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/temporal/tests/data_modeling/test_run_workflow.py::test_run_workflow_with_minio_bucket",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "(unowned)",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/test/test_startup_import_budget.py::test_setup_receivers_match_baseline",
+            "runner": "pytest",
+            "reason": "flaky on master; ported from Trunk quarantine",
+            "owner": "(unowned)",
+            "added": "2026-07-20",
+            "expires": "2026-08-19",
+            "mode": "run"
+        }
+    ]
 }


### PR DESCRIPTION
## Problem

- Trunk uploads and quarantine gates were switched off in #72143, so the tests Trunk had been auto-quarantining now red CI with no flake net.

## Changes

- Add 8 pytest entries to `.test_quarantine.json` (mode `run`, expire 2026-08-19), taken from the quarantine summaries in recent master run logs.
- Enforced immediately by the existing conftest xfail adapter, no code changes.

## How did you test this code?

- `hogli test:quarantine check` passes (8 entries OK).
- No new tests: data-only change covered by the existing quarantine contract suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude, via Claude Code) grepped recent Actions log archives for trunk-cli quarantine summaries to build the list, Raúl directed.
- The ClickHouse 26.3 union-distinct trio was deliberately not ported since #72289 merged its workaround.
- Owners resolved with `hogli owners:resolve`, two paths are unowned and marked as such.
