### PR TITLE
feat(dashboards): async-refresh stale dashboard tiles instead of blocking

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -271,6 +271,7 @@ export const FEATURE_FLAGS = {
     CUSTOMER_ANALYTICS_CSP: 'customer-analytics-csp', // owner: @arthurdedeus #team-customer-analytics, gates the Customer analytics > Accounts settings tab (account_group_type_index dropdown)
     CUSTOMER_ANALYTICS_JOURNEYS: 'customer-analytics-journeys', // owner: @arthurdedeus #team-customer-analytics
     CUSTOMER_PROFILE_CONFIG_BUTTON: 'customer-profile-config-button', // owner: @arthurdedeus #team-customer-analytics
+    DASHBOARD_ASYNC_TILE_REFRESH: 'dashboard-async-tile-refresh', // owner: @pauldambra #team-product-analytics — serve recent cache + async-refresh stale dashboard tiles instead of a per-tile blocking recompute on load
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_INLINE_TILE_INSERTION: 'dashboard-inline-tile-insertion', // owner: @MattPua #team-analytics-platform
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -3446,6 +3446,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     dashboard,
                     lastDashboardRefresh,
                 } = values
+                // Stale tiles refresh in the background (served from recent cache immediately)
+                // rather than blocking on a recompute per tile; a true cache miss still blocks so
+                // cold tiles aren't shown empty. Flag-gated for staged rollout + cost measurement.
+                const tileRefreshMode: 'blocking' | 'async_except_on_cache_miss' = values.featureFlags[
+                    FEATURE_FLAGS.DASHBOARD_ASYNC_TILE_REFRESH
+                ]
+                    ? 'async_except_on_cache_miss'
+                    : 'blocking'
 
                 const fetchSyncInsightFunctions = sortedTilesToRefresh.map((tile) => async () => {
                     const insight = tile.insight
@@ -3463,7 +3471,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             insight,
                             dashboardId,
                             queryId,
-                            forceRefresh ? 'force_blocking' : 'blocking', // 'blocking' returns cached data if available, when manual refresh is triggered we want fresh results
+                            forceRefresh ? 'force_blocking' : tileRefreshMode,
                             methodOptions,
                             effectiveRefreshFilters,
                             urlVariables,

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -249,7 +249,7 @@ export async function getInsightWithRetry(
     insight: QueryBasedInsightModel,
     dashboardId: number,
     queryId: string,
-    refresh: 'force_blocking' | 'blocking',
+    refresh: 'force_blocking' | 'blocking' | 'async_except_on_cache_miss',
     methodOptions?: ApiMethodOptions,
     filtersOverride?: DashboardFilter,
     variablesOverride?: Record<string, HogQLVariable>,

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1721,6 +1721,7 @@ def refresh_requested_by_client(request: Request) -> bool | str:
         request,
         allowed_values=[
             "async",
+            "async_except_on_cache_miss",
             "blocking",
             "force_async",
             "force_blocking",


### PR DESCRIPTION
## Problem

When a dashboard loads, the frontend refreshes each stale tile with `refresh=blocking` (`getInsightWithRetry` in `dashboardLogic`), recomputing stale tiles synchronously, per tile, on every open. Route-level cost attribution shows this per-tile refresh (the `insights/{pk}` + `from_dashboard` path) is the single largest slice of dashboard insight recompute cost — and it multiplies across concurrent viewers of the same dashboard, which is how a handful of always-open dashboards dominate the bill.

## Changes

- Behind a new `DASHBOARD_ASYNC_TILE_REFRESH` flag, the per-tile dashboard-load refresh becomes `async_except_on_cache_miss`: serve the recent cached result immediately, refresh a stale tile in the background, and still **block on a true cache miss** so a cold tile renders data instead of an empty state. The manual single-insight refresh keeps `force_blocking` (a person asking for fresh data still gets it).
- Add `async_except_on_cache_miss` to the refresh values `refresh_requested_by_client` accepts. It was already an `ExecutionMode` value but wasn't requestable over the wire, so the frontend couldn't ask for it.

Flag is off by default. When on, stale tiles serve instantly and their background refresh lands on the next auto-refresh cycle; concurrent opens of the same stale tile collapse to one server-side async recompute instead of N blocking ones. The recent-cache staleness window is unchanged, so this removes redundant blocking recomputes and their latency rather than changing how often a tile is considered stale.

Pairs with #72536 (backend refresh-policy refactor), which makes this the declarable default for the dashboard surface later; this PR delivers the behavior now, gated and measurable.

## How did you test this code?

- Backend: `ruff check` / `ruff format` clean and `python -m py_compile` passes on `posthog/utils.py`.
- Agent-authored: the frontend toolchain (oxlint / oxfmt / `tsgo` typecheck) isn't installed in this task environment, so I could not run it here — please let CI run frontend lint + typecheck. The change is a flag-gated string-mode swap plus a one-value type widening on `getInsightWithRetry`; no API types or components were hand-written.
- Existing `dashboardLogic` refresh tests (`frontend/src/scenes/dashboard/dashboardLogic.test.ts`) exercise `getInsightWithRetry`; with the flag off, behavior is unchanged. Recommend a test with the flag on asserting the tiles request `async_except_on_cache_miss`.

## Rollout / measurement

Enable the flag for a small set of teams, watch `recompute_per_open` on the dashboard cost-per-open sentinel, then widen. Roll back by disabling the flag (no deploy).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal refresh behavior, flag-gated, no API-schema change (the new `refresh` value is additive).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — requested by @pauldambra. This is the behavior-changing half of a two-PR pair (with #72536); route-cost analysis identified the per-tile blocking refresh on dashboard load as where the recompute cost concentrates.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*