### PR TITLE
chore(ci): remove GitHub merge queue support

### DIFF
--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -53,11 +53,8 @@ GitHub caps _workflow-run dispatch_ at 500 runs per 10s per repo; overflow fails
       paths:
         - '.github/workflows/ci-x.yml'
         - 'path/to/product/**'
-    merge_group:
     workflow_dispatch:
   ```
-
-  `merge_group:` currently no-ops — no merge queue is enabled right now — but it's harmless and forward-compatible, so keep it on merge-gate workflows for when a queue returns.
 
 - **Judgment call — trigger `paths:` vs a runtime `dorny/paths-filter` job.**
   Use trigger `paths:` for a workflow that is _skippable as a whole_.

--- a/.agents/skills/gating-production-deploys/SKILL.md
+++ b/.agents/skills/gating-production-deploys/SKILL.md
@@ -24,7 +24,7 @@ publishes/deploys from the wrong place.
 
 - Release/distribution workflows — GitHub release, npm, crate, Homebrew (e.g.
   `build-phrocs.yml`, `release-cli.yml`). They publish from public; leave them.
-- `pull_request` / `merge_group` validation builds (gating them breaks contributor CI).
+- `pull_request` validation builds (gating them breaks contributor CI).
 - change-detection / setup jobs (use the org check only, not the variable).
 
 The test is "pushes a prod image or triggers a deploy" — not "builds on master".
@@ -53,7 +53,7 @@ if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && 
 # push step, master-only:
 push: ${{ github.ref == 'refs/heads/master' && vars.CD_DEPLOY_ENABLED == 'true' }}
 # push step, `push: true` (also pushes on PR for validation):
-push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
+push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
 
 # reusable that pushes — add a `push` boolean input (default true), pass from caller:
 #   with: { push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }} }

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -55,7 +55,7 @@
 #   .depot/workflows/ci-backend-update-test-timing.yml, so shard counts match GitHub Actions.
 #   Committed .test_durations is the fallback.
 # - master (push) runs only check-migrations to prime the shared schema cache; the
-#   test matrices are skipped on master (canonical runs them). PRs/merge_group/dispatch
+#   test matrices are skipped on master (canonical runs them). PRs and dispatches
 #   run the full graph — that is where the apples-to-apples comparison happens
 # - check-migrations timeout widened to 60m because it also runs the folded OpenAPI generation
 
@@ -69,7 +69,7 @@ name: '[optional, does not block merge] Backend CI'
 # CI_DEPOT_SHADOW_PERCENT Depot CI variable (0-100; 0 or unset = fully off) is both the
 # master switch and the pull_request sample rate: when >0, pull_request runs are sampled at
 # that percent; master (push) runs only check-migrations to prime the schema cache (test
-# matrices are skipped there); workflow_dispatch and merge_group always run. The `sample` job rolls a deterministic
+# matrices are skipped there); workflow_dispatch always runs. The `sample` job rolls a deterministic
 # per-run dice; `changes` (root of the needs graph) only runs when sampled in, so the
 # whole workflow cascades off on a miss. This is a Depot variable, NOT a GitHub one —
 # Depot CI reads its own `vars` store. Set it with:
@@ -92,7 +92,6 @@ on:
         # `run-ci-backend` label (labeled/unlabeled re-trigger) to force the full
         # matrices on a draft. Mirrors canonical.
         types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    merge_group:
 concurrency:
     # PRs: one active run per branch, cancel stale. Push: per-SHA so master
     # pushes never cancel each other (check-migrations always completes).
@@ -164,7 +163,7 @@ jobs:
                   EVENT: ${{ github.event_name }}
               run: |
                   set -euo pipefail
-                  # Only pull_request is sampled; push/workflow_dispatch/merge_group always run
+                  # Only pull_request is sampled; push and workflow_dispatch always run
                   # when enabled (sampling them would skip cache priming or no-op a dispatch).
                   if [ "$EVENT" != "pull_request" ]; then
                       echo "sampled=true" >> "$GITHUB_OUTPUT"
@@ -545,8 +544,8 @@ jobs:
     select-tests:
         name: Select tests
         needs: [changes, turbo-discover]
-        # Only draft PRs do selective runs; ready PRs and non-PR events (push,
-        # merge_group) always run full, which build_django_matrix falls back to
+        # Only draft PRs do selective runs; ready PRs and pushes always run full,
+        # which build_django_matrix falls back to
         # when select-tests is skipped (empty MODE). The run-ci-backend label
         # forces the full matrices on a draft.
         if: |

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -1,6 +1,808 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ 5868:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ChangeStatus = void 0;
+var ChangeStatus;
+(function (ChangeStatus) {
+    ChangeStatus["Added"] = "added";
+    ChangeStatus["Copied"] = "copied";
+    ChangeStatus["Deleted"] = "deleted";
+    ChangeStatus["Modified"] = "modified";
+    ChangeStatus["Renamed"] = "renamed";
+    ChangeStatus["Unmerged"] = "unmerged";
+})(ChangeStatus || (exports.ChangeStatus = ChangeStatus = {}));
+
+
+/***/ }),
+
+/***/ 8504:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Filter = void 0;
+const jsyaml = __importStar(__nccwpck_require__(4281));
+const picomatch_1 = __importDefault(__nccwpck_require__(4006));
+// Minimatch options used in all matchers
+const MatchOptions = {
+    dot: true
+};
+// picomatch.scan tells a real negation ('!foo/**') from an extglob group ('!(a|b)'),
+// so we let the matching library own that rule rather than re-deriving it by hand.
+function isNegatedPattern(pattern) {
+    return picomatch_1.default.scan(pattern).negated;
+}
+function positivePattern(pattern) {
+    return isNegatedPattern(pattern) ? pattern.slice(1) : pattern;
+}
+class Filter {
+    // Creates instance of Filter and load rules from YAML if it's provided
+    constructor(yaml) {
+        this.rules = {};
+        if (yaml) {
+            this.load(yaml);
+        }
+    }
+    // Load rules from YAML string
+    load(yaml) {
+        if (!yaml) {
+            return;
+        }
+        const doc = jsyaml.load(yaml);
+        if (typeof doc !== 'object') {
+            this.throwInvalidFormatError('Root element is not an object');
+        }
+        for (const [key, item] of Object.entries(doc)) {
+            this.rules[key] = this.parseFilterItemYaml(item);
+        }
+    }
+    match(files) {
+        const result = {};
+        for (const [key, patterns] of Object.entries(this.rules)) {
+            const includes = patterns.filter(rule => !rule.negated);
+            const excludes = patterns.filter(rule => rule.negated);
+            result[key] = files.filter(file => this.isMatch(file, includes, excludes));
+        }
+        return result;
+    }
+    // Positive patterns are includes, OR-ed together; every '!' pattern is an exclude
+    // that vetoes a match. A file matches when it hits at least one include (or there
+    // are no includes) and hits no exclude.
+    isMatch(file, includes, excludes) {
+        const matches = (rule) => (rule.status === undefined || rule.status.includes(file.status)) && rule.isMatch(file.filename);
+        const included = includes.length === 0 || includes.some(matches);
+        return included && !excludes.some(matches);
+    }
+    parseFilterItemYaml(item) {
+        if (Array.isArray(item)) {
+            return item.map(i => this.parseFilterItemYaml(i)).flat();
+        }
+        if (typeof item === 'string') {
+            return [
+                { status: undefined, negated: isNegatedPattern(item), isMatch: (0, picomatch_1.default)(positivePattern(item), MatchOptions) }
+            ];
+        }
+        if (typeof item === 'object') {
+            return Object.entries(item).map(([key, pattern]) => {
+                if (typeof key !== 'string' || (typeof pattern !== 'string' && !Array.isArray(pattern))) {
+                    this.throwInvalidFormatError(`Expected [key:string]= pattern:string | string[], but [${key}:${typeof key}]= ${pattern}:${typeof pattern} found`);
+                }
+                // A '!' pattern only becomes an exclude when it's a top-level filter entry (the
+                // string branch above). Inside this array form it would silently fall through to
+                // picomatch's raw array-negation semantics instead — matching nearly every file
+                // rather than excluding one — so reject it instead of matching the wrong thing.
+                if (Array.isArray(pattern) && pattern.some(p => isNegatedPattern(p))) {
+                    this.throwInvalidFormatError(`'!' patterns are not supported inside a change-status array (key '${key}') — write them as separate top-level filter entries instead`);
+                }
+                const negated = typeof pattern === 'string' && isNegatedPattern(pattern);
+                return {
+                    status: key
+                        .split('|')
+                        .map(x => x.trim())
+                        .filter(x => x.length > 0)
+                        .map(x => x.toLowerCase()),
+                    negated,
+                    isMatch: (0, picomatch_1.default)(negated ? positivePattern(pattern) : pattern, MatchOptions)
+                };
+            });
+        }
+        this.throwInvalidFormatError(`Unexpected element type '${typeof item}'`);
+    }
+    throwInvalidFormatError(message) {
+        throw new Error(`Invalid filter YAML format: ${message}.`);
+    }
+}
+exports.Filter = Filter;
+
+
+/***/ }),
+
+/***/ 9412:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.HEAD = exports.NULL_SHA = void 0;
+exports.getChangesInLastCommit = getChangesInLastCommit;
+exports.getChanges = getChanges;
+exports.getChangesOnHead = getChangesOnHead;
+exports.getChangesSinceMergeBase = getChangesSinceMergeBase;
+exports.parseGitDiffOutput = parseGitDiffOutput;
+exports.listAllFilesAsAdded = listAllFilesAsAdded;
+exports.getCurrentRef = getCurrentRef;
+exports.getShortName = getShortName;
+exports.isGitSha = isGitSha;
+const exec_1 = __nccwpck_require__(5236);
+const core = __importStar(__nccwpck_require__(7484));
+const file_1 = __nccwpck_require__(5868);
+exports.NULL_SHA = '0000000000000000000000000000000000000000';
+exports.HEAD = 'HEAD';
+async function getChangesInLastCommit() {
+    core.startGroup(`Change detection in last commit`);
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['log', '--format=', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+async function getChanges(base, head) {
+    const baseRef = await ensureRefAvailable(base);
+    const headRef = await ensureRefAvailable(head);
+    // Get differences between ref and HEAD
+    core.startGroup(`Change detection ${base}..${head}`);
+    let output = '';
+    try {
+        // Two dots '..' change detection - directly compares two versions
+        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', `${baseRef}..${headRef}`]))
+            .stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+async function getChangesOnHead() {
+    // Get current changes - both staged and unstaged
+    core.startGroup(`Change detection on HEAD`);
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', 'HEAD'])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+async function getChangesSinceMergeBase(base, head, initialFetchDepth) {
+    let baseRef;
+    let headRef;
+    async function hasMergeBase() {
+        if (baseRef === undefined || headRef === undefined) {
+            return false;
+        }
+        return (await (0, exec_1.getExecOutput)('git', ['merge-base', baseRef, headRef], { ignoreReturnCode: true })).exitCode === 0;
+    }
+    let noMergeBase = false;
+    core.startGroup(`Searching for merge-base ${base}...${head}`);
+    try {
+        baseRef = await getLocalRef(base);
+        headRef = await getLocalRef(head);
+        if (!(await hasMergeBase())) {
+            await (0, exec_1.getExecOutput)('git', ['fetch', '--no-tags', `--depth=${initialFetchDepth}`, 'origin', base, head]);
+            if (baseRef === undefined || headRef === undefined) {
+                baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
+                headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
+                if (baseRef === undefined || headRef === undefined) {
+                    await (0, exec_1.getExecOutput)('git', ['fetch', '--tags', '--depth=1', 'origin', base, head], {
+                        ignoreReturnCode: true // returns exit code 1 if tags on remote were updated - we can safely ignore it
+                    });
+                    baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
+                    headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
+                    if (baseRef === undefined) {
+                        throw new Error(`Could not determine what is ${base} - fetch works but it's not a branch, tag or commit SHA`);
+                    }
+                    if (headRef === undefined) {
+                        throw new Error(`Could not determine what is ${head} - fetch works but it's not a branch, tag or commit SHA`);
+                    }
+                }
+            }
+            let depth = initialFetchDepth;
+            let lastCommitCount = await getCommitCount();
+            while (!(await hasMergeBase())) {
+                depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER);
+                await (0, exec_1.getExecOutput)('git', ['fetch', `--deepen=${depth}`, 'origin', base, head]);
+                const commitCount = await getCommitCount();
+                if (commitCount === lastCommitCount) {
+                    core.info('No more commits were fetched');
+                    core.info('Last attempt will be to fetch full history');
+                    await (0, exec_1.getExecOutput)('git', ['fetch']);
+                    if (!(await hasMergeBase())) {
+                        noMergeBase = true;
+                    }
+                    break;
+                }
+                lastCommitCount = commitCount;
+            }
+        }
+    }
+    finally {
+        core.endGroup();
+    }
+    // Three dots '...' change detection - finds merge-base and compares against it
+    let diffArg = `${baseRef}...${headRef}`;
+    if (noMergeBase) {
+        core.warning('No merge base found - change detection will use direct <commit>..<commit> comparison');
+        diffArg = `${baseRef}..${headRef}`;
+    }
+    // Get changes introduced on ref compared to base
+    core.startGroup(`Change detection ${diffArg}`);
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', diffArg])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+function parseGitDiffOutput(output) {
+    const tokens = output.split('\u0000').filter(s => s.length > 0);
+    const files = [];
+    for (let i = 0; i + 1 < tokens.length; i += 2) {
+        files.push({
+            status: statusMap[tokens[i]],
+            filename: tokens[i + 1]
+        });
+    }
+    return files;
+}
+async function listAllFilesAsAdded() {
+    core.startGroup('Listing all files tracked by git');
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['ls-files', '-z'])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return output
+        .split('\u0000')
+        .filter(s => s.length > 0)
+        .map(path => ({
+        status: file_1.ChangeStatus.Added,
+        filename: path
+    }));
+}
+async function getCurrentRef() {
+    core.startGroup(`Get current git ref`);
+    try {
+        const branch = (await (0, exec_1.getExecOutput)('git', ['branch', '--show-current'])).stdout.trim();
+        if (branch) {
+            return branch;
+        }
+        const describe = await (0, exec_1.getExecOutput)('git', ['describe', '--tags', '--exact-match'], { ignoreReturnCode: true });
+        if (describe.exitCode === 0) {
+            return describe.stdout.trim();
+        }
+        return (await (0, exec_1.getExecOutput)('git', ['rev-parse', exports.HEAD])).stdout.trim();
+    }
+    finally {
+        core.endGroup();
+    }
+}
+function getShortName(ref) {
+    if (!ref)
+        return '';
+    const heads = 'refs/heads/';
+    const tags = 'refs/tags/';
+    if (ref.startsWith(heads))
+        return ref.slice(heads.length);
+    if (ref.startsWith(tags))
+        return ref.slice(tags.length);
+    return ref;
+}
+function isGitSha(ref) {
+    return /^[a-z0-9]{40}$/.test(ref);
+}
+async function hasCommit(ref) {
+    return (await (0, exec_1.getExecOutput)('git', ['cat-file', '-e', `${ref}^{commit}`], { ignoreReturnCode: true })).exitCode === 0;
+}
+async function getCommitCount() {
+    const output = (await (0, exec_1.getExecOutput)('git', ['rev-list', '--count', '--all'])).stdout;
+    const count = parseInt(output);
+    return isNaN(count) ? 0 : count;
+}
+async function getLocalRef(shortName) {
+    if (isGitSha(shortName)) {
+        return (await hasCommit(shortName)) ? shortName : undefined;
+    }
+    const output = (await (0, exec_1.getExecOutput)('git', ['show-ref', shortName], { ignoreReturnCode: true })).stdout;
+    const refs = output
+        .split(/\r?\n/g)
+        .map(l => l.match(/refs\/(?:(?:heads)|(?:tags)|(?:remotes\/origin))\/(.*)$/))
+        .filter(match => match !== null && match[1] === shortName)
+        .map(match => { var _a; return (_a = match === null || match === void 0 ? void 0 : match[0]) !== null && _a !== void 0 ? _a : ''; }); // match can't be null here but compiler doesn't understand that
+    if (refs.length === 0) {
+        return undefined;
+    }
+    const remoteRef = refs.find(ref => ref.startsWith('refs/remotes/origin/'));
+    if (remoteRef) {
+        return remoteRef;
+    }
+    return refs[0];
+}
+async function ensureRefAvailable(name) {
+    core.startGroup(`Ensuring ${name} is fetched from origin`);
+    try {
+        let ref = await getLocalRef(name);
+        if (ref === undefined) {
+            await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--no-tags', 'origin', name]);
+            ref = await getLocalRef(name);
+            if (ref === undefined) {
+                await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--tags', 'origin', name]);
+                ref = await getLocalRef(name);
+                if (ref === undefined) {
+                    throw new Error(`Could not determine what is ${name} - fetch works but it's not a branch, tag or commit SHA`);
+                }
+            }
+        }
+        return ref;
+    }
+    finally {
+        core.endGroup();
+    }
+}
+function fixStdOutNullTermination() {
+    // Previous command uses NULL as delimiters and output is printed to stdout.
+    // We have to make sure next thing written to stdout will start on new line.
+    // Otherwise things like ::set-output wouldn't work.
+    core.info('');
+}
+const statusMap = {
+    A: file_1.ChangeStatus.Added,
+    C: file_1.ChangeStatus.Copied,
+    D: file_1.ChangeStatus.Deleted,
+    M: file_1.ChangeStatus.Modified,
+    R: file_1.ChangeStatus.Renamed,
+    U: file_1.ChangeStatus.Unmerged
+};
+
+
+/***/ }),
+
+/***/ 9835:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.csvEscape = csvEscape;
+// Returns filename escaped for CSV
+// Wraps file name into "..." only when it contains some potentially unsafe character
+function csvEscape(value) {
+    if (value === '')
+        return value;
+    // Only safe characters
+    if (/^[a-zA-Z0-9._+:@%/-]+$/m.test(value)) {
+        return value;
+    }
+    // https://tools.ietf.org/html/rfc4180
+    // If double-quotes are used to enclose fields, then a double-quote
+    // appearing inside a field must be escaped by preceding it with
+    // another double quote
+    return `"${value.replace(/"/g, '""')}"`;
+}
+
+
+/***/ }),
+
+/***/ 9797:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.backslashEscape = backslashEscape;
+exports.shellEscape = shellEscape;
+// Backslash escape every character except small subset of definitely safe characters
+function backslashEscape(value) {
+    return value.replace(/([^a-zA-Z0-9,._+:@%/-])/gm, '\\$1');
+}
+// Returns filename escaped for usage as shell argument.
+// Applies "human readable" approach with as few escaping applied as possible
+function shellEscape(value) {
+    if (value === '')
+        return value;
+    // Only safe characters
+    if (/^[a-zA-Z0-9,._+:@%/-]+$/m.test(value)) {
+        return value;
+    }
+    if (value.includes("'")) {
+        // Only safe characters, single quotes and white-spaces
+        if (/^[a-zA-Z0-9,._+:@%/'\s-]+$/m.test(value)) {
+            return `"${value}"`;
+        }
+        // Split by single quote and apply escaping recursively
+        return value.split("'").map(shellEscape).join("\\'");
+    }
+    // Contains some unsafe characters but no single quote
+    return `'${value}'`;
+}
+
+
+/***/ }),
+
+/***/ 5915:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const fs = __importStar(__nccwpck_require__(9896));
+const core = __importStar(__nccwpck_require__(7484));
+const github = __importStar(__nccwpck_require__(3228));
+const filter_1 = __nccwpck_require__(8504);
+const file_1 = __nccwpck_require__(5868);
+const git = __importStar(__nccwpck_require__(9412));
+const shell_escape_1 = __nccwpck_require__(9797);
+const csv_escape_1 = __nccwpck_require__(9835);
+async function run() {
+    try {
+        const workingDirectory = core.getInput('working-directory', { required: false });
+        if (workingDirectory) {
+            process.chdir(workingDirectory);
+        }
+        const token = core.getInput('token', { required: false });
+        const ref = core.getInput('ref', { required: false });
+        const base = core.getInput('base', { required: false });
+        const filtersInput = core.getInput('filters', { required: true });
+        const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput;
+        const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none';
+        const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', { required: false })) || 10;
+        if (!isExportFormat(listFiles)) {
+            core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`);
+            return;
+        }
+        const filter = new filter_1.Filter(filtersYaml);
+        const files = await getChangedFiles(token, base, ref, initialFetchDepth);
+        core.info(`Detected ${files.length} changed files`);
+        const results = filter.match(files);
+        exportResults(results, listFiles);
+    }
+    catch (error) {
+        core.setFailed(getErrorMessage(error));
+    }
+}
+function isPathInput(text) {
+    return !(text.includes('\n') || text.includes(':'));
+}
+function getConfigFileContent(configPath) {
+    if (!fs.existsSync(configPath)) {
+        throw new Error(`Configuration file '${configPath}' not found`);
+    }
+    if (!fs.lstatSync(configPath).isFile()) {
+        throw new Error(`'${configPath}' is not a file.`);
+    }
+    return fs.readFileSync(configPath, { encoding: 'utf8' });
+}
+async function getChangedFiles(token, base, ref, initialFetchDepth) {
+    var _a, _b;
+    // if base is 'HEAD' only local uncommitted changes will be detected
+    // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
+    if (base === git.HEAD) {
+        if (ref) {
+            core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
+        }
+        return await git.getChangesOnHead();
+    }
+    switch (github.context.eventName) {
+        // To keep backward compatibility, commits in GitHub pull request event
+        // take precedence over manual inputs.
+        case 'pull_request':
+        case 'pull_request_review':
+        case 'pull_request_review_comment':
+        case 'pull_request_target': {
+            if (ref) {
+                core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
+            }
+            if (base) {
+                core.warning(`'base' input parameter is ignored when action is triggered by pull request event`);
+            }
+            const pr = github.context.payload.pull_request;
+            if (token) {
+                return await getChangedFilesFromApi(token, pr);
+            }
+            if (github.context.eventName === 'pull_request_target') {
+                // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
+                // Therefore it's not possible to look at changes in last commit
+                // At the same time we don't want to fetch any code from forked repository
+                throw new Error(`'token' input parameter is required if action is triggered by 'pull_request_target' event`);
+            }
+            core.info('Github token is not available - changes will be detected using git diff');
+            const baseSha = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.base.sha;
+            const defaultBranch = (_b = github.context.payload.repository) === null || _b === void 0 ? void 0 : _b.default_branch;
+            const currentRef = await git.getCurrentRef();
+            return await git.getChanges(base || baseSha || defaultBranch, currentRef);
+        }
+    }
+    return getChangedFilesFromGit(base, ref, initialFetchDepth);
+}
+async function getChangedFilesFromGit(base, head, initialFetchDepth) {
+    var _a;
+    const defaultBranch = (_a = github.context.payload.repository) === null || _a === void 0 ? void 0 : _a.default_branch;
+    const beforeSha = github.context.eventName === 'push' ? github.context.payload.before : null;
+    const currentRef = await git.getCurrentRef();
+    head = git.getShortName(head || github.context.ref || currentRef);
+    base = git.getShortName(base || defaultBranch);
+    if (!head) {
+        throw new Error("This action requires 'head' input to be configured, 'ref' to be set in the event payload or branch/tag checked out in current git repository");
+    }
+    if (!base) {
+        throw new Error("This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload");
+    }
+    const isBaseSha = git.isGitSha(base);
+    const isBaseSameAsHead = base === head;
+    // If base is commit SHA we will do comparison against the referenced commit
+    // Or if base references same branch it was pushed to, we will do comparison against the previously pushed commit
+    if (isBaseSha || isBaseSameAsHead) {
+        const baseSha = isBaseSha ? base : beforeSha;
+        if (!baseSha) {
+            core.warning(`'before' field is missing in event payload - changes will be detected from last commit`);
+            if (head !== currentRef) {
+                core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
+            }
+            return await git.getChangesInLastCommit();
+        }
+        // If there is no previously pushed commit,
+        // we will do comparison against the default branch or return all as added
+        if (baseSha === git.NULL_SHA) {
+            if (defaultBranch && base !== defaultBranch) {
+                core.info(`First push of a branch detected - changes will be detected against the default branch ${defaultBranch}`);
+                return await git.getChangesSinceMergeBase(defaultBranch, head, initialFetchDepth);
+            }
+            else {
+                core.info('Initial push detected - all files will be listed as added');
+                if (head !== currentRef) {
+                    core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
+                }
+                return await git.listAllFilesAsAdded();
+            }
+        }
+        core.info(`Changes will be detected between ${baseSha} and ${head}`);
+        return await git.getChanges(baseSha, head);
+    }
+    core.info(`Changes will be detected between ${base} and ${head}`);
+    return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
+}
+// Uses github REST api to get list of files changed in PR
+async function getChangedFilesFromApi(token, pullRequest) {
+    core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
+    try {
+        const client = github.getOctokit(token);
+        const per_page = 100;
+        const files = [];
+        core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
+        for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            pull_number: pullRequest.number,
+            per_page
+        }))) {
+            if (response.status !== 200) {
+                throw new Error(`Fetching list of changed files from GitHub API failed with error code ${response.status}`);
+            }
+            core.info(`Received ${response.data.length} items`);
+            for (const row of response.data) {
+                core.info(`[${row.status}] ${row.filename}`);
+                // There's no obvious use-case for detection of renames
+                // Therefore we treat it as if rename detection in git diff was turned off.
+                // Rename is replaced by delete of original filename and add of new filename
+                if (row.status === file_1.ChangeStatus.Renamed) {
+                    files.push({
+                        filename: row.filename,
+                        status: file_1.ChangeStatus.Added
+                    });
+                    files.push({
+                        // 'previous_filename' for some unknown reason isn't in the type definition or documentation
+                        filename: row.previous_filename,
+                        status: file_1.ChangeStatus.Deleted
+                    });
+                }
+                else {
+                    // Github status and git status variants are same except for deleted files
+                    const status = row.status === 'removed' ? file_1.ChangeStatus.Deleted : row.status;
+                    files.push({
+                        filename: row.filename,
+                        status
+                    });
+                }
+            }
+        }
+        return files;
+    }
+    finally {
+        core.endGroup();
+    }
+}
+function exportResults(results, format) {
+    core.info('Results:');
+    const changes = [];
+    for (const [key, files] of Object.entries(results)) {
+        const value = files.length > 0;
+        core.startGroup(`Filter ${key} = ${value}`);
+        if (files.length > 0) {
+            changes.push(key);
+            core.info('Matching files:');
+            for (const file of files) {
+                core.info(`${file.filename} [${file.status}]`);
+            }
+        }
+        else {
+            core.info('Matching files: none');
+        }
+        core.setOutput(key, value);
+        core.setOutput(`${key}_count`, files.length);
+        if (format !== 'none') {
+            const filesValue = serializeExport(files, format);
+            core.setOutput(`${key}_files`, filesValue);
+        }
+        core.endGroup();
+    }
+    if (results['changes'] === undefined) {
+        const changesJson = JSON.stringify(changes);
+        core.info(`Changes output set to ${changesJson}`);
+        core.setOutput('changes', changesJson);
+    }
+    else {
+        core.info('Cannot set changes output variable - name already used by filter output');
+    }
+}
+function serializeExport(files, format) {
+    const fileNames = files.map(file => file.filename);
+    switch (format) {
+        case 'csv':
+            return fileNames.map(csv_escape_1.csvEscape).join(',');
+        case 'json':
+            return JSON.stringify(fileNames);
+        case 'escape':
+            return fileNames.map(shell_escape_1.backslashEscape).join(' ');
+        case 'shell':
+            return fileNames.map(shell_escape_1.shellEscape).join(' ');
+        default:
+            return '';
+    }
+}
+function isExportFormat(value) {
+    return ['none', 'csv', 'shell', 'json', 'escape'].includes(value);
+}
+function getErrorMessage(error) {
+    if (error instanceof Error)
+        return error.message;
+    return String(error);
+}
+run();
+
+
+/***/ }),
+
 /***/ 4914:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -42126,820 +42928,6 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 3765:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ChangeStatus = void 0;
-var ChangeStatus;
-(function (ChangeStatus) {
-    ChangeStatus["Added"] = "added";
-    ChangeStatus["Copied"] = "copied";
-    ChangeStatus["Deleted"] = "deleted";
-    ChangeStatus["Modified"] = "modified";
-    ChangeStatus["Renamed"] = "renamed";
-    ChangeStatus["Unmerged"] = "unmerged";
-})(ChangeStatus || (exports.ChangeStatus = ChangeStatus = {}));
-
-
-/***/ }),
-
-/***/ 9037:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Filter = void 0;
-const jsyaml = __importStar(__nccwpck_require__(4281));
-const picomatch_1 = __importDefault(__nccwpck_require__(4006));
-// Minimatch options used in all matchers
-const MatchOptions = {
-    dot: true
-};
-// picomatch.scan tells a real negation ('!foo/**') from an extglob group ('!(a|b)'),
-// so we let the matching library own that rule rather than re-deriving it by hand.
-function isNegatedPattern(pattern) {
-    return picomatch_1.default.scan(pattern).negated;
-}
-function positivePattern(pattern) {
-    return isNegatedPattern(pattern) ? pattern.slice(1) : pattern;
-}
-class Filter {
-    // Creates instance of Filter and load rules from YAML if it's provided
-    constructor(yaml) {
-        this.rules = {};
-        if (yaml) {
-            this.load(yaml);
-        }
-    }
-    // Load rules from YAML string
-    load(yaml) {
-        if (!yaml) {
-            return;
-        }
-        const doc = jsyaml.load(yaml);
-        if (typeof doc !== 'object') {
-            this.throwInvalidFormatError('Root element is not an object');
-        }
-        for (const [key, item] of Object.entries(doc)) {
-            this.rules[key] = this.parseFilterItemYaml(item);
-        }
-    }
-    match(files) {
-        const result = {};
-        for (const [key, patterns] of Object.entries(this.rules)) {
-            const includes = patterns.filter(rule => !rule.negated);
-            const excludes = patterns.filter(rule => rule.negated);
-            result[key] = files.filter(file => this.isMatch(file, includes, excludes));
-        }
-        return result;
-    }
-    // Positive patterns are includes, OR-ed together; every '!' pattern is an exclude
-    // that vetoes a match. A file matches when it hits at least one include (or there
-    // are no includes) and hits no exclude.
-    isMatch(file, includes, excludes) {
-        const matches = (rule) => (rule.status === undefined || rule.status.includes(file.status)) && rule.isMatch(file.filename);
-        const included = includes.length === 0 || includes.some(matches);
-        return included && !excludes.some(matches);
-    }
-    parseFilterItemYaml(item) {
-        if (Array.isArray(item)) {
-            return item.map(i => this.parseFilterItemYaml(i)).flat();
-        }
-        if (typeof item === 'string') {
-            return [
-                { status: undefined, negated: isNegatedPattern(item), isMatch: (0, picomatch_1.default)(positivePattern(item), MatchOptions) }
-            ];
-        }
-        if (typeof item === 'object') {
-            return Object.entries(item).map(([key, pattern]) => {
-                if (typeof key !== 'string' || (typeof pattern !== 'string' && !Array.isArray(pattern))) {
-                    this.throwInvalidFormatError(`Expected [key:string]= pattern:string | string[], but [${key}:${typeof key}]= ${pattern}:${typeof pattern} found`);
-                }
-                // A '!' pattern only becomes an exclude when it's a top-level filter entry (the
-                // string branch above). Inside this array form it would silently fall through to
-                // picomatch's raw array-negation semantics instead — matching nearly every file
-                // rather than excluding one — so reject it instead of matching the wrong thing.
-                if (Array.isArray(pattern) && pattern.some(p => isNegatedPattern(p))) {
-                    this.throwInvalidFormatError(`'!' patterns are not supported inside a change-status array (key '${key}') — write them as separate top-level filter entries instead`);
-                }
-                const negated = typeof pattern === 'string' && isNegatedPattern(pattern);
-                return {
-                    status: key
-                        .split('|')
-                        .map(x => x.trim())
-                        .filter(x => x.length > 0)
-                        .map(x => x.toLowerCase()),
-                    negated,
-                    isMatch: (0, picomatch_1.default)(negated ? positivePattern(pattern) : pattern, MatchOptions)
-                };
-            });
-        }
-        this.throwInvalidFormatError(`Unexpected element type '${typeof item}'`);
-    }
-    throwInvalidFormatError(message) {
-        throw new Error(`Invalid filter YAML format: ${message}.`);
-    }
-}
-exports.Filter = Filter;
-
-
-/***/ }),
-
-/***/ 1243:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.HEAD = exports.NULL_SHA = void 0;
-exports.getChangesInLastCommit = getChangesInLastCommit;
-exports.getChanges = getChanges;
-exports.getChangesOnHead = getChangesOnHead;
-exports.getChangesSinceMergeBase = getChangesSinceMergeBase;
-exports.parseGitDiffOutput = parseGitDiffOutput;
-exports.listAllFilesAsAdded = listAllFilesAsAdded;
-exports.getCurrentRef = getCurrentRef;
-exports.getShortName = getShortName;
-exports.isGitSha = isGitSha;
-const exec_1 = __nccwpck_require__(5236);
-const core = __importStar(__nccwpck_require__(7484));
-const file_1 = __nccwpck_require__(3765);
-exports.NULL_SHA = '0000000000000000000000000000000000000000';
-exports.HEAD = 'HEAD';
-async function getChangesInLastCommit() {
-    core.startGroup(`Change detection in last commit`);
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['log', '--format=', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-async function getChanges(base, head) {
-    const baseRef = await ensureRefAvailable(base);
-    const headRef = await ensureRefAvailable(head);
-    // Get differences between ref and HEAD
-    core.startGroup(`Change detection ${base}..${head}`);
-    let output = '';
-    try {
-        // Two dots '..' change detection - directly compares two versions
-        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', `${baseRef}..${headRef}`]))
-            .stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-async function getChangesOnHead() {
-    // Get current changes - both staged and unstaged
-    core.startGroup(`Change detection on HEAD`);
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', 'HEAD'])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-async function getChangesSinceMergeBase(base, head, initialFetchDepth) {
-    let baseRef;
-    let headRef;
-    async function hasMergeBase() {
-        if (baseRef === undefined || headRef === undefined) {
-            return false;
-        }
-        return (await (0, exec_1.getExecOutput)('git', ['merge-base', baseRef, headRef], { ignoreReturnCode: true })).exitCode === 0;
-    }
-    let noMergeBase = false;
-    core.startGroup(`Searching for merge-base ${base}...${head}`);
-    try {
-        baseRef = await getLocalRef(base);
-        headRef = await getLocalRef(head);
-        if (!(await hasMergeBase())) {
-            await (0, exec_1.getExecOutput)('git', ['fetch', '--no-tags', `--depth=${initialFetchDepth}`, 'origin', base, head]);
-            if (baseRef === undefined || headRef === undefined) {
-                baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
-                headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
-                if (baseRef === undefined || headRef === undefined) {
-                    await (0, exec_1.getExecOutput)('git', ['fetch', '--tags', '--depth=1', 'origin', base, head], {
-                        ignoreReturnCode: true // returns exit code 1 if tags on remote were updated - we can safely ignore it
-                    });
-                    baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
-                    headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
-                    if (baseRef === undefined) {
-                        throw new Error(`Could not determine what is ${base} - fetch works but it's not a branch, tag or commit SHA`);
-                    }
-                    if (headRef === undefined) {
-                        throw new Error(`Could not determine what is ${head} - fetch works but it's not a branch, tag or commit SHA`);
-                    }
-                }
-            }
-            let depth = initialFetchDepth;
-            let lastCommitCount = await getCommitCount();
-            while (!(await hasMergeBase())) {
-                depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER);
-                await (0, exec_1.getExecOutput)('git', ['fetch', `--deepen=${depth}`, 'origin', base, head]);
-                const commitCount = await getCommitCount();
-                if (commitCount === lastCommitCount) {
-                    core.info('No more commits were fetched');
-                    core.info('Last attempt will be to fetch full history');
-                    await (0, exec_1.getExecOutput)('git', ['fetch']);
-                    if (!(await hasMergeBase())) {
-                        noMergeBase = true;
-                    }
-                    break;
-                }
-                lastCommitCount = commitCount;
-            }
-        }
-    }
-    finally {
-        core.endGroup();
-    }
-    // Three dots '...' change detection - finds merge-base and compares against it
-    let diffArg = `${baseRef}...${headRef}`;
-    if (noMergeBase) {
-        core.warning('No merge base found - change detection will use direct <commit>..<commit> comparison');
-        diffArg = `${baseRef}..${headRef}`;
-    }
-    // Get changes introduced on ref compared to base
-    core.startGroup(`Change detection ${diffArg}`);
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', diffArg])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-function parseGitDiffOutput(output) {
-    const tokens = output.split('\u0000').filter(s => s.length > 0);
-    const files = [];
-    for (let i = 0; i + 1 < tokens.length; i += 2) {
-        files.push({
-            status: statusMap[tokens[i]],
-            filename: tokens[i + 1]
-        });
-    }
-    return files;
-}
-async function listAllFilesAsAdded() {
-    core.startGroup('Listing all files tracked by git');
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['ls-files', '-z'])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return output
-        .split('\u0000')
-        .filter(s => s.length > 0)
-        .map(path => ({
-        status: file_1.ChangeStatus.Added,
-        filename: path
-    }));
-}
-async function getCurrentRef() {
-    core.startGroup(`Get current git ref`);
-    try {
-        const branch = (await (0, exec_1.getExecOutput)('git', ['branch', '--show-current'])).stdout.trim();
-        if (branch) {
-            return branch;
-        }
-        const describe = await (0, exec_1.getExecOutput)('git', ['describe', '--tags', '--exact-match'], { ignoreReturnCode: true });
-        if (describe.exitCode === 0) {
-            return describe.stdout.trim();
-        }
-        return (await (0, exec_1.getExecOutput)('git', ['rev-parse', exports.HEAD])).stdout.trim();
-    }
-    finally {
-        core.endGroup();
-    }
-}
-function getShortName(ref) {
-    if (!ref)
-        return '';
-    const heads = 'refs/heads/';
-    const tags = 'refs/tags/';
-    if (ref.startsWith(heads))
-        return ref.slice(heads.length);
-    if (ref.startsWith(tags))
-        return ref.slice(tags.length);
-    return ref;
-}
-function isGitSha(ref) {
-    return /^[a-z0-9]{40}$/.test(ref);
-}
-async function hasCommit(ref) {
-    return (await (0, exec_1.getExecOutput)('git', ['cat-file', '-e', `${ref}^{commit}`], { ignoreReturnCode: true })).exitCode === 0;
-}
-async function getCommitCount() {
-    const output = (await (0, exec_1.getExecOutput)('git', ['rev-list', '--count', '--all'])).stdout;
-    const count = parseInt(output);
-    return isNaN(count) ? 0 : count;
-}
-async function getLocalRef(shortName) {
-    if (isGitSha(shortName)) {
-        return (await hasCommit(shortName)) ? shortName : undefined;
-    }
-    const output = (await (0, exec_1.getExecOutput)('git', ['show-ref', shortName], { ignoreReturnCode: true })).stdout;
-    const refs = output
-        .split(/\r?\n/g)
-        .map(l => l.match(/refs\/(?:(?:heads)|(?:tags)|(?:remotes\/origin))\/(.*)$/))
-        .filter(match => match !== null && match[1] === shortName)
-        .map(match => { var _a; return (_a = match === null || match === void 0 ? void 0 : match[0]) !== null && _a !== void 0 ? _a : ''; }); // match can't be null here but compiler doesn't understand that
-    if (refs.length === 0) {
-        return undefined;
-    }
-    const remoteRef = refs.find(ref => ref.startsWith('refs/remotes/origin/'));
-    if (remoteRef) {
-        return remoteRef;
-    }
-    return refs[0];
-}
-async function ensureRefAvailable(name) {
-    core.startGroup(`Ensuring ${name} is fetched from origin`);
-    try {
-        let ref = await getLocalRef(name);
-        if (ref === undefined) {
-            await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--no-tags', 'origin', name]);
-            ref = await getLocalRef(name);
-            if (ref === undefined) {
-                await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--tags', 'origin', name]);
-                ref = await getLocalRef(name);
-                if (ref === undefined) {
-                    throw new Error(`Could not determine what is ${name} - fetch works but it's not a branch, tag or commit SHA`);
-                }
-            }
-        }
-        return ref;
-    }
-    finally {
-        core.endGroup();
-    }
-}
-function fixStdOutNullTermination() {
-    // Previous command uses NULL as delimiters and output is printed to stdout.
-    // We have to make sure next thing written to stdout will start on new line.
-    // Otherwise things like ::set-output wouldn't work.
-    core.info('');
-}
-const statusMap = {
-    A: file_1.ChangeStatus.Added,
-    C: file_1.ChangeStatus.Copied,
-    D: file_1.ChangeStatus.Deleted,
-    M: file_1.ChangeStatus.Modified,
-    R: file_1.ChangeStatus.Renamed,
-    U: file_1.ChangeStatus.Unmerged
-};
-
-
-/***/ }),
-
-/***/ 6146:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.csvEscape = csvEscape;
-// Returns filename escaped for CSV
-// Wraps file name into "..." only when it contains some potentially unsafe character
-function csvEscape(value) {
-    if (value === '')
-        return value;
-    // Only safe characters
-    if (/^[a-zA-Z0-9._+:@%/-]+$/m.test(value)) {
-        return value;
-    }
-    // https://tools.ietf.org/html/rfc4180
-    // If double-quotes are used to enclose fields, then a double-quote
-    // appearing inside a field must be escaped by preceding it with
-    // another double quote
-    return `"${value.replace(/"/g, '""')}"`;
-}
-
-
-/***/ }),
-
-/***/ 6880:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.backslashEscape = backslashEscape;
-exports.shellEscape = shellEscape;
-// Backslash escape every character except small subset of definitely safe characters
-function backslashEscape(value) {
-    return value.replace(/([^a-zA-Z0-9,._+:@%/-])/gm, '\\$1');
-}
-// Returns filename escaped for usage as shell argument.
-// Applies "human readable" approach with as few escaping applied as possible
-function shellEscape(value) {
-    if (value === '')
-        return value;
-    // Only safe characters
-    if (/^[a-zA-Z0-9,._+:@%/-]+$/m.test(value)) {
-        return value;
-    }
-    if (value.includes("'")) {
-        // Only safe characters, single quotes and white-spaces
-        if (/^[a-zA-Z0-9,._+:@%/'\s-]+$/m.test(value)) {
-            return `"${value}"`;
-        }
-        // Split by single quote and apply escaping recursively
-        return value.split("'").map(shellEscape).join("\\'");
-    }
-    // Contains some unsafe characters but no single quote
-    return `'${value}'`;
-}
-
-
-/***/ }),
-
-/***/ 1730:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-const fs = __importStar(__nccwpck_require__(9896));
-const core = __importStar(__nccwpck_require__(7484));
-const github = __importStar(__nccwpck_require__(3228));
-const filter_1 = __nccwpck_require__(9037);
-const file_1 = __nccwpck_require__(3765);
-const git = __importStar(__nccwpck_require__(1243));
-const shell_escape_1 = __nccwpck_require__(6880);
-const csv_escape_1 = __nccwpck_require__(6146);
-async function run() {
-    try {
-        const workingDirectory = core.getInput('working-directory', { required: false });
-        if (workingDirectory) {
-            process.chdir(workingDirectory);
-        }
-        const token = core.getInput('token', { required: false });
-        const ref = core.getInput('ref', { required: false });
-        const base = core.getInput('base', { required: false });
-        const filtersInput = core.getInput('filters', { required: true });
-        const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput;
-        const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none';
-        const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', { required: false })) || 10;
-        if (!isExportFormat(listFiles)) {
-            core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`);
-            return;
-        }
-        const filter = new filter_1.Filter(filtersYaml);
-        const files = await getChangedFiles(token, base, ref, initialFetchDepth);
-        core.info(`Detected ${files.length} changed files`);
-        const results = filter.match(files);
-        exportResults(results, listFiles);
-    }
-    catch (error) {
-        core.setFailed(getErrorMessage(error));
-    }
-}
-function isPathInput(text) {
-    return !(text.includes('\n') || text.includes(':'));
-}
-function getConfigFileContent(configPath) {
-    if (!fs.existsSync(configPath)) {
-        throw new Error(`Configuration file '${configPath}' not found`);
-    }
-    if (!fs.lstatSync(configPath).isFile()) {
-        throw new Error(`'${configPath}' is not a file.`);
-    }
-    return fs.readFileSync(configPath, { encoding: 'utf8' });
-}
-async function getChangedFiles(token, base, ref, initialFetchDepth) {
-    var _a, _b;
-    // if base is 'HEAD' only local uncommitted changes will be detected
-    // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
-    if (base === git.HEAD) {
-        if (ref) {
-            core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
-        }
-        return await git.getChangesOnHead();
-    }
-    switch (github.context.eventName) {
-        // To keep backward compatibility, commits in GitHub pull request event
-        // take precedence over manual inputs.
-        case 'pull_request':
-        case 'pull_request_review':
-        case 'pull_request_review_comment':
-        case 'pull_request_target': {
-            if (ref) {
-                core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
-            }
-            if (base) {
-                core.warning(`'base' input parameter is ignored when action is triggered by pull request event`);
-            }
-            const pr = github.context.payload.pull_request;
-            if (token) {
-                return await getChangedFilesFromApi(token, pr);
-            }
-            if (github.context.eventName === 'pull_request_target') {
-                // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
-                // Therefore it's not possible to look at changes in last commit
-                // At the same time we don't want to fetch any code from forked repository
-                throw new Error(`'token' input parameter is required if action is triggered by 'pull_request_target' event`);
-            }
-            core.info('Github token is not available - changes will be detected using git diff');
-            const baseSha = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.base.sha;
-            const defaultBranch = (_b = github.context.payload.repository) === null || _b === void 0 ? void 0 : _b.default_branch;
-            const currentRef = await git.getCurrentRef();
-            return await git.getChanges(base || baseSha || defaultBranch, currentRef);
-        }
-        // To keep backward compatibility, manual inputs take precedence over
-        // commits in GitHub merge queue event.
-        case 'merge_group': {
-            const mergeGroup = github.context.payload;
-            if (!base) {
-                base = mergeGroup.merge_group.base_sha;
-            }
-            if (!ref) {
-                ref = mergeGroup.merge_group.head_sha;
-            }
-            break;
-        }
-    }
-    return getChangedFilesFromGit(base, ref, initialFetchDepth);
-}
-async function getChangedFilesFromGit(base, head, initialFetchDepth) {
-    var _a;
-    const defaultBranch = (_a = github.context.payload.repository) === null || _a === void 0 ? void 0 : _a.default_branch;
-    const beforeSha = github.context.eventName === 'push' ? github.context.payload.before : null;
-    const currentRef = await git.getCurrentRef();
-    head = git.getShortName(head || github.context.ref || currentRef);
-    base = git.getShortName(base || defaultBranch);
-    if (!head) {
-        throw new Error("This action requires 'head' input to be configured, 'ref' to be set in the event payload or branch/tag checked out in current git repository");
-    }
-    if (!base) {
-        throw new Error("This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload");
-    }
-    const isBaseSha = git.isGitSha(base);
-    const isBaseSameAsHead = base === head;
-    // If base is commit SHA we will do comparison against the referenced commit
-    // Or if base references same branch it was pushed to, we will do comparison against the previously pushed commit
-    if (isBaseSha || isBaseSameAsHead) {
-        const baseSha = isBaseSha ? base : beforeSha;
-        if (!baseSha) {
-            core.warning(`'before' field is missing in event payload - changes will be detected from last commit`);
-            if (head !== currentRef) {
-                core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
-            }
-            return await git.getChangesInLastCommit();
-        }
-        // If there is no previously pushed commit,
-        // we will do comparison against the default branch or return all as added
-        if (baseSha === git.NULL_SHA) {
-            if (defaultBranch && base !== defaultBranch) {
-                core.info(`First push of a branch detected - changes will be detected against the default branch ${defaultBranch}`);
-                return await git.getChangesSinceMergeBase(defaultBranch, head, initialFetchDepth);
-            }
-            else {
-                core.info('Initial push detected - all files will be listed as added');
-                if (head !== currentRef) {
-                    core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
-                }
-                return await git.listAllFilesAsAdded();
-            }
-        }
-        core.info(`Changes will be detected between ${baseSha} and ${head}`);
-        return await git.getChanges(baseSha, head);
-    }
-    core.info(`Changes will be detected between ${base} and ${head}`);
-    return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
-}
-// Uses github REST api to get list of files changed in PR
-async function getChangedFilesFromApi(token, pullRequest) {
-    core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
-    try {
-        const client = github.getOctokit(token);
-        const per_page = 100;
-        const files = [];
-        core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
-        for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            pull_number: pullRequest.number,
-            per_page
-        }))) {
-            if (response.status !== 200) {
-                throw new Error(`Fetching list of changed files from GitHub API failed with error code ${response.status}`);
-            }
-            core.info(`Received ${response.data.length} items`);
-            for (const row of response.data) {
-                core.info(`[${row.status}] ${row.filename}`);
-                // There's no obvious use-case for detection of renames
-                // Therefore we treat it as if rename detection in git diff was turned off.
-                // Rename is replaced by delete of original filename and add of new filename
-                if (row.status === file_1.ChangeStatus.Renamed) {
-                    files.push({
-                        filename: row.filename,
-                        status: file_1.ChangeStatus.Added
-                    });
-                    files.push({
-                        // 'previous_filename' for some unknown reason isn't in the type definition or documentation
-                        filename: row.previous_filename,
-                        status: file_1.ChangeStatus.Deleted
-                    });
-                }
-                else {
-                    // Github status and git status variants are same except for deleted files
-                    const status = row.status === 'removed' ? file_1.ChangeStatus.Deleted : row.status;
-                    files.push({
-                        filename: row.filename,
-                        status
-                    });
-                }
-            }
-        }
-        return files;
-    }
-    finally {
-        core.endGroup();
-    }
-}
-function exportResults(results, format) {
-    core.info('Results:');
-    const changes = [];
-    for (const [key, files] of Object.entries(results)) {
-        const value = files.length > 0;
-        core.startGroup(`Filter ${key} = ${value}`);
-        if (files.length > 0) {
-            changes.push(key);
-            core.info('Matching files:');
-            for (const file of files) {
-                core.info(`${file.filename} [${file.status}]`);
-            }
-        }
-        else {
-            core.info('Matching files: none');
-        }
-        core.setOutput(key, value);
-        core.setOutput(`${key}_count`, files.length);
-        if (format !== 'none') {
-            const filesValue = serializeExport(files, format);
-            core.setOutput(`${key}_files`, filesValue);
-        }
-        core.endGroup();
-    }
-    if (results['changes'] === undefined) {
-        const changesJson = JSON.stringify(changes);
-        core.info(`Changes output set to ${changesJson}`);
-        core.setOutput('changes', changesJson);
-    }
-    else {
-        core.info('Cannot set changes output variable - name already used by filter output');
-    }
-}
-function serializeExport(files, format) {
-    const fileNames = files.map(file => file.filename);
-    switch (format) {
-        case 'csv':
-            return fileNames.map(csv_escape_1.csvEscape).join(',');
-        case 'json':
-            return JSON.stringify(fileNames);
-        case 'escape':
-            return fileNames.map(shell_escape_1.backslashEscape).join(' ');
-        case 'shell':
-            return fileNames.map(shell_escape_1.shellEscape).join(' ');
-        default:
-            return '';
-    }
-}
-function isExportFormat(value) {
-    return ['none', 'csv', 'shell', 'json', 'escape'].includes(value);
-}
-function getErrorMessage(error) {
-    if (error instanceof Error)
-        return error.message;
-    return String(error);
-}
-run();
-
-
-/***/ }),
-
 /***/ 2613:
 /***/ ((module) => {
 
@@ -43254,7 +43242,7 @@ module.exports = require("util");
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(1730);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(5915);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -1,808 +1,6 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 5868:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ChangeStatus = void 0;
-var ChangeStatus;
-(function (ChangeStatus) {
-    ChangeStatus["Added"] = "added";
-    ChangeStatus["Copied"] = "copied";
-    ChangeStatus["Deleted"] = "deleted";
-    ChangeStatus["Modified"] = "modified";
-    ChangeStatus["Renamed"] = "renamed";
-    ChangeStatus["Unmerged"] = "unmerged";
-})(ChangeStatus || (exports.ChangeStatus = ChangeStatus = {}));
-
-
-/***/ }),
-
-/***/ 8504:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Filter = void 0;
-const jsyaml = __importStar(__nccwpck_require__(4281));
-const picomatch_1 = __importDefault(__nccwpck_require__(4006));
-// Minimatch options used in all matchers
-const MatchOptions = {
-    dot: true
-};
-// picomatch.scan tells a real negation ('!foo/**') from an extglob group ('!(a|b)'),
-// so we let the matching library own that rule rather than re-deriving it by hand.
-function isNegatedPattern(pattern) {
-    return picomatch_1.default.scan(pattern).negated;
-}
-function positivePattern(pattern) {
-    return isNegatedPattern(pattern) ? pattern.slice(1) : pattern;
-}
-class Filter {
-    // Creates instance of Filter and load rules from YAML if it's provided
-    constructor(yaml) {
-        this.rules = {};
-        if (yaml) {
-            this.load(yaml);
-        }
-    }
-    // Load rules from YAML string
-    load(yaml) {
-        if (!yaml) {
-            return;
-        }
-        const doc = jsyaml.load(yaml);
-        if (typeof doc !== 'object') {
-            this.throwInvalidFormatError('Root element is not an object');
-        }
-        for (const [key, item] of Object.entries(doc)) {
-            this.rules[key] = this.parseFilterItemYaml(item);
-        }
-    }
-    match(files) {
-        const result = {};
-        for (const [key, patterns] of Object.entries(this.rules)) {
-            const includes = patterns.filter(rule => !rule.negated);
-            const excludes = patterns.filter(rule => rule.negated);
-            result[key] = files.filter(file => this.isMatch(file, includes, excludes));
-        }
-        return result;
-    }
-    // Positive patterns are includes, OR-ed together; every '!' pattern is an exclude
-    // that vetoes a match. A file matches when it hits at least one include (or there
-    // are no includes) and hits no exclude.
-    isMatch(file, includes, excludes) {
-        const matches = (rule) => (rule.status === undefined || rule.status.includes(file.status)) && rule.isMatch(file.filename);
-        const included = includes.length === 0 || includes.some(matches);
-        return included && !excludes.some(matches);
-    }
-    parseFilterItemYaml(item) {
-        if (Array.isArray(item)) {
-            return item.map(i => this.parseFilterItemYaml(i)).flat();
-        }
-        if (typeof item === 'string') {
-            return [
-                { status: undefined, negated: isNegatedPattern(item), isMatch: (0, picomatch_1.default)(positivePattern(item), MatchOptions) }
-            ];
-        }
-        if (typeof item === 'object') {
-            return Object.entries(item).map(([key, pattern]) => {
-                if (typeof key !== 'string' || (typeof pattern !== 'string' && !Array.isArray(pattern))) {
-                    this.throwInvalidFormatError(`Expected [key:string]= pattern:string | string[], but [${key}:${typeof key}]= ${pattern}:${typeof pattern} found`);
-                }
-                // A '!' pattern only becomes an exclude when it's a top-level filter entry (the
-                // string branch above). Inside this array form it would silently fall through to
-                // picomatch's raw array-negation semantics instead — matching nearly every file
-                // rather than excluding one — so reject it instead of matching the wrong thing.
-                if (Array.isArray(pattern) && pattern.some(p => isNegatedPattern(p))) {
-                    this.throwInvalidFormatError(`'!' patterns are not supported inside a change-status array (key '${key}') — write them as separate top-level filter entries instead`);
-                }
-                const negated = typeof pattern === 'string' && isNegatedPattern(pattern);
-                return {
-                    status: key
-                        .split('|')
-                        .map(x => x.trim())
-                        .filter(x => x.length > 0)
-                        .map(x => x.toLowerCase()),
-                    negated,
-                    isMatch: (0, picomatch_1.default)(negated ? positivePattern(pattern) : pattern, MatchOptions)
-                };
-            });
-        }
-        this.throwInvalidFormatError(`Unexpected element type '${typeof item}'`);
-    }
-    throwInvalidFormatError(message) {
-        throw new Error(`Invalid filter YAML format: ${message}.`);
-    }
-}
-exports.Filter = Filter;
-
-
-/***/ }),
-
-/***/ 9412:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.HEAD = exports.NULL_SHA = void 0;
-exports.getChangesInLastCommit = getChangesInLastCommit;
-exports.getChanges = getChanges;
-exports.getChangesOnHead = getChangesOnHead;
-exports.getChangesSinceMergeBase = getChangesSinceMergeBase;
-exports.parseGitDiffOutput = parseGitDiffOutput;
-exports.listAllFilesAsAdded = listAllFilesAsAdded;
-exports.getCurrentRef = getCurrentRef;
-exports.getShortName = getShortName;
-exports.isGitSha = isGitSha;
-const exec_1 = __nccwpck_require__(5236);
-const core = __importStar(__nccwpck_require__(7484));
-const file_1 = __nccwpck_require__(5868);
-exports.NULL_SHA = '0000000000000000000000000000000000000000';
-exports.HEAD = 'HEAD';
-async function getChangesInLastCommit() {
-    core.startGroup(`Change detection in last commit`);
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['log', '--format=', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-async function getChanges(base, head) {
-    const baseRef = await ensureRefAvailable(base);
-    const headRef = await ensureRefAvailable(head);
-    // Get differences between ref and HEAD
-    core.startGroup(`Change detection ${base}..${head}`);
-    let output = '';
-    try {
-        // Two dots '..' change detection - directly compares two versions
-        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', `${baseRef}..${headRef}`]))
-            .stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-async function getChangesOnHead() {
-    // Get current changes - both staged and unstaged
-    core.startGroup(`Change detection on HEAD`);
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', 'HEAD'])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-async function getChangesSinceMergeBase(base, head, initialFetchDepth) {
-    let baseRef;
-    let headRef;
-    async function hasMergeBase() {
-        if (baseRef === undefined || headRef === undefined) {
-            return false;
-        }
-        return (await (0, exec_1.getExecOutput)('git', ['merge-base', baseRef, headRef], { ignoreReturnCode: true })).exitCode === 0;
-    }
-    let noMergeBase = false;
-    core.startGroup(`Searching for merge-base ${base}...${head}`);
-    try {
-        baseRef = await getLocalRef(base);
-        headRef = await getLocalRef(head);
-        if (!(await hasMergeBase())) {
-            await (0, exec_1.getExecOutput)('git', ['fetch', '--no-tags', `--depth=${initialFetchDepth}`, 'origin', base, head]);
-            if (baseRef === undefined || headRef === undefined) {
-                baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
-                headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
-                if (baseRef === undefined || headRef === undefined) {
-                    await (0, exec_1.getExecOutput)('git', ['fetch', '--tags', '--depth=1', 'origin', base, head], {
-                        ignoreReturnCode: true // returns exit code 1 if tags on remote were updated - we can safely ignore it
-                    });
-                    baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
-                    headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
-                    if (baseRef === undefined) {
-                        throw new Error(`Could not determine what is ${base} - fetch works but it's not a branch, tag or commit SHA`);
-                    }
-                    if (headRef === undefined) {
-                        throw new Error(`Could not determine what is ${head} - fetch works but it's not a branch, tag or commit SHA`);
-                    }
-                }
-            }
-            let depth = initialFetchDepth;
-            let lastCommitCount = await getCommitCount();
-            while (!(await hasMergeBase())) {
-                depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER);
-                await (0, exec_1.getExecOutput)('git', ['fetch', `--deepen=${depth}`, 'origin', base, head]);
-                const commitCount = await getCommitCount();
-                if (commitCount === lastCommitCount) {
-                    core.info('No more commits were fetched');
-                    core.info('Last attempt will be to fetch full history');
-                    await (0, exec_1.getExecOutput)('git', ['fetch']);
-                    if (!(await hasMergeBase())) {
-                        noMergeBase = true;
-                    }
-                    break;
-                }
-                lastCommitCount = commitCount;
-            }
-        }
-    }
-    finally {
-        core.endGroup();
-    }
-    // Three dots '...' change detection - finds merge-base and compares against it
-    let diffArg = `${baseRef}...${headRef}`;
-    if (noMergeBase) {
-        core.warning('No merge base found - change detection will use direct <commit>..<commit> comparison');
-        diffArg = `${baseRef}..${headRef}`;
-    }
-    // Get changes introduced on ref compared to base
-    core.startGroup(`Change detection ${diffArg}`);
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', diffArg])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return parseGitDiffOutput(output);
-}
-function parseGitDiffOutput(output) {
-    const tokens = output.split('\u0000').filter(s => s.length > 0);
-    const files = [];
-    for (let i = 0; i + 1 < tokens.length; i += 2) {
-        files.push({
-            status: statusMap[tokens[i]],
-            filename: tokens[i + 1]
-        });
-    }
-    return files;
-}
-async function listAllFilesAsAdded() {
-    core.startGroup('Listing all files tracked by git');
-    let output = '';
-    try {
-        output = (await (0, exec_1.getExecOutput)('git', ['ls-files', '-z'])).stdout;
-    }
-    finally {
-        fixStdOutNullTermination();
-        core.endGroup();
-    }
-    return output
-        .split('\u0000')
-        .filter(s => s.length > 0)
-        .map(path => ({
-        status: file_1.ChangeStatus.Added,
-        filename: path
-    }));
-}
-async function getCurrentRef() {
-    core.startGroup(`Get current git ref`);
-    try {
-        const branch = (await (0, exec_1.getExecOutput)('git', ['branch', '--show-current'])).stdout.trim();
-        if (branch) {
-            return branch;
-        }
-        const describe = await (0, exec_1.getExecOutput)('git', ['describe', '--tags', '--exact-match'], { ignoreReturnCode: true });
-        if (describe.exitCode === 0) {
-            return describe.stdout.trim();
-        }
-        return (await (0, exec_1.getExecOutput)('git', ['rev-parse', exports.HEAD])).stdout.trim();
-    }
-    finally {
-        core.endGroup();
-    }
-}
-function getShortName(ref) {
-    if (!ref)
-        return '';
-    const heads = 'refs/heads/';
-    const tags = 'refs/tags/';
-    if (ref.startsWith(heads))
-        return ref.slice(heads.length);
-    if (ref.startsWith(tags))
-        return ref.slice(tags.length);
-    return ref;
-}
-function isGitSha(ref) {
-    return /^[a-z0-9]{40}$/.test(ref);
-}
-async function hasCommit(ref) {
-    return (await (0, exec_1.getExecOutput)('git', ['cat-file', '-e', `${ref}^{commit}`], { ignoreReturnCode: true })).exitCode === 0;
-}
-async function getCommitCount() {
-    const output = (await (0, exec_1.getExecOutput)('git', ['rev-list', '--count', '--all'])).stdout;
-    const count = parseInt(output);
-    return isNaN(count) ? 0 : count;
-}
-async function getLocalRef(shortName) {
-    if (isGitSha(shortName)) {
-        return (await hasCommit(shortName)) ? shortName : undefined;
-    }
-    const output = (await (0, exec_1.getExecOutput)('git', ['show-ref', shortName], { ignoreReturnCode: true })).stdout;
-    const refs = output
-        .split(/\r?\n/g)
-        .map(l => l.match(/refs\/(?:(?:heads)|(?:tags)|(?:remotes\/origin))\/(.*)$/))
-        .filter(match => match !== null && match[1] === shortName)
-        .map(match => { var _a; return (_a = match === null || match === void 0 ? void 0 : match[0]) !== null && _a !== void 0 ? _a : ''; }); // match can't be null here but compiler doesn't understand that
-    if (refs.length === 0) {
-        return undefined;
-    }
-    const remoteRef = refs.find(ref => ref.startsWith('refs/remotes/origin/'));
-    if (remoteRef) {
-        return remoteRef;
-    }
-    return refs[0];
-}
-async function ensureRefAvailable(name) {
-    core.startGroup(`Ensuring ${name} is fetched from origin`);
-    try {
-        let ref = await getLocalRef(name);
-        if (ref === undefined) {
-            await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--no-tags', 'origin', name]);
-            ref = await getLocalRef(name);
-            if (ref === undefined) {
-                await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--tags', 'origin', name]);
-                ref = await getLocalRef(name);
-                if (ref === undefined) {
-                    throw new Error(`Could not determine what is ${name} - fetch works but it's not a branch, tag or commit SHA`);
-                }
-            }
-        }
-        return ref;
-    }
-    finally {
-        core.endGroup();
-    }
-}
-function fixStdOutNullTermination() {
-    // Previous command uses NULL as delimiters and output is printed to stdout.
-    // We have to make sure next thing written to stdout will start on new line.
-    // Otherwise things like ::set-output wouldn't work.
-    core.info('');
-}
-const statusMap = {
-    A: file_1.ChangeStatus.Added,
-    C: file_1.ChangeStatus.Copied,
-    D: file_1.ChangeStatus.Deleted,
-    M: file_1.ChangeStatus.Modified,
-    R: file_1.ChangeStatus.Renamed,
-    U: file_1.ChangeStatus.Unmerged
-};
-
-
-/***/ }),
-
-/***/ 9835:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.csvEscape = csvEscape;
-// Returns filename escaped for CSV
-// Wraps file name into "..." only when it contains some potentially unsafe character
-function csvEscape(value) {
-    if (value === '')
-        return value;
-    // Only safe characters
-    if (/^[a-zA-Z0-9._+:@%/-]+$/m.test(value)) {
-        return value;
-    }
-    // https://tools.ietf.org/html/rfc4180
-    // If double-quotes are used to enclose fields, then a double-quote
-    // appearing inside a field must be escaped by preceding it with
-    // another double quote
-    return `"${value.replace(/"/g, '""')}"`;
-}
-
-
-/***/ }),
-
-/***/ 9797:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.backslashEscape = backslashEscape;
-exports.shellEscape = shellEscape;
-// Backslash escape every character except small subset of definitely safe characters
-function backslashEscape(value) {
-    return value.replace(/([^a-zA-Z0-9,._+:@%/-])/gm, '\\$1');
-}
-// Returns filename escaped for usage as shell argument.
-// Applies "human readable" approach with as few escaping applied as possible
-function shellEscape(value) {
-    if (value === '')
-        return value;
-    // Only safe characters
-    if (/^[a-zA-Z0-9,._+:@%/-]+$/m.test(value)) {
-        return value;
-    }
-    if (value.includes("'")) {
-        // Only safe characters, single quotes and white-spaces
-        if (/^[a-zA-Z0-9,._+:@%/'\s-]+$/m.test(value)) {
-            return `"${value}"`;
-        }
-        // Split by single quote and apply escaping recursively
-        return value.split("'").map(shellEscape).join("\\'");
-    }
-    // Contains some unsafe characters but no single quote
-    return `'${value}'`;
-}
-
-
-/***/ }),
-
-/***/ 5915:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-const fs = __importStar(__nccwpck_require__(9896));
-const core = __importStar(__nccwpck_require__(7484));
-const github = __importStar(__nccwpck_require__(3228));
-const filter_1 = __nccwpck_require__(8504);
-const file_1 = __nccwpck_require__(5868);
-const git = __importStar(__nccwpck_require__(9412));
-const shell_escape_1 = __nccwpck_require__(9797);
-const csv_escape_1 = __nccwpck_require__(9835);
-async function run() {
-    try {
-        const workingDirectory = core.getInput('working-directory', { required: false });
-        if (workingDirectory) {
-            process.chdir(workingDirectory);
-        }
-        const token = core.getInput('token', { required: false });
-        const ref = core.getInput('ref', { required: false });
-        const base = core.getInput('base', { required: false });
-        const filtersInput = core.getInput('filters', { required: true });
-        const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput;
-        const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none';
-        const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', { required: false })) || 10;
-        if (!isExportFormat(listFiles)) {
-            core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`);
-            return;
-        }
-        const filter = new filter_1.Filter(filtersYaml);
-        const files = await getChangedFiles(token, base, ref, initialFetchDepth);
-        core.info(`Detected ${files.length} changed files`);
-        const results = filter.match(files);
-        exportResults(results, listFiles);
-    }
-    catch (error) {
-        core.setFailed(getErrorMessage(error));
-    }
-}
-function isPathInput(text) {
-    return !(text.includes('\n') || text.includes(':'));
-}
-function getConfigFileContent(configPath) {
-    if (!fs.existsSync(configPath)) {
-        throw new Error(`Configuration file '${configPath}' not found`);
-    }
-    if (!fs.lstatSync(configPath).isFile()) {
-        throw new Error(`'${configPath}' is not a file.`);
-    }
-    return fs.readFileSync(configPath, { encoding: 'utf8' });
-}
-async function getChangedFiles(token, base, ref, initialFetchDepth) {
-    var _a, _b;
-    // if base is 'HEAD' only local uncommitted changes will be detected
-    // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
-    if (base === git.HEAD) {
-        if (ref) {
-            core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
-        }
-        return await git.getChangesOnHead();
-    }
-    switch (github.context.eventName) {
-        // To keep backward compatibility, commits in GitHub pull request event
-        // take precedence over manual inputs.
-        case 'pull_request':
-        case 'pull_request_review':
-        case 'pull_request_review_comment':
-        case 'pull_request_target': {
-            if (ref) {
-                core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
-            }
-            if (base) {
-                core.warning(`'base' input parameter is ignored when action is triggered by pull request event`);
-            }
-            const pr = github.context.payload.pull_request;
-            if (token) {
-                return await getChangedFilesFromApi(token, pr);
-            }
-            if (github.context.eventName === 'pull_request_target') {
-                // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
-                // Therefore it's not possible to look at changes in last commit
-                // At the same time we don't want to fetch any code from forked repository
-                throw new Error(`'token' input parameter is required if action is triggered by 'pull_request_target' event`);
-            }
-            core.info('Github token is not available - changes will be detected using git diff');
-            const baseSha = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.base.sha;
-            const defaultBranch = (_b = github.context.payload.repository) === null || _b === void 0 ? void 0 : _b.default_branch;
-            const currentRef = await git.getCurrentRef();
-            return await git.getChanges(base || baseSha || defaultBranch, currentRef);
-        }
-    }
-    return getChangedFilesFromGit(base, ref, initialFetchDepth);
-}
-async function getChangedFilesFromGit(base, head, initialFetchDepth) {
-    var _a;
-    const defaultBranch = (_a = github.context.payload.repository) === null || _a === void 0 ? void 0 : _a.default_branch;
-    const beforeSha = github.context.eventName === 'push' ? github.context.payload.before : null;
-    const currentRef = await git.getCurrentRef();
-    head = git.getShortName(head || github.context.ref || currentRef);
-    base = git.getShortName(base || defaultBranch);
-    if (!head) {
-        throw new Error("This action requires 'head' input to be configured, 'ref' to be set in the event payload or branch/tag checked out in current git repository");
-    }
-    if (!base) {
-        throw new Error("This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload");
-    }
-    const isBaseSha = git.isGitSha(base);
-    const isBaseSameAsHead = base === head;
-    // If base is commit SHA we will do comparison against the referenced commit
-    // Or if base references same branch it was pushed to, we will do comparison against the previously pushed commit
-    if (isBaseSha || isBaseSameAsHead) {
-        const baseSha = isBaseSha ? base : beforeSha;
-        if (!baseSha) {
-            core.warning(`'before' field is missing in event payload - changes will be detected from last commit`);
-            if (head !== currentRef) {
-                core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
-            }
-            return await git.getChangesInLastCommit();
-        }
-        // If there is no previously pushed commit,
-        // we will do comparison against the default branch or return all as added
-        if (baseSha === git.NULL_SHA) {
-            if (defaultBranch && base !== defaultBranch) {
-                core.info(`First push of a branch detected - changes will be detected against the default branch ${defaultBranch}`);
-                return await git.getChangesSinceMergeBase(defaultBranch, head, initialFetchDepth);
-            }
-            else {
-                core.info('Initial push detected - all files will be listed as added');
-                if (head !== currentRef) {
-                    core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
-                }
-                return await git.listAllFilesAsAdded();
-            }
-        }
-        core.info(`Changes will be detected between ${baseSha} and ${head}`);
-        return await git.getChanges(baseSha, head);
-    }
-    core.info(`Changes will be detected between ${base} and ${head}`);
-    return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
-}
-// Uses github REST api to get list of files changed in PR
-async function getChangedFilesFromApi(token, pullRequest) {
-    core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
-    try {
-        const client = github.getOctokit(token);
-        const per_page = 100;
-        const files = [];
-        core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
-        for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            pull_number: pullRequest.number,
-            per_page
-        }))) {
-            if (response.status !== 200) {
-                throw new Error(`Fetching list of changed files from GitHub API failed with error code ${response.status}`);
-            }
-            core.info(`Received ${response.data.length} items`);
-            for (const row of response.data) {
-                core.info(`[${row.status}] ${row.filename}`);
-                // There's no obvious use-case for detection of renames
-                // Therefore we treat it as if rename detection in git diff was turned off.
-                // Rename is replaced by delete of original filename and add of new filename
-                if (row.status === file_1.ChangeStatus.Renamed) {
-                    files.push({
-                        filename: row.filename,
-                        status: file_1.ChangeStatus.Added
-                    });
-                    files.push({
-                        // 'previous_filename' for some unknown reason isn't in the type definition or documentation
-                        filename: row.previous_filename,
-                        status: file_1.ChangeStatus.Deleted
-                    });
-                }
-                else {
-                    // Github status and git status variants are same except for deleted files
-                    const status = row.status === 'removed' ? file_1.ChangeStatus.Deleted : row.status;
-                    files.push({
-                        filename: row.filename,
-                        status
-                    });
-                }
-            }
-        }
-        return files;
-    }
-    finally {
-        core.endGroup();
-    }
-}
-function exportResults(results, format) {
-    core.info('Results:');
-    const changes = [];
-    for (const [key, files] of Object.entries(results)) {
-        const value = files.length > 0;
-        core.startGroup(`Filter ${key} = ${value}`);
-        if (files.length > 0) {
-            changes.push(key);
-            core.info('Matching files:');
-            for (const file of files) {
-                core.info(`${file.filename} [${file.status}]`);
-            }
-        }
-        else {
-            core.info('Matching files: none');
-        }
-        core.setOutput(key, value);
-        core.setOutput(`${key}_count`, files.length);
-        if (format !== 'none') {
-            const filesValue = serializeExport(files, format);
-            core.setOutput(`${key}_files`, filesValue);
-        }
-        core.endGroup();
-    }
-    if (results['changes'] === undefined) {
-        const changesJson = JSON.stringify(changes);
-        core.info(`Changes output set to ${changesJson}`);
-        core.setOutput('changes', changesJson);
-    }
-    else {
-        core.info('Cannot set changes output variable - name already used by filter output');
-    }
-}
-function serializeExport(files, format) {
-    const fileNames = files.map(file => file.filename);
-    switch (format) {
-        case 'csv':
-            return fileNames.map(csv_escape_1.csvEscape).join(',');
-        case 'json':
-            return JSON.stringify(fileNames);
-        case 'escape':
-            return fileNames.map(shell_escape_1.backslashEscape).join(' ');
-        case 'shell':
-            return fileNames.map(shell_escape_1.shellEscape).join(' ');
-        default:
-            return '';
-    }
-}
-function isExportFormat(value) {
-    return ['none', 'csv', 'shell', 'json', 'escape'].includes(value);
-}
-function getErrorMessage(error) {
-    if (error instanceof Error)
-        return error.message;
-    return String(error);
-}
-run();
-
-
-/***/ }),
-
 /***/ 4914:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -42928,6 +42126,808 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
+/***/ 3765:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ChangeStatus = void 0;
+var ChangeStatus;
+(function (ChangeStatus) {
+    ChangeStatus["Added"] = "added";
+    ChangeStatus["Copied"] = "copied";
+    ChangeStatus["Deleted"] = "deleted";
+    ChangeStatus["Modified"] = "modified";
+    ChangeStatus["Renamed"] = "renamed";
+    ChangeStatus["Unmerged"] = "unmerged";
+})(ChangeStatus || (exports.ChangeStatus = ChangeStatus = {}));
+
+
+/***/ }),
+
+/***/ 9037:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Filter = void 0;
+const jsyaml = __importStar(__nccwpck_require__(4281));
+const picomatch_1 = __importDefault(__nccwpck_require__(4006));
+// Minimatch options used in all matchers
+const MatchOptions = {
+    dot: true
+};
+// picomatch.scan tells a real negation ('!foo/**') from an extglob group ('!(a|b)'),
+// so we let the matching library own that rule rather than re-deriving it by hand.
+function isNegatedPattern(pattern) {
+    return picomatch_1.default.scan(pattern).negated;
+}
+function positivePattern(pattern) {
+    return isNegatedPattern(pattern) ? pattern.slice(1) : pattern;
+}
+class Filter {
+    // Creates instance of Filter and load rules from YAML if it's provided
+    constructor(yaml) {
+        this.rules = {};
+        if (yaml) {
+            this.load(yaml);
+        }
+    }
+    // Load rules from YAML string
+    load(yaml) {
+        if (!yaml) {
+            return;
+        }
+        const doc = jsyaml.load(yaml);
+        if (typeof doc !== 'object') {
+            this.throwInvalidFormatError('Root element is not an object');
+        }
+        for (const [key, item] of Object.entries(doc)) {
+            this.rules[key] = this.parseFilterItemYaml(item);
+        }
+    }
+    match(files) {
+        const result = {};
+        for (const [key, patterns] of Object.entries(this.rules)) {
+            const includes = patterns.filter(rule => !rule.negated);
+            const excludes = patterns.filter(rule => rule.negated);
+            result[key] = files.filter(file => this.isMatch(file, includes, excludes));
+        }
+        return result;
+    }
+    // Positive patterns are includes, OR-ed together; every '!' pattern is an exclude
+    // that vetoes a match. A file matches when it hits at least one include (or there
+    // are no includes) and hits no exclude.
+    isMatch(file, includes, excludes) {
+        const matches = (rule) => (rule.status === undefined || rule.status.includes(file.status)) && rule.isMatch(file.filename);
+        const included = includes.length === 0 || includes.some(matches);
+        return included && !excludes.some(matches);
+    }
+    parseFilterItemYaml(item) {
+        if (Array.isArray(item)) {
+            return item.map(i => this.parseFilterItemYaml(i)).flat();
+        }
+        if (typeof item === 'string') {
+            return [
+                { status: undefined, negated: isNegatedPattern(item), isMatch: (0, picomatch_1.default)(positivePattern(item), MatchOptions) }
+            ];
+        }
+        if (typeof item === 'object') {
+            return Object.entries(item).map(([key, pattern]) => {
+                if (typeof key !== 'string' || (typeof pattern !== 'string' && !Array.isArray(pattern))) {
+                    this.throwInvalidFormatError(`Expected [key:string]= pattern:string | string[], but [${key}:${typeof key}]= ${pattern}:${typeof pattern} found`);
+                }
+                // A '!' pattern only becomes an exclude when it's a top-level filter entry (the
+                // string branch above). Inside this array form it would silently fall through to
+                // picomatch's raw array-negation semantics instead — matching nearly every file
+                // rather than excluding one — so reject it instead of matching the wrong thing.
+                if (Array.isArray(pattern) && pattern.some(p => isNegatedPattern(p))) {
+                    this.throwInvalidFormatError(`'!' patterns are not supported inside a change-status array (key '${key}') — write them as separate top-level filter entries instead`);
+                }
+                const negated = typeof pattern === 'string' && isNegatedPattern(pattern);
+                return {
+                    status: key
+                        .split('|')
+                        .map(x => x.trim())
+                        .filter(x => x.length > 0)
+                        .map(x => x.toLowerCase()),
+                    negated,
+                    isMatch: (0, picomatch_1.default)(negated ? positivePattern(pattern) : pattern, MatchOptions)
+                };
+            });
+        }
+        this.throwInvalidFormatError(`Unexpected element type '${typeof item}'`);
+    }
+    throwInvalidFormatError(message) {
+        throw new Error(`Invalid filter YAML format: ${message}.`);
+    }
+}
+exports.Filter = Filter;
+
+
+/***/ }),
+
+/***/ 1243:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.HEAD = exports.NULL_SHA = void 0;
+exports.getChangesInLastCommit = getChangesInLastCommit;
+exports.getChanges = getChanges;
+exports.getChangesOnHead = getChangesOnHead;
+exports.getChangesSinceMergeBase = getChangesSinceMergeBase;
+exports.parseGitDiffOutput = parseGitDiffOutput;
+exports.listAllFilesAsAdded = listAllFilesAsAdded;
+exports.getCurrentRef = getCurrentRef;
+exports.getShortName = getShortName;
+exports.isGitSha = isGitSha;
+const exec_1 = __nccwpck_require__(5236);
+const core = __importStar(__nccwpck_require__(7484));
+const file_1 = __nccwpck_require__(3765);
+exports.NULL_SHA = '0000000000000000000000000000000000000000';
+exports.HEAD = 'HEAD';
+async function getChangesInLastCommit() {
+    core.startGroup(`Change detection in last commit`);
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['log', '--format=', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+async function getChanges(base, head) {
+    const baseRef = await ensureRefAvailable(base);
+    const headRef = await ensureRefAvailable(head);
+    // Get differences between ref and HEAD
+    core.startGroup(`Change detection ${base}..${head}`);
+    let output = '';
+    try {
+        // Two dots '..' change detection - directly compares two versions
+        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', `${baseRef}..${headRef}`]))
+            .stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+async function getChangesOnHead() {
+    // Get current changes - both staged and unstaged
+    core.startGroup(`Change detection on HEAD`);
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', 'HEAD'])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+async function getChangesSinceMergeBase(base, head, initialFetchDepth) {
+    let baseRef;
+    let headRef;
+    async function hasMergeBase() {
+        if (baseRef === undefined || headRef === undefined) {
+            return false;
+        }
+        return (await (0, exec_1.getExecOutput)('git', ['merge-base', baseRef, headRef], { ignoreReturnCode: true })).exitCode === 0;
+    }
+    let noMergeBase = false;
+    core.startGroup(`Searching for merge-base ${base}...${head}`);
+    try {
+        baseRef = await getLocalRef(base);
+        headRef = await getLocalRef(head);
+        if (!(await hasMergeBase())) {
+            await (0, exec_1.getExecOutput)('git', ['fetch', '--no-tags', `--depth=${initialFetchDepth}`, 'origin', base, head]);
+            if (baseRef === undefined || headRef === undefined) {
+                baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
+                headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
+                if (baseRef === undefined || headRef === undefined) {
+                    await (0, exec_1.getExecOutput)('git', ['fetch', '--tags', '--depth=1', 'origin', base, head], {
+                        ignoreReturnCode: true // returns exit code 1 if tags on remote were updated - we can safely ignore it
+                    });
+                    baseRef = baseRef !== null && baseRef !== void 0 ? baseRef : (await getLocalRef(base));
+                    headRef = headRef !== null && headRef !== void 0 ? headRef : (await getLocalRef(head));
+                    if (baseRef === undefined) {
+                        throw new Error(`Could not determine what is ${base} - fetch works but it's not a branch, tag or commit SHA`);
+                    }
+                    if (headRef === undefined) {
+                        throw new Error(`Could not determine what is ${head} - fetch works but it's not a branch, tag or commit SHA`);
+                    }
+                }
+            }
+            let depth = initialFetchDepth;
+            let lastCommitCount = await getCommitCount();
+            while (!(await hasMergeBase())) {
+                depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER);
+                await (0, exec_1.getExecOutput)('git', ['fetch', `--deepen=${depth}`, 'origin', base, head]);
+                const commitCount = await getCommitCount();
+                if (commitCount === lastCommitCount) {
+                    core.info('No more commits were fetched');
+                    core.info('Last attempt will be to fetch full history');
+                    await (0, exec_1.getExecOutput)('git', ['fetch']);
+                    if (!(await hasMergeBase())) {
+                        noMergeBase = true;
+                    }
+                    break;
+                }
+                lastCommitCount = commitCount;
+            }
+        }
+    }
+    finally {
+        core.endGroup();
+    }
+    // Three dots '...' change detection - finds merge-base and compares against it
+    let diffArg = `${baseRef}...${headRef}`;
+    if (noMergeBase) {
+        core.warning('No merge base found - change detection will use direct <commit>..<commit> comparison');
+        diffArg = `${baseRef}..${headRef}`;
+    }
+    // Get changes introduced on ref compared to base
+    core.startGroup(`Change detection ${diffArg}`);
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', diffArg])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return parseGitDiffOutput(output);
+}
+function parseGitDiffOutput(output) {
+    const tokens = output.split('\u0000').filter(s => s.length > 0);
+    const files = [];
+    for (let i = 0; i + 1 < tokens.length; i += 2) {
+        files.push({
+            status: statusMap[tokens[i]],
+            filename: tokens[i + 1]
+        });
+    }
+    return files;
+}
+async function listAllFilesAsAdded() {
+    core.startGroup('Listing all files tracked by git');
+    let output = '';
+    try {
+        output = (await (0, exec_1.getExecOutput)('git', ['ls-files', '-z'])).stdout;
+    }
+    finally {
+        fixStdOutNullTermination();
+        core.endGroup();
+    }
+    return output
+        .split('\u0000')
+        .filter(s => s.length > 0)
+        .map(path => ({
+        status: file_1.ChangeStatus.Added,
+        filename: path
+    }));
+}
+async function getCurrentRef() {
+    core.startGroup(`Get current git ref`);
+    try {
+        const branch = (await (0, exec_1.getExecOutput)('git', ['branch', '--show-current'])).stdout.trim();
+        if (branch) {
+            return branch;
+        }
+        const describe = await (0, exec_1.getExecOutput)('git', ['describe', '--tags', '--exact-match'], { ignoreReturnCode: true });
+        if (describe.exitCode === 0) {
+            return describe.stdout.trim();
+        }
+        return (await (0, exec_1.getExecOutput)('git', ['rev-parse', exports.HEAD])).stdout.trim();
+    }
+    finally {
+        core.endGroup();
+    }
+}
+function getShortName(ref) {
+    if (!ref)
+        return '';
+    const heads = 'refs/heads/';
+    const tags = 'refs/tags/';
+    if (ref.startsWith(heads))
+        return ref.slice(heads.length);
+    if (ref.startsWith(tags))
+        return ref.slice(tags.length);
+    return ref;
+}
+function isGitSha(ref) {
+    return /^[a-z0-9]{40}$/.test(ref);
+}
+async function hasCommit(ref) {
+    return (await (0, exec_1.getExecOutput)('git', ['cat-file', '-e', `${ref}^{commit}`], { ignoreReturnCode: true })).exitCode === 0;
+}
+async function getCommitCount() {
+    const output = (await (0, exec_1.getExecOutput)('git', ['rev-list', '--count', '--all'])).stdout;
+    const count = parseInt(output);
+    return isNaN(count) ? 0 : count;
+}
+async function getLocalRef(shortName) {
+    if (isGitSha(shortName)) {
+        return (await hasCommit(shortName)) ? shortName : undefined;
+    }
+    const output = (await (0, exec_1.getExecOutput)('git', ['show-ref', shortName], { ignoreReturnCode: true })).stdout;
+    const refs = output
+        .split(/\r?\n/g)
+        .map(l => l.match(/refs\/(?:(?:heads)|(?:tags)|(?:remotes\/origin))\/(.*)$/))
+        .filter(match => match !== null && match[1] === shortName)
+        .map(match => { var _a; return (_a = match === null || match === void 0 ? void 0 : match[0]) !== null && _a !== void 0 ? _a : ''; }); // match can't be null here but compiler doesn't understand that
+    if (refs.length === 0) {
+        return undefined;
+    }
+    const remoteRef = refs.find(ref => ref.startsWith('refs/remotes/origin/'));
+    if (remoteRef) {
+        return remoteRef;
+    }
+    return refs[0];
+}
+async function ensureRefAvailable(name) {
+    core.startGroup(`Ensuring ${name} is fetched from origin`);
+    try {
+        let ref = await getLocalRef(name);
+        if (ref === undefined) {
+            await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--no-tags', 'origin', name]);
+            ref = await getLocalRef(name);
+            if (ref === undefined) {
+                await (0, exec_1.getExecOutput)('git', ['fetch', '--depth=1', '--tags', 'origin', name]);
+                ref = await getLocalRef(name);
+                if (ref === undefined) {
+                    throw new Error(`Could not determine what is ${name} - fetch works but it's not a branch, tag or commit SHA`);
+                }
+            }
+        }
+        return ref;
+    }
+    finally {
+        core.endGroup();
+    }
+}
+function fixStdOutNullTermination() {
+    // Previous command uses NULL as delimiters and output is printed to stdout.
+    // We have to make sure next thing written to stdout will start on new line.
+    // Otherwise things like ::set-output wouldn't work.
+    core.info('');
+}
+const statusMap = {
+    A: file_1.ChangeStatus.Added,
+    C: file_1.ChangeStatus.Copied,
+    D: file_1.ChangeStatus.Deleted,
+    M: file_1.ChangeStatus.Modified,
+    R: file_1.ChangeStatus.Renamed,
+    U: file_1.ChangeStatus.Unmerged
+};
+
+
+/***/ }),
+
+/***/ 6146:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.csvEscape = csvEscape;
+// Returns filename escaped for CSV
+// Wraps file name into "..." only when it contains some potentially unsafe character
+function csvEscape(value) {
+    if (value === '')
+        return value;
+    // Only safe characters
+    if (/^[a-zA-Z0-9._+:@%/-]+$/m.test(value)) {
+        return value;
+    }
+    // https://tools.ietf.org/html/rfc4180
+    // If double-quotes are used to enclose fields, then a double-quote
+    // appearing inside a field must be escaped by preceding it with
+    // another double quote
+    return `"${value.replace(/"/g, '""')}"`;
+}
+
+
+/***/ }),
+
+/***/ 6880:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.backslashEscape = backslashEscape;
+exports.shellEscape = shellEscape;
+// Backslash escape every character except small subset of definitely safe characters
+function backslashEscape(value) {
+    return value.replace(/([^a-zA-Z0-9,._+:@%/-])/gm, '\\$1');
+}
+// Returns filename escaped for usage as shell argument.
+// Applies "human readable" approach with as few escaping applied as possible
+function shellEscape(value) {
+    if (value === '')
+        return value;
+    // Only safe characters
+    if (/^[a-zA-Z0-9,._+:@%/-]+$/m.test(value)) {
+        return value;
+    }
+    if (value.includes("'")) {
+        // Only safe characters, single quotes and white-spaces
+        if (/^[a-zA-Z0-9,._+:@%/'\s-]+$/m.test(value)) {
+            return `"${value}"`;
+        }
+        // Split by single quote and apply escaping recursively
+        return value.split("'").map(shellEscape).join("\\'");
+    }
+    // Contains some unsafe characters but no single quote
+    return `'${value}'`;
+}
+
+
+/***/ }),
+
+/***/ 1730:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const fs = __importStar(__nccwpck_require__(9896));
+const core = __importStar(__nccwpck_require__(7484));
+const github = __importStar(__nccwpck_require__(3228));
+const filter_1 = __nccwpck_require__(9037);
+const file_1 = __nccwpck_require__(3765);
+const git = __importStar(__nccwpck_require__(1243));
+const shell_escape_1 = __nccwpck_require__(6880);
+const csv_escape_1 = __nccwpck_require__(6146);
+async function run() {
+    try {
+        const workingDirectory = core.getInput('working-directory', { required: false });
+        if (workingDirectory) {
+            process.chdir(workingDirectory);
+        }
+        const token = core.getInput('token', { required: false });
+        const ref = core.getInput('ref', { required: false });
+        const base = core.getInput('base', { required: false });
+        const filtersInput = core.getInput('filters', { required: true });
+        const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput;
+        const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none';
+        const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', { required: false })) || 10;
+        if (!isExportFormat(listFiles)) {
+            core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`);
+            return;
+        }
+        const filter = new filter_1.Filter(filtersYaml);
+        const files = await getChangedFiles(token, base, ref, initialFetchDepth);
+        core.info(`Detected ${files.length} changed files`);
+        const results = filter.match(files);
+        exportResults(results, listFiles);
+    }
+    catch (error) {
+        core.setFailed(getErrorMessage(error));
+    }
+}
+function isPathInput(text) {
+    return !(text.includes('\n') || text.includes(':'));
+}
+function getConfigFileContent(configPath) {
+    if (!fs.existsSync(configPath)) {
+        throw new Error(`Configuration file '${configPath}' not found`);
+    }
+    if (!fs.lstatSync(configPath).isFile()) {
+        throw new Error(`'${configPath}' is not a file.`);
+    }
+    return fs.readFileSync(configPath, { encoding: 'utf8' });
+}
+async function getChangedFiles(token, base, ref, initialFetchDepth) {
+    var _a, _b;
+    // if base is 'HEAD' only local uncommitted changes will be detected
+    // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
+    if (base === git.HEAD) {
+        if (ref) {
+            core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
+        }
+        return await git.getChangesOnHead();
+    }
+    switch (github.context.eventName) {
+        // To keep backward compatibility, commits in GitHub pull request event
+        // take precedence over manual inputs.
+        case 'pull_request':
+        case 'pull_request_review':
+        case 'pull_request_review_comment':
+        case 'pull_request_target': {
+            if (ref) {
+                core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
+            }
+            if (base) {
+                core.warning(`'base' input parameter is ignored when action is triggered by pull request event`);
+            }
+            const pr = github.context.payload.pull_request;
+            if (token) {
+                return await getChangedFilesFromApi(token, pr);
+            }
+            if (github.context.eventName === 'pull_request_target') {
+                // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
+                // Therefore it's not possible to look at changes in last commit
+                // At the same time we don't want to fetch any code from forked repository
+                throw new Error(`'token' input parameter is required if action is triggered by 'pull_request_target' event`);
+            }
+            core.info('Github token is not available - changes will be detected using git diff');
+            const baseSha = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.base.sha;
+            const defaultBranch = (_b = github.context.payload.repository) === null || _b === void 0 ? void 0 : _b.default_branch;
+            const currentRef = await git.getCurrentRef();
+            return await git.getChanges(base || baseSha || defaultBranch, currentRef);
+        }
+    }
+    return getChangedFilesFromGit(base, ref, initialFetchDepth);
+}
+async function getChangedFilesFromGit(base, head, initialFetchDepth) {
+    var _a;
+    const defaultBranch = (_a = github.context.payload.repository) === null || _a === void 0 ? void 0 : _a.default_branch;
+    const beforeSha = github.context.eventName === 'push' ? github.context.payload.before : null;
+    const currentRef = await git.getCurrentRef();
+    head = git.getShortName(head || github.context.ref || currentRef);
+    base = git.getShortName(base || defaultBranch);
+    if (!head) {
+        throw new Error("This action requires 'head' input to be configured, 'ref' to be set in the event payload or branch/tag checked out in current git repository");
+    }
+    if (!base) {
+        throw new Error("This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload");
+    }
+    const isBaseSha = git.isGitSha(base);
+    const isBaseSameAsHead = base === head;
+    // If base is commit SHA we will do comparison against the referenced commit
+    // Or if base references same branch it was pushed to, we will do comparison against the previously pushed commit
+    if (isBaseSha || isBaseSameAsHead) {
+        const baseSha = isBaseSha ? base : beforeSha;
+        if (!baseSha) {
+            core.warning(`'before' field is missing in event payload - changes will be detected from last commit`);
+            if (head !== currentRef) {
+                core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
+            }
+            return await git.getChangesInLastCommit();
+        }
+        // If there is no previously pushed commit,
+        // we will do comparison against the default branch or return all as added
+        if (baseSha === git.NULL_SHA) {
+            if (defaultBranch && base !== defaultBranch) {
+                core.info(`First push of a branch detected - changes will be detected against the default branch ${defaultBranch}`);
+                return await git.getChangesSinceMergeBase(defaultBranch, head, initialFetchDepth);
+            }
+            else {
+                core.info('Initial push detected - all files will be listed as added');
+                if (head !== currentRef) {
+                    core.warning(`Ref ${head} is not checked out - results might be incorrect!`);
+                }
+                return await git.listAllFilesAsAdded();
+            }
+        }
+        core.info(`Changes will be detected between ${baseSha} and ${head}`);
+        return await git.getChanges(baseSha, head);
+    }
+    core.info(`Changes will be detected between ${base} and ${head}`);
+    return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
+}
+// Uses github REST api to get list of files changed in PR
+async function getChangedFilesFromApi(token, pullRequest) {
+    core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
+    try {
+        const client = github.getOctokit(token);
+        const per_page = 100;
+        const files = [];
+        core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
+        for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            pull_number: pullRequest.number,
+            per_page
+        }))) {
+            if (response.status !== 200) {
+                throw new Error(`Fetching list of changed files from GitHub API failed with error code ${response.status}`);
+            }
+            core.info(`Received ${response.data.length} items`);
+            for (const row of response.data) {
+                core.info(`[${row.status}] ${row.filename}`);
+                // There's no obvious use-case for detection of renames
+                // Therefore we treat it as if rename detection in git diff was turned off.
+                // Rename is replaced by delete of original filename and add of new filename
+                if (row.status === file_1.ChangeStatus.Renamed) {
+                    files.push({
+                        filename: row.filename,
+                        status: file_1.ChangeStatus.Added
+                    });
+                    files.push({
+                        // 'previous_filename' for some unknown reason isn't in the type definition or documentation
+                        filename: row.previous_filename,
+                        status: file_1.ChangeStatus.Deleted
+                    });
+                }
+                else {
+                    // Github status and git status variants are same except for deleted files
+                    const status = row.status === 'removed' ? file_1.ChangeStatus.Deleted : row.status;
+                    files.push({
+                        filename: row.filename,
+                        status
+                    });
+                }
+            }
+        }
+        return files;
+    }
+    finally {
+        core.endGroup();
+    }
+}
+function exportResults(results, format) {
+    core.info('Results:');
+    const changes = [];
+    for (const [key, files] of Object.entries(results)) {
+        const value = files.length > 0;
+        core.startGroup(`Filter ${key} = ${value}`);
+        if (files.length > 0) {
+            changes.push(key);
+            core.info('Matching files:');
+            for (const file of files) {
+                core.info(`${file.filename} [${file.status}]`);
+            }
+        }
+        else {
+            core.info('Matching files: none');
+        }
+        core.setOutput(key, value);
+        core.setOutput(`${key}_count`, files.length);
+        if (format !== 'none') {
+            const filesValue = serializeExport(files, format);
+            core.setOutput(`${key}_files`, filesValue);
+        }
+        core.endGroup();
+    }
+    if (results['changes'] === undefined) {
+        const changesJson = JSON.stringify(changes);
+        core.info(`Changes output set to ${changesJson}`);
+        core.setOutput('changes', changesJson);
+    }
+    else {
+        core.info('Cannot set changes output variable - name already used by filter output');
+    }
+}
+function serializeExport(files, format) {
+    const fileNames = files.map(file => file.filename);
+    switch (format) {
+        case 'csv':
+            return fileNames.map(csv_escape_1.csvEscape).join(',');
+        case 'json':
+            return JSON.stringify(fileNames);
+        case 'escape':
+            return fileNames.map(shell_escape_1.backslashEscape).join(' ');
+        case 'shell':
+            return fileNames.map(shell_escape_1.shellEscape).join(' ');
+        default:
+            return '';
+    }
+}
+function isExportFormat(value) {
+    return ['none', 'csv', 'shell', 'json', 'escape'].includes(value);
+}
+function getErrorMessage(error) {
+    if (error instanceof Error)
+        return error.message;
+    return String(error);
+}
+run();
+
+
+/***/ }),
+
 /***/ 2613:
 /***/ ((module) => {
 
@@ -43242,7 +43242,7 @@ module.exports = require("util");
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(5915);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(1730);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/.github/actions/paths-filter/src/main.ts
+++ b/.github/actions/paths-filter/src/main.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {GetResponseDataTypeFromEndpointMethod} from '@octokit/types'
-import {MergeGroupEvent, PullRequest, PushEvent} from '@octokit/webhooks-types'
+import {PullRequest, PushEvent} from '@octokit/webhooks-types'
 
 import {Filter, FilterResults} from './filter'
 import {File, ChangeStatus} from './file'
@@ -96,18 +96,6 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
       const defaultBranch = github.context.payload.repository?.default_branch
       const currentRef = await git.getCurrentRef()
       return await git.getChanges(base || baseSha || defaultBranch, currentRef)
-    }
-    // To keep backward compatibility, manual inputs take precedence over
-    // commits in GitHub merge queue event.
-    case 'merge_group': {
-      const mergeGroup = github.context.payload as MergeGroupEvent
-      if (!base) {
-        base = mergeGroup.merge_group.base_sha
-      }
-      if (!ref) {
-        ref = mergeGroup.merge_group.head_sha
-      }
-      break
     }
   }
 

--- a/.github/workflows/ci-agent-container.yml
+++ b/.github/workflows/ci-agent-container.yml
@@ -8,8 +8,7 @@ name: Build and deploy agent platform container images
 
 on:
     workflow_dispatch:
-    # paths mirror the changes job's dorny filter, which still gates push and
-    # merge_group events (merge_group triggers don't support paths).
+    # paths mirror the changes job's dorny filter, which still gates push events.
     pull_request:
         paths:
             - 'products/agent_platform/services/**'
@@ -27,7 +26,6 @@ on:
             - '.github/workflows/ci-agent-container.yml'
             - 'pnpm-lock.yaml'
             - 'pnpm-workspace.yaml'
-    merge_group:
     push:
         branches:
             - 'master'
@@ -43,7 +41,7 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog' && github.event_name != 'merge_group'
+        if: github.repository == 'PostHog/posthog'
         name: Determine need to run agent Docker build
         outputs:
             agent_files: ${{ steps.filter.outputs.agent_files }}
@@ -85,7 +83,6 @@ jobs:
         name: Build ${{ matrix.image }}
         if: |
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.agent_files == 'true') ||
-            github.event_name == 'merge_group' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.agent_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
         runs-on: depot-ubuntu-latest
@@ -150,7 +147,7 @@ jobs:
                   context: ${{ matrix.context }}
                   buildx-fallback: false
                   project: ${{ matrix.depot_project }}
-                  push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   file: ${{ matrix.dockerfile }}
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}

--- a/.github/workflows/ci-agent-proxy.yml
+++ b/.github/workflows/ci-agent-proxy.yml
@@ -5,7 +5,6 @@ on:
         branches:
             - master
     pull_request:
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -5,7 +5,6 @@ name: Agent services CI
 
 on:
     pull_request:
-    merge_group:
     push:
         branches:
             - master

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -202,8 +202,8 @@ jobs:
                   path: eval-artifacts/*/junit.xml
 
             # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs
+            # and master, never on fork PRs or Dependabot, which have no secret.
             # The TRUNK_UPLOAD_ENABLED repo variable is the kill-switch: when it is not 'true'
             # this upload skips.
             - name: Upload test results to Trunk

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -45,7 +45,7 @@ env:
     # The master ruleset's required status checks that run on master push — a failure
     # here means master is genuinely broken. Hand-synced with the ruleset; there is no
     # automated reconciliation, so update this when the required checks change.
-    # (container-images-ci and shellcheck are also required but only run on PR/merge_group,
+    # (container-images-ci and shellcheck are also required but only run on PRs,
     # so this push-based alerter can't observe them.)
     # Every workflow listed MUST run on every master push (no path filters) — the script verifies
     # runs freshness against master's newest commit; one that legitimately lags would wedge resolution.

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -21,9 +21,8 @@ on:
         # start without needing a new push. Cheap checks still run on drafts.
         # The `test-new-events-schema` label opts a PR into the doubled matrices that
         # rerun everything with CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA=true; unlabeled
-        # PRs run legacy-schema only (master/merge-queue runs always cover both).
+        # PRs run legacy-schema only (master runs always cover both).
         types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    merge_group:
 
 concurrency:
     # PRs: one active run per branch, cancel stale. Push: per-SHA so master
@@ -467,8 +466,8 @@ jobs:
     select-tests:
         name: Select tests
         needs: [changes, turbo-discover]
-        # Only draft PRs do selective runs; ready PRs and non-PR events (push,
-        # merge_group) always run full, which build_django_matrix falls back to
+        # Only draft PRs do selective runs; ready PRs and pushes always run full,
+        # which build_django_matrix falls back to
         # when select-tests is skipped (empty MODE). The run-ci-backend label
         # forces the full matrices on a draft.
         if: |

--- a/.github/workflows/ci-clickhouse-hcl-schema.yml
+++ b/.github/workflows/ci-clickhouse-hcl-schema.yml
@@ -16,7 +16,6 @@ on:
         paths:
             - 'posthog/clickhouse/hcl/**'
             - '.github/workflows/ci-clickhouse-hcl-schema.yml'
-    merge_group:
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -15,7 +15,6 @@ on:
             - 'tools/infra-scripts/clickhouse-multinode/**'
             - 'posthog/clickhouse/hcl/**'
             - '.github/workflows/ci-clickhouse-multinode-migrations.yml'
-    merge_group:
     workflow_dispatch:
 
 concurrency:
@@ -97,27 +96,18 @@ jobs:
 
             - name: Compute Postgres schema cache key
               id: schema-key
-              if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+              if: github.event_name == 'pull_request'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
-                  # On merge_group the queue branch is built directly on top of
-                  # this base SHA (latest master), so it is exactly the SHA the
-                  # cache producer keyed off — no merge-base computation needed.
-                  MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
               run: |
                   # ci-backend.yml's "Validate migrations" job dumps the post-PR
                   # schema and caches it keyed by master SHA. PR jobs key off the
                   # merge base so they restore the dump produced by the commit
-                  # their branch diverged from; merge_group jobs key off the
-                  # queue's base SHA directly.
-                  if [ "${GITHUB_EVENT_NAME}" = "merge_group" ]; then
-                      BASE_SHA="${MERGE_GROUP_BASE_SHA}"
-                  else
-                      # fetch-depth: 1000 on checkout bounds how far back the
-                      # merge base can be found; older divergence yields an empty
-                      # result and the graceful fallback to `migrate` below.
-                      BASE_SHA=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
-                  fi
+                  # their branch diverged from.
+                  # fetch-depth: 1000 on checkout bounds how far back the
+                  # merge base can be found; older divergence yields an empty
+                  # result and the graceful fallback to `migrate` below.
+                  BASE_SHA=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
                   # Always emit a key so the restore runs; when the exact branch-point
                   # SHA is unknown, the bare prefix lets restore-keys fall back to the
                   # most recent cached master schema (any valid schema works — the smoke
@@ -125,7 +115,7 @@ jobs:
                   echo "key=posthog-schema-master-${BASE_SHA}" >> "$GITHUB_OUTPUT"
 
             - name: Restore Postgres schema cache
-              if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+              if: github.event_name == 'pull_request'
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: schema.sql.gz

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -5,11 +5,6 @@ on:
         branches:
             - master
     pull_request:
-    # Required so `Dagster Tests Pass` (a required status check) reports on merge
-    # queue entries — without it the queue would wait for the check until timeout.
-    # The jobs themselves skip on merge_group (the suite already runs in full on
-    # every PR) and the aggregator treats skipped as success.
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -48,7 +43,6 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Validate dagster path filter coverage
-        if: github.event_name != 'merge_group'
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -64,7 +58,6 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run dagster checks
-        if: github.event_name != 'merge_group'
         # Set job outputs to values from filter step
         outputs:
             dagster: ${{ steps.filter.outputs.dagster || 'true' }}
@@ -435,8 +428,8 @@ jobs:
                   path: junit-*.xml
 
             # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs
+            # and master, never on fork PRs or Dependabot, which have no secret.
             # The TRUNK_UPLOAD_ENABLED repo variable is the kill-switch: when it is not 'true'
             # this upload skips.
             - name: Upload test results to Trunk

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -21,11 +21,6 @@ on:
     push:
         branches:
             - master
-    # Required so `Playwright tests pass` (a required status check) reports on
-    # merge queue entries — without it the queue would wait for the check until
-    # timeout. The jobs themselves skip on merge_group (the suite already runs
-    # in full on every PR) and the aggregator treats skipped as success.
-    merge_group:
 
 permissions:
     contents: read
@@ -85,11 +80,10 @@ jobs:
         # Drafts skip E2E (see the trigger comment); the `Playwright tests pass`
         # aggregator treats skipped as success, and drafts can't merge anyway.
         if: |
-            github.event_name != 'merge_group' && (
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event.pull_request.head.repo.full_name == github.repository &&
-             github.event.pull_request.draft != true))
+             github.event.pull_request.draft != true)
         name: Determine need to run E2E checks
         outputs:
             # Debounce can veto a PR run whose SHA has already been superseded (see below).
@@ -313,7 +307,7 @@ jobs:
         needs: [changes]
         # Narrow the suite only on incremental `synchronize` pushes to a ready
         # (non-draft) internal PR. Every other trigger — opened, reopened,
-        # ready_for_review, workflow_dispatch, push to master, merge_group — skips
+        # ready_for_review, workflow_dispatch, and push to master — skips
         # this job, leaving empty outputs so the playwright job runs the FULL suite.
         # The merge gate (ready_for_review run) and the post-merge master run always
         # run everything, so a selection miss is caught there. Fail-open is FULL,

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -7,7 +7,6 @@ on:
         # draft, add the `run-ci-frontend` label — labeled/unlabeled re-trigger
         # the run so it starts without needing a new push.
         types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    merge_group:
     push:
         branches:
             - master
@@ -162,7 +161,7 @@ jobs:
 
     # Pick which jest tests to run on draft PRs by passing changed files to
     # `jest --findRelatedTests` (jest's resolver walks the import graph for us).
-    # Skipped on ready PRs, master push, and merge_group; the jest job falls back
+    # Skipped on ready PRs and master pushes; the jest job falls back
     # to its full FOSS×EE × chunk matrix in those cases. The ready-for-review
     # full run is the merge gate. The run-ci-frontend label forces the full
     # matrix on a draft. When selection can't be trusted on a draft (config
@@ -332,7 +331,7 @@ jobs:
     frontend-bundle-size:
         name: Frontend bundle size
         needs: [changes]
-        if: needs.changes.outputs.frontend_code == 'true' && github.event_name != 'merge_group'
+        if: needs.changes.outputs.frontend_code == 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -621,7 +620,7 @@ jobs:
             # On draft PRs, select-jest-tests may narrow this to a single EE job
             # running only the tests reachable from changed frontend source files,
             # or skip jest entirely (should_run=false) when selection can't be
-            # trusted. On ready PRs, master push, and merge_group it's skipped, so
+            # trusted. On ready PRs and master pushes it's skipped, so
             # we fall back to the full FOSS×EE × chunk fanout (the merge gate).
             matrix: ${{ fromJson(needs.select-jest-tests.outputs.matrix || '{"segment":["FOSS","EE"],"chunk":[1,2,3,4]}') }}
 

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -13,7 +13,6 @@ on:
         branches:
             - master
     pull_request:
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -8,11 +8,6 @@ on:
         # the full PostHog backend and trigger on any Python change) run when the
         # PR is marked ready for review — that full run is the merge gate.
         types: [opened, synchronize, reopened, ready_for_review]
-    # Required so `MCP Tests Pass` (a required status check) reports on merge
-    # queue entries — without it the queue would wait for the check until timeout.
-    # The jobs themselves skip on merge_group (the suite already runs in full on
-    # every PR) and the aggregator treats skipped as success.
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -30,7 +25,6 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run MCP checks
-        if: github.event_name != 'merge_group'
         outputs:
             mcp: ${{ steps.filter.outputs.mcp || 'true' }}
         steps:

--- a/.github/workflows/ci-migrations-service-separation-check.yml
+++ b/.github/workflows/ci-migrations-service-separation-check.yml
@@ -1,7 +1,6 @@
 name: Migration & Service Separation Check
 
 # Reusable workflow, called by pr-housekeeping.yml on every PR push.
-# merge_group stays as a direct trigger for the merge queue.
 
 on:
     workflow_call:
@@ -10,7 +9,6 @@ on:
                 required: false
             GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY:
                 required: false
-    merge_group:
 
 permissions:
     contents: read
@@ -31,25 +29,9 @@ jobs:
             - name: Check for skip label
               id: skip-label
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  EVENT_NAME: ${{ github.event_name }}
                   PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-                  GITHUB_REF: ${{ github.ref }}
-                  GITHUB_REPOSITORY: ${{ github.repository }}
               run: |
-                  if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "workflow_call" ]; then
-                      labels="$PR_LABELS_JSON"
-                  elif [ "$EVENT_NAME" = "merge_group" ]; then
-                      # GITHUB_REF looks like refs/heads/gh-readonly-queue/<base>/pr-<num>-<sha>
-                      pr_num=$(echo "$GITHUB_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
-                      if [ -n "$pr_num" ]; then
-                          labels=$(gh api "repos/$GITHUB_REPOSITORY/issues/$pr_num/labels" --jq '[.[].name]')
-                      else
-                          labels='[]'
-                      fi
-                  else
-                      labels='[]'
-                  fi
+                  labels="$PR_LABELS_JSON"
                   echo "Labels: $labels"
                   if echo "$labels" | grep -q '"skip-migration-service-check"'; then
                       echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-ml-mirror-image-scrub-container.yml
+++ b/.github/workflows/ci-ml-mirror-image-scrub-container.yml
@@ -3,7 +3,6 @@ name: Build and deploy ml-mirror-image-scrub container image
 on:
     workflow_dispatch:
     pull_request:
-    merge_group:
     push:
         branches:
             - 'master'
@@ -19,7 +18,7 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog' && github.event_name != 'merge_group'
+        if: github.repository_owner == 'PostHog'
         name: Determine need to run ml-mirror-image-scrub Docker build
         outputs:
             scrub_files: ${{ steps.filter.outputs.scrub_files }}
@@ -46,9 +45,7 @@ jobs:
     test:
         needs: changes
         name: Unit-test ml-mirror-image-scrub
-        if: |
-            (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.scrub_files == 'true') ||
-            github.event_name == 'merge_group'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.scrub_files == 'true'
         runs-on: ubuntu-24.04
         timeout-minutes: 10
         permissions:
@@ -87,7 +84,6 @@ jobs:
         name: Build and push ml-mirror-image-scrub image
         if: |
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.scrub_files == 'true') ||
-            github.event_name == 'merge_group' ||
             (github.event_name == 'workflow_dispatch' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true') ||
             (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.scrub_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
         runs-on: depot-ubuntu-latest
@@ -133,7 +129,7 @@ jobs:
                   buildx-fallback: false
                   # Depot project "replay-vision-ingestion-ml-mirror-image-scrub".
                   project: 'hmrgpk84ch'
-                  push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   file: Dockerfile.ml-mirror-image-scrub
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -2,8 +2,7 @@ name: Build and deploy node container image
 
 on:
     workflow_dispatch:
-    # paths mirror the changes job's dorny filter, which still gates push and
-    # merge_group events (merge_group triggers don't support paths).
+    # paths mirror the changes job's dorny filter, which still gates push events.
     pull_request:
         paths:
             - 'nodejs/**'
@@ -22,7 +21,6 @@ on:
             - 'package.json'
             - 'pnpm-lock.yaml'
             - 'pnpm-workspace.yaml'
-    merge_group:
     push:
         branches:
             - 'master'
@@ -38,7 +36,7 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog' && github.event_name != 'merge_group'
+        if: github.repository_owner == 'PostHog'
         name: Determine need to run node Docker build
         outputs:
             node_files: ${{ steps.filter.outputs.node_files }}
@@ -81,7 +79,6 @@ jobs:
         name: Build and push node image
         if: |
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.node_files == 'true') ||
-            github.event_name == 'merge_group' ||
             (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.node_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
         runs-on: depot-ubuntu-latest
         timeout-minutes: 30
@@ -122,7 +119,7 @@ jobs:
                   context: .
                   buildx-fallback: false
                   project: '00mrvlsdvh'
-                  push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   file: Dockerfile.node
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -1,7 +1,6 @@
 name: Node.js CI
 on:
     pull_request:
-    merge_group:
     push:
         branches:
             - master
@@ -89,7 +88,7 @@ jobs:
               uses: ./.github/actions/rust-compute-affected
               with:
                   event-name: ${{ github.event_name }}
-                  pr-base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+                  pr-base-sha: ${{ github.event.pull_request.base.sha }}
                   push-before-sha: ${{ github.event.before }}
 
             - name: Decide whether Node.js checks should run

--- a/.github/workflows/ci-paths-filter.yml
+++ b/.github/workflows/ci-paths-filter.yml
@@ -5,7 +5,6 @@ on:
         paths:
             - '.github/actions/paths-filter/**'
             - '.github/workflows/ci-paths-filter.yml'
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-proto.yml
+++ b/.github/workflows/ci-proto.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches: [master]
     pull_request:
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -5,7 +5,6 @@ on:
         branches:
             - master
     pull_request:
-    merge_group:
 
 permissions:
     contents: read
@@ -235,8 +234,8 @@ jobs:
                   path: junit-dependency-detection.xml
 
             # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs
+            # and master, never on fork PRs or Dependabot, which have no secret.
             # The TRUNK_UPLOAD_ENABLED repo variable is the kill-switch: when it is not 'true'
             # this upload skips.
             - name: Upload test results to Trunk

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -2,8 +2,7 @@ name: Build and deploy recording-rasterizer container image
 
 on:
     workflow_dispatch:
-    # paths mirror the changes job's dorny filter, which still gates push and
-    # merge_group events (merge_group triggers don't support paths).
+    # paths mirror the changes job's dorny filter, which still gates push events.
     pull_request:
         paths:
             - 'nodejs/**'
@@ -23,7 +22,6 @@ on:
             - 'package.json'
             - 'pnpm-lock.yaml'
             - 'pnpm-workspace.yaml'
-    merge_group:
     push:
         branches:
             - 'master'
@@ -43,7 +41,7 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog' && github.event_name != 'merge_group'
+        if: github.repository_owner == 'PostHog'
         name: Determine need to run recording-rasterizer Docker build
         outputs:
             rasterizer_files: ${{ steps.filter.outputs.rasterizer_files }}
@@ -87,7 +85,6 @@ jobs:
         name: Build and push recording-rasterizer image
         if: |
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.rasterizer_files == 'true') ||
-            github.event_name == 'merge_group' ||
             (github.event_name == 'workflow_dispatch' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true') ||
             (github.event_name == 'schedule' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true') ||
             (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.rasterizer_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
@@ -133,7 +130,7 @@ jobs:
                   context: .
                   buildx-fallback: false
                   project: '00mrvlsdvh'
-                  push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   file: Dockerfile.recording-rasterizer
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches: [master, main]
     pull_request:
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -102,7 +101,7 @@ jobs:
               uses: ./.github/actions/rust-compute-affected
               with:
                   event-name: ${{ github.event_name }}
-                  pr-base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+                  pr-base-sha: ${{ github.event.pull_request.base.sha }}
                   push-before-sha: ${{ github.event.before }}
                   rebuild-all: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
 
@@ -470,8 +469,8 @@ jobs:
                   done
 
             # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
+            # so a Trunk outage never fails the job. Runs the token only on internal PRs
+            # and master, never on fork PRs or Dependabot, which have no secret.
             # The TRUNK_UPLOAD_ENABLED repo variable is the kill-switch: when it is not 'true'
             # this upload skips.
             - name: Upload test results to Trunk

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -3,7 +3,6 @@ on:
         branches:
             - master
     pull_request:
-    merge_group:
 
 name: Security
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -7,7 +7,6 @@ on:
         # `run-ci-frontend` label —
         # labeled/unlabeled re-trigger the run so it starts without needing a push.
         types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    merge_group:
     push:
         branches:
             - master
@@ -26,7 +25,6 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run storybook checks
-        if: github.event_name != 'merge_group'
         # Set job outputs to values from filter step
         outputs:
             # Two positive filters compared by count exclude generated-only PRs.
@@ -265,8 +263,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         needs: [changes, build-storybook, select-stories]
-        # always() so vr-setup still runs when select-stories is skipped (ready PRs,
-        # master push, merge_group). Without it, GitHub treats a skipped need as a
+        # always() so vr-setup still runs when select-stories is skipped (ready PRs
+        # and master pushes). Without it, GitHub treats a skipped need as a
         # skip-cascade and vr-setup wouldn't run when we still want it to.
         if: |
             always()
@@ -359,7 +357,6 @@ jobs:
             # Draft PRs may use chromium shards running only affected story files.
             # Ready PRs fall back to changes.outputs.matrix (full chromium), while
             # master pushes run chromium + webkit.
-            # Storybook CI is skipped entirely on merge_group (changes.if).
             matrix: ${{ fromJson(needs.select-stories.outputs.matrix || needs.changes.outputs.matrix) }}
         env:
             NODE_OPTIONS: --max-old-space-size=16384
@@ -617,7 +614,7 @@ jobs:
                   # Change detection is the root of the graph: if it fails, build-storybook
                   # (and everything after) is skipped, which the checks below would read as
                   # a pass. Fail here so a broken paths-filter/checkout can't launder into a
-                  # green required check. A legitimate skip (e.g. merge_group) still passes.
+                  # green required check.
                   if [[ "${{ needs.changes.result }}" != "success" && "${{ needs.changes.result }}" != "skipped" ]]; then
                     echo "Change detection did not succeed (result: ${{ needs.changes.result }}) — cannot certify visual regression."
                     exit 1
@@ -992,8 +989,7 @@ jobs:
         runs-on: ubuntu-latest
         continue-on-error: true
         timeout-minutes: 10
-        # Storybook CI is skipped on merge_group, so visual-regression won't run there;
-        # != 'skipped' keeps this from spinning a runner that downloads nothing, while still
+        # Avoid spinning a runner when visual-regression was skipped, while still
         # uploading failed-test results (the flake signal Trunk needs) on master push.
         # The TRUNK_UPLOAD_ENABLED repo variable is the kill-switch: when it is not 'true'
         # this job skips, so no results upload.

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -6,7 +6,6 @@ on:
         # retroactively kick off a build. ci-hobby.yml omits `reopened`, so we
         # do too — otherwise reopens would build an image with no consumer.
         types: [opened, synchronize, labeled, unlabeled]
-    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -16,9 +15,6 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        # Runs on merge_group too so the lint job below (a required check) can consume
-        # its changed-Dockerfile list there. should_build is ignored on merge_group —
-        # posthog_build forces a build regardless via its own `if`.
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run Docker checks
         permissions:
@@ -41,8 +37,6 @@ jobs:
             dockerfiles_changed: ${{ steps.filter.outputs.dockerfiles }}
             dockerfiles_files: ${{ steps.filter.outputs.dockerfiles_files }}
         steps:
-            # paths-filter uses the GitHub API on pull_request, but falls back to git for
-            # merge_group — so the repo must be checked out for the merge-queue run.
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token
@@ -86,7 +80,7 @@ jobs:
                       # by the `hobby:` filter — workflow self-edits, `.dockerignore`
                       # (silently changes the build context), and `pnpm-lock.yaml` so
                       # Renovate-style dep bumps are exercised on PR (otherwise they'd
-                      # only fail at merge_group / master push).
+                      # only fail after merging).
                       build_inputs:
                         - .github/workflows/container-images-ci.yml
                         - .github/actions/build-n-cache-image/**
@@ -108,8 +102,7 @@ jobs:
         name: Guard against dropped image files
         runs-on: ubuntu-24.04
         timeout-minutes: 10
-        # PR-time only (event == pull_request), so it's skipped on merge_group. Needs no secrets or
-        # docker login — unlike the image build below, it runs on fork PRs too.
+        # Needs no secrets or docker login, so unlike the image build below it runs on fork PRs too.
         if: github.event_name == 'pull_request' && needs.changes.outputs.dockerignore_changed == 'true'
         permissions:
             contents: read
@@ -131,7 +124,7 @@ jobs:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
         # Only on PostHog/posthog, as there's no docker login on forks
-        if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name  == github.repository && needs.changes.outputs.should_build == 'true') || github.event_name == 'merge_group' }}
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.should_build == 'true'
 
         outputs:
             digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,7 +2,6 @@ name: shellcheck
 
 on:
     pull_request:
-    merge_group:
 
 permissions:
     contents: read

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/cache_writes.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/cache_writes.py
@@ -53,7 +53,7 @@ SETUP_CACHE_ACTIONS = (
 
 # triggers whose runs can land on a non-default ref (workflow_dispatch is excluded
 # on purpose — see module docstring, condition 1)
-BRANCH_REF_TRIGGERS = frozenset({"pull_request", "pull_request_target", "merge_group", "workflow_call"})
+BRANCH_REF_TRIGGERS = frozenset({"pull_request", "pull_request_target", "workflow_call"})
 
 # step `if:` substrings (whitespace-stripped) that pin a write to the default branch.
 # Positive `==` only, so a negation like `github.ref != 'refs/heads/master'` (which runs


### PR DESCRIPTION
## Problem

- [`merge_group`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group) is the GitHub Actions event for GitHub Merge Queue.
- We do not use GitHub Merge Queue. Keeping its triggers and event-specific logic makes agents infer and preserve a queue contract that does not exist.
- We are evaluating merge options that do not use this event.

## Changes

- Remove `merge_group` triggers, conditions, payload handling, and stale agent guidance.
- If we need this event later, add it back with the concrete queue contract.

## How did you test this code?

- `hogli lint:workflows`
- `actionlint -shellcheck=`
- Paths-filter build, lint, pack, and 45 tests
- `hogli lint:skills` and `hogli build:skills`
- `hogli ci:preflight --fix`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- No user-facing documentation changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made the change using `/wt`, `/authoring-ci-workflows`, `/gating-production-deploys`, `/writing-skills`, and `/running-ci-preflight`. We chose deletion over speculative compatibility so agents see only the CI contracts that are currently real.