### PR TITLE
fix(tasks): stop the sandbox retaining a prior actor's GitHub token

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -290,6 +290,14 @@ BLOCKED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# Stripped from the agent-server's process environment at launch (env -u).
+# Two categories:
+#   - code-injection vectors a resume snapshot could smuggle in (NODE_*, LD_*, DYLD_*);
+#   - the GitHub token, so the agent-server holds no frozen copy of the acting user's
+#     credentials. The token is delivered per command via the live /tmp/agent-env file
+#     (re-sourced by BASH_ENV, seeded before this unset), so git/gh still authenticate;
+#     removing the static process-env copy is what lets a mid-session logout or rebind
+#     actually take effect instead of being resurrected from os.environ.
 SANDBOX_AGENT_LAUNCH_UNSET_ENV_VARS: tuple[str, ...] = (
     "NODE_OPTIONS",
     "NODE_REPL_EXTERNAL_MODULE",
@@ -298,6 +306,8 @@ SANDBOX_AGENT_LAUNCH_UNSET_ENV_VARS: tuple[str, ...] = (
     "LD_AUDIT",
     "DYLD_INSERT_LIBRARIES",
     "DYLD_LIBRARY_PATH",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
 )
 
 

--- a/products/tasks/backend/temporal/process_task/sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/sandbox_credentials.py
@@ -19,11 +19,13 @@ from products.tasks.backend.temporal.process_task.utils import (
     PrAuthorshipMode,
     get_github_token,
     get_pr_authorship_mode,
+    get_sandbox_github_identity_user,
     get_sandbox_github_token,
     get_task_run_credential_user,
     is_caller_token_run,
     is_slack_interaction_state,
     resolve_user_github_integration_for_task,
+    sandbox_identity_scope,
 )
 
 if TYPE_CHECKING:
@@ -159,7 +161,14 @@ def _live_sandboxes_for_user_integration(user_integration_id: int) -> list[tuple
             task__github_user_integration_id=user_integration_id,
         )
         .select_related("task")
-        .only("id", "state", "task__repository", "task__github_user_integration_id", "task__origin_product")
+        .only(
+            "id",
+            "state",
+            "task__repository",
+            "task__github_user_integration_id",
+            "task__origin_product",
+            "task__created_by_id",
+        )
     )
     for run in runs:
         sandbox_id = (run.state or {}).get("sandbox_id")
