### PR TITLE
feat(data-warehouse): implement smartengage import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -482,6 +482,7 @@ the row lists both.
 | skyvern                          | HTTP                        | requests                                                        | ✅                          |
 | slack                            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | smaily                           | HTTP                        | requests                                                        | ✅                          |
+| smartengage                      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | smartreach                       | HTTP                        | requests                                                        | ✅                          |
 | smartsheet                       | HTTP                        | requests                                                        | ✅                          |
 | smartwaiver                      | HTTP                        | requests                                                        | ✅                          |
@@ -931,7 +932,6 @@ doesn't conflict with concurrent PRs.
 - slash
 - sleekplan
 - smaily
-- smartengage
 - smartwaiver
 - solarwinds_service_desk
 - sonar_cloud

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
@@ -63,12 +63,14 @@ def build_dependent_resource(
     parent_endpoint_extra: Endpoint | None = None,
     child_endpoint_extra: Endpoint | None = None,
     child_params_extra: dict[str, Any] | None = None,
-    page_size_param: str = "limit",
+    page_size_param: str | None = "limit",
 ) -> Iterable[Any]:
     parent_config = endpoint_configs[fanout.parent_name]
     child_config = endpoint_configs[child_endpoint]
 
-    parent_params: dict[str, Any] = {page_size_param: parent_config.page_size}
+    # page_size_param=None is for APIs whose list endpoints take no page-size param at all
+    # (unpaginated, full-collection responses) — sending one would be an undocumented param.
+    parent_params: dict[str, Any] = {} if page_size_param is None else {page_size_param: parent_config.page_size}
     parent_params.update(fanout.parent_params)
 
     parent_path = parent_config.path
@@ -104,8 +106,9 @@ def build_dependent_resource(
             "resource": fanout.parent_name,
             "field": fanout.resolve_field,
         },
-        page_size_param: child_config.page_size,
     }
