### PR TITLE
feat(metrics): make the posthoganalytics sdk metrics api bump-ready for web and celery

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -78,7 +78,9 @@ class PostHogConfig(AppConfig):
         # >=7.23 it's picked up by setup(), so metrics get a real service.name
         # instead of 'unknown_service'.
         posthoganalytics.metrics = {  # type: ignore[attr-defined]
-            "service_name": settings.OTEL_SERVICE_NAME or "posthog",
+            # Same fallback as the OTel trace resource (otel_instrumentation.py) —
+            # metrics and traces from one process must share a service identity.
+            "service_name": settings.OTEL_SERVICE_NAME or "posthog-django-default",
             "service_version": os.getenv("COMMIT_SHA"),
             "environment": os.getenv("OTEL_SERVICE_ENVIRONMENT"),
         }

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -73,6 +73,15 @@ class PostHogConfig(AppConfig):
             "service": settings.OTEL_SERVICE_NAME,
             "environment": os.getenv("OTEL_SERVICE_ENVIRONMENT"),
         }
+        # Config for the SDK's `client.metrics` API. The pinned SDK version predates
+        # the metrics API and ignores this attr; once posthoganalytics is bumped to
+        # >=7.23 it's picked up by setup(), so metrics get a real service.name
+        # instead of 'unknown_service'.
+        posthoganalytics.metrics = {  # type: ignore[attr-defined]
+            "service_name": settings.OTEL_SERVICE_NAME or "posthog",
+            "service_version": os.getenv("COMMIT_SHA"),
+            "environment": os.getenv("OTEL_SERVICE_ENVIRONMENT"),
+        }
 
         if str_to_bool(os.environ.get("TEMPORAL_DISABLE_EXCEPTION_VARIABLE_CAPTURE", "false")):
             posthoganalytics.capture_exception_code_variables = False

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -227,6 +227,20 @@ def on_worker_process_shutdown(**kwargs) -> None:
 
         multiprocess.mark_process_dead(os.getpid())
 
+    # Flush the posthoganalytics SDK's final metrics window: `client.metrics`
+    # aggregates in memory and flushes on an interval, so a recycled child
+    # (--max-tasks-per-child) would otherwise drop up to one interval of samples.
+    # Inert on SDK versions without the metrics API and on untouched/disabled clients.
+    import posthoganalytics  # noqa: PLC0415 — keep the SDK off the celery import path
+
+    try:
+        client = posthoganalytics.default_client
+        metrics = getattr(client, "metrics", None) if client is not None else None
+        if metrics is not None:
+            metrics.flush()
+    except Exception:
+        logger.warning("posthoganalytics_metrics_flush_failed", exc_info=True)
+
 
 # Set up clickhouse query instrumentation
 @task_prerun.connect

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,6 +1,7 @@
 import os
 import time
 import errno
+import threading
 
 from django.dispatch import receiver
 
@@ -219,6 +220,9 @@ def on_worker_start(**kwargs) -> None:
     _initialize_worker_metrics()
 
 
+_ANALYTICS_METRICS_FLUSH_TIMEOUT_SECONDS = 5.0
+
+
 @worker_process_shutdown.connect
 def on_worker_process_shutdown(**kwargs) -> None:
     """Remove metric files for this child so recycled workers don't leak stale data."""
@@ -237,7 +241,20 @@ def on_worker_process_shutdown(**kwargs) -> None:
         client = posthoganalytics.default_client
         metrics = getattr(client, "metrics", None) if client is not None else None
         if metrics is not None:
-            metrics.flush()
+            # Bound the wait: an unreachable metrics endpoint must not hold a
+            # recycling child hostage (same hazard otel_instrumentation.py caps
+            # with a 5s force_flush). The daemon thread is abandoned on timeout.
+            def _flush() -> None:
+                try:
+                    metrics.flush()
+                except Exception:
+                    logger.warning("posthoganalytics_metrics_flush_failed", exc_info=True)
+
+            flush_thread = threading.Thread(target=_flush, name="posthoganalytics-metrics-flush", daemon=True)
+            flush_thread.start()
+            flush_thread.join(timeout=_ANALYTICS_METRICS_FLUSH_TIMEOUT_SECONDS)
+            if flush_thread.is_alive():
+                logger.warning("posthoganalytics_metrics_flush_timed_out")
     except Exception:
         logger.warning("posthoganalytics_metrics_flush_failed", exc_info=True)
 

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -1,9 +1,12 @@
+import threading
+
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 import posthoganalytics
 from parameterized import parameterized
 
+import posthog.celery
 from posthog.celery import on_worker_process_shutdown
 from posthog.tasks.tasks import clickhouse_errors_count
 
@@ -14,6 +17,26 @@ class TestWorkerShutdownFlushesAnalyticsMetrics(TestCase):
         with patch.object(posthoganalytics, "default_client", client):
             on_worker_process_shutdown()
         client.metrics.flush.assert_called_once()
