### PR TITLE
feat(settings): move internal user filtering to customization settings

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6947,9 +6947,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-csp-reporting--light:
         hash: v1.k794b7964.fd469d98fbaae429c7a81f49593b7f5723a4e068f3ceb03ed5f047b0535e227c.NLE5KInsuUjiK_nTGOj4Pgh43vBGeZXEgKsn6Rw5hXQ
     scenes-app-settings-environment--settings-environment-customization--dark:
-        hash: v1.k794b7964.0105d5cbd04ebb7d91841da2bfb0f32abc5af2713d0ac9f5df671d83f747ad4c.E7DqARfIu6yG_ImSxNoUe7RZvzpF0D9_70mES4N-v0c
+        hash: v1.k794b7964.62c21cd085915d104c92416ee218f9f12159066791fb833f576912ead2a809b7.OUqBSu9xrfAvA_NO2eN6cmVREwKJxJrx3vlevIwQD3g
     scenes-app-settings-environment--settings-environment-customization--light:
-        hash: v1.k794b7964.583304a1c5e9d985c475542863f9625ee09fe5086f3bc7775839c40e7167c68c.Hh8U4TPapqAAlr0eijLaeUl4djIHebQIgfKpPQOYKuI
+        hash: v1.k794b7964.e94d97fff18d5bff78eb6d25f0b56ecc7d8ca86ff3f05eca2186eb6696465d9d.h-lAqKJZMVq-VXGOL4mnrcH_f4ExzGTdGzUCaGg7N7Y
     scenes-app-settings-environment--settings-environment-danger-zone--dark:
         hash: v1.k794b7964.b2709895d612381724c2275aeaa291853ad3460c7a70f82f44f9b68b53d48da7.5LGiSsDKJB9hs5AsxbeWNNMpCqNP39jEiu5P91ZXcGY
     scenes-app-settings-environment--settings-environment-danger-zone--light:
@@ -6991,9 +6991,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-privacy--light:
         hash: v1.k794b7964.8a66709400822bfa0ce716ad8ab87c844f6e255d6d147ffc1d0786ae6f0c88a4.YpDwS8AJgUCgRHrbfP00tREEmFzdh7uSlh1jUPiZwgk
     scenes-app-settings-environment--settings-environment-product-analytics--dark:
-        hash: v1.k794b7964.f0bb165601b375795b1440ba408d76fb5a24321c168532c927ec3667a242ae37.WtinNtrrUMh5H-EeXUWPQo-C-4h1ro_YhnnqfXousu4
+        hash: v1.k794b7964.e30df90f25ceca35f4dedd3855f2e2c7db30e3af9ee7c5cd4ae9438ac1c126ab.6JpAbAsV7tuGsBzLRPrf-gM5jkVm7eUOc6v2NOjp3LY
     scenes-app-settings-environment--settings-environment-product-analytics--light:
-        hash: v1.k794b7964.70bf7959ecd4f39a1ac0d069beec0f6cdaf24d9afaee70e70b4cf75619f56de5.xQCvIAWzmRCUGafz6moNuItTspGJA6dwjKLb3mE16Uk
+        hash: v1.k794b7964.3695b8b1a50589b9b22613f79babe60778b46eae48ef135b8d4f8764f849770e.fwT9nSm0coPxf710QcF_HY9xWzxBZyaipgJb0A4Z0MA
     scenes-app-settings-environment--settings-environment-replay--dark:
         hash: v1.k794b7964.420f87c12f0437816ce82f7e13a45851e78a6e84198cbd81262c964a90bdc47e.CaLkZAptUT5gtkAbv8PMsSfuCUSfKnhks4ojIwUks0E
     scenes-app-settings-environment--settings-environment-replay--light:
@@ -7055,17 +7055,17 @@ snapshots:
     scenes-app-settings-project--settings-project-danger-zone--light:
         hash: v1.k794b7964.ccb4076af018bd942766ece896ed42545b08665a695728b5146c495e32a70e09.gaWS_dz8lVJzeaQNwDZmJRfJTEZ8ofu2BTn_nI8--Gs
     scenes-app-settings-project--settings-project-details--dark:
