### PR TITLE
feat(dashboards): restore throwaway edit-bar layout prototype

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -99,7 +99,7 @@ export enum DashboardEventSource {
     DashboardVariableOverride = 'dashboard_variable_override',
 }
 
-export type DashboardFilterChangeType = 'date' | 'properties' | 'breakdown' | 'variable' | 'interval'
+export type DashboardFilterChangeType = 'date' | 'properties' | 'breakdown' | 'variable' | 'interval' | 'test_account'
 
 export enum InsightEventSource {
     LongPress = 'long_press',

--- a/frontend/src/scenes/dashboard/DashboardEditBar.prototype.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.prototype.tsx
@@ -1,0 +1,707 @@
+/**
+ * PROTOTYPE — throwaway. Radically different layouts of the dashboard edit bar,
+ * switchable via `?variant=A|B|C|D|E|F` on the real dashboard route. Flip between
+ * them with the floating bottom bar (dev builds only). Delete this file and the
+ * `?variant` gate in DashboardEditBar.tsx once a direction is picked.
+ *
+ * Business logic intentionally lives in local component state here (not kea) —
+ * this is a disposable design spike, not production code.
+ */
+import { BindLogic, useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect, useState } from 'react'
+
+import {
+    IconCalendar,
+    IconChevronLeft,
+    IconChevronRight,
+    IconClock,
+    IconCollapse,
+    IconDirectedGraph,
+    IconExpand,
+    IconFilter,
+    IconGear,
+    IconPerson,
+    IconPlus,
+} from '@posthog/icons'
+import { LemonButton, LemonDropdown, LemonLabel, LemonSelect, LemonSnack } from '@posthog/lemon-ui'
+
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { dateFilterToText } from 'lib/utils/dateFilters'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
+import { getProjectEventExistence } from 'lib/utils/getAppContext'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
+import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { groupsModel } from '~/models/groupsModel'
+import { VariablesForDashboard } from '~/queries/nodes/DataVisualization/Components/Variables/Variables'
+import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
+import { DashboardMode, InsightLogicProps } from '~/types'
+
+export const PROTOTYPE_VARIANTS = ['A', 'B', 'C', 'D', 'E', 'F'] as const
+export type PrototypeVariant = (typeof PROTOTYPE_VARIANTS)[number]
+
+const VARIANT_NAMES: Record<PrototypeVariant, string> = {
+    A: 'Compact popover toolbar',
+    B: 'Labeled field grid',
+    C: 'Chip summary bar',
+    D: 'Current top bar + labeled panel',
+    E: 'Filters inline + separate variables bar',
+    F: 'Filters inline, no advanced background',
+}
+
+// A single place to reach the dashboard filter state + ensure we're in edit mode.
+function useEditModel(): {
+    filters: ReturnType<typeof useValues<typeof dashboardLogic>>['effectiveEditBarFilters']
+    hasTestFilters: boolean
+    hasPageview: boolean
+    hasScreen: boolean
+    groupsTaxonomicTypes: TaxonomicFilterGroupType[]
+    dashboardId: number | undefined
+    ensureEdit: () => void
+    setDates: (from: string | null, to: string | null, explicit?: boolean) => void
+    setInterval: (interval: string | null) => void
+    setFilterTestAccounts: (value: boolean | null) => void
+    setProperties: (properties: any[]) => void
+    setBreakdownFilter: (breakdown: BreakdownFilter | null) => void
+} {
+    const { dashboard, dashboardMode, effectiveEditBarFilters } = useValues(dashboardLogic)
+    const { setDates, setInterval, setFilterTestAccounts, setProperties, setBreakdownFilter, setDashboardMode } =
+        useActions(dashboardLogic)
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
+    const { currentTeam } = useValues(teamLogic)
+    const { hasPageview, hasScreen } = getProjectEventExistence()
+
+    const ensureEdit = (): void => {
+        if (dashboardMode !== DashboardMode.Edit) {
+            setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
+        }
+    }
+
+    return {
+        filters: effectiveEditBarFilters,
+        hasTestFilters: (currentTeam?.test_account_filters || []).length > 0,
+        hasPageview,
+        hasScreen,
+        groupsTaxonomicTypes,
+        dashboardId: dashboard?.id,
+        ensureEdit,
+        setDates: (from, to, explicit) => {
+            ensureEdit()
+            setDates(from, to, explicit)
+        },
+        setInterval: (interval) => {
+            ensureEdit()
+            setInterval(interval as any)
+        },
+        setFilterTestAccounts: (value) => {
+            ensureEdit()
+            setFilterTestAccounts(value)
+        },
+        setProperties: (properties) => {
+            ensureEdit()
+            setProperties(properties)
+        },
+        setBreakdownFilter: (breakdown) => {
+            ensureEdit()
+            setBreakdownFilter(breakdown)
+        },
+    }
+}
+
+// ----- Raw controls, reused across variants -----
+
+function DateControl(): JSX.Element {
+    const m = useEditModel()
+    return (
+        <DateFilter
+            showCustom
+            showExplicitDateToggle
+            allowTimePrecision
+            allowFixedRangeWithTime
+            dateFrom={m.filters.date_from}
+            dateTo={m.filters.date_to}
+            explicitDate={m.filters.explicitDate}
+            onChange={(from, to, explicit) => m.setDates(from, to, explicit)}
+            makeLabel={(key) => (
+                <>
+                    <IconCalendar /> <span>{key}</span>
+                </>
+            )}
+        />
+    )
+}
+
+function IntervalControl(): JSX.Element {
+    const m = useEditModel()
+    return (
+        <LemonSelect
+            size="small"
+            value={m.filters.interval ?? null}
+            dropdownMatchSelectWidth={false}
+            onChange={(interval) => m.setInterval(interval)}
+            options={[
+                { value: null, label: "each insight's interval" },
+                { value: 'hour', label: 'hour' },
+                { value: 'day', label: 'day' },
+                { value: 'week', label: 'week' },
+                { value: 'month', label: 'month' },
+            ]}
+        />
+    )
+}
+
+function TestUsersControl(): JSX.Element {
+    const m = useEditModel()
+    return (
+        <LemonSelect<boolean | null>
+            size="small"
+            value={m.filters.filterTestAccounts ?? null}
+            dropdownMatchSelectWidth={false}
+            disabledReason={
+                !m.hasTestFilters
+                    ? "You haven't set any internal test filters. Use the settings gear to configure."
+                    : undefined
+            }
+            onChange={(value) => m.setFilterTestAccounts(value)}
+            options={[
+                { value: null, label: "Each insight's setting for internal and test users" },
+                { value: true, label: 'Internal and test users excluded' },
+                { value: false, label: 'Internal and test users included' },
+            ]}
+        />
+    )
+}
+
+function BreakdownControl(): JSX.Element {
+    const m = useEditModel()
+    const insightProps: InsightLogicProps = {
+        dashboardItemId: 'new',
+        dashboardId: m.dashboardId,
+        cachedInsight: null,
+        query: { kind: NodeKind.InsightVizNode, source: { kind: NodeKind.TrendsQuery, series: [] } },
+    }
+    return (
+        <BindLogic logic={insightLogic} props={insightProps}>
+            <TaxonomicBreakdownFilter
+                insightProps={insightProps}
+                breakdownFilter={m.filters.breakdown_filter}
+                isTrends={false}
+                isFunnels={false}
+                showLabel={false}
+                hideAddButtonWhenSet
+                updateBreakdownFilter={(breakdown_filter) => {
+                    let saved: BreakdownFilter | null = breakdown_filter
+                    if (breakdown_filter && !breakdown_filter.breakdown_type && !breakdown_filter.breakdowns) {
+                        saved = null
+                    }
+                    m.setBreakdownFilter(saved)
+                }}
+                updateDisplay={() => {}}
+                disablePropertyInfo
+                size="small"
+            />
+        </BindLogic>
+    )
+}
+
+function PropertiesControl(): JSX.Element {
+    const m = useEditModel()
+    return (
+        <PropertyFilters
+            onChange={(properties) => m.setProperties(properties)}
+            pageKey={'dashboard_proto_' + m.dashboardId}
+            propertyFilters={m.filters.properties}
+            taxonomicGroupTypes={[
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.PersonProperties,
+                TaxonomicFilterGroupType.EventFeatureFlags,
+                TaxonomicFilterGroupType.EventMetadata,
+                ...(m.hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
+                ...(m.hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
+                TaxonomicFilterGroupType.EmailAddresses,
+                ...m.groupsTaxonomicTypes,
+                TaxonomicFilterGroupType.Cohorts,
+                TaxonomicFilterGroupType.Elements,
+                TaxonomicFilterGroupType.SessionProperties,
+                TaxonomicFilterGroupType.HogQLExpression,
+                TaxonomicFilterGroupType.DataWarehousePersonProperties,
+            ]}
+        />
+    )
+}
+
+function GearButton(): JSX.Element {
+    return (
+        <LemonButton
+            icon={<IconGear />}
+            size="small"
+            tooltip="Configure internal & test user filtering"
+            to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+        />
+    )
+}
+
+// Value summaries used by pill/chip variants.
+function useOverrideSummaries(): Record<string, { active: boolean; label: string }> {
+    const { filters } = useEditModel()
+    return {
+        date: {
+            active: !!filters.date_from || !!filters.date_to,
+            label: dateFilterToText(filters.date_from, filters.date_to, 'Date range') ?? 'Date range',
+        },
+        interval: { active: !!filters.interval, label: filters.interval ? `by ${filters.interval}` : 'Interval' },
+        breakdown: { active: !!filters.breakdown_filter, label: 'Breakdown' },
+        properties: {
+            active: (filters.properties?.length ?? 0) > 0,
+            label: `Filters${filters.properties?.length ? ` (${filters.properties.length})` : ''}`,
+        },
+        testUsers: {
+            active: filters.filterTestAccounts !== null && filters.filterTestAccounts !== undefined,
+            label: filters.filterTestAccounts === true ? 'Test users excluded' : 'Test users included',
+        },
+    }
+}
+
+// ===== Variant A — compact popover toolbar =====
+// Everything collapses to one row of icon pills; each opens its control in a popover.
+
+function Pill({ icon, label, active, control }: PillProps): JSX.Element {
+    return (
+        <LemonDropdown closeOnClickInside={false} overlay={<div className="p-2 min-w-[16rem]">{control}</div>}>
+            <LemonButton size="small" type={active ? 'secondary' : 'tertiary'} icon={icon}>
+                <span className={active ? 'font-medium' : 'text-muted'}>{label}</span>
+            </LemonButton>
+        </LemonDropdown>
+    )
+}
+
+interface PillProps {
+    icon: JSX.Element
+    label: string
+    active: boolean
+    control: JSX.Element
+}
+
+function VariantA(): JSX.Element {
+    const s = useOverrideSummaries()
+    return (
+        <div className="flex flex-wrap items-center gap-1">
+            <Pill icon={<IconCalendar />} label={s.date.label} active={s.date.active} control={<DateControl />} />
+            <Pill
+                icon={<IconClock />}
+                label={s.interval.label}
+                active={s.interval.active}
+                control={<IntervalControl />}
+            />
+            <Pill
+                icon={<IconDirectedGraph />}
+                label={s.breakdown.label}
+                active={s.breakdown.active}
+                control={<BreakdownControl />}
+            />
+            <Pill
+                icon={<IconFilter />}
+                label={s.properties.label}
+                active={s.properties.active}
+                control={<PropertiesControl />}
+            />
+            <Pill
+                icon={<IconPerson />}
+                label={s.testUsers.active ? s.testUsers.label : 'Test users'}
+                active={s.testUsers.active}
+                control={
+                    <div className="flex items-center gap-1">
+                        <TestUsersControl />
+                        <GearButton />
+                    </div>
+                }
+            />
+            <div className="ml-auto">
+                <VariablesForDashboard />
+            </div>
+        </div>
+    )
+}
+
+// ===== Variant B — labeled field grid =====
+// Every override is a proper labeled field on an aligned grid. No inline prose.
+
+function Field({ label, children }: { label: string; children: JSX.Element }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1 min-w-0">
+            <LemonLabel className="text-muted text-xs uppercase tracking-wide">{label}</LemonLabel>
+            {children}
+        </div>
+    )
+}
+
+function VariantB(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                <Field label="Date range">
+                    <DateControl />
+                </Field>
+                <Field label="Grouped by">
+                    <IntervalControl />
+                </Field>
+                <Field label="Breakdown">
+                    <BreakdownControl />
+                </Field>
+                <Field label="Internal & test users">
+                    <div className="flex items-center gap-1">
+                        <TestUsersControl />
+                        <GearButton />
+                    </div>
+                </Field>
+            </div>
+            <Field label="Property filters">
+                <PropertiesControl />
+            </Field>
+            <VariablesForDashboard />
+        </div>
+    )
+}
+
+// ===== Variant C — chip summary bar =====
+// A single line: "+ Add override" plus a removable chip per active override.
+// Reveals scale with usage; empty state is a single muted sentence.
+
+interface ChipDef {
+    key: string
+    label: string
+    control: JSX.Element
+    reset: () => void
+}
+
+function VariantC(): JSX.Element {
+    const m = useEditModel()
+    const s = useOverrideSummaries()
+    // Chips the user explicitly added but that don't yet hold a value.
+    const [revealed, setRevealed] = useState<Set<string>>(new Set())
+
+    const reveal = (key: string): void => setRevealed((prev) => new Set(prev).add(key))
+    const hide = (key: string): void =>
+        setRevealed((prev) => {
+            const next = new Set(prev)
+            next.delete(key)
+            return next
+        })
+
+    const defs: ChipDef[] = [
+        {
+            key: 'date',
+            label: s.date.active ? s.date.label : 'Date range',
+            control: <DateControl />,
+            reset: () => {
+                m.setDates(null, null)
+                hide('date')
+            },
+        },
+        {
+            key: 'interval',
+            label: s.interval.active ? s.interval.label : 'Interval',
+            control: <IntervalControl />,
+            reset: () => {
+                m.setInterval(null)
+                hide('interval')
+            },
+        },
+        {
+            key: 'breakdown',
+            label: 'Breakdown',
+            control: <BreakdownControl />,
+            reset: () => {
+                m.setBreakdownFilter(null)
+                hide('breakdown')
+            },
+        },
+        {
+            key: 'properties',
+            label: s.properties.label,
+            control: <PropertiesControl />,
+            reset: () => {
+                m.setProperties([])
+                hide('properties')
+            },
+        },
+        {
+            key: 'testUsers',
+            label: s.testUsers.active ? s.testUsers.label : 'Test users',
+            control: (
+                <div className="flex items-center gap-1">
+                    <TestUsersControl />
+                    <GearButton />
+                </div>
+            ),
+            reset: () => {
+                m.setFilterTestAccounts(null)
+                hide('testUsers')
+            },
+        },
+    ]
+
+    const isActive = (key: string): boolean => (s as any)[key]?.active || revealed.has(key)
+    const activeChips = defs.filter((d) => isActive(d.key))
+    const inactive = defs.filter((d) => !isActive(d.key))
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <LemonDropdown
+                closeOnClickInside
+                overlay={
+                    <div className="flex flex-col p-1">
+                        {inactive.length === 0 ? (
+                            <span className="px-2 py-1 text-muted text-xs">All overrides added</span>
+                        ) : (
+                            inactive.map((d) => (
+                                <LemonButton key={d.key} size="small" fullWidth onClick={() => reveal(d.key)}>
+                                    {d.label}
+                                </LemonButton>
+                            ))
+                        )}
+                    </div>
+                }
+            >
+                <LemonButton size="small" type="secondary" icon={<IconPlus />}>
+                    Add override
+                </LemonButton>
+            </LemonDropdown>
+
+            {activeChips.length === 0 ? (
+                <span className="text-muted text-sm">No overrides — insights use their own settings.</span>
+            ) : (
+                activeChips.map((d) => (
+                    <LemonDropdown
+                        key={d.key}
+                        closeOnClickInside={false}
+                        overlay={<div className="p-2 min-w-[16rem]">{d.control}</div>}
+                    >
+                        <LemonSnack onClose={d.reset}>{d.label}</LemonSnack>
+                    </LemonDropdown>
+                ))
+            )}
+
+            <div className="ml-auto">
+                <VariablesForDashboard />
+            </div>
+        </div>
+    )
+}
+
+// ===== Variant D — current top bar + labeled panel =====
+// Row 1 is untouched (date, grouped-by, advanced toggle, variables). The advanced
+// section becomes a shaded panel with a label above every remaining control.
+
+function VariantD(): JSX.Element {
+    const { showAdvancedOverrides, advancedOverridesCount } = useValues(dashboardLogic)
+    const { toggleAdvancedOverrides } = useActions(dashboardLogic)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-end flex-wrap">
+                <DateControl />
+                <span className="flex items-center gap-2">
+                    <span className="hidden md:inline">grouped by</span>
+                    <IntervalControl />
+                </span>
+                <LemonButton
+                    size="small"
+                    onClick={toggleAdvancedOverrides}
+                    sideIcon={showAdvancedOverrides ? <IconCollapse /> : <IconExpand />}
+                >
+                    Advanced overrides
+                    {advancedOverridesCount > 0 && <span className="ml-1 text-muted">({advancedOverridesCount})</span>}
+                </LemonButton>
+                <VariablesForDashboard />
+            </div>
+            {showAdvancedOverrides && (
+                <div className="bg-surface-secondary border rounded-lg p-3">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 items-start">
+                        <Field label="Property filters">
+                            <PropertiesControl />
+                        </Field>
+                        <Field label="Breakdown">
+                            <BreakdownControl />
+                        </Field>
+                        <Field label="Internal & test users">
+                            <div className="flex items-center gap-1">
+                                <TestUsersControl />
+                                <GearButton />
+                            </div>
+                        </Field>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+// Variant E uses the insights test-account filter (a switch) instead of the tri-state dropdown.
+// The switch is binary, so the "each insight's setting" (null) override isn't reachable here.
+// TestAccountFilter hardcodes fullWidth (0.75rem label); override both so it sits inline next to
+// the breakdown at the same 0.875rem font size.
+function InsightsTestAccountControl(): JSX.Element {
+    const m = useEditModel()
+    return (
+        <div className="[&_.LemonSwitch--full-width]:w-auto [&_.LemonSwitch_label]:text-sm">
+            <TestAccountFilter
+                size="small"
+                filters={{ filter_test_accounts: m.filters.filterTestAccounts ?? false }}
+                onChange={({ filter_test_accounts }) => m.setFilterTestAccounts(!!filter_test_accounts)}
+            />
+        </div>
+    )
+}
+
+// ===== Variants E & F — filters inline + variables below =====
+// Top bar keeps date + grouped-by and adds the always-visible Filters button next to
+// the interval. The advanced panel holds breakdown + test users. Variables sit below,
+// always visible. F is E with the advanced panel's shaded background removed.
+
+function InlineFiltersLayout({ shaded }: { shaded: boolean }): JSX.Element {
+    const { showAdvancedOverrides, advancedOverridesCount } = useValues(dashboardLogic)
+    const { toggleAdvancedOverrides } = useActions(dashboardLogic)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-end flex-wrap">
+                <DateControl />
+                <span className="flex items-center gap-2">
+                    <span className="hidden md:inline">grouped by</span>
+                    <IntervalControl />
+                </span>
+                <PropertiesControl />
+                <LemonButton
+                    size="small"
+                    onClick={toggleAdvancedOverrides}
+                    sideIcon={showAdvancedOverrides ? <IconCollapse /> : <IconExpand />}
+                >
+                    Advanced overrides
+                    {advancedOverridesCount > 0 && <span className="ml-1 text-muted">({advancedOverridesCount})</span>}
+                </LemonButton>
+            </div>
+            {showAdvancedOverrides && (
+                <div className={shaded ? 'bg-surface-secondary border rounded-lg p-3' : undefined}>
+                    <div className="flex flex-wrap items-center gap-2">
+                        <BreakdownControl />
+                        <InsightsTestAccountControl />
+                    </div>
+                </div>
+            )}
+            {/* Shrink the list-variable clear (×) from the default 1.25rem small-button icon down to the value-text size. */}
+            <div className="[&_.LemonButtonWithSideAction\_\_side-button_.LemonButton]:[--lemon-button-icon-size:0.875rem]">
+                <VariablesForDashboard />
+            </div>
+        </div>
+    )
+}
+
+function VariantE(): JSX.Element {
+    return <InlineFiltersLayout shaded />
+}
+
+function VariantF(): JSX.Element {
+    return <InlineFiltersLayout shaded={false} />
+}
+
+// ===== Switcher (dev only) =====
+
+function currentVariant(searchParams?: Record<string, any>): PrototypeVariant | null {
+    const v = (searchParams ?? router.values.searchParams).variant
+    return PROTOTYPE_VARIANTS.includes(v) ? (v as PrototypeVariant) : null
+}
+
+function goToVariant(v: PrototypeVariant | null): void {
+    const { pathname } = router.values.location
+    const params = { ...router.values.searchParams }
+    if (v) {
+        params.variant = v
+    } else {
+        delete params.variant
+    }
+    router.actions.push(pathname, params, router.values.hashParams)
+}
+
+export function PrototypeSwitcher(): JSX.Element | null {
+    const { searchParams } = useValues(router)
+    const active = PROTOTYPE_VARIANTS.includes(searchParams.variant) ? (searchParams.variant as PrototypeVariant) : null
+
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent): void => {
+            const el = document.activeElement
+            if (el && ['INPUT', 'TEXTAREA'].includes(el.tagName)) {
+                return
+            }
+            if ((el as HTMLElement)?.isContentEditable) {
+                return
+            }
+            if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') {
+                return
+            }
+            const order: (PrototypeVariant | null)[] = [null, ...PROTOTYPE_VARIANTS]
+            const idx = order.indexOf(active)
+            const nextIdx = e.key === 'ArrowRight' ? (idx + 1) % order.length : (idx - 1 + order.length) % order.length
+            goToVariant(order[nextIdx])
+        }
+        window.addEventListener('keydown', onKey)
+        return () => window.removeEventListener('keydown', onKey)
+    }, [active])
+
+    if (process.env.NODE_ENV === 'production') {
+        return null
+    }
+
+    const order: (PrototypeVariant | null)[] = [null, ...PROTOTYPE_VARIANTS]
+    const idx = order.indexOf(active)
+    const prev = order[(idx - 1 + order.length) % order.length]
+    const next = order[(idx + 1) % order.length]
+
+    return (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[10000] flex w-80 items-center justify-between gap-2 rounded-full bg-black text-white shadow-lg px-3 py-1.5">
+            <button
+                type="button"
+                className="flex items-center justify-center text-white text-lg hover:opacity-70"
+                onClick={() => goToVariant(prev)}
+            >
+                <IconChevronLeft />
+            </button>
+            <span className="text-xs font-mono whitespace-nowrap overflow-hidden text-ellipsis text-center flex-1">
+                edit-bar: {active ? `${active} — ${VARIANT_NAMES[active]}` : 'original'}
+            </span>
+            <button
+                type="button"
+                className="flex items-center justify-center text-white text-lg hover:opacity-70"
+                onClick={() => goToVariant(next)}
+            >
+                <IconChevronRight />
+            </button>
+        </div>
+    )
+}
+
+export function DashboardEditBarPrototype({ variant }: { variant: PrototypeVariant }): JSX.Element {
+    switch (variant) {
+        case 'A':
+            return <VariantA />
+        case 'B':
+            return <VariantB />
+        case 'C':
+            return <VariantC />
+        case 'D':
+            return <VariantD />
+        case 'E':
+            return <VariantE />
+        case 'F':
+            return <VariantF />
+    }
+}
+
+export { currentVariant }

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { IconCalendar } from '@posthog/icons'
 import { LemonSelect } from '@posthog/lemon-ui'
