### PR TITLE
feat(growth): one-off dagster job to prune unused sidebar products

### DIFF
--- a/posthog/dags/locations/growth.py
+++ b/posthog/dags/locations/growth.py
@@ -7,6 +7,7 @@ from products.growth.dags import (
     product_push_campaigns,
     team_production_event_activation,
     user_product_list,
+    user_product_list_pruning,
 )
 
 from . import loggers, resources
@@ -19,6 +20,8 @@ jobs = [
     # sync, but the job stays available for manual runs.
     user_product_list.sync_colleagues_products_monthly_job,
     user_product_list.sync_cross_sell_products_monthly_job,
+    # One-off sidebar cleanup, manual runs only (dry_run defaults to true).
+    user_product_list_pruning.prune_unused_user_products_job,
     team_production_event_activation.detect_first_team_production_event_job,
     product_push_campaigns.product_push_campaigns_job,
 ]

--- a/products/growth/dags/tests/test_user_product_list_pruning.py
+++ b/products/growth/dags/tests/test_user_product_list_pruning.py
@@ -1,0 +1,258 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from dagster import build_op_context
+
+from posthog.models import Organization, Team, User
+from posthog.models.file_system.user_product_list import UserProductList
+
+from products.growth.dags import user_product_list_pruning
+from products.growth.dags.user_product_list import get_valid_product_paths
+from products.growth.dags.user_product_list_pruning import (
+    SKIP_EMPTY_SIDEBAR,
+    SKIP_NO_USAGE,
+    SKIP_RECENT_USER,
+    UNMAPPED_PRODUCT_PATHS,
+    URL_KEY_TO_PRODUCT_PATH,
+    ProductListRow,
+    first_segment_whitelist,
+    parse_usage_csv,
+    prune_unused_user_products,
+    select_rows_to_prune,
+)
+
+CUTOFF = datetime(2026, 6, 1, tzinfo=UTC)
+OLD = CUTOFF - timedelta(days=30)
+RECENT = CUTOFF + timedelta(days=10)
+
+HEADER = "distinct_id,browsed_team_id,url_key,last_seen"
+SEEN = (CUTOFF + timedelta(days=5)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _row(id: str, product_path: str, *, enabled: bool = True, created_at: datetime = OLD) -> ProductListRow:
+    return ProductListRow(id=id, product_path=product_path, enabled=enabled, created_at=created_at)
+
+
+class TestSelectRowsToPrune:
+    @pytest.mark.parametrize(
+        "row,used_paths,expected_ids",
+        [
+            # Unused, old, enabled, mappable -> pruned
+            (_row("a", "Surveys"), {"Product analytics"}, ["a"]),
+            # Used in the window -> kept
+            (_row("a", "Surveys"), {"Surveys", "Product analytics"}, []),
+            # Row newer than the cutoff hasn't had a chance to be used -> kept
+            (_row("a", "Surveys", created_at=RECENT), {"Product analytics"}, []),
+            # Disabled rows are already out of the sidebar and record intent -> kept
+            (_row("a", "Surveys", enabled=False), {"Product analytics"}, []),
+            # Unmappable path (not a current product) -> kept, we can't measure it
+            (_row("a", "Retired product"), {"Product analytics"}, []),
+        ],
+    )
+    def test_row_level_rules(self, row: ProductListRow, used_paths: set[str], expected_ids: list[str]):
+        # A second, used row keeps the never-empty guard out of these cases.
+        rows = [row, _row("used", "Product analytics")]
+        decision = select_rows_to_prune(rows, user_date_joined=OLD, used_paths=used_paths, cutoff=CUTOFF)
+        assert decision.skip_reason is None
+        assert [pruned.id for pruned in decision.rows] == expected_ids
+
+    @pytest.mark.parametrize(
+        "date_joined,used_paths,expected_reason",
+        [
+            (RECENT, {"Product analytics"}, SKIP_RECENT_USER),
+            (OLD, None, SKIP_NO_USAGE),
+            (OLD, set(), SKIP_NO_USAGE),
+            # All enabled rows unused -> pruning would empty the sidebar
+            (OLD, {"Notebooks"}, SKIP_EMPTY_SIDEBAR),
+        ],
+    )
+    def test_user_level_skips(self, date_joined: datetime, used_paths: set[str] | None, expected_reason: str):
+        rows = [_row("a", "Surveys"), _row("b", "Feature flags")]
+        decision = select_rows_to_prune(rows, user_date_joined=date_joined, used_paths=used_paths, cutoff=CUTOFF)
+        assert decision.skip_reason == expected_reason
+        assert decision.rows == []
+
+    def test_empty_guard_counts_disabled_rows_as_already_gone(self):
+        # The one enabled row is unused; the disabled row doesn't keep the sidebar alive.
+        rows = [_row("a", "Surveys"), _row("b", "Feature flags", enabled=False)]
+        decision = select_rows_to_prune(rows, user_date_joined=OLD, used_paths={"Notebooks"}, cutoff=CUTOFF)
+        assert decision.skip_reason == SKIP_EMPTY_SIDEBAR
+
+
+class TestParseUsageCsv:
+    @pytest.mark.parametrize(
+        "url_key,expected_path",
+        [
+            ("insights", "Product analytics"),
+            ("web", "Web analytics"),
+            # Two-segment keys and their first-segment fallback
+            ("ai-observability/playground", "Playground"),
+            ("ai-observability/traces", "LLM analytics"),
+            ("ai-evals/datasets", "Datasets"),
+        ],
+    )
+    def test_maps_url_keys_to_product_paths(self, url_key: str, expected_path: str):
+        parsed = parse_usage_csv([HEADER, f"u1,1,{url_key},{SEEN}"], allowed_team_ids={1}, cutoff=CUTOFF)
+        assert parsed.usage == {1: {"u1": {expected_path}}}
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            f"u1,1,settings,{SEEN}",  # segment outside the whitelist
+            f"u1,1,ai-evals/unknown,{SEEN}",  # no fallback for ai-evals
+            f"u1,999,insights,{SEEN}",  # other region's team id
+            f"u1,not-a-number,insights,{SEEN}",
+            f",1,insights,{SEEN}",  # empty distinct_id
+            "u1,1,insights,2026-04-01 00:00:00",  # last_seen before the cutoff
+        ],
+    )
+    def test_drops_unusable_rows(self, row: str):
+        assert parse_usage_csv([HEADER, row], allowed_team_ids={1}, cutoff=CUTOFF).usage == {}
+
+    def test_stale_rows_are_counted_and_window_stats_reported(self):
+        # A wider SQL window than window_days must not resurrect old usage.
+        parsed = parse_usage_csv(
+            [HEADER, f"u1,1,insights,{SEEN}", "u1,1,surveys,2026-04-01 00:00:00"],
+            allowed_team_ids={1},
+            cutoff=CUTOFF,
+        )
+        assert parsed.usage == {1: {"u1": {"Product analytics"}}}
+        assert parsed.stale_rows_dropped == 1
+        assert parsed.oldest_last_seen == datetime(2026, 6, 6, tzinfo=UTC)
+
+    def test_unparseable_last_seen_keeps_the_row(self):
+        # Usage we can't date must count as usage (it can only prevent deletions).
+        parsed = parse_usage_csv([HEADER, "u1,1,insights,not-a-date"], allowed_team_ids={1}, cutoff=CUTOFF)
+        assert parsed.usage == {1: {"u1": {"Product analytics"}}}
+
+    def test_normalizes_export_header_cosmetics(self):
+        # A Metabase-style export (UTF-8 BOM, spaces after commas) must not abort the run.
+        bom_header = "﻿distinct_id, browsed_team_id, url_key, last_seen"
+        parsed = parse_usage_csv([bom_header, f"u1,1,insights,{SEEN}"], allowed_team_ids={1}, cutoff=CUTOFF)
+        assert parsed.usage == {1: {"u1": {"Product analytics"}}}
+
+    def test_rejects_csv_with_wrong_columns(self):
+        with pytest.raises(ValueError):
+            parse_usage_csv(["distinct_id,team,segment", "u1,1,insights"], allowed_team_ids={1}, cutoff=CUTOFF)
+
+
+class TestMappingDrift:
+    def test_every_product_is_classified(self):
+        # A new or renamed product must be added to URL_KEY_TO_PRODUCT_PATH (so the
+        # pruning job can measure it) or explicitly listed in UNMAPPED_PRODUCT_PATHS
+        # (so its rows are never pruned). Otherwise the job silently misjudges it.
+        product_paths = get_valid_product_paths()
+        mapped = set(URL_KEY_TO_PRODUCT_PATH.values())
+
+        assert product_paths - mapped - UNMAPPED_PRODUCT_PATHS == set()
+        # A mapping entry pointing at a nonexistent product is a typo or a stale rename.
+        assert mapped - product_paths == set()
+        assert mapped & UNMAPPED_PRODUCT_PATHS == set()
+
+    def test_whitelist_covers_two_segment_prefixes(self):
+        # The SQL whitelist is on first segments only; both shared prefixes must be in it.
+        assert {"ai-observability", "ai-evals"} <= set(first_segment_whitelist())
+
+    def test_docstring_query_whitelist_is_current(self):
+        # The module docstring carries a copy-paste-runnable query with the segment
+        # whitelist inlined; it must stay in lockstep with the mapping, or the
+        # operator's export silently misses a product's usage and its rows get pruned.
+        module_doc = " ".join((user_product_list_pruning.__doc__ or "").split())
+        expected = ", ".join(f"'{segment}'" for segment in first_segment_whitelist())
+        assert expected in module_doc
+
+
+@pytest.mark.django_db
+class TestPruneUnusedUserProductsOp:
+    def _setup_team(self) -> Team:
+        org = Organization.objects.create(name="Test Org")
+        return Team.objects.create(organization=org, name="Test Team")
+
+    def _create_user_with_rows(self, team: Team, email: str, distinct_id: str | None, paths: list[str]) -> User:
+        user = User.objects.create(
+            email=email, distinct_id=distinct_id, date_joined=timezone.now() - timedelta(days=365)
+        )
+        for path in paths:
+            UserProductList.objects.create(user=user, team=team, product_path=path, enabled=True)
+        # created_at is auto_now_add; backdate so rows are old enough to prune.
+        UserProductList.objects.filter(user=user, team=team).update(created_at=timezone.now() - timedelta(days=365))
+        return user
+
+    @staticmethod
+    def _seen() -> str:
+        # The op computes its cutoff from the wall clock, so usage must be recent
+        # relative to the real now().
+        return (timezone.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+    def test_dry_run_reports_and_live_run_deletes(self):
+        team = self._setup_team()
+        active = self._create_user_with_rows(team, "active@x.com", "d-active", ["Product analytics", "Surveys"])
+        no_usage = self._create_user_with_rows(team, "quiet@x.com", "d-quiet", ["Surveys"])
+        all_unused = self._create_user_with_rows(team, "gone@x.com", "d-gone", ["Surveys", "Feature flags"])
+        # Fail closed: no distinct_id means we can't match usage, so never prune.
+        no_identity = self._create_user_with_rows(team, "anon@x.com", None, ["Surveys"])
+
+        csv_lines = [
+            HEADER,
+            f"d-active,{team.id},insights,{self._seen()}",
+            # d-gone only used pages we don't map to any of their rows' products
+            f"d-gone,{team.id},heatmaps,{self._seen()}",
+        ]
+
+        config = {"usage_csv_urls": ["https://example.com/usage.csv"], "window_days": 60}
+        with patch(
+            "products.growth.dags.user_product_list_pruning._iter_csv_lines", return_value=iter(csv_lines)
+        ) as mock_fetch:
+            prune_unused_user_products(build_op_context(op_config={**config, "dry_run": True}))
+            mock_fetch.assert_called_once_with("https://example.com/usage.csv")
+
+        # Dry run: nothing deleted
+        assert UserProductList.objects.count() == 6
+
+        with patch(
+            "products.growth.dags.user_product_list_pruning._iter_csv_lines",
+            side_effect=lambda url: iter(csv_lines),
+        ):
+            prune_unused_user_products(build_op_context(op_config={**config, "dry_run": False}))
+
+        # active: unused Surveys deleted, used Product analytics kept
+        assert set(UserProductList.objects.filter(user=active).values_list("product_path", flat=True)) == {
+            "Product analytics"
+        }
+        # no_usage: zero pageviews -> untouched
+        assert UserProductList.objects.filter(user=no_usage).count() == 1
+        # all_unused: pruning would empty the sidebar -> untouched
+        assert UserProductList.objects.filter(user=all_unused).count() == 2
+        # no_identity: distinct_id is NULL -> unmatchable, untouched
+        assert UserProductList.objects.filter(user=no_identity).count() == 1
+
+    def test_processes_each_file_independently(self):
+        # Files partitioned by distinct_id: each user's pruning must happen in the
+        # file holding their usage, and both files' prunes must land in one run.
+        team = self._setup_team()
+        user_a = self._create_user_with_rows(team, "a@x.com", "d-a", ["Product analytics", "Surveys"])
+        user_b = self._create_user_with_rows(team, "b@x.com", "d-b", ["Session replay", "Feature flags"])
+
+        files = {
+            "https://example.com/part0.csv": [HEADER, f"d-a,{team.id},insights,{self._seen()}"],
+            "https://example.com/part1.csv": [HEADER, f"d-b,{team.id},replay,{self._seen()}"],
+        }
+
+        with patch(
+            "products.growth.dags.user_product_list_pruning._iter_csv_lines",
+            side_effect=lambda url: iter(files[url]),
+        ):
+            prune_unused_user_products(
+                build_op_context(op_config={"usage_csv_urls": list(files.keys()), "dry_run": False})
+            )
+
+        assert set(UserProductList.objects.filter(user=user_a).values_list("product_path", flat=True)) == {
+            "Product analytics"
+        }
+        assert set(UserProductList.objects.filter(user=user_b).values_list("product_path", flat=True)) == {
+            "Session replay"
+        }

--- a/products/growth/dags/tests/test_user_product_list_pruning.py
+++ b/products/growth/dags/tests/test_user_product_list_pruning.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import ANY, MagicMock, patch
 
 from django.utils import timezone
 
@@ -140,6 +140,26 @@ class TestParseUsageCsv:
             parse_usage_csv(["distinct_id,team,segment", "u1,1,insights"], allowed_team_ids={1}, cutoff=CUTOFF)
 
 
+class TestIterCsvLines:
+    def test_reads_and_decodes_lines_from_s3(self):
+        # bucket/key extraction and byte decoding are the whole S3 read path; a
+        # wrong split would make the job read the wrong object (or none).
+        body = MagicMock()
+        body.iter_lines.return_value = [HEADER.encode(), f"u1,1,insights,{SEEN}".encode()]
+        s3_client = MagicMock()
+        s3_client.get_object.return_value = {"Body": body}
+
+        lines = list(user_product_list_pruning._iter_csv_lines(s3_client, "s3://scratchpad/dir/usage.csv"))
+
+        s3_client.get_object.assert_called_once_with(Bucket="scratchpad", Key="dir/usage.csv")
+        assert lines == [HEADER, f"u1,1,insights,{SEEN}"]
+
+    @pytest.mark.parametrize("bad_path", ["https://example.com/usage.csv", "s3://bucket-only", "s3:///key-only"])
+    def test_rejects_non_s3_paths(self, bad_path: str):
+        with pytest.raises(ValueError):
+            list(user_product_list_pruning._iter_csv_lines(MagicMock(), bad_path))
+
+
 class TestMappingDrift:
     def test_every_product_is_classified(self):
         # A new or renamed product must be added to URL_KEY_TO_PRODUCT_PATH (so the
@@ -203,21 +223,22 @@ class TestPruneUnusedUserProductsOp:
             f"d-gone,{team.id},heatmaps,{self._seen()}",
         ]
 
