### PR TITLE
fix(warehouse): guard null numeric partition key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -945,6 +945,31 @@ def test_append_partition_key_to_table_does_not_type_error(name: str, data: list
         pytest.fail(f"raised TypeError for case {name} with data: {data}")
 
 
+def test_append_partition_key_numerical_handles_null_key():
+    # Numerical partitioning is only selected when partition_size is set, so the general
+    # does-not-type-error test (partition_size=None) never reaches the `key // partition_size`
+    # path. Pipedrive *_fields endpoints partition by `id` with partition_size=1 and can emit
+    # rows with a null id, which used to crash with `NoneType // int`.
+    partition_key = "id"
+    table = pa.table({partition_key: [1, 2, None, 4]})
+    logger: FilteringBoundLogger = structlog.get_logger()
+
+    result = append_partition_key_to_table(
+        table,
+        partition_keys=[partition_key],
+        partition_mode=None,
+        partition_count=None,
+        partition_size=1,
+        partition_format=None,
+        logger=logger,
+    )
+
+    assert result is not None
+    partitioned_table, mode, _, _ = result
+    assert mode == "numerical"
+    assert partitioned_table.column(PARTITION_KEY).to_pylist() == ["1", "2", "null", "4"]
+
+
 def _mock_schema(**overrides: Any) -> MagicMock:
     schema = MagicMock()
     schema.partition_count = overrides.get("partition_count")

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -516,6 +516,9 @@ def merge_observed_columns_into_schema_metadata(config: dict[str, Any], observed
 
 PARTITION_DATETIME_COLUMN_NAMES = ["created_at", "inserted_at", "createdAt"]
 
+# Bucket for rows whose numerical partition key is null — they can't be bucketed arithmetically.
+NULL_NUMERICAL_PARTITION = "null"
+
 
 async def setup_partitioning(
     pa_table: pa.Table,
@@ -665,9 +668,12 @@ def append_partition_key_to_table(
                 assert partition_size is not None, "append_partition_key_to_table: partition_size is None"
 
                 key = normalized_partition_keys[0]
-                partition = row[key] // partition_size
+                key_value = row[key]
 
-                partition_array.append(str(partition))
+                if key_value is None:
+                    partition_array.append(NULL_NUMERICAL_PARTITION)
+                else:
+                    partition_array.append(str(key_value // partition_size))
             elif mode == "datetime":
                 key = normalized_partition_keys[0]
                 date = row[key]


### PR DESCRIPTION
## Problem

The Pipedrive warehouse source has been failing ~12 syncs/day for weeks, all with the same crash:

```
TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'
```

Sometimes wrapped as `max retries exceeded: unsupported operand type(s) for //: 'NoneType' and 'int'`.

Prod data (postgres.posthog_externaldatajob across all teams) pins it to exactly three schemas: `deal_fields`, `person_fields`, `organization_fields`. It is pre-existing, steady since well before the recent Pipedrive v2 API-version work, so this is unrelated to that.

## Changes

Root cause is in generic partitioning, not Pipedrive code. In `append_partition_key_to_table`, the numerical branch did `row[key] // partition_size` with no null guard. Those three Pipedrive endpoints have no stable creation timestamp, so they partition by `id` with `partition_size=1`. Auto-detection picks numerical mode, and Pipedrive field-definition rows can arrive with a null `id`, so `None // 1` blew up and failed the whole sync.

The other two partition branches already tolerate null keys: md5 stringifies, datetime falls back to a `1970-01` sentinel. Numerical now does the same, routing null-keyed rows to a dedicated `"null"` bucket. Nothing downstream parses numerical partition values as ints (they sit alongside md5 hashes and `1970-01` labels), so a non-numeric sentinel is safe.

This is a generic fix. Any source that partitions numerically on a nullable key benefits, not just Pipedrive.

## How did you test this code?

Added `test_append_partition_key_numerical_handles_null_key`. The existing does-not-type-error test passes `partition_size=None`, which means numerical mode is never selected, so it never exercised the crashing line. The new test sets `partition_size=1` with `[1, 2, None, 4]`, forces numerical mode, and asserts the null row lands in the `"null"` bucket instead of raising.

```
10 passed (append_partition_key subset)
```

I (Claude) did not run a live Pipedrive sync — no credentials. Verification is the unit test plus the prod query that identified the failing schemas.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel directed this; I (Claude, via Claude Code) root-caused and wrote the fix. The reported hypothesis was that the `//` lived in Pipedrive pagination/progress math on the v1 offset `activities` endpoint. That turned out wrong: there is no floor division anywhere in the Pipedrive source. Grounding in prod (HogQL over `posthog_externaldatajob` joined to schema/source) showed the failures were confined to the `*_fields` schemas, which pointed at the shared numerical partition path in `pipelines/pipeline/utils.py`. No repo skills were needed beyond `/writing-tests` conventions.

The sentinel choice was the one real decision. Options were a colliding numeric bucket (e.g. `0`) or a distinct non-numeric label. I picked `"null"` after confirming no consumer parses these values as integers, matching the datetime branch's existing sentinel style.
