### PR TITLE
fix(funnels): keep compare filter when sorting detailed results

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { router } from 'kea-router'
+
+import { initKeaTests } from '~/test/init'
+
+import { LemonTable } from './LemonTable'
+
+interface Row {
+    id: number
+    name: string
+    value: number
+}
+
+const DATA: Row[] = [
+    { id: 1, name: 'alpha', value: 3 },
+    { id: 2, name: 'beta', value: 1 },
+    { id: 3, name: 'gamma', value: 2 },
+]
+
+const COLUMNS = [
+    {
+        title: 'Value',
+        key: 'value',
+        render: (_: any, row: Row) => <span data-attr="cell-name">{row.name}</span>,
+        sorter: (a: Row, b: Row) => a.value - b.value,
+    },
+]
+
+describe('LemonTable', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(cleanup)
+
+    const renderedOrder = (): string[] => screen.getAllByTestId('cell-name').map((el) => el.textContent ?? '')
+
+    it.each([
+        [true, ['alpha', 'gamma', 'beta']],
+        [false, ['alpha', 'beta', 'gamma']],
+    ])('useURLForSorting=%s reads the order search param only when enabled', (useURLForSorting, expectedOrder) => {
+        router.actions.push(router.values.location.pathname, { order: '-value' })
+        render(
+            <LemonTable
+                rowKey="id"
+                dataSource={DATA}
+                columns={COLUMNS}
+                useURLForSorting={useURLForSorting as boolean}
+            />
+        )
+        expect(renderedOrder()).toEqual(expectedOrder)
+    })
+})

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -210,11 +210,12 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
         columns: baseColumns,
     })
 
-    /** Sorting. */
+    /** Sorting. `useURLForSorting` gates both writing and reading the URL — when off, a stale
+     * `order` param must not resurrect a sort the consumer isn't controlling. */
     const currentSorting =
         sorting ||
         internalSorting ||
-        (searchParams[currentSortingParam]
+        (useURLForSorting && searchParams[currentSortingParam]
             ? searchParams[currentSortingParam].startsWith('-')
                 ? {
                       columnKey: searchParams[currentSortingParam].substr(1),

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import timekeeper from 'timekeeper'
 
@@ -804,6 +805,26 @@ describe('funnelDataLogic', () => {
 
             const order = getBreakdownOrder(logic.values.flattenedBreakdowns)
             expect(order).toEqual(expectedOrder)
+        })
+
+        it('setBreakdownSorting updates the query without clobbering compareFilter or the URL', async () => {
+            const query: FunnelsQuery = {
+                kind: NodeKind.FunnelsQuery,
+                series: [],
+                funnelsFilter: { funnelVizType: FunnelVizType.Steps },
+                compareFilter: { compare: true },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.updateQuerySource(query)
+                logic.actions.setBreakdownSorting('-total_conversion')
+            }).toFinishAllListeners()
+
+            expect(logic.values.querySource).toMatchObject({
+                funnelsFilter: { funnelVizType: FunnelVizType.Steps, breakdownSorting: '-total_conversion' },
+                compareFilter: { compare: true },
+            })
+            expect(router.values.searchParams.order).toBeUndefined()
         })
 
         it('visibleStepsWithConversionMetrics matches flattenedBreakdowns order', async () => {

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -1,5 +1,4 @@
-import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import { router } from 'kea-router'
+import { MakeLogicType, actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
 import { DataColorTheme, DataColorToken } from 'lib/colors'
 import { BIN_COUNT_AUTO } from 'lib/constants'
@@ -208,7 +207,6 @@ export interface funnelDataLogicValues {
         | WebStatsTableQuery
         | null // insightVizDataLogic
     vizSeries: (AnyEntityNode<AnyDataWarehouseNode> | GroupNode<DataWarehouseNode>)[] | null | undefined // insightVizDataLogic
-    searchParams: Record<string, any> // router
     advancedOptionsUsedCount: number
     aggregationTargetLabel: Noun
     breakdownSorting: string | undefined
@@ -289,15 +287,6 @@ export interface funnelDataLogicActions {
     updateQuerySource: (querySource: QuerySourceUpdate) => {
         querySource: QuerySourceUpdate
     } // insightVizDataLogic
-    push: (
-        url: string,
-        searchInput?: string | Record<string, any>,
-        hashInput?: string | Record<string, any>
-    ) => {
-        hashInput: string | Record<string, any>
-        searchInput: string | Record<string, any>
-        url: string
-    } // router
     commitConversionWindow: () => {
         value: true
     }
@@ -538,16 +527,12 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
             ['aggregationLabel'],
             featureFlagLogic,
             ['featureFlags'],
-            router,
-            ['searchParams'],
         ],
         actions: [
             insightVizDataLogic(props),
             ['updateInsightFilter', 'updateQuerySource'],
             insightDataLogic(props),
             ['cancelChanges'],
-            router,
-            ['push'],
         ],
     })),
 
@@ -1401,18 +1386,11 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
             }
         },
         setBreakdownSorting: ({ breakdownSorting }) => {
-            actions.updateInsightFilter({ breakdownSorting })
+            // updateInsightFilter debounces 300ms, too slow for the table's controlled sort indicator
+            const update: Partial<FunnelsQuery> = {
+                funnelsFilter: { ...values.funnelsFilter, breakdownSorting },
+            }
+            actions.updateQuerySource(update)
         },
     })),
