### PR TITLE
feat(surveys): add move question to top action

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -8,6 +8,7 @@ import { Group } from 'kea-forms'
 import { IconPlusSmall, IconTrash, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
+import { IconArrowUp } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { QuestionBranchingInput } from 'scenes/surveys/components/question-branching/QuestionBranchingInput'
 
@@ -57,7 +58,7 @@ export function SurveyEditQuestionHeader({
     translationErrorsByQuestion,
 }: SurveyQuestionHeaderProps): JSX.Element {
     const { editingLanguage } = useValues(surveyLogic)
-    const { removeQuestion } = useActions(surveyLogic)
+    const { moveQuestionToTop, removeQuestion } = useActions(surveyLogic)
     const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
         id: index.toString(),
     })
@@ -95,6 +96,19 @@ export function SurveyEditQuestionHeader({
                     >
                         <IconWarning className="text-warning" />
                     </Tooltip>
+                )}
+                {survey.questions.length > 1 && (
+                    <LemonButton
+                        icon={<IconArrowUp />}
+                        size="xsmall"
+                        data-attr={`move-survey-question-top-${index}`}
+                        tooltip="Move question to top"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            moveQuestionToTop(index)
+                        }}
+                        tooltipPlacement="top-end"
+                    />
                 )}
                 {survey.questions.length > 1 && (
                     <LemonButton

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1544,6 +1544,7 @@ export const surveyLogic = kea<surveyLogicType>([
         archiveSurvey: true,
         setWritingHTMLDescription: (writingHTML: boolean) => ({ writingHTML }),
         setSelectedPageIndex: (idx: number | null) => ({ idx }),
+        moveQuestionToTop: (index: number) => ({ index }),
         setSelectedSection: (section: SurveyEditSection | null) => ({ section }),
         resetTargeting: true,
         resetSurveyAdaptiveSampling: true,
@@ -2234,6 +2235,16 @@ export const surveyLogic = kea<surveyLogicType>([
                 } finally {
                     actions.setGeneratingTranslationDrafts(false)
                 }
+            },
+            moveQuestionToTop: ({ index }) => {
+                const questions = [...values.survey.questions]
+                const [moved] = questions.splice(index, 1)
+                if (!moved) {
+                    return
+                }
+                questions.push(moved)
+                actions.setSurveyValue('questions', questions)
+                actions.setSelectedPageIndex(0)
             },
             resetTargeting: () => {
                 actions.setSurveyValue('linked_flag_id', NEW_SURVEY.linked_flag_id)


### PR DESCRIPTION
> Test-only draft PR for validating internal review tooling. Not intended for merge.

## Problem

In longer surveys, the question you want first is often added last. Reordering by drag can be fiddly, especially with many questions.

## Changes

Adds a "Move question to top" action to each survey question row in the editor.

Expected behavior:

- Clicking the action on Question N moves that question to the top of the list (position 1).
- All other questions keep their relative order.
- The moved question stays selected so the editor keeps showing it.

## How did you test this code?

Not manually tested; this PR is intended as the target for runtime QA.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs
