### PR TITLE
fix(error-tracking): tolerate transient offset store failures in notifications consumer

### DIFF
--- a/rust/cymbal/src/modes/notifications/consumer_loop.rs
+++ b/rust/cymbal/src/modes/notifications/consumer_loop.rs
@@ -14,7 +14,8 @@ const NOTIFICATIONS_HANDLED_TOTAL: &str = "cymbal_notifications_handled_total";
 const NOTIFICATIONS_SKIPPED_TOTAL: &str = "cymbal_notifications_skipped_total";
 const NOTIFICATIONS_KAFKA_ERRORS_TOTAL: &str = "cymbal_notifications_kafka_errors_total";
 const NOTIFICATIONS_HANDLE_ERRORS_TOTAL: &str = "cymbal_notifications_handle_errors_total";
-const NOTIFICATIONS_OFFSET_STORE_ERRORS_TOTAL: &str = "cymbal_notifications_offset_store_errors_total";
+const NOTIFICATIONS_OFFSET_STORE_ERRORS_TOTAL: &str =
+    "cymbal_notifications_offset_store_errors_total";
 const NOTIFICATIONS_COMMIT_BATCH_SIZE: usize = 100;
 const NOTIFICATIONS_FETCH_BATCH_TIMEOUT: Duration = Duration::from_millis(250);
 

--- a/rust/cymbal/src/modes/notifications/consumer_loop.rs
+++ b/rust/cymbal/src/modes/notifications/consumer_loop.rs
@@ -13,13 +13,17 @@ const NOTIFICATIONS_HANDLED_TOTAL: &str = "cymbal_notifications_handled_total";
 const NOTIFICATIONS_SKIPPED_TOTAL: &str = "cymbal_notifications_skipped_total";
 const NOTIFICATIONS_KAFKA_ERRORS_TOTAL: &str = "cymbal_notifications_kafka_errors_total";
 const NOTIFICATIONS_HANDLE_ERRORS_TOTAL: &str = "cymbal_notifications_handle_errors_total";
+const NOTIFICATIONS_OFFSET_STORE_ERRORS_TOTAL: &str = "cymbal_notifications_offset_store_errors_total";
 const NOTIFICATIONS_COMMIT_BATCH_SIZE: usize = 100;
 const NOTIFICATIONS_FETCH_BATCH_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Receive messages until shutdown. Offsets are stored only after successful
 /// handling, then explicitly committed after each fetched batch. Serde and empty
 /// failures are auto-stored as poison pills inside `json_recv_batch`, so this
