### PR TITLE
feat(llm-prompts): restructure prompt detail page

### DIFF
--- a/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
+++ b/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
@@ -19,8 +19,10 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { PromptLogicProps, PromptMode, isPrompt, llmPromptLogic } from './llmPromptLogic'
 import {
+    PromptCode,
     PromptEditForm,
     PromptExperiments,
+    PromptHeaderMeta,
     PromptRelatedTraces,
     PromptUsage,
     PromptVersionSidebar,
@@ -61,8 +63,7 @@ export function LLMPromptScene(): JSX.Element {
     } = useValues(llmPromptLogic)
     const { searchParams } = useValues(router)
     const currentSearchParams = searchParams ?? {}
-    const activeViewTab =
-        searchParams?.tab === 'usage' ? 'usage' : searchParams?.tab === 'experiments' ? 'experiments' : 'overview'
+    const activeViewTab = ['code', 'usage', 'experiments'].includes(searchParams?.tab) ? searchParams.tab : 'overview'
 
     const {
         submitPromptForm,
@@ -183,6 +184,8 @@ export function LLMPromptScene(): JSX.Element {
                 }
             />
 
+            <PromptHeaderMeta />
+
             <div className="flex flex-col gap-6 xl:flex-row">
                 <div className="min-w-0 flex-1">
                     {prompt && isPrompt(prompt) ? (
@@ -201,17 +204,22 @@ export function LLMPromptScene(): JSX.Element {
                                 {
                                     key: 'overview',
                                     label: 'Overview',
-                                    content: (
-                                        <>
-                                            <PromptViewDetails />
-                                            <PromptRelatedTraces />
-                                        </>
-                                    ),
+                                    content: <PromptViewDetails />,
+                                },
+                                {
+                                    key: 'code',
+                                    label: 'Code',
+                                    content: <PromptCode prompt={prompt} />,
                                 },
                                 {
                                     key: 'usage',
                                     label: 'Usage',
-                                    content: <PromptUsage prompt={prompt} />,
+                                    content: (
+                                        <>
+                                            <PromptUsage prompt={prompt} />
+                                            <PromptRelatedTraces />
+                                        </>
+                                    ),
                                 },
                                 {
                                     key: 'experiments',
@@ -221,10 +229,7 @@ export function LLMPromptScene(): JSX.Element {
                             ]}
                         />
                     ) : (
-                        <>
-                            <PromptViewDetails />
-                            <PromptRelatedTraces />
-                        </>
+                        <PromptViewDetails />
                     )}
                 </div>
 

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -86,71 +86,44 @@ export function PromptViewDetails(): JSX.Element {
         : []
 
     return (
-        <div className="space-y-5">
-            <div className="flex flex-wrap items-center gap-2">
-                <LemonTag type="highlight" size="small">
-                    v{prompt.version}
-                </LemonTag>
-                {prompt.is_latest ? (
-                    <LemonTag type="success" size="small">
-                        Latest
-                    </LemonTag>
-                ) : (
-                    <LemonTag type="muted" size="small">
-                        Historical
-                    </LemonTag>
-                )}
-                <span className="text-secondary text-sm">
-                    This prompt has {prompt.version_count} published version{prompt.version_count === 1 ? '' : 's'}.
-                </span>
-            </div>
-
-            {prompt.version_description ? (
-                <p className="text-secondary m-0 text-sm italic" data-attr="llma-prompt-version-description">
-                    {prompt.version_description}
-                </p>
-            ) : null}
-
+        <div className="space-y-4">
             <div>
-                <label className="text-xs font-semibold uppercase text-secondary">Name</label>
-                <p className="font-mono">{prompt.name}</p>
-            </div>
-
-            <div>
-                <div className="flex items-center gap-2">
-                    <label className="text-xs font-semibold uppercase text-secondary">Prompt</label>
-                    {!isDiffVisible && (
-                        <LemonButton
-                            size="small"
-                            noPadding
-                            icon={isRenderingMarkdown ? <IconMarkdownFilled /> : <IconMarkdown />}
-                            tooltip="Toggle markdown rendering"
-                            onClick={toggleMarkdownRendering}
-                        />
-                    )}
-                    {canCompareVersions && (
-                        <LemonButton
-                            size="xsmall"
-                            type={isDiffVisible ? 'primary' : 'secondary'}
-                            icon={<IconColumns />}
-                            onClick={() => {
-                                if (isDiffVisible) {
-                                    setCompareVersion(null)
-                                } else {
-                                    const firstOption = compareVersionOptions[0]?.value
-                                    const defaultVersion = compareVersionOptions.some(
-                                        (o) => o.value === prompt.version - 1
-                                    )
-                                        ? prompt.version - 1
-                                        : (firstOption ?? null)
-                                    setCompareVersion(defaultVersion)
-                                }
-                            }}
-                            data-attr="llma-prompt-compare-versions-button"
-                        >
-                            Compare versions
-                        </LemonButton>
-                    )}
+                <div className="mb-2 flex items-center justify-between gap-2">
+                    <h3 className="m-0 font-semibold">Prompt</h3>
+                    <div className="flex items-center gap-2">
+                        {!isDiffVisible && (
+                            <LemonButton
+                                size="small"
+                                noPadding
+                                icon={isRenderingMarkdown ? <IconMarkdownFilled /> : <IconMarkdown />}
+                                tooltip="Toggle markdown rendering"
+                                onClick={toggleMarkdownRendering}
+                            />
+                        )}
+                        {canCompareVersions && (
+                            <LemonButton
+                                size="xsmall"
+                                type={isDiffVisible ? 'primary' : 'secondary'}
+                                icon={<IconColumns />}
+                                onClick={() => {
+                                    if (isDiffVisible) {
+                                        setCompareVersion(null)
+                                    } else {
+                                        const firstOption = compareVersionOptions[0]?.value
+                                        const defaultVersion = compareVersionOptions.some(
+                                            (o) => o.value === prompt.version - 1
+                                        )
+                                            ? prompt.version - 1
+                                            : (firstOption ?? null)
+                                        setCompareVersion(defaultVersion)
+                                    }
+                                }}
+                                data-attr="llma-prompt-compare-versions-button"
+                            >
+                                Compare versions
+                            </LemonButton>
+                        )}
+                    </div>
                 </div>
                 {isDiffVisible ? (
                     <PromptDiffView />
@@ -164,22 +137,8 @@ export function PromptViewDetails(): JSX.Element {
                         </div>
                     </>
                 ) : (
-                    <pre className="mt-1 max-w-3xl rounded border bg-bg-light p-3 whitespace-pre-wrap">
-                        {prompt.prompt}
-                    </pre>
+                    <pre className="mt-1 rounded border bg-bg-light p-3 whitespace-pre-wrap">{prompt.prompt}</pre>
                 )}
-            </div>
-
-            <div className="grid max-w-3xl gap-3 text-sm text-secondary sm:grid-cols-2">
-                <div className="flex flex-wrap items-center gap-1">
-                    Published {dayjs(prompt.created_at).format('MMM D, YYYY h:mm A')}
-                    {prompt.created_by ? (
-                        <span className="flex items-center gap-1">
-                            by <ProfilePicture user={prompt.created_by} showName size="sm" />
-                        </span>
-                    ) : null}
-                </div>
-                <div>First version created {dayjs(prompt.first_version_created_at).format('MMM D, YYYY h:mm A')}</div>
             </div>
 
             {variables.length > 0 && (
@@ -192,6 +151,49 @@ export function PromptViewDetails(): JSX.Element {
                     ))}
                 </div>
             )}
+        </div>
+    )
+}
+
+// One line under the page title carrying every fact the page used to repeat:
+// version, freshness, and provenance.
+export function PromptHeaderMeta(): JSX.Element | null {
+    const { prompt } = useValues(llmPromptLogic)
+
+    if (!isPrompt(prompt)) {
+        return null
+    }
+
+    return (
+        <div
+            className="-mt-2 flex flex-wrap items-center gap-2 text-sm text-secondary"
+            data-attr="llma-prompt-header-meta"
+        >
+            <LemonTag type="highlight" size="small">
+                v{prompt.version}
+            </LemonTag>
+            {prompt.is_latest ? (
+                <LemonTag type="success" size="small">
+                    Latest
+                </LemonTag>
+            ) : (
+                <LemonTag type="muted" size="small">
+                    Historical
+                </LemonTag>
+            )}
+            {prompt.version_description ? (
+                <span className="italic" data-attr="llma-prompt-version-description">
+                    “{prompt.version_description}”
+                </span>
+            ) : null}
+            <span className="flex items-center gap-1">
+                published {dayjs(prompt.created_at).format('MMM D, YYYY')}
+                {prompt.created_by ? (
+                    <span className="flex items-center gap-1">
+                        by <ProfilePicture user={prompt.created_by} showName size="sm" />
+                    </span>
+                ) : null}
+            </span>
         </div>
     )
 }
@@ -350,7 +352,7 @@ function PromptDiffView(): JSX.Element {
 
 export function PromptRelatedTraces(): JSX.Element {
     const { prompt, relatedTracesQuery, viewAllTracesUrl, analyticsScope } = useValues(llmPromptLogic)
-    const { setAnalyticsScope, setRelatedTracesQuery } = useActions(llmPromptLogic)
+    const { setRelatedTracesQuery } = useActions(llmPromptLogic)
     const tracesQueryContext = useTracesQueryContext()
 
     if (!prompt || !isPrompt(prompt)) {
@@ -358,40 +360,33 @@ export function PromptRelatedTraces(): JSX.Element {
     }
 
     return (
-        <div className="mt-8" data-attr="llma-prompt-related-traces-section">
-            <div className="mb-4 flex flex-col gap-3">
-                <div className="min-w-0 flex-1">
-                    <h3 className="text-lg font-semibold">Related traces</h3>
-                    <p className="mt-1 text-sm text-secondary">
-                        Send <code className="rounded bg-bg-light px-1">$ai_prompt_name</code> and{' '}
-                        <code className="rounded bg-bg-light px-1">$ai_prompt_version</code> with your LLM events for
-                        version-specific attribution.
-                    </p>
+        <div className="mt-6" data-attr="llma-prompt-related-traces-section">
+            <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                    <b>Related traces</b>
+                    <div className="text-secondary text-sm">
+                        {analyticsScope === PromptAnalyticsScope.Selected ? (
+                            <>
+                                Traces sending <code>$ai_prompt_name="{prompt.name}"</code> and{' '}
+                                <code>$ai_prompt_version={prompt.version}</code>. Events that only send the name appear
+                                under all versions.
+                            </>
+                        ) : (
+                            <>
+                                Traces sending <code>$ai_prompt_name="{prompt.name}"</code>, any version.
+                            </>
+                        )}
+                    </div>
                 </div>
-
-                <div className="flex flex-wrap items-center gap-2">
-                    <PromptAnalyticsScopeControls
-                        analyticsScope={analyticsScope}
-                        setAnalyticsScope={setAnalyticsScope}
-                    />
-                    <LemonButton
-                        type="secondary"
-                        to={viewAllTracesUrl}
-                        size="small"
-                        data-attr="llma-prompt-view-all-traces-button"
-                    >
-                        View all traces
-                    </LemonButton>
-                </div>
+                <LemonButton
+                    type="secondary"
+                    to={viewAllTracesUrl}
+                    size="small"
+                    data-attr="llma-prompt-view-all-traces-button"
+                >
+                    View all traces
+                </LemonButton>
             </div>
-
-            {analyticsScope === PromptAnalyticsScope.Selected && (
-                <LemonBanner type="info" className="mb-4">
-                    Currently matching <code>$ai_prompt_name="{prompt.name}"</code> and{' '}
-                    <code>$ai_prompt_version={prompt.version}</code>. If your events only send the prompt name, switch
-                    to all versions.
-                </LemonBanner>
-            )}
 
             {relatedTracesQuery && (
                 <DataTable
@@ -503,22 +498,28 @@ export function PromptCodeSnippets({ prompt }: { prompt: LLMPrompt }): JSX.Eleme
     )
 }
 
-export function PromptUsage({ prompt }: { prompt: LLMPrompt }): JSX.Element {
-    const { promptUsageLogQuery, promptUsageTrendQuery, analyticsScope } = useValues(llmPromptLogic)
-    const { setAnalyticsScope } = useActions(llmPromptLogic)
-
+export function PromptCode({ prompt }: { prompt: LLMPrompt }): JSX.Element {
     return (
-        <div data-attr="llma-prompt-usage-container">
+        <div data-attr="llma-prompt-code-container">
             <PromptCodeSnippets prompt={prompt} />
 
-            <LemonBanner type="info" className="mb-4">
+            <LemonBanner type="info">
                 During the beta period, each prompt fetch is currently charged as a Product analytics event. See the{' '}
                 <Link to="https://posthog.com/pricing" target="_blank">
                     pricing page
                 </Link>
                 .
             </LemonBanner>
+        </div>
+    )
+}
 
+export function PromptUsage({ prompt }: { prompt: LLMPrompt }): JSX.Element {
+    const { promptUsageLogQuery, promptUsageTrendQuery, analyticsScope } = useValues(llmPromptLogic)
+    const { setAnalyticsScope } = useActions(llmPromptLogic)
+
+    return (
+        <div data-attr="llma-prompt-usage-container">
             <div className="mb-4 flex flex-col gap-2">
                 <div className="min-w-0">
                     <b>Trend</b>


### PR DESCRIPTION
## Problem

The prompt detail page repeats the same information in several places and mixes unrelated content. The prompt name shows twice (title and a NAME field). The version status shows three times (chips at the top, a sentence about version count, and the version sidebar). Publish dates show twice. The Overview tab contains a large related-traces section even though a Usage tab exists. The prompt content itself, the point of the page, has less visual weight than the metadata around it.

## Changes

- One meta line under the page title now carries the version facts: version chip, Latest or Historical, the version description in quotes, and who published it when. The chips row, the version count sentence, the NAME field, and the published/created lines are removed.
- Overview now shows only the prompt content, with the markdown and compare controls in a toolbar on the content box. The width cap on the content box is removed.
- New Code tab: the code snippets and the pricing note, moved out of Usage. Setup instructions and monitoring are different jobs, so they get separate tabs.
- Usage now holds the trend, the fetch log, and related traces (moved from Overview). The traces section lost its duplicate scope toggle (the tab already has one) and its permanent info banner; one line under the heading now describes what the table matches, based on the selected scope.
- Tab order: Overview, Code, Usage, Experiments.

| Overview | Code | Usage |
| --- | --- | --- |
| ![restructure-with-description](https://raw.githubusercontent.com/PostHog/pr-assets/208bb06a0224fe226d1cf69195fcf2bd18e906f1/2026/07/d865de97-7c58-44a0-a5d8-8a529a6039b2.png) | ![tab-code](https://raw.githubusercontent.com/PostHog/pr-assets/cb0ae60ff24c5e15dc439a62aa17b2802bcb42cc/2026/07/480303ac-f2f6-486a-8246-f5a6aad6be3b.png) | ![tab-usage](https://raw.githubusercontent.com/PostHog/pr-assets/2f032bd6329d295e05dfc01d9f352c03763aa614/2026/07/1e517d1c-4c65-4f6f-b10b-10a85e475f8c.png) |

Note: this touches the same files as #72266 (prompt labels UI). Whichever merges second needs a small rebase, mostly imports.

## How did you test this code?

- This is a presentation change: components move between tabs and duplicated display is removed. No logic changed, so no new tests. The existing jest suite for the prompts folder passes (25 tests) and the TypeScript check is clean.
- Checked all four tabs in the local app, including a version with a version description and the historical-version view.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The prompt management docs screenshots will be refreshed together with the labels docs in posthog.com#18628.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @jurajmajerik. The layout came out of a design review of the live page: we listed the duplicated information and the mixed concerns, then iterated on the running app with screenshots. The Code tab split came from that review as well, since the snippets block made every visit to the analytics scroll past setup instructions. This branch is deliberately off master rather than stacked on #72266, so it can merge independently; the labels meta chip (production → vN) will be added to the new header line in a follow-up once both are merged.
