### PR TITLE
fix(conversations): keep comment text when zendesk import has an image

### DIFF
--- a/products/conversations/backend/api/tests/test_attachments_service.py
+++ b/products/conversations/backend/api/tests/test_attachments_service.py
@@ -40,10 +40,7 @@ class TestAttachmentsService(SimpleTestCase):
 
         assert rich_content is not None
         text = "".join(
-            c.get("text", "")
-            for n in rich_content["content"]
-            if n["type"] == "paragraph"
-            for c in n.get("content", [])
+            c.get("text", "") for n in rich_content["content"] if n["type"] == "paragraph" for c in n.get("content", [])
         )
         assert "please see the screenshot" in text
 

--- a/products/conversations/backend/api/tests/test_attachments_service.py
+++ b/products/conversations/backend/api/tests/test_attachments_service.py
@@ -32,6 +32,21 @@ class TestAttachmentsService(SimpleTestCase):
         assert "image" in node_types
         assert "paragraph" in node_types
 
+    def test_build_content_seeds_text_when_no_rich_content(self) -> None:
+        # Guards the Zendesk-import regression: a comment with an image passes rich_content=None,
+        # and the body text must be seeded as a paragraph node or it's dropped from the UI.
+        images = [{"url": "https://app.posthog.com/uploaded_media/img", "name": "shot.png"}]
+        _content, rich_content = build_content_with_images("please see the screenshot", None, images, [])
+
+        assert rich_content is not None
+        text = "".join(
+            c.get("text", "")
+            for n in rich_content["content"]
+            if n["type"] == "paragraph"
+            for c in n.get("content", [])
+        )
+        assert "please see the screenshot" in text
+
     def test_build_content_no_attachments_returns_unchanged(self) -> None:
         content, rich_content = build_content_with_images("just text", None, [], [])
         assert content == "just text"

--- a/products/conversations/backend/api/tests/test_attachments_service.py
+++ b/products/conversations/backend/api/tests/test_attachments_service.py
@@ -44,6 +44,20 @@ class TestAttachmentsService(SimpleTestCase):
         )
         assert "please see the screenshot" in text
 
+    def test_build_content_seeds_multiline_text_as_separate_paragraphs(self) -> None:
+        # A single text node collapses newlines to spaces in the renderer, so a multi-line
+        # body must become one paragraph per line.
+        images = [{"url": "https://app.posthog.com/uploaded_media/img", "name": "shot.png"}]
+        _content, rich_content = build_content_with_images("first line\n\nsecond line", None, images, [])
+
+        assert rich_content is not None
+        paragraphs = [
+            "".join(c.get("text", "") for c in n.get("content", []))
+            for n in rich_content["content"]
+            if n["type"] == "paragraph"
+        ]
+        assert paragraphs == ["first line", "second line"]
+
     def test_build_content_no_attachments_returns_unchanged(self) -> None:
         content, rich_content = build_content_with_images("just text", None, [], [])
         assert content == "just text"

