### PR TITLE
feat(signals): cache report signal metadata lookups

### DIFF
--- a/products/signals/backend/signal_metadata.py
+++ b/products/signals/backend/signal_metadata.py
@@ -9,6 +9,8 @@ keeps that import graph acyclic.
 
 from dataclasses import dataclass
 
+from django.core.cache import cache
+
 from posthog.schema import EmbeddingModelName
 
 from posthog.hogql import ast
@@ -20,6 +22,12 @@ from posthog.models import Team
 # The embedding model whose document rows constitute the signal store; every signals
 # ClickHouse query filters on it.
 EMBEDDING_MODEL = EmbeddingModelName.TEXT_EMBEDDING_3_SMALL_1536
+
+# The inbox list is polled aggressively while each uncached lookup scans the team's whole
+# signal history, so a short TTL already removes almost all of the ClickHouse load.
+CACHE_TTL_SECONDS = 300
+# A fresh report may not have its signals stamped yet; keep known-empty entries short-lived.
+EMPTY_CACHE_TTL_SECONDS = 60
 
 
 @dataclass(frozen=True)
@@ -33,6 +41,10 @@ class ReportSignalMeta:
     scout_name: str | None
 
 
+def _cache_key(team_id: int, report_id: str) -> str:
+    return f"signals_report_meta/{team_id}/{report_id}"
+
+
 def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict[str, ReportSignalMeta]:
     """Return a mapping of report_id -> `ReportSignalMeta` (distinct source_products + authoring scout).
 
@@ -40,7 +52,47 @@ def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict
     any non-empty `extra.skill_name` on the report's signals (all scout-authored signals of a report
     share one), or None.
 
-    Bounds the argMax dedup to documents that ever carried one of these report_ids, instead
+    Cached per report: this backs the inbox list, which API consumers poll every few seconds, while
+    the underlying query scans the team's whole signal history. Report meta only changes on
+    regroup/delete, so entries expire on a short TTL instead of being invalidated.
+    """
+    if not report_ids:
+        return {}
+
+    keys = {report_id: _cache_key(team.pk, report_id) for report_id in report_ids}
+    cached = cache.get_many(list(keys.values()))
+
+    result: dict[str, ReportSignalMeta] = {}
+    missing: list[str] = []
+    for report_id, key in keys.items():
+        entry = cached.get(key)
+        if entry is None:
+            missing.append(report_id)
+        elif entry:  # an empty dict marks a report known to have no signal metadata
+            result[report_id] = ReportSignalMeta(
+                source_products=entry["source_products"], scout_name=entry["scout_name"]
+            )
+
+    if missing:
+        fetched = _query_source_products_for_reports(team, missing)
+        found: dict[str, dict[str, list[str] | str | None]] = {
+            keys[report_id]: {"source_products": meta.source_products, "scout_name": meta.scout_name}
+            for report_id, meta in fetched.items()
+        }
+        if found:
+            cache.set_many(found, CACHE_TTL_SECONDS)
+        empty: dict[str, dict[str, list[str] | str | None]] = {
+            keys[report_id]: {} for report_id in missing if report_id not in fetched
+        }
+        if empty:
+            cache.set_many(empty, EMPTY_CACHE_TTL_SECONDS)
+        result.update(fetched)
+
+    return result
+
+
+def _query_source_products_for_reports(team: Team, report_ids: list[str]) -> dict[str, ReportSignalMeta]:
+    """Bounds the argMax dedup to documents that ever carried one of these report_ids, instead
     of deduping the team's whole signal history. The unbounded dedup's memory grows with the
     team's total signal count; the candidate-bounded form keeps it proportional to the signals
     in the requested page's reports, which is what flattens the tail on signal-heavy teams.
@@ -49,8 +101,6 @@ def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict
     report_id) but excluded by the outer filter (its latest metadata points elsewhere) — the
     same correctness trap fetch_report_ids_for_source_ids documents.
     """
