### PR TITLE
feat(notebooks): single sql node ux for the kernel-less direct lane

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6407,17 +6407,17 @@ snapshots:
     scenes-app-notebooks--bullet-list--light:
         hash: v1.k794b7964.1a8843ddd26ea3b72013b7fee8836d009f5d71558f397da48e7cdee3c28dbcae.hvFFmea_bm1gBo7xMpoXXD_1Pz4lCO64eTVDfc9Loho
     scenes-app-notebooks--collapsed-headings--dark:
-        hash: v1.k794b7964.a294cb50e76f02875e0d8aa526499cce6506b013d5930be0acf0618220f83c1b.016QmLl1Trjeo0C-YrsC6ZQJCFZy4n4WE1H2nHlu1aI
+        hash: v1.k794b7964.aa5a612e65bb07ecdc69012cb6d8815691f7c8cdbaaa1e6cb2a79f80dd48c733.98F8j02JyWfZfX0sCUWkl5kN5iPbD06gmS0GycFj-BE
     scenes-app-notebooks--collapsed-headings--light:
-        hash: v1.k794b7964.4073ee7cd2a8ef71ca5554d9304fe54c48cce4cf1b57639e2249d55b67f9c9ed.JTdhkXxIPtBNrd0I2DGB-E5-VxOEapUmbY2Q7TYQzx4
+        hash: v1.k794b7964.6d825c028024bd46bc104fccb3ff65a9850f49f3d2a600498c7523cd6fd10ff5.1pbZhaUdYM_vrgvp3BtrGVWG__COl7avdlsGW1LNSks
     scenes-app-notebooks--empty-notebook--dark:
         hash: v1.k794b7964.fa1d770a20cfd16bcdc9b3661bf47cfbaa9b38a4a33e2c497d724de07c499e9e.XfAAGxqctmjMUe848vJXbOi7APYCtDaZp9R8TYTcQKw
     scenes-app-notebooks--empty-notebook--light:
         hash: v1.k794b7964.e9b9755ff30dbb54305cf86daa403b7d9b3a8cd4990379c494b2fb122930d71b.xtARpz4io9Df4iMJYEhzVUB9Bv5kSAk986fHdyzhScY
     scenes-app-notebooks--flattened-table--dark:
-        hash: v1.k794b7964.4af1850ffcbd00ddac474e062be344b485d9ae95109465b4233ba53fb1ef50ac.LIOTcUH-F0AtaRoXCi1reMKt3gbdYF6DIg2LKrMji_c
+        hash: v1.k794b7964.e073958f489aea9dfa538cbf710039eb9d88541603df2523ea283d9f5c68ecad.96-dcNYghaw4yfNLkya02wH5bErS0_vJdxiwdD8DsKo
     scenes-app-notebooks--flattened-table--light:
-        hash: v1.k794b7964.7e08ec9949fcf8ba179a68332dc9ec65e4995b5757cb2e5f7399220d4e32110d.r2KBOe1mWHbmiN-V1CdB36vcl56JnDLfbAV3RvEcylI
+        hash: v1.k794b7964.ca65edcd4d23f163928f3519b282283c3641acace4abedb3dc1c34832be78be7.zZ-cBPlgrln4u3wjUUxvX6_jtZ_oH2kKd7QoJWfiEwQ
     scenes-app-notebooks--headings--dark:
         hash: v1.k794b7964.0d4d36634319774a86df08522142076fe37b2cdf87b4c654950004218a1e3136.RkxpWeXla9IIpBOVfi7ZsPtUaSWzEWFltzdtsn1egAQ
     scenes-app-notebooks--headings--light:
@@ -6435,9 +6435,9 @@ snapshots:
     scenes-app-notebooks--numbered-list--light:
         hash: v1.k794b7964.a7c359b0c62468903ee153f7d554332ffb23ddeb5823f8772cbbc9bdda85ef39.vqBNXyRaDc-oPTu-JlCeXZXDW3hlVysSsDe1vCbkFbk
     scenes-app-notebooks--recordings-playlist--dark:
-        hash: v1.k794b7964.2581859c81615ca1f017290f7b86eaec8d1203f32dd6e0fb1bbeb2c337d5bb75.ProVqyNuxcc6_f8mfSJUJMEYn2Rn3LWCTT5OLKk1lLk
+        hash: v1.k794b7964.bf39c6b292425894510288542c473b5d926f648af56fb9ee305715c560c06f86.rvD4Bs7KFJXywUr9a7FeSgzuIijEfgvh7EYIEBk3C8w
     scenes-app-notebooks--recordings-playlist--light:
-        hash: v1.k794b7964.de5626e727565daa0be4e02937d39c36a43fe82b85799c0d2f91304439095b91.bUKmiskhzemuQnEA4r75ET4WcbKkawJt-FaaiWhfr0Y
+        hash: v1.k794b7964.c0528384e510106068f1ec51cc84d089e229266f1af6913a7476f5072f834735.p9LDdbG6BWtaPK7MQt1_Muv90yc3wrAr6Xe9mBoNNsQ
     scenes-app-notebooks--text-formats--dark:
         hash: v1.k794b7964.6ba17ee8c1d8e0b4095b903100109314b701baa0a4956ca272f2b26f4d37879b.J-tNiP80EM3tE0ZaOdrZZ3vzZnEK1UdW5afDzziYijQ
     scenes-app-notebooks--text-formats--light:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4938,6 +4938,9 @@ const api = {
                 media?: { mime_type: string; data: string }[]
             } | null
             error: string | null
+            // Direct (no-sandbox) runs only: the full capped row set for client-side paging,
+            // present while the backend's query result is alive (~20 min).
+            rows?: (string | number | null)[][]
         }> {
             return await new ApiRequest().notebook(notebookId).withAction(`sql_v2/runs/${runId}`).get()
         },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