+    if page_size_param is not None:
+        child_params[page_size_param] = child_config.page_size
     if child_params_extra:
         child_params.update(child_params_extra)
     child_endpoint_config: Endpoint = {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/smartengage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/smartengage.py
@@ -6,4 +6,4 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common imp
 
 @config.config
 class SmartEngageSourceConfig(config.Config):
-    pass
+    api_key: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/canonical_descriptions.py
@@ -1,0 +1,46 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+_DOCS_URL = "https://smartengage.com/docs/"
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "avatars": {
+        "description": "An avatar is a SmartEngage bot/brand persona, typically linked to a Facebook page. Tags, custom fields, and sequences are all scoped to an avatar.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "avatar_id": "Unique identifier for the avatar.",
+            "brand_image": "URL of the brand image associated with the avatar.",
+            "brand_name": "Name of the brand or company the avatar represents.",
+            "facebook_page_id": "Identifier of the Facebook page linked to the avatar.",
+            "user_role": "Role of the authenticated user on the avatar.",
+        },
+    },
+    "tags": {
+        "description": "Tags defined on an avatar, used to segment and trigger automations for subscribers.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "avatar_id": "Identifier of the avatar the tag belongs to.",
+            "tag_id": "Unique identifier for the tag.",
+            "tag_name": "Display name of the tag.",
+        },
+    },
+    "custom_fields": {
+        "description": "Custom subscriber profile fields defined on an avatar.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "avatar_id": "Identifier of the avatar the custom field belongs to.",
+            "custom_field_id": "Unique identifier for the custom field.",
+            "custom_field_name": "Display name of the custom field.",
+        },
+    },
+    "sequences": {
+        "description": "Automation sequences (drip campaigns) defined on an avatar.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "avatar_id": "Identifier of the avatar the sequence belongs to.",
+            "sequence_id": "Unique identifier for the sequence.",
+            "sequence_name": "Display name of the sequence.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/settings.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass, field
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    DependentEndpointConfig,
+)
+from products.warehouse_sources.backend.types import IncrementalField
+
+SMARTENGAGE_BASE_URL = "https://api.smartengage.com"
+
+
+@dataclass
+class SmartEngageEndpointConfig:
+    name: str
+    path: str
+    primary_key: list[str]
+    # SmartEngage exposes no server-side timestamp filters, so every endpoint is full refresh.
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    default_incremental_field: str | None = None
+    # List endpoints are unpaginated (full collection per response); never sent as a param.
+    page_size: int = 0
+    fanout: DependentEndpointConfig | None = None
+
+
+def _avatar_fanout() -> DependentEndpointConfig:
+    return DependentEndpointConfig(
+        parent_name="avatars",
+        resolve_param="avatar_id",
+        resolve_field="avatar_id",
+        include_from_parent=["avatar_id"],
+        parent_field_renames={"avatar_id": "avatar_id"},
+    )
+
+
+SMARTENGAGE_ENDPOINTS: dict[str, SmartEngageEndpointConfig] = {
+    "avatars": SmartEngageEndpointConfig(
+        name="avatars",
+        path="/avatars/list",
+        primary_key=["avatar_id"],
+    ),
+    # The per-avatar list endpoints take avatar_id as a query param, but the rest_source
+    # framework only binds resolve params in the path, so the query string carries the
+    # placeholder and is formatted per parent row.
+    "tags": SmartEngageEndpointConfig(
+        name="tags",
+        path="/tags/list?avatar_id={avatar_id}",
+        # Tag ids are only documented per avatar and this table aggregates every avatar's
+        # tags, so the avatar id is part of the key to keep it unique table-wide.
+        primary_key=["avatar_id", "tag_id"],
+        fanout=_avatar_fanout(),
+    ),
+    "custom_fields": SmartEngageEndpointConfig(
+        name="custom_fields",
+        path="/customfields/list?avatar_id={avatar_id}",
+        primary_key=["avatar_id", "custom_field_id"],
+        fanout=_avatar_fanout(),
+    ),
+    "sequences": SmartEngageEndpointConfig(
+        name="sequences",
+        path="/sequences/list?avatar_id={avatar_id}",
+        primary_key=["avatar_id", "sequence_id"],
+        fanout=_avatar_fanout(),
+    ),
+}
+
+ENDPOINTS = tuple(SMARTENGAGE_ENDPOINTS)
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in SMARTENGAGE_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/smartengage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/smartengage.py
@@ -1,0 +1,136 @@
+from collections.abc import Callable, Iterable
+from typing import Any, cast
+
+from requests.exceptions import RequestException
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
+    RESTAPIConfig,
+    rest_api_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    build_dependent_resource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    SinglePagePaginator,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
+    ClientConfig,
+    Endpoint,
+    EndpointResource,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.settings import (
+    SMARTENGAGE_BASE_URL,
+    SMARTENGAGE_ENDPOINTS,
+    SmartEngageEndpointConfig,
+)
+
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def _client_config(api_key: str) -> ClientConfig:
+    return {
+        "base_url": SMARTENGAGE_BASE_URL,
+        "auth": {"type": "bearer", "token": api_key},
+        "headers": {"Accept": "application/json"},
+    }
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    try:
+        response = make_tracked_session().get(
+            f"{SMARTENGAGE_BASE_URL}/avatars/list",
+            headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except RequestException as exc:
+        return False, f"SmartEngage request failed: {exc}"
+
+    if response.status_code in (401, 403):
+        return False, "Invalid SmartEngage API key"
+    if response.status_code != 200:
+        return False, f"SmartEngage API returned status {response.status_code}"
+
+    # List endpoints return a bare JSON array; anything else (e.g. an error object served
+    # with a 200) means the key is not usable.
+    try:
+        payload = response.json()
+    except ValueError:
+        return False, "SmartEngage API returned an unexpected response"
+    if not isinstance(payload, list):
+        return False, "SmartEngage API returned an unexpected response"
+
+    return True, None
+
+
+def get_resource(endpoint: str) -> EndpointResource:
+    config = SMARTENGAGE_ENDPOINTS[endpoint]
+    if config.fanout:
+        raise ValueError(f"Fan-out endpoint '{endpoint}' must use the fan-out path")
+
+    endpoint_config: Endpoint = {
+        "path": config.path,
+        "params": {},
+        # List endpoints return a bare JSON array with no pagination.
+        "data_selector": "$",
+        "paginator": SinglePagePaginator(),
+    }
+
+    return {
+        "name": config.name,
+        "table_name": config.name,
+        "write_disposition": "replace",
+        "endpoint": endpoint_config,
+        "table_format": "delta",
+    }
+
+
+def _make_source_response(
+    endpoint_config: SmartEngageEndpointConfig, items_fn: Callable[[], Iterable[Any]]
+) -> SourceResponse:
+    # No SmartEngage table exposes a stable timestamp, so there is no partitioning.
+    return SourceResponse(
+        name=endpoint_config.name,
+        items=items_fn,
+        primary_keys=endpoint_config.primary_key,
+    )
+
+
+def smartengage_source(
+    api_key: str,
+    endpoint: str,
+    team_id: int,
+    job_id: str,
+) -> SourceResponse:
+    endpoint_config = SMARTENGAGE_ENDPOINTS[endpoint]
+
+    if endpoint_config.fanout:
+        dependent_resource = cast(
+            Iterable[Any],
+            build_dependent_resource(
+                endpoint_configs=SMARTENGAGE_ENDPOINTS,
+                child_endpoint=endpoint,
+                fanout=endpoint_config.fanout,
+                client_config=_client_config(api_key),
+                path_format_values={},
+                team_id=team_id,
+                job_id=job_id,
+                db_incremental_field_last_value=None,
+                # SmartEngage list endpoints take no page-size param — they return the
+                # full collection in one response.
+                page_size_param=None,
+                parent_endpoint_extra={"paginator": SinglePagePaginator(), "data_selector": "$"},
+                child_endpoint_extra={"paginator": SinglePagePaginator(), "data_selector": "$"},
+            ),
+        )
+        return _make_source_response(endpoint_config, lambda: dependent_resource)
+
+    config: RESTAPIConfig = {
+        "client": _client_config(api_key),
+        "resource_defaults": {"write_disposition": "replace"},
+        "resources": [get_resource(endpoint=endpoint)],
+    }
+
+    resource = rest_api_resource(config, team_id, job_id, None)
+    return _make_source_response(endpoint_config, lambda: resource)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/source.py
@@ -1,24 +1,85 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.smartengage import (
     SmartEngageSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.smartengage import (
+    smartengage_source,
+    validate_credentials as validate_smartengage_credentials,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class SmartEngageSource(SimpleSource[SmartEngageSourceConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+    api_docs_url = "https://smartengage.com/docs/"
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SMARTENGAGE
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error": "Invalid SmartEngage API key. Please update your key and reconnect.",
+            "403 Client Error": "Your SmartEngage API key does not have the required permissions. Please update the key and reconnect.",
+        }
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.canonical_descriptions import (  # noqa: PLC0415
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_schemas(
+        self,
+        config: SmartEngageSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
+
+    def validate_credentials(
+        self, config: SmartEngageSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        return validate_smartengage_credentials(config.api_key)
+
+    def source_for_pipeline(self, config: SmartEngageSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return smartengage_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            team_id=inputs.team_id,
+            job_id=inputs.job_id,
+        )
 
     @property
     def get_source_config(self) -> SourceConfig:
@@ -26,7 +87,24 @@ class SmartEngageSource(SimpleSource[SmartEngageSourceConfig]):
             name=SchemaExternalDataSourceType.SMART_ENGAGE,
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             label="SmartEngage",
+            caption="""Enter your SmartEngage API key to sync avatars, tags, custom fields, and sequences.
+
+You can find your API key in your SmartEngage account settings.
+""",
+            docsUrl="https://posthog.com/docs/cdp/sources/smartengage",
             iconPath="/static/services/smartengage.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="se_...",
+                        secret=True,
+                    ),
+                ],
+            ),
+            releaseStatus=ReleaseStatus.ALPHA,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/tests/test_smartengage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/tests/test_smartengage.py
@@ -1,0 +1,138 @@
+from typing import Any, cast
+
+import pytest
+from unittest.mock import Mock, patch
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.smartengage import (
+    get_resource,
+    smartengage_source,
+    validate_credentials,
+)
+
+
+class _FakeDltResource:
+    def __init__(self, name: str, rows: list[dict]) -> None:
+        self.name = name
+        self._rows = rows
+
+    def add_map(self, mapper):
+        self._rows = [mapper(dict(row)) for row in self._rows]
+        return self
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class TestSmartEngageTransport:
+    @parameterized.expand(
+        [
+            ("valid_key", 200, [{"avatar_id": "1"}], (True, None)),
+            ("empty_account", 200, [], (True, None)),
+            ("unauthorized", 401, {"error": "unauthorized"}, (False, "Invalid SmartEngage API key")),
+            ("forbidden", 403, {"error": "forbidden"}, (False, "Invalid SmartEngage API key")),
+            ("server_error", 503, {}, (False, "SmartEngage API returned status 503")),
+            # An error object served with a 200 must not validate as a working key.
+            (
+                "error_body_with_200",
+                200,
+                {"error": "invalid key"},
+                (False, "SmartEngage API returned an unexpected response"),
+            ),
+        ]
+    )
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.smartengage.make_tracked_session"
+    )
+    def test_validate_credentials_status_mapping(self, _name, status, payload, expected, mock_session) -> None:
+        response = Mock(status_code=status)
+        response.json.return_value = payload
+        mock_session.return_value.get.return_value = response
+
+        assert validate_credentials(api_key="se_key") == expected
+
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.smartengage.make_tracked_session"
+    )
+    def test_validate_credentials_handles_request_exception(self, mock_session) -> None:
+        mock_session.return_value.get.side_effect = requests.exceptions.RequestException("boom")
+        is_valid, message = validate_credentials(api_key="se_key")
+        assert is_valid is False
+        assert message is not None and "SmartEngage request failed" in message
+
+    def test_get_resource_avatars_is_unpaginated_root_array(self) -> None:
+        resource = cast(dict[str, Any], get_resource(endpoint="avatars"))
+        assert resource["name"] == "avatars"
+        assert resource["write_disposition"] == "replace"
+        assert resource["endpoint"]["path"] == "/avatars/list"
+        # SmartEngage returns the full collection as a bare JSON array in one response.
+        assert resource["endpoint"]["data_selector"] == "$"
+
+    @parameterized.expand([("tags",), ("custom_fields",), ("sequences",)])
+    def test_get_resource_rejects_fanout_endpoints(self, endpoint: str) -> None:
+        with pytest.raises(ValueError, match="Fan-out endpoint"):
+            get_resource(endpoint=endpoint)
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.smartengage.rest_api_resource")
+    def test_avatars_source_response(self, mock_rest_api_resource) -> None:
+        mock_rest_api_resource.return_value = Mock()
+        response = smartengage_source(api_key="se_key", endpoint="avatars", team_id=1, job_id="job-1")
+
+        assert response.name == "avatars"
+        assert response.primary_keys == ["avatar_id"]
+        # No SmartEngage table has a stable timestamp, so nothing is partitioned.
+        assert response.partition_mode is None
+
+    @parameterized.expand(
+        [
+            ("tags", "tag_id"),
+            ("custom_fields", "custom_field_id"),
+            ("sequences", "sequence_id"),
+        ]
+    )
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources"
+    )
+    def test_fanout_row_format_and_composite_key(self, endpoint, child_id_field, mock_rest_api_resources) -> None:
+        mock_rest_api_resources.return_value = [
+            _FakeDltResource("avatars", [{"avatar_id": "av_1"}]),
+            _FakeDltResource(endpoint, [{child_id_field: "child_1", "_avatars_avatar_id": "av_1"}]),
+        ]
+
+        response = smartengage_source(api_key="se_key", endpoint=endpoint, team_id=1, job_id="job-1")
+
+        rows = list(cast(Any, response.items()))
+        assert rows == [{child_id_field: "child_1", "avatar_id": "av_1"}]
+        # Child ids are only documented per avatar, so the avatar id must stay in the key —
+        # dropping it seeds duplicate rows that every later merge multi-matches.
+        assert response.primary_keys == ["avatar_id", child_id_field]
+
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources"
+    )
+    def test_fanout_binds_avatar_id_in_path_and_sends_no_page_size(self, mock_rest_api_resources) -> None:
+        mock_rest_api_resources.return_value = [
+            _FakeDltResource("avatars", []),
+            _FakeDltResource("tags", []),
+        ]
+
+        smartengage_source(api_key="se_key", endpoint="tags", team_id=1, job_id="job-1")
+
+        config = mock_rest_api_resources.call_args.args[0]
+        parent, child = config["resources"]
+
+        # The avatar_id resolve param can only be bound via a path placeholder (the framework
+        # doesn't support resolve query params), so it must ride the path's query string.
+        assert child["endpoint"]["path"] == "/tags/list?avatar_id={avatar_id}"
+        assert child["endpoint"]["params"]["avatar_id"] == {
+            "type": "resolve",
+            "resource": "avatars",
+            "field": "avatar_id",
+        }
+        assert child["include_from_parent"] == ["avatar_id"]
+
+        # SmartEngage endpoints are unpaginated: no undocumented page-size param may be sent.
+        assert "limit" not in parent["endpoint"]["params"]
+        assert "limit" not in child["endpoint"]["params"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/tests/test_smartengage_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartengage/tests/test_smartengage_source.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import (
+    DataWarehouseSourceCategory,
+    ReleaseStatus,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+)
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.smartengage import (
+    SmartEngageSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.source import SmartEngageSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestSmartEngageSource:
+    def setup_method(self) -> None:
+        self.source = SmartEngageSource()
+        self.team_id = 123
+        self.config = SmartEngageSourceConfig(api_key="se_test_key")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.SMARTENGAGE
+
+    def test_get_source_config_is_released(self) -> None:
+        config = self.source.get_source_config
+        assert config.name.value == "SmartEngage"
+        assert config.category == DataWarehouseSourceCategory.MARKETING___EMAIL
+        # The source must stay visible: unreleasedSource hides it from every user.
+        assert not config.unreleasedSource
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/smartengage"
+
+    def test_api_key_field_is_secret_password(self) -> None:
+        config = self.source.get_source_config
+        assert [f.name for f in config.fields] == ["api_key"]
+        field = config.fields[0]
+        assert isinstance(field, SourceFieldInputConfig)
+        assert field.type == SourceFieldInputConfigType.PASSWORD
+        assert field.secret is True
+        assert field.required is True
+
+    def test_get_schemas_are_full_refresh_only(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        # SmartEngage has no server-side timestamp filters, so no endpoint may advertise
+        # incremental sync — a client-side "incremental" would silently miss nothing but
+        # cost the same as full refresh and corrupt sync-type expectations.
+        for schema in schemas:
+            assert schema.supports_incremental is False
+            assert schema.supports_append is False
+            assert schema.incremental_fields == []
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["tags"])
+        assert [s.name for s in schemas] == ["tags"]
+
+    @pytest.mark.parametrize(
+        "observed_error,expected_non_retryable",
+        [
+            ("401 Client Error: Unauthorized for url: https://api.smartengage.com/avatars/list", True),
+            ("403 Client Error: Forbidden for url: https://api.smartengage.com/tags/list", True),
+            ("500 Server Error: Internal Server Error for url: https://api.smartengage.com/avatars/list", False),
+        ],
+    )
+    def test_non_retryable_errors(self, observed_error: str, expected_non_retryable: bool) -> None:
+        non_retryable = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable) is expected_non_retryable
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.source.validate_smartengage_credentials"
+    )
+    def test_validate_credentials_plumbs_api_key(self, mock_validate: mock.MagicMock) -> None:
+        mock_validate.return_value = (True, None)
+        assert self.source.validate_credentials(self.config, self.team_id) == (True, None)
+        assert mock_validate.call_args.args == ("se_test_key",)
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.smartengage.source.smartengage_source"
+    )
+    def test_source_for_pipeline_plumbs_arguments(self, mock_smartengage_source: mock.MagicMock) -> None:
+        inputs = mock.MagicMock()
+        inputs.schema_name = "tags"
+        inputs.team_id = self.team_id
+        inputs.job_id = "job-1"
+
+        self.source.source_for_pipeline(self.config, inputs)
+
+        kwargs = mock_smartengage_source.call_args.kwargs
+        assert kwargs == {
+            "api_key": "se_test_key",
+            "endpoint": "tags",
+            "team_id": self.team_id,
+            "job_id": "job-1",
+        }
+
+    def test_canonical_descriptions_cover_endpoints(self) -> None:
+        assert set(self.source.get_canonical_descriptions().keys()) == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

