### PR TITLE
feat(data-warehouse): implement glassfrog import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -239,6 +239,7 @@ the row lists both.
 | giphy                            | HTTP                        | requests                                                        | ✅                          |
 | gitlab                           | HTTP                        | requests                                                        | ✅                          |
 | gladly                           | HTTP                        | requests                                                        | ✅                          |
+| glassfrog                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | gnews                            | HTTP                        | requests                                                        | ✅                          |
 | gocardless                       | HTTP                        | requests                                                        | ✅                          |
 | goldcast                         | HTTP                        | requests                                                        | ✅                          |
@@ -722,7 +723,6 @@ doesn't conflict with concurrent PRs.
 - gerrit
 - getstream
 - gitea
-- glassfrog
 - gmail
 - gnews
 - gojiberry

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/glassfrog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/glassfrog.py
@@ -6,4 +6,4 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common imp
 
 @config.config
 class GlassfrogSourceConfig(config.Config):
-    pass
+    api_key: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/canonical_descriptions.py
@@ -1,0 +1,113 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+_DOCS_URL = "https://app.glassfrog.com/api/v3/docs"
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "assignments": {
+        "description": "An assignment of a person to a role, optionally with a focus.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the assignment.",
+            "election": "Date the person was elected into the role, for elected roles.",
+            "exclude_from_meetings": "Whether this assignment is excluded from circle meetings.",
+            "focus": "The focus of the assignment when a role is filled with a specific focus.",
+            "links": "Identifiers of the related person and role.",
+        },
+    },
+    "checklist_items": {
+        "description": "A recurring checklist item reviewed in a circle's tactical meetings.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the checklist item.",
+            "description": "Text of the checklist item.",
+            "frequency": "How often the item is reviewed (e.g. Weekly, Monthly).",
+            "global": "Whether the item applies to all circles in the organization.",
+            "link": "URL associated with the checklist item, if any.",
+            "links": "Identifiers of the related circle and role.",
+        },
+    },
+    "circles": {
+        "description": "A circle (team) in the organization's governance structure.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the circle.",
+            "name": "Name of the circle.",
+            "short_name": "Abbreviated name of the circle.",
+            "strategy": "The circle's strategy statement, if defined.",
+            "organization_id": "Identifier of the organization the circle belongs to.",
+            "links": "Identifiers of related resources: roles, policies, domain, and supported role.",
+        },
+    },
+    "custom_fields": {
+        "description": "A custom field attached to a role.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the custom field.",
+            "field_name": "Name of the custom field.",
+            "field_value": "Value of the custom field.",
+            "links": "Identifier of the role the custom field is attached to.",
+        },
+    },
+    "metrics": {
+        "description": "A metric reported in a circle's tactical meetings.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the metric.",
+            "description": "Text describing the metric.",
+            "frequency": "How often the metric is reported (e.g. Weekly, Monthly).",
+            "global": "Whether the metric applies to all circles in the organization.",
+            "link": "URL associated with the metric, if any.",
+            "role_name": "Name of the role responsible for reporting the metric.",
+            "links": "Identifiers of the related circle and role.",
+        },
+    },
+    "people": {
+        "description": "A person (member) in the organization.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the person.",
+            "name": "Full name of the person.",
+            "email": "Email address of the person.",
+            "external_id": "External identifier for the person, if set by the organization.",
+            "tag_names": "Tags applied to the person.",
+            "settings": "Per-person settings.",
+            "links": "Identifiers of the circles the person belongs to and their organizations.",
+        },
+    },
+    "projects": {
+        "description": "A project tracked by a circle or role.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the project.",
+            "description": "Text describing the project.",
+            "status": "Current status of the project (e.g. Current, Future, Waiting, Done).",
+            "waiting_on_who": "Who the project is waiting on, when status is Waiting.",
+            "waiting_on_what": "What the project is waiting on, when status is Waiting.",
+            "link": "URL associated with the project, if any.",
+            "value": "Relative value rating assigned to the project.",
+            "effort": "Relative effort rating assigned to the project.",
+            "roi": "Value/effort ratio computed from the ratings.",
+            "private_to_circle": "Whether the project is only visible inside its circle.",
+            "created_at": "When the project was created.",
+            "archived_at": "When the project was archived, if it has been.",
+            "type": "Type of the project.",
+            "links": "Identifiers of the related role, person, and circle.",
+        },
+    },
+    "roles": {
+        "description": "A role defined in the organization's governance structure.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the role.",
+            "name": "Name of the role.",
+            "is_core": "Whether this is a core role (e.g. Lead Link, Secretary, Facilitator).",
+            "purpose": "The role's purpose statement.",
+            "elected_until": "End date of the current election term, for elected roles.",
+            "organization_id": "Identifier of the organization the role belongs to.",
+            "tag_names": "Tags applied to the role.",
+            "links": "Identifiers of related resources: circle, supporting circle, domains, accountabilities, and people filling the role.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/glassfrog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/glassfrog.py
@@ -1,0 +1,74 @@
+import requests
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.settings import GLASSFROG_ENDPOINTS
+
+GLASSFROG_BASE_URL = "https://api.glassfrog.com/api/v3"
+
+
+def _make_session(api_key: str) -> requests.Session:
+    # `redact_values` masks the key in tracked logs/samples. `capture=False` keeps response bodies out
+    # of HTTP sample storage — people rows carry names/emails and org-structure data the name-based
+    # sample scrubbers can't fully recognise. Requests are still metered and logged (status + url).
+    return make_tracked_session(redact_values=(api_key,), capture=False)
+
+
+def validate_credentials(api_key: str) -> bool:
+    # `/circles` is the cheapest authenticated probe: every v3 API key can list the circles it can
+    # see, so a 200 confirms the key is genuine. allow_redirects=False because the key rides a
+    # custom header that `requests` would replay across a cross-origin redirect.
+    ok, _status = validate_via_probe(
+        lambda: _make_session(api_key),
+        f"{GLASSFROG_BASE_URL}/circles",
+        headers={"X-Auth-Token": api_key, "Accept": "application/json"},
+        allow_redirects=False,
+    )
+    return ok
+
+
+def glassfrog_source(api_key: str, endpoint: str, team_id: int, job_id: str) -> SourceResponse:
+    endpoint_config = GLASSFROG_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": GLASSFROG_BASE_URL,
+            "headers": {"Accept": "application/json"},
+            # Framework auth (not a hand-built header) so the key is redacted wherever it surfaces.
+            "auth": {"type": "api_key", "name": "X-Auth-Token", "api_key": api_key, "location": "header"},
+            # GlassFrog v3 list endpoints return the full collection in one response — no
+            # pagination, page, or cursor params are documented or honored.
+            "paginator": "single_page",
+            "session": _make_session(api_key),
+        },
+        "resources": [
+            {
+                "name": endpoint,
+                "endpoint": {
+                    "path": endpoint_config.path,
+                    # Rows are wrapped under a resource key ({"circles": [...]}); a body without it
+                    # is an unexpected/error shape. Fail loud instead of syncing zero rows.
+                    "data_selector": endpoint_config.data_selector,
+                    "data_selector_required": True,
+                },
+            }
+        ],
+    }
+
+    resource = rest_api_resource(rest_config, team_id, job_id, None)
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=endpoint_config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if endpoint_config.partition_key else None,
+        partition_format="month" if endpoint_config.partition_key else None,
+        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/glassfrog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/glassfrog.py
@@ -16,7 +16,9 @@ def _make_session(api_key: str) -> requests.Session:
     # `redact_values` masks the key in tracked logs/samples. `capture=False` keeps response bodies out
     # of HTTP sample storage — people rows carry names/emails and org-structure data the name-based
     # sample scrubbers can't fully recognise. Requests are still metered and logged (status + url).
