### PR TITLE
fix(tasks): surface custom image build failure causes

### DIFF
--- a/products/tasks/backend/temporal/build_image/test_workflow.py
+++ b/products/tasks/backend/temporal/build_image/test_workflow.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from temporalio.exceptions import ActivityError, ApplicationError, RetryState
+
+from products.tasks.backend.temporal.build_image import workflow as build_image_workflow_module
+from products.tasks.backend.temporal.build_image.activities import MarkImageBuildFailedInput
+from products.tasks.backend.temporal.build_image.workflow import BuildSandboxImageInput, BuildSandboxImageWorkflow
+
+
+@pytest.mark.asyncio
+async def test_build_failure_surfaces_activity_cause(monkeypatch: pytest.MonkeyPatch) -> None:
+    activity_error = ActivityError(
+        "Activity task failed",
+        scheduled_event_id=10,
+        started_event_id=11,
+        identity="worker-1",
+        activity_type="scan_image_spec",
+        activity_id="activity-1",
+        retry_state=RetryState.MAXIMUM_ATTEMPTS_REACHED,
+    )
+    activity_error.__cause__ = ApplicationError("Security scanner unavailable", type="ScannerUnavailableError")
+    execute_activity = AsyncMock(side_effect=[activity_error, None])
+    monkeypatch.setattr(build_image_workflow_module.workflow, "execute_activity", execute_activity)
+
+    result = await BuildSandboxImageWorkflow().run(BuildSandboxImageInput(image_id="image-id", team_id=1))
+
+    assert result.success is False
+    assert result.error == "Security scanner unavailable"
+    failure_input = execute_activity.await_args_list[1].args[1]
+    assert failure_input == MarkImageBuildFailedInput(
+        image_id="image-id", team_id=1, error="Security scanner unavailable", refresh=False
+    )

--- a/products/tasks/backend/temporal/build_image/workflow.py
+++ b/products/tasks/backend/temporal/build_image/workflow.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import ActivityError
 
 from posthog.temporal.common.base import PostHogWorkflow
 
@@ -64,12 +65,15 @@ class BuildSandboxImageWorkflow(PostHogWorkflow):
             return BuildSandboxImageOutput(success=True, modal_image_name=modal_image_name)
 
         except Exception as e:
+            cause = e.cause if isinstance(e, ActivityError) else None
+            cause_message = getattr(cause, "message", None) or (str(cause) if cause is not None else None)
+            error_message = cause_message or str(e)
             await workflow.execute_activity(
                 mark_image_build_failed,
                 MarkImageBuildFailedInput(
-                    image_id=input.image_id, team_id=input.team_id, error=str(e), refresh=input.refresh
+                    image_id=input.image_id, team_id=input.team_id, error=error_message, refresh=input.refresh
                 ),
                 start_to_close_timeout=timedelta(minutes=1),
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
-            return BuildSandboxImageOutput(success=False, error=str(e))
+            return BuildSandboxImageOutput(success=False, error=error_message)


### PR DESCRIPTION
## Problem

Custom sandbox image workflow failures persisted Temporal's generic `Activity task failed` wrapper. This hid the underlying scanner or build error and left users without an actionable reason.

**Why:** Custom environment failures need to expose their actual cause so users can fix the spec or retry an unavailable dependency.
