### PR TITLE
chore(aio): remove nodejs trial status reasons

### DIFF
--- a/nodejs/src/ai-observability/evaluation-scheduler/evaluation-scheduler.test.ts
+++ b/nodejs/src/ai-observability/evaluation-scheduler/evaluation-scheduler.test.ts
@@ -701,7 +701,7 @@ describe('Evaluation Scheduler', () => {
             expect(temporalService.startEvaluationRunWorkflow).not.toHaveBeenCalled()
         })
 
-        it('still starts evaluation workflows for trial mode evaluations', async () => {
+        it('still starts evaluation workflows for evaluations with no pinned provider key', async () => {
             const event = createAiGenerationEvent(teamId)
             const evaluation = createEvaluation({
                 team_id: teamId,

--- a/nodejs/src/ai-observability/types.ts
+++ b/nodejs/src/ai-observability/types.ts
@@ -5,8 +5,6 @@ export type EvaluationStatus = 'active' | 'paused' | 'error'
 // Keep in sync with EvaluationStatusReason in products/ai_observability/backend/models/evaluations.py
 export type EvaluationStatusReason =
     | 'provider_key_required'
-    | 'trial_limit_reached'
-    | 'model_not_allowed'
     | 'provider_key_deleted'
     | 'no_default_model'
     | 'provider_key_invalid'


### PR DESCRIPTION
## Problem

The nodejs `EvaluationStatusReason` union still carries `trial_limit_reached` and `model_not_allowed`, which the backend enum lost when trial evaluations were removed (#71518). The type's own comment mandates staying in sync with `models/evaluations.py`.

## Changes

- Drop the two stale union members. Nothing in nodejs references them (verified by grep and typecheck).
- Rename the scheduler test that mentioned trial mode to describe what it actually covers, evaluations with no pinned provider key.

## How did you test this code?

`evaluation-scheduler.test.ts`: 41 passed. nodejs typecheck introduces no new errors. Type-only change, no behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this, Claude (Claude Code) implemented it. Separate from the column-drop PR only because the migrations-service separation check forbids nodejs and Django migration changes in one PR. Suitable for the `skip-agent-review` label.
