### PR TITLE
feat(cdp): make Discord destination mentions configurable

### DIFF
--- a/posthog/cdp/templates/discord/template_discord.py
+++ b/posthog/cdp/templates/discord/template_discord.py
@@ -26,11 +26,18 @@ if (not match(inputs.webhookUrl, '^https://discord.com/api/webhooks/.*')) {
     throw Error('Invalid URL. The URL should match the format: https://discord.com/api/webhooks/...')
 }
 
+let allowedParse := [];
+if (inputs.allowedMentions == 'roles_users') {
+    allowedParse := ['roles', 'users'];
+} else if (inputs.allowedMentions == 'everyone') {
+    allowedParse := ['everyone', 'roles', 'users'];
+}
+
 let res := fetch(inputs.webhookUrl, {
     'body': {
         'content': inputs.content,
         'allowed_mentions': {
-            'parse': []
+            'parse': allowedParse
         }
     },
     'method': 'POST',
@@ -58,6 +65,29 @@ if (res.status >= 400) {
             "label": "Content",
             "description": "(see https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline)",
             "default": "**{person.name}** triggered event: '{event.event}'",
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "allowedMentions",
+            "type": "choice",
+            "label": "Allowed mentions",
+            "description": "Control which mentions in the message actually ping people. By default mentions are shown as text and nobody is pinged, which avoids accidental pings from event data. Enable roles and users to ping @roles and @users, or allow @everyone / @here too.",
+            "choices": [
+                {
+                    "label": "None (mentions shown as text, nobody is pinged)",
+                    "value": "none",
+                },
+                {
+                    "label": "Roles and users (@role and @user mentions ping)",
+                    "value": "roles_users",
+                },
+                {
+                    "label": "Everyone, roles and users (also allows @everyone and @here)",
+                    "value": "everyone",
+                },
+            ],
+            "default": "none",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/discord/test_template_discord.py
+++ b/posthog/cdp/templates/discord/test_template_discord.py
@@ -1,5 +1,7 @@
 import pytest
 
+from parameterized import parameterized
+
 from posthog.cdp.templates.discord.template_discord import template as template_discord
 from posthog.cdp.templates.helpers import BaseHogFunctionTemplateTest
 
@@ -31,6 +33,18 @@ class TestTemplateDiscord(BaseHogFunctionTemplateTest):
                 },
             },
         )
+
+    @parameterized.expand(
+        [
+            ["none", []],
+            ["roles_users", ["roles", "users"]],
+            ["everyone", ["everyone", "roles", "users"]],
+        ]
+    )
+    def test_allowed_mentions_maps_to_parse(self, choice, expected_parse):
+        self.run_function(inputs=self._inputs(allowedMentions=choice))
+
+        assert self.get_mock_fetch_calls()[0][1]["body"]["allowed_mentions"] == {"parse": expected_parse}
 
     def test_only_allow_teams_url(self):
         for url, allowed in [


### PR DESCRIPTION
## Problem

The Discord destination hardcodes `allowed_mentions: { parse: [] }` in its outgoing webhook payload. Discord reads an empty `parse` array as "render every `@role`/`@user`/`@everyone` as plain text and ping nobody." That is a sensible safety default (the message content can interpolate arbitrary event and person properties, so an unfiltered payload could otherwise trigger accidental `@everyone` pings), but it is applied unconditionally with no opt-out.

The result: you cannot intentionally ping a role or user from the Discord destination at all. Anyone who wants `@role` notifications has to drop the Discord destination and rebuild it on the generic Webhook destination, which does not set `allowed_mentions` and so pings by default. This came in via a community forum question on the Discord destination docs, [raised in a Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1784543717299879?thread_ts=1784543717.299879&cid=C06GG249PR6).

## Changes

Added an "Allowed mentions" choice input to the Discord destination that maps to Discord's `allowed_mentions.parse`:

| Choice | `parse` sent to Discord |
| --- | --- |
| None (default) | `[]` |
| Roles and users | `["roles", "users"]` |
| Everyone, roles and users | `["everyone", "roles", "users"]` |

The default is `None`, so behavior is unchanged for every existing destination, and destinations saved before this change (which have no `allowedMentions` input) also fall through to `[]`. `@everyone`/`@here` stays behind its own explicit choice so the safety intent survives.

## How did you test this code?

Added a parameterized test (`test_allowed_mentions_maps_to_parse`) asserting each of the three choices produces the correct `parse` array in the webhook body. This guards the choice-to-`parse` mapping: a regression would either silently stop pinging roles (defeating the feature) or over-permit `@everyone` (the accidental-ping risk the empty default exists to prevent). The existing `test_function_works` already covers the absent-input default.

I (the PostHog Slack app agent) could not run the DB-backed template test suite in this environment — `BaseHogFunctionTemplateTest` boots Django and needs Postgres, which was not reachable. I verified Python syntax and ran `ruff check` / `ruff format` clean on both files. CI will run the full suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The user-facing docs live in the posthog.com repo, not here, so no doc change is included in this PR.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by the PostHog Slack app agent in response to a community forum question about why role mentions do not work on the Discord destination. I traced the behavior to the hardcoded `allowed_mentions: { parse: [] }` in `template_discord.py`, confirmed via `git log` that the empty parse was a deliberate anti-accidental-ping guard, and chose to keep that as the default rather than remove it — the fix makes mentions opt-in instead of flipping the default. Used a `choice` input (matching the pattern in the siteapp templates) rather than a free-form string so users can't send an invalid `parse` value, and kept `@everyone`/`@here` behind its own explicit option. Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1784543717299879?thread_ts=1784543717.299879&cid=C06GG249PR6)*
