### PR TITLE
fix(integrations): refresh salesforce sandbox tokens at instance_url

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -503,11 +503,15 @@ def _salesforce_instance_host(instance_url: str | None) -> str | None:
         return None
     try:
         parsed = urlparse(instance_url)
+        # port/hostname/username/password are lazily parsed from netloc on access, and
+        # port in particular raises ValueError on a non-numeric or out-of-range value
+        # (e.g. https://host:abc/). Keep every derived-property read inside the try so a
+        # poisoned instance_url can never crash the refresh sweep.
+        if parsed.scheme != "https" or parsed.port is not None or parsed.username or parsed.password:
+            return None
+        host = (parsed.hostname or "").lower()
     except ValueError:
         return None
-    if parsed.scheme != "https" or parsed.port is not None or parsed.username or parsed.password:
-        return None
-    host = (parsed.hostname or "").lower()
     if not host.endswith(".salesforce.com"):
         return None
     return f"https://{host}"

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NoReturn, Optional, Self
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from products.workflows.backend.providers import MAILDEV_MOCK_DNS_RECORDS
 
@@ -488,6 +488,29 @@ def _build_posthog_slack_scope() -> str:
 
 
 POSTHOG_SLACK_SCOPE = _build_posthog_slack_scope()
+
+
+def _salesforce_instance_host(instance_url: str | None) -> str | None:
+    # Every Salesforce-issued instance_url host ends in .salesforce.com: login/test, the
+    # pod hosts (na1.salesforce.com, ...), and My Domain variants like
+    # acme.my.salesforce.com and acme--sandbox.sandbox.my.salesforce.com. Validating at
+    # the point of use means a stray write to integration.config can't cause the shared
+    # SALESFORCE_CONSUMER_SECRET to be POSTed to an attacker origin during a refresh,
+    # even if a future endpoint or admin tool exposes config as writable. Returns
+    # "https://<host>" for a legitimate value, None otherwise (caller falls back to the
+    # hardcoded prod URL).
+    if not instance_url:
+        return None
+    try:
+        parsed = urlparse(instance_url)
+    except ValueError:
+        return None
+    if parsed.scheme != "https" or parsed.port is not None or parsed.username or parsed.password:
+        return None
+    host = (parsed.hostname or "").lower()
+    if not host.endswith(".salesforce.com"):
+        return None
+    return f"https://{host}"
 
 
 class OauthIntegration:
@@ -1269,12 +1292,14 @@ class OauthIntegration:
             return
 
         revoke_url = oauth_config.token_revoke_url
-        # Salesforce sandbox integrations are stored as kind "salesforce" (the sandbox is only a
-        # token-exchange fallback), so the static prod revoke URL would miss them. Revoke at the
-        # org's own instance host instead - it serves oauth2/revoke and matches prod or sandbox.
-        instance_url = self.integration.config.get("instance_url")
-        if self.integration.kind == "salesforce" and instance_url:
-            revoke_url = f"{instance_url.rstrip('/')}/services/oauth2/revoke"
+        # Salesforce sandbox integrations are stored as kind "salesforce" (the sandbox is only
+        # a token-exchange fallback), so the static prod revoke URL would miss them. Revoke at
+        # the validated instance host so a stray write to config can't redirect the token to
+        # an attacker origin.
+        if self.integration.kind == "salesforce":
+            allowed_host = _salesforce_instance_host(self.integration.config.get("instance_url"))
+            if allowed_host:
+                revoke_url = f"{allowed_host}/services/oauth2/revoke"
 
         # allow_redirects=False so a misconfigured/compromised provider can't 30x us into
         # resending the token to another host. raise_for_status surfaces a provider rejection
@@ -1369,14 +1394,16 @@ class OauthIntegration:
             )
         else:
             token_url = oauth_config.token_url
-            # Salesforce sandbox integrations are stored as kind "salesforce" (the sandbox is
-            # only a token-exchange fallback in the OAuth callback), so the static prod token
-            # URL would refuse a sandbox-issued refresh_token. Refresh at the org's own
-            # instance host instead - it serves oauth2/token and matches prod or sandbox.
-            # Mirrors the revoke path in unlink().
-            instance_url = self.integration.config.get("instance_url")
-            if kind == "salesforce" and instance_url:
-                token_url = f"{instance_url.rstrip('/')}/services/oauth2/token"
+            # Salesforce sandbox integrations are stored as kind "salesforce" (the sandbox
+            # is only a token-exchange fallback in the OAuth callback), so the static prod
+            # token URL would refuse a sandbox-issued refresh_token. Refresh at the org's
+            # own instance host instead. Validate the host before sending client_secret +
+            # refresh_token so a stray write to config can't exfiltrate the fleet-wide
+            # Salesforce app secret; fall back to the hardcoded prod URL on rejection.
+            if kind == "salesforce":
+                allowed_host = _salesforce_instance_host(self.integration.config.get("instance_url"))
+                if allowed_host:
+                    token_url = f"{allowed_host}/services/oauth2/token"
 
             return requests.post(
                 token_url,
@@ -1387,6 +1414,7 @@ class OauthIntegration:
                     "grant_type": "refresh_token",
                 },
                 timeout=10,