SmartEngage was a scaffolded stub (`unreleasedSource=True`, empty fields, no sync logic), so users couldn't import their SmartEngage marketing automation data into the Data warehouse.

## Why

Fill in the scaffolded SmartEngage connector end to end so it ships as a visible, connectable source alongside the rest of the marketing & email catalog.

## Changes

Implements the source on the shared `rest_source` framework (no hand-rolled client):

- **Endpoints** (`settings.py`): `avatars`, `tags`, `custom_fields`, `sequences` — matching the canonical stream list for this connector. All are unpaginated (full collection per response, `SinglePagePaginator` + root-array `data_selector`) and **full refresh only**: the API exposes no server-side timestamp filters, so no endpoint advertises incremental sync, and `SimpleSource` is the right base (no cursor to resume from).
- **Per-avatar fan-out**: `tags`/`custom_fields`/`sequences` are scoped by a required `avatar_id` query param, so the source enumerates `avatars` and fans out per avatar through the shared `build_dependent_resource` helper. The framework only binds resolve params in the path, so the child paths carry the placeholder in their query string (`/tags/list?avatar_id={avatar_id}`). Child rows get `avatar_id` injected from the parent, and child primary keys are composite (`[avatar_id, <child_id>]`) since child ids are only documented per avatar.
- **Fan-out helper extension** (`common/rest_source/fanout.py`): `page_size_param` now accepts `None` for APIs whose list endpoints take no page-size param at all, so we don't send an undocumented `limit`. Existing callers are unaffected (default unchanged; all consumer suites pass).
- **Auth + errors**: framework bearer auth; `validate_credentials` probes `/avatars/list` through `make_tracked_session()` and rejects non-array 200 bodies; `get_non_retryable_errors` covers 401/403.
- **Metadata**: `canonical_descriptions.py` for all four tables, `lists_tables_without_credentials=True` (static catalog), `docsUrl` → `/docs/cdp/sources/smartengage`, regenerated `SmartEngageSourceConfig`, SOURCES.md moved to Implemented.
- **Release status**: `unreleasedSource` deleted; ships visible with `releaseStatus=ReleaseStatus.ALPHA`.