-        hash: v1.k794b7964.3d2be301614e890f70ae0e3cb60a474d6683e4d5947a59c95d8c7bfd873d2373.l0NuLwQ2HOD4wWV1glNPc20LlYzJFAfd6Nh7EWKsdUo
+        hash: v1.k794b7964.017ab15c5a5c4f47330f54f21812c6555d9fd15be6bd65d713d946de0ef13583.MHpPYLm7AICx5m5OTHpaHNDon7CRcNkJQt3FlRBLrdk
     scenes-app-settings-project--settings-project-details--light:
-        hash: v1.k794b7964.e10745ce5798fd2bd4bb8cd00a76ccf084e4b12507a7bd220c8fccb70d1c3c11.KByOR4j7f-3H1yTODOHW7sfNV_Mtr8Ga5A8DWZjzSDs
+        hash: v1.k794b7964.92d131dadd962625b5dfdd78a2cb9c42017b230b1c39f9ae1b293e8f6e9fe788.ufkrkTmgF764iFDi-uaHriqBvleJci3OVpjBAwJxiUw
     scenes-app-settings-project--settings-project-integrations--dark:
         hash: v1.k794b7964.81a9ac1dae6f0520d24618ca1164d13febe35d137184e985a344dcd1632e0cec.oySHN778JskP5Yz0hvSlx4gjJijO83k8OJLXyCNqb1w
     scenes-app-settings-project--settings-project-integrations--light:
         hash: v1.k794b7964.1934174417b65042ff2e3e967e833f604198ee713c7f7711f67b57646d9326a1.DxQZ3xs0WrHP48Y9r13SVaHcJsN4h1KJVK-NSPUSXpg
     scenes-app-settings-project--settings-project-product-analytics--dark:
-        hash: v1.k794b7964.8e23eef59c16ece233e0b9df61913e42063eea39f51acaa216e060de6182ee7f.E52Q784Oyl6sN8X0hG9tXfH-ZlWHaUpfQ1eKcwLsvdE
+        hash: v1.k794b7964.c2ca88569dd635dbb5b760fb1e56ac07f5e68c8dcb4255653794dc46f7325d3f.Koq_w77vEWShB--BvyLeITY5j7jdA96Z3pwRmBV6glY
     scenes-app-settings-project--settings-project-product-analytics--light:
-        hash: v1.k794b7964.527360edf55b268b83ba976288336721af6da9af6088605669a4395b5a9b7a20.qnXEVYP868iG2Q0bj-z9_tORjlspkGdyJEMj5GDuG-8
+        hash: v1.k794b7964.3b73b00f400d4f8793faf7f17c775acf1d382cd78eec312858f9504c9557e328.q5KhmBFvDReRabYVObsdvnFPiHgZAKhk67YoxY60KNE
     scenes-app-settings-project--settings-project-replay--dark:
         hash: v1.k794b7964.420f87c12f0437816ce82f7e13a45851e78a6e84198cbd81262c964a90bdc47e.MbG5FcxBuIFHRdrwoHEbyKJb_Pz8doVuDwvq1AaJeXM
     scenes-app-settings-project--settings-project-replay--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6991,9 +6991,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-privacy--light:
         hash: v1.k794b7964.8a66709400822bfa0ce716ad8ab87c844f6e255d6d147ffc1d0786ae6f0c88a4.YpDwS8AJgUCgRHrbfP00tREEmFzdh7uSlh1jUPiZwgk
     scenes-app-settings-environment--settings-environment-product-analytics--dark:
-        hash: v1.k794b7964.e46fa3c909c28face78dfae63a4ab350c0e72d90db7d3e02b4b5c753d03ab859.312o8Z4ytSG78A2fKFuTAFQShpVOC9RpzmifF_-NruU
+        hash: v1.k794b7964.f0bb165601b375795b1440ba408d76fb5a24321c168532c927ec3667a242ae37.WtinNtrrUMh5H-EeXUWPQo-C-4h1ro_YhnnqfXousu4
     scenes-app-settings-environment--settings-environment-product-analytics--light:
