### PR TITLE
feat(review_hog): show a calming gif when a review finds nothing

### DIFF
--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -11,6 +11,7 @@ Every entry point here is best-effort by construction: a status comment must nev
 retry a review, so all exceptions are swallowed after logging.
 """
 
+import hashlib
 import logging
 from datetime import timedelta
 from typing import Any
@@ -68,6 +69,27 @@ _PRIORITY_LABELS = {
     IssuePriority.CONSIDER: "consider",
 }
 
+# A clean review deserves a reward, not a bare "nothing here". When a run finds nothing worth
+# raising we still post the comment (so "no comment" can never be mistaken for "the run broke"),
+# but we swap the flat sign-off for a calming gif. All hand-verified as wholesome nature/animal
+# loops; picked deterministically per report so the in-place-edited comment never flickers.
+CALMING_GIFS: tuple[tuple[str, str], ...] = (
+    ("https://media.tenor.com/isp84OorcycAAAAM/hanzero.gif", "A lone tree by a lake at sunset"),
+    ("https://media.tenor.com/bsXZ73A8EKQAAAAM/beach-vacation.gif", "Calm water at sunset"),
+    ("https://media.tenor.com/ws2O3uBihokAAAAM/zen-candles.gif", "A bamboo water fountain and a candle"),
+    ("https://media.tenor.com/7hKg_qwM48YAAAAM/otters-clapping.gif", "A raft of sea otters"),
+    ("https://media.tenor.com/qofqL6CtWz4AAAAM/animal-goat.gif", "A baby goat being petted"),
+    ("https://media.tenor.com/aRhLpjBnWSkAAAAM/inner-peace-po.gif", "A panda finding its inner peace"),
+    ("https://media.tenor.com/qMR829Mi6uwAAAAM/panda-adorable.gif", "A baby panda"),
+    ("https://media.tenor.com/P-Bw6WVxh7QAAAAM/fox-excited.gif", "A fox trotting across a deck"),
+)
+
+
+def _calming_gif(report_id: str) -> tuple[str, str]:
+    """A stable (url, alt) pick for the report — same report always gets the same gif."""
+    digest = hashlib.sha256(report_id.encode()).digest()
+    return CALMING_GIFS[digest[0] % len(CALMING_GIFS)]
+
 
 def status_marker(report_id: str) -> str:
     """The hidden marker identifying the report's status comment across turns and crashed runs."""
@@ -121,7 +143,16 @@ def render_final_body(
     )
     lines = ["### \U0001f994 ReviewHog reviewed this pull request", ""]
     if found_total == 0:
-        lines.append("Found no issues worth raising, so no review was posted.")
+        gif_url, gif_alt = _calming_gif(report_id)
+        lines.extend(
+            [
+                "No issues found, so you're all clear.",
+                "",
+                "Nothing worth raising this time, so here's a calming gif instead:",
+                "",
+                f"![{gif_alt}]({gif_url})",
+            ]
+        )
     else:
         lines.append(found_line + ".")
         lines.append("")

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -11,7 +11,6 @@ Every entry point here is best-effort by construction: a status comment must nev
 retry a review, so all exceptions are swallowed after logging.
 """
 
-import hashlib
 import logging
 from datetime import timedelta
 from typing import Any
@@ -69,27 +68,6 @@ _PRIORITY_LABELS = {
     IssuePriority.CONSIDER: "consider",
 }
 
-# A clean review deserves a reward, not a bare "nothing here". When a run finds nothing worth
-# raising we still post the comment (so "no comment" can never be mistaken for "the run broke"),
-# but we swap the flat sign-off for a calming gif. All hand-verified as wholesome nature/animal
-# loops; picked deterministically per report so the in-place-edited comment never flickers.
-CALMING_GIFS: tuple[tuple[str, str], ...] = (
-    ("https://media.tenor.com/isp84OorcycAAAAM/hanzero.gif", "A lone tree by a lake at sunset"),
-    ("https://media.tenor.com/bsXZ73A8EKQAAAAM/beach-vacation.gif", "Calm water at sunset"),
-    ("https://media.tenor.com/ws2O3uBihokAAAAM/zen-candles.gif", "A bamboo water fountain and a candle"),
-    ("https://media.tenor.com/7hKg_qwM48YAAAAM/otters-clapping.gif", "A raft of sea otters"),
-    ("https://media.tenor.com/qofqL6CtWz4AAAAM/animal-goat.gif", "A baby goat being petted"),
-    ("https://media.tenor.com/aRhLpjBnWSkAAAAM/inner-peace-po.gif", "A panda finding its inner peace"),
-    ("https://media.tenor.com/qMR829Mi6uwAAAAM/panda-adorable.gif", "A baby panda"),
-    ("https://media.tenor.com/P-Bw6WVxh7QAAAAM/fox-excited.gif", "A fox trotting across a deck"),
-)
-
-
-def _calming_gif(report_id: str) -> tuple[str, str]:
-    """A stable (url, alt) pick for the report — same report always gets the same gif."""
-    digest = hashlib.sha256(report_id.encode()).digest()
-    return CALMING_GIFS[digest[0] % len(CALMING_GIFS)]
-
 
 def status_marker(report_id: str) -> str:
     """The hidden marker identifying the report's status comment across turns and crashed runs."""