+
+    def test_hung_flush_does_not_stall_worker_recycling(self) -> None:
+        release = threading.Event()
+        flush_completed = threading.Event()
+
+        def hung_flush() -> None:
+            release.wait(timeout=10)
+            flush_completed.set()
+
+        client = MagicMock(**{"metrics.flush.side_effect": hung_flush})
+        try:
+            with (
+                patch.object(posthog.celery, "_ANALYTICS_METRICS_FLUSH_TIMEOUT_SECONDS", 0.05),
+                patch.object(posthoganalytics, "default_client", client),
+            ):
+                on_worker_process_shutdown()
+            # The handler must abandon the hung flush, not wait it out.
+            assert not flush_completed.is_set()
+        finally:
+            release.set()
 
     @parameterized.expand(
         [

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -1,7 +1,45 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import posthoganalytics
+from parameterized import parameterized
+
+from posthog.celery import on_worker_process_shutdown
 from posthog.tasks.tasks import clickhouse_errors_count
+
+
+class TestWorkerShutdownFlushesAnalyticsMetrics(TestCase):
+    def test_flushes_sdk_metrics_tail_window(self) -> None:
+        client = MagicMock()
+        with patch.object(posthoganalytics, "default_client", client):
+            on_worker_process_shutdown()
+        client.metrics.flush.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("no_default_client", lambda: None),
+            # The pinned SDK version has no `metrics` API — the hook must stay
+            # inert (a bare `client.metrics.flush()` would raise on every
+            # worker recycle until the dependency is bumped).
+            (
+                "real_client_on_pinned_sdk_version",
+                lambda: posthoganalytics.Client("phc_test", sync_mode=True, disabled=True),
+            ),
+            ("flush_raises", lambda: MagicMock(**{"metrics.flush.side_effect": RuntimeError("network down")})),
+        ]
+    )
+    def test_handler_never_breaks_worker_shutdown(self, _name: str, client_factory) -> None:
+        with patch.object(posthoganalytics, "default_client", client_factory()):
+            on_worker_process_shutdown()
+
+
+class TestAnalyticsMetricsConfig(TestCase):
+    def test_apps_ready_configures_module_level_metrics(self) -> None:
+        # Deleting the "unused" attr assignment in apps.py before the SDK bump
+        # would make the bump silently ship service_name='unknown_service'.
+        config = getattr(posthoganalytics, "metrics", None)
+        assert isinstance(config, dict)
+        assert config["service_name"]
 
 
 class TestCeleryMetrics(TestCase):


### PR DESCRIPTION
## Problem

We want to record metrics from our own backend the same way customers do — `posthog.metrics.count/gauge/histogram` via the SDK — instead of hand-rolling OTel plumbing. The `client.metrics` API shipped in posthog-python 7.23, but bumping `posthoganalytics` alone isn't enough:

- the module-level client `apps.py` configures has no metrics config, so every series would ship `service.name='unknown_service'`
- celery prefork children recycle (`--max-tasks-per-child`) without flushing the SDK's in-memory aggregation window, silently dropping up to one flush interval of samples per recycle — the same failure mode `ph_scoped_capture` exists for on the events side

## Changes

Pre-lands the wiring so the version bump becomes the only remaining switch. Both changes are inert on the pinned 7.20.4:

- `posthog/apps.py`: sets `posthoganalytics.metrics = {service_name, service_version, environment}` (ignored by the pinned SDK; consumed by `setup()` once bumped — needs [PostHog/posthog-python#753](https://github.com/PostHog/posthog-python/pull/753) which adds the module-level passthrough)
- `posthog/celery.py`: `worker_process_shutdown` flushes the SDK's final metrics window, guarded so it no-ops on SDK versions without the metrics API and never breaks worker shutdown

> [!NOTE]
> This deliberately does NOT bump the dependency. When the bump lands, no further app changes are needed for `posthoganalytics.default_client.metrics` to work from web and celery.

## How did you test this code?

TDD — tests written and observed red first (flush hook absent → `flush` not called; config attr absent → `None`), then green after the implementation:

- `posthog/test/test_celery.py`: flush hook flushes the tail window; parameterized no-raise guard covering no default client, a **real client on the pinned SDK version** (locks in inertness pre-bump — a bare `client.metrics.flush()` would raise on every worker recycle), and a flush that throws; config test that fails if someone deletes the "unused" attr assignment pre-bump. All 6 pass; `ruff` and `mypy`/`ty` clean on the touched files.
- Behavioral validation with the real 7.27 SDK in a celery-prefork-shaped harness: module config → `setup()` in parent → `os.fork()` → child records → the exact hook logic flushes on exit. The child's series arrived in the Metrics product (verified via the metrics query API); a `disabled=True` client recorded and sent nothing; flush on an untouched client is a safe no-op.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code session) after investigating why agents keep inventing env vars to "push metrics into PostHog". Skills invoked: /writing-tests, /setup-web-tests (env bootstrap), /skills-store. Key decisions: flush hook uses `getattr(client, "metrics", None)` rather than a version check so it self-activates on bump; `service_name` falls back to `"posthog"` because `settings.OTEL_SERVICE_NAME` defaults to `None` outside prod (found by observation — the config test failed on it). Companion PRs: [PostHog/posthog-python#753](https://github.com/PostHog/posthog-python/pull/753) (module-level metrics passthrough), [#72413](https://github.com/PostHog/posthog/pull/72413) (skill documenting the patterns).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*