### PR TITLE
fix(data-warehouse): fence v3 recovery sweep against live batch owners

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -167,7 +167,11 @@ class BatchConsumerAdapter(Protocol):
         attempt: int,
         error_response: dict[str, Any] | None = None,
         batch_created_at: datetime | None = None,
-    ) -> None: ...
+        expected_state_changed_at: datetime | None = None,
+    ) -> None:
+        """Write the batch's status. ``expected_state_changed_at`` arms a compare-and-swap
+        where supported; a sink may signal a lost race by raising ``OwnershipLostError``."""
+        ...
 
     async def fail_run(
         self,
@@ -195,6 +199,17 @@ class BatchConsumerAdapter(Protocol):
         owner_token: str,
         lease_ttl_seconds: int,
     ) -> bool: ...
+
+    async def delete_expired_lease(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        """Remove the group's lease iff already expired, fencing a resurrecting owner
+        before the recovery sweep re-queues its batches. No-op for non-lease sinks."""
+        ...
 
     async def get_stale_executing(
         self,
@@ -627,8 +642,10 @@ class BatchConsumer:
         Renewing the lease and refreshing the executing-status grace window on
         the same cadence keeps the two reclaim signals consistent: a pod that
         stops heartbeating loses its lease and ages out of the grace window at
-        the same time. ``renew_lease`` returning False means another pod
-        reclaimed the group, so we stop heartbeating immediately.
+        the same time. ``renew_lease`` returning False means ownership is gone
+        for good (reclaimed, sweep-deleted, or expired — expiry is terminal), so
+        we stop heartbeating immediately; the pre-success ownership check then
+        abandons the in-flight batch instead of writing ``succeeded``.
         """
         interval = max((self._config.recovery_grace_seconds or RECOVERY_GRACE_SECONDS) / 3, 10.0)
         while True:
@@ -658,8 +675,8 @@ class BatchConsumer:
                 )
                 continue
             if not renewed:
-                # Another pod reclaimed the group: stop heartbeating so the
-                # in-flight apply is fenced by the per-batch ownership checks.
+                # Ownership is gone (reclaimed or expired) — never transient: stop
+                # heartbeating so the per-batch ownership checks fence the apply.
                 logger.warning(
                     self._event("batch_heartbeat_lease_lost"),
                     batch_id=batch.id,
@@ -1083,13 +1100,17 @@ class BatchConsumer:
                     attempt=batch.latest_attempt,
                 )
                 try:
+                    # Claim the corpse first: once the expired lease is gone, a resurrecting
+                    # owner's renew matches nothing, so it can't finish over the re-queue.
+                    await self._adapter.delete_expired_lease(conn, team_id=batch.team_id, schema_id=batch.schema_id)
                     if batch.latest_attempt >= self._config.max_attempts:
                         logger.warning(
                             self._event("batch_recovered_max_retries_exceeded"), attempt=batch.latest_attempt
                         )
+                        # fail_run's bulk write re-reads each batch's latest status in-statement and
+                        # targets only non-terminal ones, so it can't flip a meanwhile-succeeded batch.
                         await self._fail_run(batch, reason="max retries exceeded (likely OOM)", conn=conn)
                     else:
-                        logger.warning(self._event("batch_recovered_for_retry"), attempt=batch.latest_attempt)
                         try:
                             await self._adapter.update_status(
                                 conn,
@@ -1098,11 +1119,14 @@ class BatchConsumer:
                                 attempt=batch.latest_attempt,
                                 error_response={"error": "executing timed out - pod restart or OOM"},
                                 batch_created_at=batch.created_at,
+                                expected_state_changed_at=batch.state_changed_at,
                             )
                         except OwnershipLostError:
-                            # Batch went terminal between the scan and this requeue;
-                            # skip it without aborting the rest of the sweep.
-                            logger.info(self._event("batch_recovery_skipped_terminal"), batch_id=batch.id)
+                            # The state moved after the stale scan (owner finished, or the batch
+                            # went terminal): leave it, without aborting the rest of the sweep.
+                            logger.info(self._event("batch_recovery_skipped_state_moved"), batch_id=batch.id)
+                        else:
+                            logger.warning(self._event("batch_recovered_for_retry"), attempt=batch.latest_attempt)
                 finally:
                     structlog.contextvars.unbind_contextvars(*recovery_bound_keys)
         finally:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
@@ -328,6 +328,7 @@ class DuckgresBatchConsumerAdapter:
         attempt: int,
         error_response: dict[str, Any] | None = None,
         batch_created_at: datetime | None = None,  # delta-sink denormalization only; unused here
+        expected_state_changed_at: datetime | None = None,  # delta-sink recovery CAS only; unused here
     ) -> None:
         # Invariant: never write ANY status over a terminal 'failed' — statuses
         # are latest-row-wins, so an unconditional write would un-retire a batch
@@ -397,6 +398,17 @@ class DuckgresBatchConsumerAdapter:
             owner_token=owner_token,
             lease_ttl_seconds=lease_ttl_seconds,
         )
+
+    async def delete_expired_lease(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        # Protocol conformance only: its sole caller is the base engine's recovery
+        # sweep, which never runs here — DuckgresBatchConsumer overrides _recovery_sweep.
+        return None
 
     async def get_stale_executing(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -40,9 +40,11 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _group_by_key,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
+    _UNSET,
     FRESHNESS_WINDOW_SECONDS,
     BatchQueue,
     PendingBatch,
+    _Unset,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.metrics import (
     OLDEST_UNCLAIMED_BATCH_SECONDS,
@@ -157,10 +159,13 @@ class DeltaBatchConsumerAdapter:
         attempt: int,
         error_response: dict[str, Any] | None = None,
         batch_created_at: datetime | None = None,
+        expected_state_changed_at: datetime | None | _Unset = _UNSET,
     ) -> None:
         # 'failed' is absorbing: fail_run can retire a claimed batch mid-flight, and a
         # newer write would supersede it — un-failing a cancelled run. Takeover-sentinel
         # failures stay supersedable (see _is_job_dead's matching exemption).
+        # expected_state_changed_at additionally fences the recovery re-queue against a
+        # live owner that completed the batch after the stale scan (see the sweep).
         inserted = await BatchQueue.update_status_unless_failed(
             conn,
             batch_id=batch_id,
@@ -169,9 +174,13 @@ class DeltaBatchConsumerAdapter:
             error_response=error_response,
             batch_created_at=batch_created_at,
             supersedable_failed_error=LOCK_TAKEOVER_LATEST_ERROR,
+            expected_state_changed_at=expected_state_changed_at,
         )
         if not inserted:
-            raise OwnershipLostError(f"batch {batch_id} is already failed; refusing to write '{job_state}' over it")
+            raise OwnershipLostError(
+                f"batch {batch_id} moved under this writer (already failed or state advanced); "
+                f"refusing to write '{job_state}' over it"
+            )
 
     async def fail_run(
         self,
@@ -248,6 +257,15 @@ class DeltaBatchConsumerAdapter:
             owner_token=owner_token,
             lease_ttl_seconds=lease_ttl_seconds,
         )
+
+    async def delete_expired_lease(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        await BatchQueue.delete_expired_lease(conn, team_id=team_id, schema_id=schema_id)
 
     async def get_stale_executing(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -64,6 +64,18 @@ FRESHNESS_WINDOW_SECONDS = 48 * 60 * 60
 FRESHNESS_WINDOW = f"{FRESHNESS_WINDOW_SECONDS} seconds"
 
 
+class _Unset:
+    """Sentinel for ``update_status_unless_failed(expected_state_changed_at=...)``.
+
+    ``state_changed_at`` is nullable, so ``None`` is a legitimate value to arm the
+    compare-and-swap against. ``_UNSET`` is the only signal for "no CAS wanted",
+    keeping an ordinary write and a CAS against a genuinely-null observation apart.
+    """
+
+
+_UNSET = _Unset()
+
+
 def pending_batch_select_columns(status_alias: str) -> str:
     return f"""
         b.id, b.team_id, b.schema_id, b.source_id, b.job_id,
@@ -165,7 +177,9 @@ def build_status_dual_write_sql(*, with_batch_created_at: bool) -> str:
     """
 
 
-def build_status_dual_write_unless_failed_sql(*, with_batch_created_at: bool) -> str:
+def build_status_dual_write_unless_failed_sql(
+    *, with_batch_created_at: bool, with_expected_state_changed_at: bool = False
+) -> str:
     """Guarded twin of :func:`build_status_dual_write_sql`: inserts nothing over a
     terminal 'failed', so a consumer's newer executing/succeeded rows can't
     un-retire a batch fail_run already failed. A 'failed' carrying
@@ -173,11 +187,23 @@ def build_status_dual_write_unless_failed_sql(*, with_batch_created_at: bool) ->
     takeover deliberately lets an in-flight batch finish. Returns the INSERT count
     (0 = refused); the column UPDATE is a designed no-op for heartbeat re-inserts,
     so its rowcount can't be the signal.
+
+    ``with_expected_state_changed_at`` arms a compare-and-swap on the caller's
+    observed ``state_changed_at`` — the recovery sweep's fence against a live owner
+    that completed the batch between the stale scan and the re-queue. The predicate
+    rides the ``target`` CTE, so it is evaluated under the same ``FOR UPDATE OF b``
+    row lock that already serializes this write: a stale requeue matches no target,
+    inserts nothing, and reports 0 without racing the owner's denormalized write.
     """
     created_at_predicate = (
         "b.created_at = %(batch_created_at)s"
         if with_batch_created_at
         else f"b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'"
+    )
+    cas_predicate = (
+        "\n              AND b.state_changed_at IS NOT DISTINCT FROM %(expected_state_changed_at)s"
+        if with_expected_state_changed_at
+        else ""
     )
     return f"""
         WITH target AS (
@@ -189,7 +215,7 @@ def build_status_dual_write_unless_failed_sql(*, with_batch_created_at: bool) ->
               AND (
                   b.latest_state IS DISTINCT FROM 'failed'
                   OR s.error_response->>'error' = %(supersedable_failed_error)s
-              )
+              ){cas_predicate}
             FOR UPDATE OF b
         ),
         ins AS (
@@ -339,14 +365,16 @@ def _stale_executing_sql(scope_sql: str = "") -> str:
     The denormalized-column pre-filter keeps the lateral probing only
     currently-executing batches. The lateral itself must stay: heartbeats
     refresh the status log, deliberately not the column, so the grace clock
-    comes from ``s.created_at``.
+    comes from ``s.created_at``. The observed ``state_changed_at`` rides along
+    so the recovery sweep can compare-and-swap its re-queue against it.
 
     Bounded by ``CLAIM_ELIGIBILITY_INTERVAL``, matching the claim path: a
     recovered batch gets re-processed, which needs its parquet to still exist.
     """
     return f"""
         SELECT
-            {pending_batch_select_columns("s")}
+            {pending_batch_select_columns("s")},
+            b.state_changed_at
         FROM {BATCH_TABLE} b
         {latest_status_lateral("b", "s", join="INNER")}
         LEFT JOIN {LEASE_TABLE} l ON l.team_id = b.team_id AND l.schema_id = b.schema_id
@@ -401,6 +429,8 @@ class PendingBatch:
     metadata: dict[str, Any]
     latest_attempt: int
     created_at: datetime | None = None
+    # Observed denormalized state clock at read time; None for sinks that don't surface it.
+    state_changed_at: datetime | None = None
 
     def to_export_signal(self) -> dict[str, Any]:
         """Temporary bridge: convert a PendingBatch into an ExportSignalMessage dict
@@ -731,9 +761,16 @@ class BatchQueue:
         error_response: dict[str, Any] | None = None,
         batch_created_at: datetime | None = None,
         supersedable_failed_error: str | None = None,
+        expected_state_changed_at: datetime | None | _Unset = _UNSET,
     ) -> bool:
         """Guarded twin of :meth:`update_status`: returns False (writing nothing) over
-        a terminal 'failed' — see :func:`build_status_dual_write_unless_failed_sql`."""
+        a terminal 'failed' — see :func:`build_status_dual_write_unless_failed_sql`.
+
+        ``expected_state_changed_at`` additionally arms a compare-and-swap on the
+        observed ``state_changed_at`` (pass it, including a genuine ``None``, to
+        require the state to be unchanged; leave it unset for an ordinary write): a
+        stale requeue then writes nothing and returns False, same as a refused one."""
+        arm_cas = not isinstance(expected_state_changed_at, _Unset)
         params: dict[str, Any] = {
             "batch_id": batch_id,
             "job_state": job_state,
@@ -743,8 +780,13 @@ class BatchQueue:
         }
         if batch_created_at is not None:
             params["batch_created_at"] = batch_created_at
+        if arm_cas:
+            params["expected_state_changed_at"] = expected_state_changed_at
         cursor = await conn.execute(
-            build_status_dual_write_unless_failed_sql(with_batch_created_at=batch_created_at is not None),
+            build_status_dual_write_unless_failed_sql(
+                with_batch_created_at=batch_created_at is not None,
+                with_expected_state_changed_at=arm_cas,
+            ),
             params,
         )
         row = await cursor.fetchone()
@@ -759,18 +801,45 @@ class BatchQueue:
         owner_token: str,
         lease_ttl_seconds: int = LEASE_TTL_SECONDS,
     ) -> bool:
-        """Extend this owner's group lease. Returns False if the lease was lost (row gone or reclaimed)."""
+        """Extend this owner's live group lease. Expiry is terminal: False means ownership
+        is gone for good (row deleted, reclaimed, or expired) and the owner must abandon.
+
+        The ``expires_at > now()`` predicate makes a lapsed lease unrenewable, so an owner
+        whose lease expired (e.g. a >TTL queue-DB blip during a long write) can't resurrect
+        it and finish over a batch the recovery sweep has already re-queued."""
         async with conn.cursor() as cur:
             await cur.execute(
                 f"""
                 UPDATE {LEASE_TABLE}
                 SET expires_at = now() + make_interval(secs => %(ttl)s), updated_at = now()
                 WHERE team_id = %(team_id)s AND schema_id = %(schema_id)s AND owner_token = %(owner)s
+                  AND expires_at > now()
                 RETURNING 1
                 """,
                 {"team_id": team_id, "schema_id": schema_id, "owner": owner_token, "ttl": lease_ttl_seconds},
             )
             return (await cur.fetchone()) is not None
+
+    @staticmethod
+    async def delete_expired_lease(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        """Delete the group's lease only if it has already expired; a live lease never matches.
+
+        The recovery sweep claims a corpse with this before re-queueing its batches, so a
+        resurrecting owner's renew matches nothing even on pods still running the permissive
+        (pre-expiry-fence) renew during a rollout.
+        """
+        await conn.execute(
+            f"""
+            DELETE FROM {LEASE_TABLE}
+            WHERE team_id = %(team_id)s AND schema_id = %(schema_id)s AND expires_at <= now()
+            """,
+            {"team_id": team_id, "schema_id": schema_id},
+        )
 
     @staticmethod
     async def verify_advisory_lock(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -365,7 +366,8 @@ class TestRecoverySweep:
     @pytest.mark.asyncio
     async def test_retries_stale_below_max(self):
         consumer = _make_consumer(max_attempts=3)
-        stale_batch = _make_batch(latest_attempt=1)
+        # The observed state clock must ride into the re-queue as its CAS guard.
+        stale_batch = _make_batch(latest_attempt=1, state_changed_at=datetime(2026, 1, 1, tzinfo=UTC))
 
         with (
             patch(
@@ -392,6 +394,7 @@ class TestRecoverySweep:
             error_response={"error": "executing timed out - pod restart or OOM"},
             batch_created_at=stale_batch.created_at,
             supersedable_failed_error=LOCK_TAKEOVER_LATEST_ERROR,
+            expected_state_changed_at=stale_batch.state_changed_at,
         )
         mock_unlock.assert_called_once_with(
             consumer._recovery_conn, batches=[stale_batch], owner_token=consumer._owner_token

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -1,13 +1,21 @@
 import re
+import time
+import asyncio
 from datetime import timedelta
 from typing import Any
 from uuid import uuid4
 
 import pytest
+from unittest.mock import AsyncMock, patch
 
 import psycopg
 
 from products.warehouse_sources.backend.temporal.data_imports.metrics import LOCK_TAKEOVER_LATEST_ERROR
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer import (
+    BatchConsumer,
+    ConsumerConfig,
+    DeltaBatchConsumerAdapter,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
     BATCH_TABLE,
     CLAIM_ELIGIBILITY_INTERVAL,
@@ -16,6 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     STATUS_VIEW,
     BatchQueue,
     PendingBatch,
+    build_status_dual_write_sql,
 )
 
 # Distinct per-pod identities for the group-lease tests.
@@ -413,6 +422,18 @@ async def _insert_backdated_executing(
     )
 
 
+async def _wait_until_a_backend_blocks_on_lock(probe: psycopg.AsyncConnection[Any], *, timeout: float = 5.0) -> None:
+    """Poll until some backend is parked waiting on a lock (the isolated test DB
+    has no other traffic, so this is the requeue blocking behind the owner)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        cur = await probe.execute("SELECT 1 FROM pg_stat_activity WHERE wait_event_type = 'Lock' LIMIT 1")
+        if await cur.fetchone() is not None:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("no backend ever blocked on a lock")
+
+
 @pytest.mark.django_db(transaction=True)
 class TestBatchQueueGroupLease:
     @pytest.mark.asyncio
@@ -522,6 +543,31 @@ class TestBatchQueueLeaseRenewal:
         )
 
         assert renewed is False
+
+    @pytest.mark.asyncio
+    async def test_renew_of_expired_lease_returns_false(self, conn):
+        # Expiry is terminal: an owner whose lease lapsed (e.g. a >TTL connectivity
+        # blip) must not resurrect it and finish over a recovery re-queue.
+        await _insert_lease(conn, team_id=1, schema_id="s1", owner=OWNER_A, expires_in_seconds=-1)
+
+        renewed = await BatchQueue.renew_lease(
+            conn, team_id=1, schema_id="s1", owner_token=OWNER_A, lease_ttl_seconds=300
+        )
+
+        assert renewed is False, "the owner of an expired lease must abandon, not renew"
+
+    @pytest.mark.parametrize("expires_in_seconds,deleted", [(-1, True), (300, False)])
+    @pytest.mark.asyncio
+    async def test_sweep_delete_removes_only_the_expired_corpse(self, conn, expires_in_seconds, deleted):
+        await _insert_lease(conn, team_id=1, schema_id="s1", owner=OWNER_A, expires_in_seconds=expires_in_seconds)
+
+        await BatchQueue.delete_expired_lease(conn, team_id=1, schema_id="s1")
+
+        assert (await _lease_count(conn, schema_id="s1") == 0) is deleted
+        renewed = await BatchQueue.renew_lease(
+            conn, team_id=1, schema_id="s1", owner_token=OWNER_A, lease_ttl_seconds=300
+        )
+        assert renewed is (not deleted), "delete must fence the old owner without touching live leases"
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1119,6 +1165,96 @@ class TestUpdateStatusUnlessFailed:
         row = await cur.fetchone()
         assert row is not None and row[0] == 2  # the log still grows
 
+    @pytest.mark.parametrize(
+        "expected_kind,requeue_lands",
+        [("stale", False), ("current", True), ("omitted", True)],
+    )
+    @pytest.mark.asyncio
+    async def test_cas_requeue_yields_to_states_written_after_the_read(self, conn, expected_kind, requeue_lands):
+        # The recovery-sweep race: the sweep reads an executing batch, the owner
+        # completes it, then the sweep re-queues off its now-stale read. The CAS
+        # rides the FOR UPDATE OF b target, so a stale read writes nothing at all.
+        bid = await _insert_batch(conn)
+        await _insert_backdated_executing(conn, batch_id=bid, age_seconds=120, attempt=1)
+        _, _, observed = await _batch_state(conn, bid)
+        await BatchQueue.update_status(conn, batch_id=bid, job_state="succeeded", attempt=1)
+        _, _, current = await _batch_state(conn, bid)
+
+        cas_kwargs: dict[str, Any] = {}
+        if expected_kind == "stale":
+            cas_kwargs["expected_state_changed_at"] = observed
+        elif expected_kind == "current":
+            cas_kwargs["expected_state_changed_at"] = current
+        landed = await BatchQueue.update_status_unless_failed(
+            conn, batch_id=bid, job_state="waiting_retry", attempt=1, **cas_kwargs
+        )
+
+        state, _, _ = await _batch_state(conn, bid)
+        if requeue_lands:
+            assert (landed, state) == (True, "waiting_retry")
+        else:
+            assert (landed, state) == (False, "succeeded")
+            cur = await conn.execute(f"SELECT count(*) FROM {STATUS_TABLE} WHERE batch_id = %s", (bid,))
+            row = await cur.fetchone()
+            assert row is not None and row[0] == 2, "a CAS miss must not even append a status row"
+
+    @pytest.mark.asyncio
+    async def test_cas_armed_against_null_observation_still_yields(self, conn):
+        # state_changed_at is nullable, so the stale scan can observe None. Passing
+        # None must arm the CAS (not fall through to an unconditional write): a write
+        # that landed after the read still has to lose.
+        bid = await _insert_batch(conn)
+        await BatchQueue.update_status(conn, batch_id=bid, job_state="executing", attempt=1)
+        await conn.execute(f"UPDATE {BATCH_TABLE} SET state_changed_at = NULL WHERE id = %s", (bid,))
+        await BatchQueue.update_status(conn, batch_id=bid, job_state="succeeded", attempt=1)
+
+        landed = await BatchQueue.update_status_unless_failed(
+            conn, batch_id=bid, job_state="waiting_retry", attempt=1, expected_state_changed_at=None
+        )
+
+        state, _, _ = await _batch_state(conn, bid)
+        assert (landed, state) == (False, "succeeded")
+        cur = await conn.execute(f"SELECT count(*) FROM {STATUS_TABLE} WHERE batch_id = %s", (bid,))
+        row = await cur.fetchone()
+        assert row is not None and row[0] == 2, "a CAS miss against a null observation must not append a status row"
+
+    @pytest.mark.asyncio
+    async def test_requeue_appends_no_status_when_owner_commits_mid_write(self, conn, conn_b, _db_url):
+        # True concurrency: the owner's completion commits *while* the CAS requeue is
+        # already running. The requeue's target rides FOR UPDATE OF b, so it blocks on
+        # the owner's row lock and re-reads the moved state — appending no stray status.
+        bid = await _insert_batch(conn)
+        await _insert_backdated_executing(conn, batch_id=bid, age_seconds=120, attempt=1)
+        _, _, observed = await _batch_state(conn, bid)
+
+        async with await psycopg.AsyncConnection.connect(_db_url, autocommit=False) as owner_conn:
+            async with owner_conn.transaction():
+                # Owner completes the batch but holds the row lock (uncommitted).
+                await owner_conn.execute(
+                    build_status_dual_write_sql(with_batch_created_at=False),
+                    {"batch_id": bid, "job_state": "succeeded", "attempt": 1, "error_response": None},
+                )
+                requeue = asyncio.create_task(
+                    BatchQueue.update_status_unless_failed(
+                        conn,
+                        batch_id=bid,
+                        job_state="waiting_retry",
+                        attempt=1,
+                        expected_state_changed_at=observed,
+                    )
+                )
+                await _wait_until_a_backend_blocks_on_lock(conn_b)
+            # Leaving the transaction commits the owner's succeeded write.
+            landed = await requeue
+
+        state, _, _ = await _batch_state(conn, bid)
+        assert (landed, state) == (False, "succeeded")
+        cur = await conn.execute(
+            f"SELECT count(*) FROM {STATUS_TABLE} WHERE batch_id = %s AND job_state = 'waiting_retry'", (bid,)
+        )
+        row = await cur.fetchone()
+        assert row is not None and row[0] == 0, "a requeue that loses the race must leave no waiting_retry status row"
+
 
 @pytest.mark.django_db(transaction=True)
 class TestClaimGates:
@@ -1299,3 +1435,33 @@ class TestSyncTypeFleetPartition:
 
         assert [str(b.id) for b in cdc_stale] == [cdc_bid]
         assert {str(b.id) for b in all_stale} == {cdc_bid, fr_bid}
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRecoverySweepVsLiveOwner:
+    @pytest.mark.asyncio
+    async def test_owner_completion_between_scan_and_requeue_stays_succeeded(self, conn, _db_url):
+        # The headline race: the sweep scans a stale executing batch, a resurrected
+        # owner completes it, then the sweep's re-queue must yield instead of landing.
+        bid = await _insert_batch(conn)
+        await _insert_backdated_executing(conn, batch_id=bid, age_seconds=120, attempt=1)
+
+        consumer = BatchConsumer(
+            config=ConsumerConfig(database_url=_db_url, recovery_grace_seconds=60),
+            process_batch=AsyncMock(),
+        )
+        consumer._recovery_conn = conn
+
+        real_get_stale = DeltaBatchConsumerAdapter.get_stale_executing
+
+        async def scan_then_owner_completes(adapter, c, **kwargs):
+            stale = await real_get_stale(adapter, c, **kwargs)
+            await BatchQueue.update_status(conn, batch_id=bid, job_state="succeeded", attempt=1)
+            return stale
+
+        with patch.object(DeltaBatchConsumerAdapter, "get_stale_executing", scan_then_owner_completes):
+            await consumer._recovery_sweep()
+
+        cur = await conn.execute(f"SELECT latest_state FROM {BATCH_TABLE} WHERE id = %s", (bid,))
+        row = await cur.fetchone()
+        assert row is not None and row[0] == "succeeded", "the sweep must not re-queue a batch its owner finished"


### PR DESCRIPTION
## Problem

The pipeline v3 recovery sweep can race a batch owner that is still alive. The sweep reads batches stuck in `executing` past the grace window with no live lease, then later stamps them `waiting_retry` with no compare-and-swap. The dual write's only guard is monotonic (newest `state_changed_at` wins), so the sweep's write always lands over anything that happened after its read.

Meanwhile `renew_lease` had no expiry predicate, so an owner whose lease lapsed (for example a longer-than-TTL queue-DB connectivity blip while its Delta write kept going) could resurrect the expired lease on its next heartbeat, finish the batch, write `succeeded`, and then have the sweep's serial loop overwrite that `succeeded` with `waiting_retry`. The batch gets re-claimed and re-run: wasted work, head-of-line stalls for the schema, attempt burn that can fail a healthy run, and in the two-live-writers variant, duplicate rows on append-type syncs.

## Changes

Three small, independent fences in the lease/status layer. Each one only narrows what a writer may do, which is what makes the mixed-fleet rollout safe (see the note below).

1. **CAS on the sweep's requeue.** `build_status_dual_write_sql` gains an optional CAS mode requiring `state_changed_at IS NOT DISTINCT FROM` the sweep's observed value. Both the status INSERT and the denormalized UPDATE are gated, so a stale requeue is a full 0-row no-op (an UPDATE-only guard would leave a stray `waiting_retry` status row that the bulk-fail lateral would read as pending, re-opening the exact clobber). When the CAS is not armed the generated SQL is byte-identical to before. `get_stale_executing` now returns each batch's observed `state_changed_at`, and the sweep skips with `recovery_requeue_skipped_state_moved` on a 0-row outcome instead of retrying. The max-attempts branch needs no CAS: `fail_run`'s bulk write re-selects its targets in-statement through the latest-status lateral and only matches non-terminal states, so it cannot flip a meanwhile-`succeeded` batch (documented with a comment).
2. **Expired leases are dead.** `renew_lease` now requires `expires_at > now()`. Expiry is terminal: a lapsed owner's heartbeat gets renew=False, stops immediately (the existing hardening from #69105 already treats only exceptions as transient), and the pre-success ownership check abandons the in-flight batch with no `succeeded` write.
3. **The sweep claims the corpse.** Before acting on a stale batch, the sweep deletes the group's expired lease row via a new `BatchQueue.delete_expired_lease` (predicated on `expires_at <= now()`, so live rows never match and a concurrent re-claim makes it a no-op). After this, a resurrecting owner's renew matches nothing even on a pod without fix 2.

The duckgres adapter only gets protocol-conformance pass-throughs (an ignored kwarg and a no-op method) since it overrides the shared recovery sweep.

> [!NOTE]
> Mixed-fleet safety during rollout: old pods (no CAS, permissive renew) will coexist with new pods. An old sweep still requeues without CAS, exactly today's behavior, no worse. An old owner can still renew an expired lease, but a new sweep deletes the expired row before requeueing, fencing it anyway. A new owner facing renew=False abandons earlier than before, forfeiting only work it no longer owns. No combination of old and new pods lets two writers finish the same batch.

## How did you test this code?

Automated tests only, each pinning a named regression no existing test caught:

- `test_cas_requeue_yields_to_states_written_after_the_read` (parameterized, real SQL): a dual write with a stale expected `state_changed_at` is a full 0-row no-op (not even a status row), with the current value it lands, and omitted keeps today's monotonic behavior (pins fix 1 and its backward compatibility).
- `test_renew_of_expired_lease_returns_false`: renew of an expired lease returns False; existing tests already pin that a live-owner renew still works (pins fix 2).
- `test_sweep_delete_removes_only_the_expired_corpse` (parameterized): a sweep-deleted expired lease cannot be renewed by the old owner, and a live lease is neither deleted nor fenced (pins fix 3).
- `test_owner_completion_between_scan_and_requeue_stays_succeeded`: integration test driving the real `_recovery_sweep` against Postgres, with the owner completing the batch between the stale scan and the requeue. The batch stays `succeeded` (the headline race, pins the composition).
- Heartbeat renew=False leading to abandon rather than retry-as-transient was already pinned by the existing `test_transient_renewal_failure_does_not_end_heartbeat`, so no new test was added there.

Ran `test_jobs_db.py` (72 passed), `test_consumer.py` (77 passed), duckgres `test_consumer.py` (27 passed), ruff, and repo-wide `mypy --cache-fine-grained` (only pre-existing error outside this diff).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5) from a detailed human spec of the race and the three fixes. Skills invoked: /writing-tests. Decisions along the way: gated the CAS on the status INSERT as well as the UPDATE (the spec designed the UPDATE guard; the INSERT gate closes the stray-status-row hole described above), confirmed from the bulk-fail SQL that the max-attempts branch needs no CAS guard, and dropped a planned heartbeat test after finding existing coverage that already pins that behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)