### PR TITLE
feat(conversations): filter support ticket triggers by assigned team

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -23,7 +23,9 @@ from products.conversations.backend.events import (
     capture_ticket_priority_changed,
     capture_ticket_status_changed,
 )
-from products.conversations.backend.models import Ticket
+from products.conversations.backend.models import Ticket, TicketAssignment
+
+from ee.models.rbac.role import Role
 
 
 class TestConversationEvents(BaseTest):
@@ -112,6 +114,47 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["actor_email"] == self.user.email
         assert call_kwargs["properties"]["customer_email"] == "test@example.com"
         assert call_kwargs["properties"]["customer_distinct_id"] == self.ticket.distinct_id
+
+    @patch("products.conversations.backend.events.capture_internal")
+    def test_capture_ticket_assigned_stamps_role_name(self, mock_capture):
+        role = Role.objects.create(name="Data Warehouse", organization=self.organization)
+        capture_ticket_assigned(self.ticket, "role", str(role.id), actor=self.user, actor_type="user")
+
+        properties = mock_capture.call_args.kwargs["properties"]
+        assert properties["assignee_type"] == "role"
+        assert properties["assignee_id"] == str(role.id)
+        assert properties["assignee_role_name"] == "Data Warehouse"
+
+    @parameterized.expand(
+        [
+            ("unassigned", None, None, None),
+            ("user", "user", None, None),
+            ("role", "role", "Support Escalations", "Support Escalations"),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    def test_message_events_stamp_current_assignment(
+        self, _name, assignment_kind, role_name, expected_role_name, mock_capture
+    ):
+        if assignment_kind == "user":
+            TicketAssignment.objects.create(ticket=self.ticket, user=self.user)
+            expected_type, expected_id = "user", str(self.user.id)
+        elif assignment_kind == "role":
+            role = Role.objects.create(name=role_name, organization=self.organization)
+            TicketAssignment.objects.create(ticket=self.ticket, role=role)
+            expected_type, expected_id = "role", str(role.id)
+        else:
+            expected_type, expected_id = None, None
+
+        capture_message_received(self.ticket, "msg-1", "hi")
+        received = mock_capture.call_args.kwargs["properties"]
+        capture_message_sent(self.ticket, "msg-2", "hello", author=self.user)
+        sent = mock_capture.call_args.kwargs["properties"]
+
+        for properties in (received, sent):
+            assert properties["assignee_type"] == expected_type
+            assert properties["assignee_id"] == expected_id
+            assert properties["assignee_role_name"] == expected_role_name
 
     @patch("products.conversations.backend.events.capture_internal")
     def test_capture_message_sent_uses_team_token(self, mock_capture):

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -27,8 +27,10 @@ from posthog.personhog_client.caller_tag import personhog_caller_tag
 from posthog.settings import SITE_URL
 
 from products.conversations.backend.cache import get_cached_resolved_groups, set_cached_resolved_groups
-from products.conversations.backend.models import Ticket
+from products.conversations.backend.models import Ticket, TicketAssignment
 from products.conversations.backend.models.constants import Channel
+
+from ee.models.rbac.role import Role
 
 logger = structlog.get_logger(__name__)
 
@@ -290,6 +292,33 @@ def _get_customer_properties(ticket: Ticket, *, include_distinct_id: bool = Fals
     return properties
 
 
+def _get_assignment_properties(ticket: Ticket) -> dict:
+    """Current assignment on the ticket, so workflows can route a single team's tickets.
+
+    `assignee_type` is "user", "role", or None (unassigned). `assignee_role_name` is set only for
+    role assignments, letting filters target a team by name instead of its UUID.
+    """
+    assignment = TicketAssignment.objects.select_related("role").filter(ticket_id=ticket.id).first()
+    if assignment is None:
+        return {"assignee_type": None, "assignee_id": None, "assignee_role_name": None}
+    if assignment.user_id is not None:
+        return {"assignee_type": "user", "assignee_id": str(assignment.user_id), "assignee_role_name": None}
+    if assignment.role_id is not None:
+        return {
+            "assignee_type": "role",
+            "assignee_id": str(assignment.role_id),
+            "assignee_role_name": assignment.role.name if assignment.role else None,
+        }
+    return {"assignee_type": None, "assignee_id": None, "assignee_role_name": None}
+
+
+def _role_name_for_assignee(assignee_type: str | None, assignee_id: str | None) -> str | None:
+    """Look up a role's name for the assignment event; None for user or empty assignees."""
+    if assignee_type != "role" or not assignee_id:
+        return None
+    return Role.objects.filter(id=assignee_id).values_list("name", flat=True).first()
+
+
 def _get_sla_properties(ticket: Ticket, now: datetime) -> dict:
     """SLA state at the moment of the event.
 
@@ -393,6 +422,7 @@ def capture_ticket_assigned(
     properties = _get_ticket_base_properties(ticket)
     properties["assignee_type"] = assignee_type
     properties["assignee_id"] = assignee_id
+    properties["assignee_role_name"] = _role_name_for_assignee(assignee_type, assignee_id)
     properties.update(_get_actor_properties(actor, actor_type))
     properties.update(_get_customer_properties(ticket, include_distinct_id=True))
 
@@ -419,6 +449,7 @@ def capture_message_sent(
     properties["author_type"] = "team"
     properties.update(_get_actor_properties(author, "user"))
     properties.update(_get_customer_properties(ticket, include_distinct_id=True))
+    properties.update(_get_assignment_properties(ticket))
     properties.update(_get_sla_properties(ticket, timezone.now()))
 
     capture_internal(
@@ -438,6 +469,7 @@ def capture_message_received(ticket: Ticket, message_id: str, message_content: s
     properties["message_content"] = (message_content or "")[:1000]
     properties["author_type"] = "customer"
     properties.update(_get_customer_properties(ticket))
+    properties.update(_get_assignment_properties(ticket))
 
     team = ticket.team
     process_person = False

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -312,11 +312,15 @@ def _get_assignment_properties(ticket: Ticket) -> dict:
     return {"assignee_type": None, "assignee_id": None, "assignee_role_name": None}
 
 
-def _role_name_for_assignee(assignee_type: str | None, assignee_id: str | None) -> str | None:
+def _role_name_for_assignee(ticket: Ticket, assignee_type: str | None, assignee_id: str | None) -> str | None:
     """Look up a role's name for the assignment event; None for user or empty assignees."""
     if assignee_type != "role" or not assignee_id:
         return None
-    return Role.objects.filter(id=assignee_id).values_list("name", flat=True).first()
+    return (
+        Role.objects.filter(id=assignee_id, organization_id=ticket.team.organization_id)
+        .values_list("name", flat=True)
+        .first()
+    )
 
 
 def _get_sla_properties(ticket: Ticket, now: datetime) -> dict:
@@ -422,7 +426,7 @@ def capture_ticket_assigned(
     properties = _get_ticket_base_properties(ticket)
     properties["assignee_type"] = assignee_type
     properties["assignee_id"] = assignee_id
-    properties["assignee_role_name"] = _role_name_for_assignee(assignee_type, assignee_id)
+    properties["assignee_role_name"] = _role_name_for_assignee(ticket, assignee_type, assignee_id)
     properties.update(_get_actor_properties(actor, actor_type))
     properties.update(_get_customer_properties(ticket, include_distinct_id=True))
 

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/conversations.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/conversations.tsx
@@ -5,6 +5,7 @@ import { LemonSelect } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
+import { HogFlowPropertyFilters } from 'products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters'
 import {
     type EventTriggerConfig,
     registerTriggerType,
@@ -75,18 +76,51 @@ function StepTriggerConfigurationSupportStatusChanged({ node }: { node: any }): 
     )
 }
 
-function StepTriggerConfigurationSupportMessage({ node }: { node: any }): JSX.Element {
+const SUPPORT_TRIGGER_META: Record<string, { name: string; description: string }> = {
+    $conversation_message_received: {
+        name: 'Ticket message received',
+        description: 'This trigger runs when a customer sends a message on a ticket.',
+    },
+    $conversation_message_sent: {
+        name: 'Ticket message sent',
+        description: 'This trigger runs when a teammate sends a reply on a ticket.',
+    },
+    $conversation_ticket_assigned: {
+        name: 'Ticket assigned',
+        description: 'This trigger runs when a ticket is assigned to a teammate or team.',
+    },
+}
+
+// A support trigger is fundamentally an event subscription; these extra property filters narrow it,
+// e.g. only tickets assigned to one team (assignee_role_name), or a given priority/channel.
+function StepTriggerConfigurationSupportFilters({ node }: { node: any }): JSX.Element {
+    const { setWorkflowActionConfig } = useActions(workflowLogic)
     const config = node.data.config as EventTriggerConfig
-    const eventId = getEventId(config)
-    const kind = eventId === '$conversation_message_sent' ? 'sent' : 'received'
+    const eventId = getEventId(config) ?? '$conversation_message_received'
+    const meta = SUPPORT_TRIGGER_META[eventId] ?? SUPPORT_TRIGGER_META['$conversation_message_received']
 
     return (
         <div className="flex flex-col gap-2 w-full">
-            <p className="mb-0 text-sm text-muted-alt">
-                {kind === 'sent'
-                    ? 'This trigger runs when a teammate sends a reply on a ticket.'
-                    : 'This trigger runs when a customer sends a message on a ticket.'}
-            </p>
+            <p className="mb-0 text-sm text-muted-alt">{meta.description}</p>
+            <LemonField.Pure
+                label="Filters"
+                info="Only run when the ticket matches these properties. Filter on assignee_role_name to target a single team, or on priority, status, or channel_source."
+            >
+                <HogFlowPropertyFilters
+                    filtersKey={`support-trigger-${node.data.id}`}
+                    filters={config.filters ?? {}}
+                    setFilters={(filters) =>
+                        setWorkflowActionConfig(node.data.id, {
+                            type: 'event',
+                            filters: {
+                                ...filters,
+                                events: [{ id: eventId, type: 'events', name: meta.name }],
+                            },
+                        })
+                    }
+                    typeKey={`support-trigger-${node.data.id}`}
+                />
+            </LemonField.Pure>
         </div>
     )
 }
@@ -121,6 +155,22 @@ registerTriggerType({
 })
 
 registerTriggerType({
+    value: 'support_ticket_assigned',
+    label: 'Ticket assigned',
+    icon: <IconBolt />,
+    description: 'Trigger when a ticket is assigned to a teammate or team',
+    group: 'Support',
+    matchConfig: (config) => config.type === 'event' && getEventId(config) === '$conversation_ticket_assigned',
+    buildConfig: () => ({
+        type: 'event',
+        filters: {
+            events: [{ id: '$conversation_ticket_assigned', type: 'events', name: 'Ticket assigned' }],
+        },
+    }),
+    ConfigComponent: StepTriggerConfigurationSupportFilters,
+})
+
+registerTriggerType({
     value: 'support_message_sent',
     label: 'Ticket message sent',
     icon: <IconBolt />,
@@ -133,7 +183,7 @@ registerTriggerType({
             events: [{ id: '$conversation_message_sent', type: 'events', name: 'Ticket message sent' }],
         },
     }),
-    ConfigComponent: StepTriggerConfigurationSupportMessage,
+    ConfigComponent: StepTriggerConfigurationSupportFilters,
 })
 
 registerTriggerType({
@@ -149,5 +199,5 @@ registerTriggerType({
             events: [{ id: '$conversation_message_received', type: 'events', name: 'Ticket message received' }],
         },
     }),
-    ConfigComponent: StepTriggerConfigurationSupportMessage,
+    ConfigComponent: StepTriggerConfigurationSupportFilters,
 })


### PR DESCRIPTION
## Problem

Support workflows can trigger on ticket messages and assignments, but there was no way to scope a trigger to a single support team. The `Ticket message received` / `Ticket message sent` triggers had no filter UI at all, and the assignee never made it onto those events, so you couldn't say "only run this workflow for tickets assigned to the Data Warehouse team" (e.g. to POST that team's tickets to a webhook).

## Changes

Two parts.

**Stamp the assignee onto the events.** A ticket is assigned to a user or an `ee.Role`, but only `$conversation_ticket_assigned` carried the assignee. This adds `assignee_type` (`user`/`role`/`null`), `assignee_id`, and `assignee_role_name` to `$conversation_message_received` and `$conversation_message_sent`, and adds `assignee_role_name` to `$conversation_ticket_assigned`. The role name is included so filters can target a team by name instead of a UUID.

**Add the filter UI.** The two message triggers were description-only. They now render the standard `HogFlowPropertyFilters` editor, so you can filter the trigger directly on `assignee_role_name` (or priority, status, channel_source, etc.) without a downstream conditional branch. Also registers a new `Ticket assigned` trigger with the same filter UI.

> [!NOTE]
> `$conversation_message_received` fires on a customer's first message too, which is often before the ticket is assigned to anyone. For "route a team's tickets" the `Ticket assigned` trigger is usually the better fit since it fires the moment routing happens.

## How did you test this code?

Added backend coverage in `products/conversations/backend/api/tests/test_events.py`:

- `test_message_events_stamp_current_assignment` (parameterized over unassigned / user-assigned / role-assigned) — catches a regression where the assignment stamping is dropped or maps role↔user wrong, which would silently make a team-scoped filter match every team.
- `test_capture_ticket_assigned_stamps_role_name` — guards the role-name lookup on the assignment event.

I (Claude) could not run the backend tests locally: this checkout's virtualenv is Python 3.12, but current master fails to import on 3.12 (the `AsyncGenerator[dict]` single-arg syntax in `posthog/temporal/common/clickhouse.py` needs 3.13). That is a pre-existing env mismatch unrelated to this change and it blocks collection of the whole module, so the tests will run in CI. `ruff check`/`ruff format` are clean on the Python, and `oxfmt` is clean on the frontend. I did not do manual UI testing (no running frontend in this environment), so no screenshot.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). I invoked the `/writing-tests` skill before adding the test cases to keep them behavior-focused and parameterized.

The original ask was just an outbound webhook for one team's tickets. Investigation showed the workflow webhook destination already exists, so the real gap was filtering: the assignee wasn't on the message events and the message triggers had no filter UI. I considered a bespoke role picker (like the existing status dropdown) but chose the generic `HogFlowPropertyFilters` editor instead — it reuses the same component the conditional-branch step already uses, needs no roles-fetching logic, and lets you filter on anything on the event, not just the team. I skipped adding the new properties to the taxonomy JSON because none of the sibling conversation properties (`channel_source`, `new_status`, etc.) are defined there either, so a lone entry would be inconsistent.
