### PR TITLE
feat(notebooks): add pinned-only filter to profile properties node

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroupProperties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroupProperties.tsx
@@ -32,6 +32,7 @@ const Component = (): JSX.Element | null => {
 
     return (
         <Properties
+            key={`${groupData.group_type_index}-${groupData.group_key}`}
             properties={groupData.group_properties || {}}
             pinnedProperties={pinnedGroupProperties}
             onPin={pinGroupProperty}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonProperties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonProperties.tsx
@@ -35,6 +35,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonPropertie
 
     return (
         <Properties
+            key={id}
             properties={person.properties || {}}
             pinnedProperties={pinnedPersonProperties}
             onPin={pinPersonProperty}

--- a/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
@@ -28,6 +28,7 @@ export function Properties({
     type,
 }: PropertiesProps): JSX.Element | null {
     const [searchTerm, setSearchTerm] = useState('')
+    const [showPinnedOnly, setShowPinnedOnly] = useState(true)
     const { hideNullValues } = useValues(userPreferencesLogic)
     const { setHideNullValues } = useActions(userPreferencesLogic)
 
@@ -48,10 +49,14 @@ export function Properties({
             entries = entries.filter(([, value]) => value !== null)
         }
 
+        if (showPinnedOnly) {
+            entries = entries.filter(([key]) => pinnedProperties.includes(key))
+        }
+
         entries = sortProperties(entries, pinnedProperties)
 
         return Object.fromEntries(entries)
-    }, [properties, searchTerm, hideNullValues, pinnedProperties])
+    }, [properties, searchTerm, hideNullValues, showPinnedOnly, pinnedProperties])
 
     const numProperties = Object.keys(filteredProperties).length
     const totalProperties = Object.keys(properties).length
@@ -73,13 +78,21 @@ export function Properties({
                     label="Show null"
                     size="small"
                 />
+                <LemonCheckbox
+                    checked={showPinnedOnly}
+                    onChange={setShowPinnedOnly}
+                    label="Pinned only"
+                    size="small"
+                />
             </div>
 
             {numProperties === 0 ? (
                 <div className="text-muted text-center py-2 text-xs">
-                    {searchTerm || hideNullValues
-                        ? `No properties match your filters (${totalProperties} total)`
-                        : 'No properties'}
+                    {showPinnedOnly && !searchTerm && !hideNullValues
+                        ? `No pinned properties (${totalProperties} total)`
+                        : searchTerm || hideNullValues || showPinnedOnly
+                          ? `No properties match your filters (${totalProperties} total)`
+                          : 'No properties'}
                 </div>
             ) : (
                 <div>
@@ -111,7 +124,7 @@ export function Properties({
                 </div>
             )}
 
-            {(searchTerm || hideNullValues) && numProperties > 0 && (
+            {(searchTerm || hideNullValues || showPinnedOnly) && numProperties > 0 && (
                 <div className="text-muted text-xs mt-1">
                     Showing {numProperties} of {totalProperties} properties
                 </div>

--- a/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
@@ -78,12 +78,7 @@ export function Properties({
                     label="Show null"
                     size="small"
                 />
-                <LemonCheckbox
-                    checked={showPinnedOnly}
-                    onChange={setShowPinnedOnly}
-                    label="Pinned only"
-                    size="small"
-                />
+                <LemonCheckbox checked={showPinnedOnly} onChange={setShowPinnedOnly} label="Pinned only" size="small" />
             </div>
 
             {numProperties === 0 ? (


### PR DESCRIPTION
## Problem

In the customer profile view, the properties node lists every property a person or group has. That's a lot of noise when you mostly care about the handful you've pinned. There was no quick way to collapse the list down to just pinned properties.

## Changes

Added a "Pinned only" checkbox to the properties node (person and group profiles), next to the existing search and "Show null" controls. It's toggled **on by default**, so the node opens showing only pinned properties. Unchecking it reveals the full list. The empty state now reads "No pinned properties" when the filter hides everything, and the "showing X of Y" count accounts for the new filter.

## How did you test this code?

I (Claude, the PostHog Slack app) wasn't able to run the frontend test/lint tooling in this environment — `node_modules` isn't installed, so `pnpm fix` and `typescript:check` couldn't run. The change is small and local: it adds a `useState` boolean, one `LemonCheckbox`, and a filter step in the existing `useMemo`. Worth a manual pass in a running app to confirm the default-on behavior and toggle feel right.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: add a checkbox to the properties node in customer profiles, on by default, that shows only pinned properties. The properties node (`Properties.tsx`) already had pin/unpin support, so this reuses the existing `pinnedProperties` and mirrors the existing "Show null" checkbox pattern. Filtering to pinned happens in the same `useMemo` as search/null filtering, before the sort-to-top step.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08GGECGJF4/p1784101767412949?thread_ts=1784101767.412949&cid=C08GGECGJF4)*