+                allow_redirects=False,
             )
 
     @staticmethod

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1368,8 +1368,18 @@ class OauthIntegration:
                 timeout=10,
             )
         else:
+            token_url = oauth_config.token_url
+            # Salesforce sandbox integrations are stored as kind "salesforce" (the sandbox is
+            # only a token-exchange fallback in the OAuth callback), so the static prod token
+            # URL would refuse a sandbox-issued refresh_token. Refresh at the org's own
+            # instance host instead - it serves oauth2/token and matches prod or sandbox.
+            # Mirrors the revoke path in unlink().
+            instance_url = self.integration.config.get("instance_url")
+            if kind == "salesforce" and instance_url:
+                token_url = f"{instance_url.rstrip('/')}/services/oauth2/token"
+
             return requests.post(
-                oauth_config.token_url,
+                token_url,
                 data={
                     "client_id": client_id,
                     "client_secret": client_secret,

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -540,6 +540,7 @@ class TestOauthIntegrationModel(BaseTest):
                 "refresh_token": "REFRESH",
             },
             timeout=10,
+            allow_redirects=False,
         )
 
         assert integration.config["expires_in"] == 1000
@@ -1020,6 +1021,47 @@ class TestOauthIntegrationModel(BaseTest):
 
         called_url = mock_post.call_args.args[0]
         assert called_url == f"{sandbox_instance_url}/services/oauth2/token"
+
+    @parameterized.expand(
+        [
+            ("attacker_https", "https://attacker.example.com"),
+            ("attacker_lookalike_suffix", "https://salesforce.com.attacker.example"),
+            ("attacker_lookalike_prefix", "https://acmesalesforce.com"),
+            ("http_scheme_downgrade", "http://acme.my.salesforce.com"),
+            ("with_userinfo", "https://user:pass@acme.my.salesforce.com"),
+            ("with_port", "https://acme.my.salesforce.com:8443"),
+            ("garbage_value", "not a url"),
+            ("empty_value", ""),
+        ]
+    )
+    @patch("posthog.models.integration.reload_integrations_on_workers")
+    @patch("posthog.models.integration.requests.post")
+    def test_salesforce_refresh_rejects_untrusted_instance_url(self, _name, bad_instance_url, mock_post, mock_reload):
+        # If a future write path (a partial_update action, an admin tool, a data migration)
+        # lets an attacker set instance_url, the refresh must not POST client_secret +
+        # refresh_token to that origin - the client_secret is fleet-wide and its leak forces
+        # rotation and reconnect for every Salesforce integration. Any instance_url that isn't
+        # an https .salesforce.com host falls back to the hardcoded prod token URL, and the
+        # refresh must not follow redirects that would move the secret to another host.
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "access_token": "REFRESHED_ACCESS_TOKEN",
+            "expires_in": 3600,
+        }
+
+        integration = self.create_integration(
+            kind="salesforce",
+            config={"instance_url": bad_instance_url},
+        )
+
+        with self.settings(**self.mock_settings):
+            OauthIntegration(integration).refresh_access_token()
+
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "https://login.salesforce.com/services/oauth2/token"
+
+        called_kwargs = mock_post.call_args.kwargs
+        assert called_kwargs["allow_redirects"] is False
 
     @patch("posthog.models.integration.reload_integrations_on_workers")
     @patch("posthog.models.integration.requests.post")

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -993,6 +993,36 @@ class TestOauthIntegrationModel(BaseTest):
 
     @patch("posthog.models.integration.reload_integrations_on_workers")
     @patch("posthog.models.integration.requests.post")
