### PR TITLE
feat(cymbal): set posthog-android and posthog-server wire-order cutoffs

### DIFF
--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -102,6 +102,13 @@ fn lib_rules() -> &'static [LibRule] {
                     "posthog-php" => Some(Version::new(4, 11, 0)),
                     // posthog-go ships the flip in 1.20.0 (PostHog/posthog-go#254).
                     "posthog-go" => Some(Version::new(1, 20, 0)),
+                    // android + the java server SDK flip together (shared
+                    // coercer, one release train: PostHog/posthog-android#603),
+                    // but each module reports its own version stream.
+                    "posthog-android" => Some(Version::new(3, 56, 0)),
+                    "posthog-server" => Some(Version::new(2, 9, 0)),
+                    // `posthog-java` is the tombstoned legacy SDK: it will
+                    // never ship the flip, so no cutoff, ever.
                     _ => None,
                 },
             })
@@ -317,6 +324,43 @@ mod test {
         // Natively-canonical SDKs have no legacy order.
         assert!(legacy_wire_order(Some("posthog-node"), &canonical).is_none());
         assert!(legacy_wire_order(None, &canonical).is_none());
+    }
+
+    #[test]
+    fn android_and_server_cutoffs_gate_normalization_by_version() {
+        // Both modules flip in one release train but carry separate version
+        // streams; each gate keys on its own module's version.
+        for (lib, below, at) in [
+            ("posthog-android", "3.55.2", "3.56.0"),
+            ("posthog-server", "2.8.1", "2.9.0"),
+        ] {
+            for version in [Some(below), Some("1.0.0"), Some("garbage"), None] {
+                let mut list: ExceptionList =
+                    vec![exception_with_frames("Boom", &["main", "boom"])].into();
+                let legacy = normalize_wire_order(&mut list, Some(lib), version);
+                assert!(legacy.is_some(), "{lib} {version:?} should normalize");
+                assert_eq!(frame_names(&list[0]), vec!["boom", "main"]);
+            }
+
+            let mut list: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = normalize_wire_order(&mut list, Some(lib), Some(at));
+            assert!(legacy.is_none(), "{lib} {at} should pass through");
+            assert_eq!(frame_names(&list[0]), vec!["main", "boom"]);
+
+            // Legacy hashing still reconstructs pre-flip order post-cutoff.
+            let canonical: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = legacy_wire_order(Some(lib), &canonical)
+                .expect("reconstruction must ignore the cutoff");
+            assert_eq!(frame_names(&legacy[0]), vec!["boom", "main"]);
+        }
+
+        // The tombstoned java SDK keeps normalizing at any version.
+        let mut list: ExceptionList = vec![exception_with_frames("Boom", &["main", "boom"])].into();
+        let legacy = normalize_wire_order(&mut list, Some("posthog-java"), Some("99.0.0"));
+        assert!(legacy.is_some(), "posthog-java has no cutoff");
+        assert_eq!(frame_names(&list[0]), vec!["boom", "main"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Fourth step of the wire-order rollout (PostHog/sdk-specs#11), and the first double-entry one: the android SDK and the java server SDK share their stack-building code (the core module's ThrowableCoercer) and release from one train — PostHog/posthog-android#603 flips both with a single merge (its changeset bumps core + posthog-android + posthog-server together). Each module reports its own `$lib`/`$lib_version`, so the gate needs two cutoffs landing together:

- `posthog-android` → **3.56.0** (current 3.55.3 + minor)
- `posthog-server` → **2.9.0** (current 2.8.1 + minor)

`posthog-java` (the tombstoned legacy SDK) never ships the flip and deliberately keeps no cutoff.

## Changes

- Both table entries above, plus a parameterized gate test covering each module (below-cutoff/unparseable/missing normalize; at-cutoff passes through; legacy reconstruction ignores the cutoff) and a pin that `posthog-java` normalizes at any version, forever.

## Merge sequencing — tighter than usual

The android repo releases frequently, so the version-claim window here is hot. Same-day choreography:

1. Immediately before merging this, re-verify `androidVersion` / `serverVersion` on posthog-android main are still at 3.55.x / 2.8.x with no unrelated minor released (a claim by an unrelated release means renumbering, as happened with php 4.10.0 / go 1.19.0).
2. Merge this, wait for cymbal autodeploy.
3. Merge PostHog/posthog-android#603 the same day and let the release train cut 3.56.0 + 2.9.0.
4. No other posthog-android-repo release between steps 2 and 3 (patches of the current minors are fine). Worth a heads-up to the mobile team for the window.

Watch `et-wire-order-launch` as with rs/php/go. Android fleet adoption will be months-long (mobile), which stretches the legacy-decay curve but not the risk: pre-flip events keep matching via snapshot hashes, post-flip via reconstruction.

## How did you test this code?

Automated only: new parameterized `android_and_server_cutoffs_gate_normalization_by_version` unit test; normalization module green (14 tests); clippy `-D warnings` and fmt clean. Fourth instance of the reviewed cutoff pattern (#69837 / #70879 / #71365).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Rollout process documented in the sdk-specs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this under my direction after investigating the android/server release coupling (separate version streams per module, but a shared coercer and a changeset that bumps all three modules — so one merge flips both `$lib`s, hence one cutoff PR with two entries). Targets derived from module versions on main plus #603's changeset; no other changesets queued.

