### PR TITLE
fix(mcp-store): allow OAuth access to server icons

### DIFF
--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -208,7 +208,7 @@ class MCPServerViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.G
 
     # Image bytes for <img src>; deliberately outside the typed client surface.
     @extend_schema(exclude=True)
-    @action(methods=["GET"], detail=False)
+    @action(methods=["GET"], detail=False, required_scopes=["project:read"])
     def icon(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         # Canonicalized (lowercase, no FQDN trailing dot) before validation so case variants
         # share one cache entry downstream.

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -1,4 +1,5 @@
 import hashlib
+from datetime import timedelta
 from urllib.parse import parse_qs, urlparse
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
@@ -6,10 +7,13 @@ from unittest.mock import patch
 
 from django.http import HttpResponse
 from django.test import TestCase
+from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIClient
+
+from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 
 from products.mcp_store.backend.models import MCPOAuthState, MCPServerInstallation, MCPServerTemplate
 from products.mcp_store.backend.presentation.views import _is_valid_posthog_code_callback_url
@@ -174,6 +178,35 @@ class TestMCPServerAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         service.return_value.get_icon_http_response.assert_called_once_with(
             "linear.app", theme=expected_theme, fallback="404", team_id=self.team.id
         )
+
+    def test_icon_allows_oauth_project_read_scope(self):
+        oauth_application = OAuthApplication.objects.create(
+            name="MCP icon test",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            organization=self.organization,
+            user=self.user,
+        )
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_application,
+            token="pha_test_mcp_icon",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="project:read",
+        )
+        client = APIClient()
+
+        with patch("products.mcp_store.backend.presentation.views.CDPIconsService") as service:
+            service.return_value.get_icon_http_response.return_value = HttpResponse(b"png", content_type="image/png")
+            response = client.get(
+                f"/api/environments/{self.team.id}/mcp_servers/icon/",
+                data={"domain": "linear.app"},
+                headers={"authorization": f"Bearer {access_token.token}"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
 
     def test_unauthenticated_access(self):
         client = APIClient()


### PR DESCRIPTION
## Problem

The MCP Store icon route is a custom DRF action. OAuth clients such as PostHog Code can read the MCP catalog, but icon requests return `403` because the action does not declare an API scope. Those clients fall back to generic icons.

## Changes

- Declare `project:read` as the required scope for the read-only icon action.
- Add a regression test that calls the endpoint with an OAuth bearer token containing exactly `project:read`.

## How did you test this code?

- Passed the Python lint, format, and type checks run by the commit hook.
- Passed focused Ruff lint and format checks for both changed files.
- Added `test_icon_allows_oauth_project_read_scope`, which catches the OAuth `403` that the existing session-authenticated icon tests do not cover.
- I attempted the focused test locally, but the local ClickHouse service failed during Django setup before the test could be collected. The failure was infrastructure-related, not an assertion failure.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This restores intended OAuth access to an existing endpoint without changing its public contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored the change using `/improving-drf-endpoints`, `/writing-tests`, `/yeet`, and `/writing-pr-descriptions`. I chose an explicit action-level scope because DRF's default scope mapping only covers standard actions, and this endpoint is a custom read-only action.
