### PR TITLE
fix(self-capture): use dogfood-flags team token for `js_posthog_api_key`

### DIFF
--- a/posthog/test/test_get_context_for_template.py
+++ b/posthog/test/test_get_context_for_template.py
@@ -23,14 +23,13 @@ class TestGetContextForTemplate(APIBaseTest):
                 MagicMock(),
             )
 
-        # the current team has an api_token
+        # Under self-capture, posthog-js evaluates PostHog's own flags with the dogfood-flags team's
+        # token (first team by PK), which in this test is self.team — not the PH Cloud key.
         assert self.team.api_token != "sTMFPsFhdP1Ssg"
-        # but we use the posthog cloud api_token for the context
         assert actual == {
             "git_rev": mock.ANY,
             "js_capture_time_to_see_data": False,
-            # NB: we default to the PH Cloud key
-            "js_posthog_api_key": "sTMFPsFhdP1Ssg",
+            "js_posthog_api_key": self.team.api_token,
             "js_posthog_host": "",
             "js_url": "http://localhost:8234",
             "opt_out_capture": False,

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -11,6 +11,7 @@ from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import call, patch
 
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest
@@ -42,6 +43,7 @@ from posthog.utils import (
     format_query_params_absolute_url,
     get_available_timezones_with_offsets,
     get_compare_period_dates,
+    get_context_for_template,
     get_default_event_info,
     get_default_event_name,
     get_dogfood_flags_team_id,
@@ -1389,6 +1391,40 @@ class TestBuildFlagProvider(TestCase):
     @override_settings(SELF_CAPTURE=False, E2E_TESTING=False, CLOUD_DEPLOYMENT="EU")
     def test_explicit_env_team_id_wins_over_eu_region(self):
         assert _build_flag_provider()._resolve_team_id() == 5
+
+
+class TestSelfCaptureBrowserFlagToken(TestCase):
+    PASSWORD = "testpassword12345"
+
+    def setUp(self):
+        super().setUp()
+        # The dogfood branch reads the whole teams table; clear ambient rows so the team we create
+        # is the first one. Cascade deletes roll back with the test transaction.
+        User.objects.all().delete()
+        Organization.objects.all().delete()
+
+    @override_settings(SELF_CAPTURE=True, E2E_TESTING=False)
+    def test_browser_token_uses_dogfood_flags_team_not_self_capture_team(self):
+        # js_posthog_api_key is the token posthog-js evaluates PostHog's own flags with, so it must
+        # be the dogfood-flags team (first team, where flags are synced) even when a more-recently
+        # active user's current_team points at another team that holds no internal flags. Sourcing
+        # it from the self-capture team instead made local flags load then vanish on reload.
+        organization = Organization.objects.create(name="Org")
+        first_team = Team.objects.create(organization=organization, name="First")
+        recent_team = Team.objects.create(organization=organization, name="Recent")
+
+        recent_user = User.objects.create_and_join(organization, "recent@posthog.com", self.PASSWORD)
+        recent_user.current_team = recent_team
+        recent_user.last_login = datetime(2026, 1, 2, tzinfo=ZoneInfo("UTC"))
+        recent_user.save()
+
+        request = RequestFactory().get("/?no-preloaded-app-context=1")
+        request.user = AnonymousUser()
+
+        context = get_context_for_template("head.html", request)
+
+        assert context["js_posthog_api_key"] == first_team.api_token
+        assert first_team.api_token != recent_team.api_token
 
 
 VALID_PRELOAD_MANIFEST = {

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -531,7 +531,17 @@ def _build_template_context(
         context["js_posthog_ui_host"] = "https://us.posthog.com"
 
     elif settings.SELF_CAPTURE:
-        if posthoganalytics.api_key:
+        # posthog-js uses this token to evaluate PostHog's own gating flags, so it must point at the
+        # team those flags are synced to — the dogfood-flags team (first team by PK), the same team
+        # the server-side bootstrap evaluates against via _build_flag_provider(). Do NOT use the
+        # self-capture team here (posthoganalytics.api_key = most-recently-active user's current_team):
+        # it drifts onto demo teams that hold no internal flags, so flags load from the bootstrap and
+        # then vanish the moment posthog-js reloads them against that team.
+        dogfood_team = resolve_dogfood_flags_team()
+        if dogfood_team is not None:
+            context["js_posthog_api_key"] = dogfood_team.api_token
+            context["js_posthog_host"] = ""  # Becomes location.origin in the frontend
+        elif posthoganalytics.api_key:
             context["js_posthog_api_key"] = posthoganalytics.api_key
             context["js_posthog_host"] = ""  # Becomes location.origin in the frontend
     else:


### PR DESCRIPTION
## Problem

In local self-capture mode, PostHog's own product gating flags would load and then vanish on reload once more than one project exists locally. `js_posthog_api_key` (the token posthog-js uses to evaluate PostHog's flags in the browser) was sourced from `posthoganalytics.api_key`, which resolves to the most-recently-active user's `current_team`. With multiple local projects that drifts onto a demo team holding no internal flags — so flags load from the server-side bootstrap and then disappear the moment posthog-js re-evaluates them against that team.

## Changes

- In `_build_template_context`, when `SELF_CAPTURE` is on, source `js_posthog_api_key` from the dogfood-flags team (`resolve_dogfood_flags_team()`, first team by PK) — the same team the server-side bootstrap evaluates against via `_build_flag_provider()`. Falls back to the previous `posthoganalytics.api_key` behavior when no dogfood team is resolvable.
- Adds `TestSelfCaptureBrowserFlagToken`, asserting the browser token uses the first/dogfood team even when a more-recently-active user's `current_team` points at another team.

## How did you test this code?

- `hogli ci:preflight` passed (ruff lint/format clean; branch even with master).
- Added `TestSelfCaptureBrowserFlagToken.test_browser_token_uses_dogfood_flags_team_not_self_capture_team`. I did not run the Python suite locally this session — it runs in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — local self-capture dev behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @rafaeelaudibert is the DRI.

Built with Claude Code (Opus 4.8). Split out from the ProductEmptyState PR (#72442): this fix is an unrelated concern that surfaced during that work — local feature flags drifting off the dogfood-flags team when several projects exist locally.