@@ -66,6 +66,7 @@ const Component = ({
         isStale,
         isChainRunning,
         staleDownstreamCount,
+        pendingKernelStart,
     } = useValues(dataLogic)
     const { setPage, setPageSize, runStaleChain } = useActions(dataLogic)
 
@@ -109,6 +110,9 @@ const Component = ({
                             disabledReason={isRunning ? 'This cell is running' : (operationBlockReason ?? undefined)}
                         />
                     </div>
+                ) : null}
+                {isRunning && pendingKernelStart ? (
+                    <div className="shrink-0 px-2 pt-1 text-xs text-muted">Starting compute sandbox…</div>
                 ) : null}
                 {hasStreamOutput ? (
                     <div className="shrink-0 space-y-2 px-2 pt-1" onClick={(event) => event.stopPropagation()}>

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
@@ -1,5 +1,5 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { IconCornerDownRight, IconPlayFilled } from '@posthog/icons'
 
@@ -20,6 +20,10 @@ import { NotebookDataframeResult } from './pythonExecution'
 // The revamped Python cell: code runs in the notebook's sandbox kernel via the SQLV2 run
 // path, with sibling SQLV2 frames materialized as pandas frames. A separate node type from
 // the legacy ph-python cell (in-browser kernel) so the two flows never share run wiring.
+
+// The default node height only fits a couple of table rows; grow to this once output lands
+// so results and figures aren't clipped and the user doesn't have to resize by hand to read them.
+const RESULT_MIN_HEIGHT = 300
 
 export type NotebookNodePythonV2Attributes = {
     code: string
@@ -85,11 +89,26 @@ const Component = ({
         ? pageResult.has_more
         : (result?.has_more ?? (result?.first_page ?? []).length >= SQL_V2_DEFAULT_PAGE_SIZE)
 
+    const hasStreamOutput = !!(result?.stdout || result?.stderr || result?.media?.length)
+
+    // Grow a still-default (too-short) node the first time output lands so it's readable without
+    // a manual resize. Only grows below the target and only on fresh output, so a deliberate
+    // resize (or a taller reload) is left untouched.
+    const hadOutputRef = useRef(hasStreamOutput || !!dataframeResult)
+    useEffect(() => {
+        const hasOutput = hasStreamOutput || !!dataframeResult
+        if (hasOutput && !hadOutputRef.current) {
+            if (typeof attributes.height !== 'number' || attributes.height < RESULT_MIN_HEIGHT) {
+                updateAttributes({ height: RESULT_MIN_HEIGHT })
+            }
+        }
+        hadOutputRef.current = hasOutput
+        // oxlint-disable-next-line exhaustive-deps
+    }, [dataframeResult, hasStreamOutput])
+
     if (!expanded) {
         return null
     }
-
-    const hasStreamOutput = !!(result?.stdout || result?.stderr || result?.media?.length)
 
     return (
         <div data-attr="notebook-node-python-v2" className="flex h-full min-h-0 flex-col">

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
@@ -48,12 +48,18 @@ export type NotebookNodeSQLV2Attributes = {
 // Matches the SQL editor output pane's default so charts land at v1-node size.
 const VIZ_MIN_HEIGHT = 350
 
-// The dataframe name becomes a CTE alias in referencing queries, so it must be a plain
-// SQL identifier. Empty is fine — the cell is then display-only.
-const returnVariableValidationError = (returnVariable: string): string | null =>
-    returnVariable && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(returnVariable)
-        ? 'Use letters, numbers, and underscores. The name cannot start with a number.'
-        : null
+// The dataframe name is referenced as a bare SQL table name and becomes a Python variable
+// when a python cell reads the frame, so it must be a plain identifier. Empty is fine —
+// the cell is then display-only.
+const VALID_RETURN_VARIABLE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const returnVariableValidationError = (returnVariable: string): string | null => {
+    if (!returnVariable || VALID_RETURN_VARIABLE.test(returnVariable)) {
+        return null
+    }
+    const suggestion = returnVariable.replace(/[^A-Za-z0-9_]/g, '_').replace(/^(?=\d)/, '_')
+    const hint = VALID_RETURN_VARIABLE.test(suggestion) ? ` Try ${suggestion}.` : ''
+    return `Use letters, numbers, and underscores. The name cannot start with a number.${hint}`
+}
 
 const toDataframeResult = (result: NotebookNodeSQLV2Result): NotebookDataframeResult => {
     const columns = result.columns ?? []

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
@@ -48,6 +48,13 @@ export type NotebookNodeSQLV2Attributes = {
 // Matches the SQL editor output pane's default so charts land at v1-node size.
 const VIZ_MIN_HEIGHT = 350
 
+// The dataframe name becomes a CTE alias in referencing queries, so it must be a plain
+// SQL identifier. Empty is fine — the cell is then display-only.
+const returnVariableValidationError = (returnVariable: string): string | null =>
+    returnVariable && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(returnVariable)
+        ? 'Use letters, numbers, and underscores. The name cannot start with a number.'
+        : null
+
 const toDataframeResult = (result: NotebookNodeSQLV2Result): NotebookDataframeResult => {
     const columns = result.columns ?? []
     const firstPage = result.first_page ?? []
@@ -101,6 +108,7 @@ const Component = ({
         isStale,
         isChainRunning,
         staleDownstreamCount,
+        pendingKernelStart,
     } = useValues(dataLogic)
     const { setPage, setPageSize, runStaleChain } = useActions(dataLogic)
 
@@ -108,6 +116,7 @@ const Component = ({
         title.trim() || getCellLabel(nodeIndex, nodeType) || 'SQL'
 
     const result = attributes.result ?? null
+    const returnVariableError = returnVariableValidationError(attributes.returnVariable ?? '')
     // Page 1 at the default size comes straight from the envelope; other pages re-query CH.
     const dataframeResult = useMemo(() => {
         if (pageResult) {
@@ -159,6 +168,9 @@ const Component = ({
                             disabledReason={isRunning ? 'This cell is running' : (operationBlockReason ?? undefined)}
                         />
                     </div>
+                ) : null}
+                {isRunning && pendingKernelStart ? (
+                    <div className="shrink-0 px-2 pt-1 text-xs text-muted">Starting compute sandbox…</div>
                 ) : null}
                 {runError ? (
                     <div className="p-2 text-xs font-mono text-danger whitespace-pre-wrap">{runError}</div>
@@ -250,11 +262,14 @@ const Component = ({
                 <input
                     type="text"
                     // A dataframe name other SQL nodes reference by table name (`from sql_df`).
+                    // Optional: left empty, the cell is display-only and exports nothing.
                     className="rounded border border-border px-1.5 py-0.5 text-xs font-mono bg-bg-light text-default focus:outline-none focus:ring-1 focus:ring-primary"
                     value={attributes.returnVariable ?? ''}
                     onChange={(event) => updateAttributes({ returnVariable: event.target.value })}
+                    placeholder="Dataframe name (optional)"
                     spellCheck={false}
                 />
+                {returnVariableError ? <span className="text-danger">{returnVariableError}</span> : null}
                 {sqlV2ReturnVariableUsage.length > 0 ? (
                     <span className="text-muted">
                         Used in{' '}
@@ -291,7 +306,7 @@ const Settings = ({
         hasResult: !!attributes.result,
         getContent: () => notebookLogic.values.content ?? null,
     })
-    const { isRunning, isInterrupting, operationBlockReason } = useValues(dataLogic)
+    const { isRunning, isInterrupting, operationBlockReason, activeRunLane } = useValues(dataLogic)
     const { runQuery, interruptRun } = useActions(dataLogic)
 
     return (
@@ -304,8 +319,10 @@ const Settings = ({
             onRunQuery={(code) => runQuery(code, collectSqlV2Refs(notebookLogic.values.content, nodeId))}
             runQueryLoading={isRunning}
             runQueryDisabledReason={operationBlockReason ?? undefined}
-            runQueryTooltip="Run SQL (v2) query"
-            onCancelQuery={interruptRun}
+            runQueryTooltip="Run SQL query"
+            // Direct (no-sandbox) runs cannot be cancelled — there is no kernel to signal;
+            // they finish on their own bounded schedule. Stop applies to kernel-lane runs only.
+            onCancelQuery={activeRunLane === 'kernel' ? interruptRun : undefined}
             cancelQueryLoading={isInterrupting}
         />
     )
@@ -313,7 +330,7 @@ const Settings = ({
 
 export const NotebookNodeSQLV2 = createPostHogWidgetNode<NotebookNodeSQLV2Attributes>({
     nodeType: NotebookNodeType.SQLV2,
-    titlePlaceholder: 'SQL (v2)',
+    titlePlaceholder: 'SQL',
     Component,
     heightEstimate: 120,
     minHeight: 80,
@@ -323,8 +340,10 @@ export const NotebookNodeSQLV2 = createPostHogWidgetNode<NotebookNodeSQLV2Attrib
         code: {
             default: '',
         },
+        // Optional: empty means the cell binds no dataframe (display-only). Existing cells
+        // carry their persisted name ('sql_df' was the old default) and keep exporting it.
         returnVariable: {
-            default: 'sql_df',
+            default: '',
         },
         runId: {
             default: null,

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
@@ -1,5 +1,5 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { IconCornerDownRight } from '@posthog/icons'
 
@@ -47,6 +47,9 @@ export type NotebookNodeSQLV2Attributes = {
 
 // Matches the SQL editor output pane's default so charts land at v1-node size.
 const VIZ_MIN_HEIGHT = 350
+// The default node height only fits a couple of table rows; grow to this once a result lands
+// so the output isn't clipped and the user doesn't have to resize by hand to read it.
+const RESULT_MIN_HEIGHT = 300
 
 // The dataframe name is referenced as a bare SQL table name and becomes a Python variable
 // when a python cell reads the frame, so it must be a plain identifier. Empty is fine —
@@ -58,7 +61,17 @@ const returnVariableValidationError = (returnVariable: string): string | null =>
     }
     const suggestion = returnVariable.replace(/[^A-Za-z0-9_]/g, '_').replace(/^(?=\d)/, '_')
     const hint = VALID_RETURN_VARIABLE.test(suggestion) ? ` Try ${suggestion}.` : ''
-    return `Use letters, numbers, and underscores. The name cannot start with a number.${hint}`
+    // Call out only the rule that was actually broken so a name like `people-df` isn't told it
+    // "can't start with a number" when the real problem is the hyphen.
+    const startsWithDigit = /^\d/.test(returnVariable)
+    const hasInvalidChars = /[^A-Za-z0-9_]/.test(returnVariable)
+    const reason =
+        startsWithDigit && hasInvalidChars
+            ? "Use letters, numbers, and underscores, and don't start with a number."
+            : startsWithDigit
+              ? "The name can't start with a number."
+              : 'Use letters, numbers, and underscores.'
+    return `${reason}${hint}`
 }
 
 const toDataframeResult = (result: NotebookNodeSQLV2Result): NotebookDataframeResult => {
@@ -150,6 +163,22 @@ const Component = ({
         }),
         [attributes.vizQuery, attributes.code]
     )
+
+    // Grow a still-default (too-short) node the first time a result lands so it's readable
+    // without a manual resize. Only grows below the target and only on a fresh result, so a
+    // deliberate resize (or a taller reload) is left untouched.
+    const hadResultRef = useRef(!!result)
+    useEffect(() => {
+        const hasResult = !!dataframeResult
+        if (hasResult && !hadResultRef.current) {
+            const target = activeTab === OutputTab.Visualization ? VIZ_MIN_HEIGHT : RESULT_MIN_HEIGHT
+            if (typeof attributes.height !== 'number' || attributes.height < target) {
+                updateAttributes({ height: target })
+            }
+        }
+        hadResultRef.current = hasResult
+        // oxlint-disable-next-line exhaustive-deps
+    }, [dataframeResult])
 
     if (!expanded) {
         return null

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
@@ -74,6 +74,20 @@ describe('buildNotebookDependencyGraph', () => {
         expect(graph.upstreamSourcesByNode['reader'].sql_df.nodeId).toEqual('named')
     })
 
+    it('an invalid SQL frame name binds nothing (not exported, not browsable)', () => {
+        // A non-empty but invalid name like `people-df` can never be referenced (bare
+        // `people-df` is not a valid identifier), so it must not enter the dependency
+        // graph or the schema browser as an export the way a valid name does.
+        const content = {
+            type: 'doc',
+            content: [sqlV2Node('bad', 'people-df', 'select 1'), sqlV2Node('ok', 'sql_df', 'select id from events')],
+        }
+        const graph = buildNotebookDependencyGraph(content)
+        expect(graph.nodesById['bad'].exports).toEqual([])
+        expect(graph.nodesById['ok'].exports).toEqual(['sql_df'])
+        expect(collectNotebookFrameNodes(content).map((frame) => frame.name)).toEqual(['sql_df'])
+    })
+
     it('links PythonV2 cells in both directions (python reads sql, sql joins the python frame)', () => {
         // Journey 10 staleness walks these edges: without PythonV2 in the graph, running a
         // SQL cell never marks its Python dependents stale, and vice versa.

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
@@ -41,6 +41,23 @@ describe('buildNotebookDependencyGraph', () => {
         expect(graph.upstreamSourcesByNode['c'].sql_df.nodeId).toEqual('a')
     })
 
+    it('an unnamed SQL cell exports nothing and reserves no name', () => {
+        // The dataframe name is optional: a blank-name cell is display-only, and it must not
+        // squat the 'sql_df' default (which would misroute references to a named sibling).
+        const content = {
+            type: 'doc',
+            content: [
+                sqlV2Node('blank', '', 'select 1'),
+                sqlV2Node('named', 'sql_df', 'select id from events'),
+                sqlV2Node('reader', 'joined', 'select * from sql_df'),
+            ],
+        }
+        const graph = buildNotebookDependencyGraph(content)
+        expect(graph.nodesById['blank'].exports).toEqual([])
+        expect(graph.nodesById['named'].exports).toEqual(['sql_df'])
+        expect(graph.upstreamSourcesByNode['reader'].sql_df.nodeId).toEqual('named')
+    })
+
     it('links PythonV2 cells in both directions (python reads sql, sql joins the python frame)', () => {
         // Journey 10 staleness walks these edges: without PythonV2 in the graph, running a
         // SQL cell never marks its Python dependents stale, and vice versa.

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
@@ -1,6 +1,10 @@
 import { buildMarkdownNotebookContent, serializeMarkdownNotebookComponent } from '../Notebook/markdownNotebookV2'
 import { NotebookNodeType } from '../types'
-import { buildNotebookDependencyGraph, extractPythonIdentifiers } from './notebookNodeContent'
+import {
+    buildNotebookDependencyGraph,
+    collectNotebookFrameNodes,
+    extractPythonIdentifiers,
+} from './notebookNodeContent'
 
 describe('buildNotebookDependencyGraph', () => {
     const sqlV2Node = (nodeId: string, returnVariable: string, code: string): Record<string, unknown> => ({
@@ -39,6 +43,18 @@ describe('buildNotebookDependencyGraph', () => {
         expect(graph.nodesById['b'].exports).toEqual(['sql_df_2'])
         expect(graph.downstreamUsageByNode['a'].sql_df.map((usage) => usage.nodeId)).toEqual(['c'])
         expect(graph.upstreamSourcesByNode['c'].sql_df.nodeId).toEqual('a')
+    })
+
+    it('an unnamed SQL cell is not browsable as a dataframe', () => {
+        // The schema browser lists document-derived frames; a blank-name cell binds no
+        // dataframe, so it must not appear (nor push a real 'sql_df' cell to 'sql_df_2').
+        const content = {
+            type: 'doc',
+            content: [sqlV2Node('blank', '', 'select 1'), sqlV2Node('named', 'sql_df', 'select id from events')],
+        }
+        const frames = collectNotebookFrameNodes(content)
+        expect(frames.map((frame) => frame.name)).toEqual(['sql_df'])
+        expect(frames[0].nodeId).toEqual('named')
     })
 
     it('an unnamed SQL cell exports nothing and reserves no name', () => {

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -280,10 +280,18 @@ export const getUniqueSqlV2ReturnVariable = (
     fallbackReturnVariable: string
 ): string => {
     const used = new Set<string>()
-    let resolvedReturnVariable = resolveSqlV2ReturnVariable(fallbackReturnVariable)
+    let resolvedReturnVariable = fallbackReturnVariable.trim() ? resolveSqlV2ReturnVariable(fallbackReturnVariable) : ''
     let resolvedFromNodes = false
 
     nodes.forEach((node) => {
+        // An unnamed cell binds no dataframe: it claims no name and needs none reserved.
+        if (!node.returnVariable) {
+            if (node.nodeId === nodeId) {
+                resolvedReturnVariable = ''
+                resolvedFromNodes = true
+            }
+            return
+        }
         const baseReturnVariable = resolveSqlV2ReturnVariable(node.returnVariable)
         const uniqueReturnVariable = buildUniqueSqlV2ReturnVariable(baseReturnVariable, used)
         used.add(normalizeSqlIdentifier(uniqueReturnVariable))
@@ -294,7 +302,7 @@ export const getUniqueSqlV2ReturnVariable = (
         }
     })
 
-    if (!resolvedFromNodes) {
+    if (!resolvedFromNodes && resolvedReturnVariable) {
         resolvedReturnVariable = buildUniqueSqlV2ReturnVariable(resolvedReturnVariable, used)
     }
 
@@ -365,11 +373,15 @@ export const collectSqlV2Nodes = (content?: JSONContent | null): SqlV2NodeSummar
         if (node.type === NotebookNodeType.SQLV2) {
             const attrs = node.attrs ?? {}
             const code = typeof attrs.code === 'string' ? attrs.code : ''
-            const baseReturnVariable = resolveSqlV2ReturnVariable(
-                typeof attrs.returnVariable === 'string' ? attrs.returnVariable : 'sql_df'
-            )
-            const returnVariable = buildUniqueSqlV2ReturnVariable(baseReturnVariable, usedReturnVariables)
-            usedReturnVariables.add(normalizeSqlIdentifier(returnVariable))
+            // A missing attribute predates the optional name (legacy default); an explicit
+            // blank means the user left it empty — the cell binds no dataframe.
+            const rawReturnVariable = typeof attrs.returnVariable === 'string' ? attrs.returnVariable : 'sql_df'
+            const returnVariable = rawReturnVariable.trim()
+                ? buildUniqueSqlV2ReturnVariable(resolveSqlV2ReturnVariable(rawReturnVariable), usedReturnVariables)
+                : ''
+            if (returnVariable) {
+                usedReturnVariables.add(normalizeSqlIdentifier(returnVariable))
+            }
             nodes.push({
                 nodeId: attrs.nodeId ?? '',
                 code,
@@ -771,11 +783,17 @@ export const buildNotebookDependencyGraph = (content?: JSONContent | null): Note
         if (node.type === NotebookNodeType.SQLV2) {
             const attrs = node.attrs ?? {}
             sqlV2Index += 1
-            const baseReturnVariable = resolveSqlV2ReturnVariable(
-                typeof attrs.returnVariable === 'string' ? attrs.returnVariable : 'sql_df'
-            )
-            const returnVariable = buildUniqueSqlV2ReturnVariable(baseReturnVariable, usedSqlV2ReturnVariables)
-            usedSqlV2ReturnVariables.add(normalizeSqlIdentifier(returnVariable))
+            // Blank name = display-only cell: it exports nothing (see collectSqlV2Nodes).
+            const rawReturnVariable = typeof attrs.returnVariable === 'string' ? attrs.returnVariable : 'sql_df'
+            const returnVariable = rawReturnVariable.trim()
+                ? buildUniqueSqlV2ReturnVariable(
+                      resolveSqlV2ReturnVariable(rawReturnVariable),
+                      usedSqlV2ReturnVariables
+                  )
+                : ''
+            if (returnVariable) {
+                usedSqlV2ReturnVariables.add(normalizeSqlIdentifier(returnVariable))
+            }
             const code = typeof attrs.code === 'string' ? attrs.code : ''
             nodes.push({
                 nodeId: attrs.nodeId ?? '',

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -258,6 +258,14 @@ export const resolveSqlV2ReturnVariable = (returnVariable: string): string => {
     return returnVariable.trim() || 'sql_df'
 }
 
+// A dataframe name is referenced as a bare SQL table name and becomes a Python variable, so
+// only a plain identifier can ever be referenced. A blank name is display-only; a non-blank
+// but invalid one (e.g. `people-df`) is treated the same way for collection — it exports
+// nothing, so it never pollutes the dependency graph or schema browser with an unusable name.
+const SQL_V2_FRAME_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+export const isReferenceableSqlV2FrameName = (returnVariable: string): boolean =>
+    SQL_V2_FRAME_NAME.test(returnVariable.trim())
+
 const buildUniqueSqlV2ReturnVariable = (baseReturnVariable: string, used: Set<string>): string => {
     const normalizedBase = normalizeSqlIdentifier(baseReturnVariable)
     if (!used.has(normalizedBase)) {
@@ -280,11 +288,13 @@ export const getUniqueSqlV2ReturnVariable = (
     fallbackReturnVariable: string
 ): string => {
     const used = new Set<string>()
-    let resolvedReturnVariable = fallbackReturnVariable.trim() ? resolveSqlV2ReturnVariable(fallbackReturnVariable) : ''
+    let resolvedReturnVariable = isReferenceableSqlV2FrameName(fallbackReturnVariable)
+        ? resolveSqlV2ReturnVariable(fallbackReturnVariable)
+        : ''
     let resolvedFromNodes = false
 
     nodes.forEach((node) => {
-        // An unnamed cell binds no dataframe: it claims no name and needs none reserved.
+        // An unnamed or invalid cell binds no dataframe: it claims no name and needs none reserved.
         if (!node.returnVariable) {
             if (node.nodeId === nodeId) {
                 resolvedReturnVariable = ''
@@ -374,9 +384,9 @@ export const collectSqlV2Nodes = (content?: JSONContent | null): SqlV2NodeSummar
             const attrs = node.attrs ?? {}
             const code = typeof attrs.code === 'string' ? attrs.code : ''
             // A missing attribute predates the optional name (legacy default); an explicit
-            // blank means the user left it empty — the cell binds no dataframe.
+            // blank or invalid one binds no dataframe (nothing can reference it).
             const rawReturnVariable = typeof attrs.returnVariable === 'string' ? attrs.returnVariable : 'sql_df'
-            const returnVariable = rawReturnVariable.trim()
+            const returnVariable = isReferenceableSqlV2FrameName(rawReturnVariable)
                 ? buildUniqueSqlV2ReturnVariable(resolveSqlV2ReturnVariable(rawReturnVariable), usedReturnVariables)
                 : ''
             if (returnVariable) {
@@ -489,12 +499,12 @@ export const collectNotebookFrameNodes = (content?: JSONContent | null): Noteboo
             const attrs = node.attrs ?? {}
             const isSql = node.type === NotebookNodeType.SQLV2
             // A missing SQL attribute predates the optional name (legacy 'sql_df' default);
-            // an explicit blank means the cell binds no dataframe — nothing to browse.
+            // an explicit blank or invalid one binds no dataframe — nothing to browse.
             const rawReturnVariable =
                 typeof attrs.returnVariable === 'string' ? attrs.returnVariable : isSql ? 'sql_df' : ''
             let name: string | null
             if (isSql) {
-                name = rawReturnVariable.trim()
+                name = isReferenceableSqlV2FrameName(rawReturnVariable)
                     ? buildUniqueSqlV2ReturnVariable(resolveSqlV2ReturnVariable(rawReturnVariable), usedReturnVariables)
                     : null
                 if (name) {
@@ -789,9 +799,9 @@ export const buildNotebookDependencyGraph = (content?: JSONContent | null): Note
         if (node.type === NotebookNodeType.SQLV2) {
             const attrs = node.attrs ?? {}
             sqlV2Index += 1
-            // Blank name = display-only cell: it exports nothing (see collectSqlV2Nodes).
+            // Blank or invalid name = display-only cell: it exports nothing (see collectSqlV2Nodes).
             const rawReturnVariable = typeof attrs.returnVariable === 'string' ? attrs.returnVariable : 'sql_df'
-            const returnVariable = rawReturnVariable.trim()
+            const returnVariable = isReferenceableSqlV2FrameName(rawReturnVariable)
                 ? buildUniqueSqlV2ReturnVariable(
                       resolveSqlV2ReturnVariable(rawReturnVariable),
                       usedSqlV2ReturnVariables

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -488,27 +488,33 @@ export const collectNotebookFrameNodes = (content?: JSONContent | null): Noteboo
         if (node.type === NotebookNodeType.SQLV2 || node.type === NotebookNodeType.PythonV2) {
             const attrs = node.attrs ?? {}
             const isSql = node.type === NotebookNodeType.SQLV2
-            const rawReturnVariable = typeof attrs.returnVariable === 'string' ? attrs.returnVariable : ''
-            let name: string
+            // A missing SQL attribute predates the optional name (legacy 'sql_df' default);
+            // an explicit blank means the cell binds no dataframe — nothing to browse.
+            const rawReturnVariable =
+                typeof attrs.returnVariable === 'string' ? attrs.returnVariable : isSql ? 'sql_df' : ''
+            let name: string | null
             if (isSql) {
-                name = buildUniqueSqlV2ReturnVariable(
-                    resolveSqlV2ReturnVariable(rawReturnVariable),
-                    usedReturnVariables
-                )
-                usedReturnVariables.add(normalizeSqlIdentifier(name))
+                name = rawReturnVariable.trim()
+                    ? buildUniqueSqlV2ReturnVariable(resolveSqlV2ReturnVariable(rawReturnVariable), usedReturnVariables)
+                    : null
+                if (name) {
+                    usedReturnVariables.add(normalizeSqlIdentifier(name))
+                }
             } else {
                 name = rawReturnVariable.trim() || 'df'
             }
-            const result = attrs.result ?? null
-            nodes.push({
-                nodeId: attrs.nodeId ?? '',
-                name,
-                nodeType: isSql ? 'sql' : 'python',
-                columns: frameNodeColumns(result),
-                rowCount: typeof result?.row_count === 'number' ? result.row_count : null,
-                hasRun: Boolean(result),
-                code: typeof attrs.code === 'string' ? attrs.code : '',
-            })
+            if (name) {
+                const result = attrs.result ?? null
+                nodes.push({
+                    nodeId: attrs.nodeId ?? '',
+                    name,
+                    nodeType: isSql ? 'sql' : 'python',
+                    columns: frameNodeColumns(result),
+                    rowCount: typeof result?.row_count === 'number' ? result.row_count : null,
+                    hasRun: Boolean(result),
+                    code: typeof attrs.code === 'string' ? attrs.code : '',
+                })
+            }
         }
         if (node.type === NotebookNodeType.MarkdownNotebook) {
             expandMarkdownNotebookNodesOfTypes(node, [NotebookNodeType.SQLV2, NotebookNodeType.PythonV2]).forEach(walk)

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
@@ -2,6 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import { initKeaTests } from '~/test/init'
 
@@ -155,21 +156,24 @@ describe('notebookNodeSQLV2Logic', () => {
             })
         })
 
-        it('opens the kernel panel for a kernel-lane run and not for a direct one', async () => {
+        it('opens the kernel panel and notifies for a kernel-lane run, and not for a direct one', async () => {
             // Scenario B: a run that needs the sandbox must surface the provisioning wait;
-            // a pure-SQL run must never pop the panel (it needs no sandbox at all).
+            // a pure-SQL run must never pop the panel or toast (it needs no sandbox at all).
+            const toastSpy = jest.spyOn(lemonToast, 'info')
             mount()
             logic.actions.runQuery('select 1')
             await expectLogic(logic).toFinishAllListeners()
             expect(logic.values.activeRunLane).toEqual('direct')
             expect(notebookSettingsLogic.findMounted()?.values.showKernelInfo).toBe(false)
             expect(logic.values.pendingKernelStart).toBe(false)
+            expect(toastSpy).not.toHaveBeenCalled()
 
             logic.actions.runQuery('select * from new_events', { new_events: { node_id: 'py', kind: 'local' } })
             await expectLogic(logic).toFinishAllListeners()
             expect(logic.values.activeRunLane).toEqual('kernel')
             expect(notebookSettingsLogic.findMounted()?.values.showKernelInfo).toBe(true)
             expect(logic.values.pendingKernelStart).toBe(true)
+            expect(toastSpy).toHaveBeenCalledWith(expect.stringContaining('Starting a compute sandbox'))
         })
     })
 

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
@@ -6,6 +6,7 @@ import { JSONContent } from 'lib/components/RichContentEditor/types'
 import { initKeaTests } from '~/test/init'
 
 import { buildMarkdownNotebookContent, serializeMarkdownNotebookComponent } from '../Notebook/markdownNotebookV2'
+import { notebookSettingsLogic } from '../Notebook/notebookSettingsLogic'
 import { NotebookNodeType } from '../types'
 import { collectSqlV2Refs, notebookNodeSQLV2Logic } from './notebookNodeSQLV2Logic'
 
@@ -67,9 +68,11 @@ describe('notebookNodeSQLV2Logic', () => {
             expect(collectSqlV2Refs(document, 'self')).toEqual({ sql_df: hogql('a'), sql_df_2: hogql('b') })
         })
 
-        it('resolves blank names to the default the dependency graph shows', () => {
-            const document = doc(sqlNode('a', ''), sqlNode('b', '  '))
-            expect(collectSqlV2Refs(document, 'self')).toEqual({ sql_df: hogql('a'), sql_df_2: hogql('b') })
+        it('skips unnamed cells and lets a named sibling keep the default name', () => {
+            // The dataframe name is optional: a blank-name cell is display-only and exports
+            // nothing — and it must not push a real 'sql_df' cell into a disambiguated name.
+            const document = doc(sqlNode('a', ''), sqlNode('b', '  '), sqlNode('c', 'sql_df'))
+            expect(collectSqlV2Refs(document, 'self')).toEqual({ sql_df: hogql('c') })
         })
 
         it('finds SQLV2 nodes nested inside other content', () => {
@@ -116,6 +119,57 @@ describe('notebookNodeSQLV2Logic', () => {
             // Without a persisted nodeId the cell falls back to its parsed fingerprint id.
             expect(refs.df3?.node_id).toMatch(/^mdn-/)
             expect(refs.new_events).toEqual(local('py'))
+        })
+    })
+
+    describe('execution lanes', () => {
+        it('pages a direct run client-side from the rows the result poll returned', async () => {
+            // The server page endpoint refuses hogql runs; losing the local slice would
+            // strand every page beyond the envelope's first.
+            const rows = Array.from({ length: 120 }, (_, index) => [index])
+            resultSpy.mockResolvedValue({
+                status: 'done',
+                result: {
+                    columns: ['a'],
+                    types: [['a', 'Int64']],
+                    row_count: 50,
+                    first_page: rows.slice(0, 50),
+                    has_more: true,
+                },
+                error: null,
+                rows,
+            })
+            const pageSpy = jest.spyOn(api.notebooks, 'sqlV2RunPage')
+            mount({ runId: 'r1', hasResult: false })
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.directRows?.rows).toHaveLength(120)
+
+            logic.actions.setPage(3)
+            await expectLogic(logic).toFinishAllListeners()
+            expect(pageSpy).not.toHaveBeenCalled()
+            expect(logic.values.pageResult).toEqual({
+                columns: ['a'],
+                types: [['a', 'Int64']],
+                rows: rows.slice(100, 120),
+                has_more: false,
+            })
+        })
+
+        it('opens the kernel panel for a kernel-lane run and not for a direct one', async () => {
+            // Scenario B: a run that needs the sandbox must surface the provisioning wait;
+            // a pure-SQL run must never pop the panel (it needs no sandbox at all).
+            mount()
+            logic.actions.runQuery('select 1')
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.activeRunLane).toEqual('direct')
+            expect(notebookSettingsLogic.findMounted()?.values.showKernelInfo).toBe(false)
+            expect(logic.values.pendingKernelStart).toBe(false)
+
+            logic.actions.runQuery('select * from new_events', { new_events: { node_id: 'py', kind: 'local' } })
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.activeRunLane).toEqual('kernel')
+            expect(notebookSettingsLogic.findMounted()?.values.showKernelInfo).toBe(true)
+            expect(logic.values.pendingKernelStart).toBe(true)
         })
     })
 

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
@@ -76,6 +76,13 @@ describe('notebookNodeSQLV2Logic', () => {
             expect(collectSqlV2Refs(document, 'self')).toEqual({ sql_df: hogql('c') })
         })
 
+        it('skips cells with an invalid (non-identifier) name', () => {
+            // `people-df` can never be referenced as a bare table name, so it must not be
+            // offered as a ref that a downstream cell would fail to resolve.
+            const document = doc(sqlNode('a', 'people-df'), sqlNode('b', 'good_df'))
+            expect(collectSqlV2Refs(document, 'self')).toEqual({ good_df: hogql('b') })
+        })
+
         it('finds SQLV2 nodes nested inside other content', () => {
             const document = doc({ type: 'column', content: [sqlNode('a', 'df1')] })
             expect(collectSqlV2Refs(document, 'self')).toEqual({ df1: hogql('a') })

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
@@ -174,15 +174,6 @@ export interface notebookNodeSQLV2LogicActions {
     interruptRun: () => {
         value: true
     }
-    setActiveRunLane: (activeRunLane: SqlV2RunLane) => {
-        activeRunLane: SqlV2RunLane
-    }
-    setDirectRows: (directRows: NotebookNodeSQLV2DirectRows | null) => {
-        directRows: NotebookNodeSQLV2DirectRows | null
-    }
-    setPendingKernelStart: (pendingKernelStart: boolean) => {
-        pendingKernelStart: boolean
-    }
     pollResult: (runId: string) => {
         runId: string
     }
@@ -197,6 +188,12 @@ export interface notebookNodeSQLV2LogicActions {
         code: string
         opts: RunQueryOptions
         refs: Record<string, SqlV2RunRef>
+    }
+    setActiveRunLane: (activeRunLane: SqlV2RunLane) => {
+        activeRunLane: SqlV2RunLane
+    }
+    setDirectRows: (directRows: NotebookNodeSQLV2DirectRows | null) => {
+        directRows: NotebookNodeSQLV2DirectRows | null
     }
     setIsInterrupting: (isInterrupting: boolean) => {
         isInterrupting: boolean
@@ -215,6 +212,9 @@ export interface notebookNodeSQLV2LogicActions {
     }
     setPageSize: (pageSize: number) => {
         pageSize: number
+    }
+    setPendingKernelStart: (pendingKernelStart: boolean) => {
+        pendingKernelStart: boolean
     }
     setRunError: (runError: string | null) => {
         runError: string | null
@@ -501,6 +501,7 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                     if (!kernelKnownRunning) {
                         actions.setShowKernelInfo(true)
                         actions.setPendingKernelStart(true)
+                        lemonToast.info('Starting a compute sandbox. The cell will run once it’s ready.')
                     }
                 }
                 actions.startOperation(runOperation)

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
@@ -17,10 +17,17 @@ import api from 'lib/api'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
+import { notebookKernelInfoLogic } from '../Notebook/notebookKernelInfoLogic'
 import { notebookNodeStalenessLogic } from '../Notebook/notebookNodeStalenessLogic'
 import { NotebookOperation, notebookOperationsLogic } from '../Notebook/notebookOperationsLogic'
+import { notebookSettingsLogic } from '../Notebook/notebookSettingsLogic'
 import { NotebookNodeType } from '../types'
-import { buildNotebookDependencyGraph, collectPythonKernelNodes, collectSqlV2Nodes } from './notebookNodeContent'
+import {
+    buildNotebookDependencyGraph,
+    collectPythonKernelNodes,
+    collectSqlV2Nodes,
+    extractDuckSqlTables,
+} from './notebookNodeContent'
 import { NotebookNodeSQLV2Result } from './NotebookNodeSQLV2'
 
 export type SqlV2RunRef = {
@@ -42,7 +49,8 @@ export type SqlV2RunRef = {
 export function collectSqlV2Refs(doc: JSONContent | null | undefined, selfNodeId: string): Record<string, SqlV2RunRef> {
     const refs: Record<string, SqlV2RunRef> = {}
     for (const node of collectSqlV2Nodes(doc)) {
-        if (node.nodeId && node.nodeId !== selfNodeId) {
+        // An unnamed cell (blank dataframe name) is display-only: nothing can reference it.
+        if (node.nodeId && node.nodeId !== selfNodeId && node.returnVariable) {
             refs[node.returnVariable] = { node_id: node.nodeId, kind: 'hogql' }
         }
     }
@@ -67,6 +75,18 @@ export type NotebookNodeSQLV2Page = {
     rows: (string | number | null)[][]
     has_more: boolean
 }
+
+// The full capped row set a direct (ClickHouse, no-sandbox) run returns with its result,
+// held in memory for client-side paging — never persisted into the document.
+export type NotebookNodeSQLV2DirectRows = {
+    columns: string[]
+    types: [string, string][]
+    rows: (string | number | null)[][]
+}
+
+// Which execution lane the node's current run took: 'direct' runs on ClickHouse with no
+// sandbox (no Stop affordance, client-side paging); 'kernel' runs in the sandbox.
+export type SqlV2RunLane = 'direct' | 'kernel'
 
 export interface RunQueryOptions {
     nodeType?: 'hogql' | 'python'
@@ -97,6 +117,8 @@ export interface notebookNodeSQLV2LogicValues {
     staleNodeIds: Record<string, true> // notebookNodeStalenessLogic
     activeOperation: NotebookOperation | null // notebookOperationsLogic
     isBusy: boolean // notebookOperationsLogic
+    activeRunLane: SqlV2RunLane | null
+    directRows: NotebookNodeSQLV2DirectRows | null
     isInterrupting: boolean
     isRunning: boolean
     isStale: boolean
@@ -105,6 +127,7 @@ export interface notebookNodeSQLV2LogicValues {
     pageLoading: boolean
     pageResult: NotebookNodeSQLV2Page | null
     pageSize: number
+    pendingKernelStart: boolean
     runError: string | null
     staleDownstreamCount: number
 }
@@ -145,8 +168,20 @@ export interface notebookNodeSQLV2LogicActions {
     startOperation: (operation: NotebookOperation) => {
         operation: NotebookOperation
     } // notebookOperationsLogic
+    setShowKernelInfo: (showKernelInfo: boolean) => {
+        showKernelInfo: boolean
+    } // notebookSettingsLogic
     interruptRun: () => {
         value: true
+    }
+    setActiveRunLane: (activeRunLane: SqlV2RunLane) => {
+        activeRunLane: SqlV2RunLane
+    }
+    setDirectRows: (directRows: NotebookNodeSQLV2DirectRows | null) => {
+        directRows: NotebookNodeSQLV2DirectRows | null
+    }
+    setPendingKernelStart: (pendingKernelStart: boolean) => {
+        pendingKernelStart: boolean
     }
     pollResult: (runId: string) => {
         runId: string
@@ -225,6 +260,8 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
             ['startOperation', 'finishOperation', 'finishNodeOperations'],
             notebookNodeStalenessLogic({ shortId: props.notebookShortId }),
             ['nodeRunFinished', 'dispatchChainRun', 'runStaleChain', 'registerChainNode', 'unregisterChainNode'],
+            notebookSettingsLogic,
+            ['setShowKernelInfo'],
         ],
     })),
     actions({
@@ -249,6 +286,9 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
         setPageResult: (pageResult: NotebookNodeSQLV2Page | null) => ({ pageResult }),
         setPageLoading: (pageLoading: boolean) => ({ pageLoading }),
         resetPaging: true,
+        setDirectRows: (directRows: NotebookNodeSQLV2DirectRows | null) => ({ directRows }),
+        setActiveRunLane: (activeRunLane: SqlV2RunLane) => ({ activeRunLane }),
+        setPendingKernelStart: (pendingKernelStart: boolean) => ({ pendingKernelStart }),
     }),
     reducers({
         // Tracks the run being in progress; driven by the run's status, not a socket lifecycle.
@@ -311,12 +351,46 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                 resetPaging: () => false,
             },
         ],
+        // Session-local rows for client-side paging of direct runs; a new run invalidates them.
+        directRows: [
+            null as NotebookNodeSQLV2DirectRows | null,
+            {
+                setDirectRows: (_, { directRows }) => directRows,
+                runQuery: () => null,
+            },
+        ],
+        activeRunLane: [
+            null as SqlV2RunLane | null,
+            {
+                setActiveRunLane: (_, { activeRunLane }) => activeRunLane,
+            },
+        ],
+        // A kernel-lane run was submitted while no kernel was known to be up: the backend is
+        // provisioning the sandbox; drives the "Starting compute sandbox…" caption.
+        pendingKernelStart: [
+            false,
+            {
+                setPendingKernelStart: (_, { pendingKernelStart }) => pendingKernelStart,
+                stopPolling: () => false,
+            },
+        ],
     }),
     listeners(({ props, actions, cache, values }) => {
         // One operation at a time across the whole notebook (see notebookOperationsLogic);
         // ids are per node + kind so re-registering our own operation stays idempotent.
         const runOperation: NotebookOperation = { id: `${props.nodeId}:run`, nodeId: props.nodeId, kind: 'run' }
         const pageOperation: NotebookOperation = { id: `${props.nodeId}:page`, nodeId: props.nodeId, kind: 'page' }
+
+        // Slice a page out of the in-memory direct-run rows — no network, no operation lock.
+        const sliceDirectRows = (rows: NotebookNodeSQLV2DirectRows, page: number, pageSize: number): void => {
+            const start = (page - 1) * pageSize
+            actions.setPageResult({
+                columns: rows.columns,
+                types: rows.types,
+                rows: rows.rows.slice(start, start + pageSize),
+                has_more: start + pageSize < rows.rows.length,
+            })
+        }
 
         const loadCurrentPage = async (): Promise<void> => {
             const { page, pageSize } = values
@@ -327,6 +401,10 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
             if (page === 1 && pageSize === SQL_V2_DEFAULT_PAGE_SIZE) {
                 // The envelope already carries this page — no round trip.
                 actions.setPageResult(null)
+                return
+            }
+            if (values.directRows) {
+                sliceDirectRows(values.directRows, page, pageSize)
                 return
             }
             // The pagination UI is disabled while the notebook is busy; this guards the
@@ -340,6 +418,26 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
             const fetchId = (cache.pageFetchId = (cache.pageFetchId ?? 0) + 1)
             actions.setPageLoading(true)
             try {
+                // A direct run keeps its full row set on the result endpoint while the backend's
+                // query result is alive — recover it once (e.g. after a reload) and page locally
+                // from then on. Kernel runs return no rows here and fall through to server paging.
+                try {
+                    const recovered = await api.notebooks.sqlV2RunResult(props.notebookShortId, runId)
+                    if (recovered.status === 'done' && recovered.rows) {
+                        const directRows: NotebookNodeSQLV2DirectRows = {
+                            columns: recovered.result?.columns ?? [],
+                            types: recovered.result?.types ?? [],
+                            rows: recovered.rows,
+                        }
+                        actions.setDirectRows(directRows)
+                        if (cache.pageFetchId === fetchId) {
+                            sliceDirectRows(directRows, page, pageSize)
+                        }
+                        return
+                    }
+                } catch {
+                    // Recovery is best-effort; the server page below reports real errors.
+                }
                 const pageResult = await api.notebooks.sqlV2RunPage(props.notebookShortId, runId, {
                     offset: (page - 1) * pageSize,
                     limit: pageSize,
@@ -385,6 +483,25 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                     actions.setIsRunning(false)
                     actions.nodeRunFinished(props.nodeId, 'failed', null)
                     return
+                }
+                // Which lane will this run take? Mirrors the backend's routing: python always
+                // needs the kernel; SQL needs it only when it reads a local (python-made) frame.
+                // The backend stays authoritative — this only drives the Stop affordance and
+                // the kernel panel, never dispatch.
+                const isKernelLane =
+                    opts.nodeType === 'python' ||
+                    extractDuckSqlTables(code).some((name) => refs[name]?.kind === 'local')
+                actions.setActiveRunLane(isKernelLane ? 'kernel' : 'direct')
+                if (isKernelLane) {
+                    // The backend provisions the sandbox itself when none is running; open the
+                    // kernel panel so the user can watch it come up instead of guessing.
+                    const kernelKnownRunning =
+                        notebookKernelInfoLogic.findMounted({ shortId: props.notebookShortId })?.values.isRunning ??
+                        false
+                    if (!kernelKnownRunning) {
+                        actions.setShowKernelInfo(true)
+                        actions.setPendingKernelStart(true)
+                    }
                 }
                 actions.startOperation(runOperation)
                 try {
@@ -453,11 +570,21 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                 }
                 cache.pollInFlight = true
                 try {
-                    const { status, result, error } = await api.notebooks.sqlV2RunResult(props.notebookShortId, runId)
+                    const { status, result, error, rows } = await api.notebooks.sqlV2RunResult(
+                        props.notebookShortId,
+                        runId
+                    )
                     // A newer run started while this poll was in flight — its result and poller
                     // must win, so drop this stale response instead of overwriting/stopping it.
                     if (runId !== cache.activeRunId) {
                         return
+                    }
+                    // Once the kernel panel reports the sandbox up, the wait is execution, not startup.
+                    if (
+                        values.pendingKernelStart &&
+                        notebookKernelInfoLogic.findMounted({ shortId: props.notebookShortId })?.values.isRunning
+                    ) {
+                        actions.setPendingKernelStart(false)
                     }
                     const envelopeResult: NotebookNodeSQLV2Result | null = result
                         ? {
@@ -472,6 +599,17 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                           }
                         : null
                     if (status === 'done') {
+                        // A direct run's full capped row set arrives with the result — keep it
+                        // in memory for client-side paging (kernel runs return no rows here).
+                        actions.setDirectRows(
+                            rows
+                                ? {
+                                      columns: result?.columns ?? [],
+                                      types: result?.types ?? [],
+                                      rows,
+                                  }
+                                : null
+                        )
                         props.updateAttributes({ result: envelopeResult })
                         // A fresh envelope replaces whatever page the user had drilled into.
                         actions.resetPaging()

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -554,7 +554,9 @@
         }
 
         .Notebook__markdown-v2 .MarkdownNotebook__canvas {
-            padding-bottom: 6rem;
+            // Generous trailing space so the last cell can scroll up off the bottom edge —
+            // room to breathe while editing a cell near the end of the notebook.
+            padding-bottom: max(18rem, 40vh);
         }
 
         .NotebookColumn--left.NotebookColumn--showing {

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
@@ -1,5 +1,7 @@
 import { render } from '@testing-library/react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+
 import { NotebookNodeType } from '../types'
 import { KNOWN_NODES } from '../utils'
 import {
@@ -7,12 +9,31 @@ import {
     RealNotebookNodeEdit,
     getEditableNodeAttributeKeys,
     getMarkdownNodeAttributeLabel,
+    getMarkdownRegistryForFeatureFlags,
     getQueryTitle,
     getSerializableAttributeInputValue,
     getSerializableProps,
 } from './markdownNotebookRegistry'
 
 describe('markdownNotebookRegistry', () => {
+    describe('getMarkdownRegistryForFeatureFlags', () => {
+        it('offers a single SQL and Python cell, gated by the revamped notebooks flag', () => {
+            // The unified insert surface: SQLV2 ("SQL") and PythonV2 ("Python") are the only
+            // insertable code cells with the flag on; the legacy SQL/Python cells and the
+            // legacy query node render but must never be insertable in markdown notebooks.
+            const flagOn = getMarkdownRegistryForFeatureFlags({ [FEATURE_FLAGS.REVAMPED_PY_NOTEBOOKS]: true })
+            expect(flagOn.components.SQLV2.insertCommand).toBeTruthy()
+            expect(flagOn.components.PythonV2.insertCommand).toBeTruthy()
+            for (const legacyTag of ['Query', 'Python', 'DuckSQL', 'HogQLSQL']) {
+                expect(flagOn.components[legacyTag].insertCommand).toBeUndefined()
+            }
+
+            const flagOff = getMarkdownRegistryForFeatureFlags({})
+            expect(flagOff.components.SQLV2.insertCommand).toBeUndefined()
+            expect(flagOff.components.PythonV2.insertCommand).toBeUndefined()
+        })
+    })
+
     it('does not make real notebook nodes mutually exclusive in markdown notebooks', () => {
         expect(NOTEBOOK_MARKDOWN_REGISTRY.components.Recording.exclusiveEditPanel).toBeUndefined()
         expect(NOTEBOOK_MARKDOWN_REGISTRY.components.FeatureFlag.exclusiveEditPanel).toBeUndefined()

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -173,7 +173,9 @@ export const MARKDOWN_NODE_DEFINITIONS: {
     {
         tagName: 'SQLV2',
         category: 'SQL',
-        label: 'SQL (v2)',
+        // The single SQL node once the legacy SQL cells are deprecated (they render but
+        // are not insertable), so it reads as plain "SQL" in the insert menu.
+        label: 'SQL',
         insertCommand: {
             aliases: ['data', 'sql'],
             // New cells get a durable nodeId up front: parsed markdown block ids are content


### PR DESCRIPTION
## Problem

Frontend half of the kernel-less SQL work (stacked on #72362). With the backend direct lane in place, the SQLV2 cell UI still assumed every run had a sandbox: the dataframe name was mandatory (defaulting to `sql_df` whether you wanted a binding or not), Stop was offered on runs that cannot be cancelled, paging always called the now-retired server endpoint, and a python run submitted without a kernel gave no hint that a sandbox was being provisioned.

## Changes

- The dataframe name is now optional. Empty means display-only, the cell exports nothing, reserves no name, and stays out of the schema browser. Non-empty names validate as identifiers with a concrete suggestion (`people-df` hints "Try people_df."), since the name is referenced as a bare SQL table name and becomes a Python variable when a python cell reads the frame. Cells with a missing attribute keep the legacy `sql_df` default, so existing notebooks are unaffected.
- Runs are lane-aware, mirroring the backend's routing. A kernel-lane run (python cell, or SQL cell reading a local frame) submitted with no kernel known to be running auto-opens the kernel panel, shows an info toast ("Starting a compute sandbox. The cell will run once it's ready.") and renders a "Starting compute sandbox…" caption in the cell until the panel reports the sandbox up. Direct runs never show Stop, there is nothing to signal.
- Direct results page client-side from the transient row set the result poll returns, with no network and no operation lock. After a reload, the first out-of-envelope page does a one-shot recovery fetch from the result endpoint; kernel frames keep server paging.
- The insert menu presents SQLV2 as plain "SQL" (it is the single insertable SQL cell in markdown notebooks; the legacy SQL cells render but were already not insertable). A new registry test pins the whole surface under the flag, on and off.
- Integration fix after #71709 landed: the dataframe browser's document-derived collector now skips explicitly-unnamed cells instead of listing them under the legacy `sql_df` default (which also pushed a genuinely named `sql_df` cell into `sql_df_2`).

No screenshots, I (Claude) could not capture the browser; the flow was exercised live in the local dev stack during the session.

## How did you test this code?

- 62 jest tests across the four touched suites pass (`notebookNodeSQLV2Logic`, `notebookNodeContent`, `markdownNotebookRegistry`, `notebookDataframeTree`).
- New or changed pins, each catching a regression nothing else caught: a blank-name cell exports nothing and cannot push a named `sql_df` sibling into a disambiguated name (this flips one old test that pinned the opposite behavior, deliberately); a direct run pages client-side without ever calling the retired page endpoint; a kernel-lane run opens the kernel panel and toasts while a direct run does neither; the registry offers exactly one SQL and one Python insertable cell with the flag on; unnamed cells stay out of the dataframe browser.
- Scoped oxlint/oxfmt clean. The full `typescript:check` cannot pass in my checkout (kea typegen artifacts absent, hundreds of pre-existing errors in untouched files), but a filtered pass shows zero errors in the files this PR touches; CI regenerates typegen before its check and is the arbiter.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None, flag-gated pre-GA surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Claude Fable 5), directed by the assignee. Skills invoked: `/adopting-generated-api-types` (kept the manual `api.notebooks.*` calls, these endpoints are schema-excluded so no generated types exist), `/writing-tests`.
- Lane detection lives in the shared `notebookNodeSQLV2Logic` so python and SQL cells get identical behavior from one implementation; the kernel-status logic is read with `findMounted` so SQL-only notebooks never mount the kernel status poller.
- Rendering results through `dataNodeLogic`/DataTable was considered for reuse and rejected: python and DuckDB cells must render envelopes, and splitting the table implementation across cell kinds costs more than it saves.
- The transient rows are held in kea state and never persisted into the notebook document, keeping the envelope-stays-small rule intact.