@@ -143,16 +121,7 @@ def render_final_body(
     )
     lines = ["### \U0001f994 ReviewHog reviewed this pull request", ""]
     if found_total == 0:
-        gif_url, gif_alt = _calming_gif(report_id)
-        lines.extend(
-            [
-                "No issues found, so you're all clear.",
-                "",
-                "Nothing worth raising this time, so here's a calming gif instead:",
-                "",
-                f"![{gif_alt}]({gif_url})",
-            ]
-        )
+        lines.append("Nothing worth raising this time.")
     else:
         lines.append(found_line + ".")
         lines.append("")

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -68,6 +68,15 @@ _PRIORITY_LABELS = {
     IssuePriority.CONSIDER: "consider",
 }
 
+# A clean review deserves a reward, not a bare "nothing here". We still post the comment (so "no
+# comment" can never be mistaken for "the run broke"), but swap the flat sign-off for a calming gif.
+# Self-hosted on pr-assets (SHA-pinned, permanent) rather than hotlinked, to keep it copyright-clean.
+_NO_ISSUES_GIF_URL = (
+    "https://raw.githubusercontent.com/PostHog/pr-assets/"
+    "24e9d1f83ef8bf85b66272011c3566563022fd8a/2026/07/8c4c3c83-bad4-4e0c-a007-20402aef3c78.gif"
+)
+_NO_ISSUES_GIF_ALT = "A frog chilling on the water"
+
 
 def status_marker(report_id: str) -> str:
     """The hidden marker identifying the report's status comment across turns and crashed runs."""
@@ -121,7 +130,13 @@ def render_final_body(
     )
     lines = ["### \U0001f994 ReviewHog reviewed this pull request", ""]
     if found_total == 0:
