### PR TITLE
fix(inbox): left-align search, right-align filters, drop filter banner

### DIFF
--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -1,8 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { ComponentType, JSX, useEffect, useRef } from 'react'
 
-import { LemonBanner } from '@posthog/lemon-ui'
-
 import { captureInboxReportsImpressed, captureInboxViewed } from '../inboxAnalytics'
 import { inboxSceneLogic } from '../inboxSceneLogic'
 import { inboxFiltersLogic } from '../logics/inboxFiltersLogic'
@@ -40,22 +38,6 @@ export function InboxReportList(props: InboxReportListProps): JSX.Element {
         <BindLogic logic={reportListLogic} props={{ tabKey: props.tabKey, listParams: props.listParams }}>
             <InboxReportListInner {...props} />
         </BindLogic>
-    )
-}
-
-/** Sleek reminder that the list is filtered, with a one-click reset. Renders nothing when no filter is active. */
-function ActiveFiltersBanner(): JSX.Element | null {
-    const { hasActiveFilters } = useValues(inboxFiltersLogic)
-    const { clearFilters } = useActions(inboxFiltersLogic)
-
-    if (!hasActiveFilters) {
-        return null
-    }
-
-    return (
-        <LemonBanner type="info" action={{ children: 'Clear', onClick: () => clearFilters() }}>
-            Filters are applied – some reports may be hidden.
-        </LemonBanner>
     )
 }
 
