### PR TITLE
feat(integrations): add just-in-time OAuth token refresh to the gateway

### DIFF
--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -1,5 +1,7 @@
+import os
+
 from posthog.settings.base_variables import DEBUG, TEST
-from posthog.settings.utils import get_from_env, str_to_bool
+from posthog.settings.utils import get_from_env, get_list, str_to_bool
 
 # integration-gateway (Rust credential service). URL Django/consumers call, and the dedicated
 # scoped-JWT signing secret (see posthog/integration_gateway_jwt.py). The secret defaults to a known
@@ -11,6 +13,10 @@ INTEGRATION_GATEWAY_JWT_SECRET = get_from_env(
     "INTEGRATION_GATEWAY_JWT_SECRET",
     LOCAL_DEV_INTEGRATION_GATEWAY_JWT_SECRET if DEBUG or TEST else "",
 )
+# Integration kinds the gateway refreshes, sharing the exact env var the gateway reads. These are
+# excluded from the Celery refresh beat (posthog/tasks/integrations.py) so exactly one system
+# refreshes a given kind. Empty (default) = the beat refreshes everything, gateway refreshes nothing.
+INTEGRATION_GATEWAY_REFRESH_KINDS = get_list(os.getenv("INTEGRATION_GATEWAY_REFRESH_KINDS", ""))
 
 HUBSPOT_APP_CLIENT_ID = get_from_env("HUBSPOT_APP_CLIENT_ID", "")
 HUBSPOT_APP_CLIENT_SECRET = get_from_env("HUBSPOT_APP_CLIENT_SECRET", "")

