### PR TITLE
fix(integrations): classify hubspot BAD_HUB and 429 oauth refresh failures

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -112,6 +112,7 @@ REFRESH_FAILURE_REASON_INVALID_GRANT = "invalid_grant"
 REFRESH_FAILURE_REASON_INVALID_CLIENT = "invalid_client"
 REFRESH_FAILURE_REASON_HTTP_5XX = "http_5xx"
 REFRESH_FAILURE_REASON_NETWORK = "network"
+REFRESH_FAILURE_REASON_RATE_LIMITED = "rate_limited"
 REFRESH_FAILURE_REASON_OTHER = "other"
 
 
@@ -126,6 +127,17 @@ def oauth_refresh_failure_reason(status_code: int, body: dict, kind: str | None 
     # endpoint means the grant, not the request - match that exact shape for reddit only.
     if kind == "reddit-ads" and status_code == 400 and error == 400:
         return REFRESH_FAILURE_REASON_INVALID_GRANT
+    # HubSpot reports a grant whose portal (hub) was deleted or disconnected as
+    # `{"status": "BAD_HUB", "error": "access_denied", ...}` - no `invalid_grant` code, so
+    # without this mapping the row is retried forever instead of going terminal. Its
+    # `BAD_REFRESH_TOKEN` responses do carry `"error": "invalid_grant"` and need no special case.
+    if kind == "hubspot" and status_code < 500 and body.get("status") == "BAD_HUB":
+        return REFRESH_FAILURE_REASON_INVALID_GRANT
+    # Transient throttling, not a credential problem: the backoff cap synchronises failed
+    # integrations into retry herds that can trip a provider's per-second limit and take
+    # healthy refreshes in the same second down with them.
+    if status_code == 429:
+        return REFRESH_FAILURE_REASON_RATE_LIMITED
     if status_code >= 500:
         return REFRESH_FAILURE_REASON_HTTP_5XX
     return REFRESH_FAILURE_REASON_OTHER
@@ -139,8 +151,8 @@ def record_refresh_failure(integration: "Integration", *, reason: str = REFRESH_
     integration goes terminal and the sweep stops retrying entirely. The streak is tracked
     separately from the total failure count and resets on any other reason, so one transient
     invalid_grant amid e.g. a 5xx outage can't brick the integration. Other reasons
-    (invalid_client, 5xx, network) never go terminal - a platform-side credential fix must let
-    the fleet self-recover.
+    (invalid_client, 5xx, network, rate_limited) never go terminal - a platform-side credential
+    fix must let the fleet self-recover.
 
     Returns "first"/"retry" for the metric's `attempt` label - a spike in first failures means
     connections are newly breaking, regardless of retry noise.

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -861,6 +861,30 @@ class TestOauthIntegrationModel(BaseTest):
             ("reddit_shape_on_other_kind", 400, {"message": "Bad Request", "error": 400}, "hubspot", "other"),
             ("reddit_5xx", 502, {"message": "Bad Gateway", "error": 502}, "reddit-ads", "http_5xx"),
             ("reddit_oauth_error_code", 400, {"error": "invalid_grant"}, "reddit-ads", "invalid_grant"),
+            (
+                "hubspot_dead_hub_shape",
+                400,
+                {"status": "BAD_HUB", "message": "missing or unknown hub id", "error": "access_denied"},
+                "hubspot",
+                "invalid_grant",
+            ),
+            (
+                "hubspot_shape_on_other_kind",
+                400,
+                {"status": "BAD_HUB", "error": "access_denied"},
+                "salesforce",
+                "other",
+            ),
+            ("hubspot_bad_hub_5xx_is_outage", 502, {"status": "BAD_HUB"}, "hubspot", "http_5xx"),
+            (
+                "hubspot_bad_refresh_token_still_oauth_code",
+                400,
+                {"status": "BAD_REFRESH_TOKEN", "error": "invalid_grant"},
+                "hubspot",
+                "invalid_grant",
+            ),
+            ("rate_limited", 429, {"status": "error", "errorType": "RATE_LIMIT"}, "hubspot", "rate_limited"),
+            ("rate_limited_any_kind", 429, {}, None, "rate_limited"),
         ]
     )
     def test_oauth_refresh_failure_reason(self, _name, status_code, body, kind, expected):


### PR DESCRIPTION
## Problem

The `integration_oauth_refresh` metric buckets failures by `reason` so alerting can tell credential breakage from provider trouble, and so dead grants can go terminal (an unbroken `invalid_grant` streak) instead of being retried forever.

HubSpot breaks both mechanisms for one failure shape. A grant whose portal (hub) was deleted or disconnected comes back as `{"status": "BAD_HUB", "error": "access_denied", ...}` with no `invalid_grant` code, so it buckets as `other` and never terminates. Those rows retry at the backoff cap forever, and because the cap is a fixed interval they synchronize into periodic retry herds. The herds are big enough to trip HubSpot's per-second rate limit, which then also fails healthy refreshes that land in the same second, and those 429s bucket as `other` too.

## Changes

- Map HubSpot's `BAD_HUB` shape (4xx + `"status": "BAD_HUB"`) to `invalid_grant`, mirroring the existing reddit-ads special case for a dead grant reported without an OAuth error code. Dead hubs now go terminal after the usual streak and stop retrying. HubSpot's `BAD_REFRESH_TOKEN` responses already carry `"error": "invalid_grant"` and need no special case.
- Bucket HTTP 429 as a new `rate_limited` reason for all kinds, checked after the credential shapes and before the 5xx bucket, so throttling reads as transient provider pressure rather than an unclassified failure. Downstream alerting (PostHog/charts#13344) treats `rate_limited` as provider-transient alongside `http_5xx`/`network`.

> [!NOTE]
> Existing `BAD_HUB` rows start terminating only as they fail again after this deploys; the backlog drains over the following hours as each row accumulates its streak.

## How did you test this code?

- Extended the existing parameterized `test_oauth_refresh_failure_reason` with six cases; regressions each group catches:
  - `hubspot_dead_hub_shape` - the core mapping; fails without the new branch.
  - `hubspot_shape_on_other_kind` - the mapping must stay scoped to hubspot, like the reddit case.
  - `hubspot_bad_hub_5xx_is_outage` - a 5xx with a weird body is still an outage, not a dead grant.
  - `hubspot_bad_refresh_token_still_oauth_code` - the standard `invalid_grant` path keeps precedence.
  - `rate_limited` / `rate_limited_any_kind` - 429 buckets independently of body shape and kind.
- `hogli test posthog/models/test/test_integration_model.py -- -k refresh` - 68 passed (covers backoff, terminal-state, and streak-reset behavior around the changed function).
- No manual testing beyond reading production refresh-failure log bodies to confirm the exact shapes being classified.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed - internal metric classification only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The failure shapes were taken verbatim from production refresh-failure logs (Loki) while investigating why hubspot's `other` failure bursts recur on a fixed period; the burst timing matched the backoff cap and the in-burst failures were RATE_LIMIT bodies, which is what motivated the separate `rate_limited` bucket rather than folding 429s into `other` or `http_5xx`. Considered gating `BAD_HUB` on exact status 400 like the reddit case, but chose `< 500` since the logged shape is unambiguous and a provider-side 5xx that happens to echo a body should still bucket as an outage (covered by a test). Tests follow the file's existing parameterized pattern.