@@ -162,7 +144,6 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     return (
         <div className="@container mx-auto max-w-4xl flex flex-col gap-4 px-6 py-4">
             <InboxSearchFilterBar onRefresh={() => refresh()} refreshing={reportsResponseLoading} />
-            <ActiveFiltersBanner />
             <InboxBulkSelectionBar />
 
             {showSkeleton ? (

--- a/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
@@ -125,7 +125,10 @@ export function InboxSearchFilterBar({
                 size="small"
             />
 
-            <div className="flex items-center gap-2 ml-auto">
+            {/* ml-auto right-aligns the cluster; flex-wrap + max-w-full keep the controls from
+                overflowing on narrow viewports — each can wrap within the group rather than the
+                whole row clipping, the behavior the flat (ungrouped) layout had before. */}
+            <div className="flex flex-wrap items-center justify-end gap-2 ml-auto max-w-full">
                 <FilterPopover
                     label="Sort"
                     value={activeSort?.label ?? 'Priority first'}

--- a/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
@@ -116,7 +116,7 @@ export function InboxSearchFilterBar({
     return (
         <div className="flex items-center gap-2 flex-wrap w-full">
             <LemonInput
-                className="flex-1 min-w-[220px]"
+                className="min-w-[220px] max-w-[420px]"
                 type="search"
                 value={searchQuery}
                 onChange={setSearchQuery}
@@ -125,80 +125,82 @@ export function InboxSearchFilterBar({
                 size="small"
             />
 
-            <FilterPopover
-                label="Sort"
-                value={activeSort?.label ?? 'Priority first'}
-                icon={<IconSort />}
-                active={activeSortKey !== 'priority:asc'}
-            >
-                {INBOX_SORT_OPTIONS.map((option) => (
-                    <FilterItem
-                        key={inboxSortOptionKey(option.field, option.direction)}
-                        icon={option.icon}
-                        label={option.label}
-                        active={sortField === option.field && sortDirection === option.direction}
-                        onClick={() => setSort(option.field, option.direction)}
-                    />
-                ))}
-            </FilterPopover>
+            <div className="flex items-center gap-2 ml-auto">
+                <FilterPopover
+                    label="Sort"
+                    value={activeSort?.label ?? 'Priority first'}
+                    icon={<IconSort />}
+                    active={activeSortKey !== 'priority:asc'}
+                >
+                    {INBOX_SORT_OPTIONS.map((option) => (
+                        <FilterItem
+                            key={inboxSortOptionKey(option.field, option.direction)}
+                            icon={option.icon}
+                            label={option.label}
+                            active={sortField === option.field && sortDirection === option.direction}
+                            onClick={() => setSort(option.field, option.direction)}
+                        />
+                    ))}
+                </FilterPopover>
 
-            <FilterPopover
-                label="Source"
-                value={inboxSourceFilterLabel(sourceProductFilter)}
-                icon={<IconTarget />}
-                active={sourceProductFilter.length > 0}
-            >
-                {INBOX_SOURCE_OPTIONS.map((option) => (
-                    <FilterItem
-                        key={option.value}
-                        icon={option.icon}
-                        label={option.label}
-                        active={sourceProductFilter.includes(option.value)}
-                        onClick={() => toggleSourceProduct(option.value)}
-                    />
-                ))}
-            </FilterPopover>
+                <FilterPopover
+                    label="Source"
+                    value={inboxSourceFilterLabel(sourceProductFilter)}
+                    icon={<IconTarget />}
+                    active={sourceProductFilter.length > 0}
+                >
+                    {INBOX_SOURCE_OPTIONS.map((option) => (
+                        <FilterItem
+                            key={option.value}
+                            icon={option.icon}
+                            label={option.label}
+                            active={sourceProductFilter.includes(option.value)}
+                            onClick={() => toggleSourceProduct(option.value)}
+                        />
+                    ))}
+                </FilterPopover>
 
-            <FilterPopover
-                label="Priority"
-                value={inboxPriorityFilterLabel(priorityFilter)}
-                icon={<IconFlag />}
-                active={priorityFilter.length > 0}
-            >
-                {INBOX_PRIORITY_OPTIONS.map((priority) => (
-                    <FilterItem
-                        key={priority}
-                        icon={
-                            <span
-                                className="size-2 rounded-full"
-                                // eslint-disable-next-line react/forbid-dom-props
-                                style={{ backgroundColor: PRIORITY_ACCENT[priority] }}
-                            />
-                        }
-                        label={
-                            <span>
-                                {priority}
-                                <span className="text-muted"> · {PRIORITY_MEANING[priority].label}</span>
-                            </span>
-                        }
-                        active={priorityFilter.includes(priority)}
-                        onClick={() => togglePriority(priority)}
-                    />
-                ))}
-            </FilterPopover>
+                <FilterPopover
+                    label="Priority"
+                    value={inboxPriorityFilterLabel(priorityFilter)}
+                    icon={<IconFlag />}
+                    active={priorityFilter.length > 0}
+                >
+                    {INBOX_PRIORITY_OPTIONS.map((priority) => (
+                        <FilterItem
+                            key={priority}
+                            icon={
+                                <span
+                                    className="size-2 rounded-full"
+                                    // eslint-disable-next-line react/forbid-dom-props
+                                    style={{ backgroundColor: PRIORITY_ACCENT[priority] }}
+                                />
+                            }
+                            label={
+                                <span>
+                                    {priority}
+                                    <span className="text-muted"> · {PRIORITY_MEANING[priority].label}</span>
+                                </span>
+                            }
+                            active={priorityFilter.includes(priority)}
+                            onClick={() => togglePriority(priority)}
+                        />
+                    ))}
+                </FilterPopover>
 
-            {onRefresh && (
-                <LemonButton
-                    type="secondary"
-                    size="xsmall"
-                    icon={<IconRefresh />}
-                    loading={refreshing}
-                    tooltip="Refresh"
-                    aria-label="Refresh"
-                    onClick={onRefresh}
-                    className="bg-surface-primary ml-auto"
-                />
-            )}
+                {onRefresh && (
+                    <LemonButton
+                        type="secondary"
+                        size="xsmall"
+                        icon={<IconRefresh />}
+                        loading={refreshing}
+                        tooltip="Refresh"
+                        aria-label="Refresh"
+                        onClick={onRefresh}
+                        className="bg-surface-primary"
+                    />
+                )}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
HUMAN

noticed this in a thread

<img width="1942" height="432" alt="CleanShot 2026-07-21 at 11 50 38@2x" src="https://github.com/user-attachments/assets/c10be13b-357e-479e-adf8-bd2cf72e51bf" />

1. when showing a list of things we put the search on the left and the actions on the right

2. telling me that filters might filter felt patronising :)

-----

ROBOT 

## Problem

On the inbox report-list tabs (pull requests / reports / not actionable / archived), the filter bar's search input used `flex-1`, so it stretched to fill available width and the Sort/Source/Priority filter popovers trailed it instead of sitting right-aligned. A separate banner ("Filters are applied – some reports may be hidden.") showed under the bar whenever any filter was active, restating what users already understand filtering does.

## Changes

- **Search/filter alignment** (`InboxSearchFilterBar.tsx`): the search input now anchors left at a natural width (`min-w-[220px] max-w-[420px]`), and the Sort / Source / Priority popovers plus Refresh are grouped in a right-aligned container (`ml-auto`). The row still wraps gracefully on narrow widths.
- **Removed the active-filters banner** (`InboxReportList.tsx`): deleted the `ActiveFiltersBanner` component and the now-unused `LemonBanner` import. The "Clear" affordance is gone; each filter chip still shows its active value inline and can be toggled off directly.

## How did you test this code?

Visual layout change only; no logic, props, or state changed. I could not run `pnpm --filter=@posthog/frontend fix` or `typescript:check` in this environment (no `node_modules`, no `flox`), so the frontend lint/typecheck gates are unverified locally. The edits are self-contained (no new imports, no signature changes), so there's nothing type-risky. No tests or stories referenced the removed banner, so nothing broke.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference the inbox filter bar layout or the removed banner.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Work was directed from a screenshot of the inbox list view showing the search and filter controls, with two requests: left-align the search / right-align the filters, and drop the filter-hides-information banner entirely.
- No skills were invoked; this is a small presentational change to two files under `frontend/src/scenes/inbox/`.
- Chose to group the filter popovers + refresh into one right-aligned container rather than giving each its own `ml-auto` (only the first margin-auto takes effect), so the whole control cluster anchors to the right edge as a unit.
- Kept the search at a capped `max-w-[420px]` rather than `flex-1` so it doesn't push the filters back toward the middle on wide viewports.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*