### PR TITLE
chore(tach): expose event_definitions property_type in public interface

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -1040,6 +1040,7 @@ layer = "modules"
 expose = [
     "backend\\.logic\\.placeholder.*",
     "backend\\.models.*",
+    "backend\\.property_type.*",
 ]
 from = [
     "products.event_definitions",


### PR DESCRIPTION
## Problem

Backend CI's repo checks fail on every PR that runs them, with:

```
[FAIL] posthog/hogql/property_planner.py:41: The path 'products.event_definitions.backend.property_type.PropertyType' is not part of the public interface for 'products.event_definitions'.
```

#70734 added a tach `[[interfaces]]` entry for `products.event_definitions` exposing only `backend.models.*` and `backend.logic.placeholder.*`. But `posthog/hogql/property_planner.py` imports `PropertyType` from the pure module `backend.property_type` (deliberately, since #71913 relocated these enums to pure modules), so tach now fails module boundary checks. The check only runs on PRs touching backend files, which is why it didn't surface on master directly. Example failing run: https://github.com/PostHog/posthog/actions/runs/29774979645/job/88462200354

## Changes

One-line fix, adds the pure module to the exposed interface:

```diff
 [[interfaces]]
 expose = [
     "backend\\.logic\\.placeholder.*",
     "backend\\.models.*",
+    "backend\\.property_type.*",
 ]
 from = [
     "products.event_definitions",
 ]
```

The alternative of rerouting the import through `backend.models.property_definition` would undo the pure-module split from #71913, so widening the interface is the intent-preserving fix.

The same one-liner is also included in #70159 to unblock its CI. Whichever merges first, the other merges cleanly.

## How did you test this code?

Ran `uv run tach check --dependencies --interfaces` locally. It reproduces the failure before the change and reports `✅ All modules validated!` after.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) while diagnosing failing CI on #70159. Traced the repo-checks failure to the tach interface added in #70734, confirmed the violating import predates it, and validated the fix with tach locally.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*