### PR TITLE
feat(data-warehouse): implement tinyemail import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -526,6 +526,7 @@ the row lists both.
 | thinkific                        | HTTP                        | requests                                                        | ✅                          |
 | tickettailor                     | HTTP                        | requests                                                        | ✅                          |
 | tiktok_ads                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| tinyemail                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | tmdb                             | HTTP                        | requests                                                        | ✅                          |
 | todoist                          | HTTP                        | requests                                                        | ✅                          |
 | together_ai                      | HTTP                        | requests                                                        | ✅                          |
@@ -962,7 +963,6 @@ doesn't conflict with concurrent PRs.
 - ticktick
 - tile38
 - timely
-- tinyemail
 - toggl
 - track_pms
 - tremendous

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/tinyemail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/tinyemail.py
@@ -6,4 +6,4 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common imp
 
 @config.config
 class TinyemailSourceConfig(config.Config):
-    pass
+    api_key: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/canonical_descriptions.py
@@ -1,0 +1,78 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+TINYEMAIL_API_DOCS_URL = "https://docs.tinyemail.com/docs/tiny-email/tinyemail"
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "campaigns": {
+        "description": "An email campaign, including its content, schedule, and delivery statistics.",
+        "docs_url": TINYEMAIL_API_DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the campaign.",
+            "campaign": "The campaign's name, subject line, and preview text.",
+            "status": "Current status of the campaign (for example, draft, scheduled, or sent).",
+            "senderId": "Identifier of the sender profile used for the campaign.",
+            "contactIds": "Identifiers of the contact lists the campaign targets.",
+            "schedule": "Scheduling details, including the date and time the campaign is set to send.",
+            "template": "The campaign's email template, including the rendered HTML.",
+            "requests": "Number of send requests issued for the campaign.",
+            "sent": "Number of emails sent.",
+            "delivered": "Number of emails delivered.",
+            "open": "Number of unique opens.",
+            "totalOpen": "Total number of opens, including repeats.",
+            "clicked": "Number of unique clicks.",
+            "totalClicked": "Total number of clicks, including repeats.",
+            "bounced": "Number of emails that bounced.",
+            "spam": "Number of spam complaints.",
+            "unsubscribed": "Number of recipients who unsubscribed.",
+        },
+    },
+    "contacts": {
+        "description": "A contact list (audience) that campaigns can be sent to.",
+        "docs_url": TINYEMAIL_API_DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the contact list.",
+            "name": "Name of the contact list.",
+            "numberOfMembers": "Number of members in the contact list.",
+        },
+    },
+    "contact_members": {
+        "description": "A subscriber within a contact list, with their profile fields and tags.",
+        "docs_url": TINYEMAIL_API_DOCS_URL,
+        "columns": {
+            "contact_id": "Identifier of the contact list this member belongs to.",
+            "email": "The member's email address.",
+            "firstName": "The member's first name.",
+            "lastName": "The member's last name.",
+            "company": "The member's company.",
+            "address1": "First line of the member's address.",
+            "address2": "Second line of the member's address.",
+            "city": "The member's city.",
+            "province": "The member's province or state.",
+            "country": "The member's country.",
+            "postalCode": "The member's postal code.",
+            "birthday": "The member's birthday.",
+            "currency": "The member's preferred currency.",
+            "source": "Where the member was imported or captured from.",
+            "tags": "Tags applied to the member.",
+        },
+    },
+    "sender_details": {
+        "description": "A sender profile (from name, email, and postal address) used to send campaigns.",
+        "docs_url": TINYEMAIL_API_DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the sender profile.",
+            "name": "The sender's from name.",
+            "email": "The sender's from email address.",
+            "emailConfirmed": "Whether the sender email address has been confirmed.",
+            "dkimSigned": "Whether emails from this sender are DKIM signed.",
+            "defaults": "Whether this is the default sender profile.",
+            "address": "The sender's street address.",
+            "city": "The sender's city.",
+            "region": "The sender's region or state.",
+            "country": "The sender's country.",
+            "postalCode": "The sender's postal code.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/settings.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass, field
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    DependentEndpointConfig,
+)
+from products.warehouse_sources.backend.types import IncrementalField
+
+TINYEMAIL_BASE_URL = "https://api.tinyemail.com/v1"
+
+# tinyEmail does not document a maximum page size, so these mirror the page sizes the
+# vendor's own tooling has verified against the live API. Campaign pages are 0-indexed
+# while contact member pages are 1-indexed.
+CAMPAIGNS_PAGE_SIZE = 20
+CONTACT_MEMBERS_PAGE_SIZE = 100
+
+
+@dataclass
+class TinyemailEndpointConfig:
+    name: str
+    path: str
+    data_selector: str
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    default_incremental_field: str | None = None
+    page_size: int = CONTACT_MEMBERS_PAGE_SIZE
+    paginated: bool = False
+    base_page: int = 0
+    primary_key: str | list[str] = "id"
+    fanout: DependentEndpointConfig | None = None
+
+
+TINYEMAIL_ENDPOINTS: dict[str, TinyemailEndpointConfig] = {
+    "campaigns": TinyemailEndpointConfig(
+        name="campaigns",
+        # The list path really is singular, with rows wrapped in `campaigns.content`.
+        path="/campaign",
+        data_selector="campaigns.content",
+        paginated=True,
+        base_page=0,
+        page_size=CAMPAIGNS_PAGE_SIZE,
+    ),
+    "contacts": TinyemailEndpointConfig(
+        name="contacts",
+        path="/contacts",
+        data_selector="contacts",
+    ),
+    "contact_members": TinyemailEndpointConfig(
+        name="contact_members",
+        path="/contacts/{contact_id}/members",
+        data_selector="members.content",
+        paginated=True,
+        base_page=1,
+        page_size=CONTACT_MEMBERS_PAGE_SIZE,
+        # Members carry no id of their own and an email is only unique within one contact
+        # list, so the parent contact id is part of the key to keep it unique table-wide.
+        primary_key=["contact_id", "email"],
+        fanout=DependentEndpointConfig(
+            parent_name="contacts",
+            resolve_param="contact_id",
+            resolve_field="id",
+            include_from_parent=["id"],
+            parent_field_renames={"id": "contact_id"},
+        ),
+    ),
+    "sender_details": TinyemailEndpointConfig(
+        name="sender_details",
+        path="/sender-details",
+        data_selector="senderDetailses",
+    ),
+}
+
+ENDPOINTS = tuple(TINYEMAIL_ENDPOINTS)
+
+# tinyEmail exposes no server-side updated-after/since filter on any endpoint, so every
+# table is full refresh only.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {name: [] for name in TINYEMAIL_ENDPOINTS}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/source.py
@@ -1,21 +1,46 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.tinyemail import (
     TinyemailSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail import (
+    tinyemail_source,
+    validate_credentials as validate_tinyemail_credentials,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class TinyemailSource(SimpleSource[TinyemailSourceConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+    api_docs_url = "https://docs.tinyemail.com/docs/tiny-email/tinyemail"
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.TINYEMAIL
@@ -25,8 +50,62 @@ class TinyemailSource(SimpleSource[TinyemailSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.TINYEMAIL,
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
-            label="Tinyemail",
+            label="tinyEmail",
+            keywords=["tiny email"],
+            docsUrl="https://posthog.com/docs/cdp/sources/tinyemail",
             iconPath="/static/services/tinyemail.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            caption="""Enter a tinyEmail API key to sync campaigns, contact lists, contact members, and sender details.
+
+You can generate an API key in tinyEmail under **My account → API keys**. Note that tinyEmail API access requires an Enterprise plan.
+""",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+            releaseStatus=ReleaseStatus.ALPHA,
+        )
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error": "Your tinyEmail API key is invalid or expired. Please generate a new key and reconnect.",
+            "403 Client Error": "Your tinyEmail API key does not have access to this resource. Note that tinyEmail API access requires an Enterprise plan.",
+        }
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.canonical_descriptions import (  # noqa: PLC0415
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_schemas(
+        self,
+        config: TinyemailSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
+
+    def validate_credentials(
+        self, config: TinyemailSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        return validate_tinyemail_credentials(api_key=config.api_key)
+
+    def source_for_pipeline(self, config: TinyemailSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return tinyemail_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tests/test_tinyemail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tests/test_tinyemail.py
@@ -98,6 +98,7 @@ class TestTinyemailTransport:
 
         kwargs = mock_build_dependent_resource.call_args.kwargs
         assert kwargs["page_size_param"] == "size"
+        assert kwargs["client_config"]["allow_redirects"] is False
         assert kwargs["fanout"].parent_name == "contacts"
         assert isinstance(kwargs["parent_endpoint_extra"]["paginator"], SinglePagePaginator)
         assert kwargs["parent_endpoint_extra"]["data_selector"] == "contacts"
@@ -131,6 +132,8 @@ class TestTinyemailTransport:
         assert call.args[0] == "https://api.tinyemail.com/v1/contacts"
         assert call.kwargs["headers"]["X-API-KEY"] == "secret-key"
         assert mock_session.call_args.kwargs["redact_values"] == ("secret-key",)
+        # A followed cross-host redirect would replay the X-API-KEY header off-host.
+        assert mock_session.call_args.kwargs["allow_redirects"] is False
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail.make_tracked_session")
     def test_validate_credentials_handles_request_exception(self, mock_session) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tests/test_tinyemail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tests/test_tinyemail.py
@@ -1,0 +1,142 @@
+from typing import Any, cast
+
+import pytest
+from unittest.mock import Mock, patch
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail import (
+    INVALID_CREDENTIALS_MESSAGE,
+    get_resource,
+    tinyemail_source,
+    validate_credentials,
+)
+
+
+class _FakeDltResource:
+    def __init__(self, name: str, rows: list[dict]) -> None:
+        self.name = name
+        self._rows = rows
+
+    def add_map(self, mapper):
+        self._rows = [mapper(dict(row)) for row in self._rows]
+        return self
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class TestTinyemailTransport:
+    @parameterized.expand(
+        [
+            # The campaigns list path really is singular, rows wrapped in `campaigns.content`,
+            # and pages are 0-indexed.
+            ("campaigns", "/campaign", "campaigns.content", PageNumberPaginator, 0, 20),
+            ("contacts", "/contacts", "contacts", SinglePagePaginator, None, None),
+            ("sender_details", "/sender-details", "senderDetailses", SinglePagePaginator, None, None),
+        ]
+    )
+    def test_get_resource_top_level(self, endpoint, path, data_selector, paginator_type, base_page, size) -> None:
+        resource = cast(dict[str, Any], get_resource(endpoint))
+
+        assert resource["name"] == endpoint
+        assert resource["write_disposition"] == "replace"
+        assert resource["table_format"] == "delta"
+        assert resource["endpoint"]["path"] == path
+        assert resource["endpoint"]["data_selector"] == data_selector
+
+        paginator = resource["endpoint"]["paginator"]
+        assert isinstance(paginator, paginator_type)
+        if base_page is not None:
+            assert paginator.page == base_page
+        if size is not None:
+            assert resource["endpoint"]["params"]["size"] == size
+        else:
+            assert "size" not in resource["endpoint"]["params"]
+
+    def test_get_resource_rejects_fanout_endpoint(self) -> None:
+        with pytest.raises(ValueError, match="Fan-out endpoint"):
+            get_resource("contact_members")
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail.rest_api_resource")
+    def test_tinyemail_source_top_level_response(self, mock_rest_api_resource) -> None:
+        mock_rest_api_resource.return_value = Mock()
+
+        response = tinyemail_source(api_key="key", endpoint="campaigns", team_id=1, job_id="job-1")
+
+        assert response.name == "campaigns"
+        assert response.primary_keys == ["id"]
+
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources"
+    )
+    def test_tinyemail_source_contact_members_row_format(self, mock_rest_api_resources) -> None:
+        mock_rest_api_resources.return_value = [
+            _FakeDltResource("contacts", [{"id": "list_1", "name": "Newsletter"}]),
+            _FakeDltResource("contact_members", [{"email": "a@example.com", "_contacts_id": "list_1"}]),
+        ]
+
+        response = tinyemail_source(api_key="key", endpoint="contact_members", team_id=1, job_id="job-1")
+
+        rows = list(cast(Any, response.items()))
+        assert rows == [{"email": "a@example.com", "contact_id": "list_1"}]
+        # An email is only unique within one contact list, so the parent id is part of the key.
+        assert response.primary_keys == ["contact_id", "email"]
+
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail.build_dependent_resource"
+    )
+    def test_tinyemail_source_contact_members_wiring(self, mock_build_dependent_resource) -> None:
+        mock_build_dependent_resource.return_value = iter([])
+
+        tinyemail_source(api_key="key", endpoint="contact_members", team_id=1, job_id="job-1")
+
+        kwargs = mock_build_dependent_resource.call_args.kwargs
+        assert kwargs["page_size_param"] == "size"
+        assert kwargs["fanout"].parent_name == "contacts"
+        assert isinstance(kwargs["parent_endpoint_extra"]["paginator"], SinglePagePaginator)
+        assert kwargs["parent_endpoint_extra"]["data_selector"] == "contacts"
+        child_paginator = kwargs["child_endpoint_extra"]["paginator"]
+        assert isinstance(child_paginator, PageNumberPaginator)
+        # Member pages are 1-indexed (unlike campaign pages) — starting at 0 would duplicate page one.
+        assert child_paginator.page == 1
+        assert kwargs["child_endpoint_extra"]["data_selector"] == "members.content"
+
+    @parameterized.expand(
+        [
+            ("valid", 200, True, None),
+            ("invalid_key", 401, False, INVALID_CREDENTIALS_MESSAGE),
+            ("forbidden", 403, False, INVALID_CREDENTIALS_MESSAGE),
+            ("server_error", 500, False, "tinyEmail API returned an unexpected status code 500"),
+        ]
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail.make_tracked_session")
+    def test_validate_credentials_status_mapping(self, _name, status, expected_valid, expected_message, mock_session):
+        mock_session.return_value.get.return_value = Mock(status_code=status)
+
+        assert validate_credentials(api_key="key") == (expected_valid, expected_message)
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail.make_tracked_session")
+    def test_validate_credentials_sends_api_key_header(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = Mock(status_code=200)
+
+        validate_credentials(api_key="secret-key")
+
+        call = mock_session.return_value.get.call_args
+        assert call.args[0] == "https://api.tinyemail.com/v1/contacts"
+        assert call.kwargs["headers"]["X-API-KEY"] == "secret-key"
+        assert mock_session.call_args.kwargs["redact_values"] == ("secret-key",)
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.tinyemail.make_tracked_session")
+    def test_validate_credentials_handles_request_exception(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.exceptions.RequestException("boom")
+
+        is_valid, message = validate_credentials(api_key="key")
+
+        assert is_valid is False
+        assert message is not None and "Could not connect to the tinyEmail API" in message

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tests/test_tinyemail_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tests/test_tinyemail_source.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import (
+    DataWarehouseSourceCategory,
+    ReleaseStatus,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+)
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.tinyemail import (
+    TinyemailSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.source import TinyemailSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestTinyemailSource:
+    def setup_method(self) -> None:
+        self.source = TinyemailSource()
+        self.team_id = 123
+        self.config = TinyemailSourceConfig(api_key="tinyemail-key")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.TINYEMAIL
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+        assert config.name.value == "Tinyemail"
+        assert config.label == "tinyEmail"
+        assert config.category == DataWarehouseSourceCategory.MARKETING___EMAIL
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert not config.unreleasedSource
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/tinyemail"
+        assert config.iconPath == "/static/services/tinyemail.png"
+        assert self.source.lists_tables_without_credentials is True
+
+    def test_api_key_field_is_secret_password(self) -> None:
+        config = self.source.get_source_config
+        assert [f.name for f in config.fields] == ["api_key"]
+        field = config.fields[0]
+        assert isinstance(field, SourceFieldInputConfig)
+        assert field.type == SourceFieldInputConfigType.PASSWORD
+        assert field.secret is True
+        assert field.required is True
+
+    def test_get_schemas_are_full_refresh_only(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        # tinyEmail has no server-side timestamp filter on any endpoint, so nothing
+        # may advertise incremental or append sync.
+        for schema in schemas:
+            assert schema.supports_incremental is False
+            assert schema.supports_append is False
+            assert schema.incremental_fields == []
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["campaigns"])
+        assert [s.name for s in schemas] == ["campaigns"]
+
+    @pytest.mark.parametrize(
+        "observed_error,expected_non_retryable",
+        [
+            ("401 Client Error: Unauthorized for url: https://api.tinyemail.com/v1/campaign", True),
+            ("403 Client Error: Forbidden for url: https://api.tinyemail.com/v1/contacts", True),
+            ("429 Client Error: Too Many Requests for url: https://api.tinyemail.com/v1/campaign", False),
+            ("500 Server Error: Internal Server Error for url: https://api.tinyemail.com/v1/campaign", False),
+        ],
+    )
+    def test_non_retryable_errors(self, observed_error: str, expected_non_retryable: bool) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable) is expected_non_retryable
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.source.validate_tinyemail_credentials"
+    )
+    def test_validate_credentials_plumbs_api_key(self, mock_validate: mock.MagicMock) -> None:
+        mock_validate.return_value = (True, None)
+
+        assert self.source.validate_credentials(self.config, self.team_id) == (True, None)
+        assert mock_validate.call_args.kwargs["api_key"] == "tinyemail-key"
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.source.tinyemail_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_tinyemail_source: mock.MagicMock) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "contact_members"
+        inputs.team_id = self.team_id
+        inputs.job_id = "job-1"
+
+        self.source.source_for_pipeline(self.config, inputs)
+
+        kwargs = mock_tinyemail_source.call_args.kwargs
+        assert kwargs["api_key"] == "tinyemail-key"
+        assert kwargs["endpoint"] == "contact_members"
+        assert kwargs["team_id"] == self.team_id
+        assert kwargs["job_id"] == "job-1"
+
+    def test_canonical_descriptions_cover_endpoints(self) -> None:
+        descriptions = self.source.get_canonical_descriptions()
+        assert set(descriptions.keys()) == set(ENDPOINTS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tinyemail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tinyemail.py
@@ -1,0 +1,144 @@
+from collections.abc import Iterable
+from typing import Any, cast
+
+from requests.exceptions import RequestException
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    build_dependent_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    BasePaginator,
+    PageNumberPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+    EndpointResource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.tinyemail.settings import (
+    TINYEMAIL_BASE_URL,
+    TINYEMAIL_ENDPOINTS,
+    TinyemailEndpointConfig,
+)
+
+REQUEST_TIMEOUT_SECONDS = 30
+
+INVALID_CREDENTIALS_MESSAGE = (
+    "Invalid tinyEmail API key. Generate a new key in tinyEmail under My account > API keys and reconnect. "
+    "Note that tinyEmail API access requires an Enterprise plan."
+)
+
+
+def _client_config(api_key: str) -> ClientConfig:
+    return {
+        "base_url": TINYEMAIL_BASE_URL,
+        "auth": {"type": "api_key", "name": "X-API-KEY", "api_key": api_key, "location": "header"},
+        "headers": {"Accept": "application/json"},
+    }
+
+
+def _paginator(config: TinyemailEndpointConfig) -> BasePaginator:
+    if not config.paginated:
+        return SinglePagePaginator()
+    return PageNumberPaginator(base_page=config.base_page, page_param="page")
+
+
+def get_resource(endpoint: str) -> EndpointResource:
+    config = TINYEMAIL_ENDPOINTS[endpoint]
+    if config.fanout:
+        raise ValueError(f"Fan-out endpoint '{endpoint}' must use the fan-out path")
+
+    endpoint_config: Endpoint = {
+        "path": config.path,
+        "params": {"size": config.page_size} if config.paginated else {},
+        "data_selector": config.data_selector,
+        "paginator": _paginator(config),
+    }
+
+    return {
+        "name": config.name,
+        "table_name": config.name,
+        "write_disposition": "replace",
+        "endpoint": endpoint_config,
+        "table_format": "delta",
+    }
+
+
+def _make_source_response(endpoint_config: TinyemailEndpointConfig, items_fn: Any) -> SourceResponse:
+    return SourceResponse(
+        name=endpoint_config.name,
+        items=items_fn,
+        primary_keys=endpoint_config.primary_key
+        if isinstance(endpoint_config.primary_key, list)
+        else [endpoint_config.primary_key],
+    )
+
+
+def tinyemail_source(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+) -> SourceResponse:
+    endpoint_config = TINYEMAIL_ENDPOINTS[endpoint]
+
+    if endpoint_config.fanout:
+        parent_config = TINYEMAIL_ENDPOINTS[endpoint_config.fanout.parent_name]
+        dependent_resource = cast(
+            Iterable[Any],
+            build_dependent_resource(
+                endpoint_configs=TINYEMAIL_ENDPOINTS,
+                child_endpoint=endpoint,
+                fanout=endpoint_config.fanout,
+                client_config=_client_config(api_key),
+                path_format_values={},
+                team_id=team_id,
+                job_id=job_id,
+                db_incremental_field_last_value=None,
+                page_size_param="size",
+                parent_endpoint_extra={
+                    "paginator": _paginator(parent_config),
+                    "data_selector": parent_config.data_selector,
+                },
+                child_endpoint_extra={
+                    "paginator": _paginator(endpoint_config),
+                    "data_selector": endpoint_config.data_selector,
+                },
+            ),
+        )
+        return _make_source_response(endpoint_config, lambda: dependent_resource)
+
+    config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resource_defaults": {"write_disposition": "replace"},
+        "resources": [get_resource(endpoint)],
+    }
+
+    resource = rest_api_resource(config, team_id, job_id, None)
+    return _make_source_response(endpoint_config, lambda: resource)
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    session = make_tracked_session(redact_values=(api_key,))
+    try:
+        response = session.get(
+            f"{TINYEMAIL_BASE_URL}/contacts",
+            headers={"X-API-KEY": api_key, "Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except RequestException as exc:
+        return False, f"Could not connect to the tinyEmail API: {exc}"
+
+    if response.status_code == 200:
+        return True, None
+    # tinyEmail has no per-endpoint scopes, so both 401 and 403 mean the key itself is unusable.
+    if response.status_code in (401, 403):
+        return False, INVALID_CREDENTIALS_MESSAGE
+    return False, f"tinyEmail API returned an unexpected status code {response.status_code}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tinyemail.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tinyemail.py
@@ -41,6 +41,9 @@ def _client_config(api_key: str) -> ClientConfig:
         "base_url": TINYEMAIL_BASE_URL,
         "auth": {"type": "api_key", "name": "X-API-KEY", "api_key": api_key, "location": "header"},
         "headers": {"Accept": "application/json"},
+        # The API responds directly on a fixed host, and `requests` would replay the
+        # X-API-KEY header across a cross-host redirect — so never follow one.
+        "allow_redirects": False,
     }
 
 
@@ -126,7 +129,7 @@ def tinyemail_source(
 
 
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
-    session = make_tracked_session(redact_values=(api_key,))
+    session = make_tracked_session(redact_values=(api_key,), allow_redirects=False)
     try:
         response = session.get(
             f"{TINYEMAIL_BASE_URL}/contacts",


### PR DESCRIPTION
## Problem

tinyEmail was scaffolded as a data warehouse source (registered with `unreleasedSource=True` and no fields or sync logic), so users couldn't connect it. Teams running email marketing on tinyEmail have no way to analyze campaign performance or audience data alongside their product data in PostHog.

## Changes

Implements the tinyEmail source end to end on the shared `rest_source` framework, following the standard `source.py` / `settings.py` / `tinyemail.py` split:

- **Four tables**: `campaigns` (page-number pagination from page 0), `contacts` and `sender_details` (unpaginated), and `contact_members` (single-hop fan-out over `contacts/{id}/members` via `build_dependent_resource`, page-number pagination from page 1).
- **Auth**: API key sent as an `X-API-KEY` header through the framework's `api_key` auth, so the secret is redacted from logs and samples automatically. Credential validation probes `/v1/contacts` through `make_tracked_session()` with `redact_values`.
- **Full refresh only**: tinyEmail exposes no server-side `updated_after`/`since` filter on any endpoint, so no table advertises incremental sync.
- **Primary keys**: `id` everywhere except `contact_members`, which has no id of its own – member email is only unique within one list, so the key is `["contact_id", "email"]` with the parent contact id injected and renamed from the fan-out.
- **No partitioning**: no stream exposes a stable creation timestamp.
- Ships **visible** with `releaseStatus=ReleaseStatus.ALPHA` (the `unreleasedSource=True` stub flag is deleted), plus `canonical_descriptions.py`, `lists_tables_without_credentials=True` for the public docs table catalog, `get_non_retryable_errors()` for 401/403, and the SOURCES.md inventory row moved from Scaffolded to Implemented.

> [!NOTE]
> The tinyEmail API is gated to Enterprise accounts and I didn't have credentials, so authenticated behavior couldn't be smoke-tested live. Endpoint paths, response shapes, wrappers, and pagination were verified against the current API docs and the vendor-tested connector config, and the live API was probed unauthenticated (all three top-level paths respond, 401 on bad keys). Page sizes (20 for campaigns, 100 for members) mirror the tested config since no maximum is documented.

## How did you test this code?

- `products/warehouse_sources/backend/temporal/data_imports/sources/tinyemail/tests/` – 25 tests, all passing:
  - `test_tinyemail.py` (transport): endpoint path/selector/paginator wiring per table (catches a regression to the singular `/campaign` path or the wrapped `campaigns.content` selector), the 0-indexed vs 1-indexed page starts (an off-by-one would skip or duplicate a page), fan-out parent-field rename and the `["contact_id", "email"]` composite key (a broken rename would seed duplicate rows and degrade every later merge), and credential validation status mapping including the redaction plumbing.
  - `test_tinyemail_source.py` (source class): source config essentials (alpha, visible, docsUrl/slug agreement), all four schemas full-refresh only (guards someone flipping incremental on without a server-side filter), non-retryable 401/403 matching, argument plumbing, canonical descriptions covering every endpoint.
- Registry-wide invariants still pass: `test_source_categories.py`, `test_source_versions.py`, `test_generated_configs.py` (2,622 tests).
- `hogli ci:preflight --fix` clean; repo-wide `mypy --cache-fine-grained .` reports no errors in changed files; `ruff check` / `ruff format` clean.
- Not done: a live authenticated sync (no Enterprise tinyEmail credentials available).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

User-facing doc written per the docs template (`Linking tinyEmail as a source`, `sourceId: Tinyemail`, alpha callout, `<SourceParameters />` + `<SourceTables />`); opened as [PostHog/posthog.com#18739](https://github.com/PostHog/posthog.com/pull/18739) (`contents/docs/cdp/sources/tinyemail.md`). `docsUrl` here already points at `/docs/cdp/sources/tinyemail`, and `audit_source_docs` reports no tinyemail issues against that doc.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task). Skills invoked: `implementing-warehouse-sources`, `documenting-warehouse-sources`, `writing-tests`.

Decisions along the way:

- Chose the shared `rest_source` framework over a hand-rolled client – declarative endpoints plus framework auth/paginators/tracked transport cover everything this API needs; no bespoke retry layer was added since the tracked transport already handles 429/5xx with `Retry-After`.
- Chose `SimpleSource` over `ResumableSource`: only two streams paginate at all, the API is full-refresh only, and the fan-out helper (which serves the largest table) has no resume seam – the extra machinery would buy resume for the small campaigns table only.
- Stream catalog, wrappers, and page indexing cross-referenced with the vendor-tested connector configuration; `curl` used to confirm the live endpoints exist and return 401 on invalid keys.
- The config generator also reformatted 14 other generated modules (pre-existing drift); those were reverted so the diff stays scoped to tinyemail.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

