### PR TITLE
refactor(oauth-proxy): introduce reusable request validators

### DIFF
--- a/services/oauth-proxy/src/handlers/authorize.ts
+++ b/services/oauth-proxy/src/handlers/authorize.ts
@@ -1,5 +1,6 @@
 import { type Region, baseUrlForRegion } from '@/lib/constants'
 import { type ClientMapping, getClientMapping, putCallbackRedirectUri, putRegionSelection } from '@/lib/kv'
+import { type ValidationError, errorResponse } from '@/lib/validation'
 
 import REGION_PICKER_HTML from '../static/region-picker.html'
 
@@ -12,26 +13,17 @@ const REGION_PICKER_HEADERS: Record<string, string> = {
     'Referrer-Policy': 'no-referrer',
 }
 
-// OAuth request parameters MUST NOT be included more than once (RFC 6749 §3.1).
-// We enforce it because the proxy reads these with `.get()` (first value) for KV
-// keying but forwards the last value to the regional server via `.set()`. A
-// duplicated `state` splits those two reads, letting an attacker route a victim's
-// callback to a preloaded redirect URI. `resource` (RFC 8707) is intentionally
-// excluded — it is allowed to repeat.
-const SINGLE_VALUED_PARAMS = [
-    'state',
-    'client_id',
-    'redirect_uri',
-    'response_type',
-    'scope',
-    'code_challenge',
-    'code_challenge_method',
-] as const
-
-function findDuplicatedParam(url: URL): string | null {
-    for (const param of SINGLE_VALUED_PARAMS) {
-        if (url.searchParams.getAll(param).length > 1) {
-            return param
+// Prevent open redirects: for clients registered through the proxy (which have
+// stored redirect_uris), the requested redirect_uri must be one of them. Legacy
+// clients without stored redirect_uris fall through to regional server validation.
+function validateRegisteredRedirectUri(
+    redirectUri: string | null,
+    mapping: ClientMapping | null
+): ValidationError | null {
+    if (mapping?.redirect_uris && redirectUri && !mapping.redirect_uris.includes(redirectUri)) {
+        return {
+            error: 'invalid_request',
+            error_description: 'redirect_uri is not registered for this client',
         }
     }
     return null
@@ -48,17 +40,6 @@ function findDuplicatedParam(url: URL): string | null {
  */
 export async function handleAuthorize(request: Request, kv: KVNamespace): Promise<Response> {
     const url = new URL(request.url)
-
-    const duplicatedParam = findDuplicatedParam(url)
-    if (duplicatedParam) {
-        return new Response(
-            JSON.stringify({
-                error: 'invalid_request',
-                error_description: `Duplicate ${duplicatedParam} parameter is not allowed`,
-            }),
-            { status: 400, headers: { 'Content-Type': 'application/json' } }
-        )
-    }
 
     // If region is already selected (via query param from the picker page),
     // redirect to the regional authorize endpoint
@@ -86,18 +67,9 @@ async function redirectToRegionalAuthorize(url: URL, region: Region, kv: KVNames
         }
     }
 
-    // Validate redirect_uri against registered URIs to prevent open redirects.
-    // Only enforced for clients registered through the proxy (which have stored redirect_uris).
-    if (mapping?.redirect_uris && originalRedirectUri) {
-        if (!mapping.redirect_uris.includes(originalRedirectUri)) {
-            return new Response(
-                JSON.stringify({
-                    error: 'invalid_request',
-                    error_description: 'redirect_uri is not registered for this client',
-                }),
-                { status: 400, headers: { 'Content-Type': 'application/json' } }
-            )
-        }
+    const redirectUriError = validateRegisteredRedirectUri(originalRedirectUri, mapping)
+    if (redirectUriError) {
+        return errorResponse(redirectUriError)
     }
 
     // Store region selection keyed by both state and client_id.

--- a/services/oauth-proxy/src/handlers/passthrough.ts
+++ b/services/oauth-proxy/src/handlers/passthrough.ts
@@ -1,6 +1,7 @@
 import { POSTHOG_EU_BASE_URL, POSTHOG_US_BASE_URL } from '@/lib/constants'
 import { getClientMapping, getRegionSelection } from '@/lib/kv'
 import { proxyPostWithClientId, proxyToRegion, tryBothRegions } from '@/lib/proxy'
+import { errorResponse } from '@/lib/validation'
 
 /**
  * Passthrough handlers for OAuth endpoints that simply need to reach the correct region.
@@ -79,10 +80,7 @@ async function routeByClientId(request: Request, kv: KVNamespace, path: string):
             const json = JSON.parse(body) as Record<string, unknown>
             clientId = (json.client_id as string) || null
         } catch {
-            return new Response(
-                JSON.stringify({ error: 'invalid_request', error_description: 'Malformed JSON body' }),
-                { status: 400, headers: { 'Content-Type': 'application/json' } }
-            )
+            return errorResponse({ error: 'invalid_request', error_description: 'Malformed JSON body' })
         }
     } else {
         const params = new URLSearchParams(body)

--- a/services/oauth-proxy/src/handlers/token.ts
+++ b/services/oauth-proxy/src/handlers/token.ts
@@ -7,6 +7,7 @@ import {
     resolveMappingRewrite,
 } from '@/lib/kv'
 import { proxyPostWithClientId, tryBothRegions } from '@/lib/proxy'
+import { errorResponse } from '@/lib/validation'
 
 /**
  * OAuth Token Exchange — proxy to the correct region.
@@ -29,9 +30,9 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
             clientId = (json.client_id as string) || null
             grantType = (json.grant_type as string) || null
         } catch {
-            return new Response(
-                JSON.stringify({ error: 'invalid_request', error_description: 'Malformed JSON body' }),
-                { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
+            return errorResponse(
+                { error: 'invalid_request', error_description: 'Malformed JSON body' },
+                { 'Cache-Control': 'no-store' }
             )
         }
     } else {

--- a/services/oauth-proxy/src/index.ts
+++ b/services/oauth-proxy/src/index.ts
@@ -13,6 +13,7 @@ import { handleMetadata } from '@/handlers/metadata'
 import { handleIntrospect, handleJwks, handleRevoke, handleUserInfo } from '@/handlers/passthrough'
 import { handleRegister } from '@/handlers/register'
 import { handleToken } from '@/handlers/token'
+import { type Validator, errorResponse, noDuplicateParams, runValidators } from '@/lib/validation'
 
 export interface Env {
     AUTH_KV: KVNamespace
@@ -23,6 +24,7 @@ type Handler = (request: Request, kv: KVNamespace) => Response | Promise<Respons
 interface Route {
     paths: string[]
     method?: string
+    validators?: Validator[]
     handler: Handler
 }
 
@@ -46,6 +48,21 @@ const routes: Route[] = [
     },
     {
         paths: ['/oauth/authorize', '/authorize'],
+        // The proxy reads these with `.get()` (first value) for KV keying but forwards
+        // the last value downstream via `.set()`; a duplicate would split those reads
+        // and let an attacker route a victim's callback to a preloaded redirect URI.
+        // `resource` (RFC 8707) is intentionally excluded — it is allowed to repeat.
+        validators: [
+            noDuplicateParams(
+                'state',
+                'client_id',
+                'redirect_uri',
+                'response_type',
+                'scope',
+                'code_challenge',
+                'code_challenge_method'
+            ),
+        ],
         handler: handleAuthorize,
     },
     {
@@ -84,6 +101,12 @@ export default {
                     continue
                 }
                 if (route.paths.some((p) => normalizePath(p) === normalized)) {
+                    if (route.validators) {
+                        const validationError = runValidators(route.validators, request, url)
+                        if (validationError) {
+                            return errorResponse(validationError)
+                        }
+                    }
                     return await route.handler(request, env.AUTH_KV)
                 }
             }

--- a/services/oauth-proxy/src/lib/validation.ts
+++ b/services/oauth-proxy/src/lib/validation.ts
@@ -1,0 +1,57 @@
+/**
+ * Request validation primitives.
+ *
+ * A `Validator` is a pure function of the request that returns a `ValidationError`
+ * when a rule is broken, or `null` when it passes. Routes declare validators in
+ * `index.ts` and the router runs them before the handler, so request-shape rules
+ * live in one place instead of being smeared across controllers.
+ *
+ * Validators are intentionally synchronous and stateless. Rules that need I/O
+ * (e.g. checking a value against a stored KV mapping) stay in the handler, which
+ * can still reuse `ValidationError` + `errorResponse` for a consistent 400.
+ */
+
+export interface ValidationError {
+    error: string
+    error_description: string
+}
+
+export type Validator = (request: Request, url: URL) => ValidationError | null
+
+/** Render a `ValidationError` as an OAuth-style 400 JSON response. */
+export function errorResponse(error: ValidationError, extraHeaders: Record<string, string> = {}): Response {
+    return new Response(JSON.stringify(error), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', ...extraHeaders },
+    })
+}
+
+/** Run validators in order, returning the first failure (or `null` if all pass). */
+export function runValidators(validators: Validator[], request: Request, url: URL): ValidationError | null {
+    for (const validate of validators) {
+        const error = validate(request, url)
+        if (error) {
+            return error
+        }
+    }
+    return null
+}
+
+/**
+ * Rejects a request that repeats any of the named query params.
+ *
+ * OAuth request parameters MUST NOT be included more than once (RFC 6749 §3.1).
+ */
+export function noDuplicateParams(...params: string[]): Validator {
+    return (_request, url) => {
+        for (const param of params) {
+            if (url.searchParams.getAll(param).length > 1) {
+                return {
+                    error: 'invalid_request',
+                    error_description: `Duplicate ${param} parameter is not allowed`,
+                }
+            }
+        }
+        return null
+    }
+}

--- a/services/oauth-proxy/tests/authorize.test.ts
+++ b/services/oauth-proxy/tests/authorize.test.ts
@@ -202,28 +202,6 @@ describe('handleAuthorize', () => {
         expect(callbackPuts).toHaveLength(0)
     })
 
-    it.each([
-        'state',
-        'client_id',
-        'redirect_uri',
-        'response_type',
-        'scope',
-        'code_challenge',
-        'code_challenge_method',
-    ])('rejects duplicate %s to prevent parameter-pollution code theft', async (param) => {
-        const request = new Request(
-            `https://oauth.posthog.com/oauth/authorize/?client_id=abc&response_type=code&${param}=first&${param}=second&_region=us`
-        )
-        const response = await handleAuthorize(request, mockKV)
-
-        expect(response.status).toBe(400)
-        const data = (await response.json()) as Record<string, unknown>
-        expect(data.error).toBe('invalid_request')
-        expect(data.error_description).toBe(`Duplicate ${param} parameter is not allowed`)
-        // Nothing gets keyed in KV when the request is rejected up front.
-        expect(vi.mocked(mockKV.put)).not.toHaveBeenCalled()
-    })
-
     it('sets security and cache headers on region picker page', async () => {
         const request = new Request('https://oauth.posthog.com/oauth/authorize/?client_id=abc&response_type=code')
         const response = await handleAuthorize(request, mockKV)

--- a/services/oauth-proxy/tests/router.test.ts
+++ b/services/oauth-proxy/tests/router.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import worker from '@/index'
 
+import { createMockKV } from './helpers'
+
 const mockEnv = {
     AUTH_KV: {} as KVNamespace,
 }
@@ -47,6 +49,29 @@ describe('router', () => {
         const response = await worker.fetch(request, mockEnv)
         expect(response.status).toBe(expectedStatus)
         expect(response.headers.get('content-type')).toContain(expectedContentType)
+    })
+
+    it.each([
+        'state',
+        'client_id',
+        'redirect_uri',
+        'response_type',
+        'scope',
+        'code_challenge',
+        'code_challenge_method',
+    ])('rejects duplicate %s on /oauth/authorize before the handler runs', async (param) => {
+        const kv = createMockKV()
+        const request = new Request(
+            `https://oauth.posthog.com/oauth/authorize/?client_id=abc&response_type=code&${param}=first&${param}=second&_region=us`
+        )
+        const response = await worker.fetch(request, { AUTH_KV: kv })
+
+        expect(response.status).toBe(400)
+        const data = (await response.json()) as Record<string, unknown>
+        expect(data.error).toBe('invalid_request')
+        expect(data.error_description).toBe(`Duplicate ${param} parameter is not allowed`)
+        // Rejected at the router before the handler, so nothing is keyed in KV.
+        expect(vi.mocked(kv.put)).not.toHaveBeenCalled()
     })
 
     it('returns 404 for unknown paths', async () => {


### PR DESCRIPTION
## Problem

Fernando left a review nit on #72655: the OAuth authorize handler enforced its rules inline, mixed with control flow. The duplicate-param check and the redirect_uri registration check were hand-built 400s smeared across `handleAuthorize` and `redirectToRegionalAuthorize`, and every handler that rejects a bad request rolled its own `error/error_description` response. There was no shared notion of "validate the request", so adding a new rule meant more bespoke branching inside a controller.

Stacked on top of #72655.

## Changes

Introduce a small validator primitive in `services/oauth-proxy/src/lib/validation.ts`:

- `ValidationError` — the `{ error, error_description }` shape.
- `Validator = (request, url) => ValidationError | null` — a pure, stateless rule.
- `errorResponse(error, extraHeaders?)` — renders a `ValidationError` as an OAuth-style 400.
- `runValidators(...)` — runs a list in order, returning the first failure.
- `noDuplicateParams(...names)` — a factory; building a new rule is one small function.

Routes declare `validators` and the router runs them before the handler, so request-shape rules live in one place. The `/oauth/authorize` route now declares `noDuplicateParams(...)` instead of the check living inside the handler. The stateful redirect_uri check (needs a KV mapping lookup) stays in the handler but is re-expressed as a local validator reusing the same `ValidationError` + `errorResponse`, showing the concept works at both the router and handler tiers. The malformed-JSON 400s in `token` and `passthrough` now go through `errorResponse` too.

Behavior is unchanged: same status codes, same error bodies, same headers.

> [!NOTE]
> This is a pure refactor on a security-sensitive OAuth path. No request is accepted or rejected differently than before.

### Why not move everything into the validator layer

The router layer only fits rules that are **stateless** (decidable from `request` + `url` alone) and **pure rejection** (the handler doesn't need the checked value afterward). I audited every 400/error path in the proxy against that bar:

| Check | Location | Moved to router layer? |
|---|---|---|
| Duplicate params | authorize | ✅ yes |
| `redirect_uri` registered | authorize | ❌ stateful (KV mapping) — stays in handler, reuses `errorResponse` |
| Malformed JSON body | token, passthrough | ❌ needs the parsed body the handler also uses — stays in handler, reuses `errorResponse` |
| "Unable to determine region" | token, proxy | ❌ stateful (KV / network outcome), not request validation |
| Metadata upstream failure (502) | metadata | ❌ network failure, not a 400 |
| Missing `state` | callback | ❌ borderline, left in handler (see below) |
| Expired/unknown `state` | callback | ❌ stateful (KV) — stays in handler |

The duplicate-param check was the only pure-rejection rule, so it's the only one hoisted. Everything else is stateful and correctly stays where the state lives; the JSON ones already share `errorResponse` for consistent rendering.

callback's missing-`state` check is the one borderline case. It looks hoistable (it's stateless), but it's a poorer fit than duplicate-params for two reasons, so I left it in the handler:

1. **The handler consumes the value.** Right after the check, `getCallbackRedirectUri(kv, state)` needs `state: string`. These validators are reject-only — they don't thread a narrowed value back to the handler — so hoisting would force an unsafe cast or a duplicated guard. Duplicate-params had no such downstream dependency, which is why it hoisted cleanly.
2. **Different error contract.** callback returns plain-text 400s while the validator layer emits OAuth JSON; moving only the presence check would leave callback's two adjacent 400s in two different formats.

## How did you test this code?

`pnpm test run` (47 pass), `pnpm typecheck`, `oxfmt --check`, and `oxlint` all green in `services/oauth-proxy`. I (Claude) did not do manual browser testing.

The duplicate-param `it.each` moved from `authorize.test.ts` to `router.test.ts` because the check now runs at the router, not in `handleAuthorize`. It exercises the real `fetch` → validator → 400 path and asserts rejection happens before any KV write — the same parameter-pollution regression the original test caught, at the layer where the behavior now lives. No new test surface; it's a relocation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafael asked whether Fernando's "create a validator, decouple from the controller" nit could be generalized into a reusable validator concept used across the oauth-proxy handlers, and whether a framework would help. I (Claude) checked the service first: it's a dependency-free Cloudflare Worker with a hand-rolled router and no validation lib. I laid out options (adopt Hono + zod, add zod only, a homegrown primitive, or a local extraction) and we chose the homegrown primitive to keep the worker's zero-runtime-dep supply chain intact on a security-sensitive path. A key design decision: only stateless, pure-rejection rules hoist to the router; stateful checks that need KV stay in the handler but reuse the same `ValidationError`/`errorResponse`, so the concept unifies error rendering without forcing a spurious KV read on the region-picker path.

Rafael then asked whether any other validation could move to the router layer. I audited every handler (table above) and we agreed the pattern is already applied everywhere it genuinely fits — callback's `state` check is the one borderline candidate, deliberately left in the handler because it feeds a value the handler consumes and callback uses a plain-text error contract. Nothing else moved.

Skills invoked: `/writing-tests` (gated the test relocation — confirmed it's a move, not new bloat).