-    if not report_ids:
-        return {}
 
     ch_query = """
         SELECT

--- a/products/signals/backend/test/test_signal_queries.py
+++ b/products/signals/backend/test/test_signal_queries.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime, timedelta
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+from django.core.cache import cache
+
 from parameterized import parameterized
 
 from posthog.clickhouse.client import sync_execute
@@ -179,6 +181,39 @@ class TestFetchSourceProductsForReports(_SignalEmbeddingsTestBase):
         )
 
         assert fetch_source_products_for_reports(self.team, report_ids) == expected
+
+    def test_batches_cached_and_uncached_reports(self) -> None:
+        self._emit_version(document_id="d1", report_id="rA", source_product="errors", inserted_at=self.base)
+        assert fetch_source_products_for_reports(self.team, ["rA"]) == {
+            "rA": ReportSignalMeta(source_products=["errors"], scout_name=None)
+        }
+
+        # rA's change is invisible until the TTL lapses (served from cache); rB is fetched fresh
+        self._emit_version(
+            document_id="d1", report_id="rA", source_product="replay", inserted_at=self.base + timedelta(hours=1)
+        )
+        self._emit_version(document_id="d2", report_id="rB", source_product="surveys", inserted_at=self.base)
+        assert fetch_source_products_for_reports(self.team, ["rA", "rB"]) == {
+            "rA": ReportSignalMeta(source_products=["errors"], scout_name=None),
+            "rB": ReportSignalMeta(source_products=["surveys"], scout_name=None),
+        }
+
+        cache.clear()
+        assert fetch_source_products_for_reports(self.team, ["rA"]) == {
+            "rA": ReportSignalMeta(source_products=["replay"], scout_name=None)
+        }
+
+    def test_reports_without_metadata_are_negatively_cached(self) -> None:
+        assert fetch_source_products_for_reports(self.team, ["rEmpty"]) == {}
+
+        # without the negative entry every poll of a meta-less report would rescan the history
+        self._emit_version(document_id="d1", report_id="rEmpty", source_product="errors", inserted_at=self.base)
+        assert fetch_source_products_for_reports(self.team, ["rEmpty"]) == {}
+
+        cache.clear()
+        assert fetch_source_products_for_reports(self.team, ["rEmpty"]) == {
+            "rEmpty": ReportSignalMeta(source_products=["errors"], scout_name=None)
+        }
 
 
 class TestFetchSignalsForReportSync(_SignalEmbeddingsTestBase):


### PR DESCRIPTION
## Problem

The signals inbox list endpoint calls `fetch_source_products_for_reports` on every page load to decorate reports with source-product badges and scout names. API consumers poll that endpoint every few seconds, and each call scans the team's entire signal history in ClickHouse twice (JSON-extracting `report_id` from every document's metadata) — averaging hundreds of MB and up to several GB read per call on signal-heavy teams. On our internal query performance dashboard this is one of the highest total-read query patterns fleet-wide, almost all of it the same reports re-resolved every few seconds.

## Changes

Cache the lookup per `(team, report)` in Django's cache, keeping the function signature unchanged:

- reports with metadata cache for 5 minutes
- reports with no metadata cache for 60 seconds, so a freshly grouped report picks up its badges quickly (and meta-less reports stop triggering a full history scan on every poll)
- batches with a mix of cached and uncached reports only query ClickHouse for the misses

Report metadata only changes on regroup or signal deletion, and every consumer is decorative (inbox badges, scout label, auto-start analytics), so TTL staleness of a few minutes is acceptable and there is no invalidation plumbing to maintain.

Follow-up worth considering: denormalizing `source_products` / `scout_name` onto `SignalReport` at grouping time would remove the ClickHouse lookup from the read path entirely.

## How did you test this code?

For a client polling the list every ~4 seconds (the observed cadence), a 5 minute TTL removes ~99% of the scans; on cache hits the list endpoint also skips its ClickHouse phase entirely (several hundred ms at p50 for signal-heavy teams).

Tests, and the regression each catches:

- `test_batches_cached_and_uncached_reports`: the cache stops being consulted (every poll re-scans, the regression this PR exists to prevent), or a mixed batch drops cached entries / skips querying misses.
- `test_reports_without_metadata_are_negatively_cached`: removing the empty-result sentinel would make every poll of a meta-less report re-scan the team's history — the most common case in production.

Existing coverage: the full `TestFetchSourceProductsForReports` class (correctness of the underlying query, now `_query_source_products_for_reports`) passes unchanged through the cached path, and the signals report API + auto-start suites pass (215 tests). Repo-wide mypy and ruff clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5). Skills invoked: `query-clickhouse-via-metabase` (production profiling of the pattern), `writing-tests`.

The target was picked off our internal query performance dashboard as the highest read-volume first-party pattern. Production profiling showed the volume is polling amplification (single OAuth consumers issuing the list call every few seconds), so a TTL cache attacks the multiplier rather than the query shape; restructuring the query itself was rejected (its cost is inherently the full-history scan, a rewrite gains at most 2x), and write-time denormalization onto `SignalReport` was left as the durable follow-up since it touches every grouping/regroup/delete path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