-        lines.append("Nothing worth raising this time.")
+        lines.extend(
+            [
+                "Nothing worth raising this time, so here's a calming gif instead:",
+                "",
+                f"![{_NO_ISSUES_GIF_ALT}]({_NO_ISSUES_GIF_URL})",
+            ]
+        )
     else:
         lines.append(found_line + ".")
         lines.append("")

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -73,9 +73,9 @@ _PRIORITY_LABELS = {
 # Self-hosted on pr-assets (SHA-pinned, permanent) rather than hotlinked, to keep it copyright-clean.
 _NO_ISSUES_GIF_URL = (
     "https://raw.githubusercontent.com/PostHog/pr-assets/"
-    "f1e44af03c5b884871f774d198f5934787a8da5c/2026/07/9b53d405-e8e6-4fba-ac7d-f23f8706cd67.gif"
+    "2cfa8ec2d6e5c88ed94a98881499a09153681886/2026/07/41e56d03-cfbe-4660-b7d5-8774d805af5c.gif"
 )
-_NO_ISSUES_GIF_ALT = "A happy hedgehog floating with a flower"
+_NO_ISSUES_GIF_ALT = "Someone relaxing in a sunny garden"
 
 
 def status_marker(report_id: str) -> str:

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -73,9 +73,9 @@ _PRIORITY_LABELS = {
 # Self-hosted on pr-assets (SHA-pinned, permanent) rather than hotlinked, to keep it copyright-clean.
 _NO_ISSUES_GIF_URL = (
     "https://raw.githubusercontent.com/PostHog/pr-assets/"
-    "24e9d1f83ef8bf85b66272011c3566563022fd8a/2026/07/8c4c3c83-bad4-4e0c-a007-20402aef3c78.gif"
+    "f1e44af03c5b884871f774d198f5934787a8da5c/2026/07/9b53d405-e8e6-4fba-ac7d-f23f8706cd67.gif"
 )
-_NO_ISSUES_GIF_ALT = "A frog chilling on the water"
+_NO_ISSUES_GIF_ALT = "A happy hedgehog floating with a flower"
 
 
 def status_marker(report_id: str) -> str:

--- a/products/review_hog/backend/tests/test_status_comment.py
+++ b/products/review_hog/backend/tests/test_status_comment.py
@@ -92,7 +92,7 @@ class TestRenderFinalBody:
                 0,
                 IssuePriority.SHOULD_FIX,
                 None,
-                ["No issues found, so you're all clear.", "calming gif", "https://media.tenor.com/"],
+                ["Nothing worth raising this time."],
                 ["Published", "stayed below"],
             ),
             # Posted on a prior crashed attempt (marker skip): published, but no link to render.

--- a/products/review_hog/backend/tests/test_status_comment.py
+++ b/products/review_hog/backend/tests/test_status_comment.py
@@ -92,7 +92,7 @@ class TestRenderFinalBody:
                 0,
                 IssuePriority.SHOULD_FIX,
                 None,
-                ["Nothing worth raising this time."],
+                ["Nothing worth raising this time, so here's a calming gif instead:", "![", "pr-assets"],
                 ["Published", "stayed below"],
             ),
             # Posted on a prior crashed attempt (marker skip): published, but no link to render.

--- a/products/review_hog/backend/tests/test_status_comment.py
+++ b/products/review_hog/backend/tests/test_status_comment.py
@@ -92,7 +92,7 @@ class TestRenderFinalBody:
                 0,
                 IssuePriority.SHOULD_FIX,
                 None,
-                ["Found no issues worth raising, so no review was posted."],
+                ["No issues found, so you're all clear.", "calming gif", "https://media.tenor.com/"],
                 ["Published", "stayed below"],
             ),
             # Posted on a prior crashed attempt (marker skip): published, but no link to render.


### PR DESCRIPTION
## Problem

When ReviewHog finishes a run and finds nothing worth raising, the PR status comment ended on a flat "Found no issues worth raising, so no review was posted." We still post the comment (so "no comment" is never mistaken for "the run broke"), but the sign-off can be warmer.

## Changes

- The zero-findings status comment now reads "Nothing worth raising this time, so here's a calming gif instead:" and embeds a calming gif.
- The gif is self-hosted on `PostHog/pr-assets` (SHA-pinned, permanent, public) rather than hotlinked from a third party, to keep it copyright-clean.

![reviewhog-no-issues](https://raw.githubusercontent.com/PostHog/pr-assets/2cfa8ec2d6e5c88ed94a98881499a09153681886/2026/07/41e56d03-cfbe-4660-b7d5-8774d805af5c.gif)

## How did you test this code?

Updated and ran the existing `render_final_body` parametrized tests (`TestRenderFinalBody`) — the zero-findings case asserts the new copy and the embedded gif. Ran ruff check + format. The DB-backed tests in the same file need a Postgres connection not available in this environment, so those weren't run here; the changed code path is pure string rendering covered by the passing tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: soften ReviewHog's "no issues" status comment with a calming gif. The clip was supplied by a human and self-hosted on pr-assets instead of hotlinked (copyright). An earlier revision explored a deterministically-picked library of gifs; this lands on a single vetted one.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1784566297006139?thread_ts=1784566297.006139&cid=C09SK2PAGKF)*
