### PR TITLE
fix(mcp-store): gate api_key auto-activation on an open handshake

### DIFF
--- a/products/mcp_store/backend/catalog_sync.py
+++ b/products/mcp_store/backend/catalog_sync.py
@@ -17,9 +17,11 @@ Semantics, chosen so the sync can run unattended at every app startup:
 - **Activation gate**: a newly created entry is probed live (``probe.probe_mcp_server``)
   and born active only when the probe passes for the auth model the catalog declares —
   DCR OAuth servers must complete a real client registration and serve an authorization
-  page; API-key/open servers must speak the MCP handshake. Servers needing shared OAuth
-  credentials are always born inactive: an operator provisions credentials in admin and
-  activates. Probes run only on creation — a DCR probe mints a real client on the
+  page; API-key servers must complete the MCP handshake without credentials. An API-key
+  server that auth-walls the handshake (the common case) yields no MCP evidence, so it
+  is born inactive for an operator to vet and activate in admin. Servers needing shared
+  OAuth credentials are always born inactive: an operator provisions credentials in
+  admin and activates. Probes run only on creation — a DCR probe mints a real client on the
   provider, so re-probing every sync cycle would leak registrations.
 
   The probe is a liveness and protocol check, not a security control: it catches a dead
@@ -59,7 +61,10 @@ def _activation_allowed(entry: CatalogEntry, probe: ProbeResult) -> bool:
     if not probe.passed_activation_gate:
         return False
     if entry.auth_type == "api_key":
-        return probe.auth_flavor in ("open", "api_key_or_unknown")
+        # A reachable but auth-walled endpoint ("api_key_or_unknown") never passes the
+        # gate — a bare 401/403 proves nothing about MCP — so agreement here means the
+        # handshake completed without credentials.
+        return probe.auth_flavor == "open"
     return probe.auth_flavor == "oauth_dcr"
 
 

--- a/products/mcp_store/backend/test/test_catalog_sync.py
+++ b/products/mcp_store/backend/test/test_catalog_sync.py
@@ -74,10 +74,18 @@ class TestSyncMCPCatalog(TestCase):
                 False,
             ),
             (
-                "api_key_pass",
+                "api_key_open_handshake_pass",
                 _entry(auth_type="api_key"),
-                ProbeResult(reachable=True, speaks_mcp=True, auth_flavor="api_key_or_unknown"),
+                ProbeResult(reachable=True, speaks_mcp=True, auth_flavor="open"),
                 True,
+            ),
+            # A reachable but auth-walled endpoint proves nothing about MCP, so the entry
+            # must stay inactive for an operator to vet and activate in admin.
+            (
+                "api_key_auth_walled_stays_inactive",
+                _entry(auth_type="api_key"),
+                ProbeResult(reachable=True, speaks_mcp=False, auth_flavor="api_key_or_unknown"),
+                False,
             ),
             ("unreachable", _entry(), ProbeResult(reachable=False), False),
             # The probe saying "this is a DCR OAuth server" for a catalog entry declared api_key


### PR DESCRIPTION
## Problem

The catalog sync in #70162 was written against the probe's earlier, looser activation gate. Commit 2977ca358 ("require mcp evidence before passing the activation gate") deliberately made `api_key_or_unknown` verdicts never pass the gate (a bare 401/403 carries no MCP evidence), so the sync's agreement check and one activation-matrix test case now disagree with the probe module — `test_created_entries_gate_activation_on_probe_2_api_key_pass` fails in the mcp-store CI shard.

## Changes

- `_activation_allowed` accepts an `api_key` entry only when the unauthenticated handshake completed (`open` flavor); an auth-walled endpoint is born inactive for an operator to vet and activate in admin.
- Module docstring updated to state the same.
- The `api_key_pass` matrix case became two cases: open handshake → active, auth-walled → inactive.

## How did you test this code?

`ruff check` and `ruff format` pass on both files; this sandbox can't run pytest, so the updated cases run in the mcp-store product-tests shard on #70162 once this merges. The open-handshake case catches a regression where `api_key` entries can never auto-activate; the auth-walled case catches re-loosening the sync to activate rows with no MCP evidence.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code session) while preparing the MCP-store catalog stack for merge; skills invoked: `/writing-tests`. This PR targets the feature branch `claude/mcp-store-4-catalog-sync` rather than master so #70162 stays green standalone — it is stack maintenance, merged immediately.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
