### PR TITLE
fix(conversations): align composer with private note mode

### DIFF
--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -49,7 +49,7 @@ export interface ChatViewProps {
     /** Recipient description shown in the draft-mode send confirmation */
     sendConfirmationMessage?: string
     /** When provided, renders a dropdown next to the send button to send and set the ticket status in one go */
-    sendAndSetStatusOptions?: { value: TicketStatus; label: string }[]
+    sendAndSetStatusOptions?: { value: TicketStatus; statusLabel: string }[]
     /** Other unsaved ticket edits that sending with a status would also persist */
     unsavedTicketChanges?: string[]
     latestAiMessageId?: string | null

--- a/products/conversations/frontend/components/Chat/MessageInput.test.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.test.tsx
@@ -1,0 +1,79 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+
+import type { TicketStatus } from '../../types'
+import { MessageInput } from './MessageInput'
+
+// The real SupportEditor pulls in tiptap, mentions, and uploads; the behavior under test is
+// MessageInput's own wiring, which only needs an editor exposing getJSON().
+jest.mock('../Editor', () => {
+    const React = jest.requireActual<typeof import('react')>('react')
+    return {
+        SupportEditor: ({ onCreate }: { onCreate: (editor: unknown) => void }) => {
+            React.useEffect(() => {
+                onCreate({ getJSON: () => ({ type: 'doc' }), clear: () => {} })
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+            }, [])
+            return React.createElement('div')
+        },
+        serializeToMarkdown: (): string => 'hello',
+    }
+})
+
+const SEND_AND_SET_STATUS_OPTIONS: { value: TicketStatus; statusLabel: string }[] = [
+    { value: 'pending', statusLabel: 'pending' },
+    { value: 'on_hold', statusLabel: 'on hold' },
+    { value: 'resolved', statusLabel: 'resolved' },
+]
+
+describe('MessageInput send-and-set-status dropdown', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    // Guards the private-note flag through the dropdown path: dropping it would deliver an
+    // internal note to the customer as a real reply.
+    test.each<[string, boolean, string]>([
+        ['regular mode', false, 'Send'],
+        ['private note mode', true, 'Attach'],
+    ])('in %s the dropdown labels use the mode verb and preserve the private flag', async (_name, isPrivate, verb) => {
+        const onSendMessage = jest.fn()
+
+        render(
+            <Provider>
+                <MessageInput
+                    onSendMessage={onSendMessage}
+                    messageSending={false}
+                    showPrivateOption
+                    isPrivate={isPrivate}
+                    onPrivateChange={jest.fn()}
+                    draftMode={false}
+                    onDraftModeChange={jest.fn()}
+                    draftContent={{ type: 'doc', content: [] }}
+                    sendAndSetStatusOptions={SEND_AND_SET_STATUS_OPTIONS}
+                />
+            </Provider>
+        )
+
+        // Draft mode has no effect on private notes, so its switch is disabled in private note mode
+        expect(screen.getByRole('switch')).toHaveProperty('disabled', isPrivate)
+
+        await userEvent.click(screen.getByLabelText(`${verb} and set ticket status`))
+        expect(await screen.findByText(`${verb} and set pending`)).toBeInTheDocument()
+        expect(screen.getByText(`${verb} and set on hold`)).toBeInTheDocument()
+        expect(screen.getByText(`${verb} and set resolved`)).toBeInTheDocument()
+
+        await userEvent.click(screen.getByText(`${verb} and set pending`))
+        expect(onSendMessage).toHaveBeenCalledTimes(1)
+        expect(onSendMessage).toHaveBeenCalledWith('hello', { type: 'doc' }, isPrivate, expect.any(Function), 'pending')
+    })
+})

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -43,7 +43,7 @@ export interface MessageInputProps {
     /** Recipient description shown in the draft-mode send confirmation (e.g. "This will send to ...") */
     sendConfirmationMessage?: string
     /** When provided, renders a dropdown next to the send button to send and set the ticket status in one go */
-    sendAndSetStatusOptions?: { value: TicketStatus; label: string }[]
+    sendAndSetStatusOptions?: { value: TicketStatus; statusLabel: string }[]
     /** Other unsaved ticket edits that sending with a status would also persist; when non-empty, asks for confirmation first */
     unsavedTicketChanges?: string[]
 }
