### PR TITLE
chore(funnels): prototype dual-axis options for compare-mode steps chart

### DIFF
--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -22,6 +22,8 @@ import {
     resolveFunnelStepClick,
     type FunnelStepsBarSeriesMeta,
 } from './funnelStepsBarTransforms'
+// PROTOTYPE (throwaway, dev-only) — compare-mode dual-axis exploration, see ./prototype/PROTOTYPE.md
+import { useFunnelCompareAxesPrototype } from './prototype/FunnelCompareAxesPrototype'
 
 const BASE_STEP_WIDTH_PX = 240
 const PER_BAR_WIDTH_PX = 20
@@ -72,9 +74,22 @@ export function FunnelStepsBarChart({
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
     const showTime = steps.some((step) => step.average_conversion_time != null)
 
+    // PROTOTYPE (throwaway, dev-only): null in production and for non-compare funnels — the chart
+    // then renders exactly as before. See ./prototype/PROTOTYPE.md.
+    const axesPrototype = useFunnelCompareAxesPrototype({
+        steps,
+        series,
+        baseConfig: CHART_CONFIG,
+        resolvedDateRange: insightData?.resolved_date_range,
+        compareTo: querySource?.compareFilter?.compare_to,
+    })
+    const chartSeries = axesPrototype?.series ?? series
+    const chartConfig = axesPrototype?.config ?? CHART_CONFIG
+    const chartMargins = { ...DEFAULT_MARGINS, ...chartConfig.margins }
+
     const breakdownCount = series.length
     const stepWidthPx = Math.max(BASE_STEP_WIDTH_PX, breakdownCount * PER_BAR_WIDTH_PX)
-    const chartWidth = DEFAULT_MARGINS.left + steps.length * stepWidthPx + DEFAULT_MARGINS.right
+    const chartWidth = chartMargins.left + steps.length * stepWidthPx + chartMargins.right
 
     const onStepClick = useCallback(
         (clickData: FunnelStepClickData<FunnelStepsBarSeriesMeta>): void => {
@@ -131,15 +146,18 @@ export function FunnelStepsBarChart({
             <div className="flex flex-1 flex-col" style={{ width: chartWidth }} data-attr="funnel-steps-bar-chart">
                 <FunnelChart<FunnelStepsBarSeriesMeta>
                     steps={stepLabels}
-                    series={series}
+                    series={chartSeries}
                     theme={theme}
-                    config={CHART_CONFIG}
+                    config={chartConfig}
                     tooltip={renderTooltip}
                     onStepClick={showPersonsModal ? onStepClick : undefined}
                     stepFooter={renderStepFooter}
                     dataAttr="funnel-steps-bar-chart-canvas"
                     onError={handleChartError}
-                />
+                >
+                    {axesPrototype?.overlay}
+                </FunnelChart>
+                {axesPrototype?.switcher}
             </div>
         </ScrollableShadows>
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/prototype/FunnelCompareAxesPrototype.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/prototype/FunnelCompareAxesPrototype.tsx
@@ -1,0 +1,360 @@
+/* eslint-disable react/forbid-dom-props -- prototype overlay positions come from d3 scales */
+/**
+ * PROTOTYPE — THROWAWAY, DO NOT SHIP. See PROTOTYPE.md in this folder.
+ *
+ * Question: with "compare against" enabled, the funnel steps chart scales both periods against the
+ * larger period's entrants, so only the larger period's first step reads 100% on the single percent
+ * axis. Should the chart get a second value axis, and what should each axis show?
+ *
+ * Plan: three variants + the live rendering, on the existing funnel insight route, switchable via
+ * `?funnel_axes_variant=` or the floating bottom pill. Dev builds only, pure compare funnels only.
+ */
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+import { useCallback, useEffect, useMemo } from 'react'
+
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { useChartLayout } from '@posthog/quill-charts'
+import type { FunnelChartConfig, Series } from '@posthog/quill-charts'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
+import { funnelComparePeriodDateRange } from 'scenes/funnels/funnelUtils'
+
+import type { FunnelStepWithConversionMetrics } from '~/types'
+
+import { RATE_TO_PERCENT } from '../../shared/funnelBarHorizontalShared'
+import type { FunnelStepsBarSeriesMeta } from '../funnelStepsBarTransforms'
+
+const VARIANT_PARAM = 'funnel_axes_variant'
+
+type VariantKey = 'live' | 'A' | 'B' | 'C'
+
+const VARIANTS: { key: VariantKey; name: string; description: string }[] = [
+    {
+        key: 'live',
+        name: 'Live (shared axis)',
+        description: 'Production rendering: one percent axis, both periods scaled to the larger period.',
+    },
+    {
+        key: 'A',
+        name: 'Twin percent axes',
+        description:
+            'Each period normalized to its own entrants — both first steps read 100%. Left axis = this period, right axis = previous. Bar heights compare conversion rates directly; the volume difference is no longer visible.',
+    },
+    {
+        key: 'B',
+        name: 'Volume-true + second axis',
+        description:
+            "Bars exactly as today (volume-true, blank gap above the smaller period). Adds a right axis with the smaller period's own 0–100% compressed to its entry level, so its first step also reads 100% — on its axis.",
+    },
+    {
+        key: 'C',
+        name: 'Count axes',
+        description:
+            'Bars as in A (each period = its own 100%), but the axes are labeled in absolute user counts per period, so the axis carries the volume difference the bars no longer show.',
+    },
+]
+
+interface PeriodInfo {
+    breakdownIndex: number
+    label: 'current' | 'previous'
+    color: string | undefined
+    /** First-step count of this period. */
+    entrants: number
+    /** entrants / max(entrants of both periods) — where this period's 100% sits on the shared scale. */
+    entryShare: number
+    /** Per-step conversion as % of this period's own entrants. */
+    selfPercentData: number[]
+}
+
+interface PrototypeAxisSpec {
+    side: 'left' | 'right'
+    color?: string
+    title?: string | null
+    /** Label the primary scale's own ticks (0–100). */
+    scaleTickLabel?: (tick: number) => string
+    /** Fixed ticks in primary-scale units — for axes whose scale differs from the primary one. */
+    fixedTicks?: { value: number; label: string }[]
+}
+
+export interface FunnelCompareAxesPrototypeRender {
+    series: Series<FunnelStepsBarSeriesMeta>[]
+    config: FunnelChartConfig
+    /** Render as a FunnelChart child (draws the prototype axes inside the chart wrapper). */
+    overlay: JSX.Element | null
+    /** Floating variant switcher, portaled to document.body. */
+    switcher: JSX.Element
+}
+
+const PROTOTYPE_MARGINS = { left: 48, right: 56, top: 28 }
+
+function resolvePeriods(
+    steps: FunnelStepWithConversionMetrics[],
+    series: Series<FunnelStepsBarSeriesMeta>[]
+): { current: PeriodInfo; previous: PeriodInfo } | null {
+    // Pure compare only: exactly one current + one previous series, no breakdown values.
+    if (series.length !== 2 || steps.length === 0 || !series.every((s) => s.meta?.compareLabel != null)) {
+        return null
+    }
+    const infos = series.map((s): PeriodInfo => {
+        const breakdownIndex = s.meta?.breakdownIndex ?? 0
+        return {
+            breakdownIndex,
+            label: s.meta?.compareLabel === 'previous' ? 'previous' : 'current',
+            color: s.color,
+            entrants: steps[0].nested_breakdown?.[breakdownIndex]?.count ?? 0,
+            entryShare: 0,
+            selfPercentData: steps.map(
+                (step) => (step.nested_breakdown?.[breakdownIndex]?.conversionRates.total ?? 0) * RATE_TO_PERCENT
+            ),
+        }
+    })
+    const maxEntrants = Math.max(...infos.map((p) => p.entrants))
+    if (maxEntrants <= 0) {
+        return null
+    }
+    for (const info of infos) {
+        info.entryShare = info.entrants / maxEntrants
+    }
+    const current = infos.find((p) => p.label === 'current')
+    const previous = infos.find((p) => p.label === 'previous')
+    return current && previous ? { current, previous } : null
+}
+
+const percentTick = (tick: number): string => `${Math.round(tick)}%`
+
+function buildVariant(
+    variant: VariantKey,
+    periods: { current: PeriodInfo; previous: PeriodInfo },
+    series: Series<FunnelStepsBarSeriesMeta>[],
+    periodTitles: { current: string | null; previous: string | null }
+): { series: Series<FunnelStepsBarSeriesMeta>[]; axes: PrototypeAxisSpec[] } {
+    const { current, previous } = periods
+    const selfNormalized = series.map((s) => ({
+        ...s,
+        data: (s.meta?.compareLabel === 'previous' ? previous : current).selfPercentData,
+        trackData: undefined, // no blank volume gap — each period's drop-off track runs to its own 100%
+    }))
+
+    switch (variant) {
+        case 'A':
+            return {
+                series: selfNormalized,
+                axes: [
+                    { side: 'left', color: current.color, title: periodTitles.current, scaleTickLabel: percentTick },
+                    {
+                        side: 'right',
+                        color: previous.color,
+                        title: periodTitles.previous,
+                        scaleTickLabel: percentTick,
+                    },
+                ],
+            }
+        case 'B': {
+            const [larger, smaller] =
+                current.entryShare >= previous.entryShare ? [current, previous] : [previous, current]
+            return {
+                series,
+                axes: [
+                    {
+                        side: 'left',
+                        color: larger.color,
+                        title: periodTitles[larger.label],
+                        scaleTickLabel: percentTick,
+                    },
+                    {
+                        side: 'right',
+                        color: smaller.color,
+                        title: periodTitles[smaller.label],
+                        // The smaller period's own 0–100%, compressed so its 100% sits at its entry level.
+                        fixedTicks: [0, 25, 50, 75, 100].map((tick) => ({
+                            value: smaller.entryShare * tick,
+                            label: `${tick}%`,
+                        })),
+                    },
+                ],
+            }
+        }
+        case 'C':
+            return {
+                series: selfNormalized,
+                axes: [
+                    {
+                        side: 'left',
+                        color: current.color,
+                        title: periodTitles.current,
+                        scaleTickLabel: (tick) => humanFriendlyLargeNumber((tick / 100) * current.entrants),
+                    },
+                    {
+                        side: 'right',
+                        color: previous.color,
+                        title: periodTitles.previous,
+                        scaleTickLabel: (tick) => humanFriendlyLargeNumber((tick / 100) * previous.entrants),
+                    },
+                ],
+            }
+        default:
+            return { series, axes: [] }
+    }
+}
+
+/** Draws the prototype value axes as absolutely-positioned labels inside the chart wrapper,
+ *  mirroring the geometry of the built-in AxisLabels (which the prototype config hides). */
+function PrototypeAxesOverlay({ axes }: { axes: PrototypeAxisSpec[] }): JSX.Element {
+    const { scales, dimensions } = useChartLayout()
+    const scaleTicks = scales.yTicks()
+    const plotBottom = dimensions.plotTop + dimensions.plotHeight
+
+    return (
+        <>
+            {axes.map((axis) => {
+                const edge =
+                    axis.side === 'left'
+                        ? { right: dimensions.width - dimensions.plotLeft + 8 }
+                        : { left: dimensions.plotLeft + dimensions.plotWidth + 8 }
+                const ticks = [
+                    ...(axis.scaleTickLabel
+                        ? scaleTicks.map((tick) => ({ value: tick, label: axis.scaleTickLabel!(tick) }))
+                        : []),
+                    ...(axis.fixedTicks ?? []),
+                ]
+                return (
+                    <div key={axis.side}>
+                        {ticks.map(({ value, label }) => {
+                            const y = scales.y(value)
+                            if (!isFinite(y) || y < dimensions.plotTop - 1 || y > plotBottom + 1) {
+                                return null
+                            }
+                            return (
+                                <div
+                                    key={value}
+                                    className="pointer-events-none absolute whitespace-nowrap text-xs"
+                                    style={{ ...edge, top: y, transform: 'translateY(-50%)', color: axis.color }}
+                                >
+                                    {label}
+                                </div>
+                            )
+                        })}
+                        {axis.title && (
+                            <div
+                                className="pointer-events-none absolute top-1 whitespace-nowrap text-[10px] font-semibold"
+                                style={{
+                                    color: axis.color,
+                                    ...(axis.side === 'left' ? { left: 4 } : { right: 4 }),
+                                }}
+                            >
+                                {axis.title}
+                            </div>
+                        )}
+                    </div>
+                )
+            })}
+        </>
+    )
+}
+
+function PrototypeSwitcher({ variant }: { variant: VariantKey }): JSX.Element {
+    const index = Math.max(
+        0,
+        VARIANTS.findIndex((v) => v.key === variant)
+    )
+
+    const cycle = useCallback(
+        (direction: 1 | -1): void => {
+            const next = VARIANTS[(index + direction + VARIANTS.length) % VARIANTS.length]
+            const { location, searchParams, hashParams } = router.values
+            router.actions.replace(location.pathname, { ...searchParams, [VARIANT_PARAM]: next.key }, hashParams)
+        },
+        [index]
+    )
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent): void => {
+            if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+                return
+            }
+            const target = event.target as HTMLElement | null
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return
+            }
+            cycle(event.key === 'ArrowLeft' ? -1 : 1)
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    }, [cycle])
+
+    const active = VARIANTS[index]
+
+    // Plain `fixed` (no portal — react-dom isn't a product_analytics dependency, and this is throwaway).
+    return (
+        <div
+            className="fixed bottom-4 left-1/2 z-[9999] flex -translate-x-1/2 items-center gap-1 rounded-full border border-accent bg-surface-primary py-1 pl-1 pr-3 shadow-lg"
+            title={active.description}
+        >
+            <LemonButton
+                size="xsmall"
+                icon={<IconChevronLeft />}
+                onClick={() => cycle(-1)}
+                tooltip="Previous variant"
+            />
+            <LemonButton size="xsmall" icon={<IconChevronRight />} onClick={() => cycle(1)} tooltip="Next variant" />
+            <span className="text-xs font-semibold">
+                PROTOTYPE&ensp;{active.key} — {active.name}
+            </span>
+        </div>
+    )
+}
+
+/** Entry point grafted into FunnelStepsBarChart. Returns null (production rendering, no prototype
+ *  chrome) outside dev builds or when the funnel isn't a pure compare-against-previous funnel. */
+export function useFunnelCompareAxesPrototype({
+    steps,
+    series,
+    baseConfig,
+    resolvedDateRange,
+    compareTo,
+}: {
+    steps: FunnelStepWithConversionMetrics[]
+    series: Series<FunnelStepsBarSeriesMeta>[]
+    baseConfig: FunnelChartConfig
+    resolvedDateRange?: Parameters<typeof funnelComparePeriodDateRange>[1]
+    compareTo?: string | null
+}): FunnelCompareAxesPrototypeRender | null {
+    const isDev = process.env.NODE_ENV === 'development'
+    const { searchParams } = useValues(router)
+    const rawVariant = searchParams[VARIANT_PARAM]
+    const variant: VariantKey = VARIANTS.some((v) => v.key === rawVariant) ? (rawVariant as VariantKey) : 'live'
+
+    const periods = useMemo(() => (isDev ? resolvePeriods(steps, series) : null), [isDev, steps, series])
+
+    const model = useMemo(() => {
+        if (!periods) {
+            return null
+        }
+        const periodTitles = {
+            current: funnelComparePeriodDateRange('current', resolvedDateRange, compareTo) ?? 'This period',
+            previous: funnelComparePeriodDateRange('previous', resolvedDateRange, compareTo) ?? 'Previous period',
+        }
+        return buildVariant(variant, periods, series, periodTitles)
+    }, [periods, variant, series, resolvedDateRange, compareTo])
+
+    const config = useMemo<FunnelChartConfig>(
+        () =>
+            variant === 'live'
+                ? baseConfig
+                : { ...baseConfig, hideValueAxis: true, margins: { ...baseConfig.margins, ...PROTOTYPE_MARGINS } },
+        [variant, baseConfig]
+    )
+
+    if (!isDev || !periods || !model) {
+        return null
+    }
+
+    return {
+        series: model.series,
+        config,
+        overlay: model.axes.length > 0 ? <PrototypeAxesOverlay axes={model.axes} /> : null,
+        switcher: <PrototypeSwitcher variant={variant} />,
+    }
+}

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/prototype/PROTOTYPE.md
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/prototype/PROTOTYPE.md
@@ -1,0 +1,44 @@
+# PROTOTYPE — funnel steps chart: two axes in compare mode
+
+**Throwaway code. Do not ship. Do not merge to master.**
+
+## The question
+
+With "compare against" enabled, the funnel steps chart scales both periods against the **larger** period's entrants (`count / max(currentEntrants, previousEntrants)`).
+So only the larger period's first step reads 100% on the single percent axis; the other period's first step reads e.g. 79%, with its missing volume left as a blank gap above.
+Should the chart get a second value axis so each period gets its own 100% reference — and what should each axis show?
+
+## The plan (one line)
+
+Three variants + the live rendering of the funnel steps chart in compare mode, on the existing insight route, switchable via `?funnel_axes_variant=` — dev builds only, pure compare funnels only (no breakdown).
+
+## How to run
+
+1. `hogli start` (or `./bin/start`) and open any funnel insight in the Steps visualization.
+2. Enable **Compare to previous period** (or any "compare against" option).
+3. A floating `PROTOTYPE` pill appears bottom-center. Flip variants with its arrows, the `←`/`→` keys, or the URL: `?funnel_axes_variant=live|A|B|C`.
+
+## The variants
+
+| Key    | Name                       | Bars                                                                       | Axes                                                                                                                          |
+| ------ | -------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `live` | Shared axis (production)   | Volume-true: larger period fills 100%, smaller leaves a blank gap above    | One percent axis; only the larger period's first step reads 100%                                                              |
+| `A`    | Twin percent axes          | Each period normalized to its own entrants — both first steps at the top   | Left = this period's %, right = previous period's %, color-coded. Both read 0–100%; heights compare conversion rates directly |
+| `B`    | Volume-true + second axis  | Unchanged from `live`                                                      | Left = larger period's % (unchanged scale). Right = the smaller period's own 0–100% **compressed to its entry level**          |
+| `C`    | Count axes                 | As in `A` (each period = its own 100%)                                     | Both axes labeled in absolute user counts per period — the axis carries the volume difference the bars no longer show          |
+
+What to judge:
+
+- Does a second axis actually resolve the "the other period isn't 100%" confusion, or does it add more?
+- `A`/`C` trade the volume-true bars for directly comparable conversion heights — is that gain worth losing the volume gap?
+- `B` keeps today's bars but its right axis has ticks that don't align with the grid (two different scales) — classic dual-axis confusion?
+
+## Known shortcuts (prototype constraints)
+
+- Pure compare only; breakdown × compare falls back to the live rendering.
+- Tooltip and StepLegend are untouched, so in `A`/`C` the bar heights use per-period normalization while the tooltip still reports production percentages.
+- Axis title/tick styling is approximate (absolutely-positioned overlay labels, not the built-in axis renderer).
+
+## Capturing the answer
+
+When a variant wins: fold the decision into the real chart (`funnelStepsBarTransforms.ts` for the data shape; expose axis config through `FunnelChartConfig` in `@posthog/quill-charts` — the core `ChartConfig.yAxes` already supports per-series axes), then delete this folder and the graft in `FunnelStepsBarChart.tsx`. This branch stays as the primary source.

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/prototype/PROTOTYPE.md
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/prototype/PROTOTYPE.md
@@ -20,12 +20,12 @@ Three variants + the live rendering of the funnel steps chart in compare mode, o
 
 ## The variants
 
-| Key    | Name                       | Bars                                                                       | Axes                                                                                                                          |
-| ------ | -------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `live` | Shared axis (production)   | Volume-true: larger period fills 100%, smaller leaves a blank gap above    | One percent axis; only the larger period's first step reads 100%                                                              |
-| `A`    | Twin percent axes          | Each period normalized to its own entrants — both first steps at the top   | Left = this period's %, right = previous period's %, color-coded. Both read 0–100%; heights compare conversion rates directly |
-| `B`    | Volume-true + second axis  | Unchanged from `live`                                                      | Left = larger period's % (unchanged scale). Right = the smaller period's own 0–100% **compressed to its entry level**          |
-| `C`    | Count axes                 | As in `A` (each period = its own 100%)                                     | Both axes labeled in absolute user counts per period — the axis carries the volume difference the bars no longer show          |
+| Key    | Name                      | Bars                                                                     | Axes                                                                                                                          |
+| ------ | ------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `live` | Shared axis (production)  | Volume-true: larger period fills 100%, smaller leaves a blank gap above  | One percent axis; only the larger period's first step reads 100%                                                              |
+| `A`    | Twin percent axes         | Each period normalized to its own entrants — both first steps at the top | Left = this period's %, right = previous period's %, color-coded. Both read 0–100%; heights compare conversion rates directly |
+| `B`    | Volume-true + second axis | Unchanged from `live`                                                    | Left = larger period's % (unchanged scale). Right = the smaller period's own 0–100% **compressed to its entry level**         |
+| `C`    | Count axes                | As in `A` (each period = its own 100%)                                   | Both axes labeled in absolute user counts per period — the axis carries the volume difference the bars no longer show         |
 
 What to judge:
 


### PR DESCRIPTION
## TL;DR (eli5)

When a funnel compares two time periods, both periods share one percent axis, and only the bigger period's first bar touches 100% — the smaller one stops short, which reads as "this period didn't start at 100%?". This PR is a **throwaway prototype** that lets you flip between three ways of giving each period its own axis, right on a real funnel insight, so we can pick one before building it properly. **Not meant to be merged.**

## Problem

With "compare against" enabled, the steps chart scales both periods against the larger period's entrants, so the smaller period's first step reads below 100% on the single percent axis. Question raised: should the chart have two axes so each period gets its own 100% reference — and what should each axis show?

## Changes

A dev-only, throwaway prototype (per the `/prototype` skill) mounted inside the existing `FunnelStepsBarChart`:

- `prototype/FunnelCompareAxesPrototype.tsx` — all throwaway code: variant data transforms, an overlay that draws the extra axes, and a floating bottom pill to flip variants (arrows or `←`/`→` keys). Gated to dev builds and pure compare funnels; returns `null` otherwise so production rendering is byte-identical.
- `prototype/PROTOTYPE.md` — the question, the variants, what to judge, and the fold-in plan.
- `FunnelStepsBarChart.tsx` — a clearly-marked graft that swaps in the prototype series/config when active.

To try it: open any steps funnel with **Compare to previous period** on in a dev build, then flip via the pill or `?funnel_axes_variant=live|A|B|C`:

| Key | Bars | Axes |
| --- | --- | --- |
| `live` | Volume-true (production) | One shared percent axis |
| `A` | Each period normalized to its own entrants | Twin 0–100% axes, color-coded per period |
| `B` | Unchanged from live | Right axis: smaller period's own 0–100% compressed to its entry level |
| `C` | As in A | Axes labeled in absolute entrant counts per period |

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the touched files (remaining errors are pre-existing unbuilt-quill-package noise in this environment, identical before/after).
- `pnpm --filter=@posthog/frontend fix` — lint and format clean.
- I (Claude) could not run the app or a browser in this environment, so the variants have not been viewed rendered — that's the point of this PR: check out the branch and flip through them.
- No tests added on purpose: prototype code, gated out of production and test builds.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — dev-only throwaway prototype, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) via the `/prototype` skill, from Thomas's question about adding two axes to the compare-mode funnel steps chart. Decisions: kept all throwaway code in a `prototype/` folder next to the chart with a minimal graft; drew the extra axes as a `useChartLayout` overlay instead of extending `@posthog/quill-charts` (the core `ChartConfig.yAxes` already supports per-series axes — that's the path for the real implementation once a variant wins); avoided a `react-dom` portal because `product_analytics` doesn't declare that dependency and adding it for a prototype wasn't worth lockfile churn.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
