### PR TITLE
feat(surveys): add duplicate question action

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -5,7 +5,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { useActions, useValues } from 'kea'
 import { Group } from 'kea-forms'
 
-import { IconPlusSmall, IconTrash, IconWarning } from '@posthog/icons'
+import { IconCopy, IconPlusSmall, IconTrash, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -57,7 +57,7 @@ export function SurveyEditQuestionHeader({
     translationErrorsByQuestion,
 }: SurveyQuestionHeaderProps): JSX.Element {
     const { editingLanguage } = useValues(surveyLogic)
-    const { removeQuestion } = useActions(surveyLogic)
+    const { duplicateQuestion, removeQuestion } = useActions(surveyLogic)
     const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
         id: index.toString(),
     })
@@ -96,6 +96,17 @@ export function SurveyEditQuestionHeader({
                         <IconWarning className="text-warning" />
                     </Tooltip>
                 )}
+                <LemonButton
+                    icon={<IconCopy />}
+                    size="xsmall"
+                    data-attr={`duplicate-survey-question-${index}`}
+                    tooltip="Duplicate question"
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        duplicateQuestion(index)
+                    }}
+                    tooltipPlacement="top-end"
+                />
                 {survey.questions.length > 1 && (
                     <LemonButton
                         icon={<IconTrash />}

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1544,6 +1544,7 @@ export const surveyLogic = kea<surveyLogicType>([
         archiveSurvey: true,
         setWritingHTMLDescription: (writingHTML: boolean) => ({ writingHTML }),
         setSelectedPageIndex: (idx: number | null) => ({ idx }),
+        duplicateQuestion: (index: number) => ({ index }),
         setSelectedSection: (section: SurveyEditSection | null) => ({ section }),
         resetTargeting: true,
         resetSurveyAdaptiveSampling: true,
@@ -2234,6 +2235,19 @@ export const surveyLogic = kea<surveyLogicType>([
                 } finally {
                     actions.setGeneratingTranslationDrafts(false)
                 }
+            },
+            duplicateQuestion: ({ index }) => {
+                const original = values.survey.questions[index]
+                if (!original) {
+                    return
+                }
+                const copy = {
+                    ...original,
+                    question: `${original.question ?? ''} (copy)`,
+                }
+                const questions = [...values.survey.questions, copy]
+                actions.setSurveyValue('questions', questions)
+                actions.setSelectedPageIndex(questions.length - 1)
             },
             resetTargeting: () => {
                 actions.setSurveyValue('linked_flag_id', NEW_SURVEY.linked_flag_id)


### PR DESCRIPTION
> Test-only draft PR for validating the internal qa-frontend skill. Not intended for merge.

## Problem

When building longer surveys, users often want to duplicate an existing question with the same type, options, description, and validation, then tweak only the copy.

## Changes

Adds a Duplicate question action to each survey question row.

Expected behavior:

- Clicking Duplicate on Question N inserts the copy directly after Question N.
- The copy keeps the original's type, options, and settings, with " (copy)" appended to the question title.
- The editor focuses the newly created copy.

## How did you test this code?

Not manually tested; this PR is intended as the target for runtime QA.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs
