### PR TITLE
fix(ci): publish posthog-replay-anonymizer on merge instead of tags

### DIFF
--- a/.github/workflows/publish-replay-anonymizer-crate.yml
+++ b/.github/workflows/publish-replay-anonymizer-crate.yml
@@ -126,12 +126,12 @@ jobs:
                       fi
                       echo "posthog-replay-anonymizer $version is already on crates.io; nothing to publish."
                       echo "publish-needed=false" >> $GITHUB_OUTPUT
-                  else
-                      # 404 = needs release; on a persistent registry error assume unpublished and let
-                      # cargo publish decide — it is authoritative, cannot overwrite an existing
-                      # version, and failing beats silently skipping a needed release.
+                  elif [[ "$http_code" == '404' ]]; then
                       echo "Publishing posthog-replay-anonymizer v$version"
                       echo "publish-needed=true" >> $GITHUB_OUTPUT
+                  else
+                      echo "::error::No definitive answer from crates.io (HTTP $http_code) for posthog-replay-anonymizer $version after 3 attempts. Re-run this job once crates.io recovers."
+                      exit 1
                   fi
 
             - name: Install rust

--- a/.github/workflows/publish-replay-anonymizer-crate.yml
+++ b/.github/workflows/publish-replay-anonymizer-crate.yml
@@ -2,50 +2,116 @@ name: Publish posthog-replay-anonymizer to crates.io
 
 on:
     push:
