### PR TITLE
feat(web-analytics): fleet-wide demand-driven cache warming + dry-run

### DIFF
--- a/posthog/dags/locations/web_analytics.py
+++ b/posthog/dags/locations/web_analytics.py
@@ -55,6 +55,7 @@ defs = dagster.Definitions(
         web_preaggregated_team_selection.web_analytics_team_candidates_job,
         web_analytics_watchdog.web_analytics_watchdog_job,
         cache_warming.web_analytics_cache_warming_job,
+        cache_warming.web_analytics_cache_warming_dry_run_job,
         eager_web_analytics_precompute.web_analytics_eager_baseline_warming_job,
         eager_web_analytics_precompute.web_analytics_eager_backfill_job,
         web_dimensional_precompute.web_dimensional_precompute_job,

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -301,6 +301,11 @@ CONSTANCE_CONFIG = {
         "Teams that will have web analytics cache warming enabled",
         list[int],
     ),
+    "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS": (
+        get_from_env("WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS", default=0, type_cast=int),
+        "Max number of most-active web analytics teams to demand-warm on top of the static list (0 = static list only)",
+        int,
+    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -356,6 +361,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "REDIRECT_APP_TO_US",
     "WEB_ANALYTICS_WARMING_DAYS",
     "WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT",
+    "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -301,9 +301,9 @@ CONSTANCE_CONFIG = {
         "Teams that will have web analytics cache warming enabled",
         list[int],
     ),
-    "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS": (
-        get_from_env("WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS", default=0, type_cast=int),
-        "Max number of most-active web analytics teams to demand-warm on top of the static list (0 = static list only)",
+    "WEB_ANALYTICS_WARMING_MAX_SHAPES": (
+        get_from_env("WEB_ANALYTICS_WARMING_MAX_SHAPES", default=20000, type_cast=int),
+        "Cap on the number of hot query shapes web analytics warming selects fleet-wide per run",
         int,
     ),
 }
@@ -361,7 +361,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "REDIRECT_APP_TO_US",
     "WEB_ANALYTICS_WARMING_DAYS",
     "WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT",
-    "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS",
+    "WEB_ANALYTICS_WARMING_MAX_SHAPES",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)

--- a/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
@@ -77,6 +77,15 @@ class TestIsPrecomputeEnabledForTeam(BaseTest):
 
     @override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[])
     @mock.patch(f"{_COMMON}.is_org_feature_flag_enabled", return_value=False)
+    @mock.patch(f"{_COMMON}.is_background_warming_request", return_value=True)
+    def test_background_warming_bypasses_org_flag(self, _warming, flag) -> None:
+        # Without this bypass, the Dagster warmers (where flag evaluation is
+        # unreliable) silently warm the raw path instead of building buckets.
+        assert is_precompute_enabled_for_team(self.team) is True
+        flag.assert_not_called()
+
+    @override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[])
+    @mock.patch(f"{_COMMON}.is_org_feature_flag_enabled", return_value=False)
     def test_unrestricted_team_is_enrolled_without_being_in_enrollment_list(self, flag) -> None:
         with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_UNRESTRICTED_TEAM_IDS=[self.team.pk]):
             assert is_precompute_enabled_for_team(self.team) is True

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -452,6 +452,13 @@ def is_precompute_enabled_for_team(team: Team) -> bool:
         return True
     if is_precompute_unrestricted_for_team(team):
         return True
+    # Background warmers build buckets for every active team regardless of the
+    # rollout flag: warming precedes read enablement, and flag evaluation is not
+    # reliably available in the Dagster processes the warmers run in. User-facing
+    # reads still require flag enrollment; the restricted filter-shape gate keeps
+    # the warmed set bounded to canonical shapes.
+    if is_background_warming_request():
+        return True
     return is_org_feature_flag_enabled(team)
 
 

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1,4 +1,5 @@
 import json
+import statistics
 
 from django.utils.dateparse import parse_datetime
 
