### PR TITLE
feat(review-hog): group review skills under a "Review skills" header

### DIFF
--- a/products/review_hog/frontend/CodeReviewScene.tsx
+++ b/products/review_hog/frontend/CodeReviewScene.tsx
@@ -1389,7 +1389,7 @@ function PerspectivesSection(): JSX.Element {
     const { togglePerspective } = useActions(reviewHogSettingsLogic)
 
     return (
-        <section className="flex flex-col gap-4 border-t border-primary pt-8">
+        <section className="flex flex-col gap-4">
             <SectionHeader
                 icon={<IconStack />}
                 title="Perspectives"
@@ -1447,7 +1447,7 @@ function SingleActiveSection({
     const { blockSingleActiveDeactivation } = useActions(reviewHogSettingsLogic)
 
     return (
-        <section className="flex flex-col gap-4 border-t border-primary pt-8">
+        <section className="flex flex-col gap-4">
             <SectionHeader
                 icon={icon}
                 title={title}
@@ -1570,30 +1570,41 @@ export function CodeReviewScene(): JSX.Element {
                 <RecentReviewsSection />
                 <PipelineSection />
                 <TriggersSection />
+                <section className="flex flex-col gap-8 border-t border-primary pt-8">
+                    <div className="flex flex-col gap-1.5">
+                        <h2 className="m-0 text-xl font-bold">Review skills</h2>
+                        <p className="m-0 max-w-160 text-sm text-secondary">
+                            Everything below is a regular skill, stored in your PostHog skills store like anything else
+                            you've added. Perspectives read your changed code, a blind-spot sweep catches what they
+                            missed, and validation criteria decide what reaches the pull request. Toggling one here
+                            applies only to your pull request reviews; editing a skill changes it for the whole team.
+                        </p>
+                    </div>
+                    <PerspectivesSection />
+                    <SingleActiveSection
+                        icon={<IconSearch />}
+                        title="Blind-spot check"
+                        intro="After the enabled perspectives finish, ReviewHog runs one more sweep over each chunk — it sees what they found and hunts for real issues they all missed. Add as many sweeps as you like, but only one runs."
+                        kind="blind_spots"
+                        kindLabel="blind-spot check"
+                        preamble={<EffectivenessCard kind="blind_spots" />}
+                        createLabel="Create your own blind-spot check"
+                        skills={blindSpots?.map((s) => ({ ...s, on: s.active })) ?? null}
+                        onSelect={selectBlindSpots}
+                    />
+                    <SingleActiveSection
+                        icon={<IconShield />}
+                        title="Validation criteria"
+                        intro="Every candidate finding is checked against your quality bar before publishing, so noisy, speculative, or low-value issues never reach the pull request. Keep several bars on hand, but only one is applied."
+                        kind="validator"
+                        kindLabel="validator"
+                        createLabel="Create your own validation criteria"
+                        preamble={<ValidatorEffectivenessCard />}
+                        skills={validators?.map((s) => ({ ...s, on: s.active })) ?? null}
+                        onSelect={selectValidator}
+                    />
+                </section>
                 <UrgencySection />
-                <PerspectivesSection />
-                <SingleActiveSection
-                    icon={<IconSearch />}
-                    title="Blind-spot check"
-                    intro="After the enabled perspectives finish, ReviewHog runs one more sweep over each chunk — it sees what they found and hunts for real issues they all missed. Add as many sweeps as you like, but only one runs."
-                    kind="blind_spots"
-                    kindLabel="blind-spot check"
-                    preamble={<EffectivenessCard kind="blind_spots" />}
-                    createLabel="Create your own blind-spot check"
-                    skills={blindSpots?.map((s) => ({ ...s, on: s.active })) ?? null}
-                    onSelect={selectBlindSpots}
-                />
-                <SingleActiveSection
-                    icon={<IconShield />}
-                    title="Validation criteria"
-                    intro="Every candidate finding is checked against your quality bar before publishing, so noisy, speculative, or low-value issues never reach the pull request. Keep several bars on hand, but only one is applied."
-                    kind="validator"
-                    kindLabel="validator"
-                    createLabel="Create your own validation criteria"
-                    preamble={<ValidatorEffectivenessCard />}
-                    skills={validators?.map((s) => ({ ...s, on: s.active })) ?? null}
-                    onSelect={selectValidator}
-                />
 
                 <SkillDrawer />
                 <ReviewDetailDrawer />


### PR DESCRIPTION
## Problem

Perspectives, blind-spot checks, and validation criteria in ReviewHog are all regular skills stored in the PostHog skills store, but the settings page presented them as separate, differently-named blocks. As raised in the Slack thread, that framing hid the fact they're ordinary skills users can add and edit, so people didn't realize they interoperate with skills they already have.

## Changes

Grouped the three skill sections (Perspectives, Blind-spot check, Validation criteria) under a single "Review skills" header on the code review settings page, with a short description making clear they're regular skills in the skills store. Removed the individual top dividers from those sections so they nest under the group, and moved the "Urgency threshold" slider below the group.

![review-skills-header](https://raw.githubusercontent.com/PostHog/pr-assets/81a7590de9f9a136e741dc700aca85aa7b9f7dc8/2026/07/9c2d087f-00b6-42f0-ad96-d0805dfc846e.png)

## How did you test this code?

Frontend-only JSX regroup. Verified the rendered result in Storybook (a throwaway story with mocked review_hog endpoints, not committed) and captured the screenshot above. No automated tests added — this is a copy/layout change with no logic.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The change is confined to `products/review_hog/frontend/CodeReviewScene.tsx`: a new "Review skills" grouping section wraps the three skill `<section>`s, whose own `border-t`/`pt-8` dividers were dropped so they read as one group, and `UrgencySection` was moved after the group.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1784563632051999?thread_ts=1784563632.051999&cid=C09SK2PAGKF)*
