### PR TITLE
fix(experiments): hide AI analysis tab for drafts and metric-less experiments

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5565,7 +5565,7 @@ snapshots:
     scenes-app-dashboards--show-without-post-hog-ai-button-label--narrow--dark:
         hash: v1.k794b7964.88687d2cc1bbd12296214f07d5f6bb2548705ae3baae37985858225116896a10.YogXGZXR1uFB4qD8nOjCfWyWL--g1SLKNxz0gZvEoWw
     scenes-app-dashboards--show-without-post-hog-ai-button-label--narrow--light:
-        hash: v1.k794b7964.2035f84708f35d51de9ca7ce036c497c17d8a812e4a64c682d76caa066cb0954._S1SJobvQ3RqTPgANTGgE3vUYRijIBEFRYinuHFsQIA
+        hash: v1.k794b7964.e73cea1e916b6bc329aea490ca111439f3bebfa3dbae2d54ad54e5a174651057.7cswn9IwKIF60hyao0mI2skKmlWjur4GWI1cCisomlE
     scenes-app-dashboards--show-without-post-hog-ai-button-label--superwide--dark:
         hash: v1.k794b7964.cad32a04659183c6bfecbc34e5ae23c08c095f70df65ef0ee7d863d2103a124d.2bYQoklhY3opedkpy5pUC52pEvCwdnEfKowjCBPaDb8
     scenes-app-dashboards--show-without-post-hog-ai-button-label--superwide--light:

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconSparkles } from '@posthog/icons'
-import { LemonTabs } from '@posthog/lemon-ui'
+import { LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -162,6 +162,71 @@ export function ExperimentView(): JSX.Element {
         return <LegacyExperimentView />
     }
 
+    const tabs: LemonTab<string>[] = [
+        {
+            key: 'settings',
+            label: 'Settings',
+            content: <SettingsTab />,
+        },
+        {
+            key: 'metrics',
+            label: 'Metrics',
+            content: <MetricsTab />,
+        },
+        // Both AI analysis actions require a launched experiment with primary metrics
+        ...(isExperimentLaunched && orderedPrimaryMetricsWithResults.length > 0
+            ? [
+                  {
+                      key: 'ai_analysis',
+                      label: (
+                          <div className="flex items-center gap-1">
+                              <IconSparkles />
+                              <span>AI analysis</span>
+                          </div>
+                      ),
+                      content: <AiAnalysisTab />,
+                  },
+              ]
+            : []),
+        ...(featureFlags[FEATURE_FLAGS.EXPERIMENT_RECORDINGS_TAB]
+            ? [
+                  {
+                      key: 'recordings',
+                      label: 'Recordings',
+                      content: <ExperimentReplayTab experiment={experiment} />,
+                  },
+              ]
+            : []),
+        ...(!isExperimentDraft
+            ? [
+                  {
+                      key: 'code',
+                      label: 'Code',
+                      content: <CodeTab />,
+                  },
+              ]
+            : []),
+        {
+            key: 'variants',
+            label: 'Variants',
+            content: <VariantsTab />,
+        },
+        {
+            key: 'history',
+            label: 'History',
+            content: <ActivityLog scope={ActivityScope.EXPERIMENT} id={experimentId} />,
+        },
+        ...(experiment.feature_flag
+            ? [
+                  {
+                      key: 'feedback',
+                      label: 'User feedback',
+                      content: <ExperimentFeedbackTab experiment={experiment} />,
+                  },
+              ]
+            : []),
+    ]
+
     return (
         <SceneContent>
             <PageHeaderCustom />
@@ -187,73 +252,11 @@ export function ExperimentView(): JSX.Element {
                     <Info />
                     <ExperimentHeader />
                     <LemonTabs
-                        activeKey={activeTabKey}
+                        // Fall back to the default tab if the active one is conditionally hidden
+                        activeKey={tabs.some((tab) => tab.key === activeTabKey) ? activeTabKey : 'metrics'}
                         onChange={(key) => setActiveTabKey(key)}
                         sceneInset
-                        tabs={[
-                            {
-                                key: 'settings',
-                                label: 'Settings',
-                                content: <SettingsTab />,
-                            },
-                            {
-                                key: 'metrics',
-                                label: 'Metrics',
-                                content: <MetricsTab />,
-                            },
-                            // Both AI analysis actions require a launched experiment with primary metrics
-                            ...(isExperimentLaunched && orderedPrimaryMetricsWithResults.length > 0
-                                ? [
-                                      {
-                                          key: 'ai_analysis',
-                                          label: (
-                                              <div className="flex items-center gap-1">
-                                                  <IconSparkles />
-                                                  <span>AI analysis</span>
-                                              </div>
-                                          ),
-                                          content: <AiAnalysisTab />,
-                                      },
-                                  ]
-                                : []),
-                            ...(featureFlags[FEATURE_FLAGS.EXPERIMENT_RECORDINGS_TAB]
-                                ? [
-                                      {
-                                          key: 'recordings',
-                                          label: 'Recordings',
-                                          content: <ExperimentReplayTab experiment={experiment} />,
-                                      },
-                                  ]
-                                : []),
-                            ...(!isExperimentDraft
-                                ? [
-                                      {
-                                          key: 'code',
-                                          label: 'Code',
-                                          content: <CodeTab />,
-                                      },
-                                  ]
-                                : []),
-                            {
-                                key: 'variants',
-                                label: 'Variants',
-                                content: <VariantsTab />,
-                            },
-                            {
-                                key: 'history',
-                                label: 'History',
-                                content: <ActivityLog scope={ActivityScope.EXPERIMENT} id={experimentId} />,
-                            },
-                            ...(experiment.feature_flag
-                                ? [
-                                      {
-                                          key: 'feedback',
-                                          label: 'User feedback',
-                                          content: <ExperimentFeedbackTab experiment={experiment} />,
-                                      },
-                                  ]
-                                : []),
-                        ]}
+                        tabs={tabs}
                     />
 
                     {/* Modern experiment modals */}

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -130,8 +130,16 @@ const VariantsTab = (): JSX.Element => {
 }
 
 export function ExperimentView(): JSX.Element {
-    const { experimentLoading, experimentId, experiment, isExperimentDraft, exposureCriteria, showDebugPanel } =
-        useValues(experimentLogic)
+    const {
+        experimentLoading,
+        experimentId,
+        experiment,
+        isExperimentDraft,
+        isExperimentLaunched,
+        orderedPrimaryMetricsWithResults,
+        exposureCriteria,
+        showDebugPanel,
+    } = useValues(experimentLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const {
         setExperiment,
@@ -193,16 +201,21 @@ export function ExperimentView(): JSX.Element {
                                 label: 'Metrics',
                                 content: <MetricsTab />,
                             },
-                            {
-                                key: 'ai_analysis',
-                                label: (
-                                    <div className="flex items-center gap-1">
-                                        <IconSparkles />
-                                        <span>AI analysis</span>
-                                    </div>
-                                ),
-                                content: <AiAnalysisTab />,
-                            },
+                            // Both AI analysis actions require a launched experiment with primary metrics
+                            ...(isExperimentLaunched && orderedPrimaryMetricsWithResults.length > 0
+                                ? [
+                                      {
+                                          key: 'ai_analysis',
+                                          label: (
+                                              <div className="flex items-center gap-1">
+                                                  <IconSparkles />
+                                                  <span>AI analysis</span>
+                                              </div>
+                                          ),
+                                          content: <AiAnalysisTab />,
+                                      },
+                                  ]
+                                : []),
                             ...(featureFlags[FEATURE_FLAGS.EXPERIMENT_RECORDINGS_TAB]
                                 ? [
                                       {


### PR DESCRIPTION
## Problem

The AI analysis tab renders two AI action buttons that both hide themselves unless the experiment is launched and has primary metrics. In that state the tab shows only the buttons' caption paragraphs with nothing to click.

## Changes

Include the `ai_analysis` tab only when the experiment is launched and has primary metrics, matching the condition the buttons themselves use. Same conditional-tab pattern as the code, recordings, and feedback tabs. This also hides the tab for drafts on the `experiment-session-replays-skill` flag path, where the recordings button previously rendered unconditionally.

## How did you test this code?

Ran oxlint on the changed file and the full frontend `typescript:check` (only pre-existing unrelated failures). No new test: the gate is a conjunction of two existing selectors, and a render test would only re-assert kea wiring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code traced the empty state to `useMaxTool` returning a null `openMax` when inactive, with both button hooks computing active as launched && has primary metrics. Considered gating only on "has metrics" per the original report, but matched the buttons' full condition so the tab never renders button-less.