+    def test_salesforce_refresh_uses_instance_url_for_sandbox(self, mock_post, mock_reload):
+        # Sandbox integrations are stored as kind="salesforce" (the sandbox is a token-exchange
+        # fallback in the OAuth callback), so the config's instance_url is the only signal that
+        # the refresh must go to test.salesforce.com or the org's own host rather than the
+        # hardcoded prod token URL. Salesforce rejects a sandbox refresh_token posted to
+        # login.salesforce.com, which shows up to users as "Authentication token could not be
+        # refreshed. Please reconnect." within a few hours of connecting.
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "access_token": "REFRESHED_ACCESS_TOKEN",
+            "expires_in": 3600,
+        }
+
+        sandbox_instance_url = "https://ryan-co--sandbox.sandbox.my.salesforce.com"
+        integration = self.create_integration(
+            kind="salesforce",
+            config={"instance_url": sandbox_instance_url},
+        )
+
+        with self.settings(**self.mock_settings):
+            OauthIntegration(integration).refresh_access_token()
+
+        assert integration.errors == ""
+        assert integration.sensitive_config["access_token"] == "REFRESHED_ACCESS_TOKEN"
+
+        called_url = mock_post.call_args.args[0]
+        assert called_url == f"{sandbox_instance_url}/services/oauth2/token"
+
+    @patch("posthog.models.integration.reload_integrations_on_workers")
+    @patch("posthog.models.integration.requests.post")
     def test_non_salesforce_refresh_access_token_preserves_none_expires_in(self, mock_post, mock_reload):
         """Test that non-Salesforce integrations preserve None expires_in from refresh response"""
         mock_post.return_value.status_code = 200

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1030,6 +1030,7 @@ class TestOauthIntegrationModel(BaseTest):
             ("http_scheme_downgrade", "http://acme.my.salesforce.com"),
             ("with_userinfo", "https://user:pass@acme.my.salesforce.com"),
             ("with_port", "https://acme.my.salesforce.com:8443"),
+            ("invalid_port_raises_valueerror", "https://acme.my.salesforce.com:abc"),
             ("garbage_value", "not a url"),
             ("empty_value", ""),
         ]


### PR DESCRIPTION
## Problem

Users on Salesforce Sandbox report that the integration disconnects within a few hours and reconnecting throws "Authentication token could not be refreshed. Please reconnect." — the connection is never durable.

The OAuth callback in `posthog/models/integration.py` already knows about sandbox: if the initial token exchange against `login.salesforce.com` fails, it retries against `test.salesforce.com` as a fallback and saves the resulting refresh token. But the integration is stored under `kind="salesforce"` regardless of which host issued the token, and the refresh path in `_post_token_refresh` blindly uses `oauth_config.token_url` — which is hardcoded to `https://login.salesforce.com/services/oauth2/token`. Salesforce rejects a sandbox-issued refresh token posted to the prod token endpoint, the sweep marks the integration as `ERROR_TOKEN_REFRESH_FAILED`, and the frontend renders the reconnect message. Access tokens live ~1–2 hours, which matches the "few hours to a day" cadence users see.

The revoke path in `unlink()` already handled this correctly by deriving the URL from `config["instance_url"]`; refresh just never got the mirror change.

## Changes

- In `_post_token_refresh`, when `kind == "salesforce"` and `config["instance_url"]` is set, POST the refresh at `{instance_url}/services/oauth2/token` instead of the static prod URL. Falls back to the hardcoded URL when `instance_url` is missing (older integrations that never captured it).
- Mirrors the existing revoke-time behavior at `posthog/models/integration.py:1275-1277`.
- Also fixes the same failure mode for custom-domain prod orgs (`*.my.salesforce.com`) that happened to work only when their custom domain also accepted refresh at `login.salesforce.com`.

Not changed in this PR (deliberate follow-ups):
- No user-facing "Sandbox" toggle in the OAuth start flow — the callback fallback still handles new sandbox connections. Worth revisiting so the intent is explicit instead of implicit, but out of scope here.

## How did you test this code?

Added one Django `TestCase` in `posthog/models/test/test_integration_model.py`:

- `test_salesforce_refresh_uses_instance_url_for_sandbox` — creates a `salesforce`-kind integration whose `config["instance_url"]` is a sandbox host, calls `refresh_access_token()` with `requests.post` mocked, and asserts the POST went to `{instance_url}/services/oauth2/token`. Regression it catches: any future refactor of `_post_token_refresh` that reverts to the static prod URL will fail this test. No existing salesforce refresh test asserted the URL — the closest (`test_salesforce_refresh_access_token_without_expires_in_response`) only checked expiry defaults, so today's regression would ship green.

Ran locally against the fix:

- `posthog/models/test/test_integration_model.py::TestOauthIntegrationModel` — 55 passed (all 6 salesforce cases green, including the new one).

Did not test end-to-end against a real Salesforce sandbox — the mocked-boundary test covers the failure mode reported by the user.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated via the /Explore agent and direct code reads to trace the sandbox OAuth path across `oauth_config_for_kind`, `integration_from_oauth_response` (the sandbox-fallback "hack"), `unlink` (which already used `instance_url`), and `refresh_access_token` → `_post_token_refresh` (which did not). No skills invoked beyond `/writing-tests` for the gate on the new test. Chose to mirror the revoke path's exact shape rather than plumb a per-kind override through `OauthConfig`, because only Salesforce has the prod/sandbox split and only Salesforce stores `instance_url` — a targeted branch is smaller and matches how the revoke fix landed.

Tools: Explore agent (once), Bash/Read/Edit/Grep. No manual browser testing performed.