--- a/posthog/tasks/integrations.py
+++ b/posthog/tasks/integrations.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from celery import shared_task
 
 from posthog.models.integration import (
@@ -17,8 +19,14 @@ from products.workflows.backend.providers import SESProvider
 def refresh_integrations() -> int:
     from posthog.models.integration import Integration, OauthIntegration
 
+    # Kinds the integration-gateway refreshes are excluded here so exactly one system refreshes a
+    # given kind (empty list by default => no change). The gateway only supports OAuth2 kinds, which
+    # is exactly this query, so a gcloud/github/firebase kind mislisted there stays refreshed below.
     oauth_integrations = defer_repository_cache_fields(
-        Integration.objects.filter(kind__in=OauthIntegration.supported_kinds).exclude(kind="meta-ads").all()
+        Integration.objects.filter(kind__in=OauthIntegration.supported_kinds)
+        .exclude(kind="meta-ads")
+        .exclude(kind__in=settings.INTEGRATION_GATEWAY_REFRESH_KINDS)
+        .all()
     )
 
     for integration in oauth_integrations:

--- a/posthog/tasks/test/test_integrations.py
+++ b/posthog/tasks/test/test_integrations.py
@@ -4,6 +4,8 @@ from typing import Optional
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.test import override_settings
+
 from parameterized import parameterized
 
 from posthog.models.integration import Integration
@@ -38,6 +40,17 @@ class TestIntegrationsTasks(APIBaseTest):
             refresh_integrations()
             # Both 3 and 4 should be refreshed
             assert refresh_integration_mock.call_args_list == [((integration_3.id,),), ((integration_4.id,),)]
+
+    @override_settings(INTEGRATION_GATEWAY_REFRESH_KINDS=["slack"])
+    def test_refresh_integrations_skips_gateway_owned_kinds(self) -> None:
+        # Dual-writer coordination: a kind the integration-gateway refreshes must be excluded from the
+        # Celery beat, so exactly one system refreshes it. A non-owned kind is still scheduled.
+        self.create_integration("slack", config={"refreshed_at": time.time() - 3600})  # expired, gateway-owned
+        hubspot = self.create_integration("hubspot", config={"refreshed_at": time.time() - 3600})  # expired, not owned
+
+        with patch("posthog.tasks.integrations.refresh_integration.delay") as refresh_integration_mock:
+            refresh_integrations()
+            assert refresh_integration_mock.call_args_list == [((hubspot.id,),)]
 
     @parameterized.expand(
         [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5302,6 +5302,7 @@ dependencies = [
  "base64 0.22.1",
  "common-alloc",
  "common-metrics",
+ "common-redis",
  "envconfig",
  "fernet",
  "jsonwebtoken",

--- a/rust/integration-gateway/Cargo.toml
+++ b/rust/integration-gateway/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# integration-gateway: read-only credential-fetch service (PR 1). See
-# README.md. Decrypts posthog_integration.sensitive_config
-# on behalf of callers behind a scoped-JWT auth boundary + audit trail. Django still owns
-# writes/refresh; this service never writes. Token refresh arrives in PR 2 (feature-flagged).
+# integration-gateway: credential-fetch service. Decrypts posthog_integration.sensitive_config on
+# behalf of callers behind a scoped-JWT auth boundary + audit trail, and (opt-in per kind via
+# INTEGRATION_GATEWAY_REFRESH_KINDS) refreshes OAuth access tokens just-in-time, single-flight via a
+# Redis lock. See README.md.
 
 [dependencies]
 async-trait = { workspace = true }
@@ -18,6 +18,8 @@ fernet = { workspace = true }
 jsonwebtoken = "8.3"
 moka = { workspace = true }
 pbkdf2 = "0.12"
+# Outbound OAuth token-refresh calls (json + stream features come from the workspace).
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"
@@ -31,12 +33,8 @@ uuid = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
 common-alloc = { path = "../common/alloc" }
 common-metrics = { path = "../common/metrics" }
+common-redis = { path = "../common/redis" }
 serve-metrics = { path = "../common/serve_metrics" }
-
-[dev-dependencies]
-# HTTP client for the seeded-DB integration test (tests/api.rs). tokio (full), sqlx (postgres),
-# serde, serde_json, jsonwebtoken, fernet, base64, uuid are already normal deps and usable in tests.
-reqwest = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/integration-gateway/src/config.rs
+++ b/rust/integration-gateway/src/config.rs
@@ -49,6 +49,59 @@ pub struct Config {
     /// Max integration ids accepted in one /fetch request.
     #[envconfig(default = "100")]
     pub max_batch_size: usize,
+
+    // ---- Token refresh (writer) ----
+    // Off by default: `refresh_kinds` empty => the gateway never refreshes (pure pass-through) and
+    // Django's beat owns all refresh. Enable a kind here AND exclude it from the Django beat
+    // (settings.INTEGRATION_GATEWAY_REFRESH_KINDS) so exactly one system refreshes it.
+    /// Redis used only for the per-integration refresh single-flight lock.
+    #[envconfig(from = "REDIS_URL", default = "redis://localhost:6379/")]
+    pub redis_url: String,
+
+    /// TTL (seconds) of the per-integration refresh lock — an upper bound on one refresh attempt.
+    #[envconfig(default = "30")]
+    pub token_refresh_lock_ttl_seconds: u64,
+
+    /// Integration kinds the gateway refreshes, comma-separated (e.g. "hubspot,salesforce").
+    #[envconfig(from = "INTEGRATION_GATEWAY_REFRESH_KINDS", default = "")]
+    pub refresh_kinds: String,
+
+    /// Timeout (seconds) for outbound OAuth token-refresh HTTP calls.
+    #[envconfig(default = "10")]
+    pub refresh_http_timeout_seconds: u64,
+
+    /// Optional override for the OAuth token endpoint used by ALL refreshes. Empty in prod (the
+    /// per-provider URLs are used); point at a local mock for e2e testing.
+    #[envconfig(default = "")]
+    pub refresh_token_url_override: String,
+
+    // Per-provider OAuth client credentials, sourced from the same env vars as
+    // posthog/settings/integrations.py so a deployment provisions them once. A kind whose
+    // credentials are empty is skipped even if listed in `refresh_kinds`.
+    #[envconfig(from = "HUBSPOT_APP_CLIENT_ID", default = "")]
+    pub hubspot_client_id: String,
+    #[envconfig(from = "HUBSPOT_APP_CLIENT_SECRET", default = "")]
+    pub hubspot_client_secret: String,
+    #[envconfig(from = "SALESFORCE_CONSUMER_KEY", default = "")]
+    pub salesforce_client_id: String,
+    #[envconfig(from = "SALESFORCE_CONSUMER_SECRET", default = "")]
+    pub salesforce_client_secret: String,
+    #[envconfig(from = "GOOGLE_ADS_APP_CLIENT_ID", default = "")]
+    pub google_ads_client_id: String,
+    #[envconfig(from = "GOOGLE_ADS_APP_CLIENT_SECRET", default = "")]
+    pub google_ads_client_secret: String,
+    #[envconfig(from = "GOOGLE_ANALYTICS_APP_CLIENT_ID", default = "")]
+    pub google_analytics_client_id: String,
+    #[envconfig(from = "GOOGLE_ANALYTICS_APP_CLIENT_SECRET", default = "")]
+    pub google_analytics_client_secret: String,
+    #[envconfig(from = "GOOGLE_SEARCH_CONSOLE_APP_CLIENT_ID", default = "")]
+    pub google_search_console_client_id: String,
+    #[envconfig(from = "GOOGLE_SEARCH_CONSOLE_APP_CLIENT_SECRET", default = "")]
+    pub google_search_console_client_secret: String,
+    #[envconfig(from = "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY", default = "")]
+    pub google_sheets_client_id: String,
+    #[envconfig(from = "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET", default = "")]
+    pub google_sheets_client_secret: String,
 }
 
 fn split_csv(raw: &str) -> Vec<String> {
@@ -84,5 +137,10 @@ impl Config {
         let mut keys = split_csv(&self.integration_gateway_jwt_secret);
         keys.extend(split_csv(&self.integration_gateway_jwt_secret_fallbacks));
         keys
+    }
+
+    /// Integration kinds the gateway refreshes. Empty => refresh disabled entirely.
+    pub fn refresh_kinds_list(&self) -> Vec<String> {
+        split_csv(&self.refresh_kinds)
     }
 }

--- a/rust/integration-gateway/src/crypto/decryptor.rs
+++ b/rust/integration-gateway/src/crypto/decryptor.rs
@@ -101,4 +101,12 @@ impl IntegrationDecryptor {
             .ok()
             .and_then(|bytes| String::from_utf8(bytes).ok())
     }
+
+    /// Encrypt one value under the PRIMARY key. `MultiFernet::encrypt` uses the first key in the
+    /// chain, matching Django's `EncryptedJSONField` write path (`MultiFernet(keys).encrypt`, first
+    /// key = `ENCRYPTION_SALT_KEYS[0]`). The result is a standard Fernet token Django can decrypt.
+    /// Used by the token-refresh writer to re-encrypt rotated tokens before writing them back.
+    pub fn encrypt_leaf(&self, plaintext: &str) -> String {
+        self.multi.encrypt(plaintext.as_bytes())
+    }
 }

--- a/rust/integration-gateway/src/integrations/repository.rs
+++ b/rust/integration-gateway/src/integrations/repository.rs
@@ -1,6 +1,10 @@
+use serde_json::Value;
 use sqlx::{PgPool, Row};
 
 use super::model::IntegrationRow;
+
+/// Sole `errors` sentinel, matching Django's `ERROR_TOKEN_REFRESH_FAILED` (posthog/models/integration.py).
+pub const ERROR_TOKEN_REFRESH_FAILED: &str = "TOKEN_REFRESH_FAILED";
 
 /// Fetch integration rows by id. Read-only (SELECT). `config`/`sensitive_config` are `jsonb`
 /// and decode straight into `serde_json::Value` (sqlx `json` feature).
@@ -31,4 +35,40 @@ pub async fn fetch_by_ids(pool: &PgPool, ids: &[i64]) -> Result<Vec<IntegrationR
         });
     }
     Ok(out)
