### PR TITLE
chore(aio): remove unused llm-analytics-user-feedback flag constant

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -346,7 +346,6 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_OFFLINE_EVALS: 'llm-analytics-offline-evals', // owner: #team-ai-observability
     LLM_ANALYTICS_TAGS: 'llm-analytics-tags', // owner: #team-ai-observability
     LLM_ANALYTICS_TRACE_NAVIGATION: 'llm-analytics-trace-navigation', // owner: #team-ai-observability
-    LLM_ANALYTICS_USER_FEEDBACK: 'llm-analytics-user-feedback', // owner: @adboio #team-surveys
     LLM_OBSERVABILITY_TRACE_SEARCH: 'llm-observability-trace-search', // owner: #team-ai-observability
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs


### PR DESCRIPTION
## Problem

The `llm-analytics-user-feedback` feature flag (constant `LLM_ANALYTICS_USER_FEEDBACK` in `constants.tsx`) is dead config. It backed a beta early access feature for AI observability user feedback, but no code ever reads it: the flag key and its constant appear only at their declaration and nowhere else in the frontend or backend. The AI observability Feedback tab it was nominally gating renders unconditionally (`showFeedbackTab = true`), so the flag's rollout had no bearing on who could use the feature.

The early access feature has been removed separately. This PR cleans up the leftover constant.

## Changes

- Remove the unused `LLM_ANALYTICS_USER_FEEDBACK` entry from `frontend/src/lib/constants.tsx`.

No behavior change: nothing consumed the flag, and the Feedback tab stays available to everyone exactly as before.

## How did you test this code?

No manual testing. This is a one-line removal of a constant with zero references — verified via a repo-wide search that the flag key and its constant symbol appeared only at the declaration site before removal. I (the agent) did not run the frontend build or test suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by a PostHog employee via Slack. The task was to remove the dead `llm-analytics-user-feedback` early access feature and its unused code. I deleted the early access feature via the PostHog API (which clears enrollment conditions from the linked flag but leaves the flag record itself), then confirmed the flag key was referenced nowhere in the codebase before removing the constant. The underlying feature flag record is left intact and can be deleted separately if desired.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784561232389969?thread_ts=1784561232.389969&cid=C087XQ7K9K7)*
