### PR TITLE
chore(ci): throwaway playwright quarantine enforcement proof

### DIFF
--- a/.test_quarantine.json
+++ b/.test_quarantine.json
@@ -1,4 +1,65 @@
 {
     "version": 1,
-    "entries": []
+    "entries": [
+        {
+            "id": "playwright/e2e/qmatrix",
+            "runner": "playwright",
+            "reason": "CI proof: directory selector, mode run",
+            "owner": "@rnegron",
+            "issue": "https://github.com/PostHog/posthog/pull/67974",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "playwright/e2e/qmatrix/control.spec.ts",
+            "runner": "jest",
+            "reason": "CI proof: jest-runner entry must be ignored by the playwright adapter",
+            "owner": "@rnegron",
+            "issue": "https://github.com/PostHog/posthog/pull/67974",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "playwright/e2e/qmatrix/control.spec.ts",
+            "runner": "playwright",
+            "reason": "CI proof: file selector, mode run",
+            "owner": "@rnegron",
+            "issue": "https://github.com/PostHog/posthog/pull/67974",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "playwright/e2e/qmatrix/runmode.spec.ts::runmode still executes",
+            "runner": "playwright",
+            "reason": "CI proof: exact name-qualified selector, mode run",
+            "owner": "@rnegron",
+            "issue": "https://github.com/PostHog/posthog/pull/67974",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        },
+        {
+            "id": "playwright/e2e/qmatrix/skipmode.spec.ts::Skip outer",
+            "runner": "playwright",
+            "reason": "CI proof: nested-describe skip via space boundary",
+            "owner": "@rnegron",
+            "issue": "https://github.com/PostHog/posthog/pull/67974",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "skip"
+        },
+        {
+            "id": "product:links",
+            "runner": "playwright",
+            "reason": "CI proof: product selector, mode run",
+            "owner": "@rnegron",
+            "issue": "https://github.com/PostHog/posthog/pull/67974",
+            "added": "2026-07-21",
+            "expires": "2026-08-04",
+            "mode": "run"
+        }
+    ]
 }

--- a/playwright/e2e/qmatrix/control.spec.ts
+++ b/playwright/e2e/qmatrix/control.spec.ts
@@ -1,0 +1,5 @@
+import { expect, test } from '../../utils/playwright-test-core'
+
+test('control fails without quarantine', () => {
+    expect(1).toBe(2)
+})

--- a/playwright/e2e/qmatrix/runmode.spec.ts
+++ b/playwright/e2e/qmatrix/runmode.spec.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs'
+
+import { expect, test } from '../../utils/playwright-test-core'
+
+test('runmode still executes', () => {
+    if (process.env.QMATRIX_MARKER_RUN) {
+        fs.appendFileSync(process.env.QMATRIX_MARKER_RUN, 'executed\n')
+    }
+    expect(1).toBe(2)
+})

--- a/playwright/e2e/qmatrix/skipmode.spec.ts
+++ b/playwright/e2e/qmatrix/skipmode.spec.ts
@@ -1,0 +1,14 @@
+import * as fs from 'fs'
+
+import { expect, test } from '../../utils/playwright-test-core'
+
+test.describe('Skip outer', () => {
+    test.describe('Skip inner', () => {
+        test('fails hard when executed', () => {
+            if (process.env.QMATRIX_MARKER_SKIP) {
+                fs.appendFileSync(process.env.QMATRIX_MARKER_SKIP, 'executed\n')
+            }
+            expect(1).toBe(2)
+        })
+    })
+})

--- a/products/links/frontend/e2e/qmatrix-product.spec.ts
+++ b/products/links/frontend/e2e/qmatrix-product.spec.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs'
+
+import { expect, test } from '@playwright-utils/workspace-test-base'
+
+test('product scope matrix probe', () => {
+    if (process.env.QMATRIX_MARKER_PRODUCT) {
+        fs.appendFileSync(process.env.QMATRIX_MARKER_PRODUCT, 'executed\n')
+    }
+    expect(1).toBe(2)
+})

--- a/tools/playwright_area_map.json
+++ b/tools/playwright_area_map.json
@@ -116,6 +116,10 @@
     "full_suite_only": [
         "playwright/e2e/oauth-mcp-consent.spec.ts",
         "playwright/e2e/preflight.spec.ts",
-        "playwright/e2e/system-status.spec.ts"
+        "playwright/e2e/qmatrix/control.spec.ts",
+        "playwright/e2e/qmatrix/runmode.spec.ts",
+        "playwright/e2e/qmatrix/skipmode.spec.ts",
+        "playwright/e2e/system-status.spec.ts",
+        "products/links/frontend/e2e/qmatrix-product.spec.ts"
     ]
 }


### PR DESCRIPTION
## Problem

- CI-level proof for the [playwright quarantine adapter](https://github.com/PostHog/posthog/pull/67974). **Throwaway - do not merge.**

## Changes

- 4 deliberately failing playwright fixtures (3 under `playwright/e2e/qmatrix/`, 1 under `products/links/frontend/e2e/`); none touch the app.
- 6 CLI-authored `.test_quarantine.json` entries: directory, file, exact name-qualified, nested-describe (mode skip), and `product:` selectors, plus a jest-runner decoy the playwright adapter must ignore.
- Expected: E2E Playwright goes green only because the reporter tolerates the quarantined failures; logs must show 3 tolerated + 1 skipped + status override.

## How did you test this code?

- Local run of the fixtures: 3 tolerated, 1 skipped, exit 0.
- Drafts skip E2E, so the run is forced via workflow_dispatch on this branch.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude, via PostHog Code) authored fixtures + entries; Raúl directed. Validation vehicle only.