+}
+
+/// Fetch a single row by id (used to re-read under the refresh lock so we don't refresh a token a
+/// concurrent head already rotated). Returns `None` if the row no longer exists.
+pub async fn fetch_one(pool: &PgPool, id: i64) -> Result<Option<IntegrationRow>, sqlx::Error> {
+    Ok(fetch_by_ids(pool, &[id]).await?.into_iter().next())
+}
+
+/// Persist a successful refresh: new plaintext `config` and re-encrypted `sensitive_config`, and
+/// clear any prior refresh error. Mirrors Django's `refresh_access_token` write.
+pub async fn update_after_refresh(
+    pool: &PgPool,
+    id: i64,
+    config: &Value,
+    sensitive_config: &Value,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE posthog_integration SET config = $1, sensitive_config = $2, errors = '' WHERE id = $3",
+    )
+    .bind(config)
+    .bind(sensitive_config)
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Record a failed refresh so the app surfaces "reconnect this integration" (same sentinel Django
+/// sets). Leaves the stored tokens untouched.
+pub async fn mark_refresh_failed(pool: &PgPool, id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE posthog_integration SET errors = $1 WHERE id = $2")
+        .bind(ERROR_TOKEN_REFRESH_FAILED)
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
 }

--- a/rust/integration-gateway/src/integrations/service.rs
+++ b/rust/integration-gateway/src/integrations/service.rs
@@ -7,12 +7,16 @@ use super::model::DecryptedIntegration;
 use super::repository;
 use crate::cache::CredentialCache;
 use crate::crypto::{decrypt_sensitive_config, IntegrationDecryptor};
+use crate::refresh::RefreshManager;
 
-/// Loads, decrypts, caches, and team-scopes integrations. Read-only.
+/// Loads, decrypts, caches, and team-scopes integrations. When a `RefreshManager` is present and
+/// owns a row's kind, an expired token is refreshed just-in-time on the DB-load path before it's
+/// decrypted and cached (so the cache never holds a stale pre-refresh token).
 pub struct IntegrationService {
     pool: PgPool,
     decryptor: IntegrationDecryptor,
     cache: CredentialCache,
+    refresh: Option<Arc<RefreshManager>>,
 }
 
 /// Outcome of a batch fetch, so the handler can emit an accurate audit line.
@@ -23,11 +27,17 @@ pub struct FetchOutcome {
 }
 
 impl IntegrationService {
-    pub fn new(pool: PgPool, decryptor: IntegrationDecryptor, cache: CredentialCache) -> Self {
+    pub fn new(
+        pool: PgPool,
+        decryptor: IntegrationDecryptor,
+        cache: CredentialCache,
+        refresh: Option<Arc<RefreshManager>>,
+    ) -> Self {
         Self {
             pool,
             decryptor,
             cache,
+            refresh,
         }
     }
 
@@ -61,6 +71,13 @@ impl IntegrationService {
             let rows = repository::fetch_by_ids(&self.pool, &misses).await?;
             db_loaded = rows.len();
             for row in rows {
+                // Just-in-time refresh for owned kinds before decrypt/cache, so a stale token is
+                // never cached. No-op (returns the row unchanged) when refresh is disabled, the kind
+                // isn't owned, the token is still fresh, or the refresh fails (fail-open).
+                let row = match &self.refresh {
+                    Some(manager) if manager.owns(&row.kind) => manager.refresh(row).await,
+                    _ => row,
+                };
                 let decrypted = Arc::new(DecryptedIntegration {
                     id: row.id,
                     team_id: row.team_id,

--- a/rust/integration-gateway/src/lib.rs
+++ b/rust/integration-gateway/src/lib.rs
@@ -6,4 +6,5 @@ pub mod config;
 pub mod crypto;
 pub mod integrations;
 pub mod metrics_consts;
+pub mod refresh;
 pub mod router;

--- a/rust/integration-gateway/src/main.rs
+++ b/rust/integration-gateway/src/main.rs
@@ -14,11 +14,14 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
+use common_redis::{CompressionConfig, RedisClient, RedisValueFormat};
+
 use integration_gateway::app_context::AppState;
 use integration_gateway::cache;
 use integration_gateway::config::Config;
 use integration_gateway::crypto::IntegrationDecryptor;
 use integration_gateway::integrations::IntegrationService;
+use integration_gateway::refresh::RefreshManager;
 use integration_gateway::router as gw_router;
 
 common_alloc::used!();
@@ -70,7 +73,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     let cache = cache::build(config.cache_ttl_seconds, config.cache_max_capacity);
-    let service = Arc::new(IntegrationService::new(pool, decryptor, cache));
+
+    // Token refresh (writer) is opt-in per kind. With no kinds configured we skip Redis entirely and
+    // run pure pass-through (Django's beat owns all refresh), keeping the read-only deploy free of a
+    // Redis dependency.
+    let refresh_manager = if config.refresh_kinds_list().is_empty() {
+        info!("No refresh_kinds configured; token refresh disabled (pass-through)");
+        None
+    } else {
+        let redis = RedisClient::with_config(
+            config.redis_url.clone(),
+            CompressionConfig::disabled(),
+            RedisValueFormat::Utf8,
+            Some(Duration::from_millis(500)),
+            Some(Duration::from_secs(5)),
+        )
+        .await?;
+        info!(kinds = ?config.refresh_kinds_list(), "Token refresh enabled");
+        Some(Arc::new(RefreshManager::new(
+            pool.clone(),
+            Arc::new(redis),
+            decryptor.clone(),
+            Arc::new(config.clone()),
+        )))
+    };
+
+    let service = Arc::new(IntegrationService::new(
+        pool,
+        decryptor,
+        cache,
+        refresh_manager,
+    ));
 
     let state = AppState {
         service,

--- a/rust/integration-gateway/src/metrics_consts.rs
+++ b/rust/integration-gateway/src/metrics_consts.rs
@@ -1,2 +1,6 @@
 /// `result` label values: "ok" | "error". `caller` label = the JWT `caller` claim.
 pub const FETCH_TOTAL: &str = "integration_gateway_fetch_total";
+
+/// Token-refresh outcomes. `result` label: "refreshed" | "failed" | "locked" | "skipped".
+/// `kind` label = the integration kind.
+pub const REFRESH_TOTAL: &str = "integration_gateway_refresh_total";

--- a/rust/integration-gateway/src/refresh/expiry.rs
+++ b/rust/integration-gateway/src/refresh/expiry.rs
@@ -1,0 +1,82 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+/// Whether an OAuth access token should be proactively refreshed, mirroring Django's
+/// `OauthIntegration.access_token_expired`: refresh once past the half-life,
+/// i.e. `now > refreshed_at + expires_in - expires_in/2`.
+///
+/// Returns false (never refresh) when the timing fields are absent — same as Django, which can't
+/// judge expiry without them.
+pub fn access_token_expired(kind: &str, config: &Value) -> bool {
+    let refreshed_at = config.get("refreshed_at").and_then(Value::as_f64);
+    let mut expires_in = config.get("expires_in").and_then(Value::as_f64);
+
+    // Salesforce/Stripe often omit expires_in in their responses; Django assumes 3600s for them.
+    if expires_in.is_none() && (kind == "salesforce" || kind == "stripe") {
+        expires_in = Some(3600.0);
+    }
+
+    let (Some(expires_in), Some(refreshed_at)) = (expires_in, refreshed_at) else {
+        return false;
+    };
+    if expires_in <= 0.0 {
+        return false;
+    }
+
+    let threshold = expires_in / 2.0;
+    now_secs() > refreshed_at + expires_in - threshold
+}
+
+/// Seconds since the Unix epoch as f64 (matches Django's `time.time()`).
+pub fn now_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn not_expired_without_timing_fields() {
+        assert!(!access_token_expired("hubspot", &json!({})));
+        assert!(!access_token_expired(
+            "hubspot",
+            &json!({ "expires_in": 3600 })
+        ));
+        assert!(!access_token_expired(
+            "hubspot",
+            &json!({ "refreshed_at": 1000 })
+        ));
+    }
+
+    #[test]
+    fn expired_past_half_life() {
+        let now = now_secs();
+        // refreshed 3000s ago, 3600s lifetime => 83% elapsed, past the 50% half-life threshold.
+        let config = json!({ "expires_in": 3600, "refreshed_at": now - 3000.0 });
+        assert!(access_token_expired("hubspot", &config));
+    }
+
+    #[test]
+    fn fresh_before_half_life() {
+        let now = now_secs();
+        // refreshed 100s ago, 3600s lifetime => well before half-life.
+        let config = json!({ "expires_in": 3600, "refreshed_at": now - 100.0 });
+        assert!(!access_token_expired("hubspot", &config));
+    }
+
+    #[test]
+    fn salesforce_defaults_expires_in() {
+        let now = now_secs();
+        // No expires_in, but Salesforce assumes 3600 => refreshed 3000s ago is past half-life.
+        let config = json!({ "refreshed_at": now - 3000.0 });
+        assert!(access_token_expired("salesforce", &config));
+        // A non-defaulting kind with no expires_in never refreshes.
+        assert!(!access_token_expired("hubspot", &config));
+    }
+}

--- a/rust/integration-gateway/src/refresh/mod.rs
+++ b/rust/integration-gateway/src/refresh/mod.rs
@@ -1,0 +1,269 @@
+pub mod expiry;
+pub mod providers;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_metrics::inc;
+use common_redis::Client as RedisTrait;
+use serde::Deserialize;
+use serde_json::Value;
+use sqlx::PgPool;
+use tracing::warn;
+
+use crate::config::Config;
+use crate::crypto::IntegrationDecryptor;
+use crate::integrations::model::IntegrationRow;
+use crate::integrations::repository;
+use crate::metrics_consts;
+
+#[derive(Debug, thiserror::Error)]
+enum RefreshError {
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("provider returned {0}: {1}")]
+    Provider(u16, String),
+    #[error("integration has no stored refresh_token")]
+    NoRefreshToken,
+    #[error("provider response had no access_token")]
+    NoAccessToken,
+}
+
+/// Standard OAuth2 token-refresh response fields we care about.
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: Option<String>,
+    expires_in: Option<f64>,
+    refresh_token: Option<String>,
+}
+
+struct RefreshedTokens {
+    access_token: String,
+    expires_in: Option<f64>,
+    refresh_token: Option<String>,
+}
+
+/// Owns just-in-time OAuth token refresh for the kinds listed in `refresh_kinds`. Single-flight per
+/// integration via a Redis lock, so only one head refreshes a given row at a time — important for
+/// providers that rotate the refresh token. Django's beat MUST exclude these kinds.
+pub struct RefreshManager {
+    pool: PgPool,
+    redis: Arc<dyn RedisTrait + Send + Sync>,
+    http: reqwest::Client,
+    decryptor: IntegrationDecryptor,
+    config: Arc<Config>,
+    owned_kinds: HashSet<String>,
+}
+
+impl RefreshManager {
+    pub fn new(
+        pool: PgPool,
+        redis: Arc<dyn RedisTrait + Send + Sync>,
+        decryptor: IntegrationDecryptor,
+        config: Arc<Config>,
+    ) -> Self {
+        let owned_kinds = config.refresh_kinds_list().into_iter().collect();
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.refresh_http_timeout_seconds))
+            .build()
+            .expect("failed to build reqwest client for token refresh");
+        Self {
+            pool,
+            redis,
+            http,
+            decryptor,
+            config,
+            owned_kinds,
+        }
+    }
+
+    pub fn owns(&self, kind: &str) -> bool {
+        self.owned_kinds.contains(kind)
+    }
+
+    /// Refresh `row` if its access token is past half-life, returning the (possibly updated) row with
+    /// re-encrypted credentials. Fail-open: on any error the input row is returned unchanged, so the
+    /// read path still serves the existing token (which is still valid — we refresh proactively at
+    /// half-life, so an error just means we serve a valid-but-aging token until the next attempt).
+    pub async fn refresh(&self, row: IntegrationRow) -> IntegrationRow {
+        if !expiry::access_token_expired(&row.kind, &row.config) {
+            return row;
+        }
+
+        let provider = match providers::provider_for(&row.kind, &self.config) {
+            Some(p) => p,
+            None => {
+                warn!(kind = %row.kind, id = row.id, "refresh requested but no provider/credentials configured; skipping");
+                self.record(&row.kind, "skipped");
+                return row;
+            }
+        };
+
+        let lock_key = format!("integration-gateway:refresh-lock:{}", row.id);
+        match self
+            .redis
+            .set_nx_ex(
+                lock_key.clone(),
+                "1".to_string(),
+                self.config.token_refresh_lock_ttl_seconds,
+            )
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                // Another head holds the lock; the current token is still valid (half-life refresh).
+                self.record(&row.kind, "locked");
+                return row;
+            }
+            Err(e) => {
+                warn!(id = row.id, error = %e, "failed to acquire refresh lock; skipping");
+                self.record(&row.kind, "skipped");
+                return row;
+            }
+        }
+
+        let result = self.refresh_locked(&row, &provider).await;
+        // Best-effort lock release; on failure the lock TTL-expires on its own.
+        if let Err(e) = self.redis.del(lock_key).await {
+            warn!(id = row.id, error = %e, "failed to release refresh lock");
+        }
+
+        match result {
+            Ok(updated) => {
+                self.record(&row.kind, "refreshed");
+                updated
+            }
+            Err(e) => {
+                warn!(id = row.id, kind = %row.kind, error = %e, "token refresh failed");
+                if let Err(mark_err) = repository::mark_refresh_failed(&self.pool, row.id).await {
+                    warn!(id = row.id, error = %mark_err, "failed to record refresh error");
+                }
+                self.record(&row.kind, "failed");
+                row
+            }
+        }
+    }
+
+    async fn refresh_locked(
+        &self,
+        row: &IntegrationRow,
+        provider: &providers::Provider,
+    ) -> Result<IntegrationRow, RefreshError> {
+        // Re-read under the lock: a concurrent head (or Django) may have just rotated the token.
+        let fresh = repository::fetch_one(&self.pool, row.id)
+            .await?
+            .unwrap_or_else(|| row.clone());
+        if !expiry::access_token_expired(&fresh.kind, &fresh.config) {
+            return Ok(fresh);
+        }
+
+        let refresh_token = self.decrypt_refresh_token(&fresh)?;
+        let tokens = self.request_refresh(provider, &refresh_token).await?;
+
+        // Some providers omit expires_in on refresh; Django assumes 3600s for Salesforce/Stripe.
+        let expires_in = match tokens.expires_in {
+            Some(v) => Value::from(v),
+            None if fresh.kind == "salesforce" || fresh.kind == "stripe" => Value::from(3600),
+            None => Value::Null,
+        };
+
+        let mut new_config = fresh.config.clone();
+        set_key(
+            &mut new_config,
+            "refreshed_at",
+            Value::from(expiry::now_secs() as i64),
+        );
+        set_key(&mut new_config, "expires_in", expires_in);
+
+        // Overwrite only the rotated leaves; other (still-encrypted) leaves are left untouched.
+        let mut new_sensitive = fresh.sensitive_config.clone();
+        set_key(
+            &mut new_sensitive,
+            "access_token",
+            Value::String(self.decryptor.encrypt_leaf(&tokens.access_token)),
+        );
+        if let Some(rotated) = &tokens.refresh_token {
+            set_key(
+                &mut new_sensitive,
+                "refresh_token",
+                Value::String(self.decryptor.encrypt_leaf(rotated)),
+            );
+        }
+
+        repository::update_after_refresh(&self.pool, fresh.id, &new_config, &new_sensitive).await?;
+
+        Ok(IntegrationRow {
+            config: new_config,
+            sensitive_config: new_sensitive,
+            ..fresh
+        })
+    }
+
+    fn decrypt_refresh_token(&self, row: &IntegrationRow) -> Result<String, RefreshError> {
+        let encrypted = row
+            .sensitive_config
+            .get("refresh_token")
+            .and_then(Value::as_str)
+            .ok_or(RefreshError::NoRefreshToken)?;
+        self.decryptor
+            .decrypt_leaf(encrypted)
+            .ok_or(RefreshError::NoRefreshToken)
+    }
+
+    async fn request_refresh(
+        &self,
+        provider: &providers::Provider,
+        refresh_token: &str,
+    ) -> Result<RefreshedTokens, RefreshError> {
+        let response = self
+            .http
+            .post(&provider.token_url)
+            .form(&[
+                ("grant_type", "refresh_token"),
+                ("refresh_token", refresh_token),
+                ("client_id", provider.client_id.as_str()),
+                ("client_secret", provider.client_secret.as_str()),
+            ])
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RefreshError::Provider(status.as_u16(), body));
+        }
+
+        let parsed: TokenResponse = response.json().await?;
+        let access_token = parsed.access_token.ok_or(RefreshError::NoAccessToken)?;
+        Ok(RefreshedTokens {
+            access_token,
+            expires_in: parsed.expires_in,
+            refresh_token: parsed.refresh_token,
+        })
+    }
+
+    fn record(&self, kind: &str, result: &str) {
+        inc(
+            metrics_consts::REFRESH_TOTAL,
+            &[
+                ("kind".to_string(), kind.to_string()),
+                ("result".to_string(), result.to_string()),
+            ],
+            1,
+        );
+    }
+}
+
+/// Insert/overwrite a key on a JSON object, coercing a non-object into a fresh object first.
+/// `config`/`sensitive_config` are always objects in practice, but stay defensive.
+fn set_key(value: &mut Value, key: &str, new: Value) {
+    if !value.is_object() {
+        *value = Value::Object(serde_json::Map::new());
+    }
+    if let Value::Object(map) = value {
+        map.insert(key.to_string(), new);
+    }
+}

