### PR TITLE
chore(ci): recognize underscore and singular feature-flag scopes in auto-labeler

### DIFF
--- a/.github/auto-assign-labels.json
+++ b/.github/auto-assign-labels.json
@@ -2,7 +2,7 @@
     "_comment": "Maps a PR's conventional-commit scope (the part in parens of `type(scope): summary`) to labels the Auto Assign Labels workflow applies. Owned by @PostHog/team-feature-flags via owners.yaml, so mappings can change without editing the workflow or script. Scopes are matched case-insensitively. Labels must already exist in the repo. Add a new object to `rules` to map more scopes.",
     "rules": [
         {
-            "scopes": ["flags", "feature-flags"],
+            "scopes": ["flags", "flag", "feature-flags", "feature-flag", "feature_flags", "feature_flag"],
             "labels": ["feature/feature-flags", "team/feature-flags"]
         },
         {

--- a/.github/scripts/label-pr-from-title.test.js
+++ b/.github/scripts/label-pr-from-title.test.js
@@ -12,7 +12,10 @@ const { parseScopes, labelsForTitle, loadRules } = require('./label-pr-from-titl
 // Mirrors the rule shape in .github/auto-assign-labels.json so the logic is
 // exercised against the real structure without reading the file.
 const RULES = [
-    { scopes: ['flags', 'feature-flags'], labels: ['feature/feature-flags', 'team/feature-flags'] },
+    {
+        scopes: ['flags', 'flag', 'feature-flags', 'feature-flag', 'feature_flags', 'feature_flag'],
+        labels: ['feature/feature-flags', 'team/feature-flags'],
+    },
     { scopes: ['cohort', 'cohorts'], labels: ['team/feature-flags', 'feature/cohorts'] },
 ]
 
@@ -43,6 +46,11 @@ const LABELS_FOR_TITLE_CASES = [
         title: 'fix(feature-flags): x',
         expected: ['feature/feature-flags', 'team/feature-flags'],
         description: 'feature-flags alias',
+    },
+    {
+        title: 'feat(feature_flags): x',
+        expected: ['feature/feature-flags', 'team/feature-flags'],
+        description: 'underscore feature_flags alias',
     },
     { title: 'fix(cohort): x', expected: ['team/feature-flags', 'feature/cohorts'], description: 'cohort scope' },
     {
@@ -84,4 +92,14 @@ test('the shipped config loads into well-formed rules', () => {
 // non-empty rather than exact labels so an intentional label rename doesn't fail.
 test('the shipped config still maps the flags scope to labels', () => {
     assert.ok(labelsForTitle('feat(flags): x', loadRules()).length > 0, 'flags scope maps to no labels')
+})
+
+// Contributors write the flags scope several ways; the underscore form was
+// silently unlabeled until it was added to the config. Bind it so a future edit
+// that drops the variants regresses loudly here.
+test('the shipped config maps the underscore feature_flags scope to labels', () => {
+    assert.ok(
+        labelsForTitle('feat(feature_flags): x', loadRules()).length > 0,
+        'feature_flags scope maps to no labels'
+    )
 })

--- a/.github/scripts/label-pr-from-title.test.js
+++ b/.github/scripts/label-pr-from-title.test.js
@@ -94,12 +94,12 @@ test('the shipped config still maps the flags scope to labels', () => {
     assert.ok(labelsForTitle('feat(flags): x', loadRules()).length > 0, 'flags scope maps to no labels')
 })
 
-// Contributors write the flags scope several ways; the underscore form was
-// silently unlabeled until it was added to the config. Bind it so a future edit
-// that drops the variants regresses loudly here.
-test('the shipped config maps the underscore feature_flags scope to labels', () => {
-    assert.ok(
-        labelsForTitle('feat(feature_flags): x', loadRules()).length > 0,
-        'feature_flags scope maps to no labels'
-    )
-})
+// Contributors write the flags scope several ways; these aliases were silently
+// unlabeled until they were added to the config. Bind each to the shipped
+// config (not just the RULES mirror) so a future edit that drops one regresses
+// loudly here.
+for (const scope of ['flag', 'feature-flag', 'feature_flags', 'feature_flag']) {
+    test(`the shipped config maps the ${scope} scope to labels`, () => {
+        assert.ok(labelsForTitle(`feat(${scope}): x`, loadRules()).length > 0, `${scope} scope maps to no labels`)
+    })
+}


### PR DESCRIPTION
## Problem

The conventional-commit auto-labeler from #66227 maps a PR's scope to team and feature labels from `.github/auto-assign-labels.json`. The flags rule only listed `flags` and `feature-flags`, but contributors write the scope several other ways. A title like `feat(feature_flags): …` matched no rule, so the PR shipped with no team label and fell off the Feature Flags team's routing.

The miss that surfaced this: #72405 `feat(feature_flags): add flag filters validators and audit command` carried no team label. I labeled it by hand.

## Changes

Add the `flag`, `feature-flag`, `feature_flags`, and `feature_flag` variants to the flags rule. This is a config-only change; the matching logic in `label-pr-from-title.js` is untouched (it already does case-insensitive exact-token matching against the scope list).

Test coverage adds the underscore case to the mapping table, updates the local rules mirror, and binds the underscore form to the shipped config so a future edit that drops the variants fails loudly instead of silently disabling labeling.

## How did you test this code?

Ran the script's unit tests: `node --test .github/scripts/label-pr-from-title.test.js`, 19/19 pass. I (Claude) did not exercise the live workflow, since `pull_request_target` config changes only take effect once merged to master.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Phil hit this during a feature-flags triage run: the triage surfaced #72405 as an unlabeled flags PR even though the auto-labeler should have caught it. Tracing it showed the scope was `feature_flags` with an underscore, which the config didn't list. I (Claude) confirmed the matching is exact-token, added the common spelling variants, and extended the existing node:test suite. No changes to the workflow or script logic.