### PR TITLE
chore(ci): jest quarantine throwaway e2e validation

### DIFF
--- a/.test_quarantine.json
+++ b/.test_quarantine.json
@@ -1,4 +1,59 @@
 {
     "version": 1,
-    "entries": []
+    "entries": [
+        {
+            "id": "common/replay-shared/src/quarantine_e2e_scratch.test.ts",
+            "runner": "jest",
+            "reason": "throwaway e2e: replay-shared suite",
+            "owner": "@raul",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "frontend/src/test/quarantine_e2e_each_scratch.test.ts",
+            "runner": "jest",
+            "reason": "throwaway e2e: file scope covers test.each rows",
+            "owner": "@raul",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "frontend/src/test/quarantine_e2e_scratch.test.ts::QuarantineAsync always rejects",
+            "runner": "jest",
+            "reason": "throwaway e2e: skipped test",
+            "owner": "@raul",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "skip"
+        },
+        {
+            "id": "frontend/src/test/quarantine_e2e_scratch.test.ts::QuarantineE2E always fails",
+            "runner": "jest",
+            "reason": "throwaway e2e: tolerated sync failure",
+            "owner": "@raul",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "nodejs/tests/quarantine_e2e_scratch.test.ts",
+            "runner": "jest",
+            "reason": "throwaway e2e: nodejs suite",
+            "owner": "@raul",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "product:engineering-analytics",
+            "runner": "jest",
+            "reason": "throwaway e2e: product scope",
+            "owner": "@raul",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        }
+    ]
 }

--- a/common/replay-shared/src/quarantine_e2e_scratch.test.ts
+++ b/common/replay-shared/src/quarantine_e2e_scratch.test.ts
@@ -1,0 +1,6 @@
+// Throwaway fixture validating the jest quarantine adapter end to end in CI. Never merge.
+describe('QuarantineReplayShared', () => {
+    test('always fails', () => {
+        expect('e2e deliberate replay-shared failure').toBe('tolerated')
+    })
+})

--- a/frontend/src/test/quarantine_e2e_each_scratch.test.ts
+++ b/frontend/src/test/quarantine_e2e_each_scratch.test.ts
@@ -1,0 +1,6 @@
+// Throwaway fixture validating the jest quarantine adapter end to end in CI. Never merge.
+describe('QuarantineEach', () => {
+    test.each([[1], [2]])('each row %i fails', (row) => {
+        expect(row).toBe('e2e deliberate each failure')
+    })
+})

--- a/frontend/src/test/quarantine_e2e_scratch.test.ts
+++ b/frontend/src/test/quarantine_e2e_scratch.test.ts
@@ -1,0 +1,17 @@
+// Throwaway fixture validating the jest quarantine adapter end to end in CI. Never merge.
+describe('QuarantineE2E', () => {
+    test('always fails', () => {
+        expect('e2e deliberate sync failure').toBe('tolerated')
+    })
+
+    test('passes normally', () => {
+        expect(1 + 1).toBe(2)
+    })
+})
+
+describe('QuarantineAsync', () => {
+    test('always rejects', async () => {
+        await Promise.resolve()
+        expect('e2e deliberate async failure').toBe('skipped')
+    })
+})

--- a/nodejs/tests/quarantine_e2e_scratch.test.ts
+++ b/nodejs/tests/quarantine_e2e_scratch.test.ts
@@ -1,0 +1,4 @@
+// Throwaway fixture validating the jest quarantine adapter end to end in CI. Never merge.
+test('quarantine e2e scratch always fails', () => {
+    expect('e2e deliberate nodejs failure').toBe('tolerated')
+})

--- a/products/engineering_analytics/frontend/quarantine_e2e_scratch.test.ts
+++ b/products/engineering_analytics/frontend/quarantine_e2e_scratch.test.ts
@@ -1,0 +1,6 @@
+// Throwaway fixture validating the jest quarantine adapter end to end in CI. Never merge.
+describe('QuarantineProduct', () => {
+    test('always fails', () => {
+        expect('e2e deliberate product-scope failure').toBe('tolerated')
+    })
+})


### PR DESCRIPTION
## Problem

- CI-level proof that the [jest quarantine adapter](https://github.com/PostHog/posthog/pull/67960) keeps deliberately failing quarantined tests from failing CI.
- **Throwaway - never merge.** Will be closed once CI settles.

## Changes

- 5 deliberately failing jest fixtures across the frontend, `products/`, `nodejs`, and `common/replay-shared` suites
- `.test_quarantine.json` entries covering them via exact-name (`run` and `skip` modes), file-scope (covers `test.each` rows), and `product:` selectors - authored with `hogli test:quarantine add --runner jest`

## How did you test this code?

- Locally in a worktree: each suite exits 0 with entries active and exits 1 without them (12-scenario matrix: expiry, wrong runner, partial names, selector specificity, malformed JSON fail-open)
- The green Jest / Node.js / replay-shared jobs on this PR are the CI-level assertion

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- None (throwaway)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session validating the adapter branch end to end
- No skills invoked; fixtures are deliberately failing throwaway files, not suite tests
