### PR TITLE
fix(auth): route blocked signups to support modal

### DIFF
--- a/frontend/src/scenes/authentication/signup/signupForm/SignupForm.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/SignupForm.tsx
@@ -4,8 +4,11 @@ import { useEffect, useState } from 'react'
 import { IconArrowLeft } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { supportLogic } from 'lib/components/Support/supportLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { Link } from 'lib/lemon-ui/Link'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { userLogic } from '../../../userLogic'
@@ -28,12 +31,31 @@ export function SignupForm(): JSX.Element | null {
         signupPanelOnboardingManualErrors,
         isSignupPanel2Submitting,
         signupPanel2ManualErrors,
+        signupPanelEmail,
         panel,
         passkeySignupEnabled,
         panelTitle,
     } = useValues(signupLogic)
     const { setPanel } = useActions(signupLogic)
+    const { preflight } = useValues(preflightLogic)
+    const { openSupportForm } = useActions(supportLogic)
     const [showSpinner, setShowSpinner] = useState(true)
+
+    const supportLink = preflight?.cloud ? (
+        <>
+            {' '}
+            <Link
+                data-attr="login-error-contact-support"
+                onClick={(e) => {
+                    e.preventDefault()
+                    openSupportForm({ kind: 'support', target_area: 'login', email: signupPanelEmail.email })
+                }}
+            >
+                Contact us
+            </Link>{' '}
+            to resolve this.
+        </>
+    ) : null
 
     useEffect(() => {
         setShowSpinner(true)
@@ -52,6 +74,7 @@ export function SignupForm(): JSX.Element | null {
                     <LemonBanner type="error">
                         {signupPanelOnboardingManualErrors.generic?.detail ||
                             'Could not complete your signup. Please try again.'}
+                        {supportLink}
                     </LemonBanner>
                 )}
                 {panel === 0 ? (
@@ -99,6 +122,7 @@ export function SignupForm(): JSX.Element | null {
             {!isSignupPanel2Submitting && signupPanel2ManualErrors?.generic && (
                 <LemonBanner type="error">
                     {signupPanel2ManualErrors.generic?.detail || 'Could not complete your signup. Please try again.'}
+                    {supportLink}
                 </LemonBanner>
             )}
             {panel === 0 ? (

--- a/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
+++ b/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
@@ -8,6 +8,7 @@ import SignupReferralSource from 'lib/components/SignupReferralSource'
 import SignupRoleSelect from 'lib/components/SignupRoleSelect'
 import passkeyLogo from 'lib/components/SocialLoginButton/passkey.svg'
 import { SocialLoginButtons } from 'lib/components/SocialLoginButton/SocialLoginButton'
+import { supportLogic } from 'lib/components/Support/supportLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
@@ -325,6 +326,7 @@ function SignupProfilePanel(): JSX.Element {
     } = useValues(signupLogic)
     const { preflight } = useValues(preflightLogic)
     const { setTurnstileToken, setPanel } = useActions(signupLogic)
+    const { openSupportForm } = useActions(supportLogic)
 
     const submitLabel = !preflight?.demo
         ? 'Create account'
@@ -374,6 +376,26 @@ function SignupProfilePanel(): JSX.Element {
             {signupPanelOnboardingManualErrors?.generic && (
                 <div className="mb-4 py-2.5 px-3 text-sm leading-normal text-primary text-left bg-danger-highlight border border-danger rounded">
                     <span>{signupPanelOnboardingManualErrors.generic.detail || 'Could not complete your signup.'}</span>
+                    {preflight?.cloud && (
+                        <>
+                            {' '}
+                            <Link
+                                data-attr="login-error-contact-support"
+                                onClick={(e) => {
+                                    e.preventDefault()
+                                    openSupportForm({
+                                        kind: 'support',
+                                        target_area: 'login',
+                                        email: signupPanelEmail.email,
+                                    })
+                                }}
+                                className="font-semibold no-underline cursor-pointer hover:underline hover:underline-offset-2 text-warning"
+                            >
+                                Contact us
+                            </Link>{' '}
+                            <span>to resolve this.</span>
+                        </>
+                    )}
                 </div>
             )}
             <Form

--- a/posthog/workos_radar.py
+++ b/posthog/workos_radar.py
@@ -34,9 +34,7 @@ WORKOS_RADAR_BYPASS_REDIS_KEY = "workos_radar_bypass_emails"
 
 class SuspiciousAttemptBlocked(APIException):
     status_code = 403
-    default_detail = (
-        "Your account has been flagged for suspicious activity. Please contact support@posthog.com to resolve this."
-    )
+    default_detail = "Your account has been flagged for suspicious activity."
     default_code = "suspicious_attempt_blocked"
     default_type = "authentication_error"
 


### PR DESCRIPTION
## Problem

When our signup fraud detection flags an email, the block message told users to email `support@posthog.com`, an inbox we no longer monitor. 

## Changes

Dropped the unmonitored email from the backend message and routed affected users to the same "Contact us" support link every other auth error already uses. It opens the support modal, which funnels into conversations. Added to the signup error banner in both auth-flow variants (legacy and paper-desk); login already had it.

| Legacy | Paper-desk |
| --- | --- |
| ![suspicious-legacy](https://raw.githubusercontent.com/PostHog/pr-assets/c154817b1924038783049681958429f332914900/2026/07/68c267d9-a9d6-437f-a5ee-2709cf94a74d.png) | ![suspicious-paperdesk](https://raw.githubusercontent.com/PostHog/pr-assets/ee0526ce17da1dc9ca0cc1585939014e0733afea/2026/07/5d1db35c-1db9-45be-a749-9b685e6445c2.png) |

## How did you test this code?

I rendered both variants in Storybook with a mocked block response and confirmed the banner reads "Your account has been flagged for suspicious activity. Contact us to resolve this." with the link opening the support modal (screenshots above). Ran ruff and oxfmt/oxlint clean. I did not run the Python suite locally (no local Postgres); no test asserts this message string, and CI covers it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

