### PR TITLE
fix(meta_ads): retry transient connection resets during pagination

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -10,7 +10,12 @@ from django.db import OperationalError, close_old_connections
 
 import structlog
 from requests import Response
-from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
+from requests.exceptions import (
+    ChunkedEncodingError,
+    ConnectionError as RequestsConnectionError,
+    JSONDecodeError as RequestsJSONDecodeError,
+    ReadTimeout,
+)
 
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
 
@@ -307,25 +312,41 @@ def _is_transient_error(response: Response) -> bool:
     return error.get("is_transient") is True
 
 
+# Meta's connection occasionally resets mid-response — `requests` raises these while decoding the
+# body, after urllib3's own connection-level retries have already returned headers, so there's no
+# `Response` object yet to inspect for `_is_transient_error`. Re-issuing the same request is safe:
+# nothing was yielded from the failed one yet.
+NETWORK_TRANSIENT_ERRORS = (ChunkedEncodingError, RequestsConnectionError, ReadTimeout)
+
+
 def _get_with_transient_retry(issue: collections.abc.Callable[[], Response]) -> Response:
-    """Issue a request, absorbing Meta's transient server errors with a short backoff.
+    """Issue a request, absorbing transient network failures and Meta's transient server errors.
 
     Re-issuing the same request is safe: a transiently-failed request yielded no rows. Too-much-data
-    timeouts are left for the caller's limit-shrinking path. If it stays transient past the bound the
-    last response is returned unchanged, so the caller raises it as usual (staying retryable upstream).
+    timeouts are left for the caller's limit-shrinking path. If a failure persists past the bound, the
+    last response (or exception) propagates as usual, so the caller raises it, staying retryable upstream.
     """
-    response = issue()
     attempt = 1
-    while (
-        attempt < META_TRANSIENT_ERROR_MAX_ATTEMPTS
-        and response.status_code != 200
-        and _is_transient_error(response)
-        and not _is_timeout_error(response)
-    ):
+    while True:
+        try:
+            response = issue()
+        except NETWORK_TRANSIENT_ERRORS:
+            if attempt >= META_TRANSIENT_ERROR_MAX_ATTEMPTS:
+                raise
+            _backoff_sleep(attempt)
+            attempt += 1
+            continue
+
+        if (
+            attempt >= META_TRANSIENT_ERROR_MAX_ATTEMPTS
+            or response.status_code == 200
+            or not _is_transient_error(response)
+            or _is_timeout_error(response)
+        ):
+            return response
+
         _backoff_sleep(attempt)
-        response = issue()
         attempt += 1
-    return response
 
 
 def _get_initial_request(url: str, params: dict) -> Response:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -8,7 +8,10 @@ from unittest import mock
 
 from django.db import OperationalError
 
-from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
+from requests.exceptions import (
+    ChunkedEncodingError,
+    JSONDecodeError as RequestsJSONDecodeError,
+)
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.integration_accounts import (
     IntegrationAccountListingError,
@@ -451,6 +454,43 @@ class TestTransientErrorRetry:
             mock_get.return_value.get.side_effect = responses
             # Still surfaces the raw failure so it stays retryable at the Temporal layer.
             with pytest.raises(Exception, match="Meta API request failed: 500"):
+                list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
+
+        assert mock_get.return_value.get.call_count == META_TRANSIENT_ERROR_MAX_ATTEMPTS
+
+
+class TestNetworkTransientRetry:
+    INITIAL_URL = "https://graph.facebook.com/v20/act_123/campaigns"
+    PARAMS: dict[str, Any] = {"fields": "id,name", "limit": 500, "access_token": "tok"}
+
+    def test_connection_reset_reissues_same_request_then_succeeds(self, monkeypatch) -> None:
+        monkeypatch.setattr(meta_ads_module, "_backoff_sleep", lambda attempt: None)
+        manager = _build_manager()
+        responses = [
+            ChunkedEncodingError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')"),
+            _mock_response(200, {"data": [{"id": "1"}], "paging": {}}),
+        ]
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session"
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            batches = list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
+
+        assert batches == [[{"id": "1"}]]
+        assert mock_get.return_value.get.call_count == 2
+
+    def test_persistent_connection_reset_raises_after_bounded_attempts(self, monkeypatch) -> None:
+        monkeypatch.setattr(meta_ads_module, "_backoff_sleep", lambda attempt: None)
+        manager = _build_manager()
+        responses = [ChunkedEncodingError("Connection broken") for _ in range(META_TRANSIENT_ERROR_MAX_ATTEMPTS)]
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session"
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            # Still surfaces the raw failure so it stays retryable at the Temporal layer.
+            with pytest.raises(ChunkedEncodingError):
                 list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
 
         assert mock_get.return_value.get.call_count == META_TRANSIENT_ERROR_MAX_ATTEMPTS


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ChunkedEncodingError` (`Connection broken: ConnectionResetError(104, 'Connection reset by peer')`) originating from the Meta Ads warehouse source's pagination code (`meta_ads.py`). The stack trace shows the TCP connection was reset while `requests` was decoding an HTTP response body — after urllib3's own connection-level retries had already returned headers, so there's no `Response` object left to inspect for the source's existing transient-error handling.

This is a self-recovering network blip, not a bug in the request itself or a user/credential problem, so it shouldn't be added to `NonRetryableErrors`. But the source had no in-process retry for this failure class at all — it would propagate straight out of the activity and rely on the outer Temporal-level retry to recover, which is slower and burns a full retry cycle for something a couple of quick retries usually clears. Several other warehouse sources (airbrake, airops, and others) already retry this exact exception tuple (`ChunkedEncodingError` / `ConnectionError` / `ReadTimeout`) with backoff — Meta Ads was missing the equivalent handling.

## Changes

- `_get_with_transient_retry` (used by both simple and time-range pagination) now also catches `ChunkedEncodingError`, `ConnectionError`, and `ReadTimeout` and retries the same request with the existing bounded backoff, alongside its existing handling of Meta's own transient server errors.
- Re-issuing the same request is safe here: a request that failed with a network error yielded no rows yet, so nothing is re-emitted or duplicated on retry.

## How did you test this code?

Added `TestNetworkTransientRetry` to `test_meta_ads.py`:
- `test_connection_reset_reissues_same_request_then_succeeds` — a `ChunkedEncodingError` followed by a successful response still yields the expected rows, exercising the exact failure shape from error tracking.
- `test_persistent_connection_reset_raises_after_bounded_attempts` — a connection reset that never recovers still raises (rather than retrying forever), keeping the failure retryable at the Temporal layer.

These catch a real regression: without the fix, a single connection reset during pagination fails the whole sync activity instead of quietly retrying in-process.

Ran the full `meta_ads` test suite locally (85 passed), `ruff check`/`ruff format --check`, and `mypy` on the changed file — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (issue `019f80b0-a6bf-7051-8f1a-12a0cdc5d3a6`), read the full stack trace and the `meta_ads.py` pagination code, and confirmed the failure genuinely originates in this source (not just referenced in serialized log context). Compared against how other warehouse sources (airbrake, airops) already handle this exact exception class to confirm this was a gap rather than an intentional omission. Searched open PRs (by exception type, message, module path, and the maintainer's own open PRs) and found no existing fix for this.