### PR TITLE
feat(activity): virtualize event-detail property tables

### DIFF
--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx
@@ -237,4 +237,40 @@ describe('PropertiesTable inline editor', () => {
             expect(container.querySelector('.ph-no-capture')).not.toBeNull()
         })
     })
+
+    describe('virtualized bounds mounted properties', () => {
+        // EventDetails passes `virtualized`, so an event with hundreds of properties windows its
+        // rows instead of mounting them all. Below the threshold it must still render the plain
+        // table; above it, the full row set must not mount as a table.
+        const manyProperties = (count: number): Record<string, string> => {
+            const props: Record<string, string> = {}
+            for (let i = 0; i < count; i++) {
+                props[`prop_${i}`] = `value_${i}`
+            }
+            return props
+        }
+
+        const renderVirtualized = (count: number): ReturnType<typeof render> =>
+            render(
+                <Provider>
+                    <PropertiesTable
+                        type={PropertyDefinitionType.Event}
+                        properties={manyProperties(count)}
+                        virtualized
+                    />
+                </Provider>
+            )
+
+        const rowCount = (container: HTMLElement): number => container.querySelectorAll('tbody tr').length
+
+        it('renders every row as a plain table when below the virtualization threshold', () => {
+            const { container } = renderVirtualized(60)
+            expect(rowCount(container)).toBe(60)
+        })
+
+        it('does not mount the full row set as a table once above the threshold', () => {
+            const { container } = renderVirtualized(150)
+            expect(rowCount(container)).toBeLessThan(150)
+        })
+    })
 })

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -3,13 +3,15 @@ import './PropertiesTable.scss'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { combineUrl } from 'kea-router'
-import { useMemo, useState } from 'react'
+import { CSSProperties, ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { List, useDynamicRowHeight } from 'react-window'
 
 import { IconPencil, IconTrash, IconWarning } from '@posthog/icons'
 import { LemonCheckbox, LemonDialog, LemonInput, LemonMenu, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
+import { AutoSizer } from 'lib/components/AutoSizer'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonTable, LemonTableColumns, LemonTableProps } from 'lib/lemon-ui/LemonTable'
+import { LemonTable, LemonTableColumn, LemonTableProps } from 'lib/lemon-ui/LemonTable'
 import { preflightLogic } from 'lib/logic/preflightLogic'
 import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { isObject, isKeyOf } from 'lib/utils/guards'
@@ -229,6 +231,121 @@ export interface PropertiesTableProps extends BasePropertyType {
      * that can be expanded on demand, rather than being expanded inline. Threads through nesting.
      */
     collapsible?: boolean
+    /**
+     * When true, top-level property rows are windowed with react-window once there are enough of
+     * them, so an event with hundreds of properties only mounts the visible rows. Off by default so
+     * every other consumer keeps LemonTable's natural full-height rendering.
+     */
+    virtualized?: boolean
+}
+
+// Above this many top-level rows the object table windows its rows; below it the DOM node count is
+// small enough that plain LemonTable rendering is cheaper than a scroll viewport.
+const VIRTUALIZED_PROPERTY_THRESHOLD = 100
+const VIRTUALIZED_MAX_HEIGHT = 600
+// react-window measures real row heights (rows vary: scalars, wrapped values, collapsed JSON), but
+// needs a starting estimate before the first paint.
+const DEFAULT_PROPERTY_ROW_HEIGHT = 34
+
+interface PropertyRowProps {
+    rows: Array<[string, any]>
+    columns: LemonTableColumn<Record<string, any>, any>[]
+    highlightedKeys?: string[]
+    highlightVariant: 'default' | 'subtle'
+    dynamicRowHeight: ReturnType<typeof useDynamicRowHeight>
+}
+
+function VirtualizedPropertyRow({
+    index,
+    style,
+    rows,
+    columns,
+    highlightedKeys,
+    highlightVariant,
+    dynamicRowHeight,
+    ariaAttributes,
+}: {
+    ariaAttributes: { 'aria-posinset': number; 'aria-setsize': number; role: 'listitem' }
+    index: number
+    style: CSSProperties
+} & PropertyRowProps): JSX.Element {
+    const rowRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (rowRef.current) {
+            return dynamicRowHeight.observeRowElements([rowRef.current])
+        }
+    }, [dynamicRowHeight])
+
+    const item = rows[index]
+    const highlighted = highlightedKeys?.includes(item[0])
+
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div ref={rowRef} style={style} data-index={index} {...ariaAttributes}>
+            <div
+                className="flex items-start gap-2 px-2 py-1 border-b border-border"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={
+                    highlighted
+                        ? { background: highlightVariant === 'subtle' ? 'var(--bg-3000)' : 'var(--mark)' }
+                        : undefined
+                }
+            >
+                {columns.map((column, columnIndex) => (
+                    <div
+                        key={typeof column.key === 'string' ? column.key : columnIndex}
+                        className={columnIndex === 1 ? 'flex-1 min-w-0 break-all' : 'shrink-0'}
+                    >
+                        {/* These columns (key/value/copy/delete) all return JSX, never the
+                            TableCellRepresentation object shape LemonTable also supports. */}
+                        {column.render?.(undefined, item, index, rows.length) as ReactNode}
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+function VirtualizedPropertiesList({
+    rows,
+    columns,
+    className,
+    highlightedKeys,
+    highlightVariant,
+}: {
+    rows: Array<[string, any]>
+    columns: LemonTableColumn<Record<string, any>, any>[]
+    className?: string
+    highlightedKeys?: string[]
+    highlightVariant: 'default' | 'subtle'
+}): JSX.Element {
+    const dynamicRowHeight = useDynamicRowHeight({ defaultRowHeight: DEFAULT_PROPERTY_ROW_HEIGHT })
+    const height = Math.min(rows.length * DEFAULT_PROPERTY_ROW_HEIGHT, VIRTUALIZED_MAX_HEIGHT)
+    const rowProps = useMemo(
+        (): PropertyRowProps => ({ rows, columns, highlightedKeys, highlightVariant, dynamicRowHeight }),
+        [rows, columns, highlightedKeys, highlightVariant, dynamicRowHeight]
+    )
+
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div className={className} style={{ height }}>
+            <AutoSizer
+                renderProp={({ height, width }) =>
+                    height && width ? (
+                        <List<PropertyRowProps>
+                            style={{ height, width }}
+                            overscanCount={10}
+                            rowCount={rows.length}
+                            rowHeight={dynamicRowHeight}
+                            rowComponent={VirtualizedPropertyRow}
+                            rowProps={rowProps}
+                        />
+                    ) : null
+                }
+            />
+        </div>
+    )
 }
 
 export function PropertiesTable({
@@ -249,6 +366,7 @@ export function PropertiesTable({
     type,
     parent,
     collapsible = false,
+    virtualized = false,
 }: PropertiesTableProps): JSX.Element {
     const [searchTerm, setSearchTerm] = useState('')
     const { hidePostHogPropertiesInTable, hideNullValues } = useValues(userPreferencesLogic)
@@ -409,7 +527,7 @@ export function PropertiesTable({
     }
 
     if (properties instanceof Object) {
-        const columns: LemonTableColumns<Record<string, any>> = [
+        const columns: LemonTableColumn<Record<string, any>, any>[] = [
             {
                 key: 'key',
                 title: 'Key',
@@ -557,46 +675,56 @@ export function PropertiesTable({
                     </div>
                 )}
 
-                <LemonTable
-                    columns={columns}
-                    showHeader={!embedded}
-                    rowKey="0"
-                    embedded={embedded}
-                    dataSource={objectProperties}
-                    className={className}
-                    emptyState={
-                        <>
-                            {hidePostHogPropertiesInTable || searchTerm ? (
-                                <span className="flex gap-2">
-                                    <span>No properties found</span>
-                                    <LemonButton
-                                        noPadding
-                                        onClick={() => {
-                                            setSearchTerm('')
-                                            setHidePostHogPropertiesInTable(false)
-                                            setHideNullValues(false)
-                                        }}
-                                    >
-                                        Clear filters
-                                    </LemonButton>
-                                </span>
-                            ) : (
-                                'No properties set yet'
-                            )}
-                        </>
-                    }
-                    inset={nestingLevel > 0}
-                    onRow={(record) =>
-                        highlightedKeys?.includes(record[0])
-                            ? {
-                                  style: {
-                                      background: highlightVariant === 'subtle' ? 'var(--bg-3000)' : 'var(--mark)',
-                                  },
-                              }
-                            : {}
-                    }
-                    {...tableProps}
-                />
+                {virtualized && nestingLevel === 0 && objectProperties.length > VIRTUALIZED_PROPERTY_THRESHOLD ? (
+                    <VirtualizedPropertiesList
+                        rows={objectProperties}
+                        columns={columns}
+                        className={className}
+                        highlightedKeys={highlightedKeys}
+                        highlightVariant={highlightVariant}
+                    />
+                ) : (
+                    <LemonTable
+                        columns={columns}
+                        showHeader={!embedded}
+                        rowKey="0"
+                        embedded={embedded}
+                        dataSource={objectProperties}
+                        className={className}
+                        emptyState={
+                            <>
+                                {hidePostHogPropertiesInTable || searchTerm ? (
+                                    <span className="flex gap-2">
+                                        <span>No properties found</span>
+                                        <LemonButton
+                                            noPadding
+                                            onClick={() => {
+                                                setSearchTerm('')
+                                                setHidePostHogPropertiesInTable(false)
+                                                setHideNullValues(false)
+                                            }}
+                                        >
+                                            Clear filters
+                                        </LemonButton>
+                                    </span>
+                                ) : (
+                                    'No properties set yet'
+                                )}
+                            </>
+                        }
+                        inset={nestingLevel > 0}
+                        onRow={(record) =>
+                            highlightedKeys?.includes(record[0])
+                                ? {
+                                      style: {
+                                          background: highlightVariant === 'subtle' ? 'var(--bg-3000)' : 'var(--mark)',
+                                      },
+                                  }
+                                : {}
+                        }
+                        {...tableProps}
+                    />
+                )}
             </>
         )
     }

--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -130,6 +130,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                 </LemonBanner>
                                 <PropertiesTable
                                     type={PropertyDefinitionType.Event}
+                                    virtualized
                                     properties={properties}
                                     sortProperties
                                     tableProps={tableProps}
@@ -149,6 +150,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                 </p>
                                 <PropertiesTable
                                     type={PropertyDefinitionType.Event}
+                                    virtualized
                                     properties={properties}
                                     useDetectedPropertyType={true}
                                     tableProps={tableProps}
@@ -169,6 +171,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                 </p>
                                 <PropertiesTable
                                     type={PropertyDefinitionType.Event}
+                                    virtualized
                                     properties={properties}
                                     useDetectedPropertyType={true}
                                     tableProps={tableProps}
@@ -199,6 +202,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                 )}
                                 <PropertiesTable
                                     type={PropertyDefinitionType.Event}
+                                    virtualized
                                     properties={properties}
                                     useDetectedPropertyType={['flags', 'properties'].includes(tabKey)}
                                     tableProps={tableProps}


### PR DESCRIPTION
## Problem

Expanding an event on `/activity/explore` mounts every property row at once. Events with hundreds of properties produce a large DOM subtree per expanded row, which is slow and inflates detached-element churn.

## Changes

Window an expanded event's top-level property rows with **react-window** — the virtualization library already used across the app (session-replay inspector, logs, tracing) — via a new opt-in `virtualized` prop on `PropertiesTable`.

- Only the visible rows mount, so a huge property list renders in a single scroll. No pagination, no page controls — the scan/search UX is preserved.
- Row heights are measured dynamically (`useDynamicRowHeight`), so inline-expandable values still work.
- Windowing only kicks in above a row threshold; below it the plain `LemonTable` renders as before.
- The prop defaults **off**, so every other `PropertiesTable` consumer (persons, error tracking, etc.) is byte-for-byte unchanged.
- `EventDetails` opts its four property tabs into virtualization.

This is the follow-up to the keyed-expansion PR (#72227); the two are independent and both sit on top of master.

## How did you test this code?

Agent-run automated tests only (no manual/browser verification):

- `frontend/src/lib/components/PropertiesTable/PropertiesTable.test.tsx` — the existing inline-editor / search / collapsible suites plus two cases guarding the virtualization bound: below the threshold the plain table still renders every row; above it the full row set is not mounted as a table. All pass locally.
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) clean.

The agent could not run the Playwright/browser path or verify detached-DOM metrics; that verification is left for post-deployment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Produced with Claude Code (PostHog Code). Split out from #72227 at the author's request so that PR stays scoped to the keyed row-expansion fix and this one carries the rendering change on its own. Skills invoked: `/writing-tests`.

Decisions:
- Virtualize rather than paginate, so all properties stay in one scannable/searchable scroll. react-window is the app's standard virtualization primitive, chosen over `@tanstack/react-virtual` (also present) for consistency with the session-replay inspector / logs / tracing lists.
- Gated behind an opt-in `virtualized` prop so the shared `PropertiesTable` is unchanged for every other consumer; only the event-detail view opts in.
- Dynamic row measurement (not fixed heights) because property rows vary — scalars, wrapped values, collapsed JSON viewers.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