-        hash: v1.k794b7964.9a08e3e1fb4186b60869058156d40c9eba697c61fdce90285a8f6743627df6f5.WTaXZbeJI75XsBB3A2ZoyoRd00iF1tY-HgnpKQeyrfc
+        hash: v1.k794b7964.70bf7959ecd4f39a1ac0d069beec0f6cdaf24d9afaee70e70b4cf75619f56de5.xQCvIAWzmRCUGafz6moNuItTspGJA6dwjKLb3mE16Uk
     scenes-app-settings-environment--settings-environment-replay--dark:
         hash: v1.k794b7964.420f87c12f0437816ce82f7e13a45851e78a6e84198cbd81262c964a90bdc47e.CaLkZAptUT5gtkAbv8PMsSfuCUSfKnhks4ojIwUks0E
     scenes-app-settings-environment--settings-environment-replay--light:
@@ -7055,17 +7055,17 @@ snapshots:
     scenes-app-settings-project--settings-project-danger-zone--light:
         hash: v1.k794b7964.ccb4076af018bd942766ece896ed42545b08665a695728b5146c495e32a70e09.gaWS_dz8lVJzeaQNwDZmJRfJTEZ8ofu2BTn_nI8--Gs
     scenes-app-settings-project--settings-project-details--dark:
-        hash: v1.k794b7964.3a27fe7f9428d4c16c9c8abc9867b7d991acc1ad3e2c1c2e64a1c5e51ee94825.UQYP5Fo78XcQExRKn7F3yxY8r3v90nE4cYR8zu9aOLU
+        hash: v1.k794b7964.3d2be301614e890f70ae0e3cb60a474d6683e4d5947a59c95d8c7bfd873d2373.l0NuLwQ2HOD4wWV1glNPc20LlYzJFAfd6Nh7EWKsdUo
     scenes-app-settings-project--settings-project-details--light:
-        hash: v1.k794b7964.b1a9ae1806176e7fbf86e77a213017877a903dae86ec32a7836b67e463a82c76.D8CZqYjdoVO_RmUP49-RtsHB66w0ANl7yRgj_v-9vH4
+        hash: v1.k794b7964.e10745ce5798fd2bd4bb8cd00a76ccf084e4b12507a7bd220c8fccb70d1c3c11.KByOR4j7f-3H1yTODOHW7sfNV_Mtr8Ga5A8DWZjzSDs
     scenes-app-settings-project--settings-project-integrations--dark:
         hash: v1.k794b7964.81a9ac1dae6f0520d24618ca1164d13febe35d137184e985a344dcd1632e0cec.oySHN778JskP5Yz0hvSlx4gjJijO83k8OJLXyCNqb1w
     scenes-app-settings-project--settings-project-integrations--light:
         hash: v1.k794b7964.1934174417b65042ff2e3e967e833f604198ee713c7f7711f67b57646d9326a1.DxQZ3xs0WrHP48Y9r13SVaHcJsN4h1KJVK-NSPUSXpg
     scenes-app-settings-project--settings-project-product-analytics--dark:
-        hash: v1.k794b7964.3f634bc4aac18546bf8fd6e3659503abe7c9445f42f2ece46bd6d3e249015657.YenI6E3QU90yUtSj4KzcYV3n3k-6TTnZv8u4cfpXbbw
+        hash: v1.k794b7964.8e23eef59c16ece233e0b9df61913e42063eea39f51acaa216e060de6182ee7f.E52Q784Oyl6sN8X0hG9tXfH-ZlWHaUpfQ1eKcwLsvdE
     scenes-app-settings-project--settings-project-product-analytics--light:
-        hash: v1.k794b7964.fb3506a82dd925f1778507d5f47eccc9b7dff193009a011dea95f777f24cda4d.bpSiJsX6URAvrJj60XvGbEnM2WTogoHagn9YkPlS3AY
+        hash: v1.k794b7964.527360edf55b268b83ba976288336721af6da9af6088605669a4395b5a9b7a20.qnXEVYP868iG2Q0bj-z9_tORjlspkGdyJEMj5GDuG-8
     scenes-app-settings-project--settings-project-replay--dark:
         hash: v1.k794b7964.420f87c12f0437816ce82f7e13a45851e78a6e84198cbd81262c964a90bdc47e.MbG5FcxBuIFHRdrwoHEbyKJb_Pz8doVuDwvq1AaJeXM
     scenes-app-settings-project--settings-project-replay--light:

