### PR TITLE
chore(wizard): include backend/tasks in contract-check inputs

### DIFF
--- a/products/wizard/turbo.json
+++ b/products/wizard/turbo.json
@@ -2,7 +2,7 @@
     "extends": ["//"],
     "tasks": {
         "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py", "backend/tasks/**"],
             "outputs": [],
             "cache": true
         }


### PR DESCRIPTION
## Problem

- Wizard has a Celery task under backend/tasks/, but its narrowed contract-check inputs omitted that wiring location.
- Changes there could skip the Django suite.

## Changes

- Add backend/tasks/** to wizard contract-check inputs, matching existing isolated-product conventions.

## How did you test this code?

- Ran ./bin/hogli product:lint --all through Flox. All 69 products passed.
- Ran hogli ci:preflight --fix. It passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- No docs change. This corrects internal CI input coverage.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used the current local session; no share link was available. Skills: /wt, /isolating-product-facade-contracts, /hogli, /running-ci-preflight.
- Confirmed the Celery shared task is registered through core autodiscovery before widening the inputs.