### PR TITLE
chore(workflows): add beta tag to push notifications action

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5565,7 +5565,7 @@ snapshots:
     scenes-app-dashboards--show-without-post-hog-ai-button-label--narrow--dark:
         hash: v1.k794b7964.88687d2cc1bbd12296214f07d5f6bb2548705ae3baae37985858225116896a10.YogXGZXR1uFB4qD8nOjCfWyWL--g1SLKNxz0gZvEoWw
     scenes-app-dashboards--show-without-post-hog-ai-button-label--narrow--light:
-        hash: v1.k794b7964.2035f84708f35d51de9ca7ce036c497c17d8a812e4a64c682d76caa066cb0954._S1SJobvQ3RqTPgANTGgE3vUYRijIBEFRYinuHFsQIA
+        hash: v1.k794b7964.e73cea1e916b6bc329aea490ca111439f3bebfa3dbae2d54ad54e5a174651057.7cswn9IwKIF60hyao0mI2skKmlWjur4GWI1cCisomlE
     scenes-app-dashboards--show-without-post-hog-ai-button-label--superwide--dark:
         hash: v1.k794b7964.cad32a04659183c6bfecbc34e5ae23c08c095f70df65ef0ee7d863d2103a124d.2bYQoklhY3opedkpy5pUC52pEvCwdnEfKowjCBPaDb8
     scenes-app-dashboards--show-without-post-hog-ai-button-label--superwide--light:

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Fragment, useEffect, useState } from 'react'
 
 import { IconDrag } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonDropdown, LemonInput, SpinnerOverlay } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonDropdown, LemonInput, LemonTag, SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { hogFunctionTemplateListLogic } from 'scenes/hog-functions/list/hogFunctionTemplateListLogic'
@@ -307,7 +307,12 @@ export function HogFlowEditorPanelBuild(): JSX.Element {
                 <HogFlowEditorToolbarNode key={`${node.type}-${index}`} action={node} />
             ))}
             {featureFlags[FEATURE_FLAGS.WORKFLOWS_PUSH_NOTIFICATIONS] && (
-                <HogFlowEditorToolbarNode key="push-notifications" action={PUSH_NOTIFICATION_ACTION_NODE} />
+                <HogFlowEditorToolbarNode key="push-notifications" action={PUSH_NOTIFICATION_ACTION_NODE}>
+                    <span className="inline-flex items-center gap-1.5">
+                        {PUSH_NOTIFICATION_ACTION_NODE.name}
+                        <LemonTag type="completion">Beta</LemonTag>
+                    </span>
+                </HogFlowEditorToolbarNode>
             )}
             <HogFunctionTemplatesChooser />
 


### PR DESCRIPTION
## Problem

Push notifications in workflows are still rolling out (gated behind the `workflows-push-notifications` flag) and aren't GA. The "Push" step in the workflow build panel had no indication it's early-access.

## Changes

Add a `Beta` tag next to the Push step in the build panel, mirroring the pattern just used for the suppression list in #72496 (`<LemonTag type="completion">Beta</LemonTag>` wrapped in an inline-flex span). Only shows where the push step already shows — behind the existing feature flag.

<img width="451" height="295" alt="Screenshot 2026-07-21 at 13 01 35" src="https://github.com/user-attachments/assets/e7364059-e675-4a5d-b2da-2cecfe7930d5" />

## How did you test this code?

Visual/label-only change. `oxfmt` and `oxlint` clean on the file (the one remaining oxlint warning on that file is a pre-existing `style` prop, untouched here). I (Claude) couldn't run the frontend typecheck in this environment; the change is type-safe (`HogFlowEditorToolbarNode` already accepts `children`, and `LemonTag type="completion"` is the same usage as #72496), and CI covers it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal UI label only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Directed by @dmarchuk, assigned as DRI.

Authored with Claude Code. Trivial UI change following the exact pattern of #72496.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbav6vE7Tm24KkdRhZmvNM)_