### PR TITLE
feat(ai): surface event description on read_taxonomy properties path

### DIFF
--- a/ee/hogai/tools/read_taxonomy/core.py
+++ b/ee/hogai/tools/read_taxonomy/core.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 from posthog.models import Team, User
 
 from ee.hogai.chat_agent.query_planner.toolkit import TaxonomyAgentToolkit
-from ee.hogai.utils.helpers import format_events_yaml
+from ee.hogai.utils.helpers import format_events_yaml, get_event_description
 
 
 class ReadEvents(BaseModel):
@@ -17,7 +17,7 @@ class ReadEvents(BaseModel):
 
 
 class ReadEventProperties(BaseModel):
-    """Returns the properties list for a provided event. Before calling this tool, ensure the event exists by reading events."""
+    """Returns the description (if one is set) and properties list for a provided event. Before calling this tool, ensure the event exists by reading events."""
 
     kind: Literal["event_properties"] = "event_properties"
     event_name: str = Field(description="The name of the event that you want to retrieve properties for.")
@@ -105,7 +105,9 @@ def execute_taxonomy_query(query: ReadTaxonomyQuery, toolkit: TaxonomyAgentToolk
             return format_events_yaml([], team, user, limit=query.limit, offset=query.offset)
         case ReadEventProperties():
             result = toolkit.retrieve_event_or_action_properties(query.event_name)
-            return f"{result}\n\n{DYNAMIC_EVENT_PROPERTIES_HINT}"
+            description = get_event_description(team, query.event_name)
+            prefix = f"Description of `{query.event_name}`: {description}\n\n" if description else ""
+            return f"{prefix}{result}\n\n{DYNAMIC_EVENT_PROPERTIES_HINT}"
         case ReadEventSamplePropertyValues():
             return toolkit.retrieve_event_or_action_property_values(query.event_name, query.property_name)
         case ReadActionProperties():

--- a/ee/hogai/tools/read_taxonomy/test/test_tool.py
+++ b/ee/hogai/tools/read_taxonomy/test/test_tool.py
@@ -19,6 +19,7 @@ from ee.hogai.tools.read_taxonomy.core import (
 from ee.hogai.tools.read_taxonomy.tool import ReadTaxonomyTool
 from ee.hogai.utils.types import AssistantState
 from ee.hogai.utils.types.base import NodePath
+from ee.models.event_definition import EnterpriseEventDefinition
 
 
 class TestReadTaxonomyTool(NonAtomicBaseTest):
@@ -141,3 +142,32 @@ class TestReadTaxonomyTool(NonAtomicBaseTest):
 
         self.assertIn(DYNAMIC_EVENT_PROPERTIES_HINT, result)
         self.assertIn("$feature/{flag_key}", result)
+
+    @parameterized.expand(
+        [
+            ("with_description", "Fired when a user retakes a quiz", True),
+            ("without_description", None, False),
+        ]
+    )
+    @patch("ee.hogai.tools.read_taxonomy.core.TaxonomyAgentToolkit")
+    def test_event_properties_surface_stored_event_description(
+        self, _name, stored_description, expect_prefix, mock_toolkit_class
+    ):
+        # Guards the single-event path surfacing a custom event's own description: without it the
+        # agent only sees the property list and wrongly concludes no description exists.
+        mock_toolkit = mock_toolkit_class.return_value
+        mock_toolkit.retrieve_event_or_action_properties.return_value = "- mixer_session_id\n- is_autoplay"
+        if stored_description is not None:
+            EnterpriseEventDefinition.objects.create(
+                team=self.team, name="quiz_retaken", description=stored_description
+            )
+
+        result = execute_taxonomy_query(
+            ReadEventProperties(event_name="quiz_retaken"), mock_toolkit, self.team, self.user
+        )
+
+        if expect_prefix:
+            self.assertIn(f"Description of `quiz_retaken`: {stored_description}", result)
+        else:
+            self.assertNotIn("Description of `quiz_retaken`", result)
+        self.assertIn("mixer_session_id", result)

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -245,12 +245,8 @@ def _process_events_data(
                 event_core_definition.get("system") or event_core_definition.get("ignored_in_assistant")
             ):
                 continue  # Skip irrelevant events but keep events the user has added to the context
-            if description := event_core_definition.get("description"):
-                if label := event_core_definition.get("label_llm") or event_core_definition.get("label"):
-                    event_data["description"] = f"{label}. {description}"
-                else:
-                    event_data["description"] = description
-                event_data["description"] = remove_line_breaks(event_data["description"])
+            if core_description := _format_core_event_description(event_core_definition):
+                event_data["description"] = core_description
         elif event_name in event_to_description:
             event_data["description"] = sanitize_event_description(event_to_description[event_name])
         elif event_name in db_event_descriptions:
@@ -259,6 +255,31 @@ def _process_events_data(
         processed_events.append(event_data)
 
     return processed_events, event_to_description, has_more
+
+
+def _format_core_event_description(event_core_definition: Mapping[str, Any]) -> str | None:
+    """Build a single-line description for a core taxonomy event, prefixed with its label."""
+    description = event_core_definition.get("description")
+    if not description:
+        return None
+    if label := event_core_definition.get("label_llm") or event_core_definition.get("label"):
+        description = f"{label}. {description}"
+    return remove_line_breaks(description)
+
+
+def get_event_description(team: Team, event_name: str) -> str | None:
+    """Return a human-readable description for a single event, or None if none is known.
+
+    Mirrors the precedence used when listing events: the built-in core taxonomy description wins,
+    otherwise fall back to the user-authored description stored on the event definition (EE only).
+    Used to surface a description on the single-event properties path so the agent doesn't have to
+    list every event to learn what one event means.
+    """
+    if event_core_definition := CORE_FILTER_DEFINITIONS_BY_GROUP["events"].get(event_name):
+        return _format_core_event_description(event_core_definition)
+    if description := _get_event_definition_descriptions(team, [event_name], {}).get(event_name):
+        return sanitize_event_description(description)
+    return None
 
 
 def _get_event_definition_descriptions(


### PR DESCRIPTION
## Problem

Max can read a custom event's description now (via PR #72088), but only on the events-*listing* taxonomy path. For a single event, `read_taxonomy` with `kind: event_properties` returned just the property list and never the event's own description.

That matters because when a user asks "what does event X mean?", Max reflexively calls `event_properties` for that one event. It sees no description in the response and concludes none exists, even when the team has written one in Data management. So the descriptions people maintain still don't reliably reach the agent.

**Why:** raised from a Slack thread where Max repeatedly told a user it couldn't read an event's description, and even claimed the Data management field was empty when it wasn't. Root cause was the wrong-endpoint gap above, not the merged fix.

## Changes

- Add `get_event_description(team, event_name)` in `ee/hogai/utils/helpers.py`. It returns a single event's description using the same precedence as the list path: built-in core taxonomy first, then the user-authored `EnterpriseEventDefinition.description` (EE-gated, no-op on OSS).
- Prepend that description to the `event_properties` result in `ee/hogai/tools/read_taxonomy/core.py`, so the single-event lookup Max actually uses returns it.
- Refactor the core-taxonomy description formatting shared by both paths into `_format_core_event_description` (no behavior change on the list path).

> [!NOTE]
> No new query on the hot path when there's nothing to fetch: core events short-circuit before touching the DB, and the EE lookup reuses the existing batched helper for the one event.

## How did you test this code?

Added a parameterized test to `ee/hogai/tools/read_taxonomy/test/test_tool.py` covering the `event_properties` path: a custom event with a stored description now surfaces it (`Description of \`quiz_retaken\`: ...`), and one without a description emits no prefix. This guards the exact regression this PR fixes — no existing test exercised descriptions on the single-event path.

I (via the PostHog Slack app) could not run the suite in this environment: no Postgres is reachable and the test creates an `EnterpriseEventDefinition` row, so it errors at DB setup. I ran `ruff check` / `ruff format` (clean) and `py_compile` (passes) on all three files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread using the PostHog AI-observability trace tools. Confirmed the events-list path already returns the description (proving the earlier fix is deployed and working) and that Max's failures all came from it querying `event_properties` instead. Chose to surface the description on that path rather than change the model's routing, and reused the existing EE description helper to avoid an N+1. Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BALLBBKAB/p1784649913361349)*
