### PR TITLE
feat(insights): prototype visual insight type picker for new button

### DIFF
--- a/frontend/bin/check-toolbar-graph.mjs
+++ b/frontend/bin/check-toolbar-graph.mjs
@@ -41,7 +41,7 @@ const FORBIDDEN_PACKAGES = [
 // Ratchet policy: when an edge is cut, lower the budget to lock it in; raise it only as a
 // conscious, reviewed decision in the PR that needs it. There is headroom for churn, but any
 // reintroduced leak jumps the graph back toward ~100 MiB and fails loudly.
-const TOTAL_INPUT_BYTES_BUDGET = 14_436_000
+const TOTAL_INPUT_BYTES_BUDGET = 14_470_000
 
 function fail(message) {
     console.error(`\n❌ ${message}`)

--- a/frontend/src/scenes/saved-insights/InsightTypeSketch.tsx
+++ b/frontend/src/scenes/saved-insights/InsightTypeSketch.tsx
@@ -231,6 +231,114 @@ export function AiSketch(): JSX.Element {
     )
 }
 
+export function WorldMapSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            <path
+                d="M22 22 C 30 14, 44 16, 48 24 C 52 32, 44 36, 46 44 C 48 52, 38 60, 32 54 C 26 48, 28 44, 24 38 C 20 32, 16 28, 22 22 Z"
+                fill={INK}
+                opacity="0.15"
+            />
+            <path
+                d="M66 18 C 76 12, 92 14, 96 22 C 100 30, 92 34, 94 42 C 96 52, 84 58, 78 50 C 72 44, 74 38, 68 32 C 62 26, 60 22, 66 18 Z"
+                fill={INK}
+                opacity="0.15"
+            />
+            <path
+                d="M104 26 C 116 18, 136 22, 140 32 C 144 42, 132 46, 130 54 C 128 62, 116 64, 112 56 C 108 48, 112 40, 104 26 Z"
+                fill={INK}
+                opacity="0.15"
+            />
+            <path
+                d="M116 62 C 122 58, 132 60, 132 66 C 132 72, 124 74, 120 70 C 116 66, 112 66, 116 62 Z"
+                fill={INK}
+                opacity="0.15"
+            />
+            <circle cx="36" cy="34" r="9" fill={INK} opacity="0.8" />
+            <circle cx="82" cy="32" r="6" fill={INK} opacity="0.65" />
+            <circle cx="124" cy="40" r="12" fill={INK} opacity="0.9" />
+            <circle cx="123" cy="67" r="4" fill={INK} opacity="0.5" />
+        </SketchSvg>
+    )
+}
+
+export function TableSketch(): JSX.Element {
+    const values = [64, 44, 30, 18]
+    return (
+        <SketchSvg>
+            <rect x="14" y="12" width="132" height="64" rx="3" stroke={AXIS} strokeWidth="1.5" />
+            <path d="M14 26 H146 M14 40 H146 M14 54 H146 M14 68 H146" stroke={AXIS} strokeWidth="1" opacity="0.6" />
+            <path d="M62 12 V76" stroke={AXIS} strokeWidth="1" opacity="0.6" />
+            <rect x="20" y="16" width="28" height="5" rx="2.5" fill={INK_ALT} />
+            <rect x="68" y="16" width="20" height="5" rx="2.5" fill={INK_ALT} />
+            {values.map((value, index) => (
+                <g key={index}>
+                    <rect x="20" y={30 + index * 14} width={34 - index * 5} height="5" rx="2.5" fill={AXIS} />
+                    <rect
+                        x="68"
+                        y={30 + index * 14}
+                        width={value}
+                        height="5"
+                        rx="2.5"
+                        fill={INK}
+                        opacity={1 - index * 0.18}
+                    />
+                </g>
+            ))}
+        </SketchSvg>
+    )
+}
+
+export function NumberSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            <rect x="26" y="14" width="44" height="6" rx="3" fill={AXIS} />
+            <text x="26" y="58" fill={INK} fontSize="34" fontWeight="700">
+                1,024
+            </text>
+            <path
+                d="M112 52 L119 42 L126 52"
+                stroke={INK_UP}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <rect x="26" y="66" width="24" height="5" rx="2.5" fill={INK_UP} opacity="0.8" />
+        </SketchSvg>
+    )
+}
+
+export function PieSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            <path d="M80 44 L80 16 A28 28 0 0 1 80 72 Z" fill={INK} opacity="0.9" />
+            <path d="M80 44 L80 72 A28 28 0 0 1 53.4 35.3 Z" fill={INK} opacity="0.5" />
+            <path d="M80 44 L53.4 35.3 A28 28 0 0 1 80 16 Z" fill={INK} opacity="0.25" />
+        </SketchSvg>
+    )
+}
+
+export function BarValueSketch(): JSX.Element {
+    const widths = [112, 84, 58, 36]
+    return (
+        <SketchSvg>
+            <path d="M14 10 V78" stroke={AXIS} strokeWidth="1.5" strokeDasharray="3 4" strokeLinecap="round" />
+            {widths.map((width, index) => (
+                <rect
+                    key={index}
+                    x="16"
+                    y={14 + index * 17}
+                    width={width}
+                    height="12"
+                    rx="2.5"
+                    fill={INK}
+                    opacity={1 - index * 0.2}
+                />
+            ))}
+        </SketchSvg>
+    )
+}
+
 /** Fallback for insight types without a dedicated sketch. */
 export function GenericInsightSketch(): JSX.Element {
     const heights = [22, 38, 30, 48, 40, 56]

--- a/frontend/src/scenes/saved-insights/InsightTypeSketch.tsx
+++ b/frontend/src/scenes/saved-insights/InsightTypeSketch.tsx
@@ -1,0 +1,264 @@
+import { InsightType } from '~/types'
+
+// Hand-drawn-style previews for the new insight picker. Colors come from theme
+// CSS variables so the sketches adapt to light/dark mode automatically.
+const AXIS = 'var(--color-border-primary)'
+const INK = 'var(--data-color-1)'
+const INK_ALT = 'var(--data-color-14)'
+const INK_UP = 'var(--data-color-7)'
+const INK_DOWN = 'var(--data-color-5)'
+const INK_AI = 'var(--color-ai)'
+
+function SketchSvg({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        <svg viewBox="0 0 160 88" className="w-full h-auto" fill="none" aria-hidden="true">
+            {children}
+        </svg>
+    )
+}
+
+function Star({ cx, cy, r, fill }: { cx: number; cy: number; r: number; fill: string }): JSX.Element {
+    const inner = r * 0.32
+    return (
+        <path
+            d={`M${cx} ${cy - r} L${cx + inner} ${cy - inner} L${cx + r} ${cy} L${cx + inner} ${cy + inner} L${cx} ${cy + r} L${cx - inner} ${cy + inner} L${cx - r} ${cy} L${cx - inner} ${cy - inner} Z`}
+            fill={fill}
+        />
+    )
+}
+
+export function TrendsSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            <path d="M12 10 V74 H148" stroke={AXIS} strokeWidth="1.5" strokeDasharray="3 4" strokeLinecap="round" />
+            <path
+                d="M14 68 C 30 66, 40 62, 54 61 C 68 60, 78 54, 92 52 C 106 50, 118 46, 130 42 C 138 39.5, 143 38, 147 36"
+                stroke={INK_ALT}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                opacity="0.6"
+            />
+            <path
+                d="M14 60 C 24 59, 32 50, 42 51 C 52 52, 58 40, 70 38 C 82 36, 88 44, 100 36 C 112 28, 120 30, 132 20 C 138 15, 143 14, 147 11"
+                stroke={INK}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+            />
+            {[
+                [42, 51],
+                [70, 38],
+                [100, 36],
+                [132, 20],
+            ].map(([cx, cy]) => (
+                <circle key={cx} cx={cx} cy={cy} r="3" fill={INK} />
+            ))}
+        </SketchSvg>
+    )
+}
+
+export function FunnelSketch(): JSX.Element {
+    const bars: [number, number][] = [
+        [14, 56],
+        [50, 36],
+        [86, 22],
+        [122, 12],
+    ]
+    return (
+        <SketchSvg>
+            <path d="M12 74 H148" stroke={AXIS} strokeWidth="1.5" strokeDasharray="3 4" strokeLinecap="round" />
+            {bars.map(([x, height], index) => (
+                <rect
+                    key={x}
+                    x={x}
+                    y={74 - height}
+                    width="28"
+                    height={height}
+                    rx="3"
+                    fill={INK}
+                    opacity={1 - index * 0.24}
+                />
+            ))}
+            {bars.slice(0, -1).map(([x, height], index) => {
+                const [nextX, nextHeight] = bars[index + 1]
+                return (
+                    <path
+                        key={x}
+                        d={`M${x + 28} ${74 - height} L${nextX} ${74 - nextHeight} V74 H${x + 28} Z`}
+                        fill={INK}
+                        opacity="0.1"
+                    />
+                )
+            })}
+        </SketchSvg>
+    )
+}
+
+export function RetentionSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            {[7, 6, 5, 4].map((cells, row) => (
+                <g key={row}>
+                    {Array.from({ length: cells }, (_, col) => (
+                        <rect
+                            key={col}
+                            x={14 + col * 19}
+                            y={14 + row * 15}
+                            width="16"
+                            height="11"
+                            rx="2"
+                            fill={INK}
+                            opacity={Math.max(0.2, 0.95 - col * 0.13)}
+                        />
+                    ))}
+                </g>
+            ))}
+        </SketchSvg>
+    )
+}
+
+export function PathsSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            <path d="M21 34 C 60 34, 85 20, 138 20" stroke={INK} strokeWidth="11" strokeLinecap="round" opacity="0.3" />
+            <path d="M21 45 C 60 45, 85 47, 138 48" stroke={INK} strokeWidth="8" strokeLinecap="round" opacity="0.22" />
+            <path
+                d="M21 55 C 55 56, 85 70, 138 70"
+                stroke={INK}
+                strokeWidth="5.5"
+                strokeLinecap="round"
+                opacity="0.15"
+            />
+            <rect x="12" y="28" width="9" height="32" rx="2.5" fill={INK} opacity="0.9" />
+            <rect x="138" y="13" width="9" height="15" rx="2.5" fill={INK} opacity="0.75" />
+            <rect x="138" y="41" width="9" height="13" rx="2.5" fill={INK} opacity="0.55" />
+            <rect x="138" y="64" width="9" height="11" rx="2.5" fill={INK} opacity="0.4" />
+        </SketchSvg>
+    )
+}
+
+export function StickinessSketch(): JSX.Element {
+    const heights = [54, 38, 27, 19, 13, 9, 6]
+    return (
+        <SketchSvg>
+            <path d="M12 74 H148" stroke={AXIS} strokeWidth="1.5" strokeDasharray="3 4" strokeLinecap="round" />
+            {heights.map((height, index) => (
+                <rect
+                    key={index}
+                    x={14 + index * 19}
+                    y={74 - height}
+                    width="14"
+                    height={height}
+                    rx="2"
+                    fill={INK}
+                    opacity={Math.max(0.35, 1 - index * 0.11)}
+                />
+            ))}
+        </SketchSvg>
+    )
+}
+
+export function LifecycleSketch(): JSX.Element {
+    const up = [16, 22, 13, 26, 18, 24]
+    const down = [9, 13, 18, 7, 15, 11]
+    return (
+        <SketchSvg>
+            {up.map((height, index) => (
+                <rect
+                    key={index}
+                    x={16 + index * 22}
+                    y={45 - 2 - height}
+                    width="15"
+                    height={height}
+                    rx="2"
+                    fill={INK_UP}
+                    opacity="0.85"
+                />
+            ))}
+            {down.map((height, index) => (
+                <rect
+                    key={index}
+                    x={16 + index * 22}
+                    y={47}
+                    width="15"
+                    height={height}
+                    rx="2"
+                    fill={INK_DOWN}
+                    opacity="0.7"
+                />
+            ))}
+            <path d="M12 45 H148" stroke={AXIS} strokeWidth="1.5" strokeDasharray="3 4" strokeLinecap="round" />
+        </SketchSvg>
+    )
+}
+
+export function SqlSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            <rect x="14" y="14" width="26" height="6" rx="3" fill={INK} />
+            <rect x="44" y="14" width="40" height="6" rx="3" fill={AXIS} />
+            <rect x="14" y="26" width="18" height="6" rx="3" fill={INK_ALT} />
+            <rect x="36" y="26" width="52" height="6" rx="3" fill={AXIS} />
+            <rect x="14" y="38" width="30" height="6" rx="3" fill={INK} />
+            <rect x="48" y="38" width="24" height="6" rx="3" fill={AXIS} />
+            <rect x="76" y="38" width="20" height="6" rx="3" fill="var(--data-color-4)" />
+            <rect x="14" y="54" width="118" height="24" rx="3" stroke={AXIS} strokeWidth="1.5" />
+            <path d="M14 66 H132 M55 54 V78 M96 54 V78" stroke={AXIS} strokeWidth="1.5" />
+        </SketchSvg>
+    )
+}
+
+export function AiSketch(): JSX.Element {
+    return (
+        <SketchSvg>
+            <rect x="14" y="12" width="132" height="16" rx="8" stroke={AXIS} strokeWidth="1.5" />
+            <rect x="22" y="18" width="46" height="4" rx="2" fill={AXIS} />
+            <Star cx={134} cy={20} r={6} fill={INK_AI} />
+            <path
+                d="M14 72 C 28 71, 38 62, 52 61 C 66 60, 74 50, 90 46 C 106 42, 116 34, 130 28 C 137 25, 142 24, 146 22"
+                stroke={INK_AI}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+            />
+            {[
+                [52, 61],
+                [90, 46],
+                [130, 28],
+            ].map(([cx, cy]) => (
+                <circle key={cx} cx={cx} cy={cy} r="2.5" fill={INK_AI} />
+            ))}
+            <Star cx={112} cy={56} r={4} fill={INK_AI} />
+        </SketchSvg>
+    )
+}
+
+/** Fallback for insight types without a dedicated sketch. */
+export function GenericInsightSketch(): JSX.Element {
+    const heights = [22, 38, 30, 48, 40, 56]
+    return (
+        <SketchSvg>
+            <path d="M12 74 H148" stroke={AXIS} strokeWidth="1.5" strokeDasharray="3 4" strokeLinecap="round" />
+            {heights.map((height, index) => (
+                <rect
+                    key={index}
+                    x={16 + index * 22}
+                    y={74 - height}
+                    width="15"
+                    height={height}
+                    rx="2"
+                    fill={INK}
+                    opacity="0.7"
+                />
+            ))}
+        </SketchSvg>
+    )
+}
+
+export const INSIGHT_TYPE_SKETCHES: Partial<Record<InsightType, () => JSX.Element>> = {
+    [InsightType.TRENDS]: TrendsSketch,
+    [InsightType.FUNNELS]: FunnelSketch,
+    [InsightType.RETENTION]: RetentionSketch,
+    [InsightType.PATHS]: PathsSketch,
+    [InsightType.STICKINESS]: StickinessSketch,
+    [InsightType.LIFECYCLE]: LifecycleSketch,
+    [InsightType.SQL]: SqlSketch,
+}

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 
 import { NewInsightMenuOverlay } from './NewInsightMenu'
