### PR TITLE
feat(ingestion): add minimal_flag_called_events team configuration

### DIFF
--- a/nodejs/src/common/utils/team-manager.test.ts
+++ b/nodejs/src/common/utils/team-manager.test.ts
@@ -1,5 +1,11 @@
 import { forSnapshot } from '~/tests/helpers/snapshots'
-import { createTeam, getFirstTeam, resetTestDatabase, updateOrganizationAvailableFeatures } from '~/tests/helpers/sql'
+import {
+    createTeam,
+    getFirstTeam,
+    insertRow,
+    resetTestDatabase,
+    updateOrganizationAvailableFeatures,
+} from '~/tests/helpers/sql'
 import { Hub, Team } from '~/types'
 
 import { defaultConfig } from '../config/config'
@@ -54,6 +60,7 @@ describe('TeamManager()', () => {
                   "id": 2,
                   "ingested_event": true,
                   "logs_settings": null,
+                  "minimal_flag_called_events": false,
                   "name": "TEST PROJECT",
                   "organization_id": "<REPLACED-UUID-1>",
                   "person_display_name_properties": [],
@@ -197,6 +204,38 @@ describe('TeamManager()', () => {
             const newTeamByToken = await teamManager.getTeamByToken(newTeam!.api_token)
             expect(newTeamByToken).not.toBeNull()
             expect(newTeamByToken!.drop_events_older_than_seconds).toBeNull()
+        })
+
+        it('defaults minimal_flag_called_events to false when no TeamFeatureFlagsConfig row exists', async () => {
+            const newTeamId = await createTeam(postgres, organizationId)
+
+            const newTeam = await teamManager.getTeam(newTeamId)
+            expect(newTeam).not.toBeNull()
+            expect(newTeam!.minimal_flag_called_events).toBe(false)
+        })
+
+        it('reflects minimal_flag_called_events when a TeamFeatureFlagsConfig row exists', async () => {
+            const newTeamId = await createTeam(postgres, organizationId)
+            await insertRow(postgres, 'feature_flags_teamfeatureflagsconfig', {
+                team_id: newTeamId,
+                minimal_flag_called_events: true,
+            })
+
+            const newTeam = await teamManager.getTeam(newTeamId)
+            expect(newTeam).not.toBeNull()
+            expect(newTeam!.minimal_flag_called_events).toBe(true)
+        })
+
+        it('does not leak minimal_flag_called_events across teams', async () => {
+            const teamA = await createTeam(postgres, organizationId)
+            const teamB = await createTeam(postgres, organizationId)
+            await insertRow(postgres, 'feature_flags_teamfeatureflagsconfig', {
+                team_id: teamA,
+                minimal_flag_called_events: true,
+            })
+
+            expect((await teamManager.getTeam(teamA))!.minimal_flag_called_events).toBe(true)
+            expect((await teamManager.getTeam(teamB))!.minimal_flag_called_events).toBe(false)
         })
     })
 