--- a/frontend/src/lib/components/TestAccountFiltersSwitch.test.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.test.tsx
@@ -18,12 +18,12 @@ describe('TestAccountFilterSwitch — gear icon links to internal test filtering
         cleanup()
     })
 
-    it('navigates to the project product analytics settings, scrolled to internal-user-filtering', () => {
+    it('navigates to the general project settings, scrolled to internal-user-filtering', () => {
         render(<TestAccountFilterSwitch checked={false} onChange={jest.fn()} />)
 
         // The LemonSwitch itself has role="switch"; the gear is rendered as a link.
         // The router prepends a `/project/<id>` prefix to the href, so match the suffix.
         const gear = screen.getByRole('link')
-        expect(gear.getAttribute('href')).toMatch(/\/settings\/project-product-analytics#internal-user-filtering$/)
+        expect(gear.getAttribute('href')).toMatch(/\/settings\/project-details#internal-user-filtering$/)
     })
 })

--- a/frontend/src/lib/components/TestAccountFiltersSwitch.test.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.test.tsx
@@ -18,12 +18,12 @@ describe('TestAccountFilterSwitch — gear icon links to internal test filtering
         cleanup()
     })
 
-    it('navigates to the general project settings, scrolled to internal-user-filtering', () => {
+    it('navigates to the customization settings, scrolled to internal-user-filtering', () => {
         render(<TestAccountFilterSwitch checked={false} onChange={jest.fn()} />)
 
         // The LemonSwitch itself has role="switch"; the gear is rendered as a link.
         // The router prepends a `/project/<id>` prefix to the href, so match the suffix.
         const gear = screen.getByRole('link')
-        expect(gear.getAttribute('href')).toMatch(/\/settings\/project-details#internal-user-filtering$/)
+        expect(gear.getAttribute('href')).toMatch(/\/settings\/environment-customization#internal-user-filtering$/)
     })
 })

--- a/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
@@ -34,7 +34,7 @@ export function TestAccountFilterSwitch({ checked, onChange, ...props }: TestAcc
                         size="small"
                         noPadding
                         className="ml-1"
-                        to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+                        to={urls.settings('project-details', 'internal-user-filtering')}
                     />
                 </div>
             }

--- a/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
@@ -34,7 +34,7 @@ export function TestAccountFilterSwitch({ checked, onChange, ...props }: TestAcc
                         size="small"
                         noPadding
                         className="ml-1"
-                        to={urls.settings('project-details', 'internal-user-filtering')}
+                        to={urls.settings('environment-customization', 'internal-user-filtering')}
                     />
                 </div>
             }

--- a/frontend/src/scenes/insights/filters/TestAccountFilter/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/filters/TestAccountFilter/TestAccountFilter.tsx
@@ -39,7 +39,7 @@ export function TestAccountFilter({
                     <span>Filter out internal and test users</span>
                     <LemonButton
                         icon={<IconGear />}
-                        to={urls.settings('project-details', 'internal-user-filtering')}
+                        to={urls.settings('environment-customization', 'internal-user-filtering')}
                         size="small"
                         noPadding
                         className="ml-1"

--- a/frontend/src/scenes/insights/filters/TestAccountFilter/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/filters/TestAccountFilter/TestAccountFilter.tsx
@@ -39,7 +39,7 @@ export function TestAccountFilter({
                     <span>Filter out internal and test users</span>
                     <LemonButton
                         icon={<IconGear />}
-                        to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+                        to={urls.settings('project-details', 'internal-user-filtering')}
                         size="small"
                         noPadding
                         className="ml-1"

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -276,6 +276,17 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['timezone', 'utc', 'locale', 'week start'],
             },
             {
+                // Project-wide, not product analytics specific: these filters apply to insights,
+                // web analytics, revenue analytics, session replay, and CDP destinations alike.
+                id: 'internal-user-filtering',
+                title: 'Filter out internal and test users',
+                description:
+                    'Define filters to exclude internal users and test accounts from your analytics. Filtered users will not appear in insights by default.',
+                docsUrl: 'https://posthog.com/tutorials/filter-internal-users',
+                component: <ProjectAccountFiltersSetting />,
+                keywords: ['test account', 'internal', 'exclude', 'filter'],
+            },
+            {
                 id: 'business-model',
                 title: 'Business model',
                 description:
@@ -289,17 +300,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 description: 'Set the default currency used for revenue and monetary calculations.',
                 component: <BaseCurrency hideTitle />,
                 keywords: ['money', 'currency', 'usd', 'eur'],
-            },
-            {
-                // Project-wide, not product analytics specific: these filters apply to insights,
-                // web analytics, revenue analytics, session replay, and CDP destinations alike.
-                id: 'internal-user-filtering',
-                title: 'Filter out internal and test users',
-                description:
-                    'Define filters to exclude internal users and test accounts from your analytics. Filtered users will not appear in insights by default.',
-                docsUrl: 'https://posthog.com/tutorials/filter-internal-users',
-                component: <ProjectAccountFiltersSetting />,
-                keywords: ['test account', 'internal', 'exclude', 'filter'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -190,17 +190,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['api key', 'token', 'project id'],
             },
             {
-                // Project-wide, not product analytics specific: these filters apply to insights,
-                // web analytics, revenue analytics, session replay, and CDP destinations alike.
-                id: 'internal-user-filtering',
-                title: 'Filter out internal and test users',
-                description:
-                    'Define filters to exclude internal users and test accounts from your analytics. Filtered users will not appear in insights by default.',
-                docsUrl: 'https://posthog.com/tutorials/filter-internal-users',
-                component: <ProjectAccountFiltersSetting />,
-                keywords: ['test account', 'internal', 'exclude', 'filter'],
-            },
-            {
                 id: 'snippet',
                 title: 'SDK setup',
                 description:
@@ -300,6 +289,17 @@ export const SETTINGS_MAP: SettingSection[] = [
                 description: 'Set the default currency used for revenue and monetary calculations.',
                 component: <BaseCurrency hideTitle />,
                 keywords: ['money', 'currency', 'usd', 'eur'],
+            },
+            {
+                // Project-wide, not product analytics specific: these filters apply to insights,
+                // web analytics, revenue analytics, session replay, and CDP destinations alike.
+                id: 'internal-user-filtering',
+                title: 'Filter out internal and test users',
+                description:
+                    'Define filters to exclude internal users and test accounts from your analytics. Filtered users will not appear in insights by default.',
+                docsUrl: 'https://posthog.com/tutorials/filter-internal-users',
+                component: <ProjectAccountFiltersSetting />,
+                keywords: ['test account', 'internal', 'exclude', 'filter'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -190,6 +190,17 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['api key', 'token', 'project id'],
             },
             {
+                // Project-wide, not product analytics specific: these filters apply to insights,
+                // web analytics, revenue analytics, session replay, and CDP destinations alike.
+                id: 'internal-user-filtering',
+                title: 'Filter out internal and test users',
+                description:
+                    'Define filters to exclude internal users and test accounts from your analytics. Filtered users will not appear in insights by default.',
+                docsUrl: 'https://posthog.com/tutorials/filter-internal-users',
+                component: <ProjectAccountFiltersSetting />,
+                keywords: ['test account', 'internal', 'exclude', 'filter'],
+            },
+            {
                 id: 'snippet',
                 title: 'SDK setup',
                 description:
@@ -861,15 +872,6 @@ export const SETTINGS_MAP: SettingSection[] = [
         title: 'Product analytics',
         group: 'Products',
         settings: [
-            {
-                id: 'internal-user-filtering',
-                title: 'Filter out internal and test users',
-                description:
-                    'Define filters to exclude internal users and test accounts from your analytics. Filtered users will not appear in insights by default.',
-                docsUrl: 'https://posthog.com/tutorials/filter-internal-users',
-                component: <ProjectAccountFiltersSetting />,
-                keywords: ['test account', 'internal', 'exclude', 'filter'],
-            },
             {
                 id: 'data-theme',
                 title: 'Chart color themes',

--- a/frontend/src/scenes/settings/settingsSceneLogic.test.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.test.ts
@@ -95,6 +95,31 @@ describe('settingsSceneLogic', () => {
         expect(router.values.hashParams).not.toHaveProperty('llm-analytics-byok')
     })
 
+    it('redirects internal-user-filtering deep links to its new section', async () => {
+        // The setting moved from the product analytics section to General; links in docs,
+        // CDP filter warnings, and bookmarks still point at the old section.
+        router.actions.push('/settings/project-product-analytics', {}, { 'internal-user-filtering': true })
+
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: 'project-details',
+        })
+
+        expect(router.values.location.pathname).toContain('/settings/project-details')
+        expect(router.values.hashParams).toHaveProperty('internal-user-filtering')
+
+        // Level-only URLs (as emitted by CDP filter warnings) redirect too.
+        router.actions.push('/settings/project', {}, { 'internal-user-filtering': true })
+
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: 'project-details',
+        })
+
+        expect(router.values.location.pathname).toContain('/settings/project-details')
+        expect(router.values.hashParams).toHaveProperty('internal-user-filtering')
+    })
+
     it('redirects level-only URLs to first section', async () => {
         // Each push switches to a different level, so no section at the target level is
         // selected yet and the redirect to the first section runs.
@@ -117,11 +142,14 @@ describe('settingsSceneLogic', () => {
         })
         expect(router.values.location.pathname).toContain('/settings/user-profile')
 
-        router.actions.push('/settings/project')
+        // The redirect keeps hash params, so `/settings/project#variables`-style links
+        // still scroll to their setting.
+        router.actions.push('/settings/project', {}, { variables: true })
         await expectLogic(logic).toMatchValues({
             selectedLevel: 'project',
         })
         expect(router.values.location.pathname).toContain('/settings/project-details')
+        expect(router.values.hashParams).toHaveProperty('variables')
     })
 
     it('does not bounce a level-only URL when already on a section at that level', async () => {

--- a/frontend/src/scenes/settings/settingsSceneLogic.test.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.test.ts
@@ -96,16 +96,16 @@ describe('settingsSceneLogic', () => {
     })
 
     it('redirects internal-user-filtering deep links to its new section', async () => {
-        // The setting moved from the product analytics section to General; links in docs,
+        // The setting moved from the product analytics section to Customization; links in docs,
         // CDP filter warnings, and bookmarks still point at the old section.
         router.actions.push('/settings/project-product-analytics', {}, { 'internal-user-filtering': true })
 
         await expectLogic(logic).toMatchValues({
             selectedLevel: 'project',
-            selectedSectionId: 'project-details',
+            selectedSectionId: 'project-customization',
         })
 
-        expect(router.values.location.pathname).toContain('/settings/project-details')
+        expect(router.values.location.pathname).toContain('/settings/project-customization')
         expect(router.values.hashParams).toHaveProperty('internal-user-filtering')
 
         // Level-only URLs (as emitted by CDP filter warnings) redirect too.
@@ -113,10 +113,10 @@ describe('settingsSceneLogic', () => {
 
         await expectLogic(logic).toMatchValues({
             selectedLevel: 'project',
-            selectedSectionId: 'project-details',
+            selectedSectionId: 'project-customization',
         })
 
-        expect(router.values.location.pathname).toContain('/settings/project-details')
+        expect(router.values.location.pathname).toContain('/settings/project-customization')
         expect(router.values.hashParams).toHaveProperty('internal-user-filtering')
     })
 

--- a/frontend/src/scenes/settings/settingsSceneLogic.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.ts
@@ -23,7 +23,29 @@ const LEGACY_SETTINGS_SECTIONS: Record<string, SettingSectionId> = {
     'project-llm-analytics': AI_OBSERVABILITY_SETTINGS_SECTION,
 }
 
+// Settings that moved to a different section, keyed by setting id. Deep links to the old
+// section (docs, CDP filter warnings, bookmarks) redirect to the setting's current home.
+const MOVED_SETTINGS: Record<string, SettingSectionId> = {
+    'internal-user-filtering': 'project-details',
+}
+
 const hasHashParam = (hashParams: Params, key: string): boolean => Object.prototype.hasOwnProperty.call(hashParams, key)
+
+const sectionForMovedSetting = (section: string, hashParams: Params): SettingSectionId | null => {
+    for (const [settingId, currentSection] of Object.entries(MOVED_SETTINGS)) {
+        if (section === currentSection) {
+            continue
+        }
+        if (
+            hasHashParam(hashParams, settingId) ||
+            hashParams.setting === settingId ||
+            hashParams.selectedSetting === settingId
+        ) {
+            return currentSection
+        }
+    }
+    return null
+}
 
 const canonicalSettingsSection = (section: string): string => {
     if (LEGACY_SETTINGS_SECTIONS[section]) {
@@ -177,11 +199,12 @@ export const settingsSceneLogic = kea<settingsSceneLogicType>([
 
             const canonicalSection = canonicalSettingsSection(section)
             const [hashParams, didCanonicalizeHashParams] = canonicalSettingsHashParams(router.values.hashParams)
+            const targetSection = sectionForMovedSetting(canonicalSection, hashParams) ?? canonicalSection
 
             // Use `replace` so legacy settings URLs don't become dead back-button entries.
-            if (canonicalSection !== section || didCanonicalizeHashParams) {
+            if (targetSection !== section || didCanonicalizeHashParams) {
                 router.actions.replace(
-                    urls.settings(canonicalSection as SettingSectionId),
+                    urls.settings(targetSection as SettingSectionId),
                     router.values.searchParams,
                     hashParams
                 )
@@ -204,7 +227,13 @@ export const settingsSceneLogic = kea<settingsSceneLogicType>([
 
                 const firstSection = values.sections.find((s) => s.level === effectiveLevel)
                 if (firstSection) {
-                    router.actions.replace(urls.settings(firstSection.id))
+                    // Keep the params: links like `/settings/project#variables` rely on the hash
+                    // to scroll to the setting after the redirect.
+                    router.actions.replace(
+                        urls.settings(firstSection.id),
+                        router.values.searchParams,
+                        router.values.hashParams
+                    )
                 } else {
                     actions.selectLevel(effectiveLevel)
                 }

--- a/frontend/src/scenes/settings/settingsSceneLogic.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.ts
@@ -26,7 +26,7 @@ const LEGACY_SETTINGS_SECTIONS: Record<string, SettingSectionId> = {
 // Settings that moved to a different section, keyed by setting id. Deep links to the old
 // section (docs, CDP filter warnings, bookmarks) redirect to the setting's current home.
 const MOVED_SETTINGS: Record<string, SettingSectionId> = {
-    'internal-user-filtering': 'project-details',
+    'internal-user-filtering': 'project-customization',
 }
 
 const hasHashParam = (hashParams: Params, key: string): boolean => Object.prototype.hasOwnProperty.call(hashParams, key)

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -53,6 +53,7 @@ export type SettingSectionId =
     | 'project-access-control'
     | 'project-ai-observability'
     | 'project-autocapture'
+    | 'project-customization'
     | 'project-integrations'
     | 'project-product-analytics'
     | 'project-replay'

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -328,7 +328,7 @@ class SelectFinder(TraversingVisitor):
 
 def _internal_user_settings_url(team_id: int) -> str:
     site_url = settings.SITE_URL.rstrip("/")
-    return f"{site_url}/project/{team_id}/settings/project#internal-user-filtering"
+    return f"{site_url}/project/{team_id}/settings/project-details#internal-user-filtering"
 
 
 class _LowerConstantMembership(CloningVisitor):

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -328,7 +328,7 @@ class SelectFinder(TraversingVisitor):
 
 def _internal_user_settings_url(team_id: int) -> str:
     site_url = settings.SITE_URL.rstrip("/")
-    return f"{site_url}/project/{team_id}/settings/project-details#internal-user-filtering"
+    return f"{site_url}/project/{team_id}/settings/project-customization#internal-user-filtering"
 
 
 class _LowerConstantMembership(CloningVisitor):

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -24,7 +24,7 @@ from common.hogvm.python.operation import HOGQL_BYTECODE_VERSION
 def _normalize_error(error: str) -> str:
     """Replace dynamic IDs and URLs in error messages with stable placeholders."""
     error = re.sub(r"id=\d+", "id=N", error)
-    error = re.sub(r"https?://[^/]+/project/\d+/settings/project", "SETTINGS_URL", error)
+    error = re.sub(r"https?://[^/]+/project/\d+/settings/project-details", "SETTINGS_URL", error)
     return error
 
 

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -24,7 +24,7 @@ from common.hogvm.python.operation import HOGQL_BYTECODE_VERSION
 def _normalize_error(error: str) -> str:
     """Replace dynamic IDs and URLs in error messages with stable placeholders."""
     error = re.sub(r"id=\d+", "id=N", error)
-    error = re.sub(r"https?://[^/]+/project/\d+/settings/project-details", "SETTINGS_URL", error)
+    error = re.sub(r"https?://[^/]+/project/\d+/settings/project-customization", "SETTINGS_URL", error)
     return error
 
 

--- a/products/revenue_analytics/frontend/settings/FilterTestAccountsConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/FilterTestAccountsConfiguration.tsx
@@ -25,7 +25,7 @@ export function FilterTestAccountsConfiguration(): JSX.Element {
                 <>
                     When enabled, events from test accounts will be excluded from Revenue analytics. You can configure
                     these test accounts{' '}
-                    <Link to={urls.settings('project-details', 'internal-user-filtering')}>here</Link>.
+                    <Link to={urls.settings('environment-customization', 'internal-user-filtering')}>here</Link>.
                 </>
             }
         >

--- a/products/revenue_analytics/frontend/settings/FilterTestAccountsConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/FilterTestAccountsConfiguration.tsx
@@ -25,7 +25,7 @@ export function FilterTestAccountsConfiguration(): JSX.Element {
                 <>
                     When enabled, events from test accounts will be excluded from Revenue analytics. You can configure
                     these test accounts{' '}
-                    <Link to={urls.settings('project-product-analytics', 'internal-user-filtering')}>here</Link>.
+                    <Link to={urls.settings('project-details', 'internal-user-filtering')}>here</Link>.
                 </>
             }
         >


### PR DESCRIPTION
## TL;DR

The switch that hides your own team's activity from your stats ("Filter out internal and test users") was buried under Settings → Product analytics. It now sits in Settings → Customization, with the other project-wide preferences. Old links redirect to the new spot.

## Problem

The "Filter out internal and test users" setting lived in the product analytics section, but it applies to every product: insights, web analytics, revenue analytics, session replay, and CDP destinations. People expect it near the general project settings and take a while to find it under a single product. Raised as internal feedback.

## Changes

- Moved the setting to the Customization section (`environment-customization`), right below "Date & time", with the other project-wide preferences.
- Old deep links (`/settings/project-product-analytics#internal-user-filtering`) redirect to the new home via a small `MOVED_SETTINGS` map in `settingsSceneLogic`, following the existing AI observability BYOK redirect pattern. Links in posthog.com docs and bookmarks keep working.
- Level-only settings URLs (`/settings/project#...`) now keep search and hash params through their redirect, so anchor links like the one in CDP filter warnings scroll to the setting.
- Updated the gear icon links (insight test-account filter, the shared switch component, revenue analytics settings) and the CDP filter warning URL to point at the new section.
- Added `project-customization` to the `SettingSectionId` union; the runtime already produces this id when it converts environment sections for URLs.

No visual changes to the setting itself, it renders the same block in a different section.

## How did you test this code?

- New test in `settingsSceneLogic.test.ts`: old section and level deep links redirect to Customization with the hash kept. Catches someone removing the moved-setting redirect and breaking links in docs and CDP warnings. Extended the existing level-only redirect test to lock in hash preservation, which the redirect used to drop.
- Updated `TestAccountFiltersSwitch.test.tsx` to expect the new gear link target.
- Ran both Jest files locally: 8 passed. Ruff, oxlint, and oxfmt clean. TypeScript check reports no errors in the changed files.
- I (Claude) could not run the app or the ClickHouse-backed `posthog/cdp/test/test_filters.py` in this environment (no local stack), so no screenshot; the URL change there is covered by its existing assertions in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

posthog.com tutorials point at the old section URL; the redirect keeps them working, but the navigation path in the docs should be updated to Settings → Customization.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) from teammate feedback that the setting was hard to find; assignee is the DRI. Skills invoked: `/writing-tests`. Decisions: first placed the setting in General; the DRI asked for Customization instead, where the other project-wide preferences live. Added the redirect map keyed by setting id so future setting moves reuse it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
