### PR TITLE
fix(webflow): patch renamed session constant in invalid-site-id test

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/test_webflow.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/test_webflow.py
@@ -230,7 +230,7 @@ class TestValidateCredentials:
     def test_invalid_site_id_400_does_not_leak_raw_envelope(self) -> None:
         # A malformed Site ID gets a 400 with Webflow's raw "Validation Error: ..." envelope, which
         # must not surface to the user.
-        with patch(TRANSPORT) as MockSession:
+        with patch(WEBFLOW_SESSION_PATCH) as MockSession:
             MockSession.return_value.get.return_value = _make_response(
                 {"message": "Validation Error: Provided IDs are invalid: Site ID"}, status_code=400
             )


### PR DESCRIPTION
## Problem

`master` is red on `Python code quality`: `ruff check .` fails with

```
F821 Undefined name `TRANSPORT`
 --> products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/test_webflow.py:233:20
```

PR [#72505](https://github.com/PostHog/posthog/pull/72505) added `test_invalid_site_id_400_does_not_leak_raw_envelope` using `patch(TRANSPORT)`, but that constant was renamed to `WEBFLOW_SESSION_PATCH` / `CLIENT_SESSION_PATCH` in PR [#72023](https://github.com/PostHog/posthog/pull/72023). The new test was never updated, so `TRANSPORT` is undefined — breaking `ruff` repo-wide and blocking every open PR merged with master.

## Changes

One-liner: use `WEBFLOW_SESSION_PATCH` (the post-refactor name) instead of `TRANSPORT` at `test_webflow.py:233`. This test calls `validate_credentials`, whose sibling `test_status_mapping` in the same class already patches `WEBFLOW_SESSION_PATCH` — same target.

## How did I test this code?

- `ruff check .` (ruff `0.15.20`, the CI version) passes repo-wide after the fix.
- Confirmed the patch target is correct: `validate_credentials` calls `make_tracked_session` imported into `webflow.webflow` at module scope, and `WEBFLOW_SESSION_PATCH` points at that exact name — matching the sibling `test_status_mapping` test.
- Agent: did not run the pytest suite locally (no pytest in this environment); CI will run the webflow tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — test-only fix.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Surfaced while addressing CI feedback on an unrelated review-hog PR ([#72517](https://github.com/PostHog/posthog/pull/72517)): its `Python code quality` check failed on this file, which isn't in that PR's diff. Traced it to a master-red breakage from #72505 referencing a constant renamed in #72023.
- Opening as a separate PR rather than bundling onto #72517, since the change is genuinely distinct (warehouse_sources/webflow vs review_hog copy).
- No skills invoked — one-line test constant rename, no DRF/serializer/migration/production code touched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*