### PR TITLE
feat(conversations): join filter clear buttons to dropdown triggers

### DIFF
--- a/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
+++ b/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
@@ -1,11 +1,12 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconChevronDown, IconPlusSmall } from '@posthog/icons'
+import { IconPlusSmall } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDropdown, LemonInput } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
+import { clearFilterButtonProps } from '../clearFilterButtonProps'
 import { AssigneeIconDisplay, AssigneeLabelDisplay, AssigneeResolver } from './AssigneeDisplay'
 import { assigneeSelectLogic } from './assigneeSelectLogic'
 import { Assignee, AssigneeFilterEntry, MAX_ASSIGNEE_FILTER_ENTRIES } from './types'
@@ -116,7 +117,12 @@ export function AssigneeMultiSelect({
                 </div>
             }
         >
-            <LemonButton size="small" type="secondary" active={showPopover} sideIcon={<IconChevronDown />}>
+            <LemonButton
+                size="small"
+                type="secondary"
+                active={showPopover}
+                {...clearFilterButtonProps(value.length > 0 ? () => onChange([]) : null, 'Clear assignee filter')}
+            >
                 <TriggerLabel value={value} />
             </LemonButton>
         </LemonDropdown>

--- a/products/conversations/frontend/components/clearFilterButtonProps.tsx
+++ b/products/conversations/frontend/components/clearFilterButtonProps.tsx
@@ -1,0 +1,20 @@
+import { IconChevronDown, IconX } from '@posthog/icons'
+import { SideAction } from '@posthog/lemon-ui'
+
+export function clearFilterButtonProps(
+    onClear: (() => void) | null,
+    tooltip: string
+): { sideAction: SideAction; sideIcon?: undefined } | { sideIcon: JSX.Element; sideAction?: undefined } {
+    return onClear
+        ? {
+              sideAction: {
+                  icon: <IconX />,
+                  tooltip,
+                  onClick: (e) => {
+                      e.stopPropagation()
+                      onClear()
+                  },
+              },
+          }
+        : { sideIcon: <IconChevronDown /> }
+}

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -3,7 +3,7 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useMemo, useRef } from 'react'
 