> [!NOTE]
> The live API couldn't be reached from the dev environment (Cloudflare 522 on every probe), so endpoint behavior (paths, bearer auth, root-array responses, no pagination, per-avatar scoping, primary keys) is verified against the vendor's public API docs and the existing Airbyte connector manifest for this API rather than a live curl. That uncertainty is why it ships as ALPHA; short comments in the code note the conservative choices.

## How did you test this code?

- `pytest .../sources/smartengage/tests/` — 27 passed. Regressions these catch that nothing else did: the query-string resolve placeholder being "simplified" into a resolve query param (which the framework rejects at runtime), dropping `avatar_id` from child primary keys (seeds duplicate rows that every later merge multi-matches), reintroducing an undocumented page-size param, credential-validation status mapping (incl. error-object-with-200), an endpoint regressing to `supports_incremental=True` with no server filter, and the source being re-hidden via `unreleasedSource`.
- `pytest` on `common/rest_source/tests` + fillout/kandji/sentry/typeform (the other `build_dependent_resource` consumers) — 363 passed, guarding the helper signature change.
- Registry invariants (`test_source_categories`, `test_source_versions`, `test_source_config_generator`) — 2610 passed.
- `uv run mypy --cache-fine-grained .` — only failure is a pre-existing `personhog_client/converters.py` unused-ignore, reproduced with these changes stashed.
- `hogli ci:preflight --fix` — 0 failures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

User-facing doc added in [PostHog/posthog.com#18730](https://github.com/PostHog/posthog.com/pull/18730) (`sourceId: SmartEngage`, slug matches `docsUrl`). `audit_source_docs` against that checkout reports no SmartEngage findings (remaining findings are pre-existing drift for other sources).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task). Skills invoked: `implementing-warehouse-sources`, `documenting-warehouse-sources`, `writing-tests`.

Decisions along the way: preferred the declarative `rest_source` + shared fan-out helper over a hand-rolled client; extended the helper with `page_size_param=None` instead of sending an undocumented `limit` or bypassing the helper; kept child primary keys composite despite the reference connector declaring bare child ids, since per-avatar uniqueness is all the docs support; skipped a subscribers table because the API has no list/enumerate endpoint for subscribers (write-only operations), matching the reference connector's stream list.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*