-        config = {"usage_csv_urls": ["https://example.com/usage.csv"], "window_days": 60}
+        config = {"usage_csv_s3_paths": ["s3://scratchpad/usage.csv"], "window_days": 60}
+        resources = {"s3": MagicMock()}
         with patch(
             "products.growth.dags.user_product_list_pruning._iter_csv_lines", return_value=iter(csv_lines)
         ) as mock_fetch:
-            prune_unused_user_products(build_op_context(op_config={**config, "dry_run": True}))
-            mock_fetch.assert_called_once_with("https://example.com/usage.csv")
+            prune_unused_user_products(build_op_context(op_config={**config, "dry_run": True}, resources=resources))
+            mock_fetch.assert_called_once_with(ANY, "s3://scratchpad/usage.csv")
 
         # Dry run: nothing deleted
         assert UserProductList.objects.count() == 6
 
         with patch(
             "products.growth.dags.user_product_list_pruning._iter_csv_lines",
-            side_effect=lambda url: iter(csv_lines),
+            side_effect=lambda client, path: iter(csv_lines),
         ):
-            prune_unused_user_products(build_op_context(op_config={**config, "dry_run": False}))
+            prune_unused_user_products(build_op_context(op_config={**config, "dry_run": False}, resources=resources))
 
         # active: unused Surveys deleted, used Product analytics kept
         assert set(UserProductList.objects.filter(user=active).values_list("product_path", flat=True)) == {
@@ -238,16 +259,19 @@ class TestPruneUnusedUserProductsOp:
         user_b = self._create_user_with_rows(team, "b@x.com", "d-b", ["Session replay", "Feature flags"])
 
         files = {
-            "https://example.com/part0.csv": [HEADER, f"d-a,{team.id},insights,{self._seen()}"],
-            "https://example.com/part1.csv": [HEADER, f"d-b,{team.id},replay,{self._seen()}"],
+            "s3://scratchpad/part0.csv": [HEADER, f"d-a,{team.id},insights,{self._seen()}"],
+            "s3://scratchpad/part1.csv": [HEADER, f"d-b,{team.id},replay,{self._seen()}"],
         }
 
         with patch(
             "products.growth.dags.user_product_list_pruning._iter_csv_lines",
-            side_effect=lambda url: iter(files[url]),
+            side_effect=lambda client, path: iter(files[path]),
         ):
             prune_unused_user_products(
-                build_op_context(op_config={"usage_csv_urls": list(files.keys()), "dry_run": False})
+                build_op_context(
+                    op_config={"usage_csv_s3_paths": list(files.keys()), "dry_run": False},
+                    resources={"s3": MagicMock()},
+                )
             )
 
         assert set(UserProductList.objects.filter(user=user_a).values_list("product_path", flat=True)) == {

--- a/products/growth/dags/user_product_list_pruning.py
+++ b/products/growth/dags/user_product_list_pruning.py
@@ -364,8 +364,8 @@ def prune_unused_user_products(context: dagster.OpExecutionContext, config: Prun
 
     cutoff = timezone.now() - timedelta(days=config.window_days)
 
-    # Scope everything to teams that actually have sidebar rows in this
-    # region's Postgres; CSV rows for the other region's team ids are dropped.
+    # Scope everything to teams that actually have sidebar rows in this region's Postgres;
+    # CSV rows for the other region's team ids are dropped.
     allowed_team_ids = set(UserProductList.objects.values_list("team_id", flat=True).distinct())
     context.log.info(f"{len(allowed_team_ids)} teams have UserProductList rows")
 

--- a/products/growth/dags/user_product_list_pruning.py
+++ b/products/growth/dags/user_product_list_pruning.py
@@ -1,0 +1,508 @@
+"""One-off Dagster job that deletes UserProductList rows for products a user
+hasn't opened in the last 60 days, per (user, team), to simplify sidebars.
+
+"Usage" comes from PostHog's own self-capture ``$pageview`` events, which land
+in US ClickHouse under team 2 for both US and EU app traffic - so instead of
+querying ClickHouse from each region's Dagster, the aggregation below is run
+once (e.g. via Metabase) and exported as CSV(s) whose URLs are passed to the
+job in both regions. No schedule: launch manually from the Dagster UI, with
+`dry_run: true` (the default) first to review the run metadata.
+
+The aggregation query, ready to copy-run against US prod (team 2). The
+``seg1 IN (...)`` whitelist keeps non-product pages (settings, persons,
+activity, onboarding, ...) out of the export; it's kept in lockstep with
+``URL_KEY_TO_PRODUCT_PATH`` by ``test_docstring_query_whitelist_is_current``.
+The INTERVAL must be at least ``window_days`` (rows older than the job's
+window are dropped at parse time, so a wider SQL window is fine; a narrower
+one would make used products look unused):
+
+    WITH
+        extract(`mat_$pathname`, '^/project/\\d+/([^/?#]+)') AS seg1,
+        extract(`mat_$pathname`, '^/project/\\d+/[^/?#]+/([^/?#]+)') AS seg2
+    SELECT
+        distinct_id,
+        toInt64OrZero(extract(`mat_$pathname`, '^/project/(\\d+)')) AS browsed_team_id,
+        if(seg1 IN ('ai-observability', 'ai-evals'), concat(seg1, '/', seg2), seg1) AS url_key,
+        max(timestamp) AS last_seen
+    FROM events
+    WHERE team_id = 2
+      AND event = '$pageview'
+      AND timestamp >= now() - INTERVAL 60 DAY
+      AND `mat_$pathname` LIKE '/project/%'
+      AND seg1 IN (
+        'ai-evals', 'ai-gateway', 'ai-observability', 'business-knowledge', 'code_review',
+        'customer_analytics', 'dashboard', 'data-ops', 'early_access_features', 'endpoints',
+        'engineering-analytics', 'error_tracking', 'experiments', 'feature_flags', 'heatmaps',
+        'identity-matching', 'insights', 'links', 'live-debugger', 'logs', 'marketing',
+        'mcp-analytics', 'metrics', 'notebooks', 'product_tours', 'prompt-management', 'pulse',
+        'replay', 'replay-vision', 'revenue_analytics', 'skills', 'sql', 'support', 'surveys',
+        'tasks', 'toolbar', 'tracing', 'user_research', 'visual_review', 'web', 'web-scripts',
+        'workflows'
+      )
+    GROUP BY distinct_id, browsed_team_id, url_key
+    HAVING browsed_team_id > 0
+
+If the result exceeds the exporter's row cap (Metabase caps CSVs around 1M
+rows), partition it into N non-overlapping exports by adding
+``AND modulo(sipHash64(distinct_id), N) = i`` (i in 0..N-1) to the WHERE
+clause and pass every file's URL to the job.
+
+Files are processed one at a time, so memory stays O(largest file): only one
+file's usage dict is held at any point. ASSUMPTION (trusted, not re-verified
+by the job): the files partition users - the ``sipHash64(distinct_id)`` split
+above guarantees each user's complete usage sits in exactly one file. That is
+what makes per-file pruning decision-safe; files split any other way (by
+time, by team) could hold partial usage, making used products look unused.
+
+``/project/<id>`` in app pathnames is the team id (the frontend builds it from
+``getCurrentTeamId()``), and event ``distinct_id`` equals ``User.distinct_id``
+(``posthog.identify(user.distinct_id)``), so CSV rows join straight onto
+``UserProductList`` rows in either region's Postgres.
+"""
+
+import csv
+from collections import Counter
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import TypeVar
+
+from django.db import connections
+from django.utils import timezone
+
+import dagster
+import pydantic
+import requests
+
+from posthog.dags.common import JobOwners
+from posthog.models.file_system.user_product_list import UserProductList
+from posthog.models.user import User
+
+CSV_DOWNLOAD_TIMEOUT_SECONDS = (10, 600)  # (connect, read)
+TEAMS_PER_CONNECTION_CYCLE = 500
+# Stay well under Postgres' 65535 bind-parameter cap for IN (...) queries.
+SQL_IN_BATCH_SIZE = 10_000
+# If a file's oldest kept usage row is much newer than the cutoff, the SQL
+# window was probably narrower than window_days (see module docstring).
+WINDOW_COVERAGE_SLACK = timedelta(days=7)
+
+# URL key -> UserProductList.product_path. Keys are the first pathname segment
+# after `/project/<team_id>/`, except under `ai-observability` and `ai-evals`,
+# where several products share the first segment and the key keeps two segments.
+# Authored from each product's `treeItemsProducts` href in products/*/manifest.tsx;
+# `test_every_product_is_classified` guards against drift as products are
+# added/renamed.
+URL_KEY_TO_PRODUCT_PATH: dict[str, str] = {
+    "ai-gateway": "AI gateway",
+    # `ai-observability/*` defaults to LLM analytics (dashboard, traces,
+    # generations, users, ...); playground and clusters are their own products.
+    "ai-observability": "LLM analytics",
+    "ai-observability/playground": "Playground",
+    "ai-observability/clusters": "Clusters",
+    "ai-evals/datasets": "Datasets",
+    "ai-evals/evaluations": "Evaluations",
+    "ai-evals/taggers": "Taggers",
+    "prompt-management": "Prompts",
+    "business-knowledge": "Business knowledge",
+    "web-scripts": "Web scripts",
+    "support": "Support",
+    "customer_analytics": "Customer analytics",
+    "dashboard": "Dashboards",
+    "sql": "SQL editor",
+    "data-ops": "Data warehouse",
+    "early_access_features": "Early access features",
+    "endpoints": "Endpoints",
+    "engineering-analytics": "Engineering analytics",
+    "error_tracking": "Error tracking",
+    "experiments": "Experiments",
+    "feature_flags": "Feature flags",
+    "identity-matching": "Identity matching",
+    "links": "Links",
+    "live-debugger": "Live Debugger",
+    "logs": "Logs",
+    "marketing": "Marketing analytics",
+    "mcp-analytics": "MCP analytics",
+    "metrics": "Metrics",
+    "tasks": "Tasks",
+    "insights": "Product analytics",
+    "notebooks": "Notebooks",
+    "product_tours": "Product tours",
+    "pulse": "Pulse",
+    "replay": "Session replay",
+    "heatmaps": "Heatmaps",
+    "replay-vision": "Replay vision",
+    "revenue_analytics": "Revenue analytics",
+    "code_review": "Code review",
+    "skills": "Skills",
+    "surveys": "Surveys",
+    "toolbar": "Toolbar",
+    "tracing": "Tracing",
+    "user_research": "User research",
+    "visual_review": "Visual review",
+    "web": "Web analytics",
+    "workflows": "Workflows",
+}
+
+# Products with no URL key: we can't observe their usage, so their rows are
+# never pruned. Currently every product is mappable; this is the escape hatch
+# the drift-guard test points new products at when they genuinely have no
+# distinct URL prefix.
+UNMAPPED_PRODUCT_PATHS: set[str] = set()
+
+MAPPABLE_PRODUCT_PATHS: set[str] = set(URL_KEY_TO_PRODUCT_PATH.values())
+
+SKIP_RECENT_USER = "recent_user"
+SKIP_NO_USAGE = "no_usage"
+SKIP_EMPTY_SIDEBAR = "empty_sidebar"
+
+
+def first_segment_whitelist() -> list[str]:
+    """First pathname segments the ClickHouse aggregation should keep.
+
+    Derived from the mapping so the query in the module docstring and the
+    parsing below can't drift apart.
+    """
+    return sorted({key.split("/", 1)[0] for key in URL_KEY_TO_PRODUCT_PATH})
+
+
+def product_path_for_url_key(url_key: str) -> str | None:
+    """Resolve a CSV ``url_key`` to a product path: exact match first, then the
+    first segment (the `ai-observability/*` -> LLM analytics fallback)."""
+    exact = URL_KEY_TO_PRODUCT_PATH.get(url_key)
+    if exact is not None:
+        return exact
+    return URL_KEY_TO_PRODUCT_PATH.get(url_key.split("/", 1)[0])
+
+
+def usage_csv_reader(lines: Iterable[str]) -> csv.DictReader:
+    """DictReader over a usage CSV, validating the expected header.
+
+    Requires ``distinct_id``, ``browsed_team_id``, ``url_key`` and
+    ``last_seen`` (the aggregation query's output). Header cells are
+    normalized (whitespace, UTF-8 BOM) so a Metabase-flavored export doesn't
+    abort the run on cosmetics.
+    """
+    reader = csv.DictReader(lines)
+    if reader.fieldnames is not None:
+        reader.fieldnames = [name.lstrip("\ufeff").strip() for name in reader.fieldnames]
+    required = {"distinct_id", "browsed_team_id", "url_key", "last_seen"}
+    if reader.fieldnames is None or not required.issubset(reader.fieldnames):
+        raise ValueError(f"Usage CSV must have columns {sorted(required)}, got {reader.fieldnames}")
+    return reader
+
+
+def _parse_last_seen(raw: str | None) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat((raw or "").strip())
+    except ValueError:
+        return None
+    # ClickHouse exports UTC timestamps without an offset.
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ParsedUsageFile:
+    # team_id -> distinct_id -> product paths used within the window
+    usage: dict[int, dict[str, set[str]]]
+    # Oldest kept last_seen; much newer than the cutoff suggests the SQL
+    # window was narrower than window_days.
+    oldest_last_seen: datetime | None
+    stale_rows_dropped: int
+
+
+def parse_usage_csv(
+    lines: Iterable[str],
+    allowed_team_ids: set[int],
+    cutoff: datetime,
+) -> ParsedUsageFile:
+    """Fold one CSV's rows into per-team usage.
+
+    Drops rows for teams outside ``allowed_team_ids`` (the other region,
+    deleted teams), unmappable url_keys, and rows whose ``last_seen`` is older
+    than ``cutoff`` - that makes ``window_days`` authoritative even when the
+    SQL export used a wider window. Rows with an unparseable ``last_seen`` are
+    kept (counting usage we can't date is the fail-closed direction: it can
+    only prevent deletions).
+    """
+    usage: dict[int, dict[str, set[str]]] = {}
+    oldest_last_seen: datetime | None = None
+    stale_rows_dropped = 0
+
+    for row in usage_csv_reader(lines):
+        try:
+            team_id = int(row["browsed_team_id"])
+        except (TypeError, ValueError):
+            continue
+        if team_id not in allowed_team_ids:
+            continue
+        product_path = product_path_for_url_key(row["url_key"])
+        if product_path is None:
+            continue
+        distinct_id = row["distinct_id"]
+        if not distinct_id:
+            continue
+        last_seen = _parse_last_seen(row.get("last_seen"))
+        if last_seen is not None:
+            if last_seen < cutoff:
+                stale_rows_dropped += 1
+                continue
+            if oldest_last_seen is None or last_seen < oldest_last_seen:
+                oldest_last_seen = last_seen
+        usage.setdefault(team_id, {}).setdefault(distinct_id, set()).add(product_path)
+
+    return ParsedUsageFile(usage=usage, oldest_last_seen=oldest_last_seen, stale_rows_dropped=stale_rows_dropped)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProductListRow:
+    """The slice of a UserProductList row the prune decision needs."""
+
+    id: str
+    product_path: str
+    enabled: bool
+    created_at: datetime
+
+
+@dataclass(frozen=True, kw_only=True)
+class PruneDecision:
+    # Why the (user, team) pair was skipped wholesale, or None when pruning applies.
+    skip_reason: str | None = None
+    rows: list[ProductListRow] = field(default_factory=list)
+
+
+def select_rows_to_prune(
+    rows: list[ProductListRow],
+    *,
+    user_date_joined: datetime,
+    used_paths: set[str] | None,
+    cutoff: datetime,
+) -> PruneDecision:
+    """Decide what to delete for one (user, team).
+
+    ``used_paths`` is the user's mapped usage on this team (``None`` == no
+    usage entry at all). Whole-user skips: joined after the cutoff (no time to
+    use anything yet), zero observed pageviews (adblock, API-only,
+    anonymous-only - absence of data, not absence of usage), and the
+    never-empty guard (pruning must not leave a bare sidebar). Only enabled
+    rows are candidates - disabled rows are already out of the sidebar and
+    record an intentional user choice we want to keep. A row is pruned when
+    it's old enough to have been used, its product is measurable, and the
+    product wasn't opened in the window.
+    """
+    if user_date_joined >= cutoff:
+        return PruneDecision(skip_reason=SKIP_RECENT_USER)
+    if not used_paths:
+        return PruneDecision(skip_reason=SKIP_NO_USAGE)
+
+    to_delete = [
+        row
+        for row in rows
+        if row.enabled
+        and row.created_at < cutoff
+        and row.product_path in MAPPABLE_PRODUCT_PATHS
+        and row.product_path not in used_paths
+    ]
+
+    enabled_count = sum(1 for row in rows if row.enabled)
+    if to_delete and enabled_count == len(to_delete):
+        return PruneDecision(skip_reason=SKIP_EMPTY_SIDEBAR)
+
+    return PruneDecision(rows=to_delete)
+
+
+class PruneConfig(dagster.Config):
+    """Configuration for the one-off unused-product pruning run."""
+
+    usage_csv_urls: list[str] = pydantic.Field(
+        description=(
+            "URL(s) of CSV export(s) of the usage aggregation query "
+            "(columns: distinct_id, browsed_team_id, url_key, last_seen). Multiple files MUST "
+            "partition users by distinct_id (see module docstring) - the job trusts this"
+        ),
+    )
+    dry_run: bool = pydantic.Field(
+        default=True,
+        description="When true (default), only report what would be deleted",
+    )
+    window_days: int = pydantic.Field(
+        default=60,
+        description=(
+            "Usage window in days; the aggregation query's INTERVAL must be at least this wide "
+            "(older rows are dropped at parse time). Also the minimum age of users and rows "
+            "considered for pruning"
+        ),
+    )
+
+
+def _iter_csv_lines(url: str) -> Iterator[str]:
+    response = requests.get(url, stream=True, timeout=CSV_DOWNLOAD_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    yield from response.iter_lines(decode_unicode=True)
+
+
+T = TypeVar("T")
+
+
+def _in_batches(items: list[T], size: int = SQL_IN_BATCH_SIZE) -> Iterator[list[T]]:
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+@dagster.op(
+    retry_policy=dagster.RetryPolicy(
+        max_retries=3,
+        delay=30,
+        backoff=dagster.Backoff.EXPONENTIAL,
+        jitter=dagster.Jitter.FULL,
+    )
+)
+def prune_unused_user_products(context: dagster.OpExecutionContext, config: PruneConfig) -> None:
+    """Retrying the whole op is safe: deletions are idempotent (already-deleted
+    rows just aren't matched again)."""
+    if not config.usage_csv_urls:
+        raise dagster.Failure("usage_csv_urls cannot be empty")
+
+    cutoff = timezone.now() - timedelta(days=config.window_days)
+
+    # Scope everything to teams that actually have sidebar rows in this
+    # region's Postgres; CSV rows for the other region's team ids are dropped.
+    allowed_team_ids = set(UserProductList.objects.values_list("team_id", flat=True).distinct())
+    context.log.info(f"{len(allowed_team_ids)} teams have UserProductList rows")
+
+    users_evaluated = 0
+    skip_counts: Counter[str] = Counter()
+    rows_examined = 0
+    rows_deleted = 0
+    stale_rows_dropped = 0
+    deleted_by_product: Counter[str] = Counter()
+    teams_swept: set[int] = set()
+
+    # One file at a time keeps memory at O(largest file); see the module
+    # docstring for the partitioning assumption that makes this decision-safe.
+    for url in config.usage_csv_urls:
+        context.log.info(f"Downloading usage CSV: {url}")
+        parsed = parse_usage_csv(_iter_csv_lines(url), allowed_team_ids, cutoff)
+        usage = parsed.usage
+        stale_rows_dropped += parsed.stale_rows_dropped
+        context.log.info(f"File covers {len(usage)} teams, {sum(len(v) for v in usage.values())} (team, user) pairs")
+        if parsed.oldest_last_seen is not None and parsed.oldest_last_seen > cutoff + WINDOW_COVERAGE_SLACK:
+            # Can't be a hard failure: a legitimately scoped export (few teams,
+            # active users only) also has no usage near the cutoff boundary.
+            context.log.warning(
+                f"Oldest usage in {url} is {parsed.oldest_last_seen.isoformat()}, well inside the "
+                f"{config.window_days}-day window ending {cutoff.isoformat()}. If this is a full export, "
+                "the SQL INTERVAL was likely narrower than window_days and used products would look unused."
+            )
+
+        for team_index, team_id in enumerate(sorted(usage)):
+            teams_swept.add(team_id)
+            team_usage = usage[team_id]
+
+            # Resolve only the users with usage in this file; everyone else in the
+            # team is untouched by definition, so their rows are never fetched.
+            # Users we can't resolve (deleted, NULL distinct_id) or whose usage
+            # sits in another file simply don't match here - fail closed, counted
+            # in aggregate as user_team_pairs_untouched below.
+            users_by_id: dict[int, dict] = {}
+            for distinct_id_batch in _in_batches(list(team_usage.keys())):
+                users_by_id.update(
+                    (user["id"], user)
+                    for user in User.objects.filter(distinct_id__in=distinct_id_batch).values(
+                        "id", "distinct_id", "date_joined"
+                    )
+                )
+            if not users_by_id:
+                continue
+
+            rows_by_user: dict[int, list[ProductListRow]] = {}
+            for user_id_batch in _in_batches(list(users_by_id.keys())):
+                team_rows = UserProductList.objects.filter(team_id=team_id, user_id__in=user_id_batch).values_list(
+                    "id", "user_id", "product_path", "enabled", "created_at"
+                )
+                for row_id, user_id, product_path, enabled, created_at in team_rows:
+                    rows_examined += 1
+                    rows_by_user.setdefault(user_id, []).append(
+                        ProductListRow(
+                            id=str(row_id), product_path=product_path, enabled=enabled, created_at=created_at
+                        )
+                    )
+
+            team_ids_to_delete: list[str] = []
+            for user_id, user_rows in rows_by_user.items():
+                user = users_by_id[user_id]
+
+                # Files partition users by distinct_id (module-docstring
+                # assumption), so each (user, team) is evaluated in exactly one
+                # file and counters never double-count.
+                decision = select_rows_to_prune(
+                    user_rows,
+                    user_date_joined=user["date_joined"],
+                    used_paths=team_usage[user["distinct_id"]],
+                    cutoff=cutoff,
+                )
+                users_evaluated += 1
+                if decision.skip_reason is not None:
+                    skip_counts[decision.skip_reason] += 1
+                    continue
+
+                for row in decision.rows:
+                    deleted_by_product[row.product_path] += 1
+                team_ids_to_delete.extend(row.id for row in decision.rows)
+
+            if team_ids_to_delete:
+                rows_deleted += len(team_ids_to_delete)
+                if not config.dry_run:
+                    for delete_batch in _in_batches(team_ids_to_delete):
+                        UserProductList.objects.filter(id__in=delete_batch).delete()
+
+            if (team_index + 1) % TEAMS_PER_CONNECTION_CYCLE == 0:
+                context.log.info(
+                    f"Progress: {team_index + 1}/{len(usage)} teams in current file, {users_evaluated} users, "
+                    f"{rows_deleted} rows {'would be ' if config.dry_run else ''}deleted"
+                )
+                # Release per-connection buffers periodically to keep RSS flat
+                # across the full team sweep.
+                connections.close_all()
+
+    # Everything not evaluated was left untouched: pairs with no usage in any
+    # file, unresolvable identities, and pairs in teams with no usage at all.
+    # Served by the (team_id, user_id) index, so one index-only scan.
+    total_pairs = UserProductList.objects.values("team_id", "user_id").distinct().count()
+    pairs_untouched = total_pairs - users_evaluated
+
+    action = "would delete" if config.dry_run else "deleted"
+    context.log.info(
+        f"Run complete ({'DRY RUN' if config.dry_run else 'LIVE'}): {len(teams_swept)} teams swept, "
+        f"{users_evaluated}/{total_pairs} (team, user) pairs evaluated, {rows_examined} rows examined, "
+        f"{action} {rows_deleted} rows. Skips: {dict(skip_counts)}"
+    )
+
+    context.add_output_metadata(
+        {
+            "dry_run": dagster.MetadataValue.bool(config.dry_run),
+            "teams_swept": dagster.MetadataValue.int(len(teams_swept)),
+            "user_team_pairs_total": dagster.MetadataValue.int(total_pairs),
+            "user_team_pairs_evaluated": dagster.MetadataValue.int(users_evaluated),
+            "user_team_pairs_untouched_no_usage_or_unresolved": dagster.MetadataValue.int(pairs_untouched),
+            "users_skipped_recent": dagster.MetadataValue.int(skip_counts[SKIP_RECENT_USER]),
+            "users_skipped_empty_sidebar_guard": dagster.MetadataValue.int(skip_counts[SKIP_EMPTY_SIDEBAR]),
+            "rows_examined": dagster.MetadataValue.int(rows_examined),
+            "stale_usage_rows_dropped": dagster.MetadataValue.int(stale_rows_dropped),
+            "rows_deleted" if not config.dry_run else "rows_would_delete": dagster.MetadataValue.int(rows_deleted),
+            # Per-product counts surface mapping mistakes: a product with a bad
+            # URL key would show an implausibly high delete count here.
+            "deleted_by_product": dagster.MetadataValue.json(dict(deleted_by_product.most_common())),
+        }
+    )
+
+
+@dagster.job(
+    description=(
+        "One-off: delete UserProductList rows for products a user hasn't opened in the "
+        "usage window, based on a CSV export of self-capture pageview paths."
+    ),
+    executor_def=dagster.in_process_executor,
+    tags={"owner": JobOwners.TEAM_GROWTH.value},
+)
+def prune_unused_user_products_job():
+    prune_unused_user_products()

--- a/products/growth/dags/user_product_list_pruning.py
+++ b/products/growth/dags/user_product_list_pruning.py
@@ -468,7 +468,10 @@ def prune_unused_user_products(
                 rows_deleted += len(team_ids_to_delete)
                 if not config.dry_run:
                     for delete_batch in _in_batches(team_ids_to_delete):
-                        UserProductList.objects.filter(id__in=delete_batch).delete()
+                        # Re-check enabled at delete time: a row a user disables
+                        # between the read above and here records an intentional
+                        # choice we must not delete.
+                        UserProductList.objects.filter(id__in=delete_batch, enabled=True).delete()
 
             if (team_index + 1) % TEAMS_PER_CONNECTION_CYCLE == 0:
                 context.log.info(

--- a/products/growth/dags/user_product_list_pruning.py
+++ b/products/growth/dags/user_product_list_pruning.py
@@ -4,9 +4,12 @@ hasn't opened in the last 60 days, per (user, team), to simplify sidebars.
 "Usage" comes from PostHog's own self-capture ``$pageview`` events, which land
 in US ClickHouse under team 2 for both US and EU app traffic - so instead of
 querying ClickHouse from each region's Dagster, the aggregation below is run
-once (e.g. via Metabase) and exported as CSV(s) whose URLs are passed to the
-job in both regions. No schedule: launch manually from the Dagster UI, with
-`dry_run: true` (the default) first to review the run metadata.
+once (e.g. via Metabase), and the resulting CSV(s) are uploaded to the private
+scratchpad S3 bucket in each region. Their ``s3://bucket/key`` paths are passed
+to the job, which reads them straight from S3 with Dagster's read-only bucket
+grant (no public URLs, no pre-signed links). No schedule: launch manually from
+the Dagster UI, with `dry_run: true` (the default) first to review the run
+metadata.
 
 The aggregation query, ready to copy-run against US prod (team 2). The
 ``seg1 IN (...)`` whitelist keeps non-product pages (settings, persons,
@@ -45,7 +48,7 @@ one would make used products look unused):
 If the result exceeds the exporter's row cap (Metabase caps CSVs around 1M
 rows), partition it into N non-overlapping exports by adding
 ``AND modulo(sipHash64(distinct_id), N) = i`` (i in 0..N-1) to the WHERE
-clause and pass every file's URL to the job.
+clause and pass every file's S3 path to the job.
 
 Files are processed one at a time, so memory stays O(largest file): only one
 file's usage dict is held at any point. ASSUMPTION (trusted, not re-verified
@@ -66,19 +69,18 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import TypeVar
+from urllib.parse import urlparse
 
 from django.db import connections
 from django.utils import timezone
 
 import dagster
 import pydantic
-import requests
 
 from posthog.dags.common import JobOwners
 from posthog.models.file_system.user_product_list import UserProductList
 from posthog.models.user import User
 
-CSV_DOWNLOAD_TIMEOUT_SECONDS = (10, 600)  # (connect, read)
 TEAMS_PER_CONNECTION_CYCLE = 500
 # Stay well under Postgres' 65535 bind-parameter cap for IN (...) queries.
 SQL_IN_BATCH_SIZE = 10_000
@@ -313,11 +315,12 @@ def select_rows_to_prune(
 class PruneConfig(dagster.Config):
     """Configuration for the one-off unused-product pruning run."""
 
-    usage_csv_urls: list[str] = pydantic.Field(
+    usage_csv_s3_paths: list[str] = pydantic.Field(
         description=(
-            "URL(s) of CSV export(s) of the usage aggregation query "
-            "(columns: distinct_id, browsed_team_id, url_key, last_seen). Multiple files MUST "
-            "partition users by distinct_id (see module docstring) - the job trusts this"
+            "S3 path(s) (s3://bucket/key) of CSV export(s) of the usage aggregation query "
+            "(columns: distinct_id, browsed_team_id, url_key, last_seen), uploaded to the private "
+            "scratchpad bucket. Multiple files MUST partition users by distinct_id (see module "
+            "docstring) - the job trusts this"
         ),
     )
     dry_run: bool = pydantic.Field(
@@ -334,10 +337,19 @@ class PruneConfig(dagster.Config):
     )
 
 
-def _iter_csv_lines(url: str) -> Iterator[str]:
-    response = requests.get(url, stream=True, timeout=CSV_DOWNLOAD_TIMEOUT_SECONDS)
-    response.raise_for_status()
-    yield from response.iter_lines(decode_unicode=True)
+def _iter_csv_lines(s3_client, s3_path: str) -> Iterator[str]:
+    """Stream a usage CSV out of S3 one line at a time (keeps memory O(line))."""
+    parsed = urlparse(s3_path)
+    if parsed.scheme != "s3":
+        raise ValueError(f"Invalid S3 path scheme: {s3_path}. Expected s3://bucket/key")
+    bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+    if not bucket or not key:
+        raise ValueError(f"Invalid S3 path: {s3_path}. Expected s3://bucket/key")
+
+    response = s3_client.get_object(Bucket=bucket, Key=key)
+    for line in response["Body"].iter_lines():
+        yield line.decode("utf-8")
 
 
 T = TypeVar("T")
@@ -356,12 +368,15 @@ def _in_batches(items: list[T], size: int = SQL_IN_BATCH_SIZE) -> Iterator[list[
         jitter=dagster.Jitter.FULL,
     )
 )
-def prune_unused_user_products(context: dagster.OpExecutionContext, config: PruneConfig) -> None:
+def prune_unused_user_products(
+    context: dagster.OpExecutionContext, config: PruneConfig, s3: dagster.ResourceParam
+) -> None:
     """Retrying the whole op is safe: deletions are idempotent (already-deleted
     rows just aren't matched again)."""
-    if not config.usage_csv_urls:
-        raise dagster.Failure("usage_csv_urls cannot be empty")
+    if not config.usage_csv_s3_paths:
+        raise dagster.Failure("usage_csv_s3_paths cannot be empty")
 
+    s3_client = s3.get_client()
     cutoff = timezone.now() - timedelta(days=config.window_days)
 
     # Scope everything to teams that actually have sidebar rows in this region's Postgres;
@@ -379,9 +394,9 @@ def prune_unused_user_products(context: dagster.OpExecutionContext, config: Prun
 
     # One file at a time keeps memory at O(largest file); see the module
     # docstring for the partitioning assumption that makes this decision-safe.
-    for url in config.usage_csv_urls:
-        context.log.info(f"Downloading usage CSV: {url}")
-        parsed = parse_usage_csv(_iter_csv_lines(url), allowed_team_ids, cutoff)
+    for s3_path in config.usage_csv_s3_paths:
+        context.log.info(f"Reading usage CSV from S3: {s3_path}")
+        parsed = parse_usage_csv(_iter_csv_lines(s3_client, s3_path), allowed_team_ids, cutoff)
         usage = parsed.usage
         stale_rows_dropped += parsed.stale_rows_dropped
         context.log.info(f"File covers {len(usage)} teams, {sum(len(v) for v in usage.values())} (team, user) pairs")
@@ -389,7 +404,7 @@ def prune_unused_user_products(context: dagster.OpExecutionContext, config: Prun
             # Can't be a hard failure: a legitimately scoped export (few teams,
             # active users only) also has no usage near the cutoff boundary.
             context.log.warning(
-                f"Oldest usage in {url} is {parsed.oldest_last_seen.isoformat()}, well inside the "
+                f"Oldest usage in {s3_path} is {parsed.oldest_last_seen.isoformat()}, well inside the "
                 f"{config.window_days}-day window ending {cutoff.isoformat()}. If this is a full export, "
                 "the SQL INTERVAL was likely narrower than window_days and used products would look unused."
             )


### PR DESCRIPTION
## Problem

Sidebars have accumulated a lot of `UserProductList` entries over time (defaults, onboarding picks, colleague and cross-sell suggestions), and many of them point at products people never open. We want a one-time cleanup that removes entries a user hasn't used in the last 60 days, per (user, project), so sidebars get much simpler.

## Changes

Adds `prune_unused_user_products_job`, a manual-only Dagster job (no schedule, `dry_run: true` by default) registered in the growth code location.

**Why CSVs instead of querying ClickHouse from the job:** app self-capture `$pageview` events for both US and EU land in a single US ClickHouse project, so a per-region Dagster job can't query them locally. Instead, the aggregation query (documented in the module docstring, copy-paste runnable) is run once externally and exported as CSV(s) whose URLs are passed to the job. The same CSVs work for both regions since `User.distinct_id` is the join key and pathnames carry the browsed team id.

**How it decides:** pathname segments map to sidebar products via a hand-authored `URL_KEY_TO_PRODUCT_PATH` (sourced from each product manifest's tree item href), with a drift-guard test that fails whenever a product is added or renamed without being classified. A row is deleted only when the product is measurable, the row and the user are both older than the window, and the user has observed usage that doesn't include the product.

**Fail-closed rules:**
- users with zero observed pageviews (adblock, API-only, anonymous-only) are skipped entirely
- unresolvable identities (deleted user, NULL `distinct_id`) are never pruned
- rows whose `last_seen` is older than the window are dropped at parse time, so a wider SQL export window can't resurrect old usage, and a suspiciously narrow one logs a loud warning
- pruning never leaves a sidebar with zero enabled rows
- disabled rows are untouched (they record an intentional user choice)

> [!NOTE]
> Multiple CSV files are processed one at a time to keep memory at one file's worth. The job trusts that files partition users by `distinct_id` (the documented `sipHash64` split); this is a stated assumption, not something the job re-verifies.

Run metadata reports evaluated/untouched pair counts, per-product delete counts (to surface mapping mistakes before a live run), skip counters, and stale-row drops.

## How did you test this code?

Automated tests only (30 passing in `test_user_product_list_pruning.py`):
- parameterized decision tests: each destructive guard (used vs unused, recent user/row, disabled rows, unmappable paths, never-empty guard) - a flipped condition would mass-delete wrongly
- CSV parsing: url_key mapping incl. two-segment prefixes and fallback, region scoping, stale-row dropping, unparseable `last_seen` failing closed, BOM/whitespace header normalization
- mapping drift guard: every product in `products.json` must be classified; the docstring's copy-paste query whitelist must match the mapping
- op-level: dry run deletes nothing; live run deletes exactly the expected rows across multiple files while honoring the skip guards

Also ran repo-wide mypy and verified the Dagster growth location loads with the new job. I have not run this against production data yet - the rollout plan is dry-run first in each region and reviewing the metadata before flipping `dry_run: false`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal one-off tooling, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus). I directed the design; Claude explored the codebase, wrote the implementation and tests, and ran the verification. Skills invoked: /writing-tests.

Decisions along the way:
- We first considered `FileSystemViewLog` as the usage signal but chose pageview paths for full product coverage (view logs only cover item-backed products).
- The url-segment-to-product mapping can't be generated from `products.json` (the build strips hrefs), so it's hand-authored with a drift-guard test instead of extending the products build - judged the right depth for a one-off.
- A five-agent review pass (reuse, simplification, efficiency, altitude, bug hunt) reshaped the sweep to fetch only rows of users with usage in the current file (kills N+1 user queries and repeated table reads), added `last_seen` window enforcement, header normalization, IN-clause batching, and a retry policy.
- A cross-file overlap guard was initially added, then removed at my direction: the export process owns the partition-by-user guarantee, and the job documents it as a trusted assumption.