### PR TITLE
fix(clickhouse): classify self-recovering connect errors as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -257,6 +257,28 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             "is not supported for conversion into Arrow data format": "One of the columns in this table has a type ClickHouse can't export (for example an `AggregateFunction` state column on an aggregating materialized view). Deselect that column in this schema's column settings, or sync a view that finalizes it, then resync.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_get_client` already retries dropped connections and rate limits in-process
+        # (see clickhouse.py's `_is_retryable_connect_error`) before re-raising as
+        # `ClickHouseConnectionError`. Bare HTTP 502/503/504 responses skip that
+        # in-process retry by design (there's no proxy CONNECT to re-dial) and go
+        # straight to Temporal's activity retry instead. Either way, once Temporal
+        # retries the activity the failure is transient and self-recovering, so
+        # don't surface it as tracked exception noise.
+        return {
+            "UNEXPECTED_EOF_WHILE_READING",
+            "EOF occurred in violation of protocol",
+            "Connection reset by peer",
+            "Connection aborted",
+            "Tunnel connection failed: 502",
+            "Tunnel connection failed: 503",
+            "Tunnel connection failed: 504",
+            "returned response code 429",
+            "returned response code 502",
+            "returned response code 503",
+            "returned response code 504",
+        }
+
     def get_schemas(
         self,
         config: ClickHouseSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -680,6 +680,43 @@ class TestClickHouseSourceNonRetryableErrors:
         assert not is_non_retryable, f"Transient error should be retryable: {error_msg}"
 
 
+class TestClickHouseSourceRetryableErrors:
+    @pytest.fixture
+    def source(self):
+        return ClickHouseSource()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # The exact wrapped message that reached error tracking: a bare HTTP 502
+            # from clickhouse-connect's HTTPDriver (no proxy CONNECT tunnel involved).
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 502",
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 503",
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 504",
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 429",
+            "Tunnel connection failed: 502 Bad gateway",
+            "Tunnel connection failed: 503 Service Unavailable",
+            "Tunnel connection failed: 504 Gateway Timeout",
+            "EOF occurred in violation of protocol",
+            "Connection reset by peer",
+        ],
+    )
+    def test_transient_errors_are_retryable(self, source, error_msg):
+        retryable = source.get_retryable_errors()
+        assert any(pattern in error_msg for pattern in retryable), (
+            f"Transient, self-recovering error should be classified as retryable (kept out of "
+            f"error tracking): {error_msg}"
+        )
+
+    def test_permanent_errors_are_not_classified_as_retryable(self, source):
+        # A 404 is a deterministic failure (already asserted non-retryable above) — it must not
+        # also be misclassified as a benign retryable error, or `_handle_import_error` would log
+        # it at `warning` and mask the real cause.
+        error_msg = "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 404"
+        retryable = source.get_retryable_errors()
+        assert not any(pattern in error_msg for pattern in retryable)
+
+
 class TestIsTransientConnectDrop:
     @pytest.mark.parametrize(
         "message",


### PR DESCRIPTION
## Problem

PostHog's error tracking surfaced a `ClickHouseConnectionError: HTTPDriver for <host> returned response code 502` from the `clickhouse` data-warehouse import source, raised in `_get_client` while opening the connection. The remote ClickHouse endpoint briefly returned a 502.

Tracing it further: `_get_client` already retries a specific class of connect-time failures in-process (dropped connections, EOF/reset errors, an egress proxy's `Tunnel connection failed: 502/503/504`, and rate limits) before giving up and raising `ClickHouseConnectionError`. Bare HTTP 502/503/504 responses (no proxy CONNECT tunnel involved) intentionally skip that in-process retry and fall straight through to Temporal's own activity retry — the code comments in `get_non_retryable_errors()` already call this out ("5xx stay retryable via Temporal").

The gap: none of these self-recovering, already-classified-retryable failures were wired into `get_retryable_errors()`. That hook exists precisely so a source can tell `_handle_import_error` "I already know this class of failure is transient and Temporal will retry it" — without it, every one of them gets logged at `exception` level and shows up as error-tracking noise for a failure that resolves on its own.

## Changes

Add `get_retryable_errors()` to `ClickHouseSource`, following the same pattern already used by the Mixpanel source. It covers the connection-drop/rate-limit substrings `_get_client` already retries in-process, plus the bare gateway 5xx codes that are documented as intentionally deferred to Temporal's retry.

This only changes log level (`warning` vs `exception`) for an already-retryable failure path — it does not change what gets retried, and nothing is added to `get_non_retryable_errors()`.

## How did you test this code?

Extended `test_clickhouse.py` with a new `TestClickHouseSourceRetryableErrors` class:
- Parameterized case asserting the exact reported message shape (bare HTTPDriver 502/503/504, tunnel 502/503/504, EOF/connection-reset) is classified as retryable — guards against this specific error class silently reverting to tracked-exception noise.
- A case asserting a 404 (already permanent/non-retryable) is *not* also misclassified as retryable — guards against `_handle_import_error` masking a real, actionable failure behind a `warning` log.

Ran locally: `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py -q` → 209 passed (1 pre-existing failure is a Postgres-connectivity gap in this sandbox, unrelated to this change). `ruff check`/`ruff format --check` clean, and repo-wide `mypy --cache-fine-grained .` shows no new errors from this change.

## Docs update

No user-facing docs affected — this only changes internal error-tracking classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude), triaging a live error-tracking issue for the `clickhouse` warehouse source. Confirmed the exception originates in `_get_client` (not just referenced in serialized context), traced the retry/classification path through `_handle_import_error` in `import_data_sync.py`, and found the missing `get_retryable_errors()` wiring by comparing against the Mixpanel source, which already implements it. Invoked `/writing-tests` before adding the new test class.