@@ -171,6 +180,13 @@ def _live_sandboxes_for_user_integration(user_integration_id: int) -> list[tuple
         if get_pr_authorship_mode(run.task, run.state) != PrAuthorshipMode.USER:
             continue
         if is_caller_token_run(str(run.id), run.state):
+            continue
+        # A per-message actor transition may have rebound (or logged out) this sandbox's GitHub
+        # identity to someone other than the run owner. This loop carries the owner's token, so
+        # re-applying it would undo that transition and resurrect the owner's identity for the
+        # current actor. Skip when the sandbox is bound to a different actor.
+        bound_actor = get_sandbox_github_identity_user(sandbox_identity_scope(str(run.id), run.state))
+        if bound_actor is not None and bound_actor != run.task.created_by_id:
             continue
         rows.append((str(run.id), sandbox_id, run.task.repository))
     return rows

--- a/products/tasks/backend/temporal/process_task/tests/test_sandbox_credentials.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_sandbox_credentials.py
@@ -462,3 +462,43 @@ class TestLiveSandboxRegistry:
         result = _live_sandboxes_for_user_integration(integration.id)
 
         assert result == [(str(live_run.id), "sb-live", "org/live")]
+
+    @pytest.mark.parametrize("marker,included", [("none", True), ("owner", True), ("other", False)])
+    def test_actor_transition_gates_owner_token_propagation(self, marker, included):
+        from posthog.models import Organization, Team
+        from posthog.models.user import User
+        from posthog.models.user_integration import UserIntegration
+
+        from products.tasks.backend.models import Task, TaskRun
+        from products.tasks.backend.temporal.process_task.sandbox_credentials import (
+            _live_sandboxes_for_user_integration,
+        )
+        from products.tasks.backend.temporal.process_task.utils import mark_sandbox_github_identity
+
+        org = Organization.objects.create(name="o")
+        team = Team.objects.create(organization=org, name="t")
+        owner = User.objects.create(email="owner@test.com")
+        other = User.objects.create(email="other@test.com")
+        integration = UserIntegration.objects.create(
+            user=owner, kind=UserIntegration.IntegrationKind.GITHUB, integration_id="i1", config={}, sensitive_config={}
+        )
+        task = Task.objects.create(
+            team=team, created_by=owner, repository="org/repo", github_user_integration=integration
+        )
+        run = TaskRun.objects.create(
+            task=task,
+            team=team,
+            status=TaskRun.Status.IN_PROGRESS,
+            state={"sandbox_id": "sb-x", "pr_authorship_mode": "user"},
+        )
+        # An unset marker (no transition yet) and one bound to the owner both propagate; a marker
+        # bound to a different per-message actor means the sandbox was logged out / rebound, so the
+        # owner's rotating token must not overwrite it.
+        if marker == "owner":
+            mark_sandbox_github_identity("sb-x", owner.id)
+        elif marker == "other":
+            mark_sandbox_github_identity("sb-x", other.id)
+
+        result = _live_sandboxes_for_user_integration(integration.id)
+
+        assert (result == [(str(run.id), "sb-x", "org/repo")]) is included


### PR DESCRIPTION
## 🎯 Summary

Follow-up to #71941. During multiplayer testing, a follow-up actor **without** repo access pushed as the **previous** actor: the exact leak the GitHub identity gate is meant to prevent. The logout stripped the git remote and the `/tmp/agent-env` file, but the prior actor's token survived in two runtime places the file-clear can't reach. This closes both.

## When does a transition happen?

A "transition" is a follow-up in the same thread from a **different** Slack user than the one the sandbox is currently bound to. The gate fires only then (same-actor follow-ups and bot runs are skipped).

```mermaid
sequenceDiagram
    actor A as User A (has access)
    actor B as User B (no access)
    participant S as Sandbox (one shared box)
    participant G as GitHub

    A->>S: "@bot clone repo X and work on it"
    Note over S: provisioned with A's token<br/>identity marker = A
    B->>S: same thread: "commit it and open a PR"
    rect rgb(255,235,235)
    Note over S: ACTOR TRANSITION  A to B
    S->>S: gate: B has no access, so LOG OUT<br/>clears git remote + /tmp/agent-env
    S-->>S: but A's token survives elsewhere
    S->>G: git push (recovered A's token)
    G-->>B: PR opened as User A  (LEAK)
    end
```

## Why the logout didn't stick: the token lives in 3 places

One running sandbox holds A's token in three spots. Logout only reached two of them:

```text
  git remote URL     x-access-token:<A>@github.com/...     cleared on logout   OK
  /tmp/agent-env     GH_TOKEN=<A>   (live, per command)    cleared on logout   OK
  agent-server env   process.env.GH_TOKEN=<A>              frozen at launch    LEAK  <- this PR
       + periodic refresh loop re-writes A's token back into the file          LEAK  <- this PR
```

## Changes

- **`constants.py`**: add `GITHUB_TOKEN` / `GH_TOKEN` to `SANDBOX_AGENT_LAUNCH_UNSET_ENV_VARS`, so the agent-server process holds no static token. The token is still delivered per command via the live file (re-sourced by `BASH_ENV`, seeded by `env -0 > ENV_FILE` **before** the unset), so `git`/`gh` still authenticate on turn 1: only the un-revocable copy is removed. Audited every agent-server token consumer first: all resolve via the file-first `resolveGithubToken`, so the unset is safe.
- **`sandbox_credentials.py`**: the periodic refresh loop now skips a run whose `sandbox-github-identity` marker is bound to a different actor than the run owner (a transition / logout has occurred), so it can't re-inject the owner's token.

```mermaid
flowchart LR
    T([user token refreshed]) --> L{ run's sandbox marker<br/>== run owner? }
    L -- "yes / unset" --> A[re-apply owner token]
    L -- "no: transitioned away" --> S[skip, leave the current<br/>actor's state intact]
```

## Companion PR (required together)

Needs **PostHog/code#3611**, which makes the agent-server treat an emptied env file as an explicit logout (return `""`) instead of falling back to `process.env`, and runs the `gh` attribution/whoami calls as the current actor. This backend PR removes the process-env token; the code PR stops the resolver and `gh` paths from resurrecting it. Both are needed for a complete fix.

## How did you test this code?

- New `resolveGithubToken` tests in PostHog/code#3611 (11 pass), including the assertion that an emptied file does not resurrect the process-env token.
- New parameterized backend test `test_actor_transition_gates_owner_token_propagation` (marker unset / owner / other -> include / include / exclude). Could not run the DB-backed suite locally (ClickHouse held by the local dev stack); CI validates.