### PR TITLE
feat(signals): comment on a report's PR from the inbox

### DIFF
--- a/.semgrep/rules/security/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/security/idor-team-scoped-models.yaml
@@ -164,6 +164,8 @@ rules:
                               |FileSystemFolderInstructions
                               |FileSystemFolderContextGeneration
                               |GithubCommentMapping
+                              |GitHubMentionTaskMapping
+                              |GitHubPendingMention
                               |GitHubSyncConfig
                               |GitHubSyncPlan
                               |GitHubSyncedModel
@@ -482,6 +484,8 @@ rules:
                         |FileSystemFolderInstructions
                         |FileSystemFolderContextGeneration
                         |GithubCommentMapping
+                        |GitHubMentionTaskMapping
+                        |GitHubPendingMention
                         |GitHubSyncConfig
                         |GitHubSyncPlan
                         |GitHubSyncedModel

--- a/frontend/src/scenes/inbox/components/detail/PrCommentSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/PrCommentSection.tsx
@@ -1,0 +1,97 @@
+import { useActions, useValues } from 'kea'
+
+import { IconMessage } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
+
+import { TaskRunStatusDot } from 'products/posthog_ai/frontend/api/primitives'
+import { TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
+import { PrCommentResponseStatusEnumApi } from 'products/signals/frontend/generated/api.schemas'
+
+import { inboxReportDetailLogic } from '../../logics/inboxReportDetailLogic'
+import { SignalReport } from '../../types'
+import { DetailSection } from './DetailSection'
+
+/** Human-readable line for the live PR-run indicator, keyed off the run's TaskRun status. */
+function prRunStatusLabel(status: string): string {
+    switch (status) {
+        case TaskRunStatus.COMPLETED:
+            return 'The agent addressed your comment'
+        case TaskRunStatus.FAILED:
+            return 'The run failed while addressing your comment'
+        case TaskRunStatus.CANCELLED:
+            return 'The run was cancelled'
+        case TaskRunStatus.IN_PROGRESS:
+            return 'The agent is addressing your comment…'
+        default:
+            return 'Queued to address your comment'
+    }
+}
+
+/**
+ * "Comment on PR" affordance for a report whose implementation PR exists: a textarea that posts the
+ * comment to the PR and kicks off (or feeds into) the run that addresses it, plus a live indicator for
+ * that shared run. When the account isn't connected to GitHub yet, the response asks the user to connect
+ * instead of dead-ending. Only rendered when the report has an `implementation_pr_url`.
+ */
+export function PrCommentSection({ report }: { report: SignalReport }): JSX.Element {
+    const logic = inboxReportDetailLogic({ reportId: report.id, report })
+    const { prCommentDraft, prCommentResponse, prCommentResponseLoading, prActiveRun } = useValues(logic)
+    const { setPrCommentDraft, submitPrComment } = useActions(logic)
+
+    const submit = (): void => {
+        const trimmed = prCommentDraft.trim()
+        if (!trimmed) {
+            return
+        }
+        submitPrComment({ content: trimmed })
+    }
+
+    const needsConnect =
+        prCommentResponse?.status === PrCommentResponseStatusEnumApi.ConnectRequired && !!prCommentResponse.connect_url
+
+    return (
+        <DetailSection icon={<IconMessage />} title="Comment on PR">
+            <div className="flex flex-col gap-2">
+                <LemonTextArea
+                    value={prCommentDraft}
+                    onChange={setPrCommentDraft}
+                    placeholder="Ask for a change, or reply to the PR discussion. The agent will address it and push commits as you."
+                    maxLength={10000}
+                    rows={3}
+                    disabled={prCommentResponseLoading}
+                />
+                <div className="flex justify-end">
+                    <LemonButton
+                        type="primary"
+                        size="small"
+                        onClick={submit}
+                        loading={prCommentResponseLoading}
+                        disabledReason={prCommentDraft.trim() ? undefined : 'Write a comment first'}
+                    >
+                        Comment
+                    </LemonButton>
+                </div>
+
+                {needsConnect && prCommentResponse?.connect_url && (
+                    <div className="flex flex-col gap-2 rounded border border-primary bg-surface-primary px-3 py-2.5 text-xs text-secondary leading-snug">
+                        <span>Connect your GitHub account to PostHog so I can push changes as you.</span>
+                        <div>
+                            <LemonButton type="secondary" size="xsmall" to={prCommentResponse.connect_url} targetBlank>
+                                Connect GitHub
+                            </LemonButton>
+                        </div>
+                    </div>
+                )}
+
+                {prActiveRun && (
+                    <div className="flex items-center gap-2 text-xs text-secondary">
+                        <TaskRunStatusDot status={prActiveRun.status as TaskRunStatus} />
+                        <span>{prRunStatusLabel(prActiveRun.status)}</span>
+                    </div>
+                )}
+            </div>
+        </DetailSection>
+    )
+}

--- a/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
@@ -37,6 +37,7 @@ import { CommitContent } from './artefactTypes'
 import { DetailSection } from './DetailSection'
 import { DiscussReportButton } from './DiscussReportButton'
 import { PrChecksSection } from './PrChecksSection'
+import { PrCommentSection } from './PrCommentSection'
 import { PrCommentsSection } from './PrCommentsSection'
 import {
     PullRequestBranchTag,
@@ -552,6 +553,8 @@ export function ReportDetail({ report, tab }: { report: SignalReport; tab: Inbox
             summaryFooter={hasPr ? <PrCommentsSection report={report} /> : undefined}
         >
             {hasPr && <PrChecksSection report={report} />}
+            {/* Comment on the PR from the inbox and watch the run that addresses it, when a PR exists. */}
+            {hasPr && <PrCommentSection report={report} />}
         </InboxDetailFrame>
     )
 }

--- a/frontend/src/scenes/inbox/logics/inboxReportDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxReportDetailLogic.ts
@@ -22,6 +22,7 @@ import { personalIntegrationsLogic } from 'scenes/settings/user/personalIntegrat
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
+import { isTerminalRunStatus } from 'products/posthog_ai/frontend/api/logics'
 import { Task, TaskRunStatus } from 'products/posthog_ai/frontend/types/taskTypes'
 import {
     signalsReportArtefactsDiff,
@@ -32,10 +33,13 @@ import {
     signalsReportPrReviewCommentReactionsCreate,
     signalsReportPrReviewCommentsCreate,
     signalsReportPrReviewCommentUpdate,
+    signalsReportsPrCommentCreate,
     signalsReportsSignalsRetrieve,
 } from 'products/signals/frontend/generated/api'
 import type {
     CommitDiffResponseApi,
+    PrActiveRunApi,
+    PrCommentResponseApi,
     PullRequestCheckApi,
     PullRequestCommentApi,
     PullRequestCommentReactionApi,
@@ -176,15 +180,20 @@ export interface inboxReportDetailLogicValues {
     hasPersonalGithub: boolean
     inlineThreadCount: number
     inlineThreadsByFile: Record<string, ReviewThread[]>
+    isPrRunLive: boolean
     isReResearch: boolean
     isReportActive: boolean
     isUpdatingReviewers: boolean
     latestCommitArtefact: SignalReportArtefact | null
     optimisticReviewers: EnrichedReviewer[] | null
     postingThreadKey: string | null
+    prActiveRun: PrActiveRunApi | null
     prChecks: readonly PullRequestCheckApi[] | null
     prChecksError: string | null
     prChecksLoading: boolean
+    prCommentDraft: string
+    prCommentResponse: PrCommentResponseApi | null
+    prCommentResponseLoading: boolean
     prComments: readonly PullRequestCommentApi[] | null
     prCommentsError: string | null
     prCommentsLoading: boolean
@@ -369,6 +378,9 @@ export interface inboxReportDetailLogicActions {
     postReviewCommentFinished: () => {
         value: true
     }
+    refreshPrRunStatus: () => {
+        value: true
+    }
     searchAvailableReviewers: (query: string) => {
         query: string
     }
@@ -378,11 +390,38 @@ export interface inboxReportDetailLogicActions {
     setOptimisticReviewers: (reviewers: EnrichedReviewer[] | null) => {
         reviewers: EnrichedReviewer[] | null
     }
+    setPrActiveRun: (run: PrActiveRunApi | null) => {
+        run: PrActiveRunApi | null
+    }
+    setPrCommentDraft: (draft: string) => {
+        draft: string
+    }
     setReport: (report: SignalReport | null) => {
         report: SignalReport | null
     }
     setSelectedTaskId: (taskId: string | null) => {
         taskId: string | null
+    }
+    submitPrComment: ({ content }: { content: string }) => {
+        content: string
+    }
+    submitPrCommentFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    submitPrCommentSuccess: (
+        prCommentResponse: PrCommentResponseApi,
+        payload?: {
+            content: string
+        }
+    ) => {
+        prCommentResponse: PrCommentResponseApi
+        payload?: {
+            content: string
+        }
     }
     toggleExpandedTask: (taskId: string) => {
         taskId: string
@@ -415,6 +454,7 @@ export interface inboxReportDetailLogicMeta {
         currentUserGithubLogin: (personalIntegrations: PersonalGitHubIntegration[]) => string | null
         inlineThreadsByFile: (prComments: readonly PullRequestCommentApi[] | null) => Record<string, ReviewThread[]>
         inlineThreadCount: (inlineThreadsByFile: Record<string, ReviewThread[]>) => number
+        isPrRunLive: (prActiveRun: PrActiveRunApi | null) => boolean
         latestCommitArtefact: (reportArtefacts: SignalReportArtefact[] | null) => SignalReportArtefact | null
         priorityExplanation: (reportArtefacts: SignalReportArtefact[] | null) => string | null
         actionabilityExplanation: (reportArtefacts: SignalReportArtefact[] | null) => string | null
@@ -496,6 +536,13 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
         setSelectedTaskId: (taskId: string | null) => ({ taskId }),
         // Inline-expand a linked task's run log within the report detail's Runs section.
         toggleExpandedTask: (taskId: string) => ({ taskId }),
+        // The run currently addressing the report's PR comment — seeded from the report, updated by the
+        // comment response and the status poll.
+        setPrActiveRun: (run: PrActiveRunApi | null) => ({ run }),
+        // Controlled value of the "Comment on PR" textarea (kept in the logic so it clears on submit).
+        setPrCommentDraft: (draft: string) => ({ draft }),
+        // Re-read the report's `pr_active_run` so the live PR-run indicator advances while it runs.
+        refreshPrRunStatus: true,
     }),
 
     loaders(({ props, values }) => ({
@@ -634,6 +681,19 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
                 },
             },
         ],
+        // Posts a comment on the report's PR and starts (or feeds into) the run that addresses it. The
+        // response carries either the run to watch (`started`/`forwarded`), a GitHub connect prompt
+        // (`connect_required`), or `no_pr`. The button's in-flight state rides `prCommentResponseLoading`.
+        prCommentResponse: [
+            null as PrCommentResponseApi | null,
+            {
+                submitPrComment: async ({ content }: { content: string }): Promise<PrCommentResponseApi> => {
+                    return await signalsReportsPrCommentCreate(String(teamLogic.values.currentTeamId), props.reportId, {
+                        content,
+                    })
+                },
+            },
+        ],
     })),
 
     reducers({
@@ -733,6 +793,24 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
                 setReport: () => null,
             },
         ],
+        // The live PR run, updated by the comment response and the status poll. Seeded from the report's
+        // `pr_active_run` in the `setReport` listener (not here) so a stale report prop can't clobber a
+        // fresher run picked up from the poll.
+        prActiveRun: [
+            null as PrActiveRunApi | null,
+            {
+                setPrActiveRun: (_, { run }) => run,
+            },
+        ],
+        // The "Comment on PR" textarea value; cleared once the comment posts so the box empties on success
+        // but keeps the user's text on failure to retry.
+        prCommentDraft: [
+            '',
+            {
+                setPrCommentDraft: (_, { draft }) => draft,
+                submitPrCommentSuccess: () => '',
+            },
+        ],
     }),
 
     selectors({
@@ -821,6 +899,12 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
             (s) => [s.inlineThreadsByFile],
             (inlineThreadsByFile: Record<string, ReviewThread[]>): number =>
                 Object.values(inlineThreadsByFile).reduce((sum, threads) => sum + threads.length, 0),
+        ],
+        // The PR run counts as live while it has a non-terminal status — drives the status poll and the
+        // pulsing indicator. A terminal run stays visible but stops polling and reads as done.
+        isPrRunLive: [
+            (s) => [s.prActiveRun],
+            (prActiveRun: PrActiveRunApi | null): boolean => !!prActiveRun && !isTerminalRunStatus(prActiveRun.status),
         ],
         // The most recent `commit` artefact — its branch is treated as the report's branch to diff
         // against the repository default branch. A report's code work may span several pushes; the
@@ -1154,6 +1238,38 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
                     actions.loadPrComments()
                 }
             }
+            // Seed the PR run only when we don't already track one, so a stale report prop can't clobber a
+            // fresher run the poll or comment response already surfaced. `setPrActiveRun` (re)gates the poll.
+            if (values.prActiveRun === null && values.report?.pr_active_run) {
+                actions.setPrActiveRun(values.report.pr_active_run)
+            }
+        },
+        // Post succeeded: watch the returned shared run (started/forwarded). `connect_required`/`no_pr`
+        // carry no run and are surfaced inline by the component off `prCommentResponse`.
+        submitPrCommentSuccess: ({ prCommentResponse }) => {
+            if (prCommentResponse.run) {
+                actions.setPrActiveRun(prCommentResponse.run)
+            }
+        },
+        submitPrCommentFailure: ({ error }: { error: any }) => {
+            lemonToast.error(error?.detail || error?.message || "Couldn't post your comment. Please try again.")
+        },
+        // (Re)gate the PR-run status poll whenever the tracked run changes: a fresh live run starts it, a
+        // terminal run stops it. The keyed disposable replaces any running interval on re-add and is torn
+        // down automatically on unmount / tab hide.
+        setPrActiveRun: () => {
+            if (values.isPrRunLive) {
+                cache.disposables.add(() => {
+                    const interval = setInterval(() => actions.refreshPrRunStatus(), REPORT_TASKS_POLL_INTERVAL_MS)
+                    return () => clearInterval(interval)
+                }, 'prRunStatusPoll')
+            } else {
+                cache.disposables.dispose('prRunStatusPoll')
+            }
+        },
+        refreshPrRunStatus: async () => {
+            const report = await api.signalReports.get(props.reportId)
+            actions.setPrActiveRun(report.pr_active_run ?? null)
         },
     })),
 

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -1,6 +1,7 @@
 import type { UserBasicType } from '~/types'
 
 import {
+    type PrActiveRunApi,
     type SignalReportRefundApi,
     type SignalScoutRunSummaryApi,
     SignalSourceProductApi as SignalSourceProduct,
@@ -87,6 +88,8 @@ export interface SignalReport {
     /** Whether that implementation PR is merged, per the GitHub webhook. Status doesn't imply it: a
      * resolved report may have been resolved directly, without a merged PR. */
     implementation_pr_merged?: boolean
+    /** The run currently touching this report's PR, when one is active (detail/retrieve view only). */
+    pr_active_run?: PrActiveRunApi | null
     /** Reason code from the latest dismissal artefact (when archived). See dismissalReasons. */
     dismissal_reason?: string | null
     /** Free-form note from the latest dismissal artefact (when archived). */

--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -984,7 +984,11 @@ class GitHubIntegrationBase:
                 "error": f"Failed to comment on pull request: {response.text}",
                 "status_code": response.status_code,
             }
-        return {"success": True}
+        try:
+            created_id = response.json().get("id")
+        except Exception:
+            created_id = None
+        return {"success": True, "id": created_id}
 
     def comment_on_pull_request_from_url(self, pr_url: str, body: str) -> dict[str, Any]:
         """Post a comment on a pull request by its HTML URL."""

--- a/posthog/models/user_integration.py
+++ b/posthog/models/user_integration.py
@@ -432,6 +432,7 @@ class UserGitHubIntegration(GitHubIntegrationBase):
             f"/{comment_id}/reactions/{reaction_id}",
             source="signals_pr_review_comment_reaction_delete",
         )
