### PR TITLE
chore(ci): bump timeout for personhog-stateright rust test shard

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -293,8 +293,7 @@ jobs:
         needs: [changes, affected]
         if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-24.04-4
-        # The personhog-stateright shard's serialized model checks alone take ~17 min
-        # of test wall time; its only green run finished 11s under a 20-minute cap.
+        # stateright model checks need more headroom than the other shards
         timeout-minutes: ${{ contains(matrix.packages, 'personhog-stateright') && 40 || 20 }}
         permissions:
             contents: read

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -293,7 +293,9 @@ jobs:
         needs: [changes, affected]
         if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-24.04-4
-        timeout-minutes: 20
+        # The personhog-stateright shard's serialized model checks alone take ~17 min
+        # of test wall time; its only green run finished 11s under a 20-minute cap.
+        timeout-minutes: ${{ contains(matrix.packages, 'personhog-stateright') && 40 || 20 }}
         permissions:
             contents: read
         env:


### PR DESCRIPTION
## Problem

Since #71774 merged, the `Test Rust (personhog-stateright)` job times out at the test job's 20-minute cap on every run, including on master itself. Any PR that triggers the full rust matrix (for example anything touching `posthog/migrations/**`) gets a red `Rust Tests Pass` check through no fault of its own.

The numbers, from the only green run of the new suite (#71774's final PR commit, job [87979472853](https://github.com/PostHog/posthog/actions/runs/29609064317/job/87979472853)):

| Phase | Duration |
| --- | --- |
| Setup (checkout, dbs, toolchain) | ~2m10s |
| `cargo test` (compile + tests) | 17m15s |
| **Total** | **19m49s** – 11s under the cap |

Test wall time is 16m44s, dominated by two model checks that are deliberately serialized in `nextest.toml` because each saturates every core: `epoch_fenced_two_partitions_double_zombie_is_safe` (9m08s) and `two_partitions_double_zombie_loses_acked_writes` (6m44s). Every run since (master pushes and PRs, 7+ observed) hits the 20-minute kill, and cold dependency caches make it worse.

## Changes

The `test` job's `timeout-minutes` becomes conditional: 40 minutes for the shard containing `personhog-stateright` (roughly 2x the observed green runtime, per our sizing convention), 20 minutes for every other shard. The stateright crate's 700s weight already exceeds the 480s shard target, so it always gets its own shard and no other shard's cap is loosened.

An alternative is speeding up the model checks themselves; that is worth doing but belongs to the personhog folks, and this unblocks every migrations-touching PR in the meantime.

## How did you test this code?

`bin/hogli lint:workflows` passes (all 6 checks across 102 workflows). The expression form of `timeout-minutes` is standard GitHub Actions syntax. I could not run the job itself locally; the proof will be this PR's own rust CI run if the matrix triggers, or the first migrations-touching PR after merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) authored this after diagnosing why an unrelated Django-migrations PR (#72066) had a red `Rust Tests Pass` check. It traced the timeout to #71774 (which added the expanded stateright model checks and the 700s CI weight), pulled step- and test-level timings from the one green run, and confirmed master's own stateright job also dies at exactly 20 minutes. Skills invoked: /authoring-ci-workflows. Considered bumping the flat timeout for all shards but kept non-stateright shards at 20 to preserve the hang guard.