@@ -42,6 +43,11 @@ cache_warming_retry_policy = RetryPolicy(
 LAZY_PRECOMPUTE_QUERY_KINDS = frozenset(
     {"WebStatsTableQuery", "WebOverviewQuery", "WebGoalsQuery", "WebVitalsPathBreakdownQuery"}
 )
+
+# Per-team ceiling on selected shapes. Bounds how much hourly background compute a
+# single tenant can claim by running many distinct shapes past the demand threshold
+# (the queries replay outside the tenant's own request throttles).
+MAX_SHAPES_PER_TEAM = 100
 
 
 def maybe_opt_into_lazy_precompute(query_json: dict) -> dict:
@@ -94,6 +100,7 @@ def queries_to_keep_fresh(
             FROM metrics_query_log_mv
             WHERE
                 timestamp >= now() - INTERVAL %(days)s DAY
+                AND team_id != 0
                 AND (
                     startsWith(query_type, 'stats_table_')
                     -- Overview strategy variants get their own tags (no_join today,
@@ -118,9 +125,15 @@ def queries_to_keep_fresh(
         HAVING query_count >= %(minimum_query_count)s
         ORDER BY
             query_count DESC
+        LIMIT %(max_shapes_per_team)s BY team_id
         LIMIT %(max_shapes)s
         """,
-        {"days": days, "minimum_query_count": minimum_query_count, "max_shapes": max_shapes},
+        {
+            "days": days,
+            "minimum_query_count": minimum_query_count,
+            "max_shapes": max_shapes,
+            "max_shapes_per_team": MAX_SHAPES_PER_TEAM,
+        },
     )
 
     return [
@@ -178,14 +191,14 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
         if team is None:
             continue
 
-        # Tag before any runner work so the whole request — including the lazy
-        # precompute gate, which lets warming traffic through regardless of the
-        # rollout flag — is classified as background warming.
-        tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
-
-        query_json = maybe_opt_into_lazy_precompute(query_json)
-
         try:
+            # Tag before any runner work so the whole request — including the lazy
+            # precompute gate, which lets warming traffic through regardless of the
+            # rollout flag — is classified as background warming.
+            tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
+
+            query_json = maybe_opt_into_lazy_precompute(query_json)
+
             runner = get_query_runner(
                 query=query_json,
                 team=team,
@@ -236,7 +249,7 @@ def report_warming_plan_op(context: dagster.OpExecutionContext, queries: list[di
     per_team = sorted(shapes_per_team.items(), key=lambda x: -x[1])
     shape_counts = [c for _, c in per_team]
     total_underlying_requests = sum(q["query_count"] for q in queries)
-    median_shapes = shape_counts[len(shape_counts) // 2] if shape_counts else 0
+    median_shapes = statistics.median(shape_counts) if shape_counts else 0
 
     context.log.info(
         f"DRY RUN — would warm {len(queries)} query shapes across {len(per_team)} teams "

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -315,3 +315,49 @@ def web_analytics_cache_warming_schedule(context: dagster.ScheduleEvaluationCont
         return skip_reason
 
     return dagster.RunRequest()
+
+
+@dagster.op
+def report_warming_plan_op(context: dagster.OpExecutionContext, queries: dict) -> None:
+    """Dry-run reporter: summarize what the warmer WOULD warm — team count, total query
+    shapes, and the per-team distribution — without running (or precomputing) anything.
+
+    Reuses the real audience + shape-selection ops, so the counts reflect exactly what a
+    live run at the current `WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS` would touch.
+    """
+    per_team = sorted(((team_id, len(qs)) for team_id, qs in queries.items()), key=lambda x: -x[1])
+    shape_counts = [c for _, c in per_team]
+    total_shapes = sum(shape_counts)
+    total_underlying_requests = sum(qi["query_count"] for qs in queries.values() for qi in qs)
+    median_shapes = shape_counts[len(shape_counts) // 2] if shape_counts else 0
+
+    context.log.info(
+        f"DRY RUN — would warm {total_shapes} query shapes across {len(per_team)} teams "
+        f"(~{total_underlying_requests} underlying requests over the warming window). "
+        f"Per-team shapes: max={shape_counts[0] if shape_counts else 0}, median={median_shapes}. "
+        f"Top teams by shape count: {per_team[:10]}"
+    )
+    context.add_output_metadata(
+        {
+            "dry_run": True,
+            "team_count": len(per_team),
+            "total_query_shapes_to_warm": total_shapes,
+            "total_underlying_requests": total_underlying_requests,
+            "max_shapes_per_team": shape_counts[0] if shape_counts else 0,
+            "median_shapes_per_team": median_shapes,
+            "top_10_teams_by_shape_count": str(per_team[:10]),
+        }
+    )
+
+
+@dagster.job(
+    description="Dry run: report how many web analytics query shapes cache warming would warm, without warming",
+    tags={
+        "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
+        "dagster/web_analytics_cache_warming": "web_analytics_cache_warming_dry_run",
+    },
+)
+def web_analytics_cache_warming_dry_run_job():
+    team_ids = get_teams_for_warming_op()
+    queries = get_queries_for_teams_op(team_ids)
+    report_warming_plan_op(queries)

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -11,7 +11,6 @@ from posthog.hogql.constants import LimitContext
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.dags.common import JobOwners
-from posthog.dags.common.resources import PostHogAnalyticsResource
 from posthog.event_usage import EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache import DjangoCacheQueryCacheManager
@@ -19,18 +18,16 @@ from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.models import Team
 from posthog.models.instance_setting import get_instance_setting
 
-from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import is_precompute_enabled_for_team
 from products.web_analytics.dags.web_preaggregated_utils import check_for_concurrent_runs
 
-STALE_WEB_QUERIES_GAUGE = Gauge(
-    "posthog_cache_warming_stale_web_query_gauge",
-    "Number of stale web queries present",
-    ["team_id"],
+WARMING_SHAPES_SELECTED_GAUGE = Gauge(
+    "posthog_web_analytics_warming_shapes_selected",
+    "Number of hot query shapes selected for web analytics warming in the last run",
 )
-PRIORITY_WEB_QUERIES_COUNTER = Counter(
-    "posthog_cache_warming_priority_web_queries",
-    "Number of priority web queries warmed",
-    ["team_id", "normalized_query_hash", "is_cached"],
+WARMING_QUERIES_COUNTER = Counter(
+    "posthog_web_analytics_warming_queries_total",
+    "Web analytics warming outcomes per query shape",
+    ["outcome"],  # warmed | skipped_fresh | failed
 )
 
 cache_warming_retry_policy = RetryPolicy(
@@ -41,90 +38,44 @@ cache_warming_retry_policy = RetryPolicy(
 )
 
 
-def increment_counter(team_id: int, normalized_query_hash: str, is_cached: bool):
-    PRIORITY_WEB_QUERIES_COUNTER.labels(
-        team_id=team_id,
-        normalized_query_hash=normalized_query_hash,
-        is_cached=is_cached,
-    ).inc()
-
-
-def get_teams_enabled_for_web_analytics_cache_warming() -> list[int]:
-    value = get_instance_setting("WEB_ANALYTICS_WARMING_TEAMS_TO_WARM")
-    return value if isinstance(value, list) else []
-
-
-def get_active_web_analytics_team_ids(limit: int, lookback_hours: int = 24) -> list[int]:
-    """Top teams by deliberate WA dashboard activity (stats-table tile queries),
-    most active first — the demand-driven audience layered on top of the static
-    warming list.
-
-    Best-effort: any failure returns [] so warming falls back to the static list
-    rather than skipping the run.
-    """
-    if limit <= 0:
-        return []
-    try:
-        rows = sync_execute(
-            """
-            SELECT JSONExtractInt(log_comment, 'team_id') AS team_id, count() AS n
-            FROM clusterAllReplicas(%(cluster)s, system, query_log)
-            WHERE event_time > now() - INTERVAL %(hours)s HOUR
-              AND type = 'QueryFinish' AND is_initial_query = 1
-              AND JSONExtractString(log_comment, 'query_type') LIKE 'stats_table%%'
-              AND JSONExtractString(log_comment, 'feature') != 'cache_warmup'
-              AND JSONExtractString(log_comment, 'trigger') = ''
-              AND JSONExtractString(log_comment, 'access_method') != 'personal_api_key'
-              AND team_id != 0
-            GROUP BY team_id
-            ORDER BY n DESC
-            LIMIT %(limit)s
-            """,
-            {"cluster": "posthog", "hours": lookback_hours, "limit": limit},
-        )
-        return [int(row[0]) for row in rows]
-    except Exception as e:
-        capture_exception(e)
-        return []
-
-
-# Query kinds that carry the `useWebAnalyticsPrecompute` per-query opt-in.
+# Query kinds that carry the `useWebAnalyticsPrecompute` per-query toggle.
 LAZY_PRECOMPUTE_QUERY_KINDS = frozenset(
     {"WebStatsTableQuery", "WebOverviewQuery", "WebGoalsQuery", "WebVitalsPathBreakdownQuery"}
 )
 
 
-def maybe_opt_into_lazy_precompute(team: Team, query_json: dict) -> dict:
-    """Opt an enrolled team's replayed query into the lazy precompute path.
+def maybe_opt_into_lazy_precompute(query_json: dict) -> dict:
+    """Opt a replayed query into the lazy precompute path.
 
-    Replayed queries are the team's real production shapes, which for a
-    restricted-enrolled team carry no per-query opt-in (users only send one via
-    the UI toggle). Without this, warming such a team never computes its lazy
-    jobs — so enrolling a team on `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` plus
-    this warming list is what populates its precompute from real query shapes
-    while its user-facing reads stay on the raw path (their queries still have
-    no opt-in). That combination is how a team is evaluated before its reads
-    are switched over.
-
-    The opt-in changes the runner's cache key, so the warmed Django-cache entry
-    differs from the one raw user reads hit — acceptable: the durable output of
-    warming an enrolled team is the precompute jobs (shared by query shape),
-    not the result-cache row.
+    Replayed production shapes carry no per-query toggle (users only send one via
+    the UI). Injecting an explicit `True` makes the warmer build precompute
+    buckets regardless of the opt-in default in the runner's eligibility gate,
+    while an explicit user `False` in the replayed shape is preserved. Whether a
+    team may build buckets at all is decided by the runner's own gate — warming
+    requests bypass the rollout flag there, so this injection needs no
+    enablement check (flag evaluation is unreliable in Dagster anyway).
     """
     if query_json.get("kind") not in LAZY_PRECOMPUTE_QUERY_KINDS:
         return query_json
     if query_json.get("useWebAnalyticsPrecompute") is not None:
         return query_json
-    if not is_precompute_enabled_for_team(team):
-        return query_json
     return {**query_json, "useWebAnalyticsPrecompute": True}
 
 
 def queries_to_keep_fresh(
-    context: dagster.OpExecutionContext, team_id: int, days: int = 7, minimum_query_count: int = 10
+    context: dagster.OpExecutionContext, days: int = 7, minimum_query_count: int = 10, max_shapes: int = 20000
 ) -> list[dict]:
+    """Fleet-wide demand selection: every (team, query shape) with at least
+    `minimum_query_count` runs in the window, hottest first, capped at
+    `max_shapes`.
+
+    The audience is implicit — any team with a hot shape is active on web
+    analytics and benefits from warming. One batched query replaces the previous
+    per-team loop, which could not scale past a handful of teams.
+    """
     context.log.info(
-        f"Searching the last {days} days for team {team_id}'s queries with at least {minimum_query_count} runs."
+        f"Selecting fleet-wide web analytics queries with >= {minimum_query_count} runs "
+        f"in the last {days} days (cap {max_shapes} shapes)."
     )
 
     results = sync_execute(
@@ -143,7 +94,6 @@ def queries_to_keep_fresh(
             FROM metrics_query_log_mv
             WHERE
                 timestamp >= now() - INTERVAL %(days)s DAY
-                AND team_id = %(team_id)s
                 AND (
                     startsWith(query_type, 'stats_table_')
                     -- Overview strategy variants get their own tags (no_join today,
@@ -168,8 +118,9 @@ def queries_to_keep_fresh(
         HAVING query_count >= %(minimum_query_count)s
         ORDER BY
             query_count DESC
+        LIMIT %(max_shapes)s
         """,
-        {"team_id": team_id, "days": days, "minimum_query_count": minimum_query_count},
+        {"days": days, "minimum_query_count": minimum_query_count, "max_shapes": max_shapes},
     )
 
     return [
@@ -183,77 +134,58 @@ def queries_to_keep_fresh(
     ]
 
 
-@dagster.op()
-def get_teams_for_warming_op(
-    context: dagster.OpExecutionContext, posthoganalytics: PostHogAnalyticsResource
-) -> list[int]:
-    static_team_ids = get_teams_enabled_for_web_analytics_cache_warming()
-
-    max_active = get_instance_setting("WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS") or 0
-    active_team_ids = get_active_web_analytics_team_ids(max_active)
-
-    # Static list first so always-enrolled teams warm before the demand ramp when
-    # a run is truncated; dict.fromkeys dedupes teams in both lists, preserving order.
-    team_ids = list(dict.fromkeys([*static_team_ids, *active_team_ids]))
-
-    context.log.info(
-        f"Found {len(team_ids)} teams for cache warming "
-        f"({len(static_team_ids)} static, {len(active_team_ids)} demand-driven active)"
-    )
-    context.add_output_metadata(
-        {
-            "team_count": len(team_ids),
-            "static_teams": len(static_team_ids),
-            "active_teams": len(active_team_ids),
-            "team_ids": str(team_ids),
-        }
-    )
-    return team_ids
-
-
 @dagster.op
-def get_queries_for_teams_op(
-    context: dagster.OpExecutionContext,
-    team_ids: list[int],
-) -> dict:
+def get_warmable_queries_op(context: dagster.OpExecutionContext) -> list[dict]:
     days = get_instance_setting("WEB_ANALYTICS_WARMING_DAYS")
     minimum_query_count = get_instance_setting("WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT")
+    max_shapes = get_instance_setting("WEB_ANALYTICS_WARMING_MAX_SHAPES")
 
-    all_queries = {}
-    query_count = 0
-    for team_id in team_ids:
-        queries = queries_to_keep_fresh(context, team_id, days=days, minimum_query_count=minimum_query_count)
+    queries = queries_to_keep_fresh(context, days=days, minimum_query_count=minimum_query_count, max_shapes=max_shapes)
+    team_count = len({q["team_id"] for q in queries})
 
-        context.log.info(f"Loading {len(queries)} frequent web analytics queries for team {team_id}")
-
-        STALE_WEB_QUERIES_GAUGE.labels(team_id=team_id).set(len(queries))
-        all_queries[team_id] = queries
-        query_count += len(queries)
-
-    context.log.info(f"Found {query_count} total queries to warm")
-    context.add_output_metadata({"query_count": query_count, "team_count": len(team_ids)})
-    return all_queries
+    WARMING_SHAPES_SELECTED_GAUGE.set(len(queries))
+    context.log.info(f"Selected {len(queries)} hot query shapes across {team_count} teams")
+    context.add_output_metadata(
+        {
+            "query_count": len(queries),
+            "team_count": team_count,
+            "cap_reached": len(queries) >= max_shapes,
+        }
+    )
+    return queries
 
 
 @dagster.op(retry_policy=cache_warming_retry_policy)
-def warm_queries_op(context: dagster.OpExecutionContext, queries: dict) -> None:
+def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) -> None:
     queries_warmed = 0
     queries_skipped = 0
+    queries_failed = 0
 
-    for team_id, query_infos in queries.items():
-        try:
-            team = Team.objects.get(pk=team_id)
-        except Team.DoesNotExist:
-            context.log.warning(f"Team {team_id} not found, skipping")
+    teams: dict[int, Team | None] = {}
+
+    for query_info in queries:
+        team_id = query_info["team_id"]
+        query_json = query_info["query_json"]
+        normalized_query_hash = query_info["normalized_query_hash"]
+
+        if team_id not in teams:
+            try:
+                teams[team_id] = Team.objects.get(pk=team_id)
+            except Team.DoesNotExist:
+                context.log.warning(f"Team {team_id} not found, skipping")
+                teams[team_id] = None
+        team = teams[team_id]
+        if team is None:
             continue
 
-        for query_info in query_infos:
-            team_id = query_info["team_id"]
-            query_json = query_info["query_json"]
-            normalized_query_hash = query_info["normalized_query_hash"]
+        # Tag before any runner work so the whole request — including the lazy
+        # precompute gate, which lets warming traffic through regardless of the
+        # rollout flag — is classified as background warming.
+        tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
 
-            query_json = maybe_opt_into_lazy_precompute(team, query_json)
+        query_json = maybe_opt_into_lazy_precompute(query_json)
 
+        try:
             runner = get_query_runner(
                 query=query_json,
                 team=team,
@@ -261,46 +193,92 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: dict) -> None:
             )
 
             cache_manager = DjangoCacheQueryCacheManager(team_id=team.pk, cache_key=runner.get_cache_key())
+            cached_data = cache_manager.get_cache_data()
 
-            try:
-                cached_data = cache_manager.get_cache_data()
+            if cached_data is not None:
+                last_refresh = parse_datetime(cached_data["last_refresh"])
+                is_stale = runner._is_stale(last_refresh)
 
-                if cached_data is not None:
-                    last_refresh = parse_datetime(cached_data["last_refresh"])
-                    is_stale = runner._is_stale(last_refresh)
+                if not is_stale:
+                    WARMING_QUERIES_COUNTER.labels(outcome="skipped_fresh").inc()
+                    queries_skipped += 1
+                    continue
 
-                    if not is_stale:
-                        context.log.info(f"Query hash {normalized_query_hash} already cached, skipping warmup.")
-                        increment_counter(team_id, normalized_query_hash, is_cached=True)
-                        queries_skipped += 1
-                        continue
+            # TODO: We shouldn't try to run a query if it failed last run
+            runner.run(analytics_props={"source": EventSource.CACHE_WARMING})
+            WARMING_QUERIES_COUNTER.labels(outcome="warmed").inc()
+            queries_warmed += 1
 
-                tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
+        except Exception as e:
+            context.log.exception(f"Error warming query {normalized_query_hash} for team {team_id}")
+            capture_exception(e)
+            WARMING_QUERIES_COUNTER.labels(outcome="failed").inc()
+            queries_failed += 1
 
-                # TODO: We shouldn't try to run a query if it failed last run
-                runner.run(analytics_props={"source": EventSource.CACHE_WARMING})
-                increment_counter(team_id, normalized_query_hash, is_cached=False)
-                queries_warmed += 1
+    context.log.info(f"Warmed {queries_warmed} queries ({queries_skipped} already fresh, {queries_failed} failed)")
+    context.add_output_metadata(
+        {"queries_warmed": queries_warmed, "queries_skipped": queries_skipped, "queries_failed": queries_failed}
+    )
 
-            except Exception as e:
-                context.log.exception(f"Error warming query for team {team_id}")
-                capture_exception(e)
 
-    context.log.info(f"Warmed {queries_warmed} queries ({queries_skipped} were already cached)")
-    context.add_output_metadata({"queries_warmed": queries_warmed, "queries_skipped": queries_skipped})
+@dagster.op
+def report_warming_plan_op(context: dagster.OpExecutionContext, queries: list[dict]) -> None:
+    """Dry-run reporter: summarize what the warmer WOULD warm — team count, total
+    query shapes, and the per-team distribution — without running (or
+    precomputing) anything.
+
+    Reuses the real selection op, so the counts reflect exactly what a live run
+    at the current settings would touch.
+    """
+    shapes_per_team: dict[int, int] = {}
+    for q in queries:
+        shapes_per_team[q["team_id"]] = shapes_per_team.get(q["team_id"], 0) + 1
+    per_team = sorted(shapes_per_team.items(), key=lambda x: -x[1])
+    shape_counts = [c for _, c in per_team]
+    total_underlying_requests = sum(q["query_count"] for q in queries)
+    median_shapes = shape_counts[len(shape_counts) // 2] if shape_counts else 0
+
+    context.log.info(
+        f"DRY RUN — would warm {len(queries)} query shapes across {len(per_team)} teams "
+        f"(~{total_underlying_requests} underlying requests over the warming window). "
+        f"Per-team shapes: max={shape_counts[0] if shape_counts else 0}, median={median_shapes}. "
+        f"Top teams by shape count: {per_team[:10]}"
+    )
+    context.add_output_metadata(
+        {
+            "dry_run": True,
+            "team_count": len(per_team),
+            "total_query_shapes_to_warm": len(queries),
+            "total_underlying_requests": total_underlying_requests,
+            "max_shapes_per_team": shape_counts[0] if shape_counts else 0,
+            "median_shapes_per_team": median_shapes,
+            "top_10_teams_by_shape_count": str(per_team[:10]),
+        }
+    )
 
 
 @dagster.job(
-    description="Warms web analytics query cache for frequently-run queries",
+    description="Warms web analytics query cache and precompute buckets for frequently-run queries fleet-wide",
     tags={
         "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
         "dagster/web_analytics_cache_warming": "web_analytics_cache_warming",
     },
 )
 def web_analytics_cache_warming_job():
-    team_ids = get_teams_for_warming_op()
-    queries = get_queries_for_teams_op(team_ids)
+    queries = get_warmable_queries_op()
     warm_queries_op(queries)
+
+
+@dagster.job(
+    description="Dry run: report how many web analytics query shapes cache warming would warm, without warming",
+    tags={
+        "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
+        "dagster/web_analytics_cache_warming": "web_analytics_cache_warming_dry_run",
+    },
+)
+def web_analytics_cache_warming_dry_run_job():
+    queries = get_warmable_queries_op()
+    report_warming_plan_op(queries)
 
 
 @dagster.schedule(
@@ -315,49 +293,3 @@ def web_analytics_cache_warming_schedule(context: dagster.ScheduleEvaluationCont
         return skip_reason
 
     return dagster.RunRequest()
-
-
-@dagster.op
-def report_warming_plan_op(context: dagster.OpExecutionContext, queries: dict) -> None:
-    """Dry-run reporter: summarize what the warmer WOULD warm — team count, total query
-    shapes, and the per-team distribution — without running (or precomputing) anything.
-
-    Reuses the real audience + shape-selection ops, so the counts reflect exactly what a
-    live run at the current `WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS` would touch.
-    """
-    per_team = sorted(((team_id, len(qs)) for team_id, qs in queries.items()), key=lambda x: -x[1])
-    shape_counts = [c for _, c in per_team]
-    total_shapes = sum(shape_counts)
-    total_underlying_requests = sum(qi["query_count"] for qs in queries.values() for qi in qs)
-    median_shapes = shape_counts[len(shape_counts) // 2] if shape_counts else 0
-
-    context.log.info(
-        f"DRY RUN — would warm {total_shapes} query shapes across {len(per_team)} teams "
-        f"(~{total_underlying_requests} underlying requests over the warming window). "
-        f"Per-team shapes: max={shape_counts[0] if shape_counts else 0}, median={median_shapes}. "
-        f"Top teams by shape count: {per_team[:10]}"
-    )
-    context.add_output_metadata(
-        {
-            "dry_run": True,
-            "team_count": len(per_team),
-            "total_query_shapes_to_warm": total_shapes,
-            "total_underlying_requests": total_underlying_requests,
-            "max_shapes_per_team": shape_counts[0] if shape_counts else 0,
-            "median_shapes_per_team": median_shapes,
-            "top_10_teams_by_shape_count": str(per_team[:10]),
-        }
-    )
-
-
-@dagster.job(
-    description="Dry run: report how many web analytics query shapes cache warming would warm, without warming",
-    tags={
-        "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
-        "dagster/web_analytics_cache_warming": "web_analytics_cache_warming_dry_run",
-    },
-)
-def web_analytics_cache_warming_dry_run_job():
-    team_ids = get_teams_for_warming_op()
-    queries = get_queries_for_teams_op(team_ids)
-    report_warming_plan_op(queries)

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -54,6 +54,40 @@ def get_teams_enabled_for_web_analytics_cache_warming() -> list[int]:
     return value if isinstance(value, list) else []
 
 
+def get_active_web_analytics_team_ids(limit: int, lookback_hours: int = 24) -> list[int]:
+    """Top teams by deliberate WA dashboard activity (stats-table tile queries),
+    most active first — the demand-driven audience layered on top of the static
+    warming list.
+
+    Best-effort: any failure returns [] so warming falls back to the static list
+    rather than skipping the run.
+    """
+    if limit <= 0:
+        return []
+    try:
+        rows = sync_execute(
+            """
+            SELECT JSONExtractInt(log_comment, 'team_id') AS team_id, count() AS n
+            FROM clusterAllReplicas(%(cluster)s, system, query_log)
+            WHERE event_time > now() - INTERVAL %(hours)s HOUR
+              AND type = 'QueryFinish' AND is_initial_query = 1
+              AND JSONExtractString(log_comment, 'query_type') LIKE 'stats_table%%'
+              AND JSONExtractString(log_comment, 'feature') != 'cache_warmup'
+              AND JSONExtractString(log_comment, 'trigger') = ''
+              AND JSONExtractString(log_comment, 'access_method') != 'personal_api_key'
+              AND team_id != 0
+            GROUP BY team_id
+            ORDER BY n DESC
+            LIMIT %(limit)s
+            """,
+            {"cluster": "posthog", "hours": lookback_hours, "limit": limit},
+        )
+        return [int(row[0]) for row in rows]
+    except Exception as e:
+        capture_exception(e)
+        return []
+
+
 # Query kinds that carry the `useWebAnalyticsPrecompute` per-query opt-in.
 LAZY_PRECOMPUTE_QUERY_KINDS = frozenset(
     {"WebStatsTableQuery", "WebOverviewQuery", "WebGoalsQuery", "WebVitalsPathBreakdownQuery"}
@@ -153,10 +187,27 @@ def queries_to_keep_fresh(
 def get_teams_for_warming_op(
     context: dagster.OpExecutionContext, posthoganalytics: PostHogAnalyticsResource
 ) -> list[int]:
-    team_ids = get_teams_enabled_for_web_analytics_cache_warming()
+    static_team_ids = get_teams_enabled_for_web_analytics_cache_warming()
 
-    context.log.info(f"Found {len(team_ids)} teams for cache warming")
-    context.add_output_metadata({"team_count": len(team_ids), "team_ids": str(team_ids)})
+    max_active = get_instance_setting("WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS") or 0
+    active_team_ids = get_active_web_analytics_team_ids(max_active)
+
+    # Static list first so always-enrolled teams warm before the demand ramp when
+    # a run is truncated; dict.fromkeys dedupes teams in both lists, preserving order.
+    team_ids = list(dict.fromkeys([*static_team_ids, *active_team_ids]))
+
+    context.log.info(
+        f"Found {len(team_ids)} teams for cache warming "
+        f"({len(static_team_ids)} static, {len(active_team_ids)} demand-driven active)"
+    )
+    context.add_output_metadata(
+        {
+            "team_count": len(team_ids),
+            "static_teams": len(static_team_ids),
+            "active_teams": len(active_team_ids),
+            "team_ids": str(team_ids),
+        }
+    )
     return team_ids
 
 

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -1,8 +1,14 @@
 from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
 
+import dagster
 from parameterized import parameterized
 
-from products.web_analytics.dags.cache_warming import maybe_opt_into_lazy_precompute
+from products.web_analytics.dags.cache_warming import (
+    get_active_web_analytics_team_ids,
+    get_teams_for_warming_op,
+    maybe_opt_into_lazy_precompute,
+)
 
 
 class TestMaybeOptIntoLazyPrecompute(BaseTest):
@@ -32,3 +38,51 @@ class TestMaybeOptIntoLazyPrecompute(BaseTest):
             result = maybe_opt_into_lazy_precompute(self.team, query)
 
         self.assertEqual(result, query)
+
+
+class TestActiveWebAnalyticsTeamIds(BaseTest):
+    @patch("products.web_analytics.dags.cache_warming.sync_execute")
+    def test_zero_limit_skips_clickhouse(self, mock_exec: MagicMock) -> None:
+        # Ramp knob off (the default) must not run a fleet-wide query_log scan every hour.
+        self.assertEqual(get_active_web_analytics_team_ids(0), [])
+        mock_exec.assert_not_called()
+
+    @patch("products.web_analytics.dags.cache_warming.sync_execute")
+    def test_returns_ranked_team_ids(self, mock_exec: MagicMock) -> None:
+        mock_exec.return_value = [(101, 50), (202, 20)]
+        self.assertEqual(get_active_web_analytics_team_ids(5), [101, 202])
+
+    @patch("products.web_analytics.dags.cache_warming.sync_execute", side_effect=Exception("clickhouse down"))
+    def test_clickhouse_failure_falls_back_to_empty(self, _mock_exec: MagicMock) -> None:
+        # Best-effort: a CH blip must fall back to the static list, not skip the whole run.
+        self.assertEqual(get_active_web_analytics_team_ids(5), [])
+
+
+class TestWarmingAudience(BaseTest):
+    @patch("products.web_analytics.dags.cache_warming.sync_execute")
+    @patch("products.web_analytics.dags.cache_warming.get_instance_setting")
+    def test_unions_static_and_active_deduped_static_first(self, mock_setting: MagicMock, mock_exec: MagicMock) -> None:
+        # A team present in both the static list and the active audience must warm
+        # once (not twice), and static teams come first so a truncated run covers them.
+        mock_setting.side_effect = lambda key: {
+            "WEB_ANALYTICS_WARMING_TEAMS_TO_WARM": [2, 7],
+            "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS": 3,
+        }[key]
+        mock_exec.return_value = [(7, 50), (9, 20)]  # team 7 overlaps the static list
+
+        result = get_teams_for_warming_op(dagster.build_op_context(), MagicMock())
+
+        self.assertEqual(result, [2, 7, 9])
+
+    @patch("products.web_analytics.dags.cache_warming.sync_execute")
+    @patch("products.web_analytics.dags.cache_warming.get_instance_setting")
+    def test_disabled_ramp_returns_only_static(self, mock_setting: MagicMock, mock_exec: MagicMock) -> None:
+        mock_setting.side_effect = lambda key: {
+            "WEB_ANALYTICS_WARMING_TEAMS_TO_WARM": [2],
+            "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS": 0,
+        }[key]
+
+        result = get_teams_for_warming_op(dagster.build_op_context(), MagicMock())
+
+        self.assertEqual(result, [2])
+        mock_exec.assert_not_called()

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -5,19 +5,18 @@ import dagster
 from parameterized import parameterized
 
 from products.web_analytics.dags.cache_warming import (
-    get_active_web_analytics_team_ids,
-    get_teams_for_warming_op,
+    get_warmable_queries_op,
     maybe_opt_into_lazy_precompute,
+    queries_to_keep_fresh,
 )
 
 
 class TestMaybeOptIntoLazyPrecompute(BaseTest):
-    def test_enrolled_team_web_query_gets_opt_in(self) -> None:
-        # If this breaks, warming an enrolled-but-restricted team silently stops
-        # computing its lazy jobs — the pre-enrollment evaluation pipeline reads empty.
+    def test_web_query_gets_opt_in(self) -> None:
+        # If this breaks, the warmer silently stops building precompute buckets
+        # for replayed shapes wherever the opt-in default still applies.
         query = {"kind": "WebStatsTableQuery", "properties": []}
-        with self.settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[self.team.id]):
-            result = maybe_opt_into_lazy_precompute(self.team, query)
+        result = maybe_opt_into_lazy_precompute(query)
 
         self.assertIs(result["useWebAnalyticsPrecompute"], True)
         self.assertNotIn("useWebAnalyticsPrecompute", query)  # input not mutated
@@ -25,64 +24,48 @@ class TestMaybeOptIntoLazyPrecompute(BaseTest):
     @parameterized.expand(
         [
             # Non-web kinds don't carry the field; injecting it would break validation.
-            ("non_web_kind", {"kind": "TrendsQuery"}, True),
-            # Teams outside the enrollment lists must warm exactly what users run.
-            ("not_enrolled", {"kind": "WebStatsTableQuery"}, False),
+            ("non_web_kind", {"kind": "TrendsQuery"}),
             # An explicit user opt-out in the replayed shape is preserved.
-            ("explicit_opt_out", {"kind": "WebStatsTableQuery", "useWebAnalyticsPrecompute": False}, True),
+            ("explicit_opt_out", {"kind": "WebStatsTableQuery", "useWebAnalyticsPrecompute": False}),
+            ("explicit_opt_in", {"kind": "WebOverviewQuery", "useWebAnalyticsPrecompute": True}),
         ]
     )
-    def test_leaves_query_untouched(self, _name: str, query: dict, enrolled: bool) -> None:
-        team_ids = [self.team.id] if enrolled else []
-        with self.settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=team_ids):
-            result = maybe_opt_into_lazy_precompute(self.team, query)
-
-        self.assertEqual(result, query)
+    def test_leaves_query_untouched(self, _name: str, query: dict) -> None:
+        self.assertEqual(maybe_opt_into_lazy_precompute(query), query)
 
 
-class TestActiveWebAnalyticsTeamIds(BaseTest):
+class TestFleetQuerySelection(BaseTest):
     @patch("products.web_analytics.dags.cache_warming.sync_execute")
-    def test_zero_limit_skips_clickhouse(self, mock_exec: MagicMock) -> None:
-        # Ramp knob off (the default) must not run a fleet-wide query_log scan every hour.
-        self.assertEqual(get_active_web_analytics_team_ids(0), [])
-        mock_exec.assert_not_called()
+    def test_parses_fleet_rows_into_query_infos(self, mock_exec: MagicMock) -> None:
+        # Guards the row-shape contract with the selection SQL: a column reorder
+        # or JSON handling change would make the warmer warm nothing or crash.
+        mock_exec.return_value = [
+            (101, '{"kind": "WebOverviewQuery"}', 50, "hash-a"),
+            (202, '{"kind": "WebStatsTableQuery"}', 12, "hash-b"),
+        ]
+        result = queries_to_keep_fresh(dagster.build_op_context(), days=7, minimum_query_count=10, max_shapes=100)
 
-    @patch("products.web_analytics.dags.cache_warming.sync_execute")
-    def test_returns_ranked_team_ids(self, mock_exec: MagicMock) -> None:
-        mock_exec.return_value = [(101, 50), (202, 20)]
-        self.assertEqual(get_active_web_analytics_team_ids(5), [101, 202])
+        self.assertEqual(
+            result,
+            [
+                {
+                    "team_id": 101,
+                    "query_json": {"kind": "WebOverviewQuery"},
+                    "query_count": 50,
+                    "normalized_query_hash": "hash-a",
+                },
+                {
+                    "team_id": 202,
+                    "query_json": {"kind": "WebStatsTableQuery"},
+                    "query_count": 12,
+                    "normalized_query_hash": "hash-b",
+                },
+            ],
+        )
 
-    @patch("products.web_analytics.dags.cache_warming.sync_execute", side_effect=Exception("clickhouse down"))
-    def test_clickhouse_failure_falls_back_to_empty(self, _mock_exec: MagicMock) -> None:
-        # Best-effort: a CH blip must fall back to the static list, not skip the whole run.
-        self.assertEqual(get_active_web_analytics_team_ids(5), [])
-
-
-class TestWarmingAudience(BaseTest):
-    @patch("products.web_analytics.dags.cache_warming.sync_execute")
-    @patch("products.web_analytics.dags.cache_warming.get_instance_setting")
-    def test_unions_static_and_active_deduped_static_first(self, mock_setting: MagicMock, mock_exec: MagicMock) -> None:
-        # A team present in both the static list and the active audience must warm
-        # once (not twice), and static teams come first so a truncated run covers them.
-        mock_setting.side_effect = lambda key: {
-            "WEB_ANALYTICS_WARMING_TEAMS_TO_WARM": [2, 7],
-            "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS": 3,
-        }[key]
-        mock_exec.return_value = [(7, 50), (9, 20)]  # team 7 overlaps the static list
-
-        result = get_teams_for_warming_op(dagster.build_op_context(), MagicMock())
-
-        self.assertEqual(result, [2, 7, 9])
-
-    @patch("products.web_analytics.dags.cache_warming.sync_execute")
-    @patch("products.web_analytics.dags.cache_warming.get_instance_setting")
-    def test_disabled_ramp_returns_only_static(self, mock_setting: MagicMock, mock_exec: MagicMock) -> None:
-        mock_setting.side_effect = lambda key: {
-            "WEB_ANALYTICS_WARMING_TEAMS_TO_WARM": [2],
-            "WEB_ANALYTICS_WARMING_MAX_ACTIVE_TEAMS": 0,
-        }[key]
-
-        result = get_teams_for_warming_op(dagster.build_op_context(), MagicMock())
-
-        self.assertEqual(result, [2])
-        mock_exec.assert_not_called()
+    @patch("products.web_analytics.dags.cache_warming.sync_execute", return_value=[])
+    def test_op_reads_instance_settings(self, _mock_exec: MagicMock) -> None:
+        # Runs the op against the real instance-setting machinery so a renamed or
+        # unregistered setting key fails here instead of at the hourly run.
+        result = get_warmable_queries_op(dagster.build_op_context())
+        self.assertEqual(result, [])


### PR DESCRIPTION
## Problem

Web analytics cache warming only served a small static instance-setting team list, and its per-team selection loop (one ClickHouse query per team) could not scale beyond that. Meanwhile precompute bucket-building during warming depended on the rollout flag, whose local evaluation is unreliable in the Dagster processes the warmers run in — so warming flag-enrolled teams could silently warm the raw path instead of building buckets. We want warming to cover every team that is actively using web analytics, with no flag dependency, the same audience philosophy as the (deprecated) eager baseline warmer.

## Changes

- **Fleet-wide demand selection**: `queries_to_keep_fresh` is now a single batched query over `metrics_query_log_mv` — every (team, query shape) with ≥ `WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT` runs in the window, hottest first, capped by the new `WEB_ANALYTICS_WARMING_MAX_SHAPES` dynamic setting (default 20000). The audience is implicit: any team with a hot shape. The static team list, the per-team loop, and the audience-ramp machinery from earlier commits on this branch are removed.
- **Warming bypasses the precompute rollout flag**: `is_precompute_enabled_for_team` now returns enabled for background-warming requests (identified by the existing warming trigger tags), so warmers build buckets for their whole audience without evaluating the flag. User-facing reads still require enrollment, and the restricted filter-shape gate keeps the warmed set bounded to canonical shapes. `maybe_opt_into_lazy_precompute` drops its (Dagster-unreliable) enablement check and simply injects the opt-in for web query kinds, preserving explicit user opt-outs.
- **Cardinality-safe metrics**: the per-team gauge and the per-(team, query-hash) counter are replaced by an unlabeled selected-shapes gauge and an `outcome`-labeled counter (`warmed` / `skipped_fresh` / `failed`) — the old label sets would explode at fleet scale.
- **Dry-run job** (`web_analytics_cache_warming_dry_run_job`): runs the real selection and reports team count / total shapes / per-team distribution without warming anything — use it to size the warm before enabling the schedule at fleet scope.

The hourly schedule, freshness skip (already-cached-and-fresh shapes are skipped), and concurrent-run guard are unchanged; runaway runs self-limit via the existing skip-if-in-flight schedule check.

## How did you test this code?

`test_cache_warming.py` rewritten for the new design: opt-in injection (web kinds injected, non-web/explicit-opt-out/explicit-opt-in untouched, input not mutated — guards the warmer silently not building buckets), fleet row parsing (guards the SQL row-shape contract), and an op-level test through the real instance-setting machinery (guards a renamed/unregistered setting key). Added `test_background_warming_bypasses_org_flag` to the precompute gate tests — without the bypass, Dagster warmers silently warm the raw path; no existing test covered the gate under a warming trigger. 13 tests pass; both Dagster jobs verified to construct and load.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change; internal warming tooling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code as part of the precompute fleet-release effort. Lucas chose fleet-wide no-flag warming over a flag-gated audience ramp for simplicity and reliability, accepting the extra build compute; the earlier commits' audience-knob approach on this branch was superseded by this design. Skills invoked: /writing-tests.
- Key decisions: audience is implicit in the demand query (any team with a hot shape) rather than enumerated; warming bypasses the rollout flag at the gate (flag evaluation is unreliable in Dagster — documented in `is_precompute_enabled_for_team`); high-cardinality metric labels dropped before they could explode at fleet scale.
- Related: #72645 (default-on precompute reads for enrolled teams) — together these implement warm-before-read for the precompute rollout.
