### PR TITLE
fix(surveys): route translation through the LLM gateway

### DIFF
--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -34,6 +34,7 @@ Product = Literal[
     "warehouse_semantic_enrichment",
     "warehouse_custom_source_builder",
     "stamphog",
+    "survey_translation",
 ]  # If you add a product here, make sure it's also in services/llm-gateway/src/llm_gateway/products/config.py
 
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1410,6 +1410,7 @@ POSTHOG_AI_PRODUCTS = [
     "alert_investigation_agent",
     "product_analytics",
     "surveys",
+    "survey_translation",
     "replay_vision",
 ]
 

--- a/products/ai_observability/frontend/usePosthogAIBillingCalculations.ts
+++ b/products/ai_observability/frontend/usePosthogAIBillingCalculations.ts
@@ -22,6 +22,7 @@ const AI_PRODUCT_MARKUP: Record<string, number> = {
     alert_investigation_agent: AI_COST_MARKUP_PERCENT,
     product_analytics: AI_COST_MARKUP_PERCENT,
     surveys: AI_COST_MARKUP_PERCENT,
+    survey_translation: AI_COST_MARKUP_PERCENT,
     posthog_code: 0,
 }
 

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -3044,8 +3044,10 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                 "survey translation generation is only supported in PostHog Cloud or DEBUG mode"
             )
 