--- a/products/conversations/backend/services/attachments.py
+++ b/products/conversations/backend/services/attachments.py
@@ -126,7 +126,14 @@ def build_content_with_images(
     content = "\n\n".join(parts)
 
     if not isinstance(rich_content, dict):
+        # No rich_content was built upstream (e.g. Zendesk import passes plain text),
+        # so seed the doc with the text before appending attachments — otherwise the
+        # text is dropped from the UI, which renders rich_content exclusively.
         rich_content = {"type": "doc", "content": []}
+        if cleaned_text:
+            rich_content["content"].append(
+                {"type": "paragraph", "content": [{"type": "text", "text": cleaned_text}]}
+            )
     rich_nodes = rich_content.setdefault("content", [])
     for img in images:
         rich_nodes.append(

--- a/products/conversations/backend/services/attachments.py
+++ b/products/conversations/backend/services/attachments.py
@@ -125,16 +125,14 @@ def build_content_with_images(
         parts.append("\n".join(f"[{f['name']}]({f['url']})" for f in files))
     content = "\n\n".join(parts)
 
-    if not isinstance(rich_content, dict):
-        # No rich_content was built upstream (e.g. Zendesk import passes plain text),
-        # so seed the doc with the text before appending attachments — otherwise the
-        # text is dropped from the UI, which renders rich_content exclusively.
+    created_doc = not isinstance(rich_content, dict)
+    if created_doc:
         rich_content = {"type": "doc", "content": []}
-        if cleaned_text:
-            rich_content["content"].append(
-                {"type": "paragraph", "content": [{"type": "text", "text": cleaned_text}]}
-            )
     rich_nodes = rich_content.setdefault("content", [])
+    # Callers without upstream rich_content (e.g. Zendesk import) pass the text here only.
+    # Seed it as a text node, or the UI — which renders rich_content exclusively — drops it.
+    if created_doc and cleaned_text:
+        rich_nodes.append({"type": "paragraph", "content": [{"type": "text", "text": cleaned_text}]})
     for img in images:
         rich_nodes.append(
             {

--- a/products/conversations/backend/services/attachments.py
+++ b/products/conversations/backend/services/attachments.py
@@ -125,14 +125,18 @@ def build_content_with_images(
         parts.append("\n".join(f"[{f['name']}]({f['url']})" for f in files))
     content = "\n\n".join(parts)
 
-    created_doc = not isinstance(rich_content, dict)
-    if created_doc:
-        rich_content = {"type": "doc", "content": []}
+    if not isinstance(rich_content, dict):
+        # Callers without upstream rich_content (e.g. Zendesk import) pass the text here only.
+        # Seed it as paragraph nodes, or the UI — which renders rich_content exclusively — drops it.
+        # Split on newlines so multi-line bodies keep their structure (the renderer collapses \n
+        # within a single text node), matching how the Teams path builds its doc.
+        seeded = [
+            {"type": "paragraph", "content": [{"type": "text", "text": line}]}
+            for raw_line in cleaned_text.split("\n")
+            if (line := raw_line.strip())
+        ]
+        rich_content = {"type": "doc", "content": seeded}
     rich_nodes = rich_content.setdefault("content", [])
-    # Callers without upstream rich_content (e.g. Zendesk import) pass the text here only.
-    # Seed it as a text node, or the UI — which renders rich_content exclusively — drops it.
-    if created_doc and cleaned_text:
-        rich_nodes.append({"type": "paragraph", "content": [{"type": "text", "text": cleaned_text}]})
     for img in images:
         rich_nodes.append(
             {

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
@@ -519,6 +519,14 @@ class TestZendeskImportBatchActivity(BaseTest):
         assert rich_content is not None
         image_nodes = [n for n in rich_content["content"] if n.get("type") == "image"]
         self.assertEqual(image_nodes[0]["attrs"]["src"], "https://media.posthog.test/shot.png")
+        # The comment body must survive alongside the image, not be dropped from rich_content.
+        body_text = "".join(
+            c.get("text", "")
+            for n in rich_content["content"]
+            if n.get("type") == "paragraph"
+            for c in n.get("content", [])
+        )
+        self.assertIn("see image", body_text)
         content = stored.content
         assert content is not None
         self.assertIn("https://media.posthog.test/shot.png", content)


### PR DESCRIPTION
## Problem

Tickets imported from Zendesk into Conversations were dropping message text whenever a comment also had an image attachment. Plain-text comments imported fine; only comments with an image lost their text in the UI. Reported from a support thread.

## Changes

The import extracts a comment's plain-text body but starts `rich_content` as `None`, then calls `build_content_with_images`. When an image is present and `rich_content` is `None`, that helper created a brand-new empty doc and appended only the image node. The body text survived only in the plain `content` string, which the frontend never renders when `rich_content` is set. So the text vanished.

The fix seeds the freshly-created doc with the body text as a paragraph node before appending attachments, so text and image both render. The Slack and Teams import paths already build `rich_content` upstream before calling this helper, so they pass a populated dict and are unaffected.

## How did you test this code?

Added a unit test on `build_content_with_images` (`test_build_content_seeds_text_when_no_rich_content`) that guards the regression directly: text + image with `rich_content=None` must produce a paragraph text node. It fails without the fix. This ran and passes.

Also tightened the existing Zendesk import test `test_image_attachment_embedded_in_rich_content` to assert the body text survives in `rich_content` alongside the image — previously it only checked the image node. That test is DB-backed and could not run in my sandbox (no Postgres); the no-DB unit test covers the fix logic.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and authored by the PostHog Slack app (Claude) from a Slack support thread. Traced the missing text to `build_content_with_images` seeding an empty `rich_content` doc, confirmed the Slack/Teams paths seed text upstream so a fix in the shared helper is safe for all callers. Invoked the `/writing-tests` skill before adding tests. Chose to fix in the shared helper (benefits all `rich_content=None` callers) over patching only the Zendesk activity.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1784580426759429?thread_ts=1784580426.759429&cid=C08S2L0S5MZ)*
