### PR TITLE
fix(logs): render the group-by picker in the empty Group view

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
@@ -180,7 +180,9 @@ const GroupByDimensionPickers = (): JSX.Element => {
                     />
                 </Fragment>
             ))}
-            {groupBys.length > 0 && groupBys.length < MAX_GROUP_BY_DIMENSIONS && (
+            {/* First pick and "+ and" are the same add picker: with no dimension chosen yet it
+                must render (labelled "Group by") or the empty Group view has no picker at all. */}
+            {groupBys.length < MAX_GROUP_BY_DIMENSIONS && (
                 <TaxonomicStringPopover
                     {...pickerProps}
                     type="tertiary"
@@ -189,7 +191,7 @@ const GroupByDimensionPickers = (): JSX.Element => {
                     onChange={(value, groupType) =>
                         value && addGroupBy({ key: value, source: resolveGroupBySource(value, groupType) })
                     }
-                    placeholder="+ and"
+                    placeholder={groupBys.length === 0 ? 'Group by' : '+ and'}
                     data-attr="logs-group-by-add-dimension"
                 />
             )}


### PR DESCRIPTION
## Problem

The combined group-by UI ([#72246](https://github.com/PostHog/posthog/pull/72246)) gated the add picker on at least one dimension already existing — but that picker is also the only way to pick the *first* dimension. The empty Group view rendered no picker at all: the results pane says "Pick an attribute to group by" with nothing to click, making the group-by lens unusable from a fresh visit.

## Changes

Render the add picker whenever the dimension count is below the cap, labelled "Group by" for the first pick and "+ and" once dimensions exist — first pick and add-another are the same control.

## How did you test this code?

- Logs group-by and viewer-config suites pass (34 tests). No new test: the regression is a render condition in a component with no existing render coverage; the fix restores behavior the reducer tests already assume reachable, and a component-render test for one boolean gate wouldn't outlive the JON-192 recents work about to touch this picker again.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: flag-gated (`LOGS_GROUP_BY`) UI fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jon hit the broken empty state on the preview stack and reported it; I (Claude, via PostHog Code) diagnosed the render gate and fixed it. The fix was authored before [#72246](https://github.com/PostHog/posthog/pull/72246) merged but landed on the branch after the merge queue picked it up, so it reaches master via this cherry-pick.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
