### PR TITLE
fix: infer saved-query and endpoint columns as the acting user

### DIFF
--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -13,6 +13,8 @@ import structlog
 if TYPE_CHECKING:
     from posthog.schema import HogQLQueryModifiers
 
+    from posthog.models.user import User
+
 from posthog.hogql import ast
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.direct_mysql_table import DirectMySQLTable
@@ -269,7 +271,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
         self.columns = columns
         self.column_order = list(columns.keys())
 
-    def get_columns(self) -> dict[str, dict[str, Any]]:
+    def get_columns(self, user: Optional["User"] = None) -> dict[str, dict[str, Any]]:
         from posthog.api.services.query import process_query_dict
         from posthog.clickhouse.query_tagging import Feature, Product, tags_context
         from posthog.hogql_queries.query_runner import ExecutionMode
@@ -283,8 +285,12 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
         if "kind" not in query and "query" in query:
             query = {"kind": "HogQLQuery", **query}
 
+        # Resolve as the acting user so warehouse access control is enforced against them - a userless
+        # build fails closed and denies every warehouse table, breaking column inference for all users.
         with tags_context(product=Product.WAREHOUSE, feature=Feature.DATA_MODELING):
-            response = process_query_dict(self.team, query, execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+            response = process_query_dict(
+                self.team, query, execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS, user=user
+            )
         result = getattr(response, "types", [])
 
         if result is None or isinstance(result, int):

--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -440,7 +440,7 @@ class DataWarehouseSavedQuerySerializer(
                 # The columns will be inferred from the query
                 client_types = self.context["request"].data.get("types", [])
                 if len(client_types) == 0:
-                    view.set_columns(view.get_columns())
+                    view.set_columns(view.get_columns(user=self.context["request"].user))
                 else:
                     columns = {
                         str(item[0]): {
@@ -581,7 +581,7 @@ class DataWarehouseSavedQuerySerializer(
                     # The columns will be inferred from the query
                     client_types = self.context["request"].data.get("types", [])
                     if len(client_types) == 0:
-                        view.set_columns(view.get_columns())
+                        view.set_columns(view.get_columns(user=self.context["request"].user))
                     else:
                         columns = {
                             str(item[0]): {

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -259,13 +259,13 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
     def __str__(self) -> str:
         return f"{self.endpoint.name} v{self.version}"
 
-    def get_columns(self) -> list[dict]:
+    def get_columns(self, user: User | None = None) -> list[dict]:
         """Return columns, lazily populating from ClickHouse if not yet computed."""
         if self.columns is None:
             columns: list[dict] = []
             exc: Exception | None = None
             try:
-                columns = EndpointVersion.extract_columns(self.query, self.endpoint.team_id)
+                columns = EndpointVersion.extract_columns(self.query, self.endpoint.team_id, user=user)
             except Exception as e:
                 exc = e
             # Save before capture_exception (which can hang serializing large AST objects)
@@ -315,7 +315,7 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
         return can_materialize_query(self.query)
 
     @staticmethod
-    def extract_columns(query: dict, team_id: int) -> list[dict]:
+    def extract_columns(query: dict, team_id: int, user: User | None = None) -> list[dict]:
         """Extract SELECT column names and types by describing the query against ClickHouse."""
         if query.get("kind") != "HogQLQuery":
             return []
@@ -330,7 +330,9 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
         cleaned = _PLACEHOLDER_REPLACER.visit(parsed)
 
         team = Team.objects.get(pk=team_id)
-        executor = HogQLQueryExecutor(query=cleaned, team=team, limit_context=None)
+        # Resolve as the acting user so warehouse access control is enforced against them - a userless
+        # build fails closed and denies every warehouse table, breaking column inference for all users.
+        executor = HogQLQueryExecutor(query=cleaned, team=team, limit_context=None, user=user)
         clickhouse_sql, clickhouse_context = executor.generate_clickhouse_sql()
 
         if not clickhouse_sql:

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -259,13 +259,13 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
     def __str__(self) -> str:
         return f"{self.endpoint.name} v{self.version}"
 
-    def get_columns(self, user: User | None = None) -> list[dict]:
+    def get_columns(self) -> list[dict]:
         """Return columns, lazily populating from ClickHouse if not yet computed."""
         if self.columns is None:
             columns: list[dict] = []
             exc: Exception | None = None
             try:
-                columns = EndpointVersion.extract_columns(self.query, self.endpoint.team_id, user=user)
+                columns = EndpointVersion.extract_columns(self.query, self.endpoint.team_id)
             except Exception as e:
                 exc = e
             # Save before capture_exception (which can hang serializing large AST objects)
@@ -315,7 +315,7 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
         return can_materialize_query(self.query)
 
     @staticmethod
-    def extract_columns(query: dict, team_id: int, user: User | None = None) -> list[dict]:
+    def extract_columns(query: dict, team_id: int) -> list[dict]:
         """Extract SELECT column names and types by describing the query against ClickHouse."""
         if query.get("kind") != "HogQLQuery":
             return []
@@ -330,9 +330,11 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
         cleaned = _PLACEHOLDER_REPLACER.visit(parsed)
 
         team = Team.objects.get(pk=team_id)
-        # Resolve as the acting user so warehouse access control is enforced against them - a userless
-        # build fails closed and denies every warehouse table, breaking column inference for all users.
-        executor = HogQLQueryExecutor(query=cleaned, team=team, limit_context=None, user=user)
+        # Bypass warehouse access control: DESCRIBE exposes only column names/types, never rows, and
+        # `columns` is a shared cache that must be the same for every reader.
+        executor = HogQLQueryExecutor(
+            query=cleaned, team=team, limit_context=None, bypass_warehouse_access_control=True
+        )
         clickhouse_sql, clickhouse_context = executor.generate_clickhouse_sql()
 
         if not clickhouse_sql:

--- a/products/endpoints/backend/presentation/views/api.py
+++ b/products/endpoints/backend/presentation/views/api.py
@@ -316,7 +316,7 @@ class EndpointViewSet(
             "last_executed_at": endpoint.last_executed_at.isoformat() if endpoint.last_executed_at else None,
             "materialization": build_materialization_info(version),
             "bucket_overrides": version.bucket_overrides,
-            "columns": version.get_columns() if version else [],
+            "columns": version.get_columns(user=self.request.user) if version else [],
             "tags": self._get_tag_names(endpoint),
             "optional_breakdown_properties": list(version.optional_breakdown_properties or []),
         }
@@ -669,7 +669,7 @@ class EndpointViewSet(
 
         try:
             result = suggest_materialization_fix(
-                team_id=self.team_id, query=version.query, original_columns=version.get_columns()
+                team_id=self.team_id, query=version.query, original_columns=version.get_columns(user=request.user)
             )
         except APIConnectionError as e:
             capture_exception(e, {"team_id": self.team_id})

--- a/products/endpoints/backend/presentation/views/api.py
+++ b/products/endpoints/backend/presentation/views/api.py
@@ -316,7 +316,7 @@ class EndpointViewSet(
             "last_executed_at": endpoint.last_executed_at.isoformat() if endpoint.last_executed_at else None,
             "materialization": build_materialization_info(version),
             "bucket_overrides": version.bucket_overrides,
-            "columns": version.get_columns(user=self.request.user) if version else [],
+            "columns": version.get_columns() if version else [],
             "tags": self._get_tag_names(endpoint),
             "optional_breakdown_properties": list(version.optional_breakdown_properties or []),
         }
@@ -669,7 +669,7 @@ class EndpointViewSet(
 
         try:
             result = suggest_materialization_fix(
-                team_id=self.team_id, query=version.query, original_columns=version.get_columns(user=request.user)
+                team_id=self.team_id, query=version.query, original_columns=version.get_columns()
             )
         except APIConnectionError as e:
             capture_exception(e, {"team_id": self.team_id})


### PR DESCRIPTION
## Problem

`DataWarehouseSavedQuery.get_columns` (and `EndpointVersion.get_columns` → `extract_columns` for endpoints) runs the view's query to infer its output column schema, but it passed **no user** — so the HogQL database was built userless.

A userless build fails with `TableAccessDeniedError` error when warehouse access control FF is enabled (it denies every warehouse table if there's no user in the context). 

Impact on the two call sites (`saved_query.py`, both API create/update):
- **Create** re-raises → `400 "Failed to retrieve types for view"` → the view can't be created.
- **Update** swallows the exception (`capture_exception`) → the update succeeds but columns aren't refreshed (go stale) and each attempt dumps to error tracking ([error](https://us.posthog.com/project/2/error_tracking/019f8082-d44c-7da3-b8bf-5fec989c1d4e?fingerprint=59223935fac5496a5e4780b5fc2097ef855617e0d343e527cb7f700f7e74277601f0ee0197b221d961cf7128715575bff8a5cd5f651b0adea677836ba551b72a)) 

Currently masked in the normal frontend flow by the `client_types` escape hatch (when the client sends precomputed `types`, `get_columns` is skipped), so it surfaces for callers that don't send types. As the flag ramps to customers, it becomes a real "can't create/refresh a warehouse view" issue. 

## Changes

Two paths infer columns by running the query, both built userless before this. They fix it differently because their caching differs:

- **Saved queries** — thread the acting user into `process_query_dict`. `get_columns` recomputes on every call, so access is enforced against the reader. Not bypass (would leak the schema of tables they can't read), not `created_by` (there's a live request user here, avoiding the departed-creator failure mode).
- **Endpoints** — `EndpointVersion.columns` is a shared, team-level cache, so it can't be per-user: the first authorized reader would populate it and every later reader would get back that same schema. Bypass warehouse access control in the `DESCRIBE` instead — it exposes only column names/types (never rows), and never more than the `query` text already returned alongside `columns`.

Both default to no behavior change for non-warehouse callers. The `table.py`/`data_warehouse.py` `get_columns` is a different method (physical `DESCRIBE`, untouched).

## 🤖 Agent context

Found while auditing the class of "background/introspection query runs as the wrong principal under warehouse access control." This is the *userless* variant (breaks every user), distinct from the `created_by` variant (breaks only departed creators) seen in cache warming / subscriptions / exports.
