### PR TITLE
fix(ci): give toolbar graph ratchet headroom for churn

### DIFF
--- a/frontend/bin/check-toolbar-graph.mjs
+++ b/frontend/bin/check-toolbar-graph.mjs
@@ -38,10 +38,14 @@ const FORBIDDEN_PACKAGES = [
     'node_modules/hls.js/',
 ]
 
-// Ratchet policy: when an edge is cut, lower the budget to lock it in; raise it only as a
-// conscious, reviewed decision in the PR that needs it. There is headroom for churn, but any
-// reintroduced leak jumps the graph back toward ~100 MiB and fails loudly.
-const TOTAL_INPUT_BYTES_BUDGET = 14_436_000
+// Ratchet policy: this is the COARSE backstop. The precise boundary enforcement is the
+// crossing-edges baseline above — that is what fails a real leak (which jumps the graph back
+// toward ~100 MiB). This total only needs to sit far enough below that to catch a leak while
+// leaving headroom for ordinary churn: adding a couple of lines to a broadly-imported file like
+// ~/types must not trip it. Keep a few hundred KB of slack; raise it as a conscious, reviewed
+// decision when genuine toolbar-owned growth eats the slack, and never pin it to the exact
+// current size (that turns the backstop into a hair-trigger on unrelated PRs).
+const TOTAL_INPUT_BYTES_BUDGET = 14_600_000
 
 function fail(message) {
     console.error(`\n❌ ${message}`)


### PR DESCRIPTION
## Problem

The `check-toolbar-graph` step (source-input reachability guard) fails on PRs that don't actually grow the toolbar bundle, e.g. [#69730](https://github.com/PostHog/posthog/pull/69730) and [#69742](https://github.com/PostHog/posthog/pull/69742). Master passes at *exactly* the budget (`🟢 978 files, 13.77 MiB source input (budget 13.77 MiB)`), so it has zero headroom. Any PR that touches a broadly-imported file the toolbar transitively reaches — #69730 adds ~2 lines to `~/types` — tips the total a few bytes over and fails. It's a hair-trigger, not a real leak: crossing edges stay at 5 (baseline 5).

Worth separating two different checks here, since they get conflated:
- `check-toolbar-**graph**` (this one) measures *pre-build source-input bytes* reachable from the toolbar entry. It's a coarse creep/reachability ratchet, not a measure of what ships.
- `check-toolbar-**size**` measures the actual shipped bundle against the CloudFront gzip limit. That one is green: eager JS 1.55 MB, deferred 2.18 MB, every file well under the 10 MB per-file limit. We are not serving anywhere near that source-graph figure.

## Changes

Raise `TOTAL_INPUT_BYTES_BUDGET` from `14_436_000` to `14_600_000` (~160 KB / ~1.1% slack) and rewrite the ratchet-policy comment: this total is the *coarse* backstop, the crossing-edges baseline is the precise boundary enforcement, and the total should never be pinned to the exact current size.

```diff
-const TOTAL_INPUT_BYTES_BUDGET = 14_436_000
+const TOTAL_INPUT_BYTES_BUDGET = 14_600_000
```

## How did you test this code?

Traced the failure from the failing job on #69730 and the passing master run:
- master run: `🟢 978 files, 13.77 MiB (budget 13.77 MiB)` — zero headroom
- #69730 run: same 978 files / 13.77 MiB, over budget by a few bytes; only toolbar-reachable change is ~2 lines added to `~/types`

I did not run a local toolbar build (no `node_modules` in this environment); CI on this PR exercises the check.

## Docs update

skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a [Slack thread](https://posthog.slack.com/archives/C0AEM55RJ77/p1784637465678759?thread_ts=1784637465.678759&cid=C0AEM55RJ77): a couple of PRs were failing the toolbar graph check and an earlier one-liner raised the *size* budget, which is a different check. I (PostHog Slack app / Claude) traced it to the graph ratchet having been ratcheted down to master's exact size, leaving no room for ordinary churn. Considered decoupling the access-control util the failing PR added, but that util isn't reachable from the toolbar entry (crossing edges unchanged), so it wasn't the cause. The fix is to restore modest headroom to the coarse backstop while keeping the precise crossing-edges guard strict.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AEM55RJ77/p1784637465678759?thread_ts=1784637465.678759&cid=C0AEM55RJ77)*