-        tags:
-            - 'posthog-replay-anonymizer/v*'
+        branches:
+            - master
+        paths:
+            - rust/replay-anonymizer/**
+            - .github/workflows/publish-replay-anonymizer-crate.yml
+    pull_request:
+        paths:
+            - rust/replay-anonymizer/**
+            - .github/workflows/publish-replay-anonymizer-crate.yml
 
 env:
     CARGO_TERM_COLOR: always
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+    check-version-bump:
+        name: Check version was bumped
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        if: github.event_name == 'pull_request'
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Check if crate code changed
+              id: changed-files
+              uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5
+              with:
+                  files_yaml: |
+                      crate:
+                      - rust/replay-anonymizer/**
+
+            - name: Compare crate version against crates.io
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CRATE_CHANGED: ${{ steps.changed-files.outputs.crate_any_changed }}
+                  IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+              run: |
+                  if [[ "$CRATE_CHANGED" != 'true' ]]; then
+                      echo "Only the workflow changed; no version bump needed."
+                      exit 0
+                  fi
+                  version=$(grep -m1 '^version' rust/replay-anonymizer/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+                  # 200 = version already on crates.io, 404 = will publish on merge.
+                  http_code=$(curl -o /dev/null -sSL -w '%{http_code}' -A 'PostHog CI (https://github.com/PostHog/posthog)' "https://crates.io/api/v1/crates/posthog-replay-anonymizer/$version")
+                  if [[ "$IS_FORK" == 'true' ]]; then
+                      # The fork token can't post the reminder comment; surface via annotation instead.
+                      if [[ "$http_code" == '200' ]]; then
+                          echo "::warning::posthog-replay-anonymizer changed but its version stayed at $version, which is already on crates.io. Bump version in rust/replay-anonymizer/Cargo.toml."
+                      fi
+                      exit 0
+                  fi
+                  if [[ "$http_code" == '200' ]]; then
+                      message_body="It looks like the code of \`posthog-replay-anonymizer\` changed in this PR, but its version stayed the same at $version, which is already on crates.io. 👀"
+                      message_body+=$'\n'"Bump \`version\` in \`rust/replay-anonymizer/Cargo.toml\` before merging — the crate publishes automatically on merge to master."
+                      BODY="$message_body" GITHUB_TOKEN="$GH_TOKEN" node .github/scripts/post-reminder-section.mjs replay-anonymizer-crate warn "version bump needed"
+                  elif [[ "$http_code" == '404' ]]; then
+                      GITHUB_TOKEN="$GH_TOKEN" node .github/scripts/post-reminder-section.mjs replay-anonymizer-crate --clear "v$version will publish on merge"
+                  else
+                      echo "::warning::Unexpected HTTP $http_code from crates.io for posthog-replay-anonymizer $version; skipping version check."
+                  fi
+
     publish:
         name: Publish to crates.io
         runs-on: ubuntu-24.04
         timeout-minutes: 10
-        if: github.repository == 'PostHog/posthog'
-
+        if: github.event_name == 'push' && github.repository == 'PostHog/posthog'
         permissions:
             contents: read
             id-token: write
-
         defaults:
             run:
                 working-directory: rust
-
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+            - name: Check whether this version is already on crates.io
+              id: version
+              shell: bash
+              run: |
+                  version=$(grep -m1 '^version' replay-anonymizer/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+                  http_code=$(curl -o /dev/null -sSL -w '%{http_code}' -A 'PostHog CI (https://github.com/PostHog/posthog)' "https://crates.io/api/v1/crates/posthog-replay-anonymizer/$version")
+                  if [[ "$http_code" == '200' ]]; then
+                      echo "posthog-replay-anonymizer $version is already on crates.io; nothing to publish."
+                      echo "publish-needed=false" >> $GITHUB_OUTPUT
+                  else
+                      # 404 = needs release; on any other code assume unpublished and let cargo publish decide.
+                      echo "Publishing posthog-replay-anonymizer v$version"
+                      echo "publish-needed=true" >> $GITHUB_OUTPUT
+                  fi
+
             - name: Install rust
+              if: steps.version.outputs.publish-needed == 'true'
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
 
-            - name: Verify tag matches crate version
-              run: |
-                  TAG_VERSION="${GITHUB_REF_NAME#posthog-replay-anonymizer/v}"
-                  CRATE_VERSION=$(grep '^version' replay-anonymizer/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-                  if [ "$TAG_VERSION" != "$CRATE_VERSION" ]; then
-                      echo "::error::Tag version ($TAG_VERSION) does not match crate version ($CRATE_VERSION)"
-                      exit 1
-                  fi
-                  echo "Publishing posthog-replay-anonymizer v$CRATE_VERSION"
-
             - name: Authenticate with crates.io
+              if: steps.version.outputs.publish-needed == 'true'
               id: auth
               uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
             - name: Publish to crates.io
+              if: steps.version.outputs.publish-needed == 'true'
               env:
                   CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
               run: cargo publish -p posthog-replay-anonymizer

--- a/.github/workflows/publish-replay-anonymizer-crate.yml
+++ b/.github/workflows/publish-replay-anonymizer-crate.yml
@@ -51,8 +51,14 @@ jobs:
                       exit 0
                   fi
                   version=$(grep -m1 '^version' rust/replay-anonymizer/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
-                  # 200 = version already on crates.io, 404 = will publish on merge.
-                  http_code=$(curl -o /dev/null -sSL -w '%{http_code}' -A 'PostHog CI (https://github.com/PostHog/posthog)' "https://crates.io/api/v1/crates/posthog-replay-anonymizer/$version")
+                  # 200 = version already on crates.io, 404 = will publish on merge. Retry transient registry errors.
+                  for attempt in 1 2 3; do
+                      http_code=$(curl -o /dev/null -sSL -w '%{http_code}' -A 'PostHog CI (https://github.com/PostHog/posthog)' "https://crates.io/api/v1/crates/posthog-replay-anonymizer/$version") || http_code='000'
+                      if [[ "$http_code" == '200' || "$http_code" == '404' ]]; then
+                          break
+                      fi
+                      sleep 2
+                  done
                   if [[ "$IS_FORK" == 'true' ]]; then
                       # The fork token can't post the reminder comment; surface via annotation instead.
                       if [[ "$http_code" == '200' ]]; then
@@ -67,7 +73,9 @@ jobs:
                   elif [[ "$http_code" == '404' ]]; then
                       GITHUB_TOKEN="$GH_TOKEN" node .github/scripts/post-reminder-section.mjs replay-anonymizer-crate --clear "v$version will publish on merge"
                   else
-                      echo "::warning::Unexpected HTTP $http_code from crates.io for posthog-replay-anonymizer $version; skipping version check."
+                      # Refresh the sticky section rather than leaving a stale warn from an earlier push.
+                      message_body="Could not reach crates.io (HTTP $http_code) to check whether \`posthog-replay-anonymizer\` $version is already published. Push again or re-run this check to re-verify."
+                      BODY="$message_body" GITHUB_TOKEN="$GH_TOKEN" node .github/scripts/post-reminder-section.mjs replay-anonymizer-crate info "could not verify v$version against crates.io"
                   fi
 
     publish:
@@ -83,18 +91,45 @@ jobs:
                 working-directory: rust
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 0
+                  filter: blob:none
+
+            - name: Check if crate code changed in this push
+              id: changed-files
+              uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5
+              with:
+                  files_yaml: |
+                      crate:
+                      - rust/replay-anonymizer/**
 
             - name: Check whether this version is already on crates.io
               id: version
               shell: bash
+              env:
+                  CRATE_CHANGED: ${{ steps.changed-files.outputs.crate_any_changed }}
               run: |
                   version=$(grep -m1 '^version' replay-anonymizer/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
-                  http_code=$(curl -o /dev/null -sSL -w '%{http_code}' -A 'PostHog CI (https://github.com/PostHog/posthog)' "https://crates.io/api/v1/crates/posthog-replay-anonymizer/$version")
+                  for attempt in 1 2 3; do
+                      http_code=$(curl -o /dev/null -sSL -w '%{http_code}' -A 'PostHog CI (https://github.com/PostHog/posthog)' "https://crates.io/api/v1/crates/posthog-replay-anonymizer/$version") || http_code='000'
+                      if [[ "$http_code" == '200' || "$http_code" == '404' ]]; then
+                          break
+                      fi
+                      sleep 2
+                  done
                   if [[ "$http_code" == '200' ]]; then
+                      if [[ "$CRATE_CHANGED" == 'true' ]]; then
+                          # Fail loudly rather than silently shipping nothing: these crate changes
+                          # won't reach crates.io until a follow-up PR bumps the version.
+                          echo "::error::posthog-replay-anonymizer changed in this push but $version is already on crates.io. Bump version in rust/replay-anonymizer/Cargo.toml in a follow-up PR."
+                          exit 1
+                      fi
                       echo "posthog-replay-anonymizer $version is already on crates.io; nothing to publish."
                       echo "publish-needed=false" >> $GITHUB_OUTPUT
                   else
-                      # 404 = needs release; on any other code assume unpublished and let cargo publish decide.
+                      # 404 = needs release; on a persistent registry error assume unpublished and let
+                      # cargo publish decide — it is authoritative, cannot overwrite an existing
+                      # version, and failing beats silently skipping a needed release.
                       echo "Publishing posthog-replay-anonymizer v$version"
                       echo "publish-needed=true" >> $GITHUB_OUTPUT
                   fi

--- a/frontend/bin/ci-report/update-ci-report.mjs
+++ b/frontend/bin/ci-report/update-ci-report.mjs
@@ -31,6 +31,7 @@ export const SECTIONS = [
     { id: 'hogql-parser-py', title: 'hogql-parser version' },
     { id: 'hogql-parser-npm', title: '@posthog/hogql-parser version' },
     { id: 'hogql-parser-rs', title: 'hogql-parser-rs version' },
+    { id: 'replay-anonymizer-crate', title: 'posthog-replay-anonymizer version' },
     { id: 'generated-docs', title: 'Generated docs' },
     { id: 'docs-preview', title: 'Docs preview' },
     { id: 'hobby-deploy', title: 'Hobby preview' },

--- a/rust/replay-anonymizer/README.md
+++ b/rust/replay-anonymizer/README.md
@@ -15,4 +15,4 @@ Offline consumers (JSONL of individual events rather than Kafka messages) get a 
 
 Publishing to crates.io is automated by `.github/workflows/publish-replay-anonymizer-crate.yml`: bump `version` in `Cargo.toml` in your PR, and on merge to master the workflow publishes any version not yet on crates.io via trusted publishing (GitHub OIDC, no long-lived token). No tags involved.
 
-If crate code changes in a PR without a version bump, CI posts a reminder comment on the PR.
+If crate code changes in a PR without a version bump, CI posts a reminder comment on the PR. If un-bumped crate changes still reach master (say the version got taken by a PR that merged first), the publish run fails loudly instead of silently skipping; bump the version in a follow-up PR.

--- a/rust/replay-anonymizer/README.md
+++ b/rust/replay-anonymizer/README.md
@@ -13,9 +13,6 @@ Offline consumers (JSONL of individual events rather than Kafka messages) get a 
 
 ## Releasing
 
-Publishing to crates.io is automated by `.github/workflows/publish-replay-anonymizer-crate.yml`:
+Publishing to crates.io is automated by `.github/workflows/publish-replay-anonymizer-crate.yml`: bump `version` in `Cargo.toml` in your PR, and on merge to master the workflow publishes any version not yet on crates.io via trusted publishing (GitHub OIDC, no long-lived token). No tags involved.
 
-1. Bump `version` in `Cargo.toml` and merge to master.
-2. Tag the merged commit `posthog-replay-anonymizer/v<version>` and push the tag.
-
-The workflow verifies the tag matches the crate version and publishes via crates.io trusted publishing (GitHub OIDC, no long-lived token).
+If crate code changes in a PR without a version bump, CI posts a reminder comment on the PR.


### PR DESCRIPTION
## Problem

`posthog-replay-anonymizer` is not being published to crates.io automatically. The crate version was bumped to 0.2.0 on master in #71954, but crates.io still only has 0.1.0, because the publish workflow only fires on a manually pushed `posthog-replay-anonymizer/v*` tag and nobody pushed one.

Tag-driven publishing was the wrong trigger for this repo. The precedent (`build-hogql-parser-rs.yml`) publishes based on which files were touched, with no tags involved.

## Changes

Before:

```mermaid
flowchart LR
    A([PR bumps Cargo.toml version]) --> B[merge to master]
    B --> C[human remembers to push a tag]
    C --> D{{publish workflow}}
    D --> E[(crates.io)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D phBlue;
    class C phRed;
    class A,B phYellow;
    class E phGray;
```

After:

```mermaid
flowchart LR
    A([PR touches rust/replay-anonymizer/**]) --> R{{PR job: version bump reminder}}
    A --> B[merge to master]
    B --> P{{push job: publish if version not on crates.io}}
    P --> E[(crates.io)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class R,P phBlue;
    class A,B phYellow;
    class E phGray;
```

Rework of `publish-replay-anonymizer-crate.yml`, modelled on `build-hogql-parser-rs.yml`:

- On push to master touching `rust/replay-anonymizer/**` (or the workflow), check crates.io for the version in `Cargo.toml` and publish it if it's not there. Trusted publishing (OIDC) is unchanged, and since the workflow filename stays the same, no crates.io trusted-publisher config change is needed.
- On PRs touching the crate, post the sticky CI-report reminder comment if crate code changed without a version bump (and clear it once bumped), same as the hogql parser check does. New `replay-anonymizer-crate` section registered in `update-ci-report.mjs`. Fork PRs get a workflow annotation instead since their token can't comment.
- Updated the release docs in the crate README to drop the tagging step.

> [!NOTE]
> Merging this PR touches the workflow file, which triggers the master publish job, which will see 0.2.0 missing from crates.io and publish it. So the missed 0.2.0 release backfills itself on merge.

## How did you test this code?

- `bin/hogli lint:workflows` passes (actionlint isn't installed locally, it runs in CI).
- Verified the trigger endpoints manually: `https://crates.io/api/v1/crates/posthog-replay-anonymizer/0.2.0` returns 404 (would publish) and 0.1.0 returns 200 (would skip).
- The PR-side reminder path reuses the existing `post-reminder-section.mjs` plumbing already exercised by the hogql parser workflows.
- I couldn't test the OIDC publish leg without merging; it's unchanged from the tag-based workflow apart from the trigger and the version check replacing the tag check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Release docs live in `rust/replay-anonymizer/README.md` and are updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, authored with Claude Code (Fable 5). Skills invoked: /authoring-ci-workflows. Root cause diagnosis: compared master's crate version (0.2.0) against crates.io (0.1.0) and confirmed no `posthog-replay-anonymizer/v*` tag exists. Considered publishing from the PR itself like the hogql parser wheels do, but that pattern exists because monorepo CI must install the published wheel on the same PR; this crate's only registry consumer is external (MLHog), so publish-on-merge is the safer semantics. `publish-symbol-data-crate.yml` has the same tag-based setup and may want the same treatment, left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
