### PR TITLE
chore(dashboards): prototype '…' advanced options on the dashboard edit bar

### DIFF
--- a/frontend/src/lib/components/PrototypeSwitcher.tsx
+++ b/frontend/src/lib/components/PrototypeSwitcher.tsx
@@ -1,0 +1,85 @@
+/**
+ * PROTOTYPE TOOLING — floating variant switcher for throwaway UI prototypes.
+ * Renders nothing in production builds. Delete together with the prototype it serves.
+ */
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect } from 'react'
+
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+
+export interface PrototypeVariant {
+    key: string
+    name: string
+}
+
+interface PrototypeSwitcherProps {
+    variants: PrototypeVariant[]
+    current: string
+    /** Extra live-state readout shown in the bar, e.g. the prototype's current selection. */
+    stateLabel?: string
+}
+
+export function PrototypeSwitcher(props: PrototypeSwitcherProps): JSX.Element | null {
+    if (process.env.NODE_ENV !== 'development') {
+        return null
+    }
+    return <PrototypeSwitcherBar {...props} />
+}
+
+function PrototypeSwitcherBar({ variants, current, stateLabel }: PrototypeSwitcherProps): JSX.Element {
+    const { location, searchParams, hashParams } = useValues(router)
+
+    const cycle = (delta: number): void => {
+        const index = Math.max(
+            0,
+            variants.findIndex((v) => v.key === current)
+        )
+        const next = variants[(index + delta + variants.length) % variants.length]
+        router.actions.replace(location.pathname, { ...searchParams, variant: next.key }, hashParams)
+    }
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent): void => {
+            const target = e.target as HTMLElement | null
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return
+            }
+            if (e.key === 'ArrowLeft') {
+                cycle(-1)
+            } else if (e.key === 'ArrowRight') {
+                cycle(1)
+            }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    })
+
+    const currentVariant = variants.find((v) => v.key === current)
+
+    return (
+        <div className="fixed bottom-4 left-1/2 z-[10000] flex -translate-x-1/2 items-center gap-1 rounded-full bg-black/90 px-2 py-1 text-white shadow-xl">
+            <button
+                type="button"
+                className="flex cursor-pointer items-center rounded-full p-1 hover:bg-white/20"
+                onClick={() => cycle(-1)}
+                aria-label="Previous variant"
+            >
+                <IconChevronLeft />
+            </button>
+            <span className="select-none whitespace-nowrap px-1 text-xs font-semibold">
+                PROTOTYPE {current}
+                {currentVariant ? ` — ${currentVariant.name}` : ''}
+                {stateLabel ? <span className="ml-2 font-normal opacity-70">{stateLabel}</span> : null}
+            </span>
+            <button
+                type="button"
+                className="flex cursor-pointer items-center rounded-full p-1 hover:bg-white/20"
+                onClick={() => cycle(1)}
+                aria-label="Next variant"
+            >
+                <IconChevronRight />
+            </button>
+        </div>
+    )
+}

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -11,6 +11,7 @@ import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
+import { DashboardEditBarAdvancedOptionsPrototype } from 'scenes/dashboard/DashboardEditBarAdvancedOptionsPrototype'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -176,6 +177,11 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
                         size="small"
                     />
                 </BindLogic>
+            </div>
+
+            {/* PROTOTYPE (dev-only, ?variant=A/B/C): "…" advanced options for the test account filter override */}
+            <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
+                <DashboardEditBarAdvancedOptionsPrototype />
             </div>
 
             <VariablesForDashboard />

