### PR TITLE
fix(data-warehouse): make internal-IP host error actionable

### DIFF
--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -1450,7 +1450,12 @@ class TestDirectPostgresQuery(APIBaseTest):
         with self.assertRaises(ExposedHogQLError) as error:
             executor.execute()
 
-        self.assertEqual(str(error.exception), "Hosts with internal IP addresses are not allowed")
+        self.assertEqual(
+            str(error.exception),
+            "This host points to an internal or private IP address, which PostHog can't reach. "
+            "Use a host that's reachable from the public internet. "
+            "If your database isn't publicly reachable, connect through an SSH tunnel.",
+        )
         mock_connect.assert_not_called()
 
     @patch("posthog.hogql.direct_sql.postgres_adapter.psycopg.connect")

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -5016,7 +5016,14 @@ class TestExternalDataSource(APIBaseTest):
                 },
             )
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json(), {"message": "Hosts with internal IP addresses are not allowed"})
+            self.assertEqual(
+                response.json(),
+                {
+                    "message": "This host points to an internal or private IP address, which PostHog can't reach. "
+                    "Use a host that's reachable from the public internet. "
+                    "If your database isn't publicly reachable, connect through an SSH tunnel."
+                },
+            )
 
         with override_settings(CLOUD_DEPLOYMENT="EU"):
             team_1 = Team.objects.create(id=1, organization=self.team.organization)
@@ -5087,7 +5094,14 @@ class TestExternalDataSource(APIBaseTest):
                 },
             )
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json(), {"message": "Hosts with internal IP addresses are not allowed"})
+            self.assertEqual(
+                response.json(),
+                {
+                    "message": "This host points to an internal or private IP address, which PostHog can't reach. "
+                    "Use a host that's reachable from the public internet. "
+                    "If your database isn't publicly reachable, connect through an SSH tunnel."
+                },
+            )
 
         patch_get_postgres_row_count.assert_not_called()
 
@@ -5140,7 +5154,14 @@ class TestExternalDataSource(APIBaseTest):
             for url, data in [(database_schema_url, database_schema_data), (create_url, create_data)]:
                 response = self.client.post(url, data=data)
                 self.assertEqual(response.status_code, 400, f"Expected 400 for {host} on {url}")
-                self.assertEqual(response.json(), {"message": "Hosts with internal IP addresses are not allowed"})
+                self.assertEqual(
+                    response.json(),
+                    {
+                        "message": "This host points to an internal or private IP address, which PostHog can't reach. "
+                        "Use a host that's reachable from the public internet. "
+                        "If your database isn't publicly reachable, connect through an SSH tunnel."
+                    },
+                )
 
             self.assertFalse(
                 ExternalDataSource.objects.filter(team=self.team, source_type="Postgres").exists(),
@@ -6631,7 +6652,11 @@ class TestExternalDataSource(APIBaseTest):
         )
 
         assert response.status_code == 400
-        assert response.json()["detail"] == "Hosts with internal IP addresses are not allowed"
+        assert response.json()["detail"] == (
+            "This host points to an internal or private IP address, which PostHog can't reach. "
+            "Use a host that's reachable from the public internet. "
+            "If your database isn't publicly reachable, connect through an SSH tunnel."
+        )
 
         source.refresh_from_db()
         assert source.job_inputs["host"] == "db.example.com"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -20,7 +20,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.int
 
 logger = structlog.get_logger(__name__)
 
-_INTERNAL_IP_ERROR = "Hosts with internal IP addresses are not allowed"
+_INTERNAL_IP_ERROR = (
+    "This host points to an internal or private IP address, which PostHog can't reach. "
+    "Use a host that's reachable from the public internet."
+)
 _DNS_FAILURE_ERROR = "Host could not be resolved"
 
 
@@ -302,4 +305,9 @@ class ValidateDatabaseHostMixin:
         if using_ssh_tunnel:
             return True, None
 
-        return _is_host_safe(host, team_id)
+        is_valid, error = _is_host_safe(host, team_id)
+        if not is_valid and error == _INTERNAL_IP_ERROR:
+            # Direct (non-tunneled) connection, so reaching a private database through a public
+            # SSH bastion is a genuine workaround worth pointing at.
+            return is_valid, f"{error} If your database isn't publicly reachable, connect through an SSH tunnel."
+        return is_valid, error

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -112,7 +112,10 @@ class TestIsHostSafe(SimpleTestCase):
         ):
             valid, error = _is_host_safe("evil.example.com", team_id=999)
             assert not valid
-            assert error == "Hosts with internal IP addresses are not allowed"
+            assert error == (
+                "This host points to an internal or private IP address, which PostHog can't reach. "
+                "Use a host that's reachable from the public internet."
+            )
 
     @override_settings(CLOUD_DEPLOYMENT="US")
     def test_dns_resolving_to_public_ip_allowed(self):


### PR DESCRIPTION
## Problem

When someone connects a database source (Postgres, MySQL, MSSQL, Redshift, ClickHouse, MongoDB) whose host resolves to an internal or private IP, PostHog Cloud blocks the connection for SSRF safety. The message was:

> Hosts with internal IP addresses are not allowed

It states a rule but not what to do about it. In onboarding sessions people hit this and tried unrelated things (switching sync methods) before giving up, because nothing pointed them at the actual fix.

## Changes

Rewrite the message to explain what happened and the next action:

> This host points to an internal or private IP address, which PostHog can't reach. Use a host that's reachable from the public internet.

On the direct (non-tunneled) database connection path, append the escape hatch that actually unblocks a private database:

> If your database isn't publicly reachable, connect through an SSH tunnel.

The SSH-tunnel hint is added only in `ValidateDatabaseHostMixin.is_database_host_valid`, so it appears for direct DB connections but not when validating the SSH tunnel's own bastion host (where "use a tunnel" would be circular) or for non-database API sources that reuse the base host check.

This is a copy change to a validation error. No change to what is blocked, how hosts are validated, or sync behavior.

## How did you test this code?

I (Claude) ran the affected unit test suite (`test_mixins.py`, 50 tests) which exercises `_is_host_safe` and asserts the new base message — all pass. The DB-backed tests (`test_external_data_source.py`, `test_direct_postgres_query.py` internal-host cases) were updated to the new strings but could not run in this sandbox as it has no Postgres; CI is the first full run. The augmented string is exact concatenation of the base constant, verified by hand against the updated assertions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) from a Replay Vision review of data-warehouse new-source onboarding sessions, where a user hit the internal-IP block and abandoned setup after trying fixes that couldn't help.

I traced the message to the shared `_INTERNAL_IP_ERROR` constant in `common/mixins.py`, reused by both the direct DB host check and the SSH-tunnel-host check. I kept the base message generic (valid in both contexts and for API sources) and scoped the SSH-tunnel suggestion to the direct-connection path only, to avoid contradictory advice when a user is already configuring a tunnel. Tests asserting the production message were updated; source tests that mock the host check with a representative string were left as-is since they don't assert the production constant.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