-        if not settings.GEMINI_API_KEY:
-            raise exceptions.ValidationError("GEMINI_API_KEY must be configured to generate translations")
+        if not (settings.LLM_GATEWAY_URL and settings.LLM_GATEWAY_API_KEY):
+            raise exceptions.ValidationError(
+                "LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured to generate translations"
+            )
 
         if not self.team.organization.is_ai_data_processing_approved:
             return Response(

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -159,7 +159,11 @@ SURVEY_TRANSLATION_DRAFT_QUESTION_FIELDS = (
 
 
 class GenerateSurveyTranslationsRequestSerializer(serializers.Serializer):
-    target_language = serializers.CharField(help_text="Language code to generate translations for, for example pt-BR.")
+    # Bounded because it is echoed into an `x-posthog-property-*` header on the
+    # gateway call, and header values are ASCII-only on the wire.
+    target_language = serializers.CharField(
+        max_length=64, help_text="Language code to generate translations for, for example pt-BR."
+    )
     source_language = serializers.CharField(
         required=False,
         allow_blank=True,

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -504,7 +504,9 @@ class TestSurvey(APIBaseTest):
         assert "default" not in result
         assert "en" not in result
 
-    @override_settings(CLOUD_DEPLOYMENT="US", GEMINI_API_KEY="test-key")
+    @override_settings(
+        CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="https://llm-gateway.test", LLM_GATEWAY_API_KEY="test-key"
+    )
     @patch("products.surveys.backend.api.survey.generate_survey_translation")
     def test_generate_translations_returns_draft_patch(self, mock_generate_survey_translation):
         self.organization.is_ai_data_processing_approved = True
@@ -550,7 +552,9 @@ class TestSurvey(APIBaseTest):
         # source_language falls back to the survey's base_language when not provided
         assert mock_generate_survey_translation.call_args.kwargs["source_language"] == "en"
 
-    @override_settings(CLOUD_DEPLOYMENT="US", GEMINI_API_KEY="test-key")
+    @override_settings(
+        CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="https://llm-gateway.test", LLM_GATEWAY_API_KEY="test-key"
+    )
     @patch("products.surveys.backend.api.survey.generate_survey_translation")
     def test_generate_translations_uses_survey_base_language_as_source(self, mock_generate_survey_translation) -> None:
         self.organization.is_ai_data_processing_approved = True
@@ -573,7 +577,9 @@ class TestSurvey(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert mock_generate_survey_translation.call_args.kwargs["source_language"] == "es"
 
-    @override_settings(CLOUD_DEPLOYMENT="US", GEMINI_API_KEY="test-key")
+    @override_settings(
+        CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="https://llm-gateway.test", LLM_GATEWAY_API_KEY="test-key"
+    )
     @patch("products.surveys.backend.api.survey.generate_survey_translation")
     def test_generate_translations_requires_ai_data_processing_approval(self, mock_generate_survey_translation):
         self.organization.is_ai_data_processing_approved = False
@@ -589,7 +595,9 @@ class TestSurvey(APIBaseTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         mock_generate_survey_translation.assert_not_called()
 
-    @override_settings(CLOUD_DEPLOYMENT="US", GEMINI_API_KEY="test-key")
+    @override_settings(
+        CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="https://llm-gateway.test", LLM_GATEWAY_API_KEY="test-key"
+    )
     @patch("products.surveys.backend.api.survey.generate_survey_translation")
     def test_generate_translations_enforces_object_access_control(self, mock_generate_survey_translation):
         self.organization.available_product_features = [
@@ -623,7 +631,9 @@ class TestSurvey(APIBaseTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
         mock_generate_survey_translation.assert_not_called()
 
-    @override_settings(CLOUD_DEPLOYMENT="US", GEMINI_API_KEY="test-key")
+    @override_settings(
+        CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="https://llm-gateway.test", LLM_GATEWAY_API_KEY="test-key"
+    )
     @patch("products.surveys.backend.api.survey.generate_survey_translation")
     def test_generate_translations_rejects_cross_organization_survey_id(self, mock_generate_survey_translation):
         self.organization.is_ai_data_processing_approved = True

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -577,6 +577,35 @@ class TestSurvey(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert mock_generate_survey_translation.call_args.kwargs["source_language"] == "es"
 
+    @override_settings(CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="", LLM_GATEWAY_API_KEY="")
+    @patch("products.surveys.backend.api.survey.generate_survey_translation")
+    def test_generate_translations_rejects_when_gateway_unconfigured(self, mock_generate_survey_translation):
+        survey = Survey.objects.create(team=self.team, name="Customer feedback", type="popover", questions=[])
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/generate_translations/",
+            data={"target_language": "pt-BR"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_generate_survey_translation.assert_not_called()
+
+    @override_settings(CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="https://llm-gateway.test", LLM_GATEWAY_API_KEY="")
+    @patch("products.surveys.backend.api.survey.generate_survey_translation")
+    def test_generate_translations_rejects_on_partial_gateway_config(self, mock_generate_survey_translation):
+        # Pins the `and`: a URL without a key must not pass the guard.
+        survey = Survey.objects.create(team=self.team, name="Customer feedback", type="popover", questions=[])
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/generate_translations/",
+            data={"target_language": "pt-BR"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_generate_survey_translation.assert_not_called()
+
     @override_settings(
         CLOUD_DEPLOYMENT="US", LLM_GATEWAY_URL="https://llm-gateway.test", LLM_GATEWAY_API_KEY="test-key"
     )

--- a/products/surveys/backend/llm/__init__.py
+++ b/products/surveys/backend/llm/__init__.py
@@ -1,5 +1,6 @@
 """Shared LLM utilities for surveys."""
 
 from .client import create_gemini_client, generate_structured_output
+from .gateway import generate_structured_output as generate_structured_output_via_gateway
 
-__all__ = ["create_gemini_client", "generate_structured_output"]
+__all__ = ["create_gemini_client", "generate_structured_output", "generate_structured_output_via_gateway"]

--- a/products/surveys/backend/llm/gateway.py
+++ b/products/surveys/backend/llm/gateway.py
@@ -7,25 +7,53 @@ own provider credentials instead.
 
 The gateway captures `$ai_generation` itself, so the client is deliberately NOT
 wrapped with `posthoganalytics.ai` -- wrapping would double-capture every call.
+
+Shape conformance is weaker than the Gemini path this replaces: Gemini enforced
+`response_json_schema` server-side, whereas `json_object` only guarantees
+syntactically valid JSON, so the schema rides in the prompt and pydantic is the
+only real gate.
 """
 
+import re
 import json
 import uuid
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import structlog
-from pydantic import BaseModel
+from openai.types.chat import ChatCompletionMessageParam
+from pydantic import (
+    BaseModel,
+    ValidationError as PydanticValidationError,
+)
 from rest_framework import exceptions
 
 from posthog.llm.gateway_client import Product, get_llm_client
+from posthog.llm.semantic_enrichment import extract_json_object
 
 logger = structlog.get_logger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
+# These run inline on a DRF request thread, so they need a bound well under the
+# SDK's 600s default. Retries are capped because a replayed generation is billed
+# again -- nothing between here and the gateway's cost recorder deduplicates one.
+DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_MAX_TOKENS = 4096
+MAX_RETRIES = 1
+
 # `ai_product` and `$ai_billable` are owned by the gateway product config; sending
 # them as caller headers is a documented footgun (see `get_llm_client`).
 _GATEWAY_OWNED_PROPERTIES = frozenset({"ai_product", "$ai_billable"})
+
+# Header values are ASCII on the wire and CRLF is rejected outright, so a property
+# sourced from request data (a target language) would otherwise raise inside the
+# SDK and surface as a 500.
+_UNSAFE_HEADER_CHARS = re.compile(r"[^\x20-\x7e]")
+_MAX_HEADER_VALUE_LENGTH = 200
+
+
+def _header_value(value: Any) -> str:
+    return _UNSAFE_HEADER_CHARS.sub("?", str(value))[:_MAX_HEADER_VALUE_LENGTH]
 
 
 def _schema_instruction(response_schema: type[T]) -> str:
@@ -45,6 +73,8 @@ def generate_structured_output(
     posthog_properties: dict | None = None,
     team_id: int | None = None,
     distinct_id: str | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
 ) -> tuple[T, str]:
     """Ask the gateway for JSON matching `response_schema`.
 
@@ -53,36 +83,51 @@ def generate_structured_output(
     `$ai_trace_id` itself and offers no header to override it, so the returned id
     correlates via that property rather than via `$ai_trace_id`.
     """
-    client = get_llm_client(product, team_id=team_id)
+    client = get_llm_client(product, team_id=team_id).with_options(max_retries=MAX_RETRIES)
 
     trace_id = str(uuid.uuid4())
     properties = {
-        key: value for key, value in (posthog_properties or {}).items() if key not in _GATEWAY_OWNED_PROPERTIES
+        key: value
+        for key, value in (posthog_properties or {}).items()
+        if key not in _GATEWAY_OWNED_PROPERTIES and value is not None
     }
     properties["llm_trace_id"] = trace_id
 
-    extra_headers = {f"x-posthog-property-{key}": str(value) for key, value in properties.items()}
+    extra_headers = {f"x-posthog-property-{key}": _header_value(value) for key, value in properties.items()}
+
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "system", "content": f"{system_prompt}\n\n{_schema_instruction(response_schema)}"},
+        {"role": "user", "content": user_prompt},
+    ]
 
     try:
         response = client.chat.completions.create(
             model=model,
-            messages=[
-                {"role": "system", "content": f"{system_prompt}\n\n{_schema_instruction(response_schema)}"},
-                {"role": "user", "content": user_prompt},
-            ],
+            messages=messages,
             response_format={"type": "json_object"},
+            max_tokens=max_tokens,
+            timeout=timeout_seconds,
             extra_headers=extra_headers,
-            **({"user": distinct_id} if distinct_id else {}),
+            user=distinct_id or product,
         )
-
-        content = response.choices[0].message.content if response.choices else None
-        if not content:
-            raise exceptions.ValidationError("LLM gateway returned empty response")
-
-        return response_schema.model_validate_json(content), trace_id
-
-    except exceptions.ValidationError:
-        raise
     except Exception:
-        logger.exception("LLM gateway call failed", model=model, product=product, properties=properties)
+        logger.exception("llm_gateway_call_failed", model=model, product=product, properties=properties)
+        raise exceptions.APIException("Failed to generate response")
+
+    content = response.choices[0].message.content if response.choices else None
+    if not content:
+        raise exceptions.ValidationError("LLM gateway returned empty response")
+
+    # `json_object` is not reliably honoured on the gateway's Anthropic route, so the
+    # reply can arrive fenced or with leading prose (see `extract_json_object`).
+    parsed = extract_json_object(content)
+    if parsed is None:
+        logger.warning("llm_gateway_unparseable_response", model=model, product=product)
+        raise exceptions.APIException("Failed to generate response")
+
+    try:
+        return response_schema.model_validate(parsed), trace_id
+    except PydanticValidationError:
+        # Distinct from the call failure above: the model answered, the shape was wrong.
+        logger.warning("llm_gateway_schema_mismatch", model=model, product=product)
         raise exceptions.APIException("Failed to generate response")

--- a/products/surveys/backend/llm/gateway.py
+++ b/products/surveys/backend/llm/gateway.py
@@ -1,0 +1,88 @@
+"""LLM gateway client utilities for surveys.
+
+Sibling of `client.py`, which calls Gemini directly with `settings.GEMINI_API_KEY`.
+That key is per-deployment, so a bad value takes every direct caller down at once
+with no gateway in the path to absorb it. Callers routed here borrow the gateway's
+own provider credentials instead.
+
+The gateway captures `$ai_generation` itself, so the client is deliberately NOT
+wrapped with `posthoganalytics.ai` -- wrapping would double-capture every call.
+"""
+
+import json
+import uuid
+from typing import TypeVar
+
+import structlog
+from pydantic import BaseModel
+from rest_framework import exceptions
+
+from posthog.llm.gateway_client import Product, get_llm_client
+
+logger = structlog.get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+# `ai_product` and `$ai_billable` are owned by the gateway product config; sending
+# them as caller headers is a documented footgun (see `get_llm_client`).
+_GATEWAY_OWNED_PROPERTIES = frozenset({"ai_product", "$ai_billable"})
+
+
+def _schema_instruction(response_schema: type[T]) -> str:
+    return (
+        "Respond with a single JSON object and nothing else. "
+        f"It must conform to this JSON schema:\n{json.dumps(response_schema.model_json_schema())}"
+    )
+
+
+def generate_structured_output(
+    *,
+    product: Product,
+    model: str,
+    system_prompt: str,
+    user_prompt: str,
+    response_schema: type[T],
+    posthog_properties: dict | None = None,
+    team_id: int | None = None,
+    distinct_id: str | None = None,
+) -> tuple[T, str]:
+    """Ask the gateway for JSON matching `response_schema`.
+
+    Returns the validated model and a trace id. The trace id is generated here and
+    stamped as an `llm_trace_id` event property: the gateway's OpenAI route derives
+    `$ai_trace_id` itself and offers no header to override it, so the returned id
+    correlates via that property rather than via `$ai_trace_id`.
+    """
+    client = get_llm_client(product, team_id=team_id)
+
+    trace_id = str(uuid.uuid4())
+    properties = {
+        key: value for key, value in (posthog_properties or {}).items() if key not in _GATEWAY_OWNED_PROPERTIES
+    }
+    properties["llm_trace_id"] = trace_id
+
+    extra_headers = {f"x-posthog-property-{key}": str(value) for key, value in properties.items()}
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": f"{system_prompt}\n\n{_schema_instruction(response_schema)}"},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+            extra_headers=extra_headers,
+            **({"user": distinct_id} if distinct_id else {}),
+        )
+
+        content = response.choices[0].message.content if response.choices else None
+        if not content:
+            raise exceptions.ValidationError("LLM gateway returned empty response")
+
+        return response_schema.model_validate_json(content), trace_id
+
+    except exceptions.ValidationError:
+        raise
+    except Exception:
+        logger.exception("LLM gateway call failed", model=model, product=product, properties=properties)
+        raise exceptions.APIException("Failed to generate response")

--- a/products/surveys/backend/llm/gateway.py
+++ b/products/surveys/backend/llm/gateway.py
@@ -76,10 +76,9 @@ def generate_structured_output(
 ) -> tuple[T, str]:
     """Ask the gateway for JSON matching `response_schema`.
 
-    Returns the validated model and a trace id. The trace id is generated here and
-    stamped as an `llm_trace_id` event property: the gateway's OpenAI route derives
-    `$ai_trace_id` itself and offers no header to override it, so the returned id
-    correlates via that property rather than via `$ai_trace_id`.
+    Returns the validated model and a trace id. The id rides the `x-posthog-trace-id`
+    header, which the gateway stamps as the captured generation's `$ai_trace_id`, so
+    callers can join ratings and trace links onto the generation.
     """
     client = get_llm_client(product, team_id=team_id).with_options(max_retries=MAX_RETRIES)
 
@@ -89,9 +88,9 @@ def generate_structured_output(
         for key, value in (posthog_properties or {}).items()
         if key not in _GATEWAY_OWNED_PROPERTIES and value is not None
     }
-    properties["llm_trace_id"] = trace_id
 
     extra_headers = {f"x-posthog-property-{key}": _header_value(value) for key, value in properties.items()}
+    extra_headers["x-posthog-trace-id"] = trace_id
 
     messages: list[ChatCompletionMessageParam] = [
         {"role": "system", "content": f"{system_prompt}\n\n{_schema_instruction(response_schema)}"},

--- a/products/surveys/backend/llm/gateway.py
+++ b/products/surveys/backend/llm/gateway.py
@@ -1,17 +1,15 @@
 """LLM gateway client utilities for surveys.
 
-Sibling of `client.py`, which calls Gemini directly with `settings.GEMINI_API_KEY`.
-That key is per-deployment, so a bad value takes every direct caller down at once
-with no gateway in the path to absorb it. Callers routed here borrow the gateway's
-own provider credentials instead.
+Routes structured-output calls through the internal LLM gateway, which holds its
+own provider credentials. The direct-Gemini sibling in `client.py` reads the
+per-deployment `settings.GEMINI_API_KEY`, so one bad key there takes every caller
+down at once with nothing in the path to absorb it.
 
 The gateway captures `$ai_generation` itself, so the client is deliberately NOT
-wrapped with `posthoganalytics.ai` -- wrapping would double-capture every call.
+wrapped with `posthoganalytics.ai`: wrapping double-captures every call.
 
-Shape conformance is weaker than the Gemini path this replaces: Gemini enforced
-`response_json_schema` server-side, whereas `json_object` only guarantees
-syntactically valid JSON, so the schema rides in the prompt and pydantic is the
-only real gate.
+`json_object` guarantees syntactically valid JSON but not shape, so the schema
+rides in the prompt and pydantic is the only real gate.
 """
 
 import re
@@ -35,8 +33,8 @@ logger = structlog.get_logger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 # These run inline on a DRF request thread, so they need a bound well under the
-# SDK's 600s default. Retries are capped because a replayed generation is billed
-# again -- nothing between here and the gateway's cost recorder deduplicates one.
+# SDK's 600s default. Retries are capped because nothing between here and the
+# gateway's cost recorder deduplicates a replayed generation, so each one bills.
 DEFAULT_TIMEOUT_SECONDS = 60.0
 DEFAULT_MAX_TOKENS = 4096
 MAX_RETRIES = 1

--- a/products/surveys/backend/llm/test_gateway.py
+++ b/products/surveys/backend/llm/test_gateway.py
@@ -1,0 +1,116 @@
+import json
+
+import pytest
+from unittest.mock import Mock, patch
+
+from pydantic import BaseModel
+from rest_framework import exceptions
+
+from products.surveys.backend.llm.gateway import generate_structured_output
+
+
+class _Schema(BaseModel):
+    greeting: str
+
+
+def _response(content: str | None) -> Mock:
+    message = Mock()
+    message.content = content
+    choice = Mock()
+    choice.message = message
+    response = Mock()
+    response.choices = [choice]
+    return response
+
+
+def _call(**overrides):
+    kwargs = {
+        "product": "survey_translation",
+        "model": "claude-haiku-4-5",
+        "system_prompt": "Translate.",
+        "user_prompt": "hola",
+        "response_schema": _Schema,
+        "team_id": 7,
+        "distinct_id": "user-1",
+    }
+    kwargs.update(overrides)
+    return generate_structured_output(**kwargs)
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_routes_through_gateway_and_returns_validated_schema(mock_get_client: Mock) -> None:
+    client = Mock()
+    client.chat.completions.create.return_value = _response('{"greeting": "hello"}')
+    mock_get_client.return_value = client
+
+    result, trace_id = _call()
+
+    assert result == _Schema(greeting="hello")
+    assert trace_id
+
+    # The product route and per-team attribution are what make the gateway bill
+    # and tag this call correctly; a wrong product silently mis-bills.
+    mock_get_client.assert_called_once_with("survey_translation", team_id=7)
+
+    sent = client.chat.completions.create.call_args.kwargs
+    assert sent["model"] == "claude-haiku-4-5"
+    assert sent["response_format"] == {"type": "json_object"}
+    assert sent["user"] == "user-1"
+    assert sent["messages"][0]["role"] == "system"
+    assert sent["messages"][0]["content"].startswith("Translate.")
+    assert sent["messages"][1] == {"role": "user", "content": "hola"}
+    # The schema has to reach the model somehow: json_object mode enforces valid
+    # JSON but not our shape, so dropping the schema text yields unparseable output.
+    assert json.dumps(_Schema.model_json_schema()) in sent["messages"][0]["content"]
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_drops_gateway_owned_properties_and_stamps_trace_id(mock_get_client: Mock) -> None:
+    client = Mock()
+    client.chat.completions.create.return_value = _response('{"greeting": "hello"}')
+    mock_get_client.return_value = client
+
+    _result, trace_id = _call(
+        posthog_properties={
+            "ai_product": "surveys",
+            "$ai_billable": True,
+            "ai_feature": "survey_translation",
+        }
+    )
+
+    headers = client.chat.completions.create.call_args.kwargs["extra_headers"]
+    assert "x-posthog-property-ai_product" not in headers
+    assert "x-posthog-property-$ai_billable" not in headers
+    assert headers["x-posthog-property-ai_feature"] == "survey_translation"
+    assert headers["x-posthog-property-llm_trace_id"] == trace_id
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_omits_user_when_no_distinct_id(mock_get_client: Mock) -> None:
+    client = Mock()
+    client.chat.completions.create.return_value = _response('{"greeting": "hello"}')
+    mock_get_client.return_value = client
+
+    _call(distinct_id=None)
+
+    assert "user" not in client.chat.completions.create.call_args.kwargs
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_empty_content_raises_validation_error(mock_get_client: Mock) -> None:
+    client = Mock()
+    client.chat.completions.create.return_value = _response(None)
+    mock_get_client.return_value = client
+
+    with pytest.raises(exceptions.ValidationError):
+        _call()
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_provider_failure_surfaces_as_api_exception(mock_get_client: Mock) -> None:
+    client = Mock()
+    client.chat.completions.create.side_effect = RuntimeError("upstream 401")
+    mock_get_client.return_value = client
+
+    with pytest.raises(exceptions.APIException):
+        _call()

--- a/products/surveys/backend/llm/test_gateway.py
+++ b/products/surveys/backend/llm/test_gateway.py
@@ -6,21 +6,34 @@ from unittest.mock import Mock, patch
 from pydantic import BaseModel
 from rest_framework import exceptions
 
-from products.surveys.backend.llm.gateway import generate_structured_output
+from products.surveys.backend.llm.gateway import MAX_RETRIES, generate_structured_output
 
 
 class _Schema(BaseModel):
     greeting: str
 
 
-def _response(content: str | None) -> Mock:
+def _response(content: str | None, *, choices: bool = True) -> Mock:
     message = Mock()
     message.content = content
     choice = Mock()
     choice.message = message
     response = Mock()
-    response.choices = [choice]
+    response.choices = [choice] if choices else []
     return response
+
+
+def _client(mock_get_client: Mock, response: Mock | None = None, error: Exception | None = None) -> Mock:
+    client = Mock()
+    # The helper calls `.with_options(...)` before `.chat`, so the configured copy
+    # has to be the same mock the assertions read.
+    client.with_options.return_value = client
+    if error is not None:
+        client.chat.completions.create.side_effect = error
+    else:
+        client.chat.completions.create.return_value = response
+    mock_get_client.return_value = client
+    return client
 
 
 def _call(**overrides):
@@ -39,9 +52,7 @@ def _call(**overrides):
 
 @patch("products.surveys.backend.llm.gateway.get_llm_client")
 def test_routes_through_gateway_and_returns_validated_schema(mock_get_client: Mock) -> None:
-    client = Mock()
-    client.chat.completions.create.return_value = _response('{"greeting": "hello"}')
-    mock_get_client.return_value = client
+    client = _client(mock_get_client, _response('{"greeting": "hello"}'))
 
     result, trace_id = _call()
 
@@ -65,10 +76,22 @@ def test_routes_through_gateway_and_returns_validated_schema(mock_get_client: Mo
 
 
 @patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_bounds_timeout_tokens_and_retries(mock_get_client: Mock) -> None:
+    client = _client(mock_get_client, _response('{"greeting": "hello"}'))
+
+    _call(timeout_seconds=12.5, max_tokens=321)
+
+    # Unbounded, these run on a DRF worker with the SDK's 600s default and retry a
+    # billable generation twice.
+    client.with_options.assert_called_once_with(max_retries=MAX_RETRIES)
+    sent = client.chat.completions.create.call_args.kwargs
+    assert sent["timeout"] == 12.5
+    assert sent["max_tokens"] == 321
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
 def test_drops_gateway_owned_properties_and_stamps_trace_id(mock_get_client: Mock) -> None:
-    client = Mock()
-    client.chat.completions.create.return_value = _response('{"greeting": "hello"}')
-    mock_get_client.return_value = client
+    client = _client(mock_get_client, _response('{"greeting": "hello"}'))
 
     _result, trace_id = _call(
         posthog_properties={
@@ -86,21 +109,98 @@ def test_drops_gateway_owned_properties_and_stamps_trace_id(mock_get_client: Moc
 
 
 @patch("products.surveys.backend.llm.gateway.get_llm_client")
-def test_omits_user_when_no_distinct_id(mock_get_client: Mock) -> None:
-    client = Mock()
-    client.chat.completions.create.return_value = _response('{"greeting": "hello"}')
-    mock_get_client.return_value = client
+def test_omits_none_properties_rather_than_stringifying_them(mock_get_client: Mock) -> None:
+    client = _client(mock_get_client, _response('{"greeting": "hello"}'))
+
+    _call(posthog_properties={"question_id": None, "response_count": 3})
+
+    headers = client.chat.completions.create.call_args.kwargs["extra_headers"]
+    # `str(None)` would capture the literal "None" and break isNull filters.
+    assert "x-posthog-property-question_id" not in headers
+    assert headers["x-posthog-property-response_count"] == "3"
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_sanitizes_non_ascii_property_values(mock_get_client: Mock) -> None:
+    client = _client(mock_get_client, _response('{"greeting": "hello"}'))
+
+    _call(posthog_properties={"target_language": "日本語", "note": "a\r\nb"})
+
+    headers = client.chat.completions.create.call_args.kwargs["extra_headers"]
+    # Header values are ASCII on the wire; unsanitized these raise inside the SDK
+    # and surface as a 500 on a user-supplied language name.
+    for value in headers.values():
+        value.encode("ascii")
+    assert "\r" not in headers["x-posthog-property-note"]
+    assert "\n" not in headers["x-posthog-property-note"]
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_truncates_overlong_property_values(mock_get_client: Mock) -> None:
+    client = _client(mock_get_client, _response('{"greeting": "hello"}'))
+
+    _call(posthog_properties={"target_language": "x" * 5000})
+
+    headers = client.chat.completions.create.call_args.kwargs["extra_headers"]
+    assert len(headers["x-posthog-property-target_language"]) <= 200
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_falls_back_to_product_when_no_distinct_id(mock_get_client: Mock) -> None:
+    client = _client(mock_get_client, _response('{"greeting": "hello"}'))
 
     _call(distinct_id=None)
 
-    assert "user" not in client.chat.completions.create.call_args.kwargs
+    assert client.chat.completions.create.call_args.kwargs["user"] == "survey_translation"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        '```json\n{"greeting": "hello"}\n```',
+        'Here you go:\n{"greeting": "hello"}',
+        '```\n{"greeting": "hello"}\n```',
+    ],
+)
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_tolerates_fenced_or_prefixed_json(mock_get_client: Mock, content: str) -> None:
+    _client(mock_get_client, _response(content))
+
+    # json_object is not reliably honoured on the gateway's Anthropic route, so a
+    # raw json.loads would turn a good generation into a 500.
+    result, _trace_id = _call()
+
+    assert result == _Schema(greeting="hello")
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_schema_violating_json_raises_api_exception(mock_get_client: Mock) -> None:
+    _client(mock_get_client, _response('{"unexpected": 1}'))
+
+    # json_object guarantees valid JSON, not our shape; pydantic is the only gate.
+    with pytest.raises(exceptions.APIException):
+        _call()
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_unparseable_content_raises_api_exception(mock_get_client: Mock) -> None:
+    _client(mock_get_client, _response("I cannot help with that."))
+
+    with pytest.raises(exceptions.APIException):
+        _call()
 
 
 @patch("products.surveys.backend.llm.gateway.get_llm_client")
 def test_empty_content_raises_validation_error(mock_get_client: Mock) -> None:
-    client = Mock()
-    client.chat.completions.create.return_value = _response(None)
-    mock_get_client.return_value = client
+    _client(mock_get_client, _response(None))
+
+    with pytest.raises(exceptions.ValidationError):
+        _call()
+
+
+@patch("products.surveys.backend.llm.gateway.get_llm_client")
+def test_no_choices_raises_validation_error(mock_get_client: Mock) -> None:
+    _client(mock_get_client, _response('{"greeting": "hello"}', choices=False))
 
     with pytest.raises(exceptions.ValidationError):
         _call()
@@ -108,9 +208,7 @@ def test_empty_content_raises_validation_error(mock_get_client: Mock) -> None:
 
 @patch("products.surveys.backend.llm.gateway.get_llm_client")
 def test_provider_failure_surfaces_as_api_exception(mock_get_client: Mock) -> None:
-    client = Mock()
-    client.chat.completions.create.side_effect = RuntimeError("upstream 401")
-    mock_get_client.return_value = client
+    _client(mock_get_client, error=RuntimeError("upstream 401"))
 
     with pytest.raises(exceptions.APIException):
         _call()

--- a/products/surveys/backend/llm/test_gateway.py
+++ b/products/surveys/backend/llm/test_gateway.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import pytest
 from unittest.mock import Mock, patch
@@ -37,7 +38,7 @@ def _client(mock_get_client: Mock, response: Mock | None = None, error: Exceptio
 
 
 def _call(**overrides):
-    kwargs = {
+    kwargs: dict[str, Any] = {
         "product": "survey_translation",
         "model": "claude-haiku-4-5",
         "system_prompt": "Translate.",

--- a/products/surveys/backend/llm/test_gateway.py
+++ b/products/surveys/backend/llm/test_gateway.py
@@ -106,7 +106,9 @@ def test_drops_gateway_owned_properties_and_stamps_trace_id(mock_get_client: Moc
     assert "x-posthog-property-ai_product" not in headers
     assert "x-posthog-property-$ai_billable" not in headers
     assert headers["x-posthog-property-ai_feature"] == "survey_translation"
-    assert headers["x-posthog-property-llm_trace_id"] == trace_id
+    # The gateway stamps this as the generation's $ai_trace_id, so the id handed
+    # back to callers is the one ratings and trace links join on.
+    assert headers["x-posthog-trace-id"] == trace_id
 
 
 @patch("products.surveys.backend.llm.gateway.get_llm_client")

--- a/products/surveys/backend/test_translation.py
+++ b/products/surveys/backend/test_translation.py
@@ -3,9 +3,9 @@ from unittest.mock import Mock, patch
 from products.surveys.backend.translation import SurveyTranslationResponse, generate_survey_translation
 
 
-@patch("products.surveys.backend.translation.generate_structured_output")
-def test_generate_survey_translation_preserves_manual_translations(mock_generate_structured_output: Mock) -> None:
-    mock_generate_structured_output.return_value = (
+@patch("products.surveys.backend.translation.generate_structured_output_via_gateway")
+def test_generate_survey_translation_preserves_manual_translations(mock_generate_via_gateway: Mock) -> None:
+    mock_generate_via_gateway.return_value = (
         SurveyTranslationResponse.model_validate(
             {
                 "root": {
@@ -71,18 +71,23 @@ def test_generate_survey_translation_preserves_manual_translations(mock_generate
         "questions.0.translations.es.choices.1",
     ]
     assert trace_id == "trace-1"
-    assert "description_or_goal" in mock_generate_structured_output.call_args.kwargs["user_prompt"]
-    assert mock_generate_structured_output.call_args.kwargs["billable"] is True
-    assert mock_generate_structured_output.call_args.kwargs["team_id"] == 1
-    assert mock_generate_structured_output.call_args.kwargs["posthog_properties"]["ai_product"] == "surveys"
-    assert mock_generate_structured_output.call_args.kwargs["posthog_properties"]["ai_feature"] == "survey_translation"
+    assert "description_or_goal" in mock_generate_via_gateway.call_args.kwargs["user_prompt"]
+    assert mock_generate_via_gateway.call_args.kwargs["team_id"] == 1
+    assert mock_generate_via_gateway.call_args.kwargs["product"] == "survey_translation"
+    assert mock_generate_via_gateway.call_args.kwargs["model"] == "claude-haiku-4-5"
+    assert mock_generate_via_gateway.call_args.kwargs["posthog_properties"]["ai_feature"] == "survey_translation"
+    # `ai_product` / `$ai_billable` are gateway-owned; sending them as caller
+    # properties would override the product config.
+    caller_properties = mock_generate_via_gateway.call_args.kwargs["posthog_properties"]
+    assert "ai_product" not in caller_properties
+    assert "$ai_billable" not in caller_properties
 
 
-@patch("products.surveys.backend.translation.generate_structured_output")
+@patch("products.surveys.backend.translation.generate_structured_output_via_gateway")
 def test_generate_survey_translation_includes_submit_and_back_button_labels(
-    mock_generate_structured_output: Mock,
+    mock_generate_via_gateway: Mock,
 ) -> None:
-    mock_generate_structured_output.return_value = (
+    mock_generate_via_gateway.return_value = (
         SurveyTranslationResponse.model_validate(
             {
                 "root": {
@@ -114,11 +119,11 @@ def test_generate_survey_translation_includes_submit_and_back_button_labels(
     assert "translations.es.backButtonText" in generated_paths
 
 
-@patch("products.surveys.backend.translation.generate_structured_output")
+@patch("products.surveys.backend.translation.generate_structured_output_via_gateway")
 def test_generate_survey_translation_preserves_manual_choice_translations_after_choice_count_change(
-    mock_generate_structured_output: Mock,
+    mock_generate_via_gateway: Mock,
 ) -> None:
-    mock_generate_structured_output.return_value = (
+    mock_generate_via_gateway.return_value = (
         SurveyTranslationResponse.model_validate(
             {
                 "questions": [
@@ -172,9 +177,9 @@ def test_generate_survey_translation_preserves_manual_choice_translations_after_
     assert trace_id == "trace-2"
 
 
-@patch("products.surveys.backend.translation.generate_structured_output")
-def test_generate_survey_translation_matches_questions_without_ids(mock_generate_structured_output: Mock) -> None:
-    mock_generate_structured_output.return_value = (
+@patch("products.surveys.backend.translation.generate_structured_output_via_gateway")
+def test_generate_survey_translation_matches_questions_without_ids(mock_generate_via_gateway: Mock) -> None:
+    mock_generate_via_gateway.return_value = (
         SurveyTranslationResponse.model_validate(
             {
                 "questions": [
@@ -218,4 +223,4 @@ def test_generate_survey_translation_matches_questions_without_ids(mock_generate
         "questions.1.translations.es.buttonText",
     ]
     assert trace_id == "trace-2"
-    assert "__draft_question_1" in mock_generate_structured_output.call_args.kwargs["user_prompt"]
+    assert "__draft_question_1" in mock_generate_via_gateway.call_args.kwargs["user_prompt"]

--- a/products/surveys/backend/translation.py
+++ b/products/surveys/backend/translation.py
@@ -205,7 +205,7 @@ def generate_survey_translation(
             f"Questions: {questions}"
         ),
         response_schema=SurveyTranslationResponse,
-        # `ai_product` and `$ai_billable` now come from the gateway's product config.
+        # `ai_product` and `$ai_billable` come from the gateway's product config.
         posthog_properties={
             "ai_feature": "survey_translation",
             "target_language": target_language,

--- a/products/surveys/backend/translation.py
+++ b/products/surveys/backend/translation.py
@@ -2,9 +2,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from posthog.llm.gateway_client import Product
+
 from products.surveys.backend.llm import generate_structured_output_via_gateway
 
-TRANSLATION_GATEWAY_PRODUCT = "survey_translation"
+TRANSLATION_GATEWAY_PRODUCT: Product = "survey_translation"
 DEFAULT_TRANSLATION_MODEL = "claude-haiku-4-5"
 DRAFT_TRANSLATION_QUESTION_ID_PREFIX = "__draft_question_"
 

--- a/products/surveys/backend/translation.py
+++ b/products/surveys/backend/translation.py
@@ -2,9 +2,10 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from products.surveys.backend.llm import generate_structured_output
+from products.surveys.backend.llm import generate_structured_output_via_gateway
 
-DEFAULT_TRANSLATION_MODEL = "gemini-3.1-flash-lite-preview"
+TRANSLATION_GATEWAY_PRODUCT = "survey_translation"
+DEFAULT_TRANSLATION_MODEL = "claude-haiku-4-5"
 DRAFT_TRANSLATION_QUESTION_ID_PREFIX = "__draft_question_"
 
 
@@ -192,7 +193,8 @@ def generate_survey_translation(
 ) -> tuple[dict[str, dict[str, str]], list[dict[str, Any]], list[str], str]:
     root = _root_source(survey)
     questions = _questions_source(survey)
-    result, trace_id = generate_structured_output(
+    result, trace_id = generate_structured_output_via_gateway(
+        product=TRANSLATION_GATEWAY_PRODUCT,
         model=model,
         system_prompt=SYSTEM_PROMPT,
         user_prompt=(
@@ -201,14 +203,13 @@ def generate_survey_translation(
             f"Questions: {questions}"
         ),
         response_schema=SurveyTranslationResponse,
+        # `ai_product` and `$ai_billable` now come from the gateway's product config.
         posthog_properties={
-            "ai_product": "surveys",
             "ai_feature": "survey_translation",
             "target_language": target_language,
         },
         team_id=team_id,
         distinct_id=distinct_id,
-        billable=True,
     )
 
     translations, question_patches, generated_paths = _filter_existing_fields(

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -1915,7 +1915,10 @@ export interface PatchedSurveySerializerCreateUpdateOnlySchemaApi {
 export type GenerateSurveyTranslationsRequestApiSurvey = { [key: string]: unknown }
 
 export interface GenerateSurveyTranslationsRequestApi {
-    /** Language code to generate translations for, for example pt-BR. */
+    /**
+     * Language code to generate translations for, for example pt-BR.
+     * @maxLength 64
+     */
     target_language: string
     /** Optional override for the source language code. Defaults to the survey's `base_language` (or 'en' if unset). */
     source_language?: string

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -1877,10 +1877,15 @@ export const SurveysDuplicateToProjectsCreateBody = /* @__PURE__ */ zod.object({
     form_content: zod.unknown().optional(),
 })
 
+export const surveysGenerateTranslationsCreateBodyTargetLanguageMax = 64
+
 export const surveysGenerateTranslationsCreateBodyOverwriteDefault = false
 
 export const SurveysGenerateTranslationsCreateBody = /* @__PURE__ */ zod.object({
-    target_language: zod.string().describe('Language code to generate translations for, for example pt-BR.'),
+    target_language: zod
+        .string()
+        .max(surveysGenerateTranslationsCreateBodyTargetLanguageMax)
+        .describe('Language code to generate translations for, for example pt-BR.'),
     source_language: zod
         .string()
         .optional()

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -278,8 +278,8 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         credit_bucket=None,
         requires_server_credential=True,
     ),
-    # Translates survey copy into a target language on demand. Customer-facing and
-    # previously tagged $ai_billable=true client-side, so it keeps billing into AI credits.
+    # Translates survey copy into a target language on demand. Customer-facing, so its
+    # generations bill into AI credits.
     "survey_translation": ProductConfig(
         allowed_application_ids=None,
         allowed_models=frozenset({"claude-haiku-4-5"}),

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -278,6 +278,14 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         credit_bucket=None,
         requires_server_credential=True,
     ),
+    # Translates survey copy into a target language on demand. Customer-facing and
+    # previously tagged $ai_billable=true client-side, so it keeps billing into AI credits.
+    "survey_translation": ProductConfig(
+        allowed_application_ids=None,
+        allowed_models=frozenset({"claude-haiku-4-5"}),
+        allow_api_keys=True,
+        credit_bucket=CreditBucket.AI_CREDITS,
+    ),
 }
 
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -29121,7 +29121,10 @@ export namespace Schemas {
     export type GenerateSurveyTranslationsRequestSurvey = {[key: string]: unknown};
 
     export interface GenerateSurveyTranslationsRequest {
-      /** Language code to generate translations for, for example pt-BR. */
+      /**
+         * Language code to generate translations for, for example pt-BR.
+         * @maxLength 64
+         */
       target_language: string;
       /** Optional override for the source language code. Defaults to the survey's `base_language` (or 'en' if unset). */
       source_language?: string;


### PR DESCRIPTION
## Problem

Survey translation calls Gemini directly using `settings.GEMINI_API_KEY`. That key is per-deployment and is currently invalid in the EU region, so the feature returns 500s for every EU project. Because the call is direct, there is no gateway in the path to absorb a bad key.

Rotating the EU key is tracked separately and is still required for the Gemini call sites that cannot move to Claude.

## Changes

- Add `products/surveys/backend/llm/gateway.py`, a structured-output helper that routes through the internal LLM gateway on `claude-haiku-4-5` and borrows the gateway's provider credentials.
- Register a `survey_translation` gateway product, and add that slug to `POSTHOG_AI_PRODUCTS` and `AI_PRODUCT_MARKUP`. The gateway stamps `ai_product` from the route name, and both billing paths filter on that value, so registering the product without listing the slug would leave the generations tagged billable but never billed.
- Gate the translate endpoint on `LLM_GATEWAY_URL` and `LLM_GATEWAY_API_KEY` instead of `GEMINI_API_KEY`, matching what the call actually needs.
- Bound the call: explicit timeout, one retry rather than the SDK default of two, an output cap, and ASCII-safe header values.

> [!NOTE]
> Three behavior changes ride along. `ai_product` becomes `survey_translation` because the gateway owns that tag. The `project` group on `$ai_generation` resolves to the gateway key owner's team, since the gateway builds groups from its own credential rather than the caller's header. Per-team billing is unaffected, because the usage reporter reads the `team_id` event property, which is still the customer's team. The returned `trace_id` rides the `x-posthog-trace-id` request header. The gateway stamps it as the generation's `$ai_trace_id` once #73017 lands; until then the gateway derives its own id, so rating joins stay exactly as they are today and start working when #73017 deploys.

## How did you test this code?

I (Claude) ran the surveys backend suite, plus ruff and mypy. New tests cover regressions that nothing caught before: a fenced or prose-prefixed JSON reply (Gemini guaranteed bare JSON, `json_object` does not), a schema-violating but syntactically valid reply, a non-ASCII `target_language` reaching an HTTP header, and the config guard rejecting both an empty and a half-set gateway config.

I have not exercised this against a live gateway. Structured output moves from Gemini's provider-enforced `response_json_schema` to `json_object` plus a schema instruction in the prompt, so shape fidelity should get one real call before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed. The public docs for survey AI features name no model or provider.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Opus 4.8) wrote this under my direction. Invoked the repo review, comment-audit, and PR-description skills. The first draft targeted the newer Go ai-gateway; I moved it to the existing Python gateway because that one is already in production for this traffic. Review caught the billing-allowlist gap, the fenced-JSON regression, and three mypy failures, all fixed here. Requires human review.

