### PR TITLE
fix(wordpress): surface actionable error for unexpected REST responses

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress.py
@@ -276,6 +276,23 @@ class TestValidateCredentials:
             else:
                 assert expected_msg_substr in (msg or "")
 
+    @pytest.mark.parametrize(
+        "json_data, text, expects_substr, forbidden_substr",
+        [
+            # A bare proxy/WAF status line must not leak; the user gets an actionable message instead.
+            (None, "Bad Request", "unexpected response (HTTP 400)", "Bad Request"),
+            # A genuine WordPress REST error message is still surfaced.
+            ({"message": "rest_invalid_param"}, "", "rest_invalid_param", None),
+        ],
+    )
+    def test_unrecognized_status_does_not_leak_raw_body(self, json_data, text, expects_substr, forbidden_substr):
+        with self._patch_session(_response(status_code=400, json_data=json_data, text=text)):
+            valid, msg = validate_credentials("https://example.com", None, None)
+            assert valid is False
+            assert expects_substr in (msg or "")
+            if forbidden_substr is not None:
+                assert forbidden_substr not in (msg or "")
+
     def test_invalid_site_url(self):
         valid, msg = validate_credentials("", None, None)
         assert valid is False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/wordpress.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/wordpress.py
@@ -277,11 +277,22 @@ def validate_credentials(
     if response.status_code == 404:
         return False, "WordPress REST API not found at this URL — confirm the site URL and that the REST API is enabled"
 
+    # A WordPress REST error carries a JSON `message` worth surfacing. Anything else — a WAF,
+    # reverse proxy, or load balancer answering with a bare status line like "Bad Request" — gives
+    # the user nothing to act on, so replace it with an actionable message naming the status code
+    # rather than leaking the raw body.
     try:
         body = response.json()
-        return False, body.get("message", response.text)
+        wp_message = body.get("message") if isinstance(body, dict) else None
     except Exception:
-        return False, response.text
+        wp_message = None
+
+    if wp_message:
+        return False, wp_message
+    return False, (
+        f"WordPress returned an unexpected response (HTTP {response.status_code}). "
+        "Check the site URL is correct and that the REST API is enabled and reachable, then try again."
+    )
 
 
 def _parse_retry_after(response: requests.Response) -> float | None:


### PR DESCRIPTION
## Problem

When a user creates a WordPress data-warehouse source, we probe the site's REST root to validate the connection. For any status code we don't recognise (not 200/401/403/404), the validator fell through to returning the raw HTTP body.

WordPress sites often sit behind a WAF, reverse proxy, or managed-host load balancer. Those answer a rejected request with a bare status line like a plain-text `Bad Request`, which then surfaced verbatim in the setup wizard. The user got an opaque two-word string with nothing to act on.

## Changes

- In `validate_credentials`, keep surfacing a genuine WordPress JSON `message` (those carry useful REST error detail like `rest_invalid_param`).
- For anything else, return an actionable message that names the status code instead of leaking the raw body.

## How did you test this code?

Added a parameterized case to `TestValidateCredentials.test_unrecognized_status_does_not_leak_raw_body` in `test_wordpress.py`:

- a bare proxy/WAF status line (no JSON) → asserts the user gets the status-coded message and that the raw body text never appears in it.
- a genuine WordPress JSON `message` → asserts it is still surfaced.

No existing test exercised the unrecognized-status fall-through, so a revert to returning the raw body would go uncaught. Ran the `TestValidateCredentials` suite locally (15 passed). No manual/UI testing was done by me (the agent).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of WordPress source-creation validation failures and traced the opaque messages to the fall-through in `validate_credentials`. Invoked `/writing-tests` before adding the test. Chose to preserve WordPress's own JSON error messages (they're informative) and only replace non-JSON/unknown bodies, rather than blanket-replacing every non-2xx response.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