--- a/nodejs/src/common/utils/team-manager.ts
+++ b/nodejs/src/common/utils/team-manager.ts
@@ -134,6 +134,10 @@ export class TeamManager {
                 t.logs_settings,
                 t.extra_settings,
                 extract('epoch' from t.drop_events_older_than) as drop_events_older_than_seconds,
+                COALESCE(
+                    (SELECT minimal_flag_called_events FROM feature_flags_teamfeatureflagsconfig WHERE team_id = t.id),
+                    false
+                ) AS minimal_flag_called_events,
                 o.available_product_features
             FROM posthog_team t
             JOIN posthog_organization o ON o.id = t.organization_id

--- a/nodejs/src/ingestion/common/steps/event-processing/prefetch-hog-functions-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/prefetch-hog-functions-step.test.ts
@@ -20,6 +20,7 @@ const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
     heatmaps_opt_in: null,
     ingested_event: true,
     person_display_name_properties: null,
+    minimal_flag_called_events: false,
     test_account_filters: null,
     cookieless_server_hash_mode: null,
     timezone: 'UTC',

--- a/nodejs/src/ingestion/framework/ingestion-warning-handling-chunk-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/ingestion-warning-handling-chunk-pipeline.test.ts
@@ -40,6 +40,7 @@ function createTestTeam(overrides: Partial<Team> = {}): Team {
         heatmaps_opt_in: null,
         ingested_event: true,
         person_display_name_properties: null,
+        minimal_flag_called_events: false,
         test_account_filters: null,
         cookieless_server_hash_mode: null,
         timezone: 'UTC',

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -281,6 +281,7 @@ export interface Team {
     heatmaps_opt_in: boolean | null
     ingested_event: boolean
     person_display_name_properties: string[] | null
+    minimal_flag_called_events: boolean
     test_account_filters:
         | (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | CohortPropertyFilter)[]
         | null

--- a/nodejs/tests/helpers/ingestion-e2e.ts
+++ b/nodejs/tests/helpers/ingestion-e2e.ts
@@ -67,6 +67,7 @@ export const DEFAULT_TEAM: Team = {
     heatmaps_opt_in: null,
     ingested_event: true,
     person_display_name_properties: null,
+    minimal_flag_called_events: false,
     test_account_filters: null,
     cookieless_server_hash_mode: null,
     timezone: 'UTC',

--- a/nodejs/tests/helpers/team.ts
+++ b/nodejs/tests/helpers/team.ts
@@ -20,6 +20,7 @@ export function createTestTeam(overrides: Partial<Team> = {}): Team {
         heatmaps_opt_in: null,
         ingested_event: true,
         person_display_name_properties: null,
+        minimal_flag_called_events: false,
         test_account_filters: null,
         cookieless_server_hash_mode: null,
         timezone: 'UTC',

--- a/nodejs/tests/ingestion/framework/pipelines.integration.test.ts
+++ b/nodejs/tests/ingestion/framework/pipelines.integration.test.ts
@@ -32,6 +32,7 @@ const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
     heatmaps_opt_in: null,
     ingested_event: true,
     person_display_name_properties: null,
+    minimal_flag_called_events: false,
     test_account_filters: null,
     cookieless_server_hash_mode: null,
     timezone: 'UTC',

--- a/nodejs/tests/ingestion/person-properties-metadata.e2e.test.ts
+++ b/nodejs/tests/ingestion/person-properties-metadata.e2e.test.ts
@@ -52,6 +52,7 @@ const DEFAULT_TEAM: Team = {
     heatmaps_opt_in: null,
     ingested_event: true,
     person_display_name_properties: null,
+    minimal_flag_called_events: false,
     test_account_filters: null,
     cookieless_server_hash_mode: null,
     timezone: 'UTC',

--- a/nodejs/tests/ingestion/person-updates-e2e.test.ts
+++ b/nodejs/tests/ingestion/person-updates-e2e.test.ts
@@ -54,6 +54,7 @@ const DEFAULT_TEAM: Team = {
     heatmaps_opt_in: null,
     ingested_event: true,
     person_display_name_properties: [],
+    minimal_flag_called_events: false,
     person_processing_opt_out: null,
     test_account_filters: [],
     timezone: 'UTC',


### PR DESCRIPTION
## Problem

$feature_flag_called events carry every property on the request, and that payload has grown large from properties that aren't needed for most teams. Stripping them down needs to roll out gradually, team by team, rather than as a single global cutover, so this needs to be a setting we control internally, not a customer-facing toggle.

## Changes

Node's TeamManager now reads a per-team minimal_flag_called_events flag out of feature_flags_teamfeatureflagsconfig and defaults it to false when no config row exists, so nothing changes for any team until we turn it on through the staff API. The value is added to the Team interface and threaded through every test fixture that constructs a full Team object.

This PR only surfaces the setting to the Node ingestion process. The actual property stripping lives in #60569, which currently gates on an env-var exclude list and will be rebased onto this branch to read minimal_flag_called_events instead.

## How did you test this code?

Extended team-manager.test.ts with three cases:
- defaults to false when no TeamFeatureFlagsConfig row exists
- reflects true when a config row is present
- does not leak one team's value into another team's fetch, which guards the WHERE team_id = t.id correlation in the new subquery

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?