### PR TITLE
fix(conversations): keep ticket list clickable while refreshing

### DIFF
--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -173,6 +173,9 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
             dataSource={tickets}
             rowKey="id"
             loading={ticketsLoading}
+            // Keep rows clickable while a background refresh is in flight; the loading overlay
+            // otherwise captures pointer events and blocks navigation on every reload.
+            disableTableWhileLoading={false}
             embedded={embedded}
             sorting={sorting}
             onSort={(newSorting) => setSorting(newSorting)}


### PR DESCRIPTION
## Problem

Refreshing the support ticket list makes it unclickable. Every background reload sets the table's `loading` state, and `LemonTable` renders a loading overlay that sits on top of the rows. While loading, that overlay flips to `pointer-events: auto`, so it swallows every click and you can't open a ticket until the refresh finishes.

## Changes

Pass `disableTableWhileLoading={false}` to the ticket list `LemonTable`. That prop (default `true`) is exactly what gates the click-blocking overlay. With it off, the rows stay interactive during a reload. The overlay's absolute positioning and `pointer-events: auto` on `.LemonTable--loading` is the mechanism:

https://github.com/PostHog/posthog/blob/master/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss#L263-L279

Only the main list table is affected. The side-panel ticket lists don't use `LemonTable`, so nothing else needed the change.

## How did you test this code?

No automated test. This is a one-line prop wiring change, and the interactive-while-loading behavior lives in `LemonTable` itself, not this scene. A test asserting the scene passes the prop would be a change-detector, and one asserting the overlay behavior would be re-testing `LemonTable`. I (Claude) did not run the frontend locally in this environment, so no manual UI verification or screenshot. `oxfmt` is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Tom reported the bug and pointed at a LemonTable prop as the likely fix. I traced it to the `.LemonTable__overlay` / `disableTableWhileLoading` path, confirmed the overlay captures pointer events while loading, and checked the other conversations ticket lists (side panel, previous tickets) to confirm they don't share the pattern.
