### PR TITLE
fix(conversations): clarify favoriting a saved view is personal

### DIFF
--- a/products/conversations/frontend/components/SavedViews/SavedViewsModal.tsx
+++ b/products/conversations/frontend/components/SavedViews/SavedViewsModal.tsx
@@ -138,7 +138,11 @@ export function SavedViewsModal({ id }: TicketViewsLogicProps): JSX.Element {
                             <IconHeart className="text-secondary" />
                         )
                     }
-                    tooltip={view.is_favorited ? 'Remove from favorites' : 'Add to favorites'}
+                    tooltip={
+                        view.is_favorited
+                            ? 'Remove from your favorites (only visible to you)'
+                            : 'Add to your favorites (only visible to you)'
+                    }
                 />
             ),
         },


### PR DESCRIPTION
## Problem

The heart icon tooltip on saved ticket views just said "Add to favorites" / "Remove from favorites", without making it clear that favoriting is per-user rather than shared with the team.

## Changes

Updated the tooltip copy in `SavedViewsModal.tsx` to note that favoriting a view is only visible to the current user.

## How did you test this code?

Read-only copy change to a tooltip string; no automated tests added since there's no existing regression to guard against. Did not manually verify in the browser.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Made a one-line UI copy change to the favorite/heart icon tooltip in the support saved views modal, clarifying that favorites are personal to each user (matching wording already used in the backend serializer's `help_text`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*