@@ -80,6 +80,8 @@ export function MessageInput({
     const isPrivate = controlledIsPrivate ?? localIsPrivate
     const setIsPrivate = onPrivateChange ?? setLocalIsPrivate
 
+    const sendVerb = isPrivate ? 'Attach' : 'Send'
+
     const handleSubmit = (statusAfterSend?: TicketStatus): void => {
         // These guard the Cmd+Enter path, which bypasses the (disabled) button.
         if (replyDisabledReason && !isPrivate) {
@@ -112,10 +114,12 @@ export function MessageInput({
             // Sending with a status saves the whole ticket, so surface any other unsaved edits first.
             if (statusAfterSend && unsavedTicketChanges && unsavedTicketChanges.length > 0) {
                 LemonDialog.open({
-                    title: 'Send and save other changes?',
+                    title: `${sendVerb} and save other changes?`,
                     description: (
                         <>
-                            <p>Sending will also save your other unsaved ticket changes:</p>
+                            <p>
+                                {isPrivate ? 'Attaching' : 'Sending'} will also save your other unsaved ticket changes:
+                            </p>
                             <ul className="list-disc pl-5">
                                 {unsavedTicketChanges.map((change) => (
                                     <li key={change}>{change}</li>
@@ -126,7 +130,7 @@ export function MessageInput({
                             ) : null}
                         </>
                     ),
-                    primaryButton: { children: 'Send and save', type: 'primary', onClick: doSend },
+                    primaryButton: { children: `${sendVerb} and save`, type: 'primary', onClick: doSend },
                     secondaryButton: { children: 'Cancel' },
                 })
             } else if (draftMode && !isPrivate && sendConfirmationMessage) {
@@ -219,7 +223,7 @@ export function MessageInput({
                         sideAction={
                             sendAndSetStatusOptions?.length
                                 ? {
-                                      'aria-label': 'Send and set ticket status',
+                                      'aria-label': `${sendVerb} and set ticket status`,
                                       disabled: messageSending,
                                       disabledReason: sendBlockedReason,
                                       dropdown: {
@@ -231,7 +235,7 @@ export function MessageInput({
                                                   size="small"
                                                   onClick={() => handleSubmit(option.value)}
                                               >
-                                                  {option.label}
+                                                  {`${sendVerb} and set ${option.statusLabel}`}
                                               </LemonButton>
                                           )),
                                       },

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -208,9 +208,16 @@ export function MessageInput({
                 )}
                 <div className="flex items-center gap-2">
                     {onDraftModeChange && (
-                        <Tooltip title="In draft mode, sending asks you to confirm the recipient first.">
+                        <Tooltip
+                            title={isPrivate ? null : 'In draft mode, sending asks you to confirm the recipient first.'}
+                        >
                             <span>
-                                <LemonSwitch checked={draftMode} onChange={onDraftModeChange} label="Draft mode" />
+                                <LemonSwitch
+                                    checked={draftMode}
+                                    onChange={onDraftModeChange}
+                                    label="Draft mode"
+                                    disabledReason={isPrivate ? 'Draft mode has no effect on private notes' : undefined}
+                                />
                             </span>
                         </Tooltip>
                     )}

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -58,10 +58,11 @@ function getChannelThreadUrl(ticket: Ticket | null): string | undefined {
     return undefined
 }
 
-const SEND_AND_SET_STATUS_OPTIONS: { value: TicketStatus; label: string }[] = [
-    { value: 'pending', label: 'Send and set pending' },
-    { value: 'on_hold', label: 'Send and set on hold' },
-    { value: 'resolved', label: 'Send and set resolved' },
+// The rendered label is "<Send|Attach> and set <statusLabel>", depending on the private note checkbox
+const SEND_AND_SET_STATUS_OPTIONS: { value: TicketStatus; statusLabel: string }[] = [
+    { value: 'pending', statusLabel: 'pending' },
+    { value: 'on_hold', statusLabel: 'on hold' },
+    { value: 'resolved', statusLabel: 'resolved' },
 ]
 
 export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Element {


### PR DESCRIPTION
## Problem

In the ticket composer, the send-and-set-status dropdown said "Send and set pending" even in private note mode, where nothing is sent to the customer. The draft mode switch also stayed toggleable there despite having no effect on private notes.

## Changes

The dropdown (and the unsaved-changes confirmation dialog) now follows the private note checkbox, and the draft mode switch is disabled with an explanation while it's ticked. The dropdown path was verified to keep the private flag, so "Attach and set pending" adds a private note, never a customer-facing reply.

Regular mode:

![regular-mode](https://raw.githubusercontent.com/PostHog/pr-assets/c70dc1d2a02cf85f1c88cc3919e4b811acc53a0a/2026/07/2a2d8ba4-7f5f-46bb-9ce0-e2cd0ff09799.png)

Private note mode:

![private-mode](https://raw.githubusercontent.com/PostHog/pr-assets/aa116ff6f2f4b3bf8cc873427a61434786445ffc/2026/07/e7670538-4f59-4d86-a978-f356f1e3186a.png)

Disabled draft mode switch with its reason:

![private-mode-draft-switch](https://raw.githubusercontent.com/PostHog/pr-assets/4842604a37fa03f97ac3ff47de9ec50a01b619f5/2026/07/917a3645-3050-4163-a3b0-bc31eefe2659.png)

After pressing "Attach and set pending" (private note added, status set to pending):

![private-note-added](https://raw.githubusercontent.com/PostHog/pr-assets/ab9f6764f3c209ff5a7a3531c743ba3a46d11507/2026/07/ee2a2a7a-177b-4439-ae54-b79acc0e38b8.png)

## How did you test this code?

Added a parameterized jest test for MessageInput that guards the private flag through the dropdown path (dropping it would deliver an internal note to the customer as a real reply) and the mode-dependent labels/switch state; no existing test rendered this component. Also verified live: pressed "Attach and set pending" on a local ticket and confirmed via the API that the comment landed with `is_private: true` and the ticket moved to pending (last screenshot).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, UI copy only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /writing-tests, /run-posthog. The dropdown options prop was reshaped from full labels to status labels so MessageInput composes the verb itself, since it owns the private-note state (which can be uncontrolled). Verification ran against the local dev stack with a seeded widget ticket driven by Playwright.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