@@ -20,6 +21,12 @@ import { groupsModel } from '~/models/groupsModel'
 import { VariablesForDashboard } from '~/queries/nodes/DataVisualization/Components/Variables/Variables'
 import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
 import { DashboardMode, InsightLogicProps, IntervalType } from '~/types'
+
+import {
+    currentVariant as currentPrototypeVariant,
+    DashboardEditBarPrototype,
+    PrototypeSwitcher,
+} from './DashboardEditBar.prototype'
 
 interface DashboardEditBarProps {
     showDateFilter?: boolean
@@ -59,8 +66,30 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
     const { dashboard, dashboardMode, hasVariables, effectiveEditBarFilters } = useValues(dashboardLogic)
     const { setDates, setProperties, setBreakdownFilter, setDashboardMode } = useActions(dashboardLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
+    const { searchParams } = useValues(router)
 
     const { hasPageview, hasScreen } = getProjectEventExistence()
+
+    // PROTOTYPE — `?variant=A|B|C` swaps the edit bar layout; remove with DashboardEditBar.prototype.tsx.
+    const prototypeVariant = currentPrototypeVariant(searchParams)
+    if (prototypeVariant) {
+        return (
+            <div
+                className={
+                    className ??
+                    clsx(
+                        'flex flex-col gap-2 border',
+                        dashboardMode === DashboardMode.Edit
+                            ? '-m-1.5 p-1.5 border-primary border-dashed rounded-lg'
+                            : 'border-transparent'
+                    )
+                }
+            >
+                <DashboardEditBarPrototype variant={prototypeVariant} />
+                <PrototypeSwitcher />
+            </div>
+        )
+    }
 
     const insightProps: InsightLogicProps = {
         dashboardItemId: 'new',
@@ -179,6 +208,7 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
             </div>
 
             <VariablesForDashboard />
+            <PrototypeSwitcher />
         </div>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { IconEllipsis } from '@posthog/icons'
 import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
@@ -9,6 +10,7 @@ import { urls } from 'scenes/urls'
 import { DashboardMode, DashboardPlacement } from '~/types'
 
 import { DashboardEditBar } from './DashboardEditBar'
+import { currentVariant as currentPrototypeVariant } from './DashboardEditBar.prototype'
 import { DashboardEditSaveCancelButtons } from './DashboardHeaderActions'
 import { dashboardLogic } from './dashboardLogic'
 import { DashboardReloadAction, LastRefreshText } from './DashboardReloadAction'
@@ -59,6 +61,11 @@ interface DashboardFilterBarProps {
 
 export function DashboardFilterBar({ backTo }: DashboardFilterBarProps): JSX.Element {
     const { placement, dashboard, dashboardMode, hasVariables } = useValues(dashboardLogic)
+    const { searchParams } = useValues(router)
+
+    // PROTOTYPE — variant edit-bar layouts don't inline variables, so the mt-7 nudge would push
+    // "last refresh" off the top; remove with DashboardEditBar.prototype.tsx.
+    const prototypeActive = !!currentPrototypeVariant(searchParams)
 
     return (
         <div className="@container/dashboard-filters flex min-w-0 flex-1 flex-col gap-2">
@@ -83,7 +90,7 @@ export function DashboardFilterBar({ backTo }: DashboardFilterBarProps): JSX.Ele
                             'flex flex-col @4xl/dashboard-filters:flex-row items-end @4xl/dashboard-filters:items-center gap-4 dashoard-items-actions',
                             'min-w-0 @max-4xl/dashboard-filters:basis-full @max-4xl/dashboard-filters:w-full @max-4xl/dashboard-filters:ml-0 shrink-0 @4xl/dashboard-filters:ml-auto',
                             {
-                                'mt-7': hasVariables,
+                                'mt-7': hasVariables && !prototypeActive,
                             }
                         )}
                     >

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -231,6 +231,7 @@ export interface dashboardLogicValues {
     addWidgetModalOpen: boolean
     addWidgetSelectedTypes: string[]
     addWidgetTileLoading: boolean
+    advancedOverridesCount: number
     apiUrl: (
         refresh?: RefreshType | undefined,
         filtersOverride?: DashboardFilter | undefined,
@@ -321,6 +322,7 @@ export interface dashboardLogicValues {
     scrollToBottomSignal: number
     shouldReportOnAPILoad: boolean
     shouldUseStreaming: boolean
+    showAdvancedOverrides: boolean
     showApplyFiltersBanner: boolean
     showButtonTileModal: boolean
     showSubscriptions: boolean
@@ -716,6 +718,9 @@ export interface dashboardLogicActions {
     setExternalFilters: (filters: DashboardFilter) => {
         filters: DashboardFilter
     }
+    setFilterTestAccounts: (filterTestAccounts: boolean | null) => {
+        filterTestAccounts: boolean | null
+    }
     setInitialLoadResponseBytes: (responseBytes: number) => {
         responseBytes: number
     }
@@ -823,6 +828,9 @@ export interface dashboardLogicActions {
     }
     toggleAddWidgetSelectedType: (widgetType: string) => {
         widgetType: string
+    }
+    toggleAdvancedOverrides: () => {
+        value: true
     }
     togglePinned: () => {
         value: true
@@ -947,6 +955,7 @@ export interface dashboardLogicMeta {
             urlFilters: DashboardFilter,
             intermittentFilters: DashboardFilter
         ) => DashboardFilter
+        advancedOverridesCount: (effectiveEditBarFilters: DashboardFilter) => number
         effectiveRefreshFilters: (
             dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null,
             externalFilters: DashboardFilter,
@@ -1208,6 +1217,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setProperties: (properties: AnyPropertyFilter[] | null) => ({ properties }),
         setBreakdownFilter: (breakdown_filter: BreakdownFilter | null) => ({ breakdown_filter }),
         setInterval: (interval: IntervalType | null) => ({ interval }),
+        setFilterTestAccounts: (filterTestAccounts: boolean | null) => ({ filterTestAccounts }),
+        toggleAdvancedOverrides: true,
         setExternalFilters: (filters: DashboardFilter) => ({ filters }),
         saveEditModeChanges: () => true,
         resetUrlFilters: () => true,
@@ -1675,6 +1686,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 setProperties: () => false,
                 setBreakdownFilter: () => false,
                 setInterval: () => false,
+                setFilterTestAccounts: () => false,
                 loadDashboardSuccess: () => false,
                 loadDashboardFailure: () => false,
                 applyFilters: () => true,
@@ -2155,6 +2167,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 breakdown_filter: undefined,
                 explicitDate: undefined,
                 interval: undefined,
+                filterTestAccounts: undefined,
             } as DashboardFilter,
             {
                 setDates: (state, { date_from, date_to, explicitDate }) => ({
@@ -2175,6 +2188,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     ...state,
                     interval,
                 }),
+                setFilterTestAccounts: (state, { filterTestAccounts }) => ({
+                    ...state,
+                    filterTestAccounts,
+                }),
                 resetIntermittentFilters: () => ({
                     date_from: undefined,
                     date_to: undefined,
@@ -2182,7 +2199,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     breakdown_filter: undefined,
                     explicitDate: undefined,
                     interval: undefined,
+                    filterTestAccounts: undefined,
                 }),
+            },
+        ],
+        showAdvancedOverrides: [
+            false,
+            {
+                toggleAdvancedOverrides: (state) => !state,
             },
         ],
         isSavingTags: [
@@ -2355,6 +2379,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 )
                 return effectiveEditBarFilters
             },
+        ],
+        advancedOverridesCount: [
+            (s) => [s.effectiveEditBarFilters],
+            (filters: DashboardFilter): number =>
+                (filters.properties?.length ?? 0) +
+                (filters.breakdown_filter ? 1 : 0) +
+                (filters.filterTestAccounts != null ? 1 : 0),
         ],
         effectiveRefreshFilters: [
             (s) => [s.dashboard, s.externalFilters, s.urlFilters],
@@ -4005,6 +4036,18 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 })
             }
         },
+        setFilterTestAccounts: ({ filterTestAccounts }) => {
+            eventUsageLogic.actions.reportDashboardFiltersChanged(values.dashboard, 'test_account', {
+                filter_test_accounts: filterTestAccounts,
+            })
+
+            if (values.canAutoPreview) {
+                actions.refreshDashboardItems({
+                    action: RefreshDashboardItemsAction.Preview,
+                    forceRefresh: false,
+                })
+            }
+        },
         setExternalFilters: () => {
             if (values.tiles.length > 0) {
                 actions.refreshDashboardItems({
@@ -4208,6 +4251,25 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const newUrlFilters: DashboardFilter = {
                 ...urlFilters,
                 interval,
+            }
+
+            return [
+                currentLocation.pathname,
+                { ...currentLocation.searchParams, ...encodeURLFilters(newUrlFilters) },
+                currentLocation.hashParams,
+            ]
+        },
+        setFilterTestAccounts: ({ filterTestAccounts }) => {
+            if (!values.canAutoPreview) {
+                return
+            }
+
+            const { currentLocation } = router.values
+
+            const urlFilters = parseURLFilters(currentLocation.searchParams)
+            const newUrlFilters: DashboardFilter = {
+                ...urlFilters,
+                filterTestAccounts,
             }
 
             return [


### PR DESCRIPTION
## TL;DR

The dashboard edit bar had a throwaway design prototype (a bunch of alternate layouts you flip through with `?variant=A` … `F` in the URL). It got stashed and half-lost. This puts it back so I can look at the different layouts again and pick a direction. It's a scratchpad, not something we ship.

### edit-bar: A — Compact popover toolbar

<img width="725" height="56" alt="Screenshot 2026-07-21 at 13 00 15" src="https://github.com/user-attachments/assets/ef67c3d6-9366-49e3-bb05-23007f1afb19" />

<img width="688" height="55" alt="Screenshot 2026-07-21 at 13 01 10" src="https://github.com/user-attachments/assets/4e94211f-72ac-4ed6-b9fe-f5b5728330de" />

### edit-bar: B — Labeled field grid

<img width="1037" height="141" alt="Screenshot 2026-07-21 at 13 00 36" src="https://github.com/user-attachments/assets/a47ac1f4-da72-4a38-8b60-972338937bb9" />

### edit-bar: C — Chip summary bar

<img width="553" height="65" alt="Screenshot 2026-07-21 at 13 00 50" src="https://github.com/user-attachments/assets/9f2f4d62-2c72-4c70-9efd-84d3c57af254" />

### edit-bar: E — Filters inline + separate variables bar

<img width="688" height="126" alt="Screenshot 2026-07-21 at 13 02 29" src="https://github.com/user-attachments/assets/17e87173-5e04-4aed-81a6-6e43649ec6a6" />

## Problem

A disposable design spike for the dashboard edit bar was stashed across three git stashes and ended up in a broken, half-restored state on master: `DashboardFilters.tsx` imported a prototype file that no longer existed, so the frontend wouldn't compile. I wanted the working prototype back to keep iterating on layout ideas.

## Changes

Restores the throwaway prototype and the minimal supporting logic it was built on:

- `DashboardEditBar.prototype.tsx` — the prototype component. Layout variants A–F, switchable via `?variant=` on any dashboard route, with a dev-only floating switcher to flip between them. Business logic intentionally lives in local component state (it's a spike, not production).
- `DashboardEditBar.tsx` — the `?variant` gate that renders the prototype early, plus the floating switcher.
- `DashboardFilters.tsx` — variant-aware `mt-7` nudge so the "last refresh" text doesn't get pushed off the top.
- `dashboardLogic.tsx` — the prototype depends on test-account / advanced-overrides support (`setFilterTestAccounts`, `toggleAdvancedOverrides`, `showAdvancedOverrides`, `advancedOverridesCount`, `filterTestAccounts`) that isn't on master. Added those additive members (kea types regenerated). Master's `postHogAIButtonLabelVariant` is untouched.
- `eventUsageLogic.ts` — added `'test_account'` to `DashboardFilterChangeType` for the same reason.

> [!NOTE]
> This is throwaway by design — the prototype file's own header says to delete it and the `?variant` gate once a direction is picked. It also pulls in logic that isn't merged to master, so it's not meant to merge as-is. Opened as a draft to keep it out of the way.

## How did you test this code?

I (Claude, agent-assisted) ran the automated checks only — no manual UI testing:

- `pnpm --filter=@posthog/frontend typescript:check` — clean for all touched files.
- oxlint on the touched files — clean (one pre-existing `no-cycle` warning on `dashboardLogic.tsx`, not introduced here).
- oxfmt — all touched files correctly formatted.
- `hogli ci:preflight --strict` — no failures.

Not done: I did not run the app and click through the `?variant=A–F` layouts. To verify manually: open any dashboard and append `?variant=A` (then B–F) to the URL — the prototype edit bar should render and the floating switcher should flip variants; without `?variant` the normal edit bar is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) restored this from three git stashes at Thomas's request. The stashes split the work into the prototype file, its wiring, and unrelated generated-file churn. Original plan was a clean 2-file restore, but typecheck surfaced that the prototype leans on `dashboardLogic` members and a `DashboardFilterChangeType` value that were on the feature branch's older base but not on current master. I isolated the branch's own additive `dashboardLogic` diff (merge-base → tip) and applied it 3-way so master's later `postHogAIButtonLabelVariant` work was preserved, then regenerated kea types with `typegen:file`. Only the 5 prototype-related files are committed — pre-existing unrelated working-tree changes were deliberately left out. No repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