-import { IconChevronDown, IconClock, IconRefresh, IconX } from '@posthog/icons'
+import { IconChevronDown, IconClock, IconRefresh } from '@posthog/icons'
 import {
     LemonBadge,
     LemonButton,
@@ -38,6 +38,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 
 import { AssigneeDisplay, AssigneeMultiSelect, AssigneeResolver } from '../../components/Assignee'
 import { ChannelsTag } from '../../components/Channels/ChannelsTag'
+import { clearFilterButtonProps } from '../../components/clearFilterButtonProps'
 import { ComposeTicketButton } from '../../components/ComposeTicket'
 import { ConversationsDisabledBanner } from '../../components/ConversationsDisabledBanner'
 import { IdentityBadge } from '../../components/IdentityBadge/IdentityBadge'
@@ -505,7 +506,14 @@ export function SupportTicketsTableFilters(): JSX.Element {
                         </div>
                     }
                 >
-                    <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        {...clearFilterButtonProps(
+                            statusFilter.length > 0 ? () => setStatusFilter([]) : null,
+                            'Clear status filter'
+                        )}
+                    >
                         {statusFilter.length === 0
                             ? 'All statuses'
                             : statusFilter.length === 1
@@ -542,7 +550,14 @@ export function SupportTicketsTableFilters(): JSX.Element {
                         </div>
                     }
                 >
-                    <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        {...clearFilterButtonProps(
+                            priorityFilter.length > 0 ? () => setPriorityFilter([]) : null,
+                            'Clear priority filter'
+                        )}
+                    >
                         {priorityFilter.length === 0
                             ? 'All priorities'
                             : priorityFilter.length === 1
@@ -628,7 +643,14 @@ export function SupportTicketsTableFilters(): JSX.Element {
                             </div>
                         }
                     >
-                        <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            {...clearFilterButtonProps(
+                                aiTriageResultFilter.length > 0 ? () => setAiTriageResultFilter([]) : null,
+                                'Clear AI result filter'
+                            )}
+                        >
                             {aiTriageResultFilter.length === 0
                                 ? 'All AI results'
                                 : aiTriageResultFilter.length === 1
@@ -679,7 +701,19 @@ export function SupportTicketsTableFilters(): JSX.Element {
                         </div>
                     }
                 >
-                    <LemonButton type="secondary" size="small" sideIcon={<IconChevronDown />}>
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        {...clearFilterButtonProps(
+                            tagsFilter.length > 0 || tagsExcludeFilter.length > 0
+                                ? () => {
+                                      setTagsFilter([])
+                                      setTagsExcludeFilter([])
+                                  }
+                                : null,
+                            'Clear tag filter'
+                        )}
+                    >
                         {tagsFilter.length === 0 && tagsExcludeFilter.length === 0
                             ? 'All tags'
                             : [
@@ -693,18 +727,6 @@ export function SupportTicketsTableFilters(): JSX.Element {
                                   .join(', ')}
                     </LemonButton>
                 </LemonDropdown>
-                {(tagsFilter.length > 0 || tagsExcludeFilter.length > 0) && (
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        icon={<IconX />}
-                        onClick={() => {
-                            setTagsFilter([])
-                            setTagsExcludeFilter([])
-                        }}
-                        tooltip="Clear tag filter"
-                    />
-                )}
                 <AssigneeMultiSelect value={assigneeFilterEntries} onChange={setAssigneeFilter} />
             </div>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problem

In the conversations ticket list, tags was the only filter with a clear affordance, and it was a separate x button that appeared next to the dropdown. The other multi-selects (status, priority, AI triage, assignee) had no way to clear a selection in one click.

## Changes

Every multi-select filter trigger now grows a joined x segment (a `LemonButton` `sideAction`, same mechanism as the impersonation notice logout button) when one or more options are selected. Clicking it clears that filter through the existing kea setters, so pagination reset and saved-view clearing behave as before. When nothing is selected the trigger keeps its chevron, and the old standalone tags x button is gone. The tags x clears both the include and exclude lists. Channel and SLA are single-selects with an "All" option, so they are unchanged.

No selection (chevrons only):

![baseline](https://raw.githubusercontent.com/PostHog/pr-assets/b0d4393ca2eb6c67712c4d5f7191a37cfaeae47d/2026/07/f1a55656-8f93-4f37-b1ca-98231141b1b9.png)

Statuses selected, joined x on the trigger:

![status selected](https://raw.githubusercontent.com/PostHog/pr-assets/fdea6d3dd27026c0b6089ba7e29e10312239f54b/2026/07/59b769fd-40e8-4761-8f40-c6c79b8247c9.png)

<details>
<summary>More screenshots: tags, assignee, tooltip</summary>

Tags with include + exclude selections (note: no separate x button anymore):

![tags selected](https://raw.githubusercontent.com/PostHog/pr-assets/d31559edb1c6789f7f813cb60de3f5cfcc6c90df/2026/07/7c8c8a8e-830e-4cbe-b42e-defc365a6788.png)

Assignee selection:

![assignee selected](https://raw.githubusercontent.com/PostHog/pr-assets/28937913e7909bc862bdd4536ab707c940abf1d8/2026/07/98cd2eb0-5987-452c-984c-3841f2e50b50.png)

Tooltip on hover:

![tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/7613566c8f9f760cd9b781fcb20430b4b1526ba8/2026/07/a95845a6-d60f-4d8f-b0d6-ee9878cf1c61.png)

</details>

## How did you test this code?

Playwright-driven checks against the live dev app: no x renders with nothing selected, selecting status/priority/tags/assignee shows the joined x, clicking it clears only that filter without opening the dropdown, the tags x clears both include and exclude lists, the main segment still opens the dropdown while the x is present, and the tooltip renders. The AI triage trigger uses the identical helper call but was not exercised live because the test workspace has AI features off. No new unit tests, this is presentational wiring over existing setters. Scoped oxlint/oxfmt and full `typescript:check` are clean for the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover the conversations filter bar.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: `verify` and `run-posthog` for live UI verification via Playwright. Main decision: follow the existing clearable-select precedent (`LemonSelect`, `TaxonomicPopover`) where the x side action replaces the chevron while a selection is active, implemented as a small shared `clearFilterButtonProps` helper returning mutually exclusive `sideAction`/`sideIcon` props so all five triggers stay type-safe against the `LemonButtonProps` union. Kept the default divider between label and x to match the impersonation notice reference the request pointed at.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
