### PR TITLE
fix(tasks): let team members drive runs of slack-originated tasks

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1784,10 +1784,17 @@ def task_accessible_for_run_view(
     read actions, which the caller signals via ``bypass_visibility``. Run-mutating actions pass
     ``for_control`` to use the narrower ``task_control_q`` — public-channel visibility lets
     teammates watch a run, not drive it.
+
+    Slack-originated tasks are the exception: those threads are multiplayer, so any same-team
+    user can already steer the run from Slack (follow-ups record them as the run's actor, with
+    sandbox credentials minted for them). The runs API mirrors that and lets team members drive
+    and watch Slack tasks' runs — otherwise a non-creator actor's sandbox 404s on every callback
+    (reply relay, log-append heartbeat, completion PATCH) and the thread dies silently.
     """
     task_filter = Task.objects.filter(id=task_id, team_id=team_id)
     if not bypass_visibility:
-        task_filter = task_filter.filter(task_control_q(user_id) if for_control else task_visibility_q(user_id))
+        scope_q = task_control_q(user_id) if for_control else task_visibility_q(user_id)
+        task_filter = task_filter.filter(scope_q | Q(origin_product=Task.OriginProduct.SLACK))
     return task_filter.exists()
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -9944,3 +9944,66 @@ class TestSandboxCustomImageAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["status"], "scanning")
         mock_workflow.assert_called_once()
+
+
+class TestTaskRunSlackTaskTeamControl(BaseTaskAPITest):
+    """Slack-originated tasks are multiplayer: any same-team user may drive their runs.
+
+    Guards the incident where a non-creator's thread follow-up resumed a run whose sandbox
+    then 404'd on every callback (status PATCH, log append, Slack relay), so the workflow
+    starved of heartbeats and the thread died silently.
+    """
+
+    def _create_run(self, *, origin_product: Task.OriginProduct) -> tuple[Task, TaskRun]:
+        creator = self.create_organization_user("thread-starter")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=creator,
+            title="Thread task",
+            description="Test Description",
+            origin_product=origin_product,
+        )
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            environment=TaskRun.Environment.CLOUD,
+        )
+        return task, run
+
+    @parameterized.expand(
+        [
+            ("teammate_can_patch_slack_run", Task.OriginProduct.SLACK, "patch", status.HTTP_200_OK),
+            ("teammate_can_retrieve_slack_run", Task.OriginProduct.SLACK, "get", status.HTTP_200_OK),
+            (
+                "teammate_cannot_patch_user_created_run",
+                Task.OriginProduct.USER_CREATED,
+                "patch",
+                status.HTTP_404_NOT_FOUND,
+            ),
+            (
+                "teammate_cannot_retrieve_user_created_run",
+                Task.OriginProduct.USER_CREATED,
+                "get",
+                status.HTTP_404_NOT_FOUND,
+            ),
+        ]
+    )
+    @patch("products.tasks.backend.models.TaskRun.publish_stream_state_event")
+    def test_non_creator_run_access_by_origin(
+        self,
+        _case_name: str,
+        origin_product: Task.OriginProduct,
+        method: str,
+        expected_status: int,
+        _mock_publish_stream_state_event: MagicMock,
+    ) -> None:
+        task, run = self._create_run(origin_product=origin_product)
+
+        url = f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/"
+        if method == "patch":
+            response = self.client.patch(url, {"output": {"marker": "from-teammate"}}, format="json")
+        else:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, expected_status)


### PR DESCRIPTION
## Problem

Since #66212, sandbox credentials for Slack task runs are minted for whoever spoke last in the thread instead of the task creator. But the runs API still only lets the **creator** drive a run (`task_control_q`), so when anyone else replies in a thread, the sandbox 404s on all its callbacks: the Slack reply (`relay_message`), the workflow heartbeat (`append_log`), and the completion signal (status PATCH). The run does the work invisibly, times out after 45 minutes of "inactivity", and the thread goes silent akano reply, no error.

Slack threads are multiplayer by design (#60260: any same-team user can send follow-ups), so the API gate and the credential model disagreed.

Origin: https://posthog.slack.com/archives/C09SK2PAGKF/p1784574152329129

## Changes

`task_accessible_for_run_view` now also allows access when the task is Slack-originated: any team member can drive and watch runs of `origin_product == SLACK` tasks, mirroring what the Slack side already permits.

- Keyed on task origin, not the run's recorded `slack_actor_user_id` — with per-message actors (#70762) the recorded actor races in-flight messages.
- `TaskViewSet` (task edit/delete, feed visibility) unchanged; non-Slack tasks unchanged.

## How did you test this code?

`TestTaskRunSlackTaskTeamControl` (4 parameterized cases): a non-creator teammate can PATCH/GET runs of a Slack task (both 404 without the fix, verified against unpatched source), and still 404s on a `user_created` task. Neighboring auth suites (108 tests) pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None, internal authorization behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (skills: /improving-drf-endpoints, /writing-tests). Root-caused from production logs: resumed runs with sandbox callbacks failing 404 "Task not found", then completing exactly at the inactivity timeout with no heartbeats and no Slack post. First iteration gated on the run's recorded actor; reworked to the task-origin gate at the DRI's direction since per-message actors make the actor comparison racy.