### PR TITLE
feat(messaging): unregister push subscriptions via DELETE endpoint

### DIFF
--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -17,7 +17,7 @@ from posthog.exceptions import (
 from posthog.helpers.encrypted_fields import EncryptedFieldMixin
 from posthog.models.integration import Integration
 from posthog.models.team.team import Team
-from posthog.utils import load_data_from_request
+from posthog.utils import decompress, load_data_from_request
 from posthog.utils_cors import cors_response
 
 VALID_PLATFORMS = ("android", "ios")
@@ -51,12 +51,12 @@ def push_subscriptions(request: Request):
     if request.method == "OPTIONS":
         return cors_response(request, HttpResponse(""))
 
-    if request.method != "POST":
+    if request.method not in ("POST", "DELETE"):
         return cors_response(
             request,
             generate_exception_response(
                 "push_subscriptions",
-                "Only POST requests are supported.",
+                "Only POST and DELETE requests are supported.",
                 type="validation_error",
                 code="method_not_allowed",
                 status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
@@ -76,7 +76,12 @@ def push_subscriptions(request: Request):
         )
 
     try:
-        data = load_data_from_request(request)
+        if request.method == "POST":
+            data = load_data_from_request(request)
+        else:
+            # load_data_from_request only reads the body for POST (other methods read a `data` query
+            # param). DELETE carries the same gzipped JSON body as POST, so decompress it directly.
+            data = decompress(request.body, request.headers.get("content-encoding", "").lower())
     except (RequestParsingError, UnspecifiedCompressionFallbackParsingError):
         return cors_response(
             request,
@@ -185,8 +190,18 @@ def push_subscriptions(request: Request):
             ),
         )
 
-    encrypted_token = _encrypted_fields.encrypt(device_token)
     property_key = f"$device_push_subscription_{app_id}"
+
+    # $unset of an absent property is a no-op, so DELETE (logout) is idempotent. device_token is
+    # required for a symmetric contract but isn't matched against the stored value: logout clears
+    # this app_id's subscription regardless of which token the client last held.
+    properties: dict[str, dict[str, str] | list[str]]
+    if request.method == "POST":
+        properties = {"$set": {property_key: _encrypted_fields.encrypt(device_token)}}
+        failure_message = "Failed to store push subscription."
+    else:
+        properties = {"$unset": [property_key]}
+        failure_message = "Failed to remove push subscription."
 
     try:
         capture_internal(
@@ -195,7 +210,7 @@ def push_subscriptions(request: Request):
             event_source="push_subscriptions",
             distinct_id=distinct_id,
             timestamp=datetime.now(UTC),
-            properties={"$set": {property_key: encrypted_token}},
+            properties=properties,
             process_person_profile=True,
         )
     except Exception:
@@ -203,7 +218,7 @@ def push_subscriptions(request: Request):
             request,
             generate_exception_response(
                 "push_subscriptions",
-                "Failed to store push subscription.",
+                failure_message,
                 type="server_error",
                 code="capture_failed",
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -40,6 +40,14 @@ class TestPushSubscriptionsAPI(BaseTest):
             content_type="application/json",
         )
 
+    def _delete(self, data: dict, api_key: str | None = None):
+        payload = {**data, "api_key": api_key or self.team.api_token}
+        return self.client.delete(
+            "/api/push_subscriptions/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
     @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
     def test_register_android_token(self, mock_capture: MagicMock):
         mock_capture.return_value = MagicMock(status_code=200)
@@ -129,6 +137,63 @@ class TestPushSubscriptionsAPI(BaseTest):
         # It should be a non-empty string (Fernet token)
         assert isinstance(encrypted_value, str)
         assert len(encrypted_value) > 0
+
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_unregister_unsets_the_subscription_property(self, mock_capture: MagicMock):
+        mock_capture.return_value = MagicMock(status_code=200)
+
+        response = self._delete(
+            {
+                "distinct_id": "user-1",
+                "device_token": "fcm-device-token-abc",
+                "platform": "android",
+                "app_id": "my-firebase-project",
+            }
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["distinct_id"] == "user-1"
+        assert data["platform"] == "android"
+
+        mock_capture.assert_called_once()
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["token"] == self.team.api_token
+        assert call_kwargs["distinct_id"] == "user-1"
+        assert call_kwargs["event_name"] == "$set"
+        assert call_kwargs["process_person_profile"] is True
+        # Unregister clears the property instead of storing a token.
+        assert call_kwargs["properties"] == {"$unset": ["$device_push_subscription_my-firebase-project"]}
+
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_unregister_ios_token(self, mock_capture: MagicMock):
+        mock_capture.return_value = MagicMock(status_code=200)
+
+        response = self._delete(
+            {
+                "distinct_id": "user-1",
+                "device_token": "apns-device-token-abc",
+                "platform": "ios",
+                "app_id": "com.example.app",
+            }
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["properties"]["$unset"] == ["$device_push_subscription_com.example.app"]
+
+    def test_unregister_integration_not_found(self):
+        response = self._delete(
+            {
+                "distinct_id": "user-1",
+                "device_token": "device-token",
+                "platform": "android",
+                "app_id": "nonexistent-project",
+            }
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "integration" in response.json()["detail"].lower()
 
     def test_missing_api_key_returns_401(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

Workflows can deliver push notifications, and the mobile SDKs register a device token with `POST /api/push_subscriptions` so a Workflow knows where to send. There was no way to remove a token. On logout the SDKs need the device to stop receiving notifications aimed at the previous user, so they need an unregister endpoint.

## Changes

Adds `DELETE /api/push_subscriptions` on the same path. It reuses the whole `POST` validation (auth, required fields, platform, integration) and clears the person property `$device_push_subscription_<app_id>` with `$unset` instead of storing a token.

- Idempotent: `$unset` of an absent property is a no-op, so a repeated or late unregister is harmless.
- `device_token` is required for a symmetric body but is not matched against the stored value. Logout clears this `app_id`'s subscription regardless of which token the client last held.
- `load_data_from_request` only reads the body for `POST` (other methods read a `data` query param), so the DELETE handler decompresses `request.body` directly.

posthog-ios #729 and posthog-android #642 already call this on `reset()` (unregister the old identity, then re-register under the new anonymous id) and expose `unregisterPushNotificationToken()` for manual use.

## How did you test this code?

Added unit tests in `products/messaging/backend/api/test/test_push_subscriptions.py`: the `$unset` op for an Android (Firebase) and an iOS (APNs) `app_id`, plus an integration-not-found case that proves DELETE runs the full shared validation path rather than bypassing it.

I was not able to run the Django suite locally (no Postgres up), so these are not executed end to end yet. I did verify the one non-obvious piece in isolation: `decompress(request.body, content-encoding)` round-trips both a plain and a gzipped body to the expected dict, which the DELETE path relies on. The rest of the path is the same validation the POST tests already cover. Worth running the suite and the patch-coverage check before this is marked ready.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Push notifications are still rolling out behind the `workflows-push-notifications` flag; SDK docs are tracked in PostHog/posthog.com#16177. No separate backend docs change here.

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
