### PR TITLE
feat(replay-vision): run a summary's first report on setup

### DIFF
--- a/products/replay_vision/backend/api/vision_actions.py
+++ b/products/replay_vision/backend/api/vision_actions.py
@@ -3,6 +3,7 @@ from typing import Any, NoReturn, cast, get_args
 
 from django.db import IntegrityError, transaction
 from django.db.models import QuerySet
+from django.utils import timezone
 
 import structlog
 from drf_spectacular.types import OpenApiTypes
@@ -191,6 +192,19 @@ class DeliveryTargetSerializer(serializers.Serializer):
 # Alerts ride the scanner's sweep, so each enabled alert adds evaluation work to every sweep tick —
 # cap the fan-out one scanner can accumulate.
 MAX_ENABLED_ALERTS_PER_SCANNER = 10
+
+
+def _seed_immediate_first_run(action: VisionAction) -> None:
+    """Make a summary fire its first run on the next scanner sweep instead of waiting for the first
+    scheduled tick — a daily digest set up at 3pm would otherwise stay empty until 8am tomorrow.
+
+    The sweep claims any enabled schedule action whose next_run_at is due, then advances next_run_at
+    to the real rrule cadence, so seeding "now" gives an immediate first summary while leaving the
+    recurring schedule intact. The first run has no prior completed run, so it looks back 24h.
+    Written via .update() (not save()) so the model's rrule recompute can't overwrite the seed.
+    """
+    now = timezone.now()
+    VisionAction.objects.for_team(action.team_id).filter(pk=action.id).update(next_run_at=now, updated_at=now)
 
 
 class VisionActionSerializer(serializers.ModelSerializer):
@@ -511,6 +525,16 @@ class VisionActionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         with transaction.atomic():
             action = serializer.save()
             provision_delivery(action, request=self.request, team=self.team)
+            # A newly created summary shouldn't wait for its first scheduled tick — fire the first run
+            # on the next sweep. Alerts already check every sweep (every_match) or hourly, so they
+            # don't need this; the auto-provisioned digest (via digest.py, not this viewset) is left
+            # to its schedule since a brand-new scanner has nothing to summarize yet.
+            if (
+                action.enabled
+                and action.mode == ActionMode.GROUP_SUMMARY
+                and action.trigger_type == TriggerType.SCHEDULE
+            ):
+                _seed_immediate_first_run(action)
 
     def perform_update(self, serializer: BaseSerializer) -> None:
         instance = cast(VisionAction, serializer.instance)
@@ -527,6 +551,15 @@ class VisionActionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             # edits don't touch the destinations, so they must not churn them.
             if action.delivery_config != old_delivery or action.enabled != old_enabled or action.name != old_name:
                 provision_delivery(action, request=self.request, team=self.team)
+            # Resuming a paused summary fires its next run immediately, same as first setup — the user
+            # turned it back on to get a summary, not to wait for the next tick.
+            if (
+                action.enabled
+                and not old_enabled
+                and action.mode == ActionMode.GROUP_SUMMARY
+                and action.trigger_type == TriggerType.SCHEDULE
+            ):
+                _seed_immediate_first_run(action)
 
     def perform_destroy(self, instance: VisionAction) -> None:
         archive_delivery(instance, team=self.team)

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -1,7 +1,10 @@
 from typing import Any
 
+from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
+
+from django.utils import timezone
 
 from parameterized import parameterized
 
@@ -11,6 +14,7 @@ from posthog.models import Organization, Team
 from posthog.models.integration import Integration
 
 from products.replay_vision.backend.api.vision_actions import MAX_ENABLED_ALERTS_PER_SCANNER
+from products.replay_vision.backend.digest import provision_scanner_digest
 from products.replay_vision.backend.models.replay_observation import ReplayObservation
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
 from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun, VisionActionRunStatus
@@ -519,3 +523,80 @@ class TestVisionActionRunCrossTeamIDOR(_VisionActionAPITestCase):
         # The action belongs to another team, so the nested route must 404 rather than leak its runs.
         resp = self.client.get(f"/api/projects/{self.team.id}/vision/actions/{self.other_action.id}/runs/")
         self.assertEqual(resp.status_code, 404)
