### PR TITLE
fix(postgres): treat source-side read-only transaction writes as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -644,6 +644,22 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # against the source data, so retrying re-evaluates the same view and hits the same row.
             "cannot call jsonb_each on a non-object": "A view you're syncing calls jsonb_each() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
             "cannot call jsonb_each_text on a non-object": "A view you're syncing calls jsonb_each_text() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each_text() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
+            # A selected relation's own definition writes to the database while we read it — a view or
+            # trigger that calls a function which runs REFRESH MATERIALIZED VIEW (or INSERT/UPDATE/DELETE).
+            # We read inside a read-only transaction and never write to the source, so Postgres rejects
+            # the write with SQLSTATE 25006 "cannot execute <stmt> in a read-only transaction". The write
+            # lives in the customer's schema and is deterministic, so retrying re-reads into the same
+            # wall. Match the stable read-only-transaction phrase and exclude the volatile statement
+            # kind and relation name; it appears in both the raw activity-level str(e) and the
+            # Temporal-wrapped "ReadOnlySqlTransaction: ..." workflow-level form.
+            "in a read-only transaction": (
+                "One of the tables or views you selected to sync tries to write to your database while "
+                "PostHog is reading it (for example a view or trigger that refreshes a materialized "
+                "view), and PostHog reads inside a read-only transaction so the write is rejected "
+                '("cannot execute ... in a read-only transaction"). PostHog never writes to your '
+                "source. Remove that relation from the sync, or change its definition so reading it "
+                "doesn't perform a write, then re-enable the sync."
+            ),
             # A selected relation is a postgres_fdw foreign table and the connecting role has no user
             # mapping for the foreign server it points at, so every SELECT fails with
             # "UndefinedObject: user mapping not found for user <user>, server <server>" (SQLSTATE

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -882,6 +882,30 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)) — a view/trigger
+            # function refreshing a materialized view during our read-only SELECT.
+            'cannot execute REFRESH MATERIALIZED VIEW in a read-only transaction\nCONTEXT:  SQL statement "REFRESH MATERIALIZED VIEW CONCURRENTLY analyticssnapshot"',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "ReadOnlySqlTransaction: cannot execute REFRESH MATERIALIZED VIEW in a read-only transaction",
+            # Same class of upstream write via a different statement — the match must generalize.
+            "cannot execute INSERT in a read-only transaction",
+        ],
+    )
+    def test_readonly_transaction_write_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Write in a read-only transaction should be non-retryable: {error_msg}"
+
+    def test_readonly_transaction_write_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = "cannot execute REFRESH MATERIALIZED VIEW in a read-only transaction"
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Write in a read-only transaction should surface an actionable message"
+        assert "read-only transaction" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "cannot call jsonb_each on a non-object",
             "InvalidParameterValue: cannot call jsonb_each on a non-object",
             "cannot call jsonb_each_text on a non-object",


### PR DESCRIPTION
## Problem

The `postgres` data-warehouse import source surfaced a recurring error in error tracking:

- **Exception:** `ReadOnlySqlTransaction`
- **Message:** `cannot execute REFRESH MATERIALIZED VIEW in a read-only transaction` (raised from a `PL/pgSQL` function in the customer's own schema, e.g. a `REFRESH MATERIALIZED VIEW CONCURRENTLY ...`)
- Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f803f-57bf-7d40-a84f-b380e3a9f299

The stack originates in this source's read path (`.../sources/postgres/postgres.py` `get_rows` → server-side cursor `fetchmany`). The import reads inside a read-only transaction and never writes to the source. When a selected table/view's own definition performs a write while we read it — a view or trigger that calls a function running `REFRESH MATERIALIZED VIEW` (or `INSERT`/`UPDATE`/`DELETE`) — Postgres rejects it with SQLSTATE 25006.

This is a user/upstream condition: the write lives in the customer's schema and is deterministic, so Temporal retrying the whole activity just re-reads into the same wall and re-surfaces as error-tracking noise.

## Changes

- Add the stable `"in a read-only transaction"` phrase to `PostgresSource.get_non_retryable_errors` with an actionable message telling the user to remove the relation from the sync or change its definition so reading it doesn't perform a write. The match excludes the volatile statement kind and relation name, and works at both the raw activity-level `str(e)` and the Temporal-wrapped `ReadOnlySqlTransaction: ...` workflow-level form.

**Why:** so a customer view/trigger that writes during our read-only read stops retrying forever and instead surfaces one clear, actionable message — matching how the source already handles other deterministic upstream conditions (unpopulated materialized views, `jsonb_each` on non-objects, missing FDW user mappings).

## How did you test this code?

Added parameterized unit tests in `test_postgres.py`:

- `test_readonly_transaction_write_is_non_retryable` — covers the raw psycopg `REFRESH MATERIALIZED VIEW` message, the Temporal-wrapped `ReadOnlySqlTransaction: ...` form, and a different write statement (`INSERT`) to prove the match generalizes. Regression guard: catches anyone removing/narrowing the new key so this upstream error would silently become retryable again.
- `test_readonly_transaction_write_returns_friendly_message` — asserts the entry surfaces an actionable message.

Ran the new and adjacent non-retryable tests locally (`uv run pytest ... -k "readonly_transaction or read_only_cluster or unpopulated_materialized"`): 10 passed. No manual end-to-end run was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `postgres` import source. Confirmed the issue in PostHog error tracking (pulled the stack trace and a representative event) and verified the failure originates in this source's read path. Classified it as a user/upstream error (deterministic write in the customer's schema during our read-only read) rather than a fixable bug, and extended `get_non_retryable_errors` following the existing Stripe/Postgres precedent. Invoked the `/writing-tests` skill before adding tests. Checked open PRs (including the maintainer's own) for a duplicate — none addresses this error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
