### PR TITLE
fix(tasks): keep composer send button reachable on mobile browsers

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -41,6 +41,11 @@
     display: flex;
     width: 100%;
     height: 100vh;
+
+    // On mobile browsers 100vh includes the area behind the collapsible browser toolbar, pushing
+    // bottom-anchored UI (chat composers, sticky footers) out of the visible viewport with no way to
+    // scroll to it. dvh tracks the actually-visible viewport; 100vh above stays as the fallback.
+    height: 100dvh;
     overflow: hidden;
     background: var(--color-bg-primary);
 
@@ -89,6 +94,7 @@
         display: flex;
         flex-direction: column;
         height: 100vh;
+        height: 100dvh; // see .Navigation3000 — keep bottom-anchored UI reachable on mobile
     }
 }
 
@@ -723,6 +729,7 @@
     display: grid;
     grid-template: 'left content' 1fr / var(--left-nav-width) minmax(0, 1fr);
     height: 100vh;
+    height: 100dvh; // see .Navigation3000 — keep bottom-anchored UI reachable on mobile
     overflow: hidden;
 
     .storybook-test-runner & {

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
@@ -81,7 +81,7 @@ export function TaskComposer(): JSX.Element {
                                         data-attr="task-composer-input"
                                     />
                                 </Composer.Field>
-                                <Composer.Footer className="flex items-center gap-1 pl-2">
+                                <Composer.Footer className="flex flex-wrap items-center gap-1 pl-2">
                                     <ComposerModePicker
                                         selectedMode={newTaskData.permissionMode}
                                         onModeChange={(permissionMode) => setNewTaskData({ permissionMode })}

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -164,7 +164,7 @@ function LiveComposer({ logicProps }: { logicProps: RunInteractionLogicProps }):
                         </Composer.Placeholder>
                         <Composer.Textarea data-attr="sandbox-composer-input" submitShortcut="cmd-enter" />
                     </Composer.Field>
-                    <Composer.Footer className="flex items-center gap-1 pl-2">
+                    <Composer.Footer className="flex flex-wrap items-center gap-1 pl-2">
                         {/* Mode + model/effort pickers: selection lives in the bound runInteractionLogic and is
                         applied when the message is sent — synced to the running agent on a follow-up,
                         or used to seed the next run once terminal. */}


### PR DESCRIPTION
## Problem

On mobile, the task detail view's composer is partially cut off. The textarea is visible but the footer with the send button and the mode/model pickers sits below the bottom edge of the screen, and there's no way to scroll to it, so you can't send a follow-up message from a phone.

Root cause: the app frame (`.app-layout` and `.Navigation3000`) is sized with `height: 100vh` plus `overflow: hidden`. On mobile browsers `100vh` means the *largest* viewport, as if the browser's collapsible toolbar were retracted. While the toolbar is visible, the bottom strip of the app (exactly where bottom-anchored UI like chat composers lives) is pushed behind the browser chrome, and the `overflow: hidden` frame means it can never be scrolled into view.

## Changes

- Size the app frame with `height: 100dvh` (dynamic viewport height, which tracks the actually-visible viewport), keeping `height: 100vh` immediately above as the fallback for older browsers. Applied to `.app-layout`, `.Navigation3000`, and `.Navigation3000__scene--raw-no-header`. On desktop `100dvh` equals `100vh`, so this only changes behavior on mobile browsers with collapsible chrome. This also fixes the same cut-off for any other bottom-anchored UI (e.g. Max's composer in the side panel).
- Let the composer footer (mode + model/effort pickers) wrap on narrow screens in `TaskRunChat` and `TaskComposer`, so the pickers can't collide with the send button on small viewports.

The composer slot already pads for `env(safe-area-inset-bottom)`, so the notch/home-indicator case was handled. The missing piece was the viewport height itself.

## How did you test this code?

- Ran stylelint on the edited SCSS and oxfmt across the frontend - both clean.
- I (or, actually Claude) could not run the app on a real mobile device in this environment, so the fix has not been manually verified on a phone yet. `dvh` is already used elsewhere in this codebase (`LemonDrawer`, settings, inbox, AI observability), so browser support is an accepted baseline here.
- No tests added: this is a CSS viewport-unit change with no behavior observable in jsdom.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - no user-facing workflow or API change, purely a layout fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code from a mobile screenshot showing the task view composer cut off at the bottom of the screen.
- Diagnosis: traced the height chain from the task scene (`h-full min-h-0`) up to the app frame and found `height: 100vh` + `overflow: hidden` on `.app-layout` / `.Navigation3000`. Considered a scene-local fix first, but the scene can't fix an ancestor frame that is taller than the visible viewport, so the fix belongs on the frame. Chose `dvh` over `svh` (which would leave a gap when the toolbar collapses) and kept the `100vh` fallback line for older browsers.
- The footer `flex-wrap` on the two task composers is a small safeguard for narrow screens spotted while in the area.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZEMSKQFFGx66oPXpsh5j3)_