### PR TITLE
fix(webflow): surface a clear error for an invalid Site ID

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/test_webflow.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/test_webflow.py
@@ -207,6 +207,7 @@ class TestValidateCredentials:
             ("bad_token", 401, None, False),
             ("missing_scope_at_create", 403, None, True),
             ("missing_scope_for_schema", 403, "products", False),
+            ("invalid_site_id", 400, None, False),
             ("site_not_found", 404, None, False),
             ("server_error", 500, None, False),
         ]
@@ -216,6 +217,18 @@ class TestValidateCredentials:
             MockSession.return_value.get.return_value = _make_response({"message": "nope"}, status_code=status_code)
             ok, _error = validate_credentials("token", "site-1", schema_name)
         assert ok is expected_ok
+
+    def test_invalid_site_id_400_does_not_leak_raw_envelope(self) -> None:
+        # A malformed Site ID gets a 400 with Webflow's raw "Validation Error: ..." envelope, which
+        # must not surface to the user.
+        with patch(TRANSPORT) as MockSession:
+            MockSession.return_value.get.return_value = _make_response(
+                {"message": "Validation Error: Provided IDs are invalid: Site ID"}, status_code=400
+            )
+            ok, error = validate_credentials("token", "site-1")
+        assert ok is False
+        assert "Site ID isn't valid" in (error or "")
+        assert "Validation Error" not in (error or "")
 
     def test_request_exception_returns_error(self) -> None:
         with patch(TRANSPORT) as MockSession:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/webflow.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/webflow.py
@@ -107,6 +107,15 @@ def validate_credentials(api_token: str, site_id: str, schema_name: Optional[str
     if response.status_code == 404:
         return False, f"Webflow site '{site_id}' was not found or is not accessible by this token"
 
+    # A 400 means Webflow rejected the Site ID as malformed before looking it up — distinct from a
+    # 404 for a well-formed but unknown/inaccessible id. Surface a clear message instead of leaking
+    # Webflow's raw "Validation Error: ..." envelope.
+    if response.status_code == 400:
+        return (
+            False,
+            "The Webflow Site ID isn't valid. Check that you entered the Site ID (not the site name or URL) and try again.",
+        )
+
     try:
         message = response.json().get("message", response.text)
     except ValueError:


### PR DESCRIPTION
## Problem

When a user creates a Webflow data-warehouse source, we validate by probing `GET /sites/{site_id}`. If the Site ID is malformed, Webflow rejects it with an HTTP 400 and its own raw validation envelope (prefixed with `Validation Error: ...`). We handled 401/403/404 but not 400, so that raw envelope fell through and surfaced verbatim in the setup wizard.

## Changes

- Handle a 400 explicitly in `validate_credentials` with a clear, actionable message telling the user to check the Site ID.
- This is distinct from the existing 404 branch, which covers a well-formed but unknown or inaccessible site.

## How did you test this code?

- Added `test_invalid_site_id_400_does_not_leak_raw_envelope` asserting the user gets the clean message and that Webflow's raw `Validation Error` text never appears in it.
- Added a `400 → invalid` case to the existing `test_status_mapping` parameterization.

No existing test covered a 400, so a revert would go uncaught. Ran the `TestValidateCredentials` suite locally (9 passed). No manual/UI testing was done by me (the agent).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of Webflow source-creation failures and traced the opaque `Validation Error: ...` message to the missing 400 branch in `validate_credentials`. Invoked `/writing-tests` before adding tests. Kept 400 separate from 404 since they mean different things (malformed vs unknown id).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
