### PR TITLE
fix(migrations): resolve custom db_table in staged-drop detection

### DIFF
--- a/posthog/management/migration_analysis/test/test_risk_analyzer.py
+++ b/posthog/management/migration_analysis/test/test_risk_analyzer.py
@@ -8,6 +8,7 @@ from parameterized import parameterized
 from posthog.management.migration_analysis.analyzer import RiskAnalyzer
 from posthog.management.migration_analysis.models import RiskLevel
 from posthog.management.migration_analysis.policies import ConcurrentIndexIdempotencyPolicy, HotTableAlterPolicy
+from posthog.management.migration_analysis.utils import _model_name_for_table
 from posthog.migration_helpers import (
     AddConstraintNotValid,
     AddForeignKeyNotValid,
@@ -1076,6 +1077,88 @@ class TestDropTableValidation:
 
         assert migration_risk.level == RiskLevel.NEEDS_REVIEW
         assert migration_risk.max_score == 2
+
+    def test_drop_column_with_prior_state_removal_custom_db_table(self):
+        # ai_observability's EvaluationConfig model has a legacy custom db_table
+        # ("llm_analytics_evaluationconfig") that the app-label-derived string heuristic can't
+        # resolve; resolving through the app registry must still recognize this as staged.
+        mock_migration = MagicMock()
+        mock_migration.app_label = "ai_observability"
+        mock_migration.name = "0027_drop_trial_eval_limit_column"
+        mock_migration.dependencies = [("ai_observability", "0026_remove_trial_eval_limit_from_state")]
+
+        drop_op = create_mock_operation(
+            migrations.RunSQL,
+            sql="ALTER TABLE llm_analytics_evaluationconfig DROP COLUMN IF EXISTS trial_eval_limit;",
+        )
+        mock_migration.operations = [drop_op]
+
+        parent_migration = MagicMock()
+        parent_migration.app_label = "ai_observability"
+        parent_migration.name = "0026_remove_trial_eval_limit_from_state"
+
+        remove_field_op = create_mock_operation(
+            migrations.RemoveField, model_name="evaluationconfig", name="trial_eval_limit"
+        )
+        separate_op = create_mock_operation(
+            migrations.SeparateDatabaseAndState,
+            state_operations=[remove_field_op],
+            database_operations=[],
+        )
+        parent_migration.operations = [separate_op]
+
+        mock_loader = MagicMock()
+        mock_loader.disk_migrations = {
+            ("ai_observability", "0026_remove_trial_eval_limit_from_state"): parent_migration,
+            ("ai_observability", "0027_drop_trial_eval_limit_column"): mock_migration,
+        }
+
+        migration_risk = self.analyzer.analyze_migration_with_context(
+            mock_migration, "ai_observability/migrations/0027_drop_trial_eval_limit_column.py", mock_loader
+        )
+
+        assert migration_risk.level == RiskLevel.NEEDS_REVIEW
+        assert migration_risk.max_score == 2
+
+    def test_drop_column_custom_db_table_without_prior_state_removal(self):
+        # Same custom-db_table table as above, but with no prior state removal - must still block.
+        mock_migration = MagicMock()
+        mock_migration.app_label = "ai_observability"
+        mock_migration.name = "0027_drop_trial_eval_limit_column"
+        mock_migration.dependencies = [("ai_observability", "0026_unrelated")]
+
+        drop_op = create_mock_operation(
+            migrations.RunSQL,
+            sql="ALTER TABLE llm_analytics_evaluationconfig DROP COLUMN IF EXISTS trial_eval_limit;",
+        )
+        mock_migration.operations = [drop_op]
+
+        parent_migration = MagicMock()
+        parent_migration.app_label = "ai_observability"
+        parent_migration.name = "0026_unrelated"
+        parent_migration.operations = []
+
+        mock_loader = MagicMock()
+        mock_loader.disk_migrations = {
+            ("ai_observability", "0026_unrelated"): parent_migration,
+            ("ai_observability", "0027_drop_trial_eval_limit_column"): mock_migration,
+        }
+
+        migration_risk = self.analyzer.analyze_migration_with_context(
+            mock_migration, "ai_observability/migrations/0027_drop_trial_eval_limit_column.py", mock_loader
+        )
+
+        assert migration_risk.level == RiskLevel.BLOCKED
+        assert migration_risk.max_score == 5
+        assert migration_risk.operations[0].reason == "DROP COLUMN - no prior state removal found"
+
+
+class TestModelNameForTable:
+    def test_returns_none_for_unknown_app_label(self):
+        assert _model_name_for_table("not_a_real_app", "whatever_table") is None
+
+    def test_returns_none_for_table_no_model_owns(self):
+        assert _model_name_for_table("ai_observability", "not_a_real_table") is None
 
 
 class TestRunPythonOperations:

--- a/posthog/management/migration_analysis/utils.py
+++ b/posthog/management/migration_analysis/utils.py
@@ -3,6 +3,8 @@
 import re
 from typing import TYPE_CHECKING, Any, Optional
 
+from django.apps import apps
+
 if TYPE_CHECKING:
     from posthog.management.migration_analysis.models import OperationRisk
 
@@ -171,7 +173,7 @@ def check_drop_properly_staged(
     # posthog_namedquery -> NamedQuery
     # llm_analytics_evaluation (app=llm_analytics) -> Evaluation
     app_label = getattr(migration, "app_label", None)
-    model_name = _extract_model_name_from_table(table_name, app_label)
+    model_name = _model_name_for_table(app_label, table_name) or _extract_model_name_from_table(table_name, app_label)
     if not model_name:
         return False
 
@@ -205,6 +207,23 @@ def check_drop_properly_staged(
             to_check.extend(parent_migration.dependencies)
 
     return False
+
+
+def _model_name_for_table(app_label: Optional[str], table_name: str) -> Optional[str]:
+    """Resolve the model whose db_table matches via the app registry. Handles custom db_table
+    names the string heuristic can't (e.g. legacy llm_analytics_* tables owned by the
+    ai_observability app). Returns None for models no longer in the registry (deleted models);
+    callers fall back to the string heuristic."""
+    if not app_label:
+        return None
+    try:
+        app_config = apps.get_app_config(app_label)
+    except LookupError:
+        return None
+    for model in app_config.get_models():
+        if model._meta.db_table == table_name:
+            return model.__name__
+    return None
 
 
 def _extract_model_name_from_table(table_name: str, app_label: Optional[str] = None) -> Optional[str]:


### PR DESCRIPTION
## Problem

The migration risk analyzer's staged-drop check maps a table name to its model by string-parsing the table name against the app label. Apps whose models keep a legacy custom db_table break it: ai_observability models live in `llm_analytics_*` tables, so the check derives a nonexistent model name, never finds the prior `SeparateDatabaseAndState` state removal, and blocks a correctly staged `DROP COLUMN` in CI.

## Changes

- `check_drop_properly_staged` now resolves the model through the app registry first (match on `model._meta.db_table`), keeping the string heuristic as fallback for models that no longer exist in the registry (staged `DROP TABLE` of deleted models).

## How did you test this code?

Four new tests in `test_risk_analyzer.py`: a real custom-db_table staged drop is recognized (score 2, not blocked), the same drop without prior state removal is still blocked (guard not weakened), and both `None` branches of the new resolver keep the fallback reachable. Full analyzer suite: 177 passed. ruff clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, internal tooling behavior fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this, Claude (Claude Code) implemented it TDD-first. Found while preparing the stacked follow-up that physically drops the retired trial-eval columns: its `DROP COLUMN` migration was falsely blocked by this bug. Base of a 2-PR stack, kept standalone so devex can review the analyzer change in isolation.
