### PR TITLE
feat(data-warehouse): implement loops import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -329,6 +329,7 @@ the row lists both.
 | llama_cloud                      | HTTP                        | requests                                                        | ✅                          |
 | lob                              | HTTP                        | requests                                                        | ✅                          |
 | logz_io                          | HTTP                        | requests                                                        | ✅                          |
+| loops                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | luma                             | HTTP                        | requests                                                        | ✅                          |
 | mailchimp                        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | mem0                             | HTTP                        | requests                                                        | ✅                          |
@@ -793,7 +794,6 @@ doesn't conflict with concurrent PRs.
 - llama_cloud
 - lokalise
 - looker
-- loops
 - m3ter
 - mailtrap
 - mantle

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/loops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/loops.py
@@ -6,4 +6,4 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common imp
 
 @config.config
 class LoopsSourceConfig(config.Config):
-    pass
+    api_key: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loops/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loops/canonical_descriptions.py
@@ -1,0 +1,121 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "campaigns": {
+        "description": "A marketing campaign, including its status, schedule, audience, and group.",
+        "docs_url": "https://loops.so/docs/api-reference/list-campaigns",
+        "columns": {
+            "id": "The campaign ID.",
+            "name": "The campaign name.",
+            "status": "Campaign lifecycle status (for example Draft, Scheduled, Sending, Sent).",
+            "createdAt": "ISO 8601 timestamp for when the campaign was created.",
+            "updatedAt": "ISO 8601 timestamp for when the campaign was last updated.",
+            "emailMessageId": "The associated email message ID.",
+            "campaignGroupId": "The ID of the campaign group this campaign belongs to.",
+            "mailingListId": "The ID of the mailing list this campaign sends to, if set.",
+            "audienceSegmentId": "The ID of the audience segment this campaign targets, if set.",
+            "audienceFilter": "The inline audience filter, if set.",
+            "scheduling": "When the campaign is scheduled to send.",
+        },
+    },
+    "campaign_groups": {
+        "description": "A campaign group used to organize related marketing campaigns.",
+        "docs_url": "https://loops.so/docs/api-reference/list-campaign-groups",
+        "columns": {
+            "id": "The campaign group ID.",
+            "name": "The group name.",
+            "description": "The group description.",
+            "createdAt": "ISO 8601 timestamp for when the group was created.",
+            "updatedAt": "ISO 8601 timestamp for when the group was last updated.",
+        },
+    },
+    "mailing_lists": {
+        "description": "A mailing list contacts can subscribe to.",
+        "docs_url": "https://loops.so/docs/api-reference/list-mailing-lists",
+        "columns": {
+            "id": "The ID of the list.",
+            "name": "The name of the list.",
+            "description": "The list's description, or null if no description has been added.",
+            "isPublic": "Whether the list is public (true) or private (false).",
+        },
+    },
+    "audience_segments": {
+        "description": "An audience segment with filter rules, used for campaign targeting.",
+        "docs_url": "https://loops.so/docs/api-reference/list-audience-segments",
+        "columns": {
+            "id": "The audience segment ID.",
+            "name": "The segment name.",
+            "description": "An optional description for the segment.",
+            "createdAt": "ISO 8601 timestamp for when the segment was created.",
+            "updatedAt": "ISO 8601 timestamp for when the segment was last updated.",
+            "filter": "The segment's audience filter.",
+        },
+    },
+    "workflows": {
+        "description": "An automation workflow in the Loops account.",
+        "docs_url": "https://loops.so/docs/api-reference/list-workflows",
+        "columns": {
+            "id": "The workflow ID.",
+            "name": "The workflow name.",
+            "createdAt": "ISO 8601 timestamp for when the workflow was created.",
+            "updatedAt": "ISO 8601 timestamp for when the workflow was last updated.",
+        },
+    },
+    "transactional_emails": {
+        "description": "A transactional email, including its group and current draft and published messages.",
+        "docs_url": "https://loops.so/docs/api-reference/list-transactional-emails",
+        "columns": {
+            "id": "The transactional email ID.",
+            "name": "The transactional email name.",
+            "draftEmailMessageId": "The ID of the draft email message, if one exists.",
+            "publishedEmailMessageId": "The ID of the published email message, if one exists.",
+            "transactionalGroupId": "The ID of the group this transactional email belongs to.",
+            "createdAt": "ISO 8601 timestamp for when the transactional email was created.",
+            "updatedAt": "ISO 8601 timestamp for when the transactional email was last updated.",
+            "dataVariables": "Data variable names used by the published email. Empty for unpublished emails.",
+        },
+    },
+    "transactional_groups": {
+        "description": "A transactional group used to organize related transactional emails.",
+        "docs_url": "https://loops.so/docs/api-reference/list-transactional-groups",
+        "columns": {
+            "id": "The transactional group ID.",
+            "name": "The group name.",
+            "description": "The group description.",
+            "createdAt": "ISO 8601 timestamp for when the group was created.",
+            "updatedAt": "ISO 8601 timestamp for when the group was last updated.",
+        },
+    },
+    "contact_properties": {
+        "description": "A contact property (default or custom) defined in the Loops account.",
+        "docs_url": "https://loops.so/docs/api-reference/list-contact-properties",
+        "columns": {
+            "key": "The property's name key.",
+            "label": "The human-friendly label for this property.",
+            "type": "The type of property (one of string, number, boolean or date).",
+        },
+    },
+    "themes": {
+        "description": "An email theme with style attributes for authored email messages.",
+        "docs_url": "https://loops.so/docs/api-reference/list-themes",
+        "columns": {
+            "id": "The theme ID.",
+            "name": "The theme name.",
+            "styles": "The theme's style attributes, named after LMX Style tag attributes.",
+            "isDefault": "Whether this is the account's default theme.",
+            "createdAt": "ISO 8601 timestamp for when the theme was created.",
+            "updatedAt": "ISO 8601 timestamp for when the theme was last updated.",
+        },
+    },
+    "components": {
+        "description": "A reusable email component available for use in LMX templates and authored email messages.",
+        "docs_url": "https://loops.so/docs/api-reference/list-components",
+        "columns": {
+            "id": "The component ID.",
+            "name": "The component name.",
+            "lmx": "The component's LMX markup.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loops/loops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loops/loops.py
@@ -1,0 +1,141 @@
+import dataclasses
+from typing import Any, Optional
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    Endpoint,
+    EndpointResource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.settings import LOOPS_ENDPOINTS
+
+BASE_URL = "https://app.loops.so/api"
+
+# Loops caps `perPage` at 50 (allowed range 10-50, default 20) on cursor-paginated
+# list endpoints.
+PAGE_SIZE = 50
+
+
+@dataclasses.dataclass
+class LoopsResumeConfig:
+    cursor: str
+
+
+def get_resource(endpoint: str) -> EndpointResource:
+    config = LOOPS_ENDPOINTS[endpoint]
+
+    params: dict[str, Any] = dict(config.extra_params)
+
+    endpoint_config: Endpoint = {
+        "path": config.path,
+        "params": params,
+    }
+
+    if config.paginated:
+        endpoint_config["data_selector"] = "data"
+        params["perPage"] = PAGE_SIZE
+        endpoint_config["paginator"] = JSONResponseCursorPaginator(
+            cursor_path="pagination.nextCursor",
+            cursor_param="cursor",
+        )
+    else:
+        # Unpaginated endpoints (mailing lists, contact properties) return the
+        # full collection as a bare JSON array with no wrapper object.
+        endpoint_config["paginator"] = SinglePagePaginator()
+
+    return {
+        "name": config.name,
+        "table_name": config.name,
+        "write_disposition": "replace",
+        "endpoint": endpoint_config,
+        "table_format": "delta",
+    }
+
+
+def loops_source(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+    resumable_source_manager: ResumableSourceManager[LoopsResumeConfig],
+) -> SourceResponse:
+    endpoint_config = LOOPS_ENDPOINTS[endpoint]
+
+    rest_config: RESTAPIConfig = {
+        "client": {
+            "base_url": BASE_URL,
+            "auth": {
+                "type": "bearer",
+                "token": api_key,
+            },
+            "headers": {
+                "Accept": "application/json",
+            },
+        },
+        "resource_defaults": {
+            "write_disposition": "replace",
+        },
+        "resources": [get_resource(endpoint)],
+    }
+
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume_config = resumable_source_manager.load_state()
+        if resume_config is not None:
+            initial_paginator_state = {"cursor": resume_config.cursor}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Persist only when there's a next page to resume to; the Redis TTL handles
+        # cleanup once the sync finishes. Saving happens after each page is yielded,
+        # so a crash re-fetches the last page rather than skipping it.
+        if state and state.get("cursor"):
+            resumable_source_manager.save_state(LoopsResumeConfig(cursor=str(state["cursor"])))
+
+    resource = rest_api_resource(
+        rest_config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value=None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: resource,
+        primary_keys=[endpoint_config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if endpoint_config.partition_key else None,
+        partition_format="week" if endpoint_config.partition_key else None,
+        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+    )
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    try:
+        response = make_tracked_session(redact_values=(api_key,)).get(
+            f"{BASE_URL}/v1/api-key",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
+            },
+            timeout=10,
+        )
+    except Exception as e:
+        return False, str(e)
+
+    if response.status_code == 200:
+        return True, None
+    if response.status_code == 401:
+        return False, "Invalid Loops API key"
+    return False, f"Loops returned an unexpected status code: {response.status_code}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loops/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loops/settings.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from products.warehouse_sources.backend.types import IncrementalField
+
+
+@dataclass
+class LoopsEndpointConfig:
+    name: str
+    # Path under https://app.loops.so/api (e.g. "/v1/campaigns").
+    path: str
+    primary_key: str = "id"
+    # Stable created-date field to partition by, or None when the payload has no
+    # creation timestamp (mailing lists, contact properties, components).
+    partition_key: Optional[str] = None
+    # Whether the endpoint uses Loops' cursor pagination and wraps rows as
+    # {"pagination": {...}, "data": [...]}. Unpaginated endpoints return the
+    # full collection as a bare JSON array.
+    paginated: bool = True
+    # Extra query params merged into every request for this endpoint.
+    extra_params: dict[str, str] = field(default_factory=dict)
+
+
+LOOPS_ENDPOINTS: dict[str, LoopsEndpointConfig] = {
+    "campaigns": LoopsEndpointConfig(
+        name="campaigns",
+        path="/v1/campaigns",
+        partition_key="createdAt",
+    ),
+    "campaign_groups": LoopsEndpointConfig(
+        name="campaign_groups",
+        path="/v1/campaign-groups",
+        partition_key="createdAt",
+    ),
+    "mailing_lists": LoopsEndpointConfig(
+        name="mailing_lists",
+        path="/v1/lists",
+        paginated=False,
+    ),
+    "audience_segments": LoopsEndpointConfig(
+        name="audience_segments",
+        path="/v1/audience-segments",
+        partition_key="createdAt",
+    ),
+    "workflows": LoopsEndpointConfig(
+        name="workflows",
+        path="/v1/workflows",
+        partition_key="createdAt",
+    ),
+    "transactional_emails": LoopsEndpointConfig(
+        name="transactional_emails",
+        path="/v1/transactional-emails",
+        partition_key="createdAt",
+    ),
+    "transactional_groups": LoopsEndpointConfig(
+        name="transactional_groups",
+        path="/v1/transactional-groups",
+        partition_key="createdAt",
+    ),
+    "contact_properties": LoopsEndpointConfig(
+        name="contact_properties",
+        path="/v1/contacts/properties",
+        primary_key="key",
+        paginated=False,
+        extra_params={"list": "all"},
+    ),
+    "themes": LoopsEndpointConfig(
+        name="themes",
+        path="/v1/themes",
+        partition_key="createdAt",
+    ),
+    "components": LoopsEndpointConfig(
+        name="components",
+        path="/v1/components",
+    ),
+}
+
+ENDPOINTS = tuple(LOOPS_ENDPOINTS.keys())
+
+# Loops list endpoints accept only perPage/cursor — no server-side timestamp
+# filters — so every endpoint is full refresh only.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loops/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loops/source.py
@@ -1,19 +1,47 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.loops import LoopsSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.loops import (
+    LoopsResumeConfig,
+    loops_source,
+    validate_credentials as validate_loops_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class LoopsSource(SimpleSource[LoopsSourceConfig]):
+class LoopsSource(ResumableSource[LoopsSourceConfig, LoopsResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
+    api_docs_url = "https://loops.so/docs/api-reference/intro"
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.LOOPS
@@ -24,7 +52,71 @@ class LoopsSource(SimpleSource[LoopsSourceConfig]):
             name=SchemaExternalDataSourceType.LOOPS,
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             label="Loops",
+            releaseStatus=ReleaseStatus.ALPHA,
+            keywords=["loops.so", "email"],
+            caption="""Enter your Loops API key to sync your campaigns, transactional emails, mailing lists and other account data into the PostHog Data warehouse.
+
+You can generate an API key in your Loops account under **Settings > API**.
+
+Note: the Loops API has no bulk contact export, so contacts can't be synced. Some tables (campaigns, themes, components) require the Content API to be enabled for your Loops team.""",
             iconPath="/static/services/loops.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/loops",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://app.loops.so": "Your Loops API key is invalid, or this API is not enabled for your Loops team. Check the key in Settings > API and reconnect.",
+            "403 Client Error: Forbidden for url: https://app.loops.so": "Your Loops API key does not have permission to access this endpoint.",
+        }
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.loops.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_schemas(
+        self,
+        config: LoopsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
+
+    def validate_credentials(
+        self, config: LoopsSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        return validate_loops_credentials(config.api_key)
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[LoopsResumeConfig]:
+        return ResumableSourceManager[LoopsResumeConfig](inputs, LoopsResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: LoopsSourceConfig,
+        resumable_source_manager: ResumableSourceManager[LoopsResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return loops_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loops/tests/test_loops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loops/tests/test_loops.py
@@ -1,0 +1,221 @@
+import json
+from collections.abc import Iterable
+from typing import Any, cast
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from requests import Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.loops import (
+    LoopsResumeConfig,
+    loops_source,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.settings import LOOPS_ENDPOINTS
+
+
+def _make_http_response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+def _page(rows: list[dict[str, Any]], next_cursor: str | None) -> dict[str, Any]:
+    return {
+        "pagination": {
+            "totalResults": len(rows),
+            "returnedResults": len(rows),
+            "perPage": 50,
+            "totalPages": 1,
+            "nextCursor": next_cursor,
+            "nextPage": None,
+        },
+        "data": rows,
+    }
+
+
+class TestLoopsSource:
+    def _drive(
+        self, endpoint: str, manager: MagicMock, responses: list[Response]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Drive ``loops_source`` with a mocked HTTP session.
+
+        Returns ``(rows, sent_params)``: ``rows`` is the flattened row stream (the
+        resource yields one list per page), and ``sent_params`` holds shallow copies
+        of ``request.params`` captured at send-time — the Request object is mutated
+        in-place by the paginator between pages.
+        """
+        sent_params: list[dict[str, Any]] = []
+        response_iter = iter(responses)
+
+        def fake_send(request: Any, *_args: Any, **_kwargs: Any) -> Response:
+            sent_params.append(dict(request.params or {}))
+            return next(response_iter)
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+        ) as MockSession:
+            mock_session = MockSession.return_value
+            mock_session.headers = {}
+            mock_session.prepare_request.side_effect = lambda req: req
+            mock_session.send.side_effect = fake_send
+
+            source_response = loops_source(
+                api_key="test-key",
+                endpoint=endpoint,
+                team_id=123,
+                job_id="test_job",
+                resumable_source_manager=manager,
+            )
+            rows = [
+                row
+                for item in cast(Iterable[Any], source_response.items())
+                for row in (item if isinstance(item, list) else [item])
+            ]
+            return rows, sent_params
+
+    def test_fresh_run_pages_through_cursors_and_saves_state(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_http_response(_page([{"id": "c1"}], next_cursor="cursor-1")),
+            _make_http_response(_page([{"id": "c2"}], next_cursor="cursor-2")),
+            _make_http_response(_page([{"id": "c3"}], next_cursor=None)),
+        ]
+        rows, sent_params = self._drive("campaigns", manager, responses)
+
+        assert [row["id"] for row in rows] == ["c1", "c2", "c3"]
+        # First request has no cursor (fresh run); subsequent requests carry the
+        # prior page's nextCursor. Every request asks for the max page size.
+        assert [p.get("cursor") for p in sent_params] == [None, "cursor-1", "cursor-2"]
+        assert all(p.get("perPage") == 50 for p in sent_params)
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [
+            LoopsResumeConfig(cursor="cursor-1"),
+            LoopsResumeConfig(cursor="cursor-2"),
+        ]
+
+    def test_resume_seeds_paginator_with_saved_cursor(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = LoopsResumeConfig(cursor="cursor-resumed")
+
+        responses = [
+            _make_http_response(_page([{"id": "c4"}], next_cursor=None)),
+        ]
+        _, sent_params = self._drive("campaigns", manager, responses)
+
+        assert [p.get("cursor") for p in sent_params] == ["cursor-resumed"]
+        manager.load_state.assert_called_once()
+
+    def test_terminal_single_page_does_not_save_state(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_http_response(_page([{"id": "only"}], next_cursor=None)),
+        ]
+        self._drive("campaigns", manager, responses)
+
+        manager.save_state.assert_not_called()
+        manager.load_state.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("endpoint", "body", "expected_ids", "expected_params"),
+        [
+            (
+                "mailing_lists",
+                [{"id": "list-1", "name": "Beta"}, {"id": "list-2", "name": "Launch"}],
+                ["list-1", "list-2"],
+                {},
+            ),
+            (
+                "contact_properties",
+                [{"key": "firstName", "label": "First Name", "type": "string"}],
+                ["firstName"],
+                {"list": "all"},
+            ),
+        ],
+    )
+    def test_unpaginated_endpoints_yield_bare_array_in_one_request(
+        self,
+        endpoint: str,
+        body: list[dict[str, Any]],
+        expected_ids: list[str],
+        expected_params: dict[str, str],
+    ) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        rows, sent_params = self._drive(endpoint, manager, [_make_http_response(body)])
+
+        id_field = LOOPS_ENDPOINTS[endpoint].primary_key
+        assert [row[id_field] for row in rows] == expected_ids
+        assert sent_params == [expected_params]
+        manager.save_state.assert_not_called()
+
+    @pytest.mark.parametrize("endpoint", list(LOOPS_ENDPOINTS.keys()))
+    def test_source_response_primary_and_partition_keys(self, endpoint: str) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        source_response = loops_source(
+            api_key="test-key",
+            endpoint=endpoint,
+            team_id=123,
+            job_id="test_job",
+            resumable_source_manager=manager,
+        )
+
+        endpoint_config = LOOPS_ENDPOINTS[endpoint]
+        assert source_response.name == endpoint
+        assert source_response.primary_keys == [endpoint_config.primary_key]
+        if endpoint_config.partition_key:
+            assert source_response.partition_keys == [endpoint_config.partition_key]
+            assert source_response.partition_mode == "datetime"
+        else:
+            assert source_response.partition_keys is None
+            assert source_response.partition_mode is None
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        ("status_code", "expected_valid", "expected_message_fragment"),
+        [
+            (200, True, None),
+            (401, False, "Invalid Loops API key"),
+            (500, False, "unexpected status code: 500"),
+        ],
+    )
+    def test_status_code_mapping(
+        self, status_code: int, expected_valid: bool, expected_message_fragment: str | None
+    ) -> None:
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.loops.loops.make_tracked_session"
+        ) as MockSession:
+            MockSession.return_value.get.return_value = _make_http_response({"success": True}, status_code)
+
+            is_valid, message = validate_credentials("test-key")
+
+        assert is_valid is expected_valid
+        if expected_message_fragment is None:
+            assert message is None
+        else:
+            assert message is not None and expected_message_fragment in message
+
+    def test_network_error_returns_invalid(self) -> None:
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.loops.loops.make_tracked_session"
+        ) as MockSession:
+            MockSession.return_value.get.side_effect = ConnectionError("connection refused")
+
+            is_valid, message = validate_credentials("test-key")
+
+        assert is_valid is False
+        assert message is not None and "connection refused" in message

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loops/tests/test_loops_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loops/tests/test_loops_source.py
@@ -1,0 +1,145 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.loops import LoopsSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.loops import LoopsResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.loops.source import LoopsSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+def _make_inputs(**overrides: Any) -> SourceInputs:
+    defaults: dict[str, Any] = {
+        "schema_name": "campaigns",
+        "schema_id": "schema-1",
+        "source_id": "source-1",
+        "team_id": 123,
+        "should_use_incremental_field": False,
+        "db_incremental_field_last_value": None,
+        "db_incremental_field_earliest_value": None,
+        "incremental_field": None,
+        "incremental_field_type": None,
+        "job_id": "job-1",
+        "logger": mock.MagicMock(),
+        "reset_pipeline": False,
+    }
+    defaults.update(overrides)
+    return SourceInputs(**defaults)
+
+
+class TestLoopsSource:
+    def setup_method(self) -> None:
+        self.source = LoopsSource()
+        self.team_id = 123
+        self.config = LoopsSourceConfig(api_key="test-key")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.LOOPS
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+
+        assert config.name.value == "Loops"
+        assert config.label == "Loops"
+        assert config.unreleasedSource is None
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.iconPath == "/static/services/loops.png"
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/loops"
+
+        assert len(config.fields) == 1
+        api_key_field = config.fields[0]
+        assert isinstance(api_key_field, SourceFieldInputConfig)
+        assert api_key_field.name == "api_key"
+        assert api_key_field.type == SourceFieldInputConfigType.PASSWORD
+        assert api_key_field.required is True
+        assert api_key_field.secret is True
+
+    @pytest.mark.parametrize(
+        "raised_message",
+        [
+            # requests raises `<status> Client Error: <reason> for url: <url>`; the sync matcher
+            # is a substring check, so the keys must classify these as non-retryable.
+            "401 Client Error: Unauthorized for url: https://app.loops.so/api/v1/campaigns?perPage=50",
+            "403 Client Error: Forbidden for url: https://app.loops.so/api/v1/lists",
+        ],
+    )
+    def test_auth_errors_are_non_retryable(self, raised_message: str) -> None:
+        keys = self.source.get_non_retryable_errors().keys()
+        assert any(key in raised_message for key in keys)
+
+    def test_get_schemas_all_full_refresh(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        # Loops list endpoints have no server-side timestamp filters, so advertising
+        # incremental sync would silently degrade to a broken full scan.
+        assert all(not s.supports_incremental for s in schemas)
+        assert all(not s.supports_append for s in schemas)
+        assert all(s.incremental_fields == [] for s in schemas)
+
+    @pytest.mark.parametrize(
+        ("names", "expected"),
+        [
+            (["campaigns"], {"campaigns"}),
+            (["nonexistent"], set()),
+        ],
+    )
+    def test_get_schemas_filtered_by_names(self, names: list[str], expected: set[str]) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=names)
+        assert {s.name for s in schemas} == expected
+
+    @pytest.mark.parametrize(
+        ("mock_return", "expected_valid", "expected_message"),
+        [
+            ((True, None), True, None),
+            ((False, "Invalid Loops API key"), False, "Invalid Loops API key"),
+        ],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.loops.source.validate_loops_credentials"
+    )
+    def test_validate_credentials(
+        self,
+        mock_validate: mock.MagicMock,
+        mock_return: tuple[bool, str | None],
+        expected_valid: bool,
+        expected_message: str | None,
+    ) -> None:
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.api_key)
+
+    def test_get_resumable_source_manager_bound_to_resume_config(self) -> None:
+        manager = self.source.get_resumable_source_manager(_make_inputs())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is LoopsResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.loops.source.loops_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
+        inputs = _make_inputs(schema_name="workflows", team_id=99, job_id="job-xyz")
+        manager = mock.MagicMock(spec=ResumableSourceManager)
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_source.assert_called_once_with(
+            api_key="test-key",
+            endpoint="workflows",
+            team_id=99,
+            job_id="job-xyz",
+            resumable_source_manager=manager,
+        )
+
+    def test_canonical_descriptions_cover_only_known_endpoints(self) -> None:
+        # A description keyed by a name `get_schemas` never returns is dead metadata
+        # (typo'd endpoint or a rename that missed this file).
+        assert set(self.source.get_canonical_descriptions().keys()) <= set(ENDPOINTS)


### PR DESCRIPTION
## Problem

The Loops (loops.so) warehouse source existed only as a scaffolded stub (`unreleasedSource=True`, no fields, no sync logic), so users couldn't pull their Loops email marketing data into the PostHog data warehouse.

## Changes

Implements the Loops source end-to-end on the shared `rest_source` framework and ships it visible with `releaseStatus=ReleaseStatus.ALPHA`.

- **Endpoints** (all full refresh): `campaigns`, `campaign_groups`, `mailing_lists`, `audience_segments`, `workflows`, `transactional_emails`, `transactional_groups`, `contact_properties`, `themes`, `components`. Loops list endpoints accept only `perPage`/`cursor` and no server-side timestamp filters, so no endpoint advertises incremental sync.
- **Architecture** follows the standard split: `settings.py` (declarative endpoint catalog with per-endpoint primary key, partition key, pagination style), `loops.py` (transport via `RESTAPIConfig` + `rest_api_resource` with framework bearer auth and the stock `JSONResponseCursorPaginator` reading `pagination.nextCursor`), `source.py` (registration, config, schemas, credential validation).
- **Resumable**: the source is a `ResumableSource`. The cursor from `pagination.nextCursor` is checkpointed to Redis after each yielded page, so Temporal heartbeat-timeout restarts resume mid-sync instead of refetching from page one.
- **Pagination**: cursor endpoints request `perPage=50` (the documented maximum). `mailing_lists` and `contact_properties` are unpaginated bare-array responses handled with the single-page paginator.
- **Partitioning**: datetime partitioning on `createdAt` (stable) where the payload has it; no partitioning for the three endpoints without a creation timestamp (`mailing_lists`, `contact_properties`, `components`).
- **Credential validation** probes `GET /v1/api-key`, the documented key-test endpoint, so a valid key passes even if the account lacks Content API access. 401/403 sync errors are registered as non-retryable with user-facing guidance.
- **Canonical descriptions** for every table and column, sourced from the official API reference, so the AI enrichment pass doesn't need to re-derive them per team.
- Moved `loops` from Scaffolded to Implemented in `SOURCES.md`; regenerated `LoopsSourceConfig` (`api_key` field). The icon (`frontend/public/services/loops.png`) and enum wiring (`types.py`, `schema-general.ts`, `posthog/schema_enums.py`) were already in the repo, so no migration or schema rebuild was needed.

Endpoint paths, pagination shape, and response fields were verified against the live docs (loops.so/docs/api-reference sitemap + per-endpoint pages). One caveat I couldn't verify without an API key: authenticated behavior (e.g. exact 401 body for accounts without Content API). Unauthenticated probes confirm all 10 paths exist and auth-gate with 401. Hence ALPHA.

> [!NOTE]
> Contacts intentionally have no table: the Loops API only supports per-contact lookup by exact email or user ID (no bulk list/export endpoint), so the audience can't be synced.

### Docs

No posthog.com checkout was available in this environment, so the user-facing doc needs to land in the posthog.com repo as `contents/docs/cdp/sources/loops.md` (matching the `docsUrl` set here). `audit_source_docs` will fail until it lands. Ready-to-commit content:

<details>
<summary>contents/docs/cdp/sources/loops.md</summary>

```markdown
---
title: Linking Loops as a source
sidebar: Docs
showTitle: true
availability: { free: full, selfServe: full, enterprise: full }
sourceId: Loops
beta: true
---

import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
import SyncModes from "../_snippets/sync-modes.mdx"
import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
import AlphaRelease from "../_snippets/alpha-release.mdx"

<AlphaRelease />

The Loops connector syncs your [Loops](https://loops.so) email marketing data into PostHog, including campaigns, transactional emails, mailing lists, audience segments, workflows, themes, and components.

## Prerequisites

You need a Loops account with API access. Some tables (campaigns, campaign groups, audience segments, themes, components) also require the Content API to be enabled for your Loops team.

## Adding a data source

<SourceSetupIntro />

You need a Loops API key, which you can generate in your Loops account under [Settings > API](https://app.loops.so/settings?page=api).

## Sync modes

<SyncModes />

The Loops API doesn't support filtering by modification time, so all tables sync with full refresh.

## Configuration

<SourceParameters />

## Supported tables

<SourceTables />

## Limitations

Contacts can't be synced. The Loops API has no bulk contact export endpoint, only per-contact lookup by email or user ID.

## Troubleshooting

If a sync fails with an authentication error and your API key is valid, the table may need the Content API, which is not enabled for all Loops teams. Contact Loops support to enable it.

<TroubleshootingLink />
```

</details>

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/loops/tests/` - 31 passed.
  - `test_loops.py` (transport): fresh runs walk `pagination.nextCursor` and checkpoint resume state only after non-terminal pages (guards the save-before-yield data-loss bug); resumed runs seed the saved cursor into the first request; unpaginated endpoints yield the bare-array body in one request with no state saved; per-endpoint primary key (`key` for contact_properties, `id` elsewhere) and partition key mapping (guards the duplicate-primary-key merge blowup); `validate_credentials` status mapping including network errors.
  - `test_loops_source.py` (source class): the source ships released (no `unreleasedSource`) as ALPHA with a secret password `api_key` field; every schema is full-refresh only (advertising incremental would silently break syncs); non-retryable matchers classify real `requests` 401/403 messages; resumable manager binding and pipeline argument plumbing; canonical descriptions only reference real endpoints.
- Registry guards: `test_source_versions.py` and `test_source_categories.py` pass for Loops.
- `ruff check` / `ruff format` clean; repo-wide `mypy --cache-fine-grained .` shows no errors in changed files (the one remaining error is pre-existing in `posthog/personhog_client/converters.py`).
- `makemigrations --check` reports no changes.
- Not tested: a live sync against a real Loops account (no API credentials available). Endpoint paths and response shapes were verified against the official API reference and unauthenticated probes of the live API.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Doc content for posthog.com is included above and needs a companion PR in that repo.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Built with Claude Code following the `/implementing-warehouse-sources`, `/writing-tests`, and `/documenting-warehouse-sources` skills. Chargebee and ActiveCampaign were used as the reference implementations (declarative `rest_source` config + framework paginator + resumable checkpointing). Chose `ResumableSource` over the simpler `SimpleSource` because Loops' `nextCursor` is a stable keyset token the framework can checkpoint for free. Kept every endpoint full refresh after confirming from the API reference that list endpoints accept no `updated`/`since` filters. Left `supported_versions` at the framework's unversioned default since Loops has only ever had `/v1` and documents no version scheme.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*