+
     def comment_on_pull_request_as_user(self, repository: str, pr_number: int, body: str) -> dict[str, Any]:
         """Post a PR comment authored by *this connected user* (user-to-server token), not the App.
 

--- a/posthog/models/user_integration.py
+++ b/posthog/models/user_integration.py
@@ -432,6 +432,39 @@ class UserGitHubIntegration(GitHubIntegrationBase):
             f"/{comment_id}/reactions/{reaction_id}",
             source="signals_pr_review_comment_reaction_delete",
         )
+    def comment_on_pull_request_as_user(self, repository: str, pr_number: int, body: str) -> dict[str, Any]:
+        """Post a PR comment authored by *this connected user* (user-to-server token), not the App.
+
+        So a comment written from inside PostHog shows up on GitHub as the user, exactly as if they
+        had typed it on the PR. ``repository`` is ``owner/repo``. Returns
+        ``{"success": bool, "id": <created comment id> | None}``.
+        """
+        token = self.get_usable_user_access_token()
+        repo_path = repository if "/" in repository else f"{self.organization()}/{repository}"
+        try:
+            response = github_request(
+                "POST",
+                f"https://api.github.com/repos/{repo_path}/issues/{pr_number}/comments",
+                source=self.source,
+                endpoint="/repos/{owner}/{repo}/issues/{issue_number}/comments",
+                headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+                json={"body": body},
+                timeout=10,
+            )
+        except Exception:
+            logger.warning("UserGitHubIntegration: user-authored comment failed", exc_info=True)
+            return {"success": False, "error": "Network error commenting as user"}
+        if response.status_code != 201:
+            return {
+                "success": False,
+                "error": f"Failed to comment as user: {response.text}",
+                "status_code": response.status_code,
+            }
+        try:
+            created_id = response.json().get("id")
+        except Exception:
+            created_id = None
+        return {"success": True, "id": created_id}
 
     def _apply_user_token_payload(self, payload: dict[str, Any]) -> None:
         """Write a fresh user token pair + expirations onto the integration row."""

--- a/products/signals/backend/github_mention/identity.py
+++ b/products/signals/backend/github_mention/identity.py
@@ -106,3 +106,22 @@ def resolve_commenter_identity(
     login_map = get_org_member_github_login_to_user_map(team.id) or {}
     member = login_map.get(github_login.lower()) if github_login else None
     return MentionIdentity(status=MentionIdentityStatus.NEEDS_CONNECT, user=member)
+
+
+def resolve_user_push_identity(*, user: User, team: Team, repository: str) -> MentionIdentity:
+    """Whether an authenticated PostHog ``user`` may drive a run on ``repository`` for ``team``.
+
+    Used by the report-view comment endpoint, where identity is the logged-in user (not a webhook
+    payload). ELIGIBLE requires org membership plus a usable personal GitHub connection covering the
+    repo — the push token that authors commits as them. Otherwise NEEDS_CONNECT (the UI shows a
+    connect prompt); NOT_MEMBER is never returned here since the viewset already scopes to the team.
+    """
+    repository_normalized = repository.lower()
+    if not OrganizationMembership.objects.filter(organization_id=team.organization_id, user_id=user.id).exists():
+        return MentionIdentity(status=MentionIdentityStatus.NOT_MEMBER)
+
+    for integration in UserIntegration.objects.filter(kind="github", user_id=user.id):
+        github = UserGitHubIntegration(integration)
+        if _integration_is_usable(github) and _integration_covers_repository(integration, repository_normalized):
+            return MentionIdentity(status=MentionIdentityStatus.ELIGIBLE, user=user, user_github_integration=github)
+    return MentionIdentity(status=MentionIdentityStatus.NEEDS_CONNECT, user=user)

--- a/products/signals/backend/github_mention/process.py
+++ b/products/signals/backend/github_mention/process.py
@@ -7,9 +7,12 @@ them and pushes to the existing PR branch; un-connected commenters get a connect
 row that replays once they connect.
 """
 
