### PR TITLE
fix(cymbal): load cached frame parts in part order

### DIFF
--- a/rust/cymbal/.sqlx/query-83e72043b76cb774ebeb80aa6af6bfc861f3d19907ae63684c32325bd020fcda.json
+++ b/rust/cymbal/.sqlx/query-83e72043b76cb774ebeb80aa6af6bfc861f3d19907ae63684c32325bd020fcda.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, team_id, issue_id, fingerprint, version FROM posthog_errortrackingissuefingerprintv2\n            WHERE team_id = $1 AND fingerprint = ANY($2)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "issue_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "fingerprint",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "83e72043b76cb774ebeb80aa6af6bfc861f3d19907ae63684c32325bd020fcda"
+}

--- a/rust/cymbal/.sqlx/query-c2d281f6087b92e7d6b80ba2b81b47679b741de172fef49419a11ac2d9c41e57.json
+++ b/rust/cymbal/.sqlx/query-c2d281f6087b92e7d6b80ba2b81b47679b741de172fef49419a11ac2d9c41e57.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT raw_id, part, team_id, created_at, symbol_set_id, contents, resolved, context\n            FROM posthog_errortrackingstackframe\n            WHERE raw_id = $1 AND team_id = $2\n            ",
+  "query": "\n            SELECT raw_id, part, team_id, created_at, symbol_set_id, contents, resolved, context\n            FROM posthog_errortrackingstackframe\n            WHERE raw_id = $1 AND team_id = $2\n            ORDER BY part\n            ",
   "describe": {
     "columns": [
       {
@@ -61,5 +61,5 @@
       true
     ]
   },
-  "hash": "9dd6426934b34c171fb4f7ccb1387cbfe01ade742540af78966deba9251dccce"
+  "hash": "c2d281f6087b92e7d6b80ba2b81b47679b741de172fef49419a11ac2d9c41e57"
 }

--- a/rust/cymbal/src/core/symbolication/symbol/records.rs
+++ b/rust/cymbal/src/core/symbolication/symbol/records.rs
@@ -156,6 +156,7 @@ impl ErrorTrackingStackFrame {
             SELECT raw_id, part, team_id, created_at, symbol_set_id, contents, resolved, context
             FROM posthog_errortrackingstackframe
             WHERE raw_id = $1 AND team_id = $2
+            ORDER BY part
             "#,
             id.hash_id,
             id.team_id
@@ -216,6 +217,57 @@ impl ErrorTrackingStackFrame {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn frame_with_part(id: FrameId, part: i32) -> Frame {
+        Frame {
+            frame_id: id,
+            mangled_name: format!("fn_{part}"),
+            line: None,
+            column: None,
+            source: None,
+            module: None,
+            in_app: true,
+            resolved_name: None,
+            lang: "go".to_string(),
+            resolved: true,
+            resolve_failure: None,
+            synthetic: false,
+            suspicious: false,
+            junk_drawer: None,
+            code_variables: None,
+            context: None,
+            release: None,
+        }
+    }
+
+    // Multi-part records are one raw frame's inline expansion — part order is
+    // stack order, so a cache hit must return the sequence the resolver saved,
+    // not storage order. The inserts are reversed and index scans disabled so
+    // a plain heap scan surfaces the unordered rows.
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn load_all_returns_parts_in_order(pool: sqlx::PgPool) {
+        for statement in ["SET enable_indexscan = off", "SET enable_bitmapscan = off"] {
+            sqlx::query(statement).execute(&pool).await.unwrap();
+        }
+
+        let raw_id = RawFrameId::new("raw-frame-id".to_string(), 0);
+        for part in (0..8).rev() {
+            let id = FrameId::new(raw_id.hash_id.clone(), raw_id.team_id, part);
+            let frame = frame_with_part(id.clone(), part);
+            ErrorTrackingStackFrame::new(id, None, frame, true, None)
+                .save(&pool)
+                .await
+                .unwrap();
+        }
+
+        let policy = FrameResultTtlPolicy::new(Duration::minutes(30), Duration::minutes(5));
+        let loaded = ErrorTrackingStackFrame::load_all(&pool, &raw_id, policy)
+            .await
+            .unwrap();
+
+        let parts: Vec<i32> = loaded.iter().map(|record| record.id.part).collect();
+        assert_eq!(parts, (0..8).collect::<Vec<i32>>());
+    }
 
     #[test]
     fn ttl_policy_applies_expected_ttl_with_deterministic_jitter() {


### PR DESCRIPTION
## Problem

Native symbolication can resolve one raw frame into several logical frames (an inline expansion). Those are stored as multi-part records in `posthog_errortrackingstackframe`, one row per part, and `part` order is the stack order.

`load_all` fetched them with no `ORDER BY`, so a cache hit returned the parts in whatever order Postgres produced. After a resolver restart (in-memory cache cold, PG cache warm), inline frames could come back reordered: the displayed stack is wrong, and the fingerprint computed over those frames changes, splitting the same crash into a new issue. Once the frame TTL expired and frames were recalculated, the fingerprint flipped back.

## Changes

- `ErrorTrackingStackFrame::load_all` now orders by `part`.
- Regenerated the sqlx offline cache for the changed query.

## How did you test this code?

Added `load_all_returns_parts_in_order`: saves 8 parts in reverse order with index scans disabled (so the heap scan surfaces storage order) and asserts the load comes back part-ordered. Verified it fails without the `ORDER BY` and passes with it. Ran the cymbal records tests plus `SQLX_OFFLINE=true cargo check -p cymbal --lib --tests` and `cargo clippy -p cymbal --all-targets -- -D warnings` locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal cache behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this from a tester report of fingerprints flipping after a resolver restart and flipping back after the frame TTL expired. I (Claude) confirmed the unordered load in `records.rs`, reproduced it in a test (which needed index scans disabled, since the unique index on `raw_id, team_id, part` can mask the bug by returning rows sorted), and verified the fix. The pre/post-symbol-upload fingerprint split from the same report is a separate name-vocabulary issue, addressed in a stacked PR.
