### PR TITLE
fix(oauth-proxy): reject duplicate OAuth params in authorize

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -255,6 +255,18 @@ class TestOAuthAPI(APIBaseTest):
         self.assertEqual(response.json()["error"], "invalid_request")
         self.assertEqual(response.json()["error_description"], "Missing client_id parameter.")
 
+    @parameterized.expand(["client_id", "response_type", "redirect_uri", "scope", "state"])
+    def test_authorize_rejects_duplicate_param(self, param):
+        # Duplicate OAuth params (HTTP parameter pollution) must be rejected as fatal errors,
+        # so a proxy/parser reading first-vs-last can't route a victim's code elsewhere.
+        url = f"{self.base_authorization_url}&{param}=dup_one&{param}=dup_two"
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["error"], "invalid_request")
+        self.assertEqual(response.json()["error_description"], f"Duplicate {param} parameter.")
+
     def test_authorize_invalid_client_id(self):
         url = self.base_authorization_url
 

--- a/services/oauth-proxy/src/handlers/authorize.ts
+++ b/services/oauth-proxy/src/handlers/authorize.ts
@@ -12,6 +12,31 @@ const REGION_PICKER_HEADERS: Record<string, string> = {
     'Referrer-Policy': 'no-referrer',
 }
 
+// OAuth request parameters MUST NOT be included more than once (RFC 6749 §3.1).
+// We enforce it because the proxy reads these with `.get()` (first value) for KV
+// keying but forwards the last value to the regional server via `.set()`. A
+// duplicated `state` splits those two reads, letting an attacker route a victim's
+// callback to a preloaded redirect URI. `resource` (RFC 8707) is intentionally
+// excluded — it is allowed to repeat.
+const SINGLE_VALUED_PARAMS = [
+    'state',
+    'client_id',
+    'redirect_uri',
+    'response_type',
+    'scope',
+    'code_challenge',
+    'code_challenge_method',
+] as const
+
+function findDuplicatedParam(url: URL): string | null {
+    for (const param of SINGLE_VALUED_PARAMS) {
+        if (url.searchParams.getAll(param).length > 1) {
+            return param
+        }
+    }
+    return null
+}
+
 /**
  * OAuth Authorization — region picker + redirect.
  *
@@ -23,6 +48,17 @@ const REGION_PICKER_HEADERS: Record<string, string> = {
  */
 export async function handleAuthorize(request: Request, kv: KVNamespace): Promise<Response> {
     const url = new URL(request.url)
+
+    const duplicatedParam = findDuplicatedParam(url)
+    if (duplicatedParam) {
+        return new Response(
+            JSON.stringify({
+                error: 'invalid_request',
+                error_description: `Duplicate ${duplicatedParam} parameter is not allowed`,
+            }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+        )
+    }
 
     // If region is already selected (via query param from the picker page),
     // redirect to the regional authorize endpoint

--- a/services/oauth-proxy/tests/authorize.test.ts
+++ b/services/oauth-proxy/tests/authorize.test.ts
@@ -202,6 +202,28 @@ describe('handleAuthorize', () => {
         expect(callbackPuts).toHaveLength(0)
     })
 
+    it.each([
+        'state',
+        'client_id',
+        'redirect_uri',
+        'response_type',
+        'scope',
+        'code_challenge',
+        'code_challenge_method',
+    ])('rejects duplicate %s to prevent parameter-pollution code theft', async (param) => {
+        const request = new Request(
+            `https://oauth.posthog.com/oauth/authorize/?client_id=abc&response_type=code&${param}=first&${param}=second&_region=us`
+        )
+        const response = await handleAuthorize(request, mockKV)
+
+        expect(response.status).toBe(400)
+        const data = (await response.json()) as Record<string, unknown>
+        expect(data.error).toBe('invalid_request')
+        expect(data.error_description).toBe(`Duplicate ${param} parameter is not allowed`)
+        // Nothing gets keyed in KV when the request is rejected up front.
+        expect(vi.mocked(mockKV.put)).not.toHaveBeenCalled()
+    })
+
     it('sets security and cache headers on region picker page', async () => {
         const request = new Request('https://oauth.posthog.com/oauth/authorize/?client_id=abc&response_type=code')
         const response = await handleAuthorize(request, mockKV)


### PR DESCRIPTION
## Problem

The OAuth proxy parses single-valued OAuth params inconsistently when a request repeats them. In `authorize.ts` it reads params like `state` with `searchParams.get()` (first value) to key its KV entries, but when it rebuilds the URL for the regional server it uses `searchParams.set()` in a loop, which keeps the last value. So a request with a repeated `state` gets keyed under one value and forwarded under another, and the callback lookup can miss or resolve to the wrong entry. RFC 6749 §3.1 says these params must not appear more than once, so the right move is to reject the request rather than pick a winner.

## Changes

- `authorize.ts`: reject an authorize request that repeats a single-valued OAuth param (`state`, `client_id`, `redirect_uri`, `response_type`, `scope`, `code_challenge`, `code_challenge_method`) with a 400 `invalid_request`. The check sits at the top of `handleAuthorize`, so it covers both the initial hit and the `_region` resubmit. `resource` (RFC 8707) is intentionally excluded since it is allowed to repeat.
- Added a guard test on the Django `/oauth/authorize/` endpoint confirming it keeps rejecting duplicate params. That endpoint is a custom view (`OAuthLibMixin, APIView`) rather than the toolkit default, so the test locks in that it still routes through oauthlib validation and a refactor can't silently drop it.

## How did you test this code?

Automated only, no manual testing.

- `services/oauth-proxy`: full vitest suite passes (47 tests). Added 7 parameterized cases in `authorize.test.ts` asserting a repeated single-valued param returns 400 and writes nothing to KV. No existing test exercised duplicate params.
- `posthog/api/oauth/test_views.py`: added `test_authorize_rejects_duplicate_param` (5 parameterized cases over the params oauthlib guards) — passes. Catches a regression where the custom authorize view stops rejecting repeated params.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Opus 4.8) wrote the fix and tests. We looked at the proxy's param handling and traced the first-vs-last mismatch between the KV keying (`.get()`) and the forwarded URL (`.set()`). Chose to reject repeated single-valued params up front rather than normalize to first-or-last, since that matches RFC 6749 §3.1 and avoids having to keep both reads in sync forever. Confirmed the Django authorize endpoint already rejects duplicates through oauthlib, and added a test there so the custom view keeps that behavior.

Skills invoked: `/writing-tests`.