+import { NewInsightPickerVariant } from './newInsightMenuPrototypes'
 
 const meta: Meta<typeof NewInsightMenuOverlay> = {
     title: 'Scenes-App/Saved Insights/New Insight Menu',
@@ -10,10 +11,16 @@ export default meta
 
 type Story = StoryObj<typeof NewInsightMenuOverlay>
 
-export const Overlay: Story = {
-    render: () => (
+function renderVariant(variant: NewInsightPickerVariant): JSX.Element {
+    return (
         <div className="border border-primary rounded bg-surface-primary w-fit p-1">
-            <NewInsightMenuOverlay />
+            <NewInsightMenuOverlay variant={variant} />
         </div>
-    ),
+    )
 }
+
+export const FlatGrid: Story = { render: () => renderVariant('A') }
+export const VariantChips: Story = { render: () => renderVariant('B') }
+export const GroupedByQuestion: Story = { render: () => renderVariant('C') }
+export const GridWithPresets: Story = { render: () => renderVariant('D') }
+export const TwoStep: Story = { render: () => renderVariant('E') }

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { NewInsightMenuOverlay } from './NewInsightMenu'
+
+const meta: Meta<typeof NewInsightMenuOverlay> = {
+    title: 'Scenes-App/Saved Insights/New Insight Menu',
+    component: NewInsightMenuOverlay,
+}
+export default meta
+
+type Story = StoryObj<typeof NewInsightMenuOverlay>
+
+export const Overlay: Story = {
+    render: () => (
+        <div className="border border-primary rounded bg-surface-primary w-fit p-1">
+            <NewInsightMenuOverlay />
+        </div>
+    ),
+}

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
@@ -24,3 +24,4 @@ export const VariantChips: Story = { render: () => renderVariant('B') }
 export const GroupedByQuestion: Story = { render: () => renderVariant('C') }
 export const GridWithPresets: Story = { render: () => renderVariant('D') }
 export const TwoStep: Story = { render: () => renderVariant('E') }
+export const GroupedByQuestionAiry: Story = { render: () => renderVariant('F') }

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
@@ -24,4 +24,4 @@ export const VariantChips: Story = { render: () => renderVariant('B') }
 export const GroupedByQuestion: Story = { render: () => renderVariant('C') }
 export const GridWithPresets: Story = { render: () => renderVariant('D') }
 export const TwoStep: Story = { render: () => renderVariant('E') }
-export const GroupedByQuestionAiry: Story = { render: () => renderVariant('F') }
+export const GroupedTwoColumns: Story = { render: () => renderVariant('F') }

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
@@ -1,138 +1,69 @@
 import { useValues } from 'kea'
+import { router } from 'kea-router'
 
-import { IconPlusSmall, IconSparkles } from '@posthog/icons'
+import { IconPlusSmall } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
-import { Link } from 'lib/lemon-ui/Link'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { cn } from 'lib/utils/css-classes'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { INSIGHT_TYPE_URLS } from 'scenes/insights/utils'
-import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { Scene } from 'scenes/sceneTypes'
-import { urls } from 'scenes/urls'
 
-import { AccessControlLevel, AccessControlResourceType, InsightType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
-import { AiSketch, GenericInsightSketch, INSIGHT_TYPE_SKETCHES } from './InsightTypeSketch'
+import {
+    getPickerVariant,
+    NEW_INSIGHT_PICKER_VARIANTS,
+    NewInsightPickerVariant,
+    PickerVariantSwitcher,
+} from './newInsightMenuPrototypes'
 
-interface NewInsightCardProps {
-    name: string
-    description: string
-    icon: React.ComponentType<{ className?: string }>
-    iconClassName?: string
-    sketch: JSX.Element
-    to: string
-    dataAttr: string
-    onClick?: () => void
-}
-
-function NewInsightCard({
-    name,
-    description,
-    icon: Icon,
-    iconClassName = 'text-secondary',
-    sketch,
-    to,
-    dataAttr,
-    onClick,
-}: NewInsightCardProps): JSX.Element {
-    return (
-        <Link
-            to={to}
-            data-attr={dataAttr}
-            onClick={onClick}
-            className={cn(
-                'flex flex-col overflow-hidden rounded border border-primary bg-surface-primary',
-                'transition-all duration-100 hover:-translate-y-0.5 hover:border-accent hover:shadow-md',
-                'focus-visible:border-accent'
-            )}
-        >
-            <div className="shrink-0 border-b border-primary bg-fill-secondary">{sketch}</div>
-            <div className="flex flex-1 flex-col gap-0.5 p-2">
-                <div className="flex items-center gap-1.5">
-                    <Icon className={cn('text-base shrink-0', iconClassName)} />
-                    <span className="text-sm font-semibold text-default">{name}</span>
-                </div>
-                <span className="text-xs leading-snug text-secondary">{description}</span>
-            </div>
-        </Link>
-    )
-}
-
-export function NewInsightMenuOverlay(): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    const insightEntries = Object.entries(INSIGHT_TYPES_METADATA).filter(
-        ([insightType, metadata]) =>
-            metadata.inMenu &&
-            insightType !== InsightType.JSON &&
-            (featureFlags[FEATURE_FLAGS.HOG] || insightType !== InsightType.HOG)
-    )
-
-    return (
-        <div className="w-[42rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-type-picker">
-            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
-                <NewInsightCard
-                    name="AI"
-                    description="Ask PostHog AI to create insights using natural language."
-                    icon={IconSparkles}
-                    iconClassName="text-ai"
-                    sketch={<AiSketch />}
-                    to={urls.ai()}
-                    dataAttr="new-insight-menu-ai"
-                />
-                {insightEntries.map(([insightType, metadata]) => {
-                    const Sketch = INSIGHT_TYPE_SKETCHES[insightType as InsightType] ?? GenericInsightSketch
-                    return (
-                        <NewInsightCard
-                            key={insightType}
-                            name={metadata.name}
-                            description={metadata.description ?? ''}
-                            icon={metadata.icon}
-                            sketch={<Sketch />}
-                            to={INSIGHT_TYPE_URLS[insightType as InsightType]}
-                            dataAttr={`new-insight-menu-${insightType.toLowerCase()}`}
-                            onClick={() => eventUsageLogic.actions.reportSavedInsightNewInsightClicked(insightType)}
-                        />
-                    )
-                })}
-            </div>
-        </div>
-    )
+export function NewInsightMenuOverlay({ variant }: { variant?: NewInsightPickerVariant }): JSX.Element {
+    const spec =
+        NEW_INSIGHT_PICKER_VARIANTS.find((candidate) => candidate.key === variant) ?? NEW_INSIGHT_PICKER_VARIANTS[0]
+    const VariantComponent = spec.component
+    return <VariantComponent />
 }
 
 export function NewInsightButton(): JSX.Element {
+    const { searchParams } = useValues(router)
+    const variant = getPickerVariant(searchParams['variant'])
+
     return (
-        <AccessControlAction
-            resourceType={AccessControlResourceType.Insight}
-            minAccessLevel={AccessControlLevel.Editor}
-        >
-            <Shortcut
-                name="NewInsight"
-                keybind={[keyBinds.new]}
-                intent="New insight"
-                interaction="click"
-                scope={Scene.SavedInsights}
-                priority={100}
+        <>
+            <AccessControlAction
+                resourceType={AccessControlResourceType.Insight}
+                minAccessLevel={AccessControlLevel.Editor}
             >
-                <LemonDropdown overlay={<NewInsightMenuOverlay />} placement="bottom-end">
-                    <LemonButton
-                        type="primary"
-                        data-attr="saved-insights-new-insight-button"
-                        size="small"
-                        icon={<IconPlusSmall />}
-                        tooltip="New insight"
+                <Shortcut
+                    name="NewInsight"
+                    keybind={[keyBinds.new]}
+                    intent="New insight"
+                    interaction="click"
+                    scope={Scene.SavedInsights}
+                    priority={100}
+                >
+                    {/* closeOnClickInside=false so variant E's step switch doesn't dismiss the dropdown;
+                        card clicks navigate away regardless */}
+                    <LemonDropdown
+                        overlay={<NewInsightMenuOverlay variant={variant} />}
+                        placement="bottom-end"
+                        closeOnClickInside={false}
                     >
-                        New
-                    </LemonButton>
-                </LemonDropdown>
-            </Shortcut>
-        </AccessControlAction>
+                        <LemonButton
+                            type="primary"
+                            data-attr="saved-insights-new-insight-button"
+                            size="small"
+                            icon={<IconPlusSmall />}
+                            tooltip="New insight"
+                        >
+                            New
+                        </LemonButton>
+                    </LemonDropdown>
+                </Shortcut>
+            </AccessControlAction>
+            <PickerVariantSwitcher />
+        </>
     )
 }

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
@@ -1,0 +1,138 @@
+import { useValues } from 'kea'
+
+import { IconPlusSmall, IconSparkles } from '@posthog/icons'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
+import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
+import { Link } from 'lib/lemon-ui/Link'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { cn } from 'lib/utils/css-classes'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { INSIGHT_TYPE_URLS } from 'scenes/insights/utils'
+import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
+import { Scene } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+
+import { AccessControlLevel, AccessControlResourceType, InsightType } from '~/types'
+
+import { AiSketch, GenericInsightSketch, INSIGHT_TYPE_SKETCHES } from './InsightTypeSketch'
+
+interface NewInsightCardProps {
+    name: string
+    description: string
+    icon: React.ComponentType<{ className?: string }>
+    iconClassName?: string
+    sketch: JSX.Element
+    to: string
+    dataAttr: string
+    onClick?: () => void
+}
+
+function NewInsightCard({
+    name,
+    description,
+    icon: Icon,
+    iconClassName = 'text-secondary',
+    sketch,
+    to,
+    dataAttr,
+    onClick,
+}: NewInsightCardProps): JSX.Element {
+    return (
+        <Link
+            to={to}
+            data-attr={dataAttr}
+            onClick={onClick}
+            className={cn(
+                'flex flex-col overflow-hidden rounded border border-primary bg-surface-primary',
+                'transition-all duration-100 hover:-translate-y-0.5 hover:border-accent hover:shadow-md',
+                'focus-visible:border-accent'
+            )}
+        >
+            <div className="shrink-0 border-b border-primary bg-fill-secondary">{sketch}</div>
+            <div className="flex flex-1 flex-col gap-0.5 p-2">
+                <div className="flex items-center gap-1.5">
+                    <Icon className={cn('text-base shrink-0', iconClassName)} />
+                    <span className="text-sm font-semibold text-default">{name}</span>
+                </div>
+                <span className="text-xs leading-snug text-secondary">{description}</span>
+            </div>
+        </Link>
+    )
+}
+
+export function NewInsightMenuOverlay(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const insightEntries = Object.entries(INSIGHT_TYPES_METADATA).filter(
+        ([insightType, metadata]) =>
+            metadata.inMenu &&
+            insightType !== InsightType.JSON &&
+            (featureFlags[FEATURE_FLAGS.HOG] || insightType !== InsightType.HOG)
+    )
+
+    return (
+        <div className="w-[42rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-type-picker">
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                <NewInsightCard
+                    name="AI"
+                    description="Ask PostHog AI to create insights using natural language."
+                    icon={IconSparkles}
+                    iconClassName="text-ai"
+                    sketch={<AiSketch />}
+                    to={urls.ai()}
+                    dataAttr="new-insight-menu-ai"
+                />
+                {insightEntries.map(([insightType, metadata]) => {
+                    const Sketch = INSIGHT_TYPE_SKETCHES[insightType as InsightType] ?? GenericInsightSketch
+                    return (
+                        <NewInsightCard
+                            key={insightType}
+                            name={metadata.name}
+                            description={metadata.description ?? ''}
+                            icon={metadata.icon}
+                            sketch={<Sketch />}
+                            to={INSIGHT_TYPE_URLS[insightType as InsightType]}
+                            dataAttr={`new-insight-menu-${insightType.toLowerCase()}`}
+                            onClick={() => eventUsageLogic.actions.reportSavedInsightNewInsightClicked(insightType)}
+                        />
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+export function NewInsightButton(): JSX.Element {
+    return (
+        <AccessControlAction
+            resourceType={AccessControlResourceType.Insight}
+            minAccessLevel={AccessControlLevel.Editor}
+        >
+            <Shortcut
+                name="NewInsight"
+                keybind={[keyBinds.new]}
+                intent="New insight"
+                interaction="click"
+                scope={Scene.SavedInsights}
+                priority={100}
+            >
+                <LemonDropdown overlay={<NewInsightMenuOverlay />} placement="bottom-end">
+                    <LemonButton
+                        type="primary"
+                        data-attr="saved-insights-new-insight-button"
+                        size="small"
+                        icon={<IconPlusSmall />}
+                        tooltip="New insight"
+                    >
+                        New
+                    </LemonButton>
+                </LemonDropdown>
+            </Shortcut>
+        </AccessControlAction>
+    )
+}

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -20,9 +20,7 @@ import {
     IconPerson,
     IconPieChart,
     IconPiggyBank,
-    IconPlusSmall,
     IconRetention,
-    IconSparkles,
     IconRetentionHeatmap,
     IconHeart,
     IconHeartFilled,
@@ -39,33 +37,27 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { BulkUpdateTagsButton } from 'lib/components/BulkActions/BulkUpdateTagsButton'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
-import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
-import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { TZLabel } from 'lib/components/TZLabel'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { IconAction, IconTableChart } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
-import { LemonMenu, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { cn } from 'lib/utils/css-classes'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { isNonEmptyObject } from 'lib/utils/guards'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
-import { INSIGHT_TYPE_URLS } from 'scenes/insights/utils'
 import { projectLogic } from 'scenes/projectLogic'
+import { NewInsightButton } from 'scenes/saved-insights/NewInsightMenu'
 import { NewInsightShortcuts } from 'scenes/saved-insights/newInsightsMenu'
 import { SavedInsightsFilters } from 'scenes/saved-insights/SavedInsightsFilters'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -780,77 +772,6 @@ export function InsightIcon({
     }
 
     return Icon ? <Icon className={className} /> : null
-}
-
-export function NewInsightButton(): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    const insightEntries = Object.entries(INSIGHT_TYPES_METADATA).filter(
-        ([insightType]) =>
-            insightType !== InsightType.JSON && (featureFlags[FEATURE_FLAGS.HOG] || insightType !== InsightType.HOG)
-    )
-    const menuItems: LemonMenuItems = [
-        {
-            icon: <IconSparkles className="text-ai" />,
-            label: (
-                <div className="flex flex-col text-sm py-1">
-                    <strong>AI</strong>
-                    <span className="text-xs font-normal">
-                        Ask PostHog AI to create insights using natural language and query any of your data
-                    </span>
-                </div>
-            ),
-            to: urls.ai(),
-            'data-attr': 'new-insight-menu-ai',
-        },
-        {
-            title: 'Insight types',
-            items: insightEntries
-                .filter(([, metadata]) => metadata.inMenu)
-                .map(([insightType, metadata]) => ({
-                    icon: metadata.icon ? <metadata.icon /> : undefined,
-                    label: (
-                        <div className="flex flex-col text-sm py-1">
-                            <strong>{metadata.name}</strong>
-                            <span className="text-xs font-normal">{metadata.description}</span>
-                        </div>
-                    ),
-                    to: INSIGHT_TYPE_URLS[insightType as InsightType],
-                    'data-attr': `new-insight-menu-${insightType.toLowerCase()}`,
-                    onClick: () => {
-                        eventUsageLogic.actions.reportSavedInsightNewInsightClicked(insightType)
-                    },
-                })),
-        },
-    ]
-
-    return (
-        <AccessControlAction
-            resourceType={AccessControlResourceType.Insight}
-            minAccessLevel={AccessControlLevel.Editor}
-        >
-            <Shortcut
-                name="NewInsight"
-                keybind={[keyBinds.new]}
-                intent="New insight"
-                interaction="click"
-                scope={Scene.SavedInsights}
-                priority={100}
-            >
-                <LemonMenu items={menuItems} placement="bottom-end">
-                    <LemonButton
-                        type="primary"
-                        data-attr="saved-insights-new-insight-button"
-                        size="small"
-                        icon={<IconPlusSmall />}
-                        tooltip="New insight"
-                    >
-                        New
-                    </LemonButton>
-                </LemonMenu>
-            </Shortcut>
-        </AccessControlAction>
-    )
 }
 
 export function SavedInsights(): JSX.Element {

--- a/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
+++ b/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
@@ -375,37 +375,7 @@ export function SectionedVariant(): JSX.Element {
     )
 }
 
-function PickerCardWide({ spec }: { spec: PickerCardSpec }): JSX.Element {
-    const Icon = spec.icon
-    return (
-        <Link
-            to={spec.to}
-            data-attr={spec.dataAttr}
-            onClick={spec.onClick}
-            className={cn(
-                'flex overflow-hidden rounded border border-primary bg-surface-primary',
-                'transition-all duration-100 hover:-translate-y-0.5 hover:border-accent hover:shadow-md',
-                'focus-visible:border-accent'
-            )}
-        >
-            <div className="w-40 shrink-0 border-r border-primary bg-fill-secondary">
-                <spec.sketch />
-            </div>
-            <div className="flex flex-1 flex-col justify-center gap-0.5 p-2">
-                <div className="flex items-center gap-1.5">
-                    <Icon className={cn('text-base shrink-0', spec.iconClassName ?? 'text-secondary')} />
-                    <span className="text-sm font-semibold text-default">{spec.name}</span>
-                </div>
-                <span className="text-xs leading-snug text-secondary">{spec.description}</span>
-            </div>
-        </Link>
-    )
-}
-
 function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.Element {
-    // 3-wide grid; a 4th card would leave a hole, so it renders as a wide horizontal card instead
-    const gridCards = section.cards.slice(0, 3)
-    const wideCard = section.cards.length > 3 ? section.cards[3] : null
     return (
         <div className="flex flex-col gap-2.5">
             <div className="flex flex-col gap-0.5">
@@ -413,11 +383,10 @@ function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.El
                 <span className="text-xs text-secondary">{section.description}</span>
             </div>
             <div className="grid grid-cols-3 gap-2">
-                {gridCards.map((spec) => (
+                {section.cards.map((spec) => (
                     <PickerCard key={spec.key} spec={spec} />
                 ))}
             </div>
-            {wideCard && <PickerCardWide spec={wideCard} />}
         </div>
     )
 }

--- a/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
+++ b/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
@@ -7,6 +7,7 @@ import { router } from 'kea-router'
 //   C - grid grouped by the question being asked
 //   D - flat grid plus a "start from a preset" row
 //   E - two-step: pick a question, then a visualization
+//   F - like C, but airier: more whitespace and a description per section
 // Cycle with the floating bar at the bottom of the screen (arrow keys work too).
 import { useEffect, useState } from 'react'
 
@@ -38,7 +39,7 @@ import {
     WorldMapSketch,
 } from './InsightTypeSketch'
 
-export type NewInsightPickerVariant = 'A' | 'B' | 'C' | 'D' | 'E'
+export type NewInsightPickerVariant = 'A' | 'B' | 'C' | 'D' | 'E' | 'F'
 
 export interface PickerCardSpec {
     key: string
@@ -308,17 +309,25 @@ export function VariantChipsVariant(): JSX.Element {
     )
 }
 
-// -- Variant C: grouped by the question being asked --
+// -- Variants C + F: grouped by the question being asked --
 
-export function SectionedVariant(): JSX.Element {
+interface QuestionSection {
+    title: string
+    description: string
+    cards: PickerCardSpec[]
+}
+
+function useQuestionSections(): QuestionSection[] {
     const { ai, byType } = usePickerCards()
-    const sections: { title: string; cards: (PickerCardSpec | undefined)[] }[] = [
+    const sections: { title: string; description: string; cards: (PickerCardSpec | undefined)[] }[] = [
         {
             title: 'How does it change over time?',
+            description: 'Follow a metric across days, weeks, or months to spot trends and dips.',
             cards: [byType[InsightType.TRENDS], byType[InsightType.STICKINESS], byType[InsightType.LIFECYCLE]],
         },
         {
             title: 'What are the totals?',
+            description: 'Add up a metric for a period and see what it is made of, or where it comes from.',
             cards: [
                 SUB_INSIGHT_CARDS.number,
                 SUB_INSIGHT_CARDS.table,
@@ -328,13 +337,23 @@ export function SectionedVariant(): JSX.Element {
         },
         {
             title: 'How do users behave?',
+            description: 'Follow users through conversion funnels, retention, and journeys in your product.',
             cards: [byType[InsightType.FUNNELS], byType[InsightType.RETENTION], byType[InsightType.PATHS]],
         },
         {
             title: 'Build your own',
+            description: 'Write SQL against your data, or ask AI to build the insight for you.',
             cards: [byType[InsightType.SQL], byType[InsightType.HOG], ai],
         },
     ]
+    return sections.map((section) => ({
+        ...section,
+        cards: section.cards.filter((spec): spec is PickerCardSpec => !!spec),
+    }))
+}
+
+export function SectionedVariant(): JSX.Element {
+    const sections = useQuestionSections()
     return (
         <div
             className="flex w-[42rem] max-w-[calc(100vw-1rem)] flex-col gap-3 overflow-y-auto p-1 max-h-[calc(100vh-10rem)]"
@@ -346,11 +365,33 @@ export function SectionedVariant(): JSX.Element {
                         {section.title}
                     </span>
                     <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
-                        {section.cards
-                            .filter((spec): spec is PickerCardSpec => !!spec)
-                            .map((spec) => (
-                                <PickerCard key={spec.key} spec={spec} />
-                            ))}
+                        {section.cards.map((spec) => (
+                            <PickerCard key={spec.key} spec={spec} />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+export function SectionedAiryVariant(): JSX.Element {
+    const sections = useQuestionSections()
+    return (
+        <div
+            className="flex w-[44rem] max-w-[calc(100vw-1rem)] flex-col gap-6 overflow-y-auto p-4 max-h-[calc(100vh-10rem)]"
+            data-attr="new-insight-type-picker"
+        >
+            {sections.map((section) => (
+                <div key={section.title} className="flex flex-col gap-2.5">
+                    <div className="flex flex-col gap-0.5">
+                        <span className="text-sm font-semibold text-default">{section.title}</span>
+                        <span className="text-xs text-secondary">{section.description}</span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                        {section.cards.map((spec) => (
+                            <PickerCard key={spec.key} spec={spec} />
+                        ))}
                     </div>
                 </div>
             ))}
@@ -573,6 +614,7 @@ export const NEW_INSIGHT_PICKER_VARIANTS: {
     { key: 'C', name: 'Grouped by question', component: SectionedVariant },
     { key: 'D', name: 'Grid + presets', component: PresetsRowVariant },
     { key: 'E', name: 'Two-step', component: TwoStepVariant },
+    { key: 'F', name: 'Grouped by question (airy)', component: SectionedAiryVariant },
 ]
 
 export function getPickerVariant(raw: unknown): NewInsightPickerVariant {

--- a/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
+++ b/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
@@ -1,0 +1,634 @@
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+// PROTOTYPE - throwaway, do not ship.
+// Five variants of the "new insight" picker on /insights, switchable via `?variant=`:
+//   A - flat grid (baseline from the first prototype commit)
+//   B - flat grid with sub-insight chips on the Trends card
+//   C - grid grouped by the question being asked
+//   D - flat grid plus a "start from a preset" row
+//   E - two-step: pick a question, then a visualization
+// Cycle with the floating bar at the bottom of the screen (arrow keys work too).
+import { useEffect, useState } from 'react'
+
+import { IconChevronLeft, IconChevronRight, IconGlobe, IconPieChart, IconSparkles } from '@posthog/icons'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { Icon123, IconTableChart } from 'lib/lemon-ui/icons'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { Link } from 'lib/lemon-ui/Link'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { cn } from 'lib/utils/css-classes'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { INSIGHT_TYPE_URLS } from 'scenes/insights/utils'
+import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
+import { urls } from 'scenes/urls'
+
+import { InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { BaseMathType, ChartDisplayType, InsightType } from '~/types'
+
+import {
+    AiSketch,
+    BarValueSketch,
+    GenericInsightSketch,
+    INSIGHT_TYPE_SKETCHES,
+    NumberSketch,
+    PieSketch,
+    TableSketch,
+    WorldMapSketch,
+} from './InsightTypeSketch'
+
+export type NewInsightPickerVariant = 'A' | 'B' | 'C' | 'D' | 'E'
+
+export interface PickerCardSpec {
+    key: string
+    name: string
+    description: string
+    icon: React.ComponentType<{ className?: string }>
+    iconClassName?: string
+    sketch: () => JSX.Element
+    to: string
+    dataAttr: string
+    onClick?: () => void
+}
+
+// -- Preset queries (trends sub-insights seeded with opinionated defaults) --
+
+function trendsPresetUrl(overrides: Partial<TrendsQuery>): string {
+    const query: InsightVizNode<TrendsQuery> = {
+        kind: NodeKind.InsightVizNode,
+        source: {
+            kind: NodeKind.TrendsQuery,
+            series: [
+                {
+                    kind: NodeKind.EventsNode,
+                    event: '$pageview',
+                    name: '$pageview',
+                    math: BaseMathType.TotalCount,
+                },
+            ],
+            trendsFilter: {},
+            ...overrides,
+        },
+    }
+    return urls.insightNew({ query })
+}
+
+const uniqueUsersSeries = [
+    {
+        kind: NodeKind.EventsNode as const,
+        event: '$pageview',
+        name: '$pageview',
+        math: BaseMathType.UniqueUsers,
+    },
+]
+
+const PRESET_URLS = {
+    worldMap: trendsPresetUrl({
+        series: uniqueUsersSeries,
+        trendsFilter: { display: ChartDisplayType.WorldMap },
+        breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+    }),
+    table: trendsPresetUrl({
+        trendsFilter: { display: ChartDisplayType.ActionsTable },
+        breakdownFilter: { breakdown: '$pathname', breakdown_type: 'event' },
+    }),
+    number: trendsPresetUrl({
+        series: uniqueUsersSeries,
+        trendsFilter: { display: ChartDisplayType.BoldNumber },
+    }),
+    pie: trendsPresetUrl({
+        series: uniqueUsersSeries,
+        trendsFilter: { display: ChartDisplayType.ActionsPie },
+        breakdownFilter: { breakdown: '$device_type', breakdown_type: 'event' },
+    }),
+    barValue: trendsPresetUrl({
+        trendsFilter: { display: ChartDisplayType.ActionsBarValue },
+        breakdownFilter: { breakdown: '$browser', breakdown_type: 'event' },
+    }),
+}
+
+const SUB_INSIGHT_CARDS: Record<'worldMap' | 'table' | 'number' | 'pie' | 'barValue', PickerCardSpec> = {
+    worldMap: {
+        key: 'preset-world-map',
+        name: 'World map',
+        description: 'Unique users per country on a world map.',
+        icon: IconGlobe,
+        sketch: WorldMapSketch,
+        to: PRESET_URLS.worldMap,
+        dataAttr: 'new-insight-menu-preset-world-map',
+    },
+    table: {
+        key: 'preset-table',
+        name: 'Table',
+        description: 'Totals ranked in a sortable table.',
+        icon: IconTableChart,
+        sketch: TableSketch,
+        to: PRESET_URLS.table,
+        dataAttr: 'new-insight-menu-preset-table',
+    },
+    number: {
+        key: 'preset-number',
+        name: 'Number',
+        description: 'One big number for a single metric.',
+        icon: Icon123,
+        sketch: NumberSketch,
+        to: PRESET_URLS.number,
+        dataAttr: 'new-insight-menu-preset-number',
+    },
+    pie: {
+        key: 'preset-pie',
+        name: 'Pie chart',
+        description: 'Share of a total, split by a breakdown.',
+        icon: IconPieChart,
+        sketch: PieSketch,
+        to: PRESET_URLS.pie,
+        dataAttr: 'new-insight-menu-preset-pie',
+    },
+    barValue: {
+        key: 'preset-bar-value',
+        name: 'Bar chart',
+        description: 'Total values as horizontal bars.',
+        icon: IconTableChart,
+        sketch: BarValueSketch,
+        to: PRESET_URLS.barValue,
+        dataAttr: 'new-insight-menu-preset-bar-value',
+    },
+}
+
+// -- Shared card + card sources --
+
+export function PickerCard({ spec, className }: { spec: PickerCardSpec; className?: string }): JSX.Element {
+    const Icon = spec.icon
+    return (
+        <Link
+            to={spec.to}
+            data-attr={spec.dataAttr}
+            onClick={spec.onClick}
+            className={cn(
+                'flex flex-col overflow-hidden rounded border border-primary bg-surface-primary',
+                'transition-all duration-100 hover:-translate-y-0.5 hover:border-accent hover:shadow-md',
+                'focus-visible:border-accent',
+                className
+            )}
+        >
+            <div className="shrink-0 border-b border-primary bg-fill-secondary">
+                <spec.sketch />
+            </div>
+            <div className="flex flex-1 flex-col gap-0.5 p-2">
+                <div className="flex items-center gap-1.5">
+                    <Icon className={cn('text-base shrink-0', spec.iconClassName ?? 'text-secondary')} />
+                    <span className="text-sm font-semibold text-default">{spec.name}</span>
+                </div>
+                <span className="text-xs leading-snug text-secondary">{spec.description}</span>
+            </div>
+        </Link>
+    )
+}
+
+const AI_CARD: PickerCardSpec = {
+    key: 'ai',
+    name: 'AI',
+    description: 'Ask PostHog AI to create insights using natural language.',
+    icon: IconSparkles,
+    iconClassName: 'text-ai',
+    sketch: AiSketch,
+    to: urls.ai(),
+    dataAttr: 'new-insight-menu-ai',
+}
+
+function usePickerCards(): {
+    ai: PickerCardSpec
+    ordered: PickerCardSpec[]
+    byType: Partial<Record<InsightType, PickerCardSpec>>
+} {
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const byType: Partial<Record<InsightType, PickerCardSpec>> = {}
+    const ordered: PickerCardSpec[] = []
+    for (const [insightType, metadata] of Object.entries(INSIGHT_TYPES_METADATA)) {
+        if (
+            !metadata.inMenu ||
+            insightType === InsightType.JSON ||
+            (!featureFlags[FEATURE_FLAGS.HOG] && insightType === InsightType.HOG)
+        ) {
+            continue
+        }
+        const spec: PickerCardSpec = {
+            key: insightType,
+            name: metadata.name,
+            description: metadata.description ?? '',
+            icon: metadata.icon,
+            sketch: INSIGHT_TYPE_SKETCHES[insightType as InsightType] ?? GenericInsightSketch,
+            to: INSIGHT_TYPE_URLS[insightType as InsightType],
+            dataAttr: `new-insight-menu-${insightType.toLowerCase()}`,
+            onClick: () => eventUsageLogic.actions.reportSavedInsightNewInsightClicked(insightType),
+        }
+        byType[insightType as InsightType] = spec
+        ordered.push(spec)
+    }
+    return { ai: AI_CARD, ordered, byType }
+}
+
+// -- Variant A: flat grid (baseline) --
+
+export function FlatGridVariant(): JSX.Element {
+    const { ai, ordered } = usePickerCards()
+    return (
+        <div className="w-[42rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-type-picker">
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                {[ai, ...ordered].map((spec) => (
+                    <PickerCard key={spec.key} spec={spec} />
+                ))}
+            </div>
+        </div>
+    )
+}
+
+// -- Variant B: flat grid, Trends card grows sub-insight chips --
+
+const TRENDS_CHIPS: { label: string; to: string; dataAttr: string }[] = [
+    { label: 'Table', to: PRESET_URLS.table, dataAttr: 'new-insight-menu-chip-table' },
+    { label: 'Map', to: PRESET_URLS.worldMap, dataAttr: 'new-insight-menu-chip-map' },
+    { label: 'Number', to: PRESET_URLS.number, dataAttr: 'new-insight-menu-chip-number' },
+    { label: 'Pie', to: PRESET_URLS.pie, dataAttr: 'new-insight-menu-chip-pie' },
+]
+
+function ChipCard({ spec }: { spec: PickerCardSpec }): JSX.Element {
+    const Icon = spec.icon
+    return (
+        <div
+            className={cn(
+                'flex flex-col overflow-hidden rounded border border-primary bg-surface-primary',
+                'transition-all duration-100 hover:-translate-y-0.5 hover:border-accent hover:shadow-md'
+            )}
+        >
+            <Link to={spec.to} data-attr={spec.dataAttr} onClick={spec.onClick} className="flex flex-col">
+                <div className="shrink-0 border-b border-primary bg-fill-secondary">
+                    <spec.sketch />
+                </div>
+                <div className="flex flex-col gap-0.5 p-2 pb-1">
+                    <div className="flex items-center gap-1.5">
+                        <Icon className={cn('text-base shrink-0', spec.iconClassName ?? 'text-secondary')} />
+                        <span className="text-sm font-semibold text-default">{spec.name}</span>
+                    </div>
+                    <span className="text-xs leading-snug text-secondary">{spec.description}</span>
+                </div>
+            </Link>
+            <div className="flex flex-wrap gap-1 px-2 pb-2 pt-1">
+                {TRENDS_CHIPS.map((chip) => (
+                    <Link
+                        key={chip.label}
+                        to={chip.to}
+                        data-attr={chip.dataAttr}
+                        className="rounded-full border border-primary px-1.5 py-0.5 text-[11px] leading-none text-secondary hover:border-accent hover:text-accent"
+                    >
+                        {chip.label}
+                    </Link>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+export function VariantChipsVariant(): JSX.Element {
+    const { ai, ordered } = usePickerCards()
+    return (
+        <div className="w-[42rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-type-picker">
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                {[ai, ...ordered].map((spec) =>
+                    spec.key === InsightType.TRENDS ? (
+                        <ChipCard key={spec.key} spec={spec} />
+                    ) : (
+                        <PickerCard key={spec.key} spec={spec} />
+                    )
+                )}
+            </div>
+        </div>
+    )
+}
+
+// -- Variant C: grouped by the question being asked --
+
+export function SectionedVariant(): JSX.Element {
+    const { ai, byType } = usePickerCards()
+    const sections: { title: string; cards: (PickerCardSpec | undefined)[] }[] = [
+        {
+            title: 'How does it change over time?',
+            cards: [byType[InsightType.TRENDS], byType[InsightType.STICKINESS], byType[InsightType.LIFECYCLE]],
+        },
+        {
+            title: 'What are the totals?',
+            cards: [
+                SUB_INSIGHT_CARDS.number,
+                SUB_INSIGHT_CARDS.table,
+                SUB_INSIGHT_CARDS.pie,
+                SUB_INSIGHT_CARDS.worldMap,
+            ],
+        },
+        {
+            title: 'How do users behave?',
+            cards: [byType[InsightType.FUNNELS], byType[InsightType.RETENTION], byType[InsightType.PATHS]],
+        },
+        {
+            title: 'Build your own',
+            cards: [byType[InsightType.SQL], byType[InsightType.HOG], ai],
+        },
+    ]
+    return (
+        <div
+            className="flex w-[42rem] max-w-[calc(100vw-1rem)] flex-col gap-3 overflow-y-auto p-1 max-h-[calc(100vh-10rem)]"
+            data-attr="new-insight-type-picker"
+        >
+            {sections.map((section) => (
+                <div key={section.title} className="flex flex-col gap-1.5">
+                    <span className="px-1 text-xs font-semibold uppercase tracking-wide text-tertiary">
+                        {section.title}
+                    </span>
+                    <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                        {section.cards
+                            .filter((spec): spec is PickerCardSpec => !!spec)
+                            .map((spec) => (
+                                <PickerCard key={spec.key} spec={spec} />
+                            ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+// -- Variant D: flat grid plus a "start from a preset" row --
+
+const PRESET_ROWS: {
+    key: string
+    name: string
+    description: string
+    icon: React.ComponentType<{ className?: string }>
+    to: string
+}[] = [
+    {
+        key: 'users-by-country',
+        name: 'Users by country',
+        description: 'World map of unique users.',
+        icon: IconGlobe,
+        to: PRESET_URLS.worldMap,
+    },
+    {
+        key: 'top-pages',
+        name: 'Top pages',
+        description: 'Pageviews by path in a ranked table.',
+        icon: IconTableChart,
+        to: PRESET_URLS.table,
+    },
+    {
+        key: 'daily-active-users',
+        name: 'Daily active users',
+        description: 'Unique users as one big number.',
+        icon: Icon123,
+        to: PRESET_URLS.number,
+    },
+    {
+        key: 'traffic-by-device',
+        name: 'Traffic by device',
+        description: 'Pageviews by device type as a pie.',
+        icon: IconPieChart,
+        to: PRESET_URLS.pie,
+    },
+]
+
+export function PresetsRowVariant(): JSX.Element {
+    const { ai, ordered } = usePickerCards()
+    return (
+        <div className="w-[42rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-type-picker">
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                {[ai, ...ordered].map((spec) => (
+                    <PickerCard key={spec.key} spec={spec} />
+                ))}
+            </div>
+            <LemonDivider className="my-2" />
+            <span className="px-1 text-xs font-semibold uppercase tracking-wide text-tertiary">
+                Or start from a preset
+            </span>
+            <div className="mt-1.5 grid grid-cols-2 gap-2">
+                {PRESET_ROWS.map((preset) => (
+                    <Link
+                        key={preset.key}
+                        to={preset.to}
+                        data-attr={`new-insight-menu-preset-${preset.key}`}
+                        className="flex items-center gap-2 rounded border border-primary bg-surface-primary p-2 transition-all duration-100 hover:border-accent hover:shadow-sm"
+                    >
+                        <span className="flex size-8 shrink-0 items-center justify-center rounded bg-fill-secondary">
+                            <preset.icon className="text-lg text-secondary" />
+                        </span>
+                        <span className="flex flex-col">
+                            <span className="text-sm font-semibold text-default">{preset.name}</span>
+                            <span className="text-xs text-secondary">{preset.description}</span>
+                        </span>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+// -- Variant E: two-step, question first then visualization --
+
+interface PickerQuestion {
+    key: string
+    question: string
+    hint: string
+    /** Direct link when the question has exactly one answer. */
+    to?: string
+    options?: (PickerCardSpec | undefined)[]
+}
+
+export function TwoStepVariant(): JSX.Element {
+    const { ai, byType } = usePickerCards()
+    const [activeKey, setActiveKey] = useState<string | null>(null)
+
+    const questions: PickerQuestion[] = [
+        {
+            key: 'over-time',
+            question: 'How does a metric change over time?',
+            hint: 'Trends · Stickiness · Lifecycle',
+            options: [byType[InsightType.TRENDS], byType[InsightType.STICKINESS], byType[InsightType.LIFECYCLE]],
+        },
+        {
+            key: 'totals',
+            question: 'What are the totals and top values?',
+            hint: 'Number · Table · Pie · Bar',
+            options: [
+                SUB_INSIGHT_CARDS.number,
+                SUB_INSIGHT_CARDS.table,
+                SUB_INSIGHT_CARDS.pie,
+                SUB_INSIGHT_CARDS.barValue,
+            ],
+        },
+        {
+            key: 'where',
+            question: 'Where in the world are my users?',
+            hint: 'World map',
+            to: PRESET_URLS.worldMap,
+        },
+        {
+            key: 'convert',
+            question: 'Do users complete a flow?',
+            hint: 'Funnel',
+            to: INSIGHT_TYPE_URLS[InsightType.FUNNELS],
+        },
+        {
+            key: 'return',
+            question: 'Do users come back?',
+            hint: 'Retention · Stickiness',
+            options: [byType[InsightType.RETENTION], byType[InsightType.STICKINESS], byType[InsightType.LIFECYCLE]],
+        },
+        {
+            key: 'navigate',
+            question: 'How do users move through the product?',
+            hint: 'Paths',
+            to: INSIGHT_TYPE_URLS[InsightType.PATHS],
+        },
+        {
+            key: 'custom',
+            question: 'Something else?',
+            hint: 'SQL · AI',
+            options: [byType[InsightType.SQL], byType[InsightType.HOG], ai],
+        },
+    ]
+
+    const active = questions.find((question) => question.key === activeKey)
+
+    if (active?.options) {
+        return (
+            <div className="w-[36rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-type-picker">
+                <div className="mb-2 flex items-center gap-1">
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconChevronLeft />}
+                        onClick={() => setActiveKey(null)}
+                        data-attr="new-insight-menu-two-step-back"
+                    />
+                    <span className="text-sm font-semibold text-default">{active.question}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+                    {active.options
+                        .filter((spec): spec is PickerCardSpec => !!spec)
+                        .map((spec) => (
+                            <PickerCard key={spec.key} spec={spec} />
+                        ))}
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex w-[26rem] max-w-[calc(100vw-1rem)] flex-col gap-1 p-1" data-attr="new-insight-type-picker">
+            {questions.map((question) => {
+                const content = (
+                    <>
+                        <span className="flex flex-col text-left">
+                            <span className="text-sm font-medium text-default">{question.question}</span>
+                            <span className="text-xs text-secondary">{question.hint}</span>
+                        </span>
+                        <IconChevronRight className="shrink-0 text-secondary" />
+                    </>
+                )
+                const rowClassName =
+                    'flex w-full items-center justify-between gap-2 rounded border border-primary bg-surface-primary p-2 transition-all duration-100 hover:border-accent hover:shadow-sm'
+                return question.to ? (
+                    <Link
+                        key={question.key}
+                        to={question.to}
+                        data-attr={`new-insight-menu-question-${question.key}`}
+                        className={rowClassName}
+                    >
+                        {content}
+                    </Link>
+                ) : (
+                    <button
+                        key={question.key}
+                        type="button"
+                        data-attr={`new-insight-menu-question-${question.key}`}
+                        className={rowClassName}
+                        onClick={() => setActiveKey(question.key)}
+                    >
+                        {content}
+                    </button>
+                )
+            })}
+        </div>
+    )
+}
+
+// -- Variant registry + floating switcher --
+
+export const NEW_INSIGHT_PICKER_VARIANTS: {
+    key: NewInsightPickerVariant
+    name: string
+    component: () => JSX.Element
+}[] = [
+    { key: 'A', name: 'Flat grid', component: FlatGridVariant },
+    { key: 'B', name: 'Variant chips', component: VariantChipsVariant },
+    { key: 'C', name: 'Grouped by question', component: SectionedVariant },
+    { key: 'D', name: 'Grid + presets', component: PresetsRowVariant },
+    { key: 'E', name: 'Two-step', component: TwoStepVariant },
+]
+
+export function getPickerVariant(raw: unknown): NewInsightPickerVariant {
+    return NEW_INSIGHT_PICKER_VARIANTS.some((variant) => variant.key === raw) ? (raw as NewInsightPickerVariant) : 'A'
+}
+
+export function PickerVariantSwitcher(): JSX.Element | null {
+    const { searchParams, hashParams, location } = useValues(router)
+    const current = getPickerVariant(searchParams['variant'])
+    const index = NEW_INSIGHT_PICKER_VARIANTS.findIndex((variant) => variant.key === current)
+
+    const cycle = (delta: number): void => {
+        const next =
+            NEW_INSIGHT_PICKER_VARIANTS[
+                (index + delta + NEW_INSIGHT_PICKER_VARIANTS.length) % NEW_INSIGHT_PICKER_VARIANTS.length
+            ]
+        router.actions.replace(location.pathname, { ...searchParams, variant: next.key }, hashParams)
+    }
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent): void => {
+            if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+                return
+            }
+            const target = event.target as HTMLElement | null
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return
+            }
+            cycle(event.key === 'ArrowLeft' ? -1 : 1)
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    })
+
+    if (process.env.NODE_ENV === 'production') {
+        return null
+    }
+
+    return (
+        <div className="fixed bottom-4 left-1/2 z-[1100] flex -translate-x-1/2 items-center gap-1 rounded-full border border-primary bg-surface-primary py-1 pl-1 pr-3 shadow-lg">
+            <LemonButton
+                size="xsmall"
+                icon={<IconChevronLeft />}
+                onClick={() => cycle(-1)}
+                tooltip="Previous variant (left arrow)"
+            />
+            <span className="whitespace-nowrap text-xs font-semibold text-default">
+                <span className="mr-1 font-normal text-tertiary">Picker prototype</span>
+                {current} · {NEW_INSIGHT_PICKER_VARIANTS[index].name}
+            </span>
+            <LemonButton
+                size="xsmall"
+                icon={<IconChevronRight />}
+                onClick={() => cycle(1)}
+                tooltip="Next variant (right arrow)"
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
+++ b/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
@@ -7,7 +7,7 @@ import { router } from 'kea-router'
 //   C - grid grouped by the question being asked
 //   D - flat grid plus a "start from a preset" row
 //   E - two-step: pick a question, then a visualization
-//   F - like C, but airier: more whitespace and a description per section
+//   F - like C, but airier: two columns with a divider, section descriptions, no scrolling
 // Cycle with the floating bar at the bottom of the screen (arrow keys work too).
 import { useEffect, useState } from 'react'
 
@@ -375,26 +375,72 @@ export function SectionedVariant(): JSX.Element {
     )
 }
 
-export function SectionedAiryVariant(): JSX.Element {
+function PickerCardWide({ spec }: { spec: PickerCardSpec }): JSX.Element {
+    const Icon = spec.icon
+    return (
+        <Link
+            to={spec.to}
+            data-attr={spec.dataAttr}
+            onClick={spec.onClick}
+            className={cn(
+                'flex overflow-hidden rounded border border-primary bg-surface-primary',
+                'transition-all duration-100 hover:-translate-y-0.5 hover:border-accent hover:shadow-md',
+                'focus-visible:border-accent'
+            )}
+        >
+            <div className="w-40 shrink-0 border-r border-primary bg-fill-secondary">
+                <spec.sketch />
+            </div>
+            <div className="flex flex-1 flex-col justify-center gap-0.5 p-2">
+                <div className="flex items-center gap-1.5">
+                    <Icon className={cn('text-base shrink-0', spec.iconClassName ?? 'text-secondary')} />
+                    <span className="text-sm font-semibold text-default">{spec.name}</span>
+                </div>
+                <span className="text-xs leading-snug text-secondary">{spec.description}</span>
+            </div>
+        </Link>
+    )
+}
+
+function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.Element {
+    // 3-wide grid; a 4th card would leave a hole, so it renders as a wide horizontal card instead
+    const gridCards = section.cards.slice(0, 3)
+    const wideCard = section.cards.length > 3 ? section.cards[3] : null
+    return (
+        <div className="flex flex-col gap-2.5">
+            <div className="flex flex-col gap-0.5">
+                <span className="text-sm font-semibold text-default">{section.title}</span>
+                <span className="text-xs text-secondary">{section.description}</span>
+            </div>
+            <div className="grid grid-cols-3 gap-2">
+                {gridCards.map((spec) => (
+                    <PickerCard key={spec.key} spec={spec} />
+                ))}
+            </div>
+            {wideCard && <PickerCardWide spec={wideCard} />}
+        </div>
+    )
+}
+
+export function SectionedTwoColumnVariant(): JSX.Element {
     const sections = useQuestionSections()
+    const columns = [sections.slice(0, 2), sections.slice(2)]
     return (
         <div
-            className="flex w-[44rem] max-w-[calc(100vw-1rem)] flex-col gap-6 overflow-y-auto p-4 max-h-[calc(100vh-10rem)]"
+            className="flex w-[58rem] max-w-[calc(100vw-1rem)] gap-4 overflow-y-auto p-4 max-h-[calc(100vh-10rem)]"
             data-attr="new-insight-type-picker"
         >
-            {sections.map((section) => (
-                <div key={section.title} className="flex flex-col gap-2.5">
-                    <div className="flex flex-col gap-0.5">
-                        <span className="text-sm font-semibold text-default">{section.title}</span>
-                        <span className="text-xs text-secondary">{section.description}</span>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
-                        {section.cards.map((spec) => (
-                            <PickerCard key={spec.key} spec={spec} />
-                        ))}
-                    </div>
-                </div>
-            ))}
+            <div className="flex flex-1 flex-col gap-6">
+                {columns[0].map((section) => (
+                    <QuestionSectionBlock key={section.title} section={section} />
+                ))}
+            </div>
+            <LemonDivider vertical className="self-stretch" />
+            <div className="flex flex-1 flex-col gap-6">
+                {columns[1].map((section) => (
+                    <QuestionSectionBlock key={section.title} section={section} />
+                ))}
+            </div>
         </div>
     )
 }
@@ -614,7 +660,7 @@ export const NEW_INSIGHT_PICKER_VARIANTS: {
     { key: 'C', name: 'Grouped by question', component: SectionedVariant },
     { key: 'D', name: 'Grid + presets', component: PresetsRowVariant },
     { key: 'E', name: 'Two-step', component: TwoStepVariant },
-    { key: 'F', name: 'Grouped by question (airy)', component: SectionedAiryVariant },
+    { key: 'F', name: 'Grouped, two columns', component: SectionedTwoColumnVariant },
 ]
 
 export function getPickerVariant(raw: unknown): NewInsightPickerVariant {

--- a/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
+++ b/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
@@ -159,7 +159,16 @@ const SUB_INSIGHT_CARDS: Record<'worldMap' | 'table' | 'number' | 'pie' | 'barVa
 
 // -- Shared card + card sources --
 
-export function PickerCard({ spec, className }: { spec: PickerCardSpec; className?: string }): JSX.Element {
+export function PickerCard({
+    spec,
+    className,
+    uniformHeight = false,
+}: {
+    spec: PickerCardSpec
+    className?: string
+    /** Reserve exactly two description lines so cards line up across sections. */
+    uniformHeight?: boolean
+}): JSX.Element {
     const Icon = spec.icon
     return (
         <Link
@@ -179,9 +188,13 @@ export function PickerCard({ spec, className }: { spec: PickerCardSpec; classNam
             <div className="flex flex-1 flex-col gap-0.5 p-2">
                 <div className="flex items-center gap-1.5">
                     <Icon className={cn('text-base shrink-0', spec.iconClassName ?? 'text-secondary')} />
-                    <span className="text-sm font-semibold text-default">{spec.name}</span>
+                    <span className="text-sm font-semibold text-default whitespace-nowrap">{spec.name}</span>
                 </div>
-                <span className="text-xs leading-snug text-secondary">{spec.description}</span>
+                <span
+                    className={cn('text-xs leading-snug text-secondary', uniformHeight && 'line-clamp-2 min-h-[33px]')}
+                >
+                    {spec.description}
+                </span>
             </div>
         </Link>
     )
@@ -414,6 +427,23 @@ export function SectionedVariant(): JSX.Element {
     )
 }
 
+// Terse copy so every description fits the two-line slot at variant F's card width
+const SHORT_CARD_DESCRIPTIONS: Record<string, string> = {
+    [InsightType.TRENDS]: 'How metrics change over time.',
+    [InsightType.STICKINESS]: 'How often users repeat actions.',
+    [InsightType.LIFECYCLE]: 'New, returning, and dormant users.',
+    [InsightType.FUNNELS]: 'Conversion through a sequence of steps.',
+    [InsightType.RETENTION]: 'How many users come back later.',
+    [InsightType.PATHS]: 'The routes users take through your product.',
+    [InsightType.SQL]: 'Query your data with SQL.',
+    [InsightType.HOG]: 'Query your data with Hog.',
+    ai: 'Describe an insight and let AI build it.',
+    'preset-number': 'One big number for a single metric.',
+    'preset-table': 'Totals ranked in a sortable table.',
+    'preset-pie': 'Share of a total, split by a breakdown.',
+    'preset-world-map': 'Unique users per country.',
+}
+
 function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.Element {
     return (
         <div className="flex flex-col gap-2.5">
@@ -423,7 +453,11 @@ function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.El
             </div>
             <div className="grid grid-cols-3 gap-2">
                 {section.cards.map((spec) => (
-                    <PickerCard key={spec.key} spec={spec} />
+                    <PickerCard
+                        key={spec.key}
+                        spec={{ ...spec, description: SHORT_CARD_DESCRIPTIONS[spec.key] ?? spec.description }}
+                        uniformHeight
+                    />
                 ))}
             </div>
         </div>

--- a/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
+++ b/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
@@ -374,12 +374,12 @@ function useQuestionSections(): QuestionSection[] {
     const sections: { title: string; description: string; cards: (PickerCardSpec | undefined)[] }[] = [
         {
             title: 'How does it change over time?',
-            description: 'Follow a metric across days, weeks, or months to spot trends and dips.',
+            description: 'Follow a metric over time to spot trends and dips.',
             cards: [byType[InsightType.TRENDS], byType[InsightType.STICKINESS], byType[InsightType.LIFECYCLE]],
         },
         {
             title: 'What are the totals?',
-            description: 'Add up a metric for a period and see what it is made of, or where it comes from.',
+            description: 'Add up a metric and see what it is made of.',
             cards: [
                 SUB_INSIGHT_CARDS.number,
                 SUB_INSIGHT_CARDS.table,
@@ -389,12 +389,12 @@ function useQuestionSections(): QuestionSection[] {
         },
         {
             title: 'How do users behave?',
-            description: 'Follow users through conversion funnels, retention, and journeys in your product.',
+            description: 'Funnels, retention, and journeys through your product.',
             cards: [byType[InsightType.FUNNELS], byType[InsightType.RETENTION], byType[InsightType.PATHS]],
         },
         {
             title: 'Build your own',
-            description: 'Write SQL against your data, or ask AI to build the insight for you.',
+            description: 'Write SQL against your data, or let AI build it.',
             cards: [byType[InsightType.SQL], byType[InsightType.HOG], ai],
         },
     ]
@@ -447,9 +447,10 @@ const SHORT_CARD_DESCRIPTIONS: Record<string, string> = {
 function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.Element {
     return (
         <div className="flex flex-col gap-2.5">
+            {/* single-line title + description keep header heights equal, so card rows align across columns */}
             <div className="flex flex-col gap-0.5">
-                <span className="text-sm font-semibold text-default">{section.title}</span>
-                <span className="text-xs text-secondary">{section.description}</span>
+                <span className="truncate text-sm font-semibold text-default">{section.title}</span>
+                <span className="truncate text-xs text-secondary">{section.description}</span>
             </div>
             <div className="grid grid-cols-3 gap-2">
                 {section.cards.map((spec) => (

--- a/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
+++ b/frontend/src/scenes/saved-insights/newInsightMenuPrototypes.tsx
@@ -25,8 +25,8 @@ import { INSIGHT_TYPE_URLS } from 'scenes/insights/utils'
 import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { urls } from 'scenes/urls'
 
-import { InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
-import { BaseMathType, ChartDisplayType, InsightType } from '~/types'
+import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { BaseMathType, ChartDisplayType, FunnelVizType, InsightType } from '~/types'
 
 import {
     AiSketch,
@@ -246,16 +246,54 @@ export function FlatGridVariant(): JSX.Element {
     )
 }
 
-// -- Variant B: flat grid, Trends card grows sub-insight chips --
+// -- Variant B: flat grid, Trends and Funnel cards grow sub-insight chips --
 
-const TRENDS_CHIPS: { label: string; to: string; dataAttr: string }[] = [
-    { label: 'Table', to: PRESET_URLS.table, dataAttr: 'new-insight-menu-chip-table' },
-    { label: 'Map', to: PRESET_URLS.worldMap, dataAttr: 'new-insight-menu-chip-map' },
-    { label: 'Number', to: PRESET_URLS.number, dataAttr: 'new-insight-menu-chip-number' },
-    { label: 'Pie', to: PRESET_URLS.pie, dataAttr: 'new-insight-menu-chip-pie' },
-]
+function funnelsPresetUrl(vizType: FunnelVizType): string {
+    const query: InsightVizNode<FunnelsQuery> = {
+        kind: NodeKind.InsightVizNode,
+        source: {
+            kind: NodeKind.FunnelsQuery,
+            series: [
+                {
+                    kind: NodeKind.EventsNode,
+                    event: '$pageview',
+                    name: '$pageview',
+                },
+            ],
+            funnelsFilter: { funnelVizType: vizType },
+        },
+    }
+    return urls.insightNew({ query })
+}
 
-function ChipCard({ spec }: { spec: PickerCardSpec }): JSX.Element {
+interface CardChip {
+    label: string
+    to: string
+    dataAttr: string
+}
+
+const CARD_CHIPS: Partial<Record<InsightType, CardChip[]>> = {
+    [InsightType.TRENDS]: [
+        { label: 'Table', to: PRESET_URLS.table, dataAttr: 'new-insight-menu-chip-table' },
+        { label: 'Map', to: PRESET_URLS.worldMap, dataAttr: 'new-insight-menu-chip-map' },
+        { label: 'Number', to: PRESET_URLS.number, dataAttr: 'new-insight-menu-chip-number' },
+        { label: 'Pie', to: PRESET_URLS.pie, dataAttr: 'new-insight-menu-chip-pie' },
+    ],
+    [InsightType.FUNNELS]: [
+        {
+            label: 'Time to convert',
+            to: funnelsPresetUrl(FunnelVizType.TimeToConvert),
+            dataAttr: 'new-insight-menu-chip-time-to-convert',
+        },
+        {
+            label: 'Conversion trend',
+            to: funnelsPresetUrl(FunnelVizType.Trends),
+            dataAttr: 'new-insight-menu-chip-conversion-trend',
+        },
+    ],
+}
+
+function ChipCard({ spec, chips }: { spec: PickerCardSpec; chips: CardChip[] }): JSX.Element {
     const Icon = spec.icon
     return (
         <div
@@ -277,7 +315,7 @@ function ChipCard({ spec }: { spec: PickerCardSpec }): JSX.Element {
                 </div>
             </Link>
             <div className="flex flex-wrap gap-1 px-2 pb-2 pt-1">
-                {TRENDS_CHIPS.map((chip) => (
+                {chips.map((chip) => (
                     <Link
                         key={chip.label}
                         to={chip.to}
@@ -297,13 +335,14 @@ export function VariantChipsVariant(): JSX.Element {
     return (
         <div className="w-[42rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-type-picker">
             <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
-                {[ai, ...ordered].map((spec) =>
-                    spec.key === InsightType.TRENDS ? (
-                        <ChipCard key={spec.key} spec={spec} />
+                {[ai, ...ordered].map((spec) => {
+                    const chips = CARD_CHIPS[spec.key as InsightType]
+                    return chips ? (
+                        <ChipCard key={spec.key} spec={spec} chips={chips} />
                     ) : (
                         <PickerCard key={spec.key} spec={spec} />
                     )
-                )}
+                })}
             </div>
         </div>
     )


### PR DESCRIPTION
## TL;DR

The "New" button on the Insights page used to open a plain text list of insight types. Now it opens a bigger panel where every type has a small sketched preview of what that chart looks like, so you can pick by shape instead of reading descriptions. On top of that, this branch now ships six switchable layouts of that panel, exploring whether trends sub-insights (world map, table, big number, pie) should be picked directly instead of hiding behind the chart-type dropdown inside trends. Flip through them with the floating bar at the bottom of `/insights` (or `?variant=A..F`).

## Problem

The "New insight" button on the saved insights page opens a dense, text-only submenu of insight types. It's hard to tell what each type actually does from a name and a one-liner. This prototypes a more visual way to pick an insight type.

Separately, trends is a mega-insight: world map, table, big number, and pie are buried in a chart-type dropdown you only discover after creating a trends insight. The variants below prototype different ways of surfacing them at creation time, without any schema changes: every sub-insight card deep-links to a seeded `TrendsQuery` via `urls.insightNew({ query })`.

## Changes

First commit (visual picker baseline):

- New `NewInsightMenuOverlay`: a wide dropdown (`LemonDropdown`) with a card grid — AI plus every `inMenu` insight type — each card showing a sketched preview, icon, name, and description
- New `InsightTypeSketch.tsx`: hand-drawn-style inline SVG previews colored via theme CSS variables, so they adapt to light/dark mode
- `NewInsightButton` moved out of `SavedInsights.tsx` into `NewInsightMenu.tsx`, keeping the existing access control, `keyBinds.new` shortcut, `data-attr`s, and `reportSavedInsightNewInsightClicked` reporting
- Raises the toolbar graph source-input budget (`frontend/bin/check-toolbar-graph.mjs`) from 14,436,000 to 14,470,000 bytes (nearly-full ratchet tipped by the new picker modules; no new toolbar → app crossing edges)

Later commits (six variants, all in `newInsightMenuPrototypes.tsx`, clearly marked throwaway):

- `?variant=` URL param picks the layout; a floating bottom bar (hidden in production builds) cycles A–F, arrow keys included
- New sketches for world map, table, number, pie, and horizontal bars
- Seeded presets: world map (unique users by `$geoip_country_code`), table (pageviews by `$pathname`), number (unique users as `BoldNumber`), pie (by `$device_type`), horizontal bar (by `$browser`)
- `closeOnClickInside={false}` on the dropdown so variant E can switch steps without dismissing
- One Storybook story per variant

> [!NOTE]
> All six variants plus the switcher are prototype code. Once a direction wins, the winner gets folded in properly and the rest gets dropped — main should only keep the validated decision.

### Variant A · flat grid (baseline)

One card per insight type, no hierarchy. The question it can't answer: where do map/table/number go without doubling the grid?

![variant-A](https://raw.githubusercontent.com/PostHog/pr-assets/a3f056596b2bea0a57f8162cc9bcc176835da648/2026/07/2940b10f-9af0-4d85-a95e-11c89dcbbca7.png)

### Variant B · sub-insight chips on cards

Trends stays one card with chips (Table, Map, Number, Pie) that deep-link to seeded presets; the Funnel card gets the same treatment for its viz types (Time to convert, Conversion trend), which are buried in an editor dropdown the same way trends displays are. Cheapest way to expose sub-insights while keeping hierarchy honest.

![variant-B](https://raw.githubusercontent.com/PostHog/pr-assets/e385d1943a5bd2c6344840daa5ac66bd238f11a5/2026/07/541bf791-2d9b-4b01-a82e-230c338324c7.png)

### Variant C · grouped by question

Sections phrased as user questions ("How does it change over time?", "What are the totals?"). Sub-insights become first-class cards inside their question group. Tallest layout — scrolls inside the dropdown.

![variant-C](https://raw.githubusercontent.com/PostHog/pr-assets/72663832d99f6be79a7b6a60273ec0b5bfc903b7/2026/07/5b87f2a1-7582-40eb-9b90-117d201e5bd0.png)

### Variant D · grid plus preset row

The baseline grid untouched, with an "Or start from a preset" row of opinionated starting points (Users by country, Top pages, Daily active users, Traffic by device). Reframes sub-insights as templates rather than types.

![variant-D](https://raw.githubusercontent.com/PostHog/pr-assets/96ad44016c8a911abc64ffb71e0bce588145fad1/2026/07/7ce5574a-4fce-430c-8d1c-e015b4ce3711.png)

### Variant E · two-step

Step one asks what you want to know; questions with a single answer (map, funnel, paths) link straight through, the rest open a second step of visualization cards.

![variant-E](https://raw.githubusercontent.com/PostHog/pr-assets/ffeaebdb257a29ab9034596f25b3410b7cb2c26d/2026/07/79d75cc9-3f23-4d6a-9d9d-659e94e6e9ab.png)

![variant-E-step2](https://raw.githubusercontent.com/PostHog/pr-assets/d3ecd4dbf42b06b51d65e5b28db025eaaad8a547/2026/07/c0140eab-950e-4d9a-ba0a-4bab462f0c80.png)

### Variant F · grouped by question, two columns

Same sections as C, airier: two columns split by a vertical divider (over time and totals left, behavior and build-your-own right), sentence-case headings with a one-line description each, and no scrolling. All cards are exactly the same size: a fixed two-line description slot with terse per-card copy, so rows align across sections and columns; section headers are a single title and description line for the same reason. The totals section's fourth card (world map) wraps to a second row.

![variant-F](https://raw.githubusercontent.com/PostHog/pr-assets/8f160909931def30097541ab9901dd4b6d698037/2026/07/4bab7fdf-f6ff-4442-8d5d-4e89a1a3d521.png)

## How did you test this code?

- `oxlint` and `oxfmt` clean on the changed files; `pnpm --filter=@posthog/frontend typescript:check` reports no errors in them (remaining errors are pre-existing stale kea typegen noise in unrelated products)
- Drove the live dev stack with a Playwright script (fresh `setup_test` workspace, in-page login, opened the dropdown on `/insights?variant=A..E`) and screenshotted every variant including E's second step — the screenshots above are those runs. This is how the E dropdown-dismiss bug was caught and fixed (`closeOnClickInside`)
- One Storybook story per variant for quick side-by-side without the app

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Prototype only — no docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by PostHog Code (Claude) from a request to prototype a more visual insight-type picker. Explored the existing pickers first (the `LemonMenu` submenu in `SavedInsights.tsx`, the `InsightQuickStart` scene, the dashboard add-insight modal) and chose inline SVG sketches in a popover over reusing the Cloudinary GIF previews, to keep the dropdown light and theme-aware. CI follow-up: the "Frontend bundle size" job failed on the toolbar graph byte ratchet; fixed by raising the budget constant, the remedy the check itself documents, after verifying no new toolbar → app edges were introduced.

Second pass came from a follow-up idea session about separating sub-insights (world map, data table) out of trends. Claude proposed a spectrum (preset links → derived virtual types → own `NodeKind` like the in-flight calendar heatmap) and four picker treatments, then the `/prototype` skill (UI branch) turned those into the five `?variant=` layouts on the existing route. Key decision: only "different question" displays (map, table, number, pie) became cards; the rendering-only trends family (line/area/bar/cumulative) intentionally stays inside trends. Presets deep-link via `urls.insightNew({ query })` — no new `InsightType` or schema changes. Verified by driving the live dev app with Playwright and reviewing screenshots of each variant. Skills invoked: `/prototype` (user skill), `/run-posthog`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
