### PR TITLE
fix(data-imports): retry MSSQL row-count probe on deadlock instead of capturing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/mssql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/mssql.py
@@ -824,6 +824,46 @@ class MSSQLImplementation(SQLSourceImplementation[MSSQLSourceConfig, pymssql.Con
             capture_exception(e)
             return None
 
+    def get_rows_to_sync(
+        self,
+        cursor: pymssql.Cursor,
+        inner_query: str,
+        inner_query_args: Any,
+        logger: FilteringBoundLogger,
+    ) -> int:
+        """Count the rows the given `inner_query` will produce. Returns 0 on error.
+
+        Runs before any rows are streamed, so a 1205 deadlock victim here is exactly as
+        safe to rerun as the main read query — wrap it in the same `retry_on_deadlock`
+        rather than falling straight through to the base class's catch-all, which would
+        give up on the first lock conflict instead of recovering an accurate count.
+        """
+        try:
+            query = f"SELECT COUNT(*) FROM ({inner_query}) as t"
+
+            def _run() -> Any:
+                cursor.execute(query, inner_query_args)
+                return cursor.fetchone()
+
+            row = retry_on_deadlock(_run, logger=logger)
+
+            if row is None:
+                logger.debug("get_rows_to_sync: No results returned. Using 0 as rows to sync")
+                return 0
+
+            rows_to_sync_int = int(row[0] or 0)
+            logger.debug(f"get_rows_to_sync: rows_to_sync_int={rows_to_sync_int}")
+            return rows_to_sync_int
+        except Exception as e:
+            # This COUNT(*) is a best-effort estimate for progress reporting and partition
+            # sizing. It shares its FROM/WHERE with the real streaming query, so any genuine
+            # problem (missing column, bad incremental field, permissions) resurfaces there
+            # and is classified through the normal retryable/non-retryable path. Capturing it
+            # here too would only flood error tracking with handled duplicates, so log at
+            # debug and fall back to 0.
+            logger.debug(f"get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
+            return 0
+
     # ------------------------------------------------------------------
     # Pipeline build — the dlt `SourceResponse` for a single table
     # ------------------------------------------------------------------

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -465,6 +465,39 @@ class TestFetchAverageRowSize:
         assert result is None
 
 
+class TestGetRowsToSync:
+    def _deadlock_victim(self) -> pymssql.OperationalError:
+        return pymssql.OperationalError(
+            1205,
+            b"Transaction (Process ID 116) was deadlocked on lock resources with another process and has been "
+            b"chosen as the deadlock victim. Rerun the transaction.",
+        )
+
+    def test_returns_count_from_cursor(self, impl, cursor, logger):
+        cursor.fetchone.return_value = (42,)
+        assert impl.get_rows_to_sync(cursor, "SELECT id FROM t", {}, logger) == 42
+
+    def test_retries_deadlock_and_recovers_count(self, impl, cursor, logger, mocker):
+        # Runs before any rows stream, so a 1205 here is exactly as safe to rerun as the
+        # main read query — this used to fall straight to 0 instead of retrying.
+        mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mssql.mssql.time.sleep")
+        cursor.execute.side_effect = [self._deadlock_victim(), None]
+        cursor.fetchone.return_value = (7,)
+        assert impl.get_rows_to_sync(cursor, "SELECT id FROM t", {}, logger) == 7
+        assert cursor.execute.call_count == 2
+
+    def test_falls_back_to_zero_without_capturing_on_persistent_error(self, impl, cursor, logger, mocker):
+        # This COUNT(*) shares its FROM/WHERE with the real streaming query, so a genuine
+        # problem resurfaces (and is captured) there. Capturing it here too would flood
+        # error tracking with a handled duplicate of a transient/benign probe failure.
+        capture = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mssql.mssql.capture_exception"
+        )
+        cursor.execute.side_effect = RuntimeError("boom")
+        assert impl.get_rows_to_sync(cursor, "SELECT id FROM t", {}, logger) == 0
+        capture.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # End-to-end build_pipeline — wired through MSSQLImplementation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError` (SQL Server 1205, "deadlocked on lock resources … chosen as the deadlock victim") raised from `SQLSourceImplementation.get_rows_to_sync` in the shared SQL-source pipeline code ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f8098-30df-7673-b3f0-4c0c36eaa1ab)).

That method runs a best-effort `SELECT COUNT(*)` used for progress reporting, before any rows are streamed. On a deadlock it fell straight through to the base class's catch-all, which logs, reports the exception, and falls back to a count of 0.

SQL Server deadlock victims are transient lock contention, not a config or data problem — MSSQL already has a `retry_on_deadlock` helper (used around the main streaming read) built for exactly this. The row-count probe just wasn't wired up to use it, so a normal, expected deadlock produced error-tracking noise and a needlessly inaccurate row count.

## Changes

- `MSSQLImplementation` now overrides `get_rows_to_sync` to retry the count query with the existing `retry_on_deadlock` helper — the same recovery the real streaming query already gets, since this probe also runs before any rows stream.
- Stops capturing exceptions from this probe: the count query shares its `FROM`/`WHERE` with the real streaming query, so any genuine problem (bad column, permissions, etc.) resurfaces there and is already classified through the normal retryable/non-retryable path. This mirrors the pattern already used by the MySQL and Postgres sources for the equivalent probe.

## How did you test this code?

Added `TestGetRowsToSync` in `products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py`:
- `test_retries_deadlock_and_recovers_count` — a deadlock on the first attempt now retries and returns the real count instead of giving up. Catches the regression this PR fixes.
- `test_falls_back_to_zero_without_capturing_on_persistent_error` — a persistent/non-deadlock error still falls back to 0 without calling `capture_exception`, so this probe stops flooding error tracking.

Ran the full MSSQL test suite (`113 passed`), `ruff check`/`format`, and `mypy` on the changed file — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by Claude Code, triaging a live PostHog error-tracking issue in the data-warehouse import pipeline.

- Pulled the issue's stack trace and a representative event via the PostHog MCP error-tracking tools to confirm the exact raise site (`implementation.py:261`, inside `get_rows_to_sync`).
- Compared against sibling drivers (MySQL, Postgres, Redshift, Snowflake) that override the same method, and found MSSQL already has dedicated deadlock-retry infrastructure (`retry_on_deadlock`) used for the main streaming query but not for this row-count probe — that gap is the root cause.
- Searched open PRs (by exception type, error message, and module path, plus the maintainer's own open PRs) for a duplicate fix; found none touching this method or file.