+from enum import Enum
 from typing import Any
+from uuid import UUID
 
 from django.conf import settings
+from django.core.cache import cache
 from django.db import transaction
 
 import structlog
@@ -31,9 +34,23 @@ logger = structlog.get_logger(__name__)
 
 # Follow-ups on an already-actionable report's PR must not re-bill the report.
 _MENTION_BILLING_EXEMPT_REASON = "github_mention_followup"
-# Queue behind an in-flight run for the same PR by retrying until it's terminal (~1h ceiling).
+# A transient failure signalling an in-flight run is retried until it lands (~1h ceiling).
 _QUEUE_RETRY_COUNTDOWN_SECONDS = 90
 _QUEUE_MAX_RETRIES = 40
+
+# Per-PR lock so two comments arriving on an idle PR at once can't both launch a run (one shared run
+# per PR). Held only across the launch-vs-forward decision, so a short TTL is a safe self-heal.
+_DISPATCH_LOCK_KEY_PREFIX = "signals:github_mention:pr_dispatch_lock:"
+_DISPATCH_LOCK_TTL_SECONDS = 30
+
+
+class MentionOutcome(Enum):
+    # A fresh run was created for this PR (no run was active).
+    LAUNCHED = "launched"
+    # The comment was forwarded into the PR's already-running shared run.
+    FORWARDED = "forwarded"
+    # A run is active but the follow-up signal transiently failed — the caller should retry.
+    FORWARD_RETRY = "forward_retry"
 
 
 def _github_mentions_enabled() -> bool:
@@ -136,6 +153,41 @@ def _gate_connect(
     )
 
 
+def _ack_reaction(github: GitHubIntegration | None, repository: str, comment_id: int) -> None:
+    if github is None:
+        return
+    try:
+        github.add_reaction_to_comment(repository, comment_id, "eyes")
+    except Exception:
+        logger.exception("github_mention_reaction_failed", repository=repository)
+
+
+def _active_mention_run(team_id: int, pr_url: str) -> tuple[UUID, UUID] | None:
+    """The (run_id, task_id) of the PR's latest still-running mention run, or None.
+
+    There is one shared run per PR: a comment arriving while a run is active is forwarded into it
+    rather than spawning a parallel run.
+    """
+    mappings = GitHubMentionTaskMapping.objects.for_team(team_id).filter(pr_url=pr_url).order_by("-created_at")
+    for mapping in mappings:
+        if not tasks_facade.is_task_run_terminal(str(mapping.task_run_id)):
+            return mapping.task_run_id, mapping.task_id
+    return None
+
+
+def _comment_body(github: GitHubIntegration | None, repository: str, pr_number: int | None, comment_id: int) -> str:
+    """Best-effort fetch of a single conversation comment's body, for forwarding into a running run."""
+    if github is None or pr_number is None:
+        return ""
+    listed = github.list_pull_request_comments(repository, pr_number)
+    if not listed.get("success"):
+        return ""
+    for comment in listed.get("comments", []):
+        if comment.get("id") == comment_id:
+            return comment.get("body") or ""
+    return ""
+
+
 def _launch_run(
     *,
     team: Team,
@@ -147,12 +199,8 @@ def _launch_run(
     comment_id: int,
     commenter_account_id: int,
     user_id: int,
-) -> None:
-    if github is not None:
-        try:
-            github.add_reaction_to_comment(repository, comment_id, "eyes")
-        except Exception:
-            logger.exception("github_mention_reaction_failed", repository=repository)
+) -> UUID:
+    _ack_reaction(github, repository, comment_id)
 
     report_id = str(context.signal_report_id) if context.signal_report_id else None
     feedback = _gather_feedback(github, repository, pr_number, team.id) if (github and pr_number) else ""
@@ -196,6 +244,71 @@ def _launch_run(
                 run_id=str(created.latest_run.id),
                 billing_exempt_reason=_MENTION_BILLING_EXEMPT_REASON,
             )
