### PR TITLE
fix(mysql): treat non-latin-1 connection fields as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -271,6 +271,14 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # locale-independent error code (the trailing message text is translated on non-English
             # servers) so it catches both the raw pymysql string and the wrapped `(1038, ...)` form.
             "(1038,": "Your MySQL/MariaDB server ran out of sort buffer memory while ordering this table by its incremental field (error 1038). We try to avoid the sort by forcing the incremental field's index, but this table has no usable index on that field. Add an index on the incremental field, raise the server's 'sort_buffer_size', or switch this table to a full re-sync, then resync.",
+            # pymysql encodes the handshake fields (host, user, password, database) as latin-1;
+            # a value carrying a non-latin-1 character — most often an invisible zero-width space
+            # (U+200B) pasted in from another app — raises UnicodeEncodeError before any packet is
+            # sent, so the connect fails identically on every retry. Match the codec's stable
+            # range-256 reason, not the volatile character/position: it appears in the raw str(exc)
+            # the sync path classifies and in the " ".join(e.args) form validate_credentials builds
+            # (the formatted "codec can't encode character" text is reconstructed in neither).
+            "ordinal not in range(256)": "One of your connection details contains an invisible or unsupported character (for example a zero-width space pasted in from another app). Retype the affected field — host, database, user, or password — by hand instead of pasting it, then re-enable the sync.",
         }
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1850,6 +1850,23 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # str(exc) form the sync path classifies — a zero-width space pasted into a field.
+            str(UnicodeEncodeError("latin-1", "\u200b", 0, 1, "ordinal not in range(256)")),
+            # `" ".join(str(arg) for arg in exc.args)` form validate_credentials builds, where the
+            # formatted "codec can't encode character" text is absent but the reason arg remains.
+            " ".join(str(a) for a in UnicodeEncodeError("latin-1", "\u200b", 0, 1, "ordinal not in range(256)").args),
+            # A different offending character and position stays matched.
+            str(UnicodeEncodeError("latin-1", "\u3042", 4, 5, "ordinal not in range(256)")),
+        ],
+    )
+    def test_non_latin1_connection_field_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Non-latin-1 connection field error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A genuine transient connection drop (no SSL signature) must stay retryable.
             "OperationalError: (2013, 'Lost connection to MySQL server during query')",
             "Lost connection to MySQL server during query",


### PR DESCRIPTION
## Problem

Error tracking surfaced a `UnicodeEncodeError` from the MySQL data-warehouse import source:

> `'latin-1' codec can't encode character (U+200B, a zero-width space) in position 0: ordinal not in range(256)`

pymysql encodes the connection handshake fields (host, user, password, database) as latin-1, so a value carrying any non-latin-1 character raises `UnicodeEncodeError` from `pymysql.connect()` before a single packet is sent. In practice this is an invisible character accidentally pasted into a connection field from another app.

The failure is a fixed property of the entered config: every retry re-encodes the same bytes and fails identically. Today it falls through unclassified, so the sync keeps retrying to the max and the crash lands in error tracking as noise instead of telling the user what to fix.

Issue: `019f81c7-82ba-7f33-b0fc-fef6136e3ab0`

## Changes

This is a user/upstream config error, not a bug in our code and not a transient blip, so it belongs in the source's `get_non_retryable_errors()` — same pattern as the existing MySQL entries (unknown database, SSL version mismatch, host blocked, and so on).

- Add a non-retryable entry keyed on `ordinal not in range(256)` with an actionable message asking the user to retype the affected field by hand instead of pasting it.
- The key is the codec's stable range-256 reason, chosen over the volatile character or position. It also survives the two different renderings the classifier sees:
  - the raw `str(exc)` the sync path matches, and
  - the `" ".join(str(arg) for arg in exc.args)` form `validate_credentials` builds, where the formatted "codec can't encode character" text is absent but the reason arg remains.

Once classified, the sync stops retrying and surfaces the friendly guidance, and `validate_credentials` returns the message without capturing to error tracking.

## How did you test this code?

Automated only (I'm Claude, an agent — no manual DB setup):

- Added `test_non_latin1_connection_field_is_non_retryable` to `TestMySQLSourceNonRetryableErrors`, parameterized over the sync-path `str(exc)` form, the validate-path joined-args form, and a different offending character/position. It guards against the entry being removed or narrowed so a non-latin-1 connection field stops being classified non-retryable — no existing test exercised this path.
- Ran the source's `TestMySQLSourceNonRetryableErrors` (32 passed) and `TestMySQLSourceValidateCredentials` (11 passed) suites, plus ruff check/format on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Read the stack trace to the raising frame (`pymysql.connect` in `mysql.py`), confirmed the failure originates in this source, and weighed fix-the-code vs non-retryable. Sanitizing/stripping characters from credentials was rejected as risky and out of scope; a value with an unencodable character is unusable over pymysql regardless, so the right move is to stop retrying and guide the user. Chose the `ordinal not in range(256)` key after checking how both the sync path and `validate_credentials` stringify the exception, so the match holds in both.

Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