--- a/frontend/src/scenes/dashboard/DashboardEditBarAdvancedOptionsPrototype.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBarAdvancedOptionsPrototype.tsx
@@ -1,0 +1,249 @@
+/**
+ * PROTOTYPE — throwaway, do not ship. Dev builds only.
+ *
+ * Question: how should a "…" advanced-options affordance at the end of the dashboard
+ * edit bar look, hosting a tri-state test account filter override
+ * (inherit per insight / force filtering on / force filtering off)?
+ *
+ * Three structurally different variants on the existing dashboard route, switchable via
+ * `?variant=` (A/B/C) and the floating PrototypeSwitcher bar:
+ *   A — "…" opens a compact dropdown menu with radio-style choices
+ *   B — "…" opens an "Advanced filters" panel (labelled control, explanation, room to grow)
+ *   C — "…" expands the edit bar inline with a "test accounts" select, echoing "grouped by"
+ *
+ * The override lives in useState only — nothing is persisted or sent to the backend.
+ * DashboardFilter already has the matching schema field (`filterTestAccounts`), unused so far.
+ * A production version should use quill DropdownMenu for the menu variant per conventions.
+ */
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+import { useState } from 'react'
+
+import { IconCheck, IconEllipsis, IconGear, IconX } from '@posthog/icons'
+import {
+    LemonBadge,
+    LemonButton,
+    LemonDivider,
+    LemonLabel,
+    LemonSegmentedButton,
+    LemonSelect,
+    LemonSnack,
+} from '@posthog/lemon-ui'
+
+import { PrototypeSwitcher, PrototypeVariant } from 'lib/components/PrototypeSwitcher'
+import { Popover } from 'lib/lemon-ui/Popover'
+import { urls } from 'scenes/urls'
+
+type TestAccountOverride = 'inherit' | 'filter-out' | 'include'
+
+interface VariantProps {
+    value: TestAccountOverride
+    onChange: (value: TestAccountOverride) => void
+}
+
+const VARIANTS: PrototypeVariant[] = [
+    { key: 'A', name: 'Dropdown menu' },
+    { key: 'B', name: 'Advanced filters panel' },
+    { key: 'C', name: 'Inline expansion' },
+]
+
+const STATE_SUMMARY: Record<TestAccountOverride, string> = {
+    inherit: "each insight's own setting",
+    'filter-out': 'filtered out everywhere',
+    include: 'included everywhere',
+}
+
+export function DashboardEditBarAdvancedOptionsPrototype(): JSX.Element | null {
+    if (process.env.NODE_ENV !== 'development') {
+        return null
+    }
+    return <PrototypeHost />
+}
+
+function PrototypeHost(): JSX.Element {
+    const { searchParams } = useValues(router)
+    const variant = VARIANTS.some((v) => v.key === searchParams.variant) ? searchParams.variant : 'A'
+    const [override, setOverride] = useState<TestAccountOverride>('inherit')
+
+    return (
+        <>
+            {variant === 'A' && <VariantMenu value={override} onChange={setOverride} />}
+            {variant === 'B' && <VariantPanel value={override} onChange={setOverride} />}
+            {variant === 'C' && <VariantInline value={override} onChange={setOverride} />}
+            <PrototypeSwitcher
+                variants={VARIANTS}
+                current={variant}
+                stateLabel={`test accounts: ${STATE_SUMMARY[override]}`}
+            />
+        </>
+    )
+}
+
+// --- Variant A: "…" opens a compact menu with radio-style choices ---------------------------
+
+const MENU_OPTIONS: { value: TestAccountOverride; label: string; description: string }[] = [
+    { value: 'inherit', label: 'Inherit from each insight', description: 'Insights keep their own setting' },
+    { value: 'filter-out', label: 'Filter out test accounts', description: 'Force filtering on for every insight' },
+    { value: 'include', label: 'Include test accounts', description: 'Force filtering off for every insight' },
+]
+
+function VariantMenu({ value, onChange }: VariantProps): JSX.Element {
+    const [visible, setVisible] = useState(false)
+
+    return (
+        <Popover
+            visible={visible}
+            onClickOutside={() => setVisible(false)}
+            placement="bottom-start"
+            overlay={
+                <div className="flex w-72 flex-col gap-0.5 p-1">
+                    <div className="px-2 pb-0.5 pt-1 text-xs font-semibold uppercase text-secondary">
+                        Test account filtering
+                    </div>
+                    {MENU_OPTIONS.map((option) => (
+                        <LemonButton
+                            key={option.value}
+                            fullWidth
+                            size="small"
+                            active={value === option.value}
+                            icon={value === option.value ? <IconCheck /> : <span className="w-4" />}
+                            onClick={() => {
+                                onChange(option.value)
+                                setVisible(false)
+                            }}
+                        >
+                            <div className="flex flex-col py-0.5">
+                                <span>{option.label}</span>
+                                <span className="text-xs text-secondary">{option.description}</span>
+                            </div>
+                        </LemonButton>
+                    ))}
+                </div>
+            }
+        >
+            <span className="relative">
+                <LemonButton
+                    size="small"
+                    icon={<IconEllipsis />}
+                    tooltip="Advanced options"
+                    active={visible}
+                    onClick={() => setVisible(!visible)}
+                />
+                <LemonBadge size="small" position="top-right" visible={value !== 'inherit'} />
+            </span>
+        </Popover>
+    )
+}
+
+// --- Variant B: "…" opens an "Advanced filters" panel ---------------------------------------
+
+const PANEL_HINTS: Record<TestAccountOverride, string> = {
+    inherit: 'Each insight uses its own "filter out internal and test users" setting.',
+    'filter-out': 'Internal and test users are filtered out of every insight on this dashboard.',
+    include: 'Internal and test users are included in every insight on this dashboard.',
+}
+
+function VariantPanel({ value, onChange }: VariantProps): JSX.Element {
+    const [visible, setVisible] = useState(false)
+    const overrideCount = value !== 'inherit' ? 1 : 0
+
+    return (
+        <Popover
+            visible={visible}
+            onClickOutside={() => setVisible(false)}
+            placement="bottom-end"
+            overlay={
+                <div className="flex w-80 flex-col gap-2 p-2">
+                    <div>
+                        <h4 className="mb-0 font-semibold">Advanced filters</h4>
+                        <p className="mb-0 text-xs text-secondary">
+                            Overrides applied to every insight on this dashboard.
+                        </p>
+                    </div>
+                    <LemonDivider className="my-0" />
+                    <div className="flex items-center justify-between gap-2">
+                        <LemonLabel info="Force test account filtering on or off for all insights, or let each insight keep its own setting.">
+                            Test account filtering
+                        </LemonLabel>
+                        <LemonButton
+                            icon={<IconGear />}
+                            size="xsmall"
+                            noPadding
+                            to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+                            tooltip="Configure internal and test account filters"
+                        />
+                    </div>
+                    <LemonSegmentedButton<TestAccountOverride>
+                        fullWidth
+                        size="small"
+                        value={value}
+                        onChange={(next) => onChange(next)}
+                        options={[
+                            { value: 'inherit', label: 'Inherit' },
+                            { value: 'filter-out', label: 'Filter out' },
+                            { value: 'include', label: 'Include' },
+                        ]}
+                    />
+                    <p className="mb-0 text-xs text-secondary">{PANEL_HINTS[value]}</p>
+                </div>
+            }
+        >
+            <LemonButton
+                size="small"
+                type={overrideCount ? 'secondary' : 'tertiary'}
+                icon={<IconEllipsis />}
+                tooltip="Advanced filters"
+                active={visible}
+                onClick={() => setVisible(!visible)}
+                sideIcon={overrideCount ? <LemonBadge.Number count={overrideCount} size="small" /> : undefined}
+            />
+        </Popover>
+    )
+}
+
+// --- Variant C: "…" expands the bar inline, echoing the "grouped by" idiom ------------------
+
+function VariantInline({ value, onChange }: VariantProps): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+
+    if (!expanded) {
+        return (
+            <span className="flex items-center gap-2">
+                {value !== 'inherit' && (
+                    <LemonSnack onClose={() => onChange('inherit')} title="Remove override">
+                        test accounts {value === 'filter-out' ? 'filtered out' : 'included'}
+                    </LemonSnack>
+                )}
+                <LemonButton
+                    size="small"
+                    icon={<IconEllipsis />}
+                    tooltip="More filters"
+                    onClick={() => setExpanded(true)}
+                />
+            </span>
+        )
+    }
+
+    return (
+        <span className="flex items-center gap-2">
+            <span className="hidden md:inline">test accounts</span>
+            <LemonSelect<TestAccountOverride>
+                size="small"
+                value={value}
+                dropdownMatchSelectWidth={false}
+                onChange={(next) => onChange(next)}
+                options={[
+                    { value: 'inherit', label: "each insight's setting" },
+                    { value: 'filter-out', label: 'filtered out' },
+                    { value: 'include', label: 'included' },
+                ]}
+            />
+            <LemonButton
+                size="small"
+                icon={<IconX />}
+                tooltip="Hide advanced filters"
+                onClick={() => setExpanded(false)}
+            />
+        </span>
+    )
+}


