### PR TITLE
fix(cymbal): normalize go abi-wrapper suffixes in resolved frame names

### DIFF
--- a/rust/cymbal/src/core/types/langs/native.rs
+++ b/rust/cymbal/src/core/types/langs/native.rs
@@ -306,6 +306,24 @@ impl RawNativeFrame {
         self.meta.in_app && !source_path.is_some_and(is_library_source_path)
     }
 
+    /// Go's toolchain suffixes dual-ABI wrapper symbols in the debug info
+    /// (`runtime.goexit.abi0`), while the Go runtime — and therefore the
+    /// client's own frames — reports the plain name. Strip the suffix so kept
+    /// and replaced groups agree on the name vocabulary: resolved names feed
+    /// fingerprints, so a mismatch splits the same crash across issues when
+    /// symbols get uploaded.
+    fn display_name_for(&self, symbol_info: &SymbolInfo) -> String {
+        let name = &symbol_info.display_name;
+        if self.lang.as_deref() == Some("go") {
+            for suffix in [".abi0", ".abiinternal"] {
+                if let Some(stripped) = name.strip_suffix(suffix) {
+                    return stripped.to_string();
+                }
+            }
+        }
+        name.clone()
+    }
+
     fn build_resolved_frame(&self, symbol_info: &SymbolInfo) -> Frame {
         let mut f = Frame {
             frame_id: FrameId::placeholder(),
@@ -318,7 +336,7 @@ impl RawNativeFrame {
             column: None,
             source: symbol_info.filename.clone(),
             in_app: self.in_app_for(symbol_info.full_path.as_deref()),
-            resolved_name: Some(symbol_info.display_name.clone()),
+            resolved_name: Some(self.display_name_for(symbol_info)),
             lang: self.lang_for(symbol_info.filename.as_deref()),
             resolved: true,
             resolve_failure: None,
@@ -771,6 +789,52 @@ mod test {
     fn test_calculate_relative_addr_below_image_base() {
         let result = calculate_relative_addr(0x100, &image_at("test-uuid", 0x100000000));
         assert!(matches!(result, Err(NativeError::InvalidAddress(_))));
+    }
+
+    // Go frames drop the toolchain's ABI-wrapper suffix so server-resolved
+    // names match what the Go runtime (and so the client's kept frames)
+    // reports; other languages keep the symbol verbatim.
+    #[test]
+    fn go_resolved_names_drop_abi_wrapper_suffixes() {
+        let cases = [
+            (Some("go"), "runtime.goexit.abi0", "runtime.goexit"),
+            (Some("go"), "runtime.main.abiinternal", "runtime.main"),
+            (Some("go"), "main.main", "main.main"),
+            (Some("rust"), "alloc::alloc.abi0", "alloc::alloc.abi0"),
+            (None, "runtime.goexit.abi0", "runtime.goexit.abi0"),
+        ];
+
+        for (lang, symbol, expected) in cases {
+            let frame = RawNativeFrame {
+                instruction_addr: Some("0x1000".to_string()),
+                symbol_addr: None,
+                image_addr: Some("0x1000".to_string()),
+                lang: lang.map(String::from),
+                module: None,
+                function: None,
+                filename: None,
+                lineno: None,
+                colno: None,
+                client_resolved: true,
+                inline: false,
+                meta: CommonFrameMetadata::default(),
+            };
+            let symbol_info = SymbolInfo {
+                display_name: symbol.to_string(),
+                full_name: symbol.to_string(),
+                filename: None,
+                full_path: None,
+                line: 42,
+            };
+
+            let resolved = frame.build_resolved_frame(&symbol_info);
+            assert_eq!(
+                resolved.resolved_name.as_deref(),
+                Some(expected),
+                "lang={lang:?} symbol={symbol}"
+            );
+            assert_eq!(resolved.mangled_name, symbol, "full name stays verbatim");
+        }
     }
 
     #[test]

--- a/rust/cymbal/src/core/types/langs/native.rs
+++ b/rust/cymbal/src/core/types/langs/native.rs
@@ -312,12 +312,20 @@ impl RawNativeFrame {
     /// and replaced groups agree on the name vocabulary: resolved names feed
     /// fingerprints, so a mismatch splits the same crash across issues when
     /// symbols get uploaded.
+    ///
+    /// `abi0`/`abiinternal` are also valid Go identifiers (`pkg.abi0` can be
+    /// a real function), so the suffix is only dropped when the client
+    /// reported exactly the un-suffixed name for this frame — evidence it is
+    /// toolchain metadata rather than part of the name. Wrappers are physical
+    /// assembly functions, so the client name is present for them.
     fn display_name_for(&self, symbol_info: &SymbolInfo) -> String {
         let name = &symbol_info.display_name;
         if self.lang.as_deref() == Some("go") {
             for suffix in [".abi0", ".abiinternal"] {
                 if let Some(stripped) = name.strip_suffix(suffix) {
-                    return stripped.to_string();
+                    if self.function.as_deref() == Some(stripped) {
+                        return stripped.to_string();
+                    }
                 }
             }
         }
@@ -793,25 +801,57 @@ mod test {
 
     // Go frames drop the toolchain's ABI-wrapper suffix so server-resolved
     // names match what the Go runtime (and so the client's kept frames)
-    // reports; other languages keep the symbol verbatim.
+    // reports — but only when the client's own name confirms the suffix is
+    // toolchain metadata; `pkg.abi0` can be a real function. Other languages
+    // keep the symbol verbatim.
     #[test]
     fn go_resolved_names_drop_abi_wrapper_suffixes() {
         let cases = [
-            (Some("go"), "runtime.goexit.abi0", "runtime.goexit"),
-            (Some("go"), "runtime.main.abiinternal", "runtime.main"),
-            (Some("go"), "main.main", "main.main"),
-            (Some("rust"), "alloc::alloc.abi0", "alloc::alloc.abi0"),
-            (None, "runtime.goexit.abi0", "runtime.goexit.abi0"),
+            (
+                Some("go"),
+                Some("runtime.goexit"),
+                "runtime.goexit.abi0",
+                "runtime.goexit",
+            ),
+            (
+                Some("go"),
+                Some("runtime.main"),
+                "runtime.main.abiinternal",
+                "runtime.main",
+            ),
+            (Some("go"), Some("main.main"), "main.main", "main.main"),
+            // A genuine function named abi0: client and debug info agree, so
+            // nothing is stripped.
+            (Some("go"), Some("pkg.abi0"), "pkg.abi0", "pkg.abi0"),
+            // No client name means no evidence the suffix is a wrapper.
+            (
+                Some("go"),
+                None,
+                "runtime.goexit.abi0",
+                "runtime.goexit.abi0",
+            ),
+            (
+                Some("rust"),
+                Some("alloc::alloc"),
+                "alloc::alloc.abi0",
+                "alloc::alloc.abi0",
+            ),
+            (
+                None,
+                Some("runtime.goexit"),
+                "runtime.goexit.abi0",
+                "runtime.goexit.abi0",
+            ),
         ];
 
-        for (lang, symbol, expected) in cases {
+        for (lang, client_function, symbol, expected) in cases {
             let frame = RawNativeFrame {
                 instruction_addr: Some("0x1000".to_string()),
                 symbol_addr: None,
                 image_addr: Some("0x1000".to_string()),
                 lang: lang.map(String::from),
                 module: None,
-                function: None,
+                function: client_function.map(String::from),
                 filename: None,
                 lineno: None,
                 colno: None,


### PR DESCRIPTION
## Problem

The same Go crash fingerprints differently before and after debug symbols are uploaded. Fingerprint v2 already normalizes source paths to basenames, but function names are hashed verbatim, and Go's toolchain records dual-ABI wrapper symbols with a suffix in the debug info (`runtime.goexit.abi0`) while the Go runtime, and therefore the SDK's client-resolved frames, reports the plain name (`runtime.goexit`). The moment symbols become available, the resolved names change and the same crash lands on a new issue.

## Changes

When a native frame's SDK language hint is `go`, drop a trailing `.abi0`/`.abiinternal` from the resolved display name, but only when the client reported exactly the un-suffixed name for that frame. `abi0` and `abiinternal` are valid Go identifiers, so the client-name agreement is the evidence that the suffix is toolchain metadata rather than part of the function's name. ABI wrappers are physical assembly functions, so the client name is present for them. `mangled_name` keeps the full symbol verbatim.

Follows #72566 (deterministic part ordering for cached frames, now merged), the other backend cause of the same fingerprint instability report.

## How did you test this code?

Added a parameterized unit test covering: wrapper suffixes stripped when client and debug info agree, a genuine `pkg.abi0` function preserved, no stripping without a client name, and non-Go languages untouched. Ran the cymbal native and resolution suites locally (one unrelated sqlx test-db teardown flake when two suites overlap, passes alone) plus `cargo clippy -p cymbal --all-targets -- -D warnings`.

End-to-end verification of before/after-upload issue identity on a real Go binary is planned separately; server expansion can also legitimately change frame depth, which no name normalization covers.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal resolution behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this from the same tester report as #72566 (Go fingerprints splitting when symbols get uploaded). I (Claude) traced the split to the v2 fingerprint hashing resolved names verbatim while Go's DWARF and runtime disagree on wrapper symbol spelling. First version stripped the suffix unconditionally; review flagged that `abi0` is a legal identifier, so the strip now requires the client-reported name to match the stripped spelling.

