### PR TITLE
feat(error-tracking): scaffold lifecycle temporal queue

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -190,6 +190,8 @@ from products.conversations.backend.temporal import (
 from products.engineering_analytics.backend.facade.temporal import JOB_LOGS_ACTIVITIES, JOB_LOGS_WORKFLOWS
 from products.error_tracking.backend.facade.temporal import (
     ACTIVITIES as ERROR_TRACKING_ACTIVITIES,
+    LIFECYCLE_ACTIVITIES as ERROR_TRACKING_LIFECYCLE_ACTIVITIES,
+    LIFECYCLE_WORKFLOWS as ERROR_TRACKING_LIFECYCLE_WORKFLOWS,
     WORKFLOWS as ERROR_TRACKING_WORKFLOWS,
 )
 from products.experiments.backend.temporal import (
@@ -455,6 +457,11 @@ _task_queue_specs = [
         settings.ERROR_TRACKING_TASK_QUEUE,
         ERROR_TRACKING_WORKFLOWS,
         ERROR_TRACKING_ACTIVITIES,
+    ),
+    (
+        settings.ERROR_TRACKING_LIFECYCLE_TASK_QUEUE,
+        ERROR_TRACKING_LIFECYCLE_WORKFLOWS,
+        ERROR_TRACKING_LIFECYCLE_ACTIVITIES,
     ),
     (
         settings.EVENT_SCREENSHOTS_TASK_QUEUE,

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -159,6 +159,7 @@ LLMA_EVALS_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-evals-task-queue
 LLMA_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-task-queue")
 MCPA_TASK_QUEUE = _set_temporal_task_queue("mcp-analytics-task-queue")
 ERROR_TRACKING_TASK_QUEUE = _set_temporal_task_queue("error-tracking-task-queue")
+ERROR_TRACKING_LIFECYCLE_TASK_QUEUE = _set_temporal_task_queue("error-tracking-lifecycle-task-queue")
 EVENT_SCREENSHOTS_TASK_QUEUE = _set_temporal_task_queue("event-screenshots-task-queue")
 LOGS_ALERTING_TASK_QUEUE = _set_temporal_task_queue("logs-alerting-task-queue")
 RASTERIZATION_TASK_QUEUE = "rasterization-task-queue"  # Not collapsed in dev — separate Node.js worker process

--- a/products/error_tracking/backend/facade/temporal.py
+++ b/products/error_tracking/backend/facade/temporal.py
@@ -6,7 +6,7 @@ objects, not data, so they live in their own facade submodule — keeping the
 ``temporalio`` imports out of ``facade/api.py``.
 """
 
-from products.error_tracking.backend.temporal import ACTIVITIES, WORKFLOWS
+from products.error_tracking.backend.temporal import ACTIVITIES, LIFECYCLE_ACTIVITIES, LIFECYCLE_WORKFLOWS, WORKFLOWS
 from products.error_tracking.backend.temporal.recommendations_refresh.types import RecommendationsRefreshInputs
 from products.error_tracking.backend.temporal.spike_event_cleanup.schedule import (
     create_error_tracking_spike_event_cleanup_schedule,
@@ -17,6 +17,8 @@ from products.error_tracking.backend.temporal.symbol_set_cleanup.schedule import
 
 __all__ = [
     "ACTIVITIES",
+    "LIFECYCLE_ACTIVITIES",
+    "LIFECYCLE_WORKFLOWS",
     "WORKFLOWS",
     "RecommendationsRefreshInputs",
     "create_error_tracking_spike_event_cleanup_schedule",

--- a/products/error_tracking/backend/temporal/__init__.py
+++ b/products/error_tracking/backend/temporal/__init__.py
@@ -1,3 +1,7 @@
+from collections.abc import Callable
+
+from posthog.temporal.common.base import PostHogWorkflow
+
 from products.error_tracking.backend.temporal.fingerprint_embedding_result import (
     ACTIVITIES as FINGERPRINT_EMBEDDING_RESULT_ACTIVITIES,
     WORKFLOWS as FINGERPRINT_EMBEDDING_RESULT_WORKFLOWS,
@@ -37,8 +41,8 @@ ACTIVITIES = (
     + FINGERPRINT_EMBEDDING_RESULT_ACTIVITIES
 )
 
-LIFECYCLE_WORKFLOWS = []
-LIFECYCLE_ACTIVITIES = []
+LIFECYCLE_WORKFLOWS: list[type[PostHogWorkflow]] = []
+LIFECYCLE_ACTIVITIES: list[Callable[..., object]] = []
 
 __all__ = [
     "ACTIVITIES",

--- a/products/error_tracking/backend/temporal/__init__.py
+++ b/products/error_tracking/backend/temporal/__init__.py
@@ -37,8 +37,13 @@ ACTIVITIES = (
     + FINGERPRINT_EMBEDDING_RESULT_ACTIVITIES
 )
 
+LIFECYCLE_WORKFLOWS = []
+LIFECYCLE_ACTIVITIES = []
+
 __all__ = [
     "ACTIVITIES",
+    "LIFECYCLE_ACTIVITIES",
+    "LIFECYCLE_WORKFLOWS",
     "WORKFLOWS",
     "ErrorTrackingFingerprintEmbeddingResultWorkflow",
     "ErrorTrackingRecommendationsRefreshWorkflow",


### PR DESCRIPTION
## Problem

Error Tracking lifecycle workflows need an isolated Temporal task queue before their workflows and activities are implemented.

## Changes

- Add the `error-tracking-lifecycle-task-queue` setting.
- Add empty lifecycle workflow and activity registries behind the Error Tracking facade.
- Register the new queue with the Django Temporal worker bootstrap.
- Keep all existing Error Tracking workflows on `error-tracking-task-queue`.

This PR only adds application-side scaffolding. It does not deploy a production worker or move existing workflows.

## How did you test this code?

- `bin/hogli test posthog/management/commands/test/test_start_temporal_worker.py` – 5 passed.
- Targeted Ruff lint and format checks passed.
- `bin/hogli ci:preflight --fix` passed all triggered checks.
- A production-mode registry smoke test confirmed the dedicated queue is registered with zero workflows and activities.
- Full mypy checking cleared the changed files and stopped on an unrelated existing unused-ignore error in `posthog/personhog_client/converters.py`.

No new test was added because this is registry scaffolding with no workflow behavior; the existing worker import tests and production-mode smoke check cover bootstrap compatibility.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change is needed. The queue has no registered workflows or production deployment yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with OpenAI Codex through pi. Invoked `/openspec-apply-change`, `/writing-tests`, and `/pr`. The queue was intentionally scaffolded empty so future lifecycle workflows can be added without moving or disrupting existing Error Tracking workloads.
