### PR TITLE
fix(cohorts): move staff tools URL to /feature_flags/staff/cohorts

### DIFF
--- a/frontend/src/lib/utils/kea-router.test.ts
+++ b/frontend/src/lib/utils/kea-router.test.ts
@@ -29,6 +29,10 @@ describe('router-utils', () => {
         const altered = addProjectIdIfMissing('/feature_flags/123', 123)
         expect(altered).toEqual('/project/123/feature_flags/123')
     })
+    it('does not redirect the cohorts staff tools URL nested under feature flags staff', () => {
+        const altered = addProjectIdIfMissing('/feature_flags/staff/cohorts', 123)
+        expect(altered).toEqual('/feature_flags/staff/cohorts')
+    })
 
     describe('relative path normalization', () => {
         it('normalizes ../ prefix to absolute path with project id', () => {

--- a/frontend/src/lib/utils/kea-router.ts
+++ b/frontend/src/lib/utils/kea-router.ts
@@ -22,6 +22,9 @@ const pathsWithoutProjectId = [
 
 // Instance-level pages that live under a product's own path prefix rather than
 // under `/instance/*`, so they need an exact (rather than first-segment) exemption.
+// The startsWith(exactPath + '/') check below also exempts nested staff tools from
+// other products, e.g. the cohorts staff tools at /feature_flags/staff/cohorts —
+// renaming this path affects them too.
 const exactPathsWithoutProjectId = ['/feature_flags/staff']
 
 const projectIdentifierInUrlRegex = /^\/project\/(\d+|phc_)/

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -91,7 +91,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/business-knowledge': ['BusinessKnowledge', 'businessKnowledge'],
     '/transformations': ['Transformations', 'transformations'],
     '/event-filtering': ['EventFiltering', 'eventFiltering'],
-    '/cohorts/staff': ['CohortsStaffTools', 'cohortsStaffTools'],
+    '/feature_flags/staff/cohorts': ['CohortsStaffTools', 'cohortsStaffTools'],
     '/support/tickets': ['SupportTickets', 'supportTickets'],
     '/support/tickets/:ticketId': ['SupportTicketDetail', 'supportTicketDetail'],
     '/support/settings': ['SupportSettings', 'supportSettings'],
@@ -949,7 +949,8 @@ export const productUrls = {
     cohort: (id: string | number): string => `/cohorts/${id}`,
     cohorts: (): string => '/cohorts',
     cohortCalculationHistory: (id: string | number): string => `/cohorts/${id}/calculation-history`,
-    cohortsStaffTools: (cohortId?: number): string => `/cohorts/staff${cohortId ? `?cohort_id=${cohortId}` : ''}`,
+    cohortsStaffTools: (cohortId?: number): string =>
+        `/feature_flags/staff/cohorts${cohortId ? `?cohort_id=${cohortId}` : ''}`,
     supportDashboard: (): string => '/support',
     supportTickets: (): string => '/support/tickets',
     supportTicketDetail: (ticketId: string | number): string => `/support/tickets/${ticketId}`,

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -831,8 +831,6 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.groupsNew(':groupTypeIndex')]: [Scene.GroupsNew, 'groupsNew'],
     [urls.group(':groupTypeIndex', ':groupKey', false)]: [Scene.Group, 'group'],
     [urls.group(':groupTypeIndex', ':groupKey', false, ':groupTab')]: [Scene.Group, 'groupWithTab'],
-    // Must precede the cohort detail route, or /cohorts/staff resolves as cohort id "staff".
-    [urls.cohortsStaffTools()]: ['CohortsStaffTools' as Scene, 'cohortsStaffTools'],
     [urls.cohort(':id')]: [Scene.Cohort, 'cohort'],
     [urls.cohortCalculationHistory(':id')]: [Scene.CohortCalculationHistory, 'cohortCalculationHistory'],
     [urls.cohorts()]: [Scene.Cohorts, 'cohorts'],
@@ -853,6 +851,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.featureFlags()]: [Scene.FeatureFlags, 'featureFlags'],
     [urls.featureFlagTemplates()]: ['FeatureFlagTemplates' as Scene, 'featureFlagTemplates'],
     [urls.featureFlagsStaffTools()]: ['FeatureFlagsStaffTools' as Scene, 'featureFlagsStaffTools'],
+    [urls.cohortsStaffTools()]: ['CohortsStaffTools' as Scene, 'cohortsStaffTools'],
     [urls.featureFlag(':id')]: [Scene.FeatureFlag, 'featureFlag'],
     [urls.annotations()]: [Scene.DataManagement, 'annotations'],
     [urls.annotation(':id')]: [Scene.DataManagement, 'annotation'],

--- a/products/cohorts/frontend/staff/cohortsStaffToolsLogic.test.ts
+++ b/products/cohorts/frontend/staff/cohortsStaffToolsLogic.test.ts
@@ -46,7 +46,7 @@ describe('cohortsStaffToolsLogic', () => {
         })
 
         it('seeds the input and looks up the cohort from a deep link', async () => {
-            router.actions.push('/cohorts/staff?cohort_id=123')
+            router.actions.push('/feature_flags/staff/cohorts?cohort_id=123')
             await expectLogic(logic).toDispatchActions([
                 'seedCohortFromDeepLink',
                 'lookUpCohorts',
@@ -56,21 +56,21 @@ describe('cohortsStaffToolsLogic', () => {
         })
 
         it('does not clobber a manual edit when the URL is revisited with the same cohort id', async () => {
-            router.actions.push('/cohorts/staff?cohort_id=123')
+            router.actions.push('/feature_flags/staff/cohorts?cohort_id=123')
             await expectLogic(logic).toDispatchActions(['seedCohortFromDeepLink'])
 
             logic.actions.setCohortIdsInput('456')
             // Simulates urlToAction re-running for the same URL, e.g. browser back/forward.
-            router.actions.push('/cohorts/staff?cohort_id=123')
+            router.actions.push('/feature_flags/staff/cohorts?cohort_id=123')
 
             expectLogic(logic).toMatchValues({ cohortIdsInput: '456' })
         })
 
         it('re-seeds when a different cohort id is deep-linked while already seeded', async () => {
-            router.actions.push('/cohorts/staff?cohort_id=123')
+            router.actions.push('/feature_flags/staff/cohorts?cohort_id=123')
             await expectLogic(logic).toDispatchActions(['seedCohortFromDeepLink'])
 
-            router.actions.push('/cohorts/staff?cohort_id=456')
+            router.actions.push('/feature_flags/staff/cohorts?cohort_id=456')
             await expectLogic(logic).toDispatchActions(['seedCohortFromDeepLink'])
 
             expectLogic(logic).toMatchValues({ cohortIdsInput: '456' })

--- a/products/cohorts/frontend/staff/cohortsStaffToolsLogic.ts
+++ b/products/cohorts/frontend/staff/cohortsStaffToolsLogic.ts
@@ -253,7 +253,7 @@ export const cohortsStaffToolsLogic = kea<cohortsStaffToolsLogicType>([
         }
     }),
     urlToAction(({ actions, values }) => ({
-        '/cohorts/staff': (_, searchParams) => {
+        '/feature_flags/staff/cohorts': (_, searchParams) => {
             // Deep link (e.g. from a support ticket): seed the lookup with the cohort id.
             const cohortId = searchParams.cohort_id ? Number(searchParams.cohort_id) : null
             if (cohortId && cohortId !== values.lastSeededCohortId) {

--- a/products/cohorts/manifest.tsx
+++ b/products/cohorts/manifest.tsx
@@ -14,13 +14,14 @@ export const manifest: ProductManifest = {
         },
     },
     routes: {
-        '/cohorts/staff': ['CohortsStaffTools', 'cohortsStaffTools'],
+        '/feature_flags/staff/cohorts': ['CohortsStaffTools', 'cohortsStaffTools'],
     },
     urls: {
         cohort: (id: string | number): string => `/cohorts/${id}`,
         cohorts: (): string => '/cohorts',
         cohortCalculationHistory: (id: string | number): string => `/cohorts/${id}/calculation-history`,
-        cohortsStaffTools: (cohortId?: number): string => `/cohorts/staff${cohortId ? `?cohort_id=${cohortId}` : ''}`,
+        cohortsStaffTools: (cohortId?: number): string =>
+            `/feature_flags/staff/cohorts${cohortId ? `?cohort_id=${cohortId}` : ''}`,
     },
     fileSystemTypes: {
         cohort: {


### PR DESCRIPTION
## Problem

Cohort staff tools lived at `/cohorts/staff`, but the router's project-id exemption list only exempts `/feature_flags/staff` as an exact path. Since `/cohorts/staff` doesn't match that prefix, `addProjectIdIfMissing` rewrote it to `/project/<id>/cohorts/staff`, breaking deep links like the ones we send from support tickets.

## Changes

- Moved the cohorts staff tools route from `/cohorts/staff` to `/feature_flags/staff/cohorts`, nesting it under the already-exempted `/feature_flags/staff` prefix so it inherits the exemption instead of needing its own entry.
- Updated `productUrls.cohortsStaffTools()`, the route registration in `manifest.tsx`, and the `urlToAction` binding in `cohortsStaffToolsLogic.ts` to match.
- Reordered the route in `scenes.ts`: it no longer needs to precede the `/cohorts/:id` route since it's no longer nested under `/cohorts`.
- Added a comment on `exactPathsWithoutProjectId` in `kea-router.ts` calling out that the prefix match also covers nested staff tools from other products.

## How did you test this code?

Added a test in `kea-router.test.ts` confirming `/feature_flags/staff/cohorts` isn't rewritten with a project id, and updated the deep-link paths in `cohortsStaffToolsLogic.test.ts` to the new URL.

Ran both suites locally: `hogli test frontend/src/lib/utils/kea-router.test.ts products/cohorts/frontend/staff/cohortsStaffToolsLogic.test.ts` (36 tests passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, this is an internal staff-tools routing fix.