-    return make_tracked_session(redact_values=(api_key,), capture=False)
+    # `allow_redirects=False` because the key rides a custom header that `requests` would replay
+    # across a cross-origin redirect.
+    return make_tracked_session(redact_values=(api_key,), capture=False, allow_redirects=False)
 
 
 def validate_credentials(api_key: str) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/settings.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass, field
+
+from products.warehouse_sources.backend.types import IncrementalField
+
+
+@dataclass
+class GlassfrogEndpointConfig:
+    name: str
+    path: str
+    # Key wrapping the row list in the v3 response body (e.g. {"circles": [...]}).
+    data_selector: str
+    # Field to partition Delta files by. Must be a stable creation-time timestamp so a row never
+    # moves between partitions. Only `projects` exposes one (`created_at`); the other resources
+    # carry no datetime fields at all.
+    partition_key: str | None = None
+    # Incremental cursor candidates. Left empty for every GlassFrog endpoint: the v3 API exposes
+    # no server-side timestamp/cursor filters, so an "incremental" sync would still fetch the
+    # whole collection each run. Full refresh is the honest strategy.
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+
+
+GLASSFROG_ENDPOINTS: dict[str, GlassfrogEndpointConfig] = {
+    "assignments": GlassfrogEndpointConfig(
+        name="assignments",
+        path="/assignments",
+        data_selector="assignments",
+    ),
+    "checklist_items": GlassfrogEndpointConfig(
+        name="checklist_items",
+        path="/checklist_items",
+        data_selector="checklist_items",
+    ),
+    "circles": GlassfrogEndpointConfig(
+        name="circles",
+        path="/circles",
+        data_selector="circles",
+    ),
+    "custom_fields": GlassfrogEndpointConfig(
+        name="custom_fields",
+        path="/custom_fields",
+        data_selector="custom_fields",
+    ),
+    "metrics": GlassfrogEndpointConfig(
+        name="metrics",
+        path="/metrics",
+        data_selector="metrics",
+    ),
+    "people": GlassfrogEndpointConfig(
+        name="people",
+        path="/people",
+        data_selector="people",
+    ),
+    "projects": GlassfrogEndpointConfig(
+        name="projects",
+        path="/projects",
+        data_selector="projects",
+        partition_key="created_at",
+    ),
+    "roles": GlassfrogEndpointConfig(
+        name="roles",
+        path="/roles",
+        data_selector="roles",
+    ),
+}
+
+ENDPOINTS = tuple(GLASSFROG_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in GLASSFROG_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/source.py
@@ -1,21 +1,48 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.glassfrog import (
     GlassfrogSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.glassfrog import (
+    glassfrog_source,
+    validate_credentials as validate_glassfrog_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class GlassfrogSource(SimpleSource[GlassfrogSourceConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+    supported_versions = ("v3",)
+    default_version = "v3"
+    api_docs_url = "https://app.glassfrog.com/api/v3/docs"
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.GLASSFROG
@@ -25,8 +52,69 @@ class GlassfrogSource(SimpleSource[GlassfrogSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.GLASSFROG,
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
-            label="Glassfrog",
+            label="GlassFrog",
+            releaseStatus=ReleaseStatus.ALPHA,
+            caption="""Enter your GlassFrog API key to sync your organization's circles, roles, people, projects, metrics, and checklist items into the PostHog Data warehouse.
+
+You can create a v3 API key in GlassFrog under [Profile & Settings > API](https://app.glassfrog.com/). The key grants access at your user's permission level.""",
             iconPath="/static/services/glassfrog.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/glassfrog",
+            keywords=["holacracy", "governance"],
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # An invalid or revoked key surfaces as an HTTPError from `raise_for_status()`. Retrying
+            # can never satisfy a credential problem, so stop the sync. Match the stable status text
+            # and base host, not the per-request path.
+            "401 Client Error: Unauthorized for url: https://api.glassfrog.com": "Your GlassFrog API key is invalid or has been revoked. Create a new key under Profile & Settings > API in GlassFrog, then reconnect.",
+            "403 Client Error: Forbidden for url: https://api.glassfrog.com": "Your GlassFrog API key does not have access to this data. Check the key's permission level, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: GlassfrogSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Every GlassFrog endpoint is full refresh: the v3 API exposes no server-side timestamp or
+        # cursor filters, so nothing can be synced incrementally (see settings.py).
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
+
+    def validate_credentials(
+        self, config: GlassfrogSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_glassfrog_credentials(config.api_key):
+            return True, None
+
+        return False, "Invalid GlassFrog API key"
+
+    def source_for_pipeline(self, config: GlassfrogSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return glassfrog_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/tests/test_glassfrog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/tests/test_glassfrog.py
@@ -164,6 +164,9 @@ class TestKeyRedaction:
         assert MockSession.call_args.kwargs["redact_values"] == ("gf_secret",)
         # Response bodies carry people names/emails the scrubbers can't fully recognise.
         assert MockSession.call_args.kwargs["capture"] is False
+        # The key rides a custom header, which `requests` would replay across a cross-origin
+        # redirect — the sync session must never follow redirects.
+        assert MockSession.call_args.kwargs["allow_redirects"] is False
 
     @mock.patch(SESSION_PATCH)
     def test_validate_credentials_redacts_key(self, MockSession) -> None:
@@ -175,6 +178,7 @@ class TestKeyRedaction:
 
         assert MockSession.call_args.kwargs["redact_values"] == ("gf_secret",)
         assert MockSession.call_args.kwargs["capture"] is False
+        assert MockSession.call_args.kwargs["allow_redirects"] is False
 
 
 class TestValidateCredentials:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/tests/test_glassfrog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/tests/test_glassfrog.py
@@ -1,0 +1,229 @@
+import json
+from typing import Any
+
+import pytest
+from unittest import mock
+
+import requests
+from parameterized import parameterized
+from tenacity import wait_none
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClient,
+    RESTClientRetryableError,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.glassfrog import (
+    GLASSFROG_BASE_URL,
+    glassfrog_source,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.settings import GLASSFROG_ENDPOINTS
+
+# Both the sync transport and the credential probe build their session via the
+# glassfrog module's make_tracked_session (passed into the client config).
+SESSION_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.glassfrog.make_tracked_session"
+)
+
+
+def _response(status_code: int, json_body: Any = None) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp.url = f"{GLASSFROG_BASE_URL}/circles"
+    resp._content = json.dumps(json_body if json_body is not None else {}).encode()
+    return resp
+
+
+def _wire(session: mock.MagicMock, responses: list[requests.Response]) -> list[requests.PreparedRequest]:
+    """Wire a mock session and capture each request AS PREPARED (auth applied, URL resolved)."""
+    session.headers = {}
+    prepared_requests: list[requests.PreparedRequest] = []
+
+    def _prepare(request: requests.Request) -> requests.PreparedRequest:
+        prepared = request.prepare()
+        prepared_requests.append(prepared)
+        return prepared
+
+    session.prepare_request.side_effect = _prepare
+    session.send.side_effect = responses
+    return prepared_requests
+
+
+def _rows(source_response) -> list[dict[str, Any]]:
+    return [row for page in source_response.items() for row in page]
+
+
+class TestGetRows:
+    def setup_method(self) -> None:
+        # Drop the exponential backoff so retryable-status tests don't actually sleep.
+        # Saved and restored in teardown_method — this attribute is process-global, and leaving
+        # wait_none in place breaks rest_client's own retry-wait tests in the same run.
+        self._original_wait = RESTClient._send_request.retry.wait  # type: ignore[attr-defined]
+        RESTClient._send_request.retry.wait = wait_none()  # type: ignore[attr-defined]
+
+    def teardown_method(self) -> None:
+        RESTClient._send_request.retry.wait = self._original_wait  # type: ignore[attr-defined]
+
+    @mock.patch(SESSION_PATCH)
+    def test_single_request_yields_rows_unwrapped_from_resource_key(self, MockSession) -> None:
+        session = MockSession.return_value
+        rows_body = [{"id": 1, "name": "General Company Circle"}, {"id": 2, "name": "Ops"}]
+        prepared = _wire(session, [_response(200, {"circles": rows_body})])
+
+        rows = _rows(glassfrog_source("gf_key", "circles", team_id=1, job_id="j"))
+
+        assert rows == rows_body
+        # No pagination params exist — the whole collection comes back in one request.
+        assert session.send.call_count == 1
+        assert prepared[0].url == f"{GLASSFROG_BASE_URL}/circles"
+
+    @mock.patch(SESSION_PATCH)
+    def test_empty_collection_yields_no_rows(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(200, {"people": []})])
+
+        assert _rows(glassfrog_source("gf_key", "people", team_id=1, job_id="j")) == []
+
+    @mock.patch(SESSION_PATCH)
+    def test_missing_resource_key_raises(self, MockSession) -> None:
+        # v3 responses wrap rows under a resource key ({"circles": [...]}); a body without it is an
+        # unexpected/error shape. Raise so the sync fails loudly instead of syncing zero rows.
+        session = MockSession.return_value
+        _wire(session, [_response(200, {"message": "something else"})])
+
+        with pytest.raises(ValueError, match="matched nothing"):
+            _rows(glassfrog_source("gf_key", "circles", team_id=1, job_id="j"))
+
+    @parameterized.expand([(name, config.path, config.data_selector) for name, config in GLASSFROG_ENDPOINTS.items()])
+    @mock.patch(SESSION_PATCH)
+    def test_each_endpoint_requests_its_path_and_unwraps_its_key(
+        self, endpoint: str, path: str, data_selector: str, MockSession
+    ) -> None:
+        session = MockSession.return_value
+        prepared = _wire(session, [_response(200, {data_selector: [{"id": 42}]})])
+
+        rows = _rows(glassfrog_source("gf_key", endpoint, team_id=1, job_id="j"))
+
+        assert rows == [{"id": 42}]
+        assert prepared[0].url == f"{GLASSFROG_BASE_URL}{path}"
+
+    @mock.patch(SESSION_PATCH)
+    def test_api_key_sent_via_header_auth(self, MockSession) -> None:
+        session = MockSession.return_value
+        prepared = _wire(session, [_response(200, {"roles": [{"id": 1}]})])
+
+        _rows(glassfrog_source("gf_test_key", "roles", team_id=1, job_id="j"))
+
+        assert prepared[0].headers["X-Auth-Token"] == "gf_test_key"
+        assert session.headers.get("Accept") == "application/json"
+
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    @mock.patch(SESSION_PATCH)
+    def test_retryable_status_raises_after_retries(self, _name: str, status_code: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status_code, {"error": "nope"})] * 5)
+
+        with pytest.raises(RESTClientRetryableError):
+            _rows(glassfrog_source("gf_key", "circles", team_id=1, job_id="j"))
+
+        # 5 attempts before giving up.
+        assert session.send.call_count == 5
+
+    @mock.patch(SESSION_PATCH)
+    def test_recovers_after_transient_error(self, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(500, {}), _response(200, {"circles": [{"id": 1}]})])
+
+        rows = _rows(glassfrog_source("gf_key", "circles", team_id=1, job_id="j"))
+
+        assert rows == [{"id": 1}]
+        assert session.send.call_count == 2
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    @mock.patch(SESSION_PATCH)
+    def test_client_error_raises_immediately(self, _name: str, status_code: int, MockSession) -> None:
+        session = MockSession.return_value
+        _wire(session, [_response(status_code, {"message": "api key not specified or not valid"})] * 5)
+
+        with pytest.raises(requests.HTTPError):
+            _rows(glassfrog_source("gf_key", "circles", team_id=1, job_id="j"))
+
+        # Client errors are not retried — they can never succeed on retry.
+        assert session.send.call_count == 1
+
+
+class TestKeyRedaction:
+    @mock.patch(SESSION_PATCH)
+    def test_source_session_redacts_key(self, MockSession) -> None:
+        # The API key must be masked in tracked HTTP logs/samples, not left recoverable from a bucket.
+        session = MockSession.return_value
+        _wire(session, [_response(200, {"circles": []})])
+
+        _rows(glassfrog_source("gf_secret", "circles", team_id=1, job_id="j"))
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("gf_secret",)
+        # Response bodies carry people names/emails the scrubbers can't fully recognise.
+        assert MockSession.call_args.kwargs["capture"] is False
+
+    @mock.patch(SESSION_PATCH)
+    def test_validate_credentials_redacts_key(self, MockSession) -> None:
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=200)
+        MockSession.return_value = session
+
+        validate_credentials("gf_secret")
+
+        assert MockSession.call_args.kwargs["redact_values"] == ("gf_secret",)
+        assert MockSession.call_args.kwargs["capture"] is False
+
+
+class TestValidateCredentials:
+    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("forbidden", 403, False)])
+    @mock.patch(SESSION_PATCH)
+    def test_maps_status_to_bool(self, _name: str, status_code: int, expected: bool, MockSession) -> None:
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=status_code)
+        MockSession.return_value = session
+
+        assert validate_credentials("gf_key") is expected
+
+    @mock.patch(SESSION_PATCH)
+    def test_probes_circles_with_key_header_and_no_redirects(self, MockSession) -> None:
+        session = mock.MagicMock()
+        session.get.return_value = mock.MagicMock(status_code=200)
+        MockSession.return_value = session
+
+        validate_credentials("gf_key")
+
+        assert session.get.call_args.args[0] == f"{GLASSFROG_BASE_URL}/circles"
+        assert session.get.call_args.kwargs["headers"]["X-Auth-Token"] == "gf_key"
+        # The key rides a custom header, which `requests` would replay across a cross-origin
+        # redirect — the probe must not follow redirects.
+        assert session.get.call_args.kwargs["allow_redirects"] is False
+
+    @mock.patch(SESSION_PATCH)
+    def test_network_error_maps_to_not_validated(self, MockSession) -> None:
+        # The probe must never raise out of validate_credentials — an unreachable API means
+        # "not validated", not a crashed source-create request.
+        session = mock.MagicMock()
+        session.get.side_effect = requests.ConnectionError("boom")
+        MockSession.return_value = session
+
+        assert validate_credentials("gf_key") is False
+
+
+class TestGlassfrogSourceResponse:
+    @parameterized.expand([(endpoint,) for endpoint in GLASSFROG_ENDPOINTS])
+    @mock.patch(SESSION_PATCH)
+    def test_source_response_shape(self, endpoint: str, MockSession) -> None:
+        response = glassfrog_source("gf_key", endpoint, team_id=1, job_id="j")
+
+        assert response.name == endpoint
+        assert response.primary_keys == ["id"]
+        if endpoint == "projects":
+            # Partition on the stable creation timestamp — the only GlassFrog resource with one.
+            assert response.partition_keys == ["created_at"]
+            assert response.partition_mode == "datetime"
+        else:
+            assert response.partition_keys is None
+            assert response.partition_mode is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/tests/test_glassfrog_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/glassfrog/tests/test_glassfrog_source.py
@@ -1,0 +1,146 @@
+import json
+from collections.abc import Iterable
+from typing import Any, cast
+
+from unittest.mock import MagicMock, patch
+
+import requests
+from parameterized import parameterized
+
+from posthog.schema import DataWarehouseSourceCategory, ReleaseStatus, SourceFieldInputConfig
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.glassfrog import (
+    GlassfrogSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog import (
+    glassfrog,
+    source as source_module,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.glassfrog.source import GlassfrogSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+def _config() -> GlassfrogSourceConfig:
+    return GlassfrogSourceConfig(api_key="gf_test_key")
+
+
+class TestGlassfrogSourceConfig:
+    def test_source_type(self) -> None:
+        assert GlassfrogSource().source_type == ExternalDataSourceType.GLASSFROG
+
+    def test_source_config_basics(self) -> None:
+        config = GlassfrogSource().get_source_config
+
+        assert config.name == "Glassfrog"
+        assert config.category == DataWarehouseSourceCategory.PRODUCTIVITY
+        # Alpha, and visible (no unreleasedSource) — a finished source ships connectable.
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert not config.unreleasedSource
+        assert config.iconPath.endswith(".png")
+
+    def test_single_required_api_key_field(self) -> None:
+        fields = GlassfrogSource().get_source_config.fields
+
+        assert len(fields) == 1
+        field = fields[0]
+        assert isinstance(field, SourceFieldInputConfig)
+        assert field.name == "api_key"
+        assert field.required is True
+        # API keys are secrets — must never be echoed back to the client.
+        assert field.secret is True
+
+
+class TestGlassfrogSchemas:
+    def test_lists_expected_endpoints(self) -> None:
+        names = {s.name for s in GlassfrogSource().get_schemas(_config(), team_id=1)}
+
+        assert names == {
+            "assignments",
+            "checklist_items",
+            "circles",
+            "custom_fields",
+            "metrics",
+            "people",
+            "projects",
+            "roles",
+        }
+
+    @parameterized.expand([(endpoint,) for endpoint in ENDPOINTS])
+    def test_every_endpoint_is_full_refresh_only(self, endpoint: str) -> None:
+        # No GlassFrog v3 endpoint exposes a server-side timestamp or cursor filter, so nothing can
+        # sync incrementally — guarding against a future edit flipping this on without a real filter.
+        schema = next(s for s in GlassfrogSource().get_schemas(_config(), team_id=1) if s.name == endpoint)
+
+        assert schema.supports_incremental is False
+        assert schema.supports_append is False
+        assert schema.incremental_fields == []
+
+    def test_names_filter(self) -> None:
+        schemas = GlassfrogSource().get_schemas(_config(), team_id=1, names=["circles"])
+
+        assert [s.name for s in schemas] == ["circles"]
+
+    def test_documented_tables_render_for_public_docs(self) -> None:
+        # lists_tables_without_credentials=True means the public docs <SourceTables /> is fed here.
+        tables = GlassfrogSource().get_documented_tables()
+
+        by_name = {t["name"]: t for t in tables}
+        assert set(by_name) == set(ENDPOINTS)
+        assert by_name["circles"]["description"]
+        assert by_name["circles"]["sync_methods"] == ["Full refresh"]
+
+
+class TestGlassfrogCredentials:
+    @parameterized.expand([("valid", True, True), ("invalid", False, False)])
+    @patch.object(source_module, "validate_glassfrog_credentials")
+    def test_validate_credentials(
+        self, _name: str, probe_result: bool, expected_ok: bool, mock_validate: MagicMock
+    ) -> None:
+        mock_validate.return_value = probe_result
+
+        ok, error = GlassfrogSource().validate_credentials(_config(), team_id=1)
+
+        assert ok is expected_ok
+        assert (error is None) is expected_ok
+
+    def test_non_retryable_errors_cover_auth_failures(self) -> None:
+        errors = GlassfrogSource().get_non_retryable_errors()
+
+        assert any("401" in key for key in errors)
+        assert any("403" in key for key in errors)
+
+
+class TestGlassfrogPipelineHandoff:
+    @patch.object(glassfrog, "make_tracked_session")
+    def test_source_for_pipeline_plumbs_endpoint_and_key(self, mock_session_factory: MagicMock) -> None:
+        session = MagicMock()
+        session.headers = {}
+        prepared_requests: list[requests.PreparedRequest] = []
+
+        def _prepare(request: requests.Request) -> requests.PreparedRequest:
+            prepared = request.prepare()
+            prepared_requests.append(prepared)
+            return prepared
+
+        response = requests.Response()
+        response.status_code = 200
+        response._content = json.dumps({"circles": [{"id": 1, "name": "General Company Circle"}]}).encode()
+        session.prepare_request.side_effect = _prepare
+        session.send.return_value = response
+        mock_session_factory.return_value = session
+
+        inputs = MagicMock()
+        inputs.schema_name = "circles"
+        inputs.team_id = 1
+        inputs.job_id = "job_1"
+
+        source_response = GlassfrogSource().source_for_pipeline(_config(), inputs)
+
+        assert source_response.name == "circles"
+        assert source_response.primary_keys == ["id"]
+
+        # The items thunk should actually pull rows using the configured key/endpoint.
+        rows = list(cast(Iterable[Any], source_response.items()))
+        assert rows == [[{"id": 1, "name": "General Company Circle"}]]
+        assert prepared_requests[0].headers["X-Auth-Token"] == "gf_test_key"


### PR DESCRIPTION
## Problem

GlassFrog is a Holacracy/self-management governance platform where organizations model their circles, roles, people, projects, metrics, and checklist items. Teams using it want that org-structure data in the warehouse to analyze how work is distributed alongside their product data. The source was scaffolded as a stub (`unreleasedSource=True`, no fields, no sync logic), so it was hidden and unusable.

## Changes

This fills in the scaffolded `glassfrog` source end to end. Enum, TS schema, and registry wiring were already merged, so this is purely the implementation.

- **`SimpleSource` full refresh.** GlassFrog's v3 API returns each full collection in one response, with no pagination and no server-side `updated_after`/cursor filters (matching Airbyte's full-refresh-only connector). There is no cursor to persist, so nothing claims `supports_incremental` and there is no resumable state to manage.
- **Endpoints:** the eight v3 resources: `assignments`, `checklist_items`, `circles`, `custom_fields`, `metrics`, `people`, `projects`, `roles`. All key on `id`. Only `projects` carries a datetime field, so it alone partitions on the stable `created_at`; the other resources have no timestamp to partition by.
- **Declarative `rest_source` transport:** framework `api_key` auth on the `X-Auth-Token` header, `single_page` paginator, and a required `data_selector` per endpoint since v3 wraps rows under a resource key (`{"circles": [...]}`), so a response missing the key fails loud instead of syncing zero rows. The session is `make_tracked_session(redact_values=..., capture=False)` since people rows carry names and emails. Retries on 429/5xx come from the framework transport; 401/403 are non-retryable so a bad key fails fast.
- **Docs plumbing:** curated canonical table/column descriptions from the v3 API reference, `lists_tables_without_credentials = True` so the posthog.com Supported tables section renders, and version metadata pinned to `v3` (the stable API; a v5 beta exists but is not yet documented for production use).
- Ships `releaseStatus=alpha`, visible and connectable (no `unreleasedSource`). Uses the already-committed `glassfrog.png` icon. No migration needed - the enum choices migration (0086) already covers Glassfrog.

> [!NOTE]
> I could not curl-verify authenticated response shapes (no GlassFrog API key available in the run). I confirmed against the live API that `https://api.glassfrog.com/api/v3/<resource>` exists and returns `401 {"message":"api key not specified or not valid"}` for a bad `X-Auth-Token`, which validates the base URL and auth mechanism. Endpoint paths, response keys, and field names come from the official v3 API docs cross-referenced with Airbyte's connector. The required `data_selector` means any drift from that shape fails loudly rather than silently syncing nothing.

## How did you test this code?

Automated tests only (I am an agent and did not do manual/live-API testing beyond the unauthenticated 401 probe above):

- `tests/test_glassfrog.py` (transport): per-endpoint path + resource-key unwrapping (parameterized over all eight endpoints - catches a wrong path or selector), fail-loud on a missing resource key (guards the silent zero-row sync), `X-Auth-Token` header auth, retry classification (429/5xx retried, 401/403/404 raise immediately), transient-error recovery, key redaction in tracked sessions, credential-probe status mapping including the no-redirect guard (the key rides a custom header that would replay across a cross-origin redirect), and the `SourceResponse` partition/primary-key shape (locks `projects` to the stable `created_at`, never a mutable field).
- `tests/test_glassfrog_source.py` (source class): source type, config basics (alpha + visible + png icon), the single required secret `api_key` field, full-refresh-only schema contract (guards a future edit flipping on incremental without a real server-side filter), name filtering, documented-tables rendering for public docs, credential plumbing, and end-to-end `source_for_pipeline` handoff asserting the header actually carries the key.

Run locally: `52 passed`, plus the shared registry suites (`test_source_categories`, `test_source_versions`, `test_generated_configs`): `2623 passed`. Repo-wide `uv run mypy --cache-fine-grained .` reports no errors in the changed files (the single repo-wide error is pre-existing in `posthog/personhog_client/converters.py`). `ruff check`/`format` and `hogli ci:preflight --fix` are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No posthog.com checkout ships with this repo's environment, so the doc below still needs to land in the **posthog.com** repo at `contents/docs/cdp/sources/glassfrog.md`. I validated it against a sparse clone with `python manage.py audit_source_docs` - zero glassfrog issues (`docsUrl`, filename, and `sourceId` all agree). `docsUrl` points at `https://posthog.com/docs/cdp/sources/glassfrog`.

<details>
<summary>contents/docs/cdp/sources/glassfrog.md</summary>

```md
---
title: Linking GlassFrog as a source
sidebar: Docs
showTitle: true
availability:
  free: full
  selfServe: full
  enterprise: full
sourceId: Glassfrog
beta: true
---

import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
import SyncModes from "../_snippets/sync-modes.mdx"
import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
import AlphaRelease from "../_snippets/alpha-release.mdx"

<AlphaRelease />

The GlassFrog connector syncs your organization's governance data, like circles, roles, people, projects, metrics, and checklist items, into the PostHog Data warehouse, so you can analyze how your organization is structured and how work is distributed alongside your product data.

## Prerequisites

You need a GlassFrog account. Every GlassFrog user can create their own v3 API key, which grants access at that user's permission level, so use an account that can see the circles and roles you want to sync.

## Adding a data source

<SourceSetupIntro />

When linking GlassFrog, you'll need:

- **API key** – create a v3 API key in GlassFrog under **Profile & Settings → API**. The key inherits your account's permission level.

## Sync modes

<SyncModes />

The GlassFrog API doesn't support filtering records by modification time, so all tables sync with full refresh.

## Configuration

<SourceParameters />

## Supported tables

<SourceTables />

## Troubleshooting

- If you see an authentication error, your API key is invalid or has been revoked. Create a new key under **Profile & Settings → API** in GlassFrog, then reconnect.
- If a table syncs fewer records than you expect, remember the API key only sees what its user can see. Create the key from an account with broader access, then reconnect.

<TroubleshootingLink />
```

</details>

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task). Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, and the `documenting-warehouse-sources` skill for the doc.

Decisions along the way: preferred the shared `rest_source` framework over a hand-rolled client since GlassFrog's API is fully expressible declaratively (header auth + single page + data selector); chose `SimpleSource` over `ResumableSource` because there is no pagination state to resume; kept all endpoints full refresh rather than faking incremental with a client-side filter; partitioned only `projects` because it is the only resource with a stable datetime field; pinned `v3` rather than the undocumented `v5` beta. The stub's `unreleasedSource=True` was removed per the finishing contract and replaced with `releaseStatus=alpha`.


---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
