### PR TITLE
feat(conversations): show support tickets in Cmd+K recent activity

### DIFF
--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -18,6 +18,7 @@ type FileSystemLogViewType =
     | 'link'
     | 'notebook'
     | 'session_recording_playlist'
+    | 'ticket'
     | `hog_function/${string}`
 
 interface TrackFileSystemLogViewOptions {

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1478,6 +1478,13 @@ export const fileSystemTypes = {
         filterKey: 'task',
         flag: FEATURE_FLAGS.TASKS,
     },
+    ticket: {
+        name: 'Ticket',
+        iconType: 'conversations',
+        iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
+        href: (ref: string) => urls.supportTicketDetail(ref),
+        filterKey: 'ticket',
+    },
     user_interview: {
         name: 'User research',
         iconType: 'user_interview',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1481,7 +1481,7 @@ export const fileSystemTypes = {
     ticket: {
         name: 'Ticket',
         iconType: 'conversations',
-        iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
+        iconColor: ['var(--color-product-support-light)', 'var(--color-product-support-dark)'] as FileSystemIconColor,
         href: (ref: string) => urls.supportTicketDetail(ref),
         filterKey: 'ticket',
     },
@@ -2237,7 +2237,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.supportTickets(),
         type: 'conversations',
         iconType: 'conversations',
-        iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
+        iconColor: ['var(--color-product-support-light)', 'var(--color-product-support-dark)'] as FileSystemIconColor,
         sceneKey: 'SupportTickets',
         sceneKeys: ['SupportTickets', 'SupportTicketDetail', 'SupportSettings'],
     },

--- a/posthog/models/file_system/test/test_file_system_mixin.py
+++ b/posthog/models/file_system/test/test_file_system_mixin.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from posthog.models import FileSystem, Organization, Team, User
 from posthog.models.file_system.file_system_view_log import FileSystemViewLog
 
+from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -99,6 +100,24 @@ class TestFileSystemSyncMixin(TestCase):
         # Should remain in the FileSystem
         fs_entry.refresh_from_db()
         self.assertEqual(fs_entry.path, "Unfiled/Experiments/Exp #1 Updated")
+
+    def test_ticket_basic_lifecycle(self):
+        ticket = Ticket.objects.create_with_number(
+            team=self.team, widget_session_id="widget-session-1", distinct_id="distinct-1"
+        )
+        fs_entry = FileSystem.objects.filter(team=self.team, type="ticket", ref=str(ticket.id)).first()
+        assert fs_entry is not None
+        self.assertEqual(fs_entry.path, f"Unfiled/Tickets/Ticket #{ticket.ticket_number}")
+        self.assertEqual(fs_entry.href, f"/support/tickets/{ticket.ticket_number}")
+        self.assertEqual(fs_entry.shortcut, False)
+
+        ticket.status = "open"
+        ticket.save()
+        self.assertEqual(FileSystem.objects.filter(team=self.team, type="ticket", ref=str(ticket.id)).count(), 1)
+
+        ticket_id = ticket.id
+        ticket.delete()
+        assert FileSystem.objects.filter(team=self.team, type="ticket", ref=str(ticket_id)).first() is None
 
     def test_insight_deleted_or_unsaved_removes_entry(self):
         """

--- a/posthog/models/file_system/unfiled_file_saver.py
+++ b/posthog/models/file_system/unfiled_file_saver.py
@@ -14,6 +14,7 @@ from posthog.session_recordings.models.session_recording_playlist import Session
 from products.actions.backend.models.action import Action
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 from products.cohorts.backend.models.cohort import Cohort
+from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.early_access_features.backend.models import EarlyAccessFeature
 from products.experiments.backend.models.experiment import Experiment
@@ -37,6 +38,7 @@ MIXIN_MODELS: dict[str, type[FileSystemSyncMixin]] = {
     "cohort": Cohort,
     "hog_function": HogFunction,
     "survey": Survey,
+    "ticket": Ticket,
 }
 
 DESKTOP_MIXIN_MODELS: dict[str, type[FileSystemSyncMixin]] = {

--- a/products/conversations/backend/models/ticket.py
+++ b/products/conversations/backend/models/ticket.py
@@ -1,13 +1,17 @@
 from typing import TYPE_CHECKING
 
 from django.db import models, transaction
+from django.db.models import QuerySet
 
+from posthog.models.file_system.constants import DEFAULT_SURFACE
+from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
+from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.utils import UUIDTModel
 
 from .constants import Channel, ChannelDetail, Priority, Status
 
 if TYPE_CHECKING:
-    from posthog.models import Person
+    from posthog.models import Person, Team
 
 
 class TicketManager(models.Manager):
@@ -31,7 +35,7 @@ class TicketManager(models.Manager):
             return self.create(**kwargs)
 
 
-class Ticket(UUIDTModel):
+class Ticket(FileSystemSyncMixin, UUIDTModel):
     objects = TicketManager()
 
     # Dynamic attribute set by TicketViewSet._attach_persons_to_tickets for serialization
@@ -175,3 +179,21 @@ class Ticket(UUIDTModel):
 
     def __str__(self):
         return f"Ticket {self.id} - {self.widget_session_id[:8]}..."
+
+    @classmethod
+    def get_file_system_unfiled(cls, team: "Team", surface: str = DEFAULT_SURFACE) -> QuerySet["Ticket"]:
+        base_qs = cls.objects.filter(team=team)
+        return cls._filter_unfiled_queryset(base_qs, team, type="ticket", ref_field="id", surface=surface)
+
+    def get_file_system_representation(self) -> FileSystemRepresentation:
+        return FileSystemRepresentation(
+            base_folder=self._get_assigned_folder("Unfiled/Tickets"),
+            type="ticket",
+            # UUID pk as ref — ticket_number is only unique per team
+            ref=str(self.id),
+            name=f"Ticket #{self.ticket_number}",
+            href=f"/support/tickets/{self.ticket_number}",
+            meta={"created_at": str(self.created_at)},
+            # Tickets have no soft delete; hard deletes are handled by the mixin's post_delete signal
+            should_delete=False,
+        )

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -8,6 +8,7 @@ import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { TZLabel } from 'lib/components/TZLabel'
 import { dayjs } from 'lib/dayjs'
+import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
@@ -100,6 +101,8 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
         dismissKnowledgeGap,
         submitAiReplyFeedback,
     } = useActions(logic)
+
+    useFileSystemLogView({ type: 'ticket', ref: ticket?.id })
 
     const { user } = useValues(userLogic)
     const { currentTeam } = useValues(teamLogic)

--- a/products/conversations/manifest.tsx
+++ b/products/conversations/manifest.tsx
@@ -44,7 +44,10 @@ export const manifest: ProductManifest = {
         ticket: {
             name: 'Ticket',
             iconType: 'conversations',
-            iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
+            iconColor: [
+                'var(--color-product-support-light)',
+                'var(--color-product-support-dark)',
+            ] as FileSystemIconColor,
             href: (ref: string) => urls.supportTicketDetail(ref),
             filterKey: 'ticket',
         },
@@ -58,7 +61,10 @@ export const manifest: ProductManifest = {
             href: urls.supportTickets(),
             type: 'conversations',
             iconType: 'conversations',
-            iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
+            iconColor: [
+                'var(--color-product-support-light)',
+                'var(--color-product-support-dark)',
+            ] as FileSystemIconColor,
             sceneKey: 'SupportTickets',
         },
     ],

--- a/products/conversations/manifest.tsx
+++ b/products/conversations/manifest.tsx
@@ -40,7 +40,15 @@ export const manifest: ProductManifest = {
         supportTicketDetail: (ticketId: string | number): string => `/support/tickets/${ticketId}`,
         supportSettings: (): string => '/support/settings',
     },
-    fileSystemTypes: {},
+    fileSystemTypes: {
+        ticket: {
+            name: 'Ticket',
+            iconType: 'conversations',
+            iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
+            href: (ref: string) => urls.supportTicketDetail(ref),
+            filterKey: 'ticket',
+        },
+    },
     treeItemsNew: [],
     treeItemsProducts: [
         {


### PR DESCRIPTION
## Problem

Support tickets never show up in the Cmd+K \"recent activity\" list (or in project-tree search), because the `Ticket` model has no file system integration — recents are hydrated from `FileSystem` rows keyed by `(type, ref)` plus per-user `FileSystemViewLog` entries, and tickets produce neither.

## Changes

- `Ticket` now inherits `FileSystemSyncMixin` and exposes a `FileSystemRepresentation` (`type="ticket"`, ref = ticket UUID, name `Ticket #<n>`, href `/support/tickets/<n>`), so every ticket save/delete keeps a `FileSystem` row in sync under `Unfiled/Tickets`.
- Registered `ticket` in the unfiled sweep (`MIXIN_MODELS`) so pre-existing tickets are backfilled, and in the conversations frontend manifest (`fileSystemTypes`) for icon/label/href resolution.
- The ticket detail scene now calls `useFileSystemLogView({ type: 'ticket', ref: ticket?.id })`, which writes the view log entry that puts a ticket into the user's recents.
- Deliberately **not** registered in the file-system deletion registry: tickets have no soft delete, so deleting the tree entry would have to hard-delete real support tickets; unregistered types get a clean validation error instead.

## How did you test this code?

- Added `test_ticket_basic_lifecycle` to `posthog/models/file_system/test/test_file_system_mixin.py`, covering the regression no existing test catches: creating a ticket creates the `FileSystem` row with the expected path/href, re-saving doesn't duplicate it, and deleting the ticket removes it.
- Ran `ruff check`/`ruff format` on the changed Python files (clean).
- The agent sandbox had no Postgres or node_modules, so the pytest run, `typescript:check`, and `makemigrations --check` could not be completed there — please rely on CI for those. (`FileSystemSyncMixin` is an abstract mixin with no DB fields, so no migration is expected.)
- Not manually tested end-to-end; to verify: open a ticket at `/support/tickets/<n>`, then Cmd+K — the ticket should appear under recents as \"Ticket #<n>\".

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Human-driven (agent-assisted) — requested by Luke Belton: make support tickets show up in the Cmd+K recent activity menu, which required making tickets available in the file system. Confirmed choices: sync all tickets (not just viewed ones) and label them `Ticket #<n>`. `frontend/src/products.tsx` is generated from manifests; the sandbox couldn't run `build:products` (no node_modules), so the ticket entry was applied by hand identical to the generator's output — CI regeneration should produce no diff.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*