-/// loop also explicitly commits those stored offsets.
+/// loop also explicitly commits those stored offsets. Storing an offset can fail
+/// transiently when a partition is revoked mid-rebalance (librdkafka reports
+/// "Erroneous state"); that is tolerated by leaving the offset uncommitted so the
+/// notification is redelivered, rather than crashing the consumer.
 pub async fn consume_loop(
     consumer: SingleTopicConsumer,
     context: NotificationsContext,
@@ -65,7 +69,15 @@ async fn handle_notification_batch(
                 ) {
                     Ok(Some(offset)) => offset,
                     Ok(None) => continue,
-                    Err(e) => panic!("failed to store invalid notification offset: {e}"),
+                    // Storing an offset can fail transiently (e.g. the partition was
+                    // revoked mid-rebalance, which librdkafka reports as "Erroneous
+                    // state"). That's not fatal: the offset stays uncommitted and the
+                    // notification is redelivered once the rebalance settles.
+                    Err(e) => {
+                        warn!(error = %e, "failed to store invalid notification offset (will retry)");
+                        metrics::counter!(NOTIFICATIONS_OFFSET_STORE_ERRORS_TOTAL).increment(1);
+                        continue;
+                    }
                 };
 
                 log_notification_summary(&notification);
@@ -74,10 +86,14 @@ async fn handle_notification_batch(
                     Ok(()) => {
                         metrics::counter!(NOTIFICATIONS_HANDLED_TOTAL).increment(1);
                         // `commit_consumer_state` only commits offsets explicitly stored on the consumer.
+                        // A store failure here is transient (see above) rather than fatal, so leave the
+                        // offset uncommitted and let the notification be redelivered.
                         if let Err(e) = offset.store() {
-                            panic!("failed to store notification offset: {e}");
+                            warn!(error = %e, "failed to store notification offset (will retry)");
+                            metrics::counter!(NOTIFICATIONS_OFFSET_STORE_ERRORS_TOTAL).increment(1);
+                        } else {
+                            *pending_offsets += 1;
                         }
-                        *pending_offsets += 1;
                     }
                     Err(e) => {
                         metrics::counter!(NOTIFICATIONS_HANDLE_ERRORS_TOTAL).increment(1);

--- a/rust/cymbal/src/modes/notifications/consumer_loop.rs
+++ b/rust/cymbal/src/modes/notifications/consumer_loop.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use common_kafka::kafka_consumer::{Offset, RecvErr, SingleTopicConsumer};
@@ -58,9 +59,22 @@ async fn handle_notification_batch(
     batch: Vec<Result<(IngestionNotification, Offset), RecvErr>>,
     pending_offsets: &mut usize,
 ) {
+    // Partitions whose offset store failed earlier in this batch. `commit_consumer_state`
+    // commits the latest stored offset per partition, so once we skip storing an offset we
+    // must not store any later offset on the same partition — otherwise that later commit
+    // would jump the gap and permanently skip the failed message instead of redelivering it.
+    let mut poisoned_partitions: HashSet<i32> = HashSet::new();
+
     for result in batch {
         match result {
             Ok((notification, offset)) => {
+                let partition = offset.partition();
+                if poisoned_partitions.contains(&partition) {
+                    metrics::counter!(NOTIFICATIONS_SKIPPED_TOTAL, "reason" => "partition_poisoned")
+                        .increment(1);
+                    continue;
+                }
+
                 let offset = match validate_notification_with_offset(
                     &notification,
                     offset,
@@ -76,6 +90,7 @@ async fn handle_notification_batch(
                     Err(e) => {
                         warn!(error = %e, "failed to store invalid notification offset (will retry)");
                         metrics::counter!(NOTIFICATIONS_OFFSET_STORE_ERRORS_TOTAL).increment(1);
+                        poisoned_partitions.insert(partition);
                         continue;
                     }
                 };
@@ -87,10 +102,12 @@ async fn handle_notification_batch(
                         metrics::counter!(NOTIFICATIONS_HANDLED_TOTAL).increment(1);
                         // `commit_consumer_state` only commits offsets explicitly stored on the consumer.
                         // A store failure here is transient (see above) rather than fatal, so leave the
-                        // offset uncommitted and let the notification be redelivered.
+                        // offset uncommitted and poison the partition so no later offset on it advances
+                        // past this message before redelivery.
                         if let Err(e) = offset.store() {
                             warn!(error = %e, "failed to store notification offset (will retry)");
                             metrics::counter!(NOTIFICATIONS_OFFSET_STORE_ERRORS_TOTAL).increment(1);
+                            poisoned_partitions.insert(partition);
                         } else {
                             *pending_offsets += 1;
                         }


### PR DESCRIPTION
## Problem

The cymbal notifications consumer crashes with:

```
Panic: failed to store notification offset: Kafka error: Store offset error: State (Local: Erroneous state)
```

`Offset::store()` calls librdkafka's `store_offset`, which returns `RD_KAFKA_RESP_ERR__STATE` ("Erroneous state") when the partition it's storing for is no longer assigned to the consumer. That's the routine result of a consumer-group rebalance, not a fault. The consumer loop treated every store failure as fatal and `panic!`'d, so each rebalance took the process down and put it into a restart loop.

Reported via [error tracking](https://us.posthog.com/error_tracking/019f5c24-2969-7ce2-a215-7c4dc3904f8e).

## Changes

Storing an offset is a local, best-effort operation. If it fails, the offset just stays uncommitted and the notification is redelivered after the rebalance settles, which the loop already tolerates (offsets are stored only after successful handling, so it's at-least-once). So on a store failure I now log a warning and count it in a new `cymbal_notifications_offset_store_errors_total` metric instead of panicking. Both store call sites (the poison-pill path in `validate_notification_with_offset` and the handled-notification path) get the same treatment.

> [!NOTE]
> No behavior change for healthy operation. This only affects what happens when a partition is revoked out from under an in-flight store, where the old code crashed and the new code lets the message be reprocessed.

## How did you test this code?

I could not compile in this environment (no Rust toolchain available), so I have not run `cargo check`/tests here. CI will build and run the cymbal crate. The existing `validate_notification_with_offset` unit test still holds — its `pending_offsets` accounting is unchanged, since that counter is still only incremented after a successful store.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Traced the panic from the stack trace (`consumer_loop.rs:78`) to `Offset::store()` in `common/kafka`, then confirmed the `State (Local: Erroneous state)` message maps to librdkafka's `RD_KAFKA_RESP_ERR__STATE`, returned by `store_offset` for a partition that isn't currently assigned — i.e. a rebalance. Considered swallowing only the specific error code, but a failed local offset store is non-fatal regardless of the exact code (the message simply redelivers), so treating all store failures as a logged, metered warning is simpler and safe.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