+    return created.latest_run.id
+
+
+def dispatch_eligible_mention(
+    *,
+    team: Team,
+    context: Any,
+    github: GitHubIntegration | None,
+    repository: str,
+    pr_url: str,
+    pr_number: int | None,
+    comment_id: int,
+    commenter_account_id: int,
+    user_id: int,
+    followup_content: str | None = None,
+) -> tuple[MentionOutcome, UUID | None]:
+    """Launch a new run for the PR, or forward this comment into the PR's already-running shared run.
+
+    Shared by the webhook path (``process_github_mention``) and the report-view comment endpoint.
+    ``followup_content`` lets the endpoint pass the comment body it already has; the webhook path
+    fetches it from GitHub. Returns the outcome and the active/created run id.
+    """
+    # Serialize the launch-vs-forward decision per PR: without this, two comments reaching an idle PR
+    # at the same moment could both see no active run and both launch, breaking one-run-per-PR.
+    lock_key = f"{_DISPATCH_LOCK_KEY_PREFIX}{pr_url}"
+    if not cache.add(lock_key, True, _DISPATCH_LOCK_TTL_SECONDS):
+        return MentionOutcome.FORWARD_RETRY, None  # another dispatch is deciding right now — caller retries
+    try:
+        active = _active_mention_run(team.id, pr_url)
+        if active is not None:
+            run_id, task_id = active
+            _ack_reaction(github, repository, comment_id)
+            content = (
+                followup_content
+                if followup_content is not None
+                else _comment_body(github, repository, pr_number, comment_id)
+            )
+            message = (
+                "A reviewer left more feedback on this PR — address it too, then commit and push to the "
+                f"same branch:\n\n{content}"
+            )
+            result = tasks_facade.signal_task_run_user_message(
+                run_id=str(run_id), task_id=str(task_id), team_id=team.id, content=message, artifact_ids=[]
+            )
+            if result is True:
+                return MentionOutcome.FORWARDED, run_id
+            if result is False:
+                return MentionOutcome.FORWARD_RETRY, run_id
+            # result is None: the run's workflow is gone (it finished between the terminal check and now).
+            # Fall through and start a fresh run.
+
+        run_id = _launch_run(
+            team=team,
+            context=context,
+            github=github,
+            repository=repository,
+            pr_url=pr_url,
+            pr_number=pr_number,
+            comment_id=comment_id,
+            commenter_account_id=commenter_account_id,
+            user_id=user_id,
+        )
+        return MentionOutcome.LAUNCHED, run_id
+    finally:
+        cache.delete(lock_key)
 
 
 @shared_task(bind=True, ignore_result=True, max_retries=_QUEUE_MAX_RETRIES, acks_late=True)