-
-    afterMount(({ actions, values }) => {
-        // Sync URL with saved sorting on mount
-        if (values.breakdownSorting && !values.searchParams.order) {
-            actions.push(
-                window.location.pathname,
-                { ...values.searchParams, order: values.breakdownSorting },
-                window.location.hash
-            )
-        }
-    }),
 ])

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -7,7 +7,7 @@ import { LemonColorButton, LemonTag } from '@posthog/lemon-ui'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { LemonRow } from 'lib/lemon-ui/LemonRow'
-import { LemonTable, LemonTableColumn, LemonTableColumnGroup } from 'lib/lemon-ui/LemonTable'
+import { LemonTable, LemonTableColumn, LemonTableColumnGroup, Sorting } from 'lib/lemon-ui/LemonTable'
 import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { humanFriendlyDuration } from 'lib/utils/durations'
 import { humanFriendlyNumber, percentage } from 'lib/utils/numbers'
@@ -30,9 +30,8 @@ import { getActionFilterFromFunnelStep, getSignificanceFromBreakdownStep } from 
 export function FunnelStepsTable(): JSX.Element | null {
     const { insightProps, insightLoading, editingDisabledReason } = useValues(insightLogic)
     const { breakdownFilter } = useValues(insightVizDataLogic(insightProps))
-    const { steps, flattenedBreakdowns, hiddenLegendBreakdowns, getFunnelsColor, isStepOptional } = useValues(
-        funnelDataLogic(insightProps)
-    )
+    const { steps, flattenedBreakdowns, hiddenLegendBreakdowns, getFunnelsColor, isStepOptional, breakdownSorting } =
+        useValues(funnelDataLogic(insightProps))
     const { setHiddenLegendBreakdowns, toggleLegendBreakdownVisibility, setBreakdownSorting } = useActions(
         funnelDataLogic(insightProps)
     )
@@ -59,6 +58,15 @@ export function FunnelStepsTable(): JSX.Element | null {
     Likely this can be done in a better way once experiments are re-written to use their own
     queries. */
     const showCustomizationIcon = !insightProps.cachedInsight?.disable_baseline
+
+    // Sorting is controlled by the query's `funnelsFilter.breakdownSorting`, so it survives
+    // saving/reloading and never touches the URL (a router push here would make the insight
+    // scene reload the saved insight, discarding unsaved changes like the compare filter).
+    const sorting: Sorting | null = breakdownSorting
+        ? breakdownSorting.startsWith('-')
+            ? { columnKey: breakdownSorting.slice(1), order: -1 }
+            : { columnKey: breakdownSorting, order: 1 }
+        : null
 
     const columnsGrouped = [
         {
@@ -403,7 +411,8 @@ export function FunnelStepsTable(): JSX.Element | null {
             rowStatus={(record) => (record.significant ? 'highlighted' : null)}
             rowRibbonColor={getFunnelsColor}
             firstColumnSticky
-            useURLForSorting
+            sorting={sorting}
+            useURLForSorting={false}
             onSort={(newSorting) => {
                 if (!newSorting) {
                     setBreakdownSorting(undefined)


### PR DESCRIPTION
## Problem

In a funnel insight with a breakdown and "compare to previous period" enabled, clicking a sort header in the detailed results table dropped the comparison. Sorting first and then enabling compare worked, so the two settings could only coexist in one order.

## Changes

Root cause: the table's `useURLForSorting` did a `router.push` of `?order=` on every sort click (plus a `funnelDataLogic` `afterMount` push on mount). A PUSH navigation makes `insightSceneLogic` re-process the scene and reload the saved insight, wiping unsaved query edits like `compareFilter`. The sort itself survived only because its own update is debounced 300ms and landed after the wipe. Same bug class as the existing `event-correlation_page` special case in `insightSceneLogic`, and the trends `InsightsTable` already avoids URL sorting in edit mode.

- `FunnelStepsTable` no longer touches the URL and takes a controlled `sorting` prop derived from `funnelsFilter.breakdownSorting`, which is already the persisted source of truth. This also restores the sort indicator when opening a saved insight with sorting.
- `funnelDataLogic` drops the `afterMount` URL sync, and `setBreakdownSorting` updates the query source directly instead of via the 300ms-debounced `updateInsightFilter` so the controlled indicator responds instantly.
- `LemonTable` (from review): `useURLForSorting` now gates the URL *read* too, not just the write. It previously read `searchParams['order']` unconditionally, so any table opting out of URL sorting could still resurrect a sort from a stale `order` param on fresh mount. This closes the read/write asymmetry for every opt-out caller.

Sorted descending by total conversion with compare intact after the fix:

![funnel-4-fixed-after-sort-desc](https://raw.githubusercontent.com/PostHog/pr-assets/b29c6e08d95b5f27661d0500194d674cf7e7b0b8/2026/07/c21a5ebe-885a-447c-b01a-8d88f108c6f6.png)

## How did you test this code?

Two logic/component tests, each catching a regression no existing test covered. `funnelDataLogic`: `setBreakdownSorting` sets `funnelsFilter.breakdownSorting` without clobbering `compareFilter` and without writing to the URL. `LemonTable`: a stale `order` search param does not sort a table with `useURLForSorting={false}` (and still does when the flag is on). All `funnelDataLogic` (75) and `LemonTable` (58) tests pass. I (Claude) also verified end to end in a local dev stack with Playwright against seeded funnel data: enable compare, sort asc/desc/cancel, previous-period rows and the compare selection survive every transition; a saved insight with sorting plus compare reloads with both applied; and an unsorted insight opened with a stale `?order=` param sorted pre-fix but not after.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected, UI behavior fix only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`, `/run-posthog`. Considered mirroring `InsightsTable`'s `useURLForSorting={!editMode}` but rejected it: funnel sort state already persists in the query and the compare control is permission-gated rather than mode-gated, so URL sorting was disabled entirely and the removed `afterMount` URL push was replaced by a controlled `sorting` prop. Review then surfaced that `useURLForSorting={false}` only stopped URL writes, not reads, so the fix was extended into `LemonTable` itself. I left the related `sorting || internalSorting` precedence alone: `DataTable` and other hybrid callers pass `sorting={null}` and rely on `internalSorting` for click sorting, so forcing a cleared `sorting` prop to be authoritative would break them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