+
+
+# A schedule that fires at 08:00, so at the frozen noon the next tick is tomorrow morning — clearly in
+# the future, which is what makes the "run immediately on setup" seed observable.
+_FUTURE_RRULE = {"rrule": "FREQ=DAILY;BYHOUR=8;BYMINUTE=0", "timezone": "UTC"}
+_FROZEN_NOON = "2026-07-20 12:00:00"
+
+
+class TestVisionActionImmediateFirstRun(_VisionActionAPITestCase):
+    """A newly set-up summary should produce its first run on the next sweep, not wait for the first
+    scheduled tick — the sweep claims any enabled schedule action whose next_run_at is due, so
+    seeding next_run_at to "now" is what makes the first summary land within minutes."""
+
+    def test_new_summary_runs_immediately_then_keeps_the_schedule(self) -> None:
+        with freeze_time(_FROZEN_NOON):
+            resp = self.client.post(
+                self.actions_url, data=self._create_payload(trigger_config=_FUTURE_RRULE), format="json"
+            )
+            self.assertEqual(resp.status_code, 201, resp.content)
+            action = VisionAction.all_teams.get(id=resp.json()["id"])
+            # Due now (seeded), not tomorrow's 08:00 tick — the next sweep will claim and run it.
+            self.assertEqual(action.next_run_at, timezone.now())
+
+    def test_new_alert_is_not_seeded(self) -> None:
+        # Alerts already check every sweep (every_match) or hourly, so they must keep their cursor
+        # rather than being pulled to "now".
+        with freeze_time(_FROZEN_NOON):
+            resp = self.client.post(
+                self.actions_url,
+                data=self._create_payload(
+                    name="my-alert",
+                    mode="alert",
+                    alert_config={"frequency": "every_match", "metric": "count"},
+                    selection={},
+                    trigger_config=_FUTURE_RRULE,
+                ),
+                format="json",
+            )
+            self.assertEqual(resp.status_code, 201, resp.content)
+            action = VisionAction.all_teams.get(id=resp.json()["id"])
+            self.assertGreater(action.next_run_at, timezone.now())
+
+    def test_resuming_a_paused_summary_runs_immediately(self) -> None:
+        created = self.client.post(
+            self.actions_url, data=self._create_payload(trigger_config=_FUTURE_RRULE), format="json"
+        ).json()
+        # Simulate a paused summary whose cursor already sits at a future scheduled tick.
+        future = timezone.now() + timezone.timedelta(days=1)
+        VisionAction.all_teams.filter(id=created["id"]).update(enabled=False, next_run_at=future)
+
+        with freeze_time(_FROZEN_NOON):
+            resp = self.client.patch(f"{self.actions_url}{created['id']}/", data={"enabled": True}, format="json")
+            self.assertEqual(resp.status_code, 200, resp.content)
+            action = VisionAction.all_teams.get(id=created["id"])
+            self.assertEqual(action.next_run_at, timezone.now())
+
+    def test_editing_an_enabled_summary_does_not_reseed(self) -> None:
+        # Only the disabled→enabled transition (and creation) seeds an immediate run; an unrelated
+        # edit on an already-enabled summary must leave its cursor alone.
+        created = self.client.post(
+            self.actions_url, data=self._create_payload(trigger_config=_FUTURE_RRULE), format="json"
+        ).json()
+        future = timezone.now() + timezone.timedelta(days=1)
+        VisionAction.all_teams.filter(id=created["id"]).update(next_run_at=future)
+
+        resp = self.client.patch(f"{self.actions_url}{created['id']}/", data={"name": "renamed"}, format="json")
+        self.assertEqual(resp.status_code, 200, resp.content)
+        action = VisionAction.all_teams.get(id=created["id"])
+        self.assertEqual(action.next_run_at, future)
+
+    def test_auto_provisioned_digest_keeps_its_schedule(self) -> None:
+        # The digest auto-created with a scanner (via digest.py, not this viewset) has nothing to
+        # summarize yet, so it stays on its 08:00 schedule rather than firing an empty first run.
+        with freeze_time(_FROZEN_NOON):
+            digest = provision_scanner_digest(self._create_scanner(name="fresh-scanner"), self.user)
+            assert digest is not None
+            self.assertGreater(digest.next_run_at, timezone.now())


### PR DESCRIPTION
## Problem

A Replay Vision daily digest (or any scheduled summary) only runs at its scheduled tick. Turn one on at 3pm and you see nothing until 8am the next morning, which makes it feel broken right after setup. The first summary should land ASAP, without changing the recurring schedule.

## Changes

When a summary is created, or a paused one is re-enabled, through the API, its `next_run_at` is seeded to now. The scanner sweep already claims any enabled schedule action whose `next_run_at` is due and then advances the cursor to the real rrule cadence, so this gives an immediate first run within minutes while leaving the daily schedule intact. The first run has no prior completed run, so it looks back 24h and has content.

Deliberately scoped:
- **Alerts** are untouched — they already check every sweep (`every_match`) or hourly (`on_breach`).
- The **digest auto-provisioned with a brand-new scanner** (via `digest.py`, not this viewset) keeps its schedule, because a fresh scanner has no observations to summarize yet. The immediate-run path is only for user-initiated setup, where data already exists.

No new endpoint, serializer field, or schema change — `perform_create`/`perform_update` behavior only, so nothing changes downstream in generated types or MCP tools.

## How did you test this code?

Automated (all run by me, the agent), new `TestVisionActionImmediateFirstRun` in `test_vision_actions_api.py` (5 cases, `freeze_time` + a future `BYHOUR=8` rrule so the seed is observable):
- a new summary's `next_run_at` is due now, not tomorrow's tick
- a new alert is not seeded (cursor stays in the future)
- re-enabling a paused summary re-seeds it to now
- an unrelated edit (rename) on an enabled summary does not re-seed
- the auto-provisioned digest keeps its 8am schedule

Full `test_vision_actions_api.py` suite: 43 passed. ruff + ty (pre-commit) clean. I did not manually click through the running app.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Kim (@ksvat) is the DRI.

Built with Claude Code (Opus). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`.

Design note: the sweep-claim pipeline already does exactly what's needed (claim when due → advance to rrule), so rather than add a one-off trigger workflow, the change just moves the cursor. That reuses all the existing windowing/claim/idempotency logic and keeps the schedule authoritative. We considered also firing the auto-provisioned digest as soon as a scanner produces its first observations, but scoped that out — it needs a small engine gate and the scanner-creation digest is a set-and-forget default, so a next-morning first summary is acceptable there.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