@@ -224,11 +337,6 @@ def process_github_mention(
 
     # team_scope gives the fail-closed managers on the mention models a team context in this Celery task.
     with team_scope(team_id):
-        # Queue behind any in-flight mention run for this PR (ordered, no parallel run).
-        for mapping in GitHubMentionTaskMapping.objects.for_team(team_id).filter(pr_url=pr_url):
-            if not tasks_facade.is_task_run_terminal(str(mapping.task_run_id)):
-                raise self.retry(countdown=_QUEUE_RETRY_COUNTDOWN_SECONDS)
-
         github = GitHubIntegration.first_for_team_repository(team_id, repository)
         pr_number = _pr_number(pr_url)
         report_id = str(context.signal_report_id) if context.signal_report_id else None
@@ -264,7 +372,8 @@ def process_github_mention(
             )
             return
 
-        _launch_run(
+        # One shared run per PR: forward into the active run if there is one, else start a fresh run.
+        outcome, _ = dispatch_eligible_mention(
             team=team,
             context=context,
             github=github,
@@ -275,3 +384,5 @@ def process_github_mention(
             commenter_account_id=int(commenter_account_id),
             user_id=identity.user.id,
         )
+        if outcome == MentionOutcome.FORWARD_RETRY:
+            raise self.retry(countdown=_QUEUE_RETRY_COUNTDOWN_SECONDS)

--- a/products/signals/backend/github_mention/result_relay.py
+++ b/products/signals/backend/github_mention/result_relay.py
@@ -40,7 +40,8 @@ def relay_github_mention_result(*, run_id: str, status: str) -> None:
     if not body:
         return
 
-    mapping = GitHubMentionTaskMapping.all_teams.filter(task_run_id=run_id).first()
+    # Django coerces the str pk for the UUID FK lookup at runtime; django-stubs types it strictly.
+    mapping = GitHubMentionTaskMapping.all_teams.filter(task_run_id=run_id).first()  # type: ignore[misc]
     if mapping is None:
         return
 

--- a/products/signals/backend/github_mention/test/test_process.py
+++ b/products/signals/backend/github_mention/test/test_process.py
@@ -104,3 +104,23 @@ class TestProcessGitHubMention(BaseTest):
         self.create_task.assert_not_called()
         self.github.comment_on_pull_request.assert_called_once()
         self.assertEqual(GitHubPendingMention.objects.for_team(self.team.id).count(), 0)
+
+    def test_eligible_forwards_into_active_run_instead_of_starting_a_new_one(self) -> None:
+        # One shared run per PR: a comment arriving while a run is active is fed into that run.
+        run_id, task_id = uuid4(), uuid4()
+        with (
+            patch.object(process, "_active_mention_run", return_value=(run_id, task_id)),
+            patch.object(tasks_facade, "signal_task_run_user_message", return_value=True) as signal,
+            patch.object(
+                process,
+                "resolve_commenter_identity",
+                return_value=self._identity(MentionIdentityStatus.ELIGIBLE, self.user),
+            ),
+        ):
+            self._run()
+
+        self.create_task.assert_not_called()  # no parallel/new run
+        signal.assert_called_once()
+        self.assertEqual(signal.call_args.kwargs["run_id"], str(run_id))
+        self.assertEqual(signal.call_args.kwargs["task_id"], str(task_id))
+        self.github.add_reaction_to_comment.assert_called_once_with(REPO, 55, "eyes")

--- a/products/signals/backend/github_mention/test/test_webhook.py
+++ b/products/signals/backend/github_mention/test/test_webhook.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
+from typing import cast
 
 from unittest.mock import patch
 
+from django.http import HttpRequest
 from django.test import SimpleTestCase, override_settings
 
 from products.signals.backend.github_mention import webhook
@@ -9,8 +11,8 @@ from products.signals.backend.github_mention import webhook
 PR_URL = "https://github.com/acme/app/pull/7"
 
 
-def _request() -> SimpleNamespace:
-    return SimpleNamespace(headers={"X-GitHub-Delivery": "abc-123"}, body=b"{}")
+def _request() -> HttpRequest:
+    return cast(HttpRequest, SimpleNamespace(headers={"X-GitHub-Delivery": "abc-123"}, body=b"{}"))
 
 
 def _payload(*, action: str = "created", body: str = "@posthog please fix", is_pr: bool = True, via_app=None):
@@ -33,6 +35,7 @@ class TestHandleGitHubMentionEvent(SimpleTestCase):
         cache_patch = patch.object(webhook, "cache")
         self.cache = cache_patch.start()
         self.cache.add.return_value = True
+        self.cache.get.return_value = None  # comment not already handled directly by the report-view endpoint
         self.addCleanup(patch.stopall)
 
     def test_enqueues_on_bot_mention_on_signals_pr(self) -> None:
@@ -65,5 +68,12 @@ class TestHandleGitHubMentionEvent(SimpleTestCase):
 
     def test_does_not_enqueue_on_duplicate_delivery(self) -> None:
         self.cache.add.return_value = False
+        webhook.handle_github_mention_event(_request(), _payload())
+        self.delay.assert_not_called()
+
+    def test_does_not_enqueue_when_comment_already_handled_directly(self) -> None:
+        # The report-view endpoint marks the comment id before the webhook delivers it, so the
+        # user-authored comment it posted doesn't trigger a second run here.
+        self.cache.get.return_value = True
         webhook.handle_github_mention_event(_request(), _payload())
         self.delay.assert_not_called()

--- a/products/signals/backend/github_mention/webhook.py
+++ b/products/signals/backend/github_mention/webhook.py
@@ -26,9 +26,18 @@ _MENTION_DEDUP_KEY_PREFIX = "signals:github_mention:delivery:"
 # GitHub redelivers failed webhooks; 1h comfortably covers the retry window without pinning memory.
 _MENTION_DEDUP_TTL_SECONDS = 60 * 60
 
+_HANDLED_COMMENT_KEY_PREFIX = "signals:github_mention:handled_comment:"
+_HANDLED_COMMENT_TTL_SECONDS = 60 * 60
+
+
+def mark_comment_handled_directly(comment_id: int) -> None:
+    """Record that a comment's run was already triggered directly (from the report-view endpoint), so
+    the webhook skips it when GitHub delivers the same user-authored comment — no double-trigger."""
+    cache.set(f"{_HANDLED_COMMENT_KEY_PREFIX}{comment_id}", True, _HANDLED_COMMENT_TTL_SECONDS)
+
 
 def _mentions_bot(body: str) -> bool:
-    slug = (settings.GITHUB_APP_SLUG or "").strip().lower()
+    slug = (getattr(settings, "GITHUB_APP_SLUG", None) or "").strip().lower()
     if not slug:
         return False
     # Matches both "@slug" and "@slug[bot]" (the GitHub App bot login form).
@@ -53,6 +62,9 @@ def handle_github_mention_event(request: HttpRequest, payload: dict[str, Any]) -
         comment = payload.get("comment") or {}
         if comment.get("performed_via_github_app"):
             return  # our own bot comment — avoid loops
+        comment_id = comment.get("id")
+        if comment_id is not None and cache.get(f"{_HANDLED_COMMENT_KEY_PREFIX}{comment_id}"):
+            return  # the report-view endpoint already triggered this comment's run directly
         if not _mentions_bot(comment.get("body") or ""):
             return
 

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -336,6 +336,43 @@ class SignalReportRefundSerializer(serializers.ModelSerializer):
         return obj.billing_synced_at is not None
 
 
+class PrActiveRunSerializer(serializers.Serializer):
+    """The run currently touching a report's PR — id + status for the report view's live indicator."""
+
+    id = serializers.UUIDField(read_only=True, help_text="TaskRun id.")
+    status = serializers.CharField(
+        read_only=True,
+        help_text="Run status: not_started, queued, in_progress (agent working) or a terminal completed/failed/cancelled.",
+    )
+
+
+class PrCommentRequestSerializer(serializers.Serializer):
+    """Body for commenting on a report's PR from the inbox."""
+
+    content = serializers.CharField(
+        min_length=1,
+        max_length=10000,
+        trim_whitespace=True,
+        help_text="The comment to post on the PR and have the agent address.",
+    )
+
+
+class PrCommentResponseSerializer(serializers.Serializer):
+    """Result of a report-view PR comment: the shared run to watch, or a connect prompt."""
+
+    status = serializers.ChoiceField(
+        choices=["started", "forwarded", "connect_required", "no_pr"],
+        help_text=(
+            "started: a new run began. forwarded: fed into the PR's already-running run. "
+            "connect_required: connect GitHub first (see connect_url). no_pr: the report has no PR."
+        ),
+    )
+    run = PrActiveRunSerializer(allow_null=True, help_text="The shared run to watch, when one was started/forwarded.")
+    connect_url = serializers.CharField(
+        allow_null=True, help_text="Where to connect GitHub, when status is connect_required."
+    )
+
+
 class SignalReportSerializer(serializers.ModelSerializer):
     artefact_count = serializers.IntegerField(read_only=True)
     refund_ineligibility_reason = serializers.SerializerMethodField(
@@ -376,6 +413,9 @@ class SignalReportSerializer(serializers.ModelSerializer):
             "resolved directly, without a merged PR."
         ),
     )
+    pr_active_run = serializers.SerializerMethodField(
+        help_text="The run currently addressing this report's PR (id + status), or null. Detail view only.",
+    )
     refund = serializers.SerializerMethodField(
         help_text="The report's PR refund, when one exists. One refund per report, ever.",
     )
@@ -403,6 +443,7 @@ class SignalReportSerializer(serializers.ModelSerializer):
             "scout_name",
             "implementation_pr_url",
             "implementation_pr_merged",
+            "pr_active_run",
             "refund",
             "refund_ineligibility_reason",
             "billing_exempt_reason",
@@ -526,6 +567,14 @@ class SignalReportSerializer(serializers.ModelSerializer):
         # Annotated path: the JSON flag arrives as text, and NULL means no PR-bearing run at all.
         value = getattr(obj, "implementation_pr_merged", None)
         return value in (True, "true", "True")
+
+    @extend_schema_field(PrActiveRunSerializer(allow_null=True))
+    def get_pr_active_run(self, obj: SignalReport) -> dict | None:
+        # Populated only in the detail view (see SignalReportViewSet.retrieve) to avoid an N+1 in list.
+        pr_active_run_map: dict[str, dict] | None = self.context.get("pr_active_run_map")
+        if pr_active_run_map is None:
+            return None
+        return pr_active_run_map.get(str(obj.id))
 
     @extend_schema_field(SignalReportRefundSerializer(allow_null=True))
     def get_refund(self, obj: SignalReport) -> dict | None:

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.apps import apps
 from django.core.cache import cache
@@ -2454,3 +2454,114 @@ class TestSignalReportPrEndpoints(APIBaseTest):
             response = self.client.get(self._comments_url(str(report.id)))
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"comments": comments}
+class TestSignalReportPrCommentAPI(APIBaseTest):
+    def _create_report(self) -> SignalReport:
+        return SignalReport.objects.create(team=self.team, title="t", summary="s", status=SignalReport.Status.READY)
+
+    def _report_with_pr(self, pr_url: str = "https://github.com/org/repo/pull/42") -> SignalReport:
+        Task = apps.get_model("tasks", "Task")
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        report = self._create_report()
+        task = Task.objects.create(
+            team=self.team,
+            title="impl",
+            description="d",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            signal_report=report,
+            repository="org/repo",
+        )
+        record_implementation_task(team_id=self.team.id, report_id=str(report.id), task_id=str(task.id))
+        TaskRun.objects.create(team=self.team, task=task, status=TaskRun.Status.COMPLETED, output={"pr_url": pr_url})
+        return report
+
+    def _url(self, report: SignalReport) -> str:
+        return f"/api/projects/{self.team.id}/signals/reports/{report.id}/pr_comment/"
+
+    def _context(self) -> object:
+        from products.tasks.backend.facade import contracts
+
+        return contracts.SignalPrMentionContextDTO(
+            team_id=self.team.id,
+            task_id=uuid.uuid4(),
+            run_id=uuid.uuid4(),
+            repository="org/repo",
+            signal_report_id=uuid.uuid4(),
+            github_integration_id=1,
+            head_branch="head",
+        )
+
+    def test_no_pr_returns_400(self):
+        report = self._create_report()
+        response = self.client.post(self._url(report), data={"content": "please fix"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["status"] == "no_pr"
+
+    @patch("products.signals.backend.views.resolve_user_push_identity")
+    @patch("products.signals.backend.views.tasks_facade.resolve_signal_pr_mention_context")
+    def test_connect_required_when_no_usable_connection(self, mock_ctx, mock_identity):
+        from products.signals.backend.github_mention.identity import MentionIdentity, MentionIdentityStatus
+
+        report = self._report_with_pr()
+        mock_ctx.return_value = self._context()
+        mock_identity.return_value = MentionIdentity(status=MentionIdentityStatus.NEEDS_CONNECT, user=self.user)
+        github = MagicMock()
+        with patch("products.signals.backend.views.GitHubIntegration.first_for_team_repository", return_value=github):
+            response = self.client.post(self._url(report), data={"content": "fix it"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["status"] == "connect_required"
+        assert body["connect_url"]
+        github.comment_on_pull_request.assert_not_called()  # no run, no GitHub write when un-connected
+
+    @patch("products.signals.backend.views.tasks_facade.get_task_run")
+    @patch("products.signals.backend.views.dispatch_eligible_mention")
+    @patch("products.signals.backend.views.resolve_user_push_identity")
+    @patch("products.signals.backend.views.tasks_facade.resolve_signal_pr_mention_context")
+    def test_eligible_posts_comment_and_returns_started_run(self, mock_ctx, mock_identity, mock_dispatch, mock_get_run):
+        from products.signals.backend.github_mention.identity import MentionIdentity, MentionIdentityStatus
+        from products.signals.backend.github_mention.process import MentionOutcome
+
+        report = self._report_with_pr()
+        mock_ctx.return_value = self._context()
+        user_github = MagicMock()
+        user_github.comment_on_pull_request_as_user.return_value = {"success": True, "id": 555}
+        mock_identity.return_value = MentionIdentity(
+            status=MentionIdentityStatus.ELIGIBLE, user=self.user, user_github_integration=user_github
+        )
+        run_id = uuid.uuid4()
+        mock_dispatch.return_value = (MentionOutcome.LAUNCHED, run_id)
+        mock_get_run.return_value = SimpleNamespace(id=run_id, status="in_progress")
+        github = MagicMock()
+        with patch("products.signals.backend.views.GitHubIntegration.first_for_team_repository", return_value=github):
+            response = self.client.post(self._url(report), data={"content": "rename the helper"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        body = response.json()
+        assert body["status"] == "started"
+        assert body["run"]["id"] == str(run_id)
+        assert body["run"]["status"] == "in_progress"
+        # The comment is authored as the user, not the App, and the run is triggered directly.
+        user_github.comment_on_pull_request_as_user.assert_called_once()
+        github.comment_on_pull_request.assert_not_called()
+        mock_dispatch.assert_called_once()
+
+    @patch("products.signals.backend.views.tasks_facade.resolve_signal_pr_mention_context")
+    def test_rejects_pr_resolving_to_another_team(self, mock_ctx):
+        # The PR URL comes from this team's report, but the task that opened it must also be this
+        # team's — a PR recorded across projects must not cross the tenant boundary.
+        from products.tasks.backend.facade import contracts
+
+        report = self._report_with_pr()
+        mock_ctx.return_value = contracts.SignalPrMentionContextDTO(
+            team_id=self.team.id + 999,
+            task_id=uuid.uuid4(),
+            run_id=uuid.uuid4(),
+            repository="org/repo",
+            signal_report_id=uuid.uuid4(),
+            github_integration_id=1,
+            head_branch="head",
+        )
+        response = self.client.post(self._url(report), data={"content": "fix"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["status"] == "no_pr"

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -2454,6 +2454,8 @@ class TestSignalReportPrEndpoints(APIBaseTest):
             response = self.client.get(self._comments_url(str(report.id)))
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"comments": comments}
+
+
 class TestSignalReportPrCommentAPI(APIBaseTest):
     def _create_report(self) -> SignalReport:
         return SignalReport.objects.create(team=self.team, title="t", summary="s", status=SignalReport.Status.READY)

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -58,6 +58,7 @@ from posthog.models.activity_logging.activity_log import Change, Detail, log_act
 from posthog.models.activity_logging.model_activity import is_impersonated_session
 from posthog.models.github_integration_base import GitHubIntegrationBase, NormalizedPRComment
 from posthog.models.integration import GitHubIntegration, Integration
+from posthog.models.scoping import team_scope
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.user_integration import ReauthorizationRequired, UserGitHubIntegration, UserIntegration
 from posthog.permissions import APIScopePermission
@@ -87,6 +88,9 @@ from products.signals.backend.billing import (
     report_pr_is_merged,
 )
 from products.signals.backend.facade.api import emit_signal
+from products.signals.backend.github_mention.identity import MentionIdentityStatus, resolve_user_push_identity
+from products.signals.backend.github_mention.process import MentionOutcome, dispatch_eligible_mention
+from products.signals.backend.github_mention.webhook import mark_comment_handled_directly
 from products.signals.backend.implementation_pr import (
     fetch_implementation_pr_state_for_reports,
     fetch_implementation_pr_urls_for_reports,
@@ -111,6 +115,8 @@ from products.signals.backend.report_generation.resolve_reviewers import (
 )
 from products.signals.backend.serializers import (
     CommitDiffResponseSerializer,
+    PrCommentRequestSerializer,
+    PrCommentResponseSerializer,
     PullRequestChecksResponseSerializer,
     PullRequestCommentsResponseSerializer,
     PullRequestReviewCommentCreateResponseSerializer,
@@ -1212,12 +1218,27 @@ class SignalReportViewSet(
         except Exception:
             logger.exception("signals.enriched_context.implementation_pr_url_failed", report_id=str(report.id))
             implementation_pr_by_report = {}
+        implementation_pr_url_map = {rid: pr.url for rid, pr in implementation_pr_by_report.items()}
+        # Live status of the run currently addressing this report's PR (detail view only — one
+        # report, so no N+1). Best-effort: a hiccup must never 500 an otherwise-available report.
+        pr_active_run_map: dict[str, dict] = {}
+        pr_url = implementation_pr_url_map.get(str(report.id))
+        if pr_url:
+            try:
+                parsed = GitHubIntegration.parse_pull_request_url(pr_url)
+                if parsed:
+                    run = tasks_facade.get_active_run_for_pr(pr_url, f"{parsed[0]}/{parsed[1]}")
+                    if run is not None:
+                        pr_active_run_map[str(report.id)] = {"id": str(run.id), "status": run.status}
+            except Exception:
+                logger.exception("signals.enriched_context.pr_active_run_failed", report_id=str(report.id))
         return {
             **self.get_serializer_context(),
             "source_products_map": {rid: meta.source_products for rid, meta in signal_meta_map.items()},
             "scout_names_map": {rid: meta.scout_name for rid, meta in signal_meta_map.items() if meta.scout_name},
-            "implementation_pr_url_map": {rid: pr.url for rid, pr in implementation_pr_by_report.items()},
+            "implementation_pr_url_map": implementation_pr_url_map,
             "implementation_pr_merged_ids": {rid for rid, pr in implementation_pr_by_report.items() if pr.merged},
+            "pr_active_run_map": pr_active_run_map,
         }
 
     def retrieve(self, request, *args, **kwargs):
@@ -1569,6 +1590,89 @@ class SignalReportViewSet(
         report_data = SignalReportSerializer(report, context=self._enriched_report_context(report)).data
         signals_list = fetch_signals_for_report_sync(self.team, str(report.id))
         return Response({"report": report_data, "signals": signals_list})
+
+    @extend_schema(
+        request=PrCommentRequestSerializer,
+        responses={200: PrCommentResponseSerializer},
+        summary="Comment on a report's PR from the inbox",
+        description=(
+            "Post a comment on this report's pull request and have the PostHog agent address it. "
+            "The comment is posted to the PR and the run that addresses it is started (or, if a run "
+            "is already working the PR, the comment is fed into that shared run). Requires a connected "
+            "personal GitHub account with write access so commits are authored as you — otherwise "
+            "returns status 'connect_required' with a connect_url."
+        ),
+    )
+    @action(detail=True, methods=["post"], url_path="pr_comment", required_scopes=["task:write"])
+    def pr_comment(self, request, pk=None, **kwargs):
+        report = cast(SignalReport, self.get_object())
+        req = PrCommentRequestSerializer(data=request.data)
+        req.is_valid(raise_exception=True)
+        content = req.validated_data["content"]
+
+        pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
+        parsed = GitHubIntegration.parse_pull_request_url(pr_url) if pr_url else None
+        if not pr_url or parsed is None:
+            return Response({"status": "no_pr", "run": None, "connect_url": None}, status=status.HTTP_400_BAD_REQUEST)
+        repository = f"{parsed[0]}/{parsed[1]}"
+        pr_number = parsed[2]
+
+        context = tasks_facade.resolve_signal_pr_mention_context(pr_url, repository)
+        # Tenant boundary: the PR resolved from the URL must belong to THIS team's report, not another
+        # project that happens to have recorded the same PR URL.
+        if context is None or context.team_id != self.team.id:
+            return Response({"status": "no_pr", "run": None, "connect_url": None}, status=status.HTTP_400_BAD_REQUEST)
+
+        user = cast(User, request.user)
+        identity = resolve_user_push_identity(user=user, team=self.team, repository=repository)
+        if identity.status != MentionIdentityStatus.ELIGIBLE:
+            connect_url = f"{settings.SITE_URL}/project/{self.team.id}/settings/integrations"
+            return Response({"status": "connect_required", "run": None, "connect_url": connect_url})
+
+        github = GitHubIntegration.first_for_team_repository(self.team.id, repository)
+        if github is None:
+            return Response({"error": "GitHub integration unavailable."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Post the comment AS THE USER (their user-to-server token), prefixed with the bot mention, so
+        # on GitHub it reads exactly like the user @-mentioning the bot. We then trigger the run
+        # directly for an immediate response.
+        bot_slug = getattr(settings, "GITHUB_APP_SLUG", "") or ""
+        mention_prefix = f"@{bot_slug} " if bot_slug else ""
+        # ELIGIBLE guarantees a usable personal connection (see resolve_user_push_identity).
+        assert identity.user_github_integration is not None
+        posted = identity.user_github_integration.comment_on_pull_request_as_user(
+            repository, pr_number, f"{mention_prefix}{content}"
+        )
+        if not posted.get("success"):
+            return Response(
+                {"error": "Couldn't post the comment to the pull request."}, status=status.HTTP_502_BAD_GATEWAY
+            )
+        comment_id = int(posted.get("id") or 0)
+
+        with team_scope(self.team.id):
+            outcome, run_id = dispatch_eligible_mention(
+                team=self.team,
+                context=context,
+                github=github,
+                repository=repository,
+                pr_url=pr_url,
+                pr_number=pr_number,
+                comment_id=comment_id,
+                commenter_account_id=0,  # report-view path: identity is request.user, not a webhook account
+                user_id=user.id,
+                followup_content=content,
+            )
+
+        # Suppress the webhook echo of this user-authored comment only once the run has definitely
+        # received it. On FORWARD_RETRY the direct signal didn't land, so we leave the webhook free to
+        # deliver the already-posted comment instead of silently dropping the feedback.
+        if comment_id and outcome in (MentionOutcome.LAUNCHED, MentionOutcome.FORWARDED):
+            mark_comment_handled_directly(comment_id)
+
+        run_dto = tasks_facade.get_task_run(str(run_id)) if run_id else None
+        run_payload = {"id": str(run_dto.id), "status": run_dto.status} if run_dto else None
+        resp_status = "forwarded" if outcome == MentionOutcome.FORWARDED else "started"
+        return Response({"status": resp_status, "run": run_payload, "connect_url": None})
 
     @extend_schema(
         request=SignalReportStateRequestSerializer,

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -62,6 +62,16 @@ export const SignalReportStatusEnumApi = {
 } as const
 
 /**
+ * The run currently touching a report's PR — id + status for the report view's live indicator.
+ */
+export interface PrActiveRunApi {
+    /** TaskRun id. */
+    readonly id: string
+    /** Run status: not_started, queued, in_progress (agent working) or a terminal completed/failed/cancelled. */
+    readonly status: string
+}
+
+/**
  * * `pr_incorrect` - PR incorrect
  * * `pr_not_useful` - PR not useful
  * * `duplicate` - Duplicate
@@ -198,6 +208,8 @@ export interface SignalReportApi {
     readonly implementation_pr_url: string | null
     /** Whether that implementation PR is merged, per the GitHub webhook. False when there is no PR or it hasn't merged. Report status doesn't imply this: a resolved report may have been resolved directly, without a merged PR. */
     readonly implementation_pr_merged: boolean
+    /** The run currently addressing this report's PR (id + status), or null. Detail view only. */
+    readonly pr_active_run: PrActiveRunApi | null
     /** The report's PR refund, when one exists. One refund per report, ever. */
     readonly refund: SignalReportRefundApi | null
     /** Why refunding this report's PR would be rejected right now, or null when a refund would be accepted (see the field's schema for the reason values). */
@@ -270,6 +282,54 @@ export interface PullRequestCheckApi {
  */
 export interface PullRequestChecksResponseApi {
     readonly checks: readonly PullRequestCheckApi[]
+}
+
+/**
+ * Body for commenting on a report's PR from the inbox.
+ */
+export interface PrCommentRequestApi {
+    /**
+     * The comment to post on the PR and have the agent address.
+     * @minLength 1
+     * @maxLength 10000
+     */
+    content: string
+}
+
+/**
+ * * `started` - started
+ * * `forwarded` - forwarded
+ * * `connect_required` - connect_required
+ * * `no_pr` - no_pr
+ */
+export type PrCommentResponseStatusEnumApi =
+    (typeof PrCommentResponseStatusEnumApi)[keyof typeof PrCommentResponseStatusEnumApi]
+
+export const PrCommentResponseStatusEnumApi = {
+    Started: 'started',
+    Forwarded: 'forwarded',
+    ConnectRequired: 'connect_required',
+    NoPr: 'no_pr',
+} as const
+
+/**
+ * Result of a report-view PR comment: the shared run to watch, or a connect prompt.
+ */
+export interface PrCommentResponseApi {
+    /** started: a new run began. forwarded: fed into the PR's already-running run. connect_required: connect GitHub first (see connect_url). no_pr: the report has no PR.
+     *
+     * * `started` - started
+     * * `forwarded` - forwarded
+     * * `connect_required` - connect_required
+     * * `no_pr` - no_pr */
+    status: PrCommentResponseStatusEnumApi
+    /** The shared run to watch, when one was started/forwarded. */
+    run: PrActiveRunApi | null
+    /**
+     * Where to connect GitHub, when status is connect_required.
+     * @nullable
+     */
+    connect_url: string | null
 }
 
 /**

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -30,6 +30,8 @@ import type {
     PatchedSignalSourceConfigApi,
     PauseResponseApi,
     PauseUntilRequestApi,
+    PrCommentRequestApi,
+    PrCommentResponseApi,
     ProjectProfileApi,
     PullRequestChecksResponseApi,
     PullRequestCommentsResponseApi,
@@ -243,6 +245,28 @@ export const signalsReportPrChecks = async (
     return apiMutator<PullRequestChecksResponseApi>(getSignalsReportPrChecksUrl(projectId, id), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getSignalsReportsPrCommentCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/signals/reports/${id}/pr_comment/`
+}
+
+/**
+ * Post a comment on this report's pull request and have the PostHog agent address it. The comment is posted to the PR and the run that addresses it is started (or, if a run is already working the PR, the comment is fed into that shared run). Requires a connected personal GitHub account with write access so commits are authored as you — otherwise returns status 'connect_required' with a connect_url.
+ * @summary Comment on a report's PR from the inbox
+ */
+export const signalsReportsPrCommentCreate = async (
+    projectId: string,
+    id: string,
+    prCommentRequestApi: PrCommentRequestApi,
+    options?: RequestInit
+): Promise<PrCommentResponseApi> => {
+    return apiMutator<PrCommentResponseApi>(getSignalsReportsPrCommentCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(prCommentRequestApi),
     })
 }
 

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -48,6 +48,22 @@ export const SignalsReportsPartialUpdateBody = /* @__PURE__ */ zod
     )
 
 /**
+ * Post a comment on this report's pull request and have the PostHog agent address it. The comment is posted to the PR and the run that addresses it is started (or, if a run is already working the PR, the comment is fed into that shared run). Requires a connected personal GitHub account with write access so commits are authored as you — otherwise returns status 'connect_required' with a connect_url.
+ * @summary Comment on a report's PR from the inbox
+ */
+export const signalsReportsPrCommentCreateBodyContentMax = 10000
+
+export const SignalsReportsPrCommentCreateBody = /* @__PURE__ */ zod
+    .object({
+        content: zod
+            .string()
+            .min(1)
+            .max(signalsReportsPrCommentCreateBodyContentMax)
+            .describe('The comment to post on the PR and have the agent address.'),
+    })
+    .describe("Body for commenting on a report's PR from the inbox.")
+
+/**
  * Post an inline review comment on the report's implementation pull request, attributed to the requesting user's own GitHub identity via their personal GitHub connection. Either replies to an existing thread (`in_reply_to`) or starts a new thread on a diff line (`path` + `line`).
  * @summary Post an inline review comment on a report's implementation PR
  */

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -833,6 +833,9 @@ tools:
     signals-report-pr-review-comments-create:
         operation: signals_report_pr_review_comments_create
         enabled: false
+    signals-reports-pr-comment-create:
+        operation: signals_reports_pr_comment_create
+        enabled: false
     signals-reports-refund-create:
         operation: signals_reports_refund_create
         enabled: false

--- a/products/signals/package.json
+++ b/products/signals/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/products-signals",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test backend/github_mention -v --tb=short"
     }
 }

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -609,6 +609,18 @@ def resolve_signal_pr_mention_context(pr_url: str, repository: str) -> "contract
     )
 
 
+def get_active_run_for_pr(pr_url: str, repository: str) -> contracts.TaskRunDTO | None:
+    """The current run touching a Signals PR (non-terminal preferred), for live status in the report view.
+
+    Returns ``None`` when the PR isn't a Signals PR or has no run yet. The returned DTO may be terminal
+    (``is_terminal`` / ``status``) — the caller decides whether to show "working" vs an idle state.
+    """
+    context = resolve_signal_pr_mention_context(pr_url, repository)
+    if context is None:
+        return None
+    return get_task_run(context.run_id)
+
+
 def task_ids_with_pr_url_subquery(team_id: int) -> QuerySet[TaskRun, Any]:
     """A ``values('task_id')`` queryset of ``team_id``'s tasks that produced a non-empty ``output.pr_url``.
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43276,6 +43276,16 @@ export namespace Schemas {
     } as const;
 
     /**
+     * The run currently touching a report's PR — id + status for the report view's live indicator.
+     */
+    export interface PrActiveRun {
+      /** TaskRun id. */
+      readonly id: string;
+      /** Run status: not_started, queued, in_progress (agent working) or a terminal completed/failed/cancelled. */
+      readonly status: string;
+    }
+
+    /**
      * * `pr_incorrect` - PR incorrect
      * * `pr_not_useful` - PR not useful
      * * `duplicate` - Duplicate
@@ -43388,6 +43398,8 @@ export namespace Schemas {
       readonly implementation_pr_url: string | null;
       /** Whether that implementation PR is merged, per the GitHub webhook. False when there is no PR or it hasn't merged. Report status doesn't imply this: a resolved report may have been resolved directly, without a merged PR. */
       readonly implementation_pr_merged: boolean;
+      /** The run currently addressing this report's PR (id + status), or null. Detail view only. */
+      readonly pr_active_run: PrActiveRun | null;
       /** The report's PR refund, when one exists. One refund per report, ever. */
       readonly refund: SignalReportRefund | null;
       /** Why refunding this report's PR would be rejected right now, or null when a refund would be accepted (see the field's schema for the reason values). */
@@ -53887,6 +53899,54 @@ export namespace Schemas {
     export const PostgresDestinationRequestTypeEnum = {
       Postgres: 'Postgres',
     } as const;
+
+    /**
+     * Body for commenting on a report's PR from the inbox.
+     */
+    export interface PrCommentRequest {
+      /**
+         * The comment to post on the PR and have the agent address.
+         * @minLength 1
+         * @maxLength 10000
+         */
+      content: string;
+    }
+
+    /**
+     * * `started` - started
+     * * `forwarded` - forwarded
+     * * `connect_required` - connect_required
+     * * `no_pr` - no_pr
+     */
+    export type PrCommentResponseStatusEnum = typeof PrCommentResponseStatusEnum[keyof typeof PrCommentResponseStatusEnum];
+
+
+    export const PrCommentResponseStatusEnum = {
+      Started: 'started',
+      Forwarded: 'forwarded',
+      ConnectRequired: 'connect_required',
+      NoPr: 'no_pr',
+    } as const;
+
+    /**
+     * Result of a report-view PR comment: the shared run to watch, or a connect prompt.
+     */
+    export interface PrCommentResponse {
+      /** started: a new run began. forwarded: fed into the PR's already-running run. connect_required: connect GitHub first (see connect_url). no_pr: the report has no PR.
+       *
+       * * `started` - started
+       * * `forwarded` - forwarded
+       * * `connect_required` - connect_required
+       * * `no_pr` - no_pr */
+      status: PrCommentResponseStatusEnum;
+      /** The shared run to watch, when one was started/forwarded. */
+      run: PrActiveRun | null;
+      /**
+         * Where to connect GitHub, when status is connect_required.
+         * @nullable
+         */
+      connect_url: string | null;
+    }
 
     export interface PreviewInviteRequest {
       /**


### PR DESCRIPTION
## Problem

Signals opens autonomous PRs, and until now the only way to get the agent to act on review feedback was to leave GitHub and go back to PostHog. This is the second half of the @-mention feature (stacked on #71392): it lets you comment on a report's PR straight from the inbox, and it firms up the concurrency model so a review round is one coherent agent session.

## Changes

- **Comment on a PR from the inbox.** New `POST signals/reports/{id}/pr_comment`. It posts the comment to the PR **as you** (your connected GitHub user, via your user-to-server token), prefixed with the bot mention so on GitHub it reads exactly like you writing `@posthog <feedback>`. It then triggers the run directly for an immediate response. Because the comment is user-authored, the inbound webhook would also see it, so the endpoint marks the comment id and the webhook skips it. One trigger, no double-fire. If you have no push-capable GitHub connection, it returns `connect_required` with a connect link instead of dead-ending.
- **One shared run per PR.** A comment that arrives while a run is already working the PR is forwarded into that run (`signal_task_run_user_message`) instead of spawning a parallel or fresh sequential run. This replaces the earlier retry-and-respawn behavior.
- **Live run status on the report.** `pr_active_run` on the report serializer (via `get_active_run_for_pr`) surfaces the PR's current run id + status; the report detail renders a live indicator, polled while the run is active.

Frontend: a "Comment on PR" box on the report detail (`PrCommentSection`), wired through `inboxReportDetailLogic`, reusing the existing live-run status primitives.

### What it looks like

Empty, then with a comment typed (the button enables, the counter updates, and the live indicator reflects the PR's current run):

![empty state](https://raw.githubusercontent.com/PostHog/pr-assets/0d7acbf66572cf27c6213cc82a183cb2f0626e07/2026/07/3b18269c-5d5f-42eb-959d-a06b14c236cb.png)

![typed state](https://raw.githubusercontent.com/PostHog/pr-assets/c899f92b1cb474ae7c67aa37c1bceb48188ad520/2026/07/ea7b59ef-2322-438c-b63f-d4e31442faee.png)

![sped-up runthrough](https://raw.githubusercontent.com/PostHog/pr-assets/26a3161fffbbb78bdfe2af986e7a6296081b6b77/2026/07/b9b3bae1-cfc9-4c97-9e58-795d391faeb0.gif)

## How did you test this code?

Automated (I, Claude, ran these):

- The `products/signals/backend/github_mention/` suite plus the new endpoint tests, 29 passing. Regressions worth calling out that no existing test caught: forward-into-run feeds the active run instead of starting a new one, the webhook skips a comment the endpoint already handled directly (the no-double-trigger guarantee), and the `pr_comment` endpoint's three branches (`started` / `connect_required` / `no_pr`).

Browser (local dev, project 2):

- I drove the report detail view for a real Signals PR. The section renders, the character counter and button-enable behavior work, and the live-status indicator shows the PR's real run status, which confirms `pr_active_run` resolves end to end from `get_active_run_for_pr`. The screenshots above are from that run.
- I did **not** submit an actual comment through the UI. That would post to a live PR and kick off a real agent run, so the submit round-trip and the user-authored GitHub post are covered by the unit tests, not by a live end-to-end recording.

> [!NOTE]
> Stacked on #71392 and, like it, behind master. It needs a master merge before CI goes green and it can merge. The lone OpenAPI preflight advisory is that same base drift, not this diff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael directed this; I (Claude) authored it. The design went through the compound-engineering brainstorm, document-review, and plan skills before any code (the requirements and plan docs are on the base branch under `docs/`). Decisions worth flagging for review:

- Forward-into-run over retry-and-respawn, so a review round stays one agent session and the report view can show a single live run.
- The report-view comment is posted as the user, not the App. An earlier pass posted it App-authored to avoid the webhook double-trigger, but on Michael's call I switched it to author as the user so the `@posthog` mention reads naturally, and deduped the webhook by comment id instead. The user-to-server post lives on `UserGitHubIntegration.comment_on_pull_request_as_user`.
- Un-connected users get a `connect_required` response with a link rather than a dead-end, matching the connect-gate in the base feature.
