### PR TITLE
feat(workflows): tag suppression list tab as beta

### DIFF
--- a/products/workflows/frontend/WorkflowsScene.tsx
+++ b/products/workflows/frontend/WorkflowsScene.tsx
@@ -2,7 +2,7 @@ import { MakeLogicType, actions, connect, kea, path, props, reducers, selectors,
 import { urlToAction } from 'kea-router'
 
 import { IconApple, IconAndroid, IconLetter, IconPlusSmall } from '@posthog/icons'
-import { LemonButton, LemonMenu, LemonMenuItems } from '@posthog/lemon-ui'
+import { LemonButton, LemonMenu, LemonMenuItems, LemonTag } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -239,7 +239,12 @@ export function WorkflowsScene(props: WorkflowsSceneProps = {}): JSX.Element {
         ...(suppressionListEnabled
             ? [
                   {
-                      label: 'Suppression list',
+                      label: (
+                          <span className="inline-flex items-center gap-1.5">
+                              Suppression list
+                              <LemonTag type="completion">Beta</LemonTag>
+                          </span>
+                      ),
                       key: 'suppression' as const,
                       content: <SuppressionScene />,
                       link: urls.workflows('suppression'),


### PR DESCRIPTION
## Problem

The Workflows → Suppression list tab is being rolled out gradually (feature-flagged by `workflows-suppression-list`) and enforcement is only just being flipped on for CDP. Users who get the flag first should have a clear visual signal that the feature is still stabilising.

## Changes

- Add a `Beta` `LemonTag` (using `type="completion"` to match the existing convention in `HogFunctionStatusTag` / `SourceReleaseTag`) next to the "Suppression list" tab label.
- Only applies where the tab is already shown (behind the same feature flag) — nothing changes for users without the flag.

## How did you test this code?

- [ ] Locally toggled the `workflows-suppression-list` feature flag on and verified the tab shows the Beta tag next to the label.
- [ ] Toggled the flag off and verified the tab is hidden (unchanged behaviour).

## 🤖 Agent context

Follow-up to PostHog/charts#13298 (writes) and PostHog/charts#13326 (enforcement). Tags the UI so pilot users see the "beta" status while the rollout completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)