### PR TITLE
fix(hubspot): retry chunked-encoding errors during page fetch

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/hubspot.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/hubspot.py
@@ -332,7 +332,14 @@ def get_rows(
         )
 
     @retry(
-        retry=retry_if_exception_type((HubspotRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        retry=retry_if_exception_type(
+            (
+                HubspotRetryableError,
+                requests.ReadTimeout,
+                requests.ConnectionError,
+                requests.exceptions.ChunkedEncodingError,
+            )
+        ),
         stop=stop_after_attempt(5),
         wait=wait_exponential_jitter(initial=1, max=30),
         reraise=True,
@@ -425,7 +432,14 @@ def _batch_read_associations(
     by_from: dict[str, list[dict[str, Any]]] = {}
 
     @retry(
-        retry=retry_if_exception_type((HubspotRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        retry=retry_if_exception_type(
+            (
+                HubspotRetryableError,
+                requests.ReadTimeout,
+                requests.ConnectionError,
+                requests.exceptions.ChunkedEncodingError,
+            )
+        ),
         stop=stop_after_attempt(5),
         wait=wait_exponential_jitter(initial=1, max=30),
         reraise=True,
@@ -590,7 +604,14 @@ def get_rows_via_search(
     last_cursor_ms = current_lower
 
     @retry(
-        retry=retry_if_exception_type((HubspotRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        retry=retry_if_exception_type(
+            (
+                HubspotRetryableError,
+                requests.ReadTimeout,
+                requests.ConnectionError,
+                requests.exceptions.ChunkedEncodingError,
+            )
+        ),
         stop=stop_after_attempt(5),
         wait=wait_exponential_jitter(initial=1, max=30),
         reraise=True,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py
@@ -5,7 +5,10 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 
-from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
+from requests.exceptions import (
+    ChunkedEncodingError,
+    JSONDecodeError as RequestsJSONDecodeError,
+)
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.hubspot.hubspot import (
     HubspotPathologicalWindowError,
@@ -1096,6 +1099,47 @@ class TestGetRowsFullRefresh:
             )
 
         # The truncated response was reissued (same URL) and the retry yielded the row.
+        assert len(captured_urls) == 2
+        assert captured_urls[0] == captured_urls[1]
+        assert sum(t.num_rows for t in tables) == 1
+
+    def test_chunked_encoding_error_is_retried(self) -> None:
+        # Regression: a connection dropped mid-stream (server closes early during chunked
+        # transfer) raises requests' ChunkedEncodingError, which isn't a ConnectionError
+        # subclass. It must be treated as transient and retried, not crash the whole import.
+        from products.warehouse_sources.backend.temporal.data_imports.sources.hubspot.hubspot import get_rows
+
+        manager = _make_manager()
+        logger = MagicMock()
+
+        good = _make_response(200, {"results": [{"id": "1", "properties": {"hs_object_id": "1"}}]})
+        responses = iter([ChunkedEncodingError("Connection broken"), good])
+        captured_urls: list[str] = []
+
+        def _get(url, headers=None, timeout=None):  # noqa: ARG001
+            captured_urls.append(url)
+            next_response = next(responses)
+            if isinstance(next_response, Exception):
+                raise next_response
+            return next_response
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.hubspot.hubspot.make_tracked_session",
+            new=lambda *_a, **_k: type("_S", (), {"get": staticmethod(_get)})(),
+        ):
+            tables = list(
+                get_rows(
+                    api_key="k",
+                    refresh_token="r",
+                    endpoint="deals",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                    include_custom_props=False,
+                    api_version=HUBSPOT_API_VERSION_V3,
+                )
+            )
+
+        # The dropped connection was retried (same URL) and the second attempt yielded the row.
         assert len(captured_urls) == 2
         assert captured_urls[0] == captured_urls[1]
         assert sum(t.num_rows for t in tables) == 1


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ChunkedEncodingError` (`Connection broken: InvalidChunkLength(got length b'', 0 bytes read)`) originating from the HubSpot warehouse source's page-fetch code (`hubspot.py`, `fetch_page`). The connection dropped mid-stream while `requests` was decoding a chunked HTTP response body.

This is a self-recovering network blip, not a bug in the request itself or a user/credential problem, so it shouldn't be added to `NonRetryableErrors`. The source already retries `ReadTimeout` and `ConnectionError` in-process via `tenacity`, but `requests.exceptions.ChunkedEncodingError` is a sibling of `ConnectionError` in the `requests` exception hierarchy, not a subclass of it — so it fell through the retry predicate and crashed the whole sync activity instead of being retried like other transient network errors. Several other warehouse sources (bitbucket, airbrake, awin, and others) already retry this exact exception alongside `ConnectionError`/`ReadTimeout` — HubSpot was missing the equivalent handling.

## Changes

- All three `tenacity`-retried request helpers in `hubspot.py` (`fetch_page` in `get_rows`, `_post_chunk` in `_batch_read_associations`, `fetch_search` in `get_rows_via_search`) now also retry on `requests.exceptions.ChunkedEncodingError`, matching the existing `ReadTimeout`/`ConnectionError` handling and the convention already used by sibling sources.

## How did you test this code?

Added `test_chunked_encoding_error_is_retried` to `test_hubspot_search.py` (`TestGetRowsFullRefresh`): a `ChunkedEncodingError` on the first page fetch followed by a successful response still yields the expected row, exercising the exact failure shape from error tracking. This catches a real regression: without the fix, a single dropped connection during a page fetch fails the whole sync instead of retrying in-process.

Ran the full `hubspot` test suite (49 passed), `ruff check` / `ruff format --check` — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking, read the full stack trace and the `hubspot.py` page-fetch code, and confirmed the failure genuinely originates in this source (not just referenced in serialized log context). Compared against how sibling warehouse sources (bitbucket, airbrake, awin) already handle this exact exception class to confirm this was a gap rather than an intentional omission. Invoked the `/writing-tests` skill before adding the regression test. Searched open PRs (by exception type, message, module path, and the maintainer's own open PRs) and found a similar recent fix for `meta_ads` (different file, same failure class) but no existing fix for HubSpot.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*