### PR TITLE
fix(slack_app): tag the acting user on the PR-opened notification

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -206,11 +206,10 @@ def _post_pr_opened_notification_once(
     # ``latest_actor_slack_user_id``: this ping is asynchronous (it can fire long
     # after the PR opened, once the CI follow-up loop settles), so the last person to
     # touch the thread is often a casual joiner rather than the person who owns the work.
-    state = task_run.state or {}
-    mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
-    reply_target_slack_user_id = state.get("slack_actor_slack_user_id") or (
-        mapping.mentioning_slack_user_id if mapping else None
-    )
+    reply_target_slack_user_id = (task_run.state or {}).get("slack_actor_slack_user_id")
+    if not reply_target_slack_user_id:
+        mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
+        reply_target_slack_user_id = mapping.mentioning_slack_user_id if mapping else None
 
     handler.post_pr_opened(pr_url, task_url, reply_target_slack_user_id=reply_target_slack_user_id)
 

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -199,13 +199,18 @@ def _post_pr_opened_notification_once(
         handler.delete_progress()
         return
 
-    # Tag the person who started the task. This fires asynchronously (often long
-    # after the PR opened, once the CI follow-up loop settles), so tagging the
-    # latest actor would ping whoever last happened to touch the thread — a casual
-    # joiner — rather than the person who owns the work. Interactive replies still
-    # tag the current speaker; only these milestone pings key on the starter.
+    # Tag the user whose request drove this run, falling back to the original
+    # mentioner. ``slack_actor_slack_user_id`` is the resolved acting user — set at
+    # task creation and re-stamped on resume — so a run someone else picked up pings
+    # them, not the original creator. We deliberately do not consult the mapping's
+    # ``latest_actor_slack_user_id``: this ping is asynchronous (it can fire long
+    # after the PR opened, once the CI follow-up loop settles), so the last person to
+    # touch the thread is often a casual joiner rather than the person who owns the work.
+    state = task_run.state or {}
     mapping = SlackThreadTaskMapping.objects.filter(task_run=task_run).first()
-    reply_target_slack_user_id = mapping.mentioning_slack_user_id if mapping else None
+    reply_target_slack_user_id = state.get("slack_actor_slack_user_id") or (
+        mapping.mentioning_slack_user_id if mapping else None
+    )
 
     handler.post_pr_opened(pr_url, task_url, reply_target_slack_user_id=reply_target_slack_user_id)
 

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -193,10 +193,10 @@ class TestPostSlackUpdate(TestCase):
             state={},
         )
         mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
-        # This milestone ping tags the task starter, not whoever last touched the
-        # thread: latest_actor is a casual joiner here, and this update can fire long
-        # after the PR opened (once the CI follow-up loop settles), so tagging them
-        # would spam the wrong person.
+        # No resolved actor in run state, so the ping falls back to the original
+        # mentioner. The mapping's latest_actor is deliberately not consulted: this
+        # update can fire long after the PR opened (once the CI follow-up loop settles),
+        # so the last person to touch the thread is often a casual joiner.
         mock_mapping = MagicMock()
         mock_mapping.latest_actor_slack_user_id = "U123"
         mock_mapping.mentioning_slack_user_id = "U_ORIG"
@@ -221,6 +221,51 @@ class TestPostSlackUpdate(TestCase):
         mock_post_progress.assert_not_called()
         mock_run.task.mark_slack_pr_notified.assert_called_once_with("https://github.com/org/repo/pull/1")
         mock_run.save.assert_not_called()
+
+    @patch("products.slack_app.backend.models.SlackThreadTaskMapping")
+    @patch.object(SlackThreadHandler, "update_reaction")
+    @patch.object(SlackThreadHandler, "post_or_update_progress")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
+    @patch.object(SlackThreadHandler, "__init__", return_value=None)
+    @patch("products.tasks.backend.models.TaskRun")
+    def test_pr_notification_tags_resolved_run_actor_over_original_mentioner(
+        self,
+        mock_task_run_class,
+        mock_handler_init,
+        mock_post_pr_opened,
+        mock_post_progress,
+        mock_update_reaction,
+        mock_mapping_class,
+    ):
+        # A run picked up by someone other than the original mentioner (e.g. a resume)
+        # carries the resolved actor in run state. The PR-opened ping tags that actor,
+        # not the person who first mentioned the bot.
+        mock_run = self._make_mock_run(
+            mock_task_run_class.Status.IN_PROGRESS,
+            stage="Building",
+            output={"pr_url": "https://github.com/org/repo/pull/1"},
+            state={"slack_actor_slack_user_id": "U_RESUMER"},
+        )
+        mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
+        mock_mapping = MagicMock()
+        mock_mapping.mentioning_slack_user_id = "U_ORIG"
+        mock_mapping_class.objects.filter.return_value.first.return_value = mock_mapping
+
+        post_slack_update(
+            PostSlackUpdateInput(
+                run_id="run-1",
+                slack_thread_context={
+                    **self.slack_thread_context,
+                    "mentioning_slack_user_id": "U_ORIG",
+                },
+            )
+        )
+
+        mock_post_pr_opened.assert_called_once_with(
+            "https://github.com/org/repo/pull/1",
+            "http://localhost:8000/project/1/tasks/10?runId=run-1",
+            reply_target_slack_user_id="U_RESUMER",
+        )
 
     @parameterized.expand(
         [

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -171,14 +171,26 @@ class TestPostSlackUpdate(TestCase):
         # Task is still running (PR opened mid-run) — reaction stays :eyes:, not :hedgehog:.
         mock_update_reaction.assert_called_once_with("eyes")
 
+    @parameterized.expand(
+        [
+            # No resolved actor in run state: fall back to the original mentioner.
+            ("falls_back_to_mentioner", {}, "U_ORIG"),
+            # A run picked up by someone else (e.g. a resume) records the resolved actor
+            # in run state, so the ping tags them rather than the original mentioner.
+            ("prefers_resolved_run_actor", {"slack_actor_slack_user_id": "U_RESUMER"}, "U_RESUMER"),
+        ]
+    )
     @patch("products.slack_app.backend.models.SlackThreadTaskMapping")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "post_or_update_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_in_progress_with_pr_posts_notification_once(
+    def test_in_progress_with_pr_tags_actor_then_mentioner(
         self,
+        _name,
+        run_state,
+        expected_target,
         mock_task_run_class,
         mock_handler_init,
         mock_post_pr_opened,
@@ -190,15 +202,10 @@ class TestPostSlackUpdate(TestCase):
             mock_task_run_class.Status.IN_PROGRESS,
             stage="Building",
             output={"pr_url": "https://github.com/org/repo/pull/1"},
-            state={},
+            state=run_state,
         )
         mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
-        # No resolved actor in run state, so the ping falls back to the original
-        # mentioner. The mapping's latest_actor is deliberately not consulted: this
-        # update can fire long after the PR opened (once the CI follow-up loop settles),
-        # so the last person to touch the thread is often a casual joiner.
         mock_mapping = MagicMock()
-        mock_mapping.latest_actor_slack_user_id = "U123"
         mock_mapping.mentioning_slack_user_id = "U_ORIG"
         mock_mapping_class.objects.filter.return_value.first.return_value = mock_mapping
 
@@ -215,57 +222,12 @@ class TestPostSlackUpdate(TestCase):
         mock_post_pr_opened.assert_called_once_with(
             "https://github.com/org/repo/pull/1",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
-            reply_target_slack_user_id="U_ORIG",
+            reply_target_slack_user_id=expected_target,
         )
         mock_update_reaction.assert_called_once_with("eyes")
         mock_post_progress.assert_not_called()
         mock_run.task.mark_slack_pr_notified.assert_called_once_with("https://github.com/org/repo/pull/1")
         mock_run.save.assert_not_called()
-
-    @patch("products.slack_app.backend.models.SlackThreadTaskMapping")
-    @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "post_or_update_progress")
-    @patch.object(SlackThreadHandler, "post_pr_opened")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
-    @patch("products.tasks.backend.models.TaskRun")
-    def test_pr_notification_tags_resolved_run_actor_over_original_mentioner(
-        self,
-        mock_task_run_class,
-        mock_handler_init,
-        mock_post_pr_opened,
-        mock_post_progress,
-        mock_update_reaction,
-        mock_mapping_class,
-    ):
-        # A run picked up by someone other than the original mentioner (e.g. a resume)
-        # carries the resolved actor in run state. The PR-opened ping tags that actor,
-        # not the person who first mentioned the bot.
-        mock_run = self._make_mock_run(
-            mock_task_run_class.Status.IN_PROGRESS,
-            stage="Building",
-            output={"pr_url": "https://github.com/org/repo/pull/1"},
-            state={"slack_actor_slack_user_id": "U_RESUMER"},
-        )
-        mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
-        mock_mapping = MagicMock()
-        mock_mapping.mentioning_slack_user_id = "U_ORIG"
-        mock_mapping_class.objects.filter.return_value.first.return_value = mock_mapping
-
-        post_slack_update(
-            PostSlackUpdateInput(
-                run_id="run-1",
-                slack_thread_context={
-                    **self.slack_thread_context,
-                    "mentioning_slack_user_id": "U_ORIG",
-                },
-            )
-        )
-
-        mock_post_pr_opened.assert_called_once_with(
-            "https://github.com/org/repo/pull/1",
-            "http://localhost:8000/project/1/tasks/10?runId=run-1",
-            reply_target_slack_user_id="U_RESUMER",
-        )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

The "Pull request opened" Slack card always pinged the original mentioner. When someone else drives a run (e.g. a resume), the ping should go to the actual acting user, not the person who first tagged the bot.

## Changes

Tag the resolved acting user from run state (`slack_actor_slack_user_id`), falling back to the original mentioner. No change for the common case, where the two are the same.

## How did you test this code?

Automated only. `products/tasks/backend/tests/test_post_slack_update.py` (21 passed), including a new case covering the actor-over-mentioner precedence.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and implemented by Claude at Vojta's direction.
