### PR TITLE
feat(cdp): emit email_bounced_hard metric for permanent SES bounces

### DIFF
--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -324,7 +324,8 @@ describe('SesWebhookHandler', () => {
         ]
         const result = await handler.handleWebhook({ body, headers: {} })
         expect(result.status).toBe(200)
-        expect(result.metrics?.[0].metricName).toBe('email_bounced')
+        // Hard bounces emit both the catch-all metric and the AWS-comparable hard-only one
+        expect(result.metrics?.map((m) => m.metricName)).toEqual(['email_bounced', 'email_bounced_hard'])
         expect(result.metrics?.[0].distinctId).toBe('user-123')
         expect(result.hardBounceRecipients).toEqual([
             { teamId: '1', emailAddresses: ['to@example.com'], diagnostic: 'bad' },
@@ -349,7 +350,8 @@ describe('SesWebhookHandler', () => {
         ]
         const result = await handler.handleWebhook({ body, headers: {} })
         expect(result.status).toBe(200)
-        expect(result.metrics?.[0].metricName).toBe('email_bounced')
+        // Transient bounces must NOT emit email_bounced_hard — AWS's account rate excludes them
+        expect(result.metrics?.map((m) => m.metricName)).toEqual(['email_bounced'])
         expect(result.metrics?.[0].distinctId).toBe('user-123')
         expect(result.hardBounceRecipients).toEqual([])
         expect(result.transientBounceRecipients).toEqual([

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -593,6 +593,23 @@ export class SesWebhookHandler {
                     properties,
                     timestamp,
                 })
+
+                // email_bounced counts every bounce type, but AWS's account bounce rate — the
+                // number the email reputation feature is calibrated against — counts only hard
+                // (Permanent) bounces. Emit those additionally under their own metric so
+                // reputation can match AWS without changing email_bounced for its consumers.
+                if (rec.eventType === 'Bounce' && rec.bounce.bounceType === 'Permanent') {
+                    metrics.push({
+                        functionId,
+                        invocationId,
+                        actionId,
+                        parentRunId,
+                        distinctId,
+                        metricName: 'email_bounced_hard',
+                        properties,
+                        timestamp,
+                    })
+                }
             }
 
             // Allowlist actionId before interpolating into the [Action:…] rich-log token,

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -236,6 +236,7 @@ export type MinimalAppMetric = {
         | 'email_opened'
         | 'email_link_clicked'
         | 'email_bounced'
+        | 'email_bounced_hard'
         | 'email_bounce_prevented'
         | 'email_suppressed'
         | 'email_blocked'


### PR DESCRIPTION
## Problem

`email_bounced` counts every SES bounce type, but AWS's account-level bounce rate - the number the email reputation feature ([#72545](https://github.com/PostHog/posthog/pull/72545)) calibrates its thresholds against - counts **hard (Permanent) bounces only**. Transient traffic (greylisting, mailbox-full) therefore inflates our measured rate relative to what AWS actually holds against the shared sending account: a sender with 1.5% hard + 1% transient reads 2.5% on our score while AWS sees 1.5%.

## Changes

- The SES webhook now emits `email_bounced_hard` **in addition to** `email_bounced` when `bounce.bounceType === 'Permanent'`. `email_bounced` is unchanged, so every existing consumer (workflow metrics UI, exports) is unaffected - this is purely additive.
- `email_bounced_hard` added to the metric name union.

The reputation evaluator switches its bounce query to this metric (change on #72545). Deploy-order note: this should merge and deploy **ahead of** the evaluator going live, since the evaluator's volume window reaches back up to 30 days and hard-bounce data only accumulates from this deploy forward - windows spanning earlier sends undercount bounces until the metric has depth.

## How did you test this code?

I'm an agent; checks actually run: extended the two existing SES webhook bounce tests to pin the split (Permanent emits both metrics, Transient emits only `email_bounced` - the exact regressions that would silently mis-calibrate reputation), full ses.test.ts suite (44 tests) green, Node tsc clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Additive-metric shape chosen over changing `email_bounced` semantics after review discussion on #72545 (mayteio's calibration finding): renaming/splitting the existing metric would break every current consumer, while dual emission costs one extra metric row per hard bounce.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