### PR DESCRIPTION
> [!WARNING]
> **Prototype, not for merge.** Throwaway UI exploration, rendered in dev builds only. It exists so the variants can be flipped through in the browser and one can be picked; the winner gets a proper implementation and this branch gets closed.

## TL;DR (eli5)

Dashboards can force a date range or properties onto all their insights, but not the "filter out internal and test users" setting.
This PR mocks up three different ways a "…" button at the end of the dashboard edit bar could let you override that setting for the whole dashboard.
Open a dashboard, add `?variant=A` (or B or C) to the URL, and use the floating black pill at the bottom of the screen (or ←/→ keys) to flip between them.

## Problem

The dashboard edit bar overrides date range, interval, properties, and breakdown across all insights, but there's no way to override test account filtering per dashboard.
The `DashboardFilter` schema already has an unused tri-state `filterTestAccounts` field (inherit / force on / force off).
Before building the real thing, we want to settle what the affordance should look like: the ask is a "…" button behind the existing options that opens "advanced options".

## Changes

Three structurally different variants of the "…" affordance, mounted on the existing dashboard route behind a `?variant=` search param, dev builds only:

| Variant | Shape |
| --- | --- |
| `A` | "…" opens a compact dropdown menu with three radio-style choices; a badge dot marks an active override |
| `B` | "…" opens an "Advanced filters" panel with a labelled segmented control, helper text, and a gear link to filter settings; designed to host future advanced options |
| `C` | "…" expands the bar inline with a `test accounts <select>` control echoing the existing "grouped by" idiom; collapses to a removable chip when an override is active |

A shared floating `PrototypeSwitcher` bar (bottom center) cycles variants via the URL param and arrow keys.
The override state is `useState` only; nothing is persisted or sent to the backend.

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` — no new errors introduced (identical pre-existing error count with and without this change, none in these files).
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) — clean.
- I (Claude) did not manually flip through the variants in a running app; that browser pass is exactly what this PR exists for.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, throwaway prototype.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude via PostHog Code, using the user's `prototype` skill (UI branch: N radically different variants on the existing route, switchable via `?variant=`, floating switcher, in-memory state only).
- Decisions: reused the existing tri-state `filterTestAccounts` schema field as the model; kept everything LemonUI to match the surrounding edit bar (a production menu variant should use quill `DropdownMenu` per conventions); gated all prototype rendering on `NODE_ENV === 'development'` so a stray merge can't ship it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*