--- a/rust/integration-gateway/src/refresh/providers.rs
+++ b/rust/integration-gateway/src/refresh/providers.rs
@@ -1,0 +1,112 @@
+use crate::config::Config;
+
+/// Resolved OAuth provider config for a refreshable integration kind.
+pub struct Provider {
+    pub token_url: String,
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+/// Resolve the OAuth provider for `kind`, or `None` when the kind isn't a gateway-supported OAuth2
+/// provider or its client credentials aren't configured.
+///
+/// Initial supported set is the generic `grant_type=refresh_token` providers (client id/secret in
+/// the form body). Providers with non-standard refresh flows — Slack (DB-sourced creds), the
+/// HTTP-Basic ones (reddit/pinterest/stripe), TikTok (different host + `client_key`), Bing (resends
+/// scope), Jira (rotates refresh tokens), Meta (long-lived exchange), and the service-account /
+/// GitHub kinds — stay on the Django beat for now.
+///
+/// `config.refresh_token_url_override`, when set, replaces the provider URL for every kind (local
+/// e2e against a mock token endpoint).
+pub fn provider_for(kind: &str, config: &Config) -> Option<Provider> {
+    let (default_url, client_id, client_secret): (&str, &str, &str) = match kind {
+        "hubspot" => (
+            "https://api.hubapi.com/oauth/v1/token",
+            config.hubspot_client_id.as_str(),
+            config.hubspot_client_secret.as_str(),
+        ),
+        "salesforce" => (
+            "https://login.salesforce.com/services/oauth2/token",
+            config.salesforce_client_id.as_str(),
+            config.salesforce_client_secret.as_str(),
+        ),
+        "google-ads" => (
+            "https://oauth2.googleapis.com/token",
+            config.google_ads_client_id.as_str(),
+            config.google_ads_client_secret.as_str(),
+        ),
+        "google-analytics" => (
+            "https://oauth2.googleapis.com/token",
+            config.google_analytics_client_id.as_str(),
+            config.google_analytics_client_secret.as_str(),
+        ),
+        "google-search-console" => (
+            "https://oauth2.googleapis.com/token",
+            config.google_search_console_client_id.as_str(),
+            config.google_search_console_client_secret.as_str(),
+        ),
+        "google-sheets" => (
+            "https://oauth2.googleapis.com/token",
+            config.google_sheets_client_id.as_str(),
+            config.google_sheets_client_secret.as_str(),
+        ),
+        _ => return None,
+    };
+
+    if client_id.is_empty() || client_secret.is_empty() {
+        return None;
+    }
+
+    let token_url = if config.refresh_token_url_override.is_empty() {
+        default_url.to_string()
+    } else {
+        config.refresh_token_url_override.clone()
+    };
+
+    Some(Provider {
+        token_url,
+        client_id: client_id.to_string(),
+        client_secret: client_secret.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use envconfig::Envconfig;
+
+    // A Config with all defaults, credential fields explicitly cleared so ambient env can't leak in.
+    // Fields are pub, so tests set exactly what they exercise — no process-env mutation (race-free).
+    fn base() -> Config {
+        let mut c = Config::init_from_env().unwrap();
+        c.hubspot_client_id = String::new();
+        c.hubspot_client_secret = String::new();
+        c.refresh_token_url_override = String::new();
+        c
+    }
+
+    #[test]
+    fn unknown_kind_has_no_provider() {
+        let config = base();
+        assert!(provider_for("slack", &config).is_none());
+        assert!(provider_for("github", &config).is_none());
+    }
+
+    #[test]
+    fn kind_without_credentials_is_skipped() {
+        assert!(provider_for("hubspot", &base()).is_none());
+    }
+
+    #[test]
+    fn configured_kind_resolves_and_override_applies() {
+        let mut config = base();
+        config.hubspot_client_id = "cid".to_string();
+        config.hubspot_client_secret = "secret".to_string();
+        config.refresh_token_url_override = "http://localhost:9999/token".to_string();
+
+        let provider = provider_for("hubspot", &config).expect("provider");
+        assert_eq!(provider.client_id, "cid");
+        assert_eq!(provider.client_secret, "secret");
+        assert_eq!(provider.token_url, "http://localhost:9999/token");
+    }
+}

--- a/rust/integration-gateway/tests/api.rs
+++ b/rust/integration-gateway/tests/api.rs
@@ -50,7 +50,8 @@ async fn pool() -> PgPool {
 async fn spawn_app(pool: PgPool) -> String {
     let decryptor = IntegrationDecryptor::build(&[SALT_KEY_32.to_string()], &[], &[]).unwrap();
     let cache = cache::build(30, 1000);
-    let service = Arc::new(IntegrationService::new(pool, decryptor, cache));
+    // No RefreshManager: these tests exercise the read path (pass-through).
+    let service = Arc::new(IntegrationService::new(pool, decryptor, cache, None));
     let state = AppState {
         service,
         jwt_secrets: Arc::new(vec![JWT_SECRET.to_string()]),
@@ -192,7 +193,10 @@ async fn fetches_and_decrypts_for_owning_team() {
     assert_eq!(got["team_id"], json!(team_id));
     assert_eq!(got["kind"], json!("slack"));
     // sensitive_config is decrypted pass-through; the undecryptable leaf survives unchanged.
-    assert_eq!(got["sensitive_config"]["access_token"], json!("xoxb-secret-token"));
+    assert_eq!(
+        got["sensitive_config"]["access_token"],
+        json!("xoxb-secret-token")
+    );
     assert_eq!(got["sensitive_config"]["not_encrypted"], json!("plain"));
     // config is returned verbatim (not encrypted).
     assert_eq!(got["config"]["team"], json!("T-1234"));
@@ -203,8 +207,13 @@ async fn wrong_team_is_indistinguishable_from_not_found() {
     let pool = pool().await;
     let owner = seed_team(&pool).await;
     let other = seed_team(&pool).await;
-    let integration_id =
-        seed_integration(&pool, owner, "slack", json!({ "access_token": encrypt_leaf("x") })).await;
+    let integration_id = seed_integration(
+        &pool,
+        owner,
+        "slack",
+        json!({ "access_token": encrypt_leaf("x") }),
+    )
+    .await;
 
     let base = spawn_app(pool).await;
     let resp = reqwest::Client::new()
@@ -223,7 +232,10 @@ async fn wrong_team_is_indistinguishable_from_not_found() {
         .as_object()
         .unwrap()
         .contains_key(&integration_id.to_string()));
-    assert_eq!(body["integrations"][integration_id.to_string()], Value::Null);
+    assert_eq!(
+        body["integrations"][integration_id.to_string()],
+        Value::Null
+    );
 }
 
 #[tokio::test]

--- a/rust/integration-gateway/tests/crypto_parity.rs
+++ b/rust/integration-gateway/tests/crypto_parity.rs
@@ -102,6 +102,22 @@ fn decrypts_django_produced_ciphertext() {
 }
 
 #[test]
+fn encrypt_leaf_round_trips_under_primary_key() {
+    // The write path (token refresh) re-encrypts rotated tokens with `encrypt_leaf`. Together with
+    // `decrypts_django_produced_ciphertext` above — which proves this salt key is byte-identical to
+    // Django's — a value encrypted here is, by the Fernet spec, decryptable by Django too.
+    let d = IntegrationDecryptor::build(&[SALT_KEY_32.to_string()], &[], &[]).unwrap();
+    let token = d.encrypt_leaf("rotated-access-token");
+
+    // A decryptor built with ONLY the salt key recovers it => it was encrypted under the primary key.
+    let salt_only = IntegrationDecryptor::build(&[SALT_KEY_32.to_string()], &[], &[]).unwrap();
+    assert_eq!(
+        salt_only.decrypt_leaf(&token).unwrap(),
+        "rotated-access-token"
+    );
+}
+
+#[test]
 fn walks_django_produced_sensitive_config() {
     let d = IntegrationDecryptor::build(&[SALT_KEY_32.to_string()], &[], &[]).unwrap();
     let encrypted = json!({
@@ -111,6 +127,9 @@ fn walks_django_produced_sensitive_config() {
     });
     let out = decrypt_sensitive_config(&d, &encrypted);
     assert_eq!(out["access_token"], json!("django-produced-access-token"));
-    assert_eq!(out["nested"]["refresh_token"], json!("django-produced-refresh-token"));
+    assert_eq!(
+        out["nested"]["refresh_token"],
+        json!("django-produced-refresh-token")
+    );
     assert_eq!(out["not_encrypted"], json!("plain"));
 }


### PR DESCRIPTION
> [!NOTE]
> Replaces #71000, which could not accept signed-git writes (every commit/rewrite/merge to that branch was refused). Same change, fresh branch off the updated PR2 base.

## Problem

Today Django's Celery beat refreshes every integration's OAuth token, partly in Celery and partly in the model layer. The integration-gateway is meant to own credential lifecycle behind one audited service. This PR makes the gateway the just-in-time refresher for the OAuth2 kinds it owns, so a consumer reading through the gateway always gets a fresh token, and refresh logic lives in one place.

## Changes

Refresh is **opt-in per kind** and coordinated with Django so exactly one system refreshes a given kind.

**Rust (`rust/integration-gateway`)**
- New `refresh/` module: half-life expiry check (mirrors `OauthIntegration.access_token_expired`), a generic `grant_type=refresh_token` flow for the initial provider set (hubspot, salesforce, google-ads/analytics/search-console/sheets), a Redis single-flight lock per integration (`common-redis` `set_nx_ex`) so refresh-token-rotating providers can't double-refresh, re-read-under-lock, write-back of re-encrypted tokens, and `errors = TOKEN_REFRESH_FAILED` on failure (same sentinel Django uses).
- `encrypt_leaf` on the existing Fernet decryptor (primary key = `ENCRYPTION_SALT_KEYS[0]`, byte-compatible with `EncryptedJSONField`). Refresh runs on the DB-load path before decrypt/cache, so the in-proc cache is written through and never serves a stale pre-refresh token.
- Fail-open: any refresh error returns the existing token (still valid, since we refresh at half-life). Enabled via `INTEGRATION_GATEWAY_REFRESH_KINDS`; empty (default) means pure pass-through and no Redis dependency.

**Django**
- The `refresh_integrations` beat excludes `settings.INTEGRATION_GATEWAY_REFRESH_KINDS` (the same env var the gateway reads), so a gateway-owned kind isn't refreshed twice. Empty default = no behavior change.

```diff
- Integration.objects.filter(kind__in=OauthIntegration.supported_kinds).exclude(kind="meta-ads")
+ Integration.objects.filter(kind__in=OauthIntegration.supported_kinds)
+     .exclude(kind="meta-ads")
+     .exclude(kind__in=settings.INTEGRATION_GATEWAY_REFRESH_KINDS)
```

> [!NOTE]
> Stacked on #70992 (base `posthog-code/integration-gateway-cdp-cutover`), which is itself stacked on #70450. Review/merge in order.

> [!WARNING]
> A kind must be added to `INTEGRATION_GATEWAY_REFRESH_KINDS` in the same change that enables the gateway to refresh it — the setting drives both the gateway (what it refreshes) and the Django beat (what it stops refreshing). Enabling one side without the other either double-refreshes or leaves a kind unrefreshed.

**Scoped out for now** (stay on the Django beat): Slack (DB-sourced creds), the HTTP-Basic providers (reddit/pinterest/stripe), TikTok, Bing, Jira (rotating refresh token), Meta, and the service-account/GitHub kinds; the `reload-integrations` publish on refresh (`common-redis` has no publish; staleness is bounded and safe given half-life refresh — the pre-refresh token is still valid, and the gateway write-through cache covers gateway-path readers); and a dedicated write DB pool.

**Why:** move token refresh into the audited gateway, one provider at a time, without a dual-writer race against Django's beat.

## How did you test this code?

I (Claude) have **no Rust toolchain in this environment**, so I could not compile the crate — relying on CI for build/clippy. Automated tests added:

- Rust unit tests: `refresh::expiry` (half-life threshold, missing-fields, Salesforce default), `refresh::providers` (unknown kind / missing creds / override), and a `crypto_parity` encrypt round-trip.
- Crypto write parity is established transitively: the PR-1 fixture proves this salt key decrypts Django/`cryptography`-produced ciphertext (so the key is byte-identical to Django's), and `encrypt_leaf` uses that same key — so by the Fernet spec a value encrypted here is Django-readable. The true end-to-end (gateway writes a row, Django reads it) is the local e2e below.
- Python: `test_refresh_integrations_skips_gateway_owned_kinds` proves the beat excludes gateway-owned kinds (the dual-writer safety property).

Local e2e (not run here): seed an expired-but-refreshable hubspot integration with a valid refresh token, point `REFRESH_TOKEN_URL_OVERRIDE` at a mock token endpoint, set `INTEGRATION_GATEWAY_REFRESH_KINDS=hubspot`, then `/api/v1/credentials/fetch` returns a fresh token, writes it back re-encrypted, and the Django beat skips hubspot; killing the mock sets `TOKEN_REFRESH_FAILED` and the stale token is still served.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ben directed this; I (Claude) implemented it. Key decisions: single per-kind ownership list drives both sides (gateway + beat) so coordination can't drift; refresh only on the cache-miss/DB-load path (write-through) so we never cache a stale token; fail-open on every error path since a gateway blip must not break a consumer; scoped the initial provider set to the generic OAuth2 flow and left exotic/rotating/service-account providers on the Django beat. The `/writing-tests` skill wasn't available in this session — its value-gate was applied by hand (each test names a unique regression). Deferred the `reload-integrations` publish because `common-redis` exposes no publish and half-life refresh makes the staleness safe.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

