### PR TITLE
fix(matomo): keep exhausted-retry 429/5xx errors out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/source.py
@@ -61,6 +61,12 @@ class MatomoSource(ResumableSource[MatomoSourceConfig, MatomoResumeConfig], Vali
             "Matomo API error:": None,
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A 429 or 5xx is retried internally; if those retries still exhaust, the failure is
+        # transient and self-recovering, so let Temporal retry the activity without surfacing
+        # it as tracked exception noise.
+        return {"Matomo API error (retryable)"}
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/tests/test_matomo_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/matomo/tests/test_matomo_source.py
@@ -63,6 +63,19 @@ class TestMatomoSource:
         error = "500 Server Error for url: https://myorg.matomo.cloud/index.php"
         assert not any(key in error for key in non_retryable_errors)
 
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "Matomo API error (retryable): status=500",
+            "Matomo API error (retryable): status=429",
+        ],
+    )
+    def test_retryable_errors_match_known_failures(self, observed_error):
+        # Matches the message `call()` raises in matomo.py after its internal retry loop
+        # exhausts; keeps this benign, self-recovering failure out of error tracking.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors)
+
     def test_get_schemas(self):
         schemas = {schema.name: schema for schema in self.source.get_schemas(self.config, self.team_id)}
 


### PR DESCRIPTION
## Problem

Matomo's data warehouse source got flagged by PostHog error tracking: `MatomoRetryableError: Matomo API error (retryable): status=500`, originating from `products/warehouse_sources/backend/temporal/data_imports/sources/matomo/matomo.py`, with thousands of occurrences over the past month and still active.

## Changes

`get_rows` in `matomo.py` already retries 429/5xx responses internally (5 attempts with exponential backoff) before re-raising `MatomoRetryableError`. Once that internal retry loop exhausts, Temporal retries the whole activity on its own schedule, so the failure is transient and self-recovering, not a bug or a customer-config problem.

`MatomoSource` only overrode `get_non_retryable_errors()`, not `get_retryable_errors()`. Without that override, `_handle_import_error` (in `workflow_activities/import_data_sync.py`) has no way to recognize this as a benign, self-recovering failure, so it falls through to `logger.aexception`, logging every exhausted retry as a tracked exception and creating error-tracking noise.

This adds `get_retryable_errors()` to `MatomoSource`, matching the stable `"Matomo API error (retryable)"` marker, mirroring the same pattern already used by `MixpanelSource.get_retryable_errors()` for the same purpose.

## How did you test this code?

Added 2 parameterized cases to `TestMatomoSource.test_retryable_errors_match_known_failures`, asserting the new marker matches the exact message format `call()` raises for both 429 and 500 responses. No existing test verified this classification — it guards the raise-site message and the marker declaration staying in sync, so a future edit to either side can't silently let this noise come back.

Ran the full `test_matomo_source.py` suite locally (20 passed) plus `ruff check`/`ruff format` and `mypy` on the changed files — all clean.

## Docs update

Not applicable — internal retry/error-tracking classification only, no user-facing or API behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code), triaging a live PostHog error tracking issue for the Matomo warehouse source.
- Skills invoked: `/writing-tests` before adding the regression test case.
- Investigated the stack trace and confirmed the failure genuinely originates in `matomo.py`'s retry-exhaustion path, not upstream/customer error. Considered treating this as a `NonRetryableErrors` case, but ruled it out — 429/5xx from Matomo is transient infrastructure behavior, already handled by an internal retry loop, so the fix is closing the missing `get_retryable_errors()` override rather than stopping retries. Confirmed no open PR already covers this by searching for the exception type, message, and source path, and by scanning the maintainer's own open PRs.