### PR TITLE
feat(vercel): inject framework-prefixed env var aliases into marketplace resources

### DIFF
--- a/ee/api/vercel/test/test_vercel_connect.py
+++ b/ee/api/vercel/test/test_vercel_connect.py
@@ -16,6 +16,9 @@ from posthog.models.team import Team
 from ee.api.vercel.vercel_connect import _load_connect_session, _sign_connect_session, _validate_next_url
 from ee.vercel.client import OAuthTokenResponse, OperationResult
 
+# Hardcoded independently of ee.vercel.integration.CLIENT_ENV_PREFIXES so a dropped prefix fails these tests.
+EXPECTED_ENV_PREFIXES = ["NEXT_PUBLIC_", "VITE_", "NUXT_PUBLIC_", "PUBLIC_"]
+
 CACHED_SESSION_DATA = {
     "access_token": "vercel_token_123",
     "token_type": "Bearer",
@@ -293,6 +296,75 @@ class TestVercelConnectComplete(VercelConnectTestBase):
         assert call_kwargs["product_id"] == "posthog"
         assert call_kwargs["name"] == self.team.name
         mock_vercel_integration.bulk_sync_feature_flags_to_vercel.assert_called_once_with(self.team)
+
+        secrets = call_kwargs["secrets"]
+        secrets_by_name = {secret["name"]: secret for secret in secrets}
+        assert set(secrets_by_name) == {
+            "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
+            "NEXT_PUBLIC_POSTHOG_HOST",
+            "VITE_POSTHOG_PROJECT_TOKEN",
+            "VITE_POSTHOG_HOST",
+            "NUXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
+            "NUXT_PUBLIC_POSTHOG_HOST",
+            "PUBLIC_POSTHOG_PROJECT_TOKEN",
+            "PUBLIC_POSTHOG_HOST",
+        }
+        assert secrets[0]["name"] == "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN"
+        for prefix in EXPECTED_ENV_PREFIXES:
+            token_secret = secrets_by_name[f"{prefix}POSTHOG_PROJECT_TOKEN"]
+            assert token_secret["value"] == self.team.api_token
+            assert "environmentOverrides" not in token_secret
+
+            host_secret = secrets_by_name[f"{prefix}POSTHOG_HOST"]
+            assert host_secret["value"].startswith(("https://", "http://"))
+            assert "environmentOverrides" not in host_secret
+
+    @patch("ee.vercel.integration.VercelIntegration")
+    @patch("ee.api.vercel.vercel_connect.VercelAPIClient")
+    def test_link_with_different_environments_sets_overrides_on_every_prefix(
+        self, mock_client_class, mock_vercel_integration
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.import_resource.return_value = OperationResult(success=True)
+
+        preview_team = Team.objects.create(
+            organization=self.organization, name="Preview Team", api_token="preview_token"
+        )
+        development_team = Team.objects.create(
+            organization=self.organization, name="Development Team", api_token="development_token"
+        )
+        session_token = _seed_session()
+
+        response = self.client.post(
+            self.url,
+            {
+                "session": session_token,
+                "organization_id": str(self.organization.id),
+                "environment_mapping": {
+                    "production": self.team.pk,
+                    "preview": preview_team.pk,
+                    "development": development_team.pk,
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        call_kwargs = mock_client.import_resource.call_args[1]
+        secrets_by_name = {secret["name"]: secret for secret in call_kwargs["secrets"]}
+
+        for prefix in EXPECTED_ENV_PREFIXES:
+            token_secret = secrets_by_name[f"{prefix}POSTHOG_PROJECT_TOKEN"]
+            assert token_secret["value"] == self.team.api_token
+            assert token_secret["environmentOverrides"] == {
+                "preview": "preview_token",
+                "development": "development_token",
+            }
+
+            host_secret = secrets_by_name[f"{prefix}POSTHOG_HOST"]
+            assert "environmentOverrides" not in host_secret
 
     def test_non_member_returns_403(self):
         other_org = Organization.objects.create(name="Not My Org")

--- a/ee/api/vercel/test/test_vercel_resource.py
+++ b/ee/api/vercel/test/test_vercel_resource.py
@@ -284,11 +284,13 @@ class TestVercelResourceAPI(VercelTestBase):
         data = response.json()
         self.assertIn("secrets", data)
         secrets = data["secrets"]
-        self.assertEqual(len(secrets), 2)
+        expected_prefixes = ["NEXT_PUBLIC_", "VITE_", "NUXT_PUBLIC_", "PUBLIC_"]
+        self.assertEqual(len(secrets), 2 * len(expected_prefixes))
 
         secret_names = [s["name"] for s in secrets]
-        self.assertIn("NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN", secret_names)
-        self.assertIn("NEXT_PUBLIC_POSTHOG_HOST", secret_names)
+        for prefix in expected_prefixes:
+            self.assertIn(f"{prefix}POSTHOG_PROJECT_TOKEN", secret_names)
+            self.assertIn(f"{prefix}POSTHOG_HOST", secret_names)
 
         api_key_secret = next(s for s in secrets if s["name"] == "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN")
         self.assertEqual(api_key_secret["value"], self.team.api_token)

--- a/ee/api/vercel/vercel_connect.py
+++ b/ee/api/vercel/vercel_connect.py
@@ -330,32 +330,34 @@ class VercelConnectLinkViewSet(viewsets.GenericViewSet):
     ) -> list[dict]:
         from posthog.utils import absolute_uri
 
+        from ee.vercel.integration import CLIENT_ENV_PREFIXES
+
         prod_team = teams_by_id[production_id]
         preview_team = teams_by_id[preview_id]
         dev_team = teams_by_id[development_id]
 
         all_same = production_id == preview_id == development_id
+        host = absolute_uri()
 
-        secrets: list[dict] = [
-            {
-                "name": "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
-                "value": prod_team.api_token,
-                **(
-                    {}
-                    if all_same
-                    else {
-                        "environmentOverrides": {
-                            "preview": preview_team.api_token,
-                            "development": dev_team.api_token,
+        secrets: list[dict] = []
+        for prefix in CLIENT_ENV_PREFIXES:
+            secrets.append(
+                {
+                    "name": f"{prefix}POSTHOG_PROJECT_TOKEN",
+                    "value": prod_team.api_token,
+                    **(
+                        {}
+                        if all_same
+                        else {
+                            "environmentOverrides": {
+                                "preview": preview_team.api_token,
+                                "development": dev_team.api_token,
+                            }
                         }
-                    }
-                ),
-            },
-            {
-                "name": "NEXT_PUBLIC_POSTHOG_HOST",
-                "value": absolute_uri(),
-            },
-        ]
+                    ),
+                }
+            )
+            secrets.append({"name": f"{prefix}POSTHOG_HOST", "value": host})
         return secrets
 
     @decorators.action(detail=False, methods=["get"], url_path="session")

--- a/ee/management/commands/backfill_vercel_secrets.py
+++ b/ee/management/commands/backfill_vercel_secrets.py
@@ -19,6 +19,7 @@ from django.core.management.base import BaseCommand
 
 import structlog
 
+from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import Integration
 from posthog.tasks.integrations import push_vercel_secrets
 
@@ -50,12 +51,13 @@ class Command(BaseCommand):
 
         enqueued = 0
         failed = 0
-        for team_id in team_ids:
+        for index, team_id in enumerate(team_ids):
             try:
-                push_vercel_secrets.delay(team_id)
-            except Exception:
+                push_vercel_secrets.apply_async(args=[team_id], countdown=index // 2)
+            except Exception as e:
                 failed += 1
                 logger.exception("Failed to enqueue Vercel secret push", team_id=team_id, integration="vercel")
+                capture_exception(e, {"team_id": team_id})
             else:
                 enqueued += 1
 

--- a/ee/management/commands/backfill_vercel_secrets.py
+++ b/ee/management/commands/backfill_vercel_secrets.py
@@ -1,0 +1,62 @@
+"""Re-push PostHog secrets to every Vercel resource already linked to a team.
+
+Usage:
+    python manage.py backfill_vercel_secrets --dry-run
+    python manage.py backfill_vercel_secrets
+
+New installations receive the current secret set when their resource is imported, but
+existing ones are only refreshed when a team rotates its API token. Any change to the
+secret set therefore needs a one-off sweep to reach installations already out there.
+
+Work is handed to Celery one team at a time, so a single failing installation can't
+halt the sweep.
+"""
+
+from argparse import ArgumentParser
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+import structlog
+
+from posthog.models.integration import Integration
+from posthog.tasks.integrations import push_vercel_secrets
+
+logger = structlog.get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Enqueue a Vercel secret push for every team with a linked Vercel resource."
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List the teams that would be enqueued, without enqueueing anything.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        team_ids = sorted(
+            Integration.objects.filter(kind=Integration.IntegrationKind.VERCEL)
+            .values_list("team_id", flat=True)
+            .distinct()
+        )
+
+        if options["dry_run"]:
+            for team_id in team_ids:
+                self.stdout.write(str(team_id))
+            self.stdout.write(f"Would enqueue a Vercel secret push for {len(team_ids)} team(s)")
+            return
+
+        enqueued = 0
+        failed = 0
+        for team_id in team_ids:
+            try:
+                push_vercel_secrets.delay(team_id)
+            except Exception:
+                failed += 1
+                logger.exception("Failed to enqueue Vercel secret push", team_id=team_id, integration="vercel")
+            else:
+                enqueued += 1
+
+        self.stdout.write(f"Enqueued a Vercel secret push for {enqueued} team(s), {failed} failed to enqueue")

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -42,6 +42,11 @@ logger = structlog.get_logger(__name__)
 
 VercelItemType = Literal["flag", "experiment"]
 
+# Frameworks only expose an env var to client-side bundles if it carries their own prefix, so the
+# same values are injected under every prefix we support. NEXT_PUBLIC_ must stay first: it is the
+# original contract for already-installed users.
+CLIENT_ENV_PREFIXES = ("NEXT_PUBLIC_", "VITE_", "NUXT_PUBLIC_", "PUBLIC_", "EXPO_PUBLIC_")
+
 
 class VercelSSOError(Exception):
     pass
@@ -554,15 +559,14 @@ class VercelIntegration:
 
     @staticmethod
     def _build_secrets(team: Team) -> list[dict[str, str]]:
+        values = {
+            "POSTHOG_PROJECT_TOKEN": team.api_token,
+            "POSTHOG_HOST": absolute_uri(),
+        }
         return [
-            {
-                "name": "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
-                "value": team.api_token,
-            },
-            {
-                "name": "NEXT_PUBLIC_POSTHOG_HOST",
-                "value": absolute_uri(),
-            },
+            {"name": f"{prefix}{name}", "value": value}
+            for prefix in CLIENT_ENV_PREFIXES
+            for name, value in values.items()
         ]
 
     @staticmethod

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -45,7 +45,7 @@ VercelItemType = Literal["flag", "experiment"]
 # Frameworks only expose an env var to client-side bundles if it carries their own prefix, so the
 # same values are injected under every prefix we support. NEXT_PUBLIC_ must stay first: it is the
 # original contract for already-installed users.
-CLIENT_ENV_PREFIXES = ("NEXT_PUBLIC_", "VITE_", "NUXT_PUBLIC_", "PUBLIC_", "EXPO_PUBLIC_")
+CLIENT_ENV_PREFIXES = ("NEXT_PUBLIC_", "VITE_", "NUXT_PUBLIC_", "PUBLIC_")
 
 
 class VercelSSOError(Exception):

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -612,12 +612,12 @@ class VercelIntegration:
     def _setup_vercel_client_for_team(team: Team) -> VercelSetupResult | None:
         resource = VercelIntegration._get_vercel_resource_for_team(team)
         if not resource:
-            logger.debug("Vercel resource not found for team", team_id=team.id, integration="vercel")
+            logger.info("Vercel resource not found for team", team_id=team.id, integration="vercel")
             return None
 
         installation = VercelIntegration._get_installation_for_organization(team.organization)
         if not installation:
-            logger.debug(
+            logger.info(
                 "Vercel installation not found for organization",
                 team_id=team.pk,
                 organization_id=team.organization.pk,

--- a/ee/vercel/test/test_backfill_vercel_secrets.py
+++ b/ee/vercel/test/test_backfill_vercel_secrets.py
@@ -46,38 +46,53 @@ class TestBackfillVercelSecrets(TestCase):
         call_command("backfill_vercel_secrets", *args, stdout=out)
         return out.getvalue()
 
-    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
-    def test_dry_run_lists_vercel_teams_without_enqueueing(self, mock_delay):
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.apply_async")
+    def test_dry_run_lists_vercel_teams_without_enqueueing(self, mock_apply_async):
         output = self._call("--dry-run")
 
-        mock_delay.assert_not_called()
+        mock_apply_async.assert_not_called()
         assert "Would enqueue a Vercel secret push for 2 team(s)" in output
 
         listed_team_ids = sorted(int(line) for line in output.splitlines() if line.strip().isdigit())
         assert listed_team_ids == sorted(team.pk for team in self.vercel_teams)
 
-    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
-    def test_enqueues_the_task_once_per_vercel_team(self, mock_delay):
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.apply_async")
+    def test_enqueues_the_task_once_per_vercel_team(self, mock_apply_async):
         output = self._call()
 
-        enqueued_team_ids = sorted(call.args[0] for call in mock_delay.call_args_list)
+        enqueued_team_ids = sorted(call.kwargs["args"][0] for call in mock_apply_async.call_args_list)
         assert enqueued_team_ids == sorted(team.pk for team in self.vercel_teams)
         assert "Enqueued a Vercel secret push for 2 team(s), 0 failed to enqueue" in output
 
-    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
-    def test_a_failing_team_does_not_halt_the_sweep(self, mock_delay):
-        mock_delay.side_effect = [Exception("broker down"), None]
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.apply_async")
+    def test_enqueues_are_staggered_two_per_second(self, mock_apply_async):
+        extra_teams = [self._team_with_vercel_resource(f"Vercel Extra {i}") for i in range(3)]
+
+        self._call()
+
+        all_team_ids = sorted(team.pk for team in self.vercel_teams + extra_teams)
+        countdown_by_team_id = {
+            call.kwargs["args"][0]: call.kwargs["countdown"] for call in mock_apply_async.call_args_list
+        }
+        countdowns_in_enqueue_order = [countdown_by_team_id[team_id] for team_id in all_team_ids]
+        assert countdowns_in_enqueue_order == [0, 0, 1, 1, 2]
+
+    @patch("ee.management.commands.backfill_vercel_secrets.capture_exception")
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.apply_async")
+    def test_a_failing_team_does_not_halt_the_sweep(self, mock_apply_async, mock_capture_exception):
+        mock_apply_async.side_effect = [Exception("broker down"), None]
 
         output = self._call()
 
-        assert mock_delay.call_count == 2
+        assert mock_apply_async.call_count == 2
         assert "Enqueued a Vercel secret push for 1 team(s), 1 failed to enqueue" in output
+        mock_capture_exception.assert_called_once()
 
-    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
-    def test_reports_zero_teams_when_no_vercel_resources_exist(self, mock_delay):
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.apply_async")
+    def test_reports_zero_teams_when_no_vercel_resources_exist(self, mock_apply_async):
         Integration.objects.filter(kind=Integration.IntegrationKind.VERCEL).delete()
 
         output = self._call()
 
-        mock_delay.assert_not_called()
+        mock_apply_async.assert_not_called()
         assert "Enqueued a Vercel secret push for 0 team(s), 0 failed to enqueue" in output

--- a/ee/vercel/test/test_backfill_vercel_secrets.py
+++ b/ee/vercel/test/test_backfill_vercel_secrets.py
@@ -1,0 +1,83 @@
+from io import StringIO
+
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.team import Team
+from posthog.models.user import User
+
+
+class TestBackfillVercelSecrets(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email="backfill@example.com", password="test", first_name="Test")
+        self.organization = Organization.objects.create(name="Backfill Test Org")
+        self.user.join(organization=self.organization, level=OrganizationMembership.Level.OWNER)
+
+        self.vercel_teams = [
+            self._team_with_vercel_resource("Vercel One"),
+            self._team_with_vercel_resource("Vercel Two"),
+        ]
+        self.team_without_vercel = Team.objects.create(organization=self.organization, name="No Vercel")
+        Integration.objects.create(
+            team=self.team_without_vercel,
+            kind=Integration.IntegrationKind.SLACK,
+            integration_id="slack_123",
+            config={},
+            created_by=self.user,
+        )
+
+    def _team_with_vercel_resource(self, name: str) -> Team:
+        team = Team.objects.create(organization=self.organization, name=name)
+        Integration.objects.create(
+            team=team,
+            kind=Integration.IntegrationKind.VERCEL,
+            integration_id=str(team.pk),
+            config={"productId": "posthog", "name": name},
+            created_by=self.user,
+        )
+        return team
+
+    def _call(self, *args: str) -> str:
+        out = StringIO()
+        call_command("backfill_vercel_secrets", *args, stdout=out)
+        return out.getvalue()
+
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
+    def test_dry_run_lists_vercel_teams_without_enqueueing(self, mock_delay):
+        output = self._call("--dry-run")
+
+        mock_delay.assert_not_called()
+        assert "Would enqueue a Vercel secret push for 2 team(s)" in output
+
+        listed_team_ids = sorted(int(line) for line in output.splitlines() if line.strip().isdigit())
+        assert listed_team_ids == sorted(team.pk for team in self.vercel_teams)
+
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
+    def test_enqueues_the_task_once_per_vercel_team(self, mock_delay):
+        output = self._call()
+
+        enqueued_team_ids = sorted(call.args[0] for call in mock_delay.call_args_list)
+        assert enqueued_team_ids == sorted(team.pk for team in self.vercel_teams)
+        assert "Enqueued a Vercel secret push for 2 team(s), 0 failed to enqueue" in output
+
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
+    def test_a_failing_team_does_not_halt_the_sweep(self, mock_delay):
+        mock_delay.side_effect = [Exception("broker down"), None]
+
+        output = self._call()
+
+        assert mock_delay.call_count == 2
+        assert "Enqueued a Vercel secret push for 1 team(s), 1 failed to enqueue" in output
+
+    @patch("ee.management.commands.backfill_vercel_secrets.push_vercel_secrets.delay")
+    def test_reports_zero_teams_when_no_vercel_resources_exist(self, mock_delay):
+        Integration.objects.filter(kind=Integration.IntegrationKind.VERCEL).delete()
+
+        output = self._call()
+
+        mock_delay.assert_not_called()
+        assert "Enqueued a Vercel secret push for 0 team(s), 0 failed to enqueue" in output

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -20,7 +20,7 @@ from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 from ee.api.vercel.types import VercelUserClaims
-from ee.vercel.integration import VercelIntegration, _safe_vercel_sync
+from ee.vercel.integration import CLIENT_ENV_PREFIXES, VercelIntegration, _safe_vercel_sync
 
 
 class TestVercelIntegration(TestCase):
@@ -599,15 +599,29 @@ class TestVercelIntegration(TestCase):
 
         assert "name" in str(context.exception.detail)
 
-    def test_build_secrets(self):
+    def test_build_secrets_leads_with_the_next_public_names(self):
         team = Team.objects.create(organization=self.organization, name="Test Team", api_token="test_api_token")
         secrets = VercelIntegration._build_secrets(team)
 
-        assert len(secrets) == 2
         assert secrets[0]["name"] == "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN"
         assert secrets[0]["value"] == "test_api_token"
         assert secrets[1]["name"] == "NEXT_PUBLIC_POSTHOG_HOST"
         assert secrets[1]["value"].startswith(("https://", "http://"))
+
+    @parameterized.expand([(prefix,) for prefix in CLIENT_ENV_PREFIXES])
+    def test_build_secrets_injects_framework_prefixed_aliases(self, prefix: str):
+        team = Team.objects.create(organization=self.organization, name="Test Team", api_token="test_api_token")
+        secrets = {secret["name"]: secret["value"] for secret in VercelIntegration._build_secrets(team)}
+
+        assert secrets[f"{prefix}POSTHOG_PROJECT_TOKEN"] == "test_api_token"
+        assert secrets[f"{prefix}POSTHOG_HOST"].startswith(("https://", "http://"))
+
+    def test_build_secrets_covers_every_prefix_exactly_once(self):
+        team = Team.objects.create(organization=self.organization, name="Test Team", api_token="test_api_token")
+        secrets = VercelIntegration._build_secrets(team)
+
+        names = [secret["name"] for secret in secrets]
+        assert len(names) == len(set(names)) == 2 * len(CLIENT_ENV_PREFIXES)
 
     @parameterized.expand(
         [
@@ -1268,9 +1282,10 @@ class TestPushSecretsToVercel(TestCase):
         assert call_args[1]["resource_id"] == str(self.resource.pk)
 
         secrets = call_args[1]["secrets"]
-        assert len(secrets) == 2
-        assert any(s["name"] == "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN" for s in secrets)
-        assert any(s["name"] == "NEXT_PUBLIC_POSTHOG_HOST" for s in secrets)
+        assert len(secrets) == 2 * len(CLIENT_ENV_PREFIXES)
+        for prefix in CLIENT_ENV_PREFIXES:
+            assert any(s["name"] == f"{prefix}POSTHOG_PROJECT_TOKEN" for s in secrets)
+            assert any(s["name"] == f"{prefix}POSTHOG_HOST" for s in secrets)
 
     @patch("ee.vercel.integration.VercelAPIClient")
     def test_push_secrets_sends_current_api_token(self, mock_client_class):

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -20,7 +20,10 @@ from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 from ee.api.vercel.types import VercelUserClaims
-from ee.vercel.integration import CLIENT_ENV_PREFIXES, VercelIntegration, _safe_vercel_sync
+from ee.vercel.integration import VercelIntegration, _safe_vercel_sync
+
+# Hardcoded independently of ee.vercel.integration.CLIENT_ENV_PREFIXES so a dropped prefix fails these tests.
+EXPECTED_PREFIXES = ["NEXT_PUBLIC_", "VITE_", "NUXT_PUBLIC_", "PUBLIC_"]
 
 
 class TestVercelIntegration(TestCase):
@@ -608,7 +611,7 @@ class TestVercelIntegration(TestCase):
         assert secrets[1]["name"] == "NEXT_PUBLIC_POSTHOG_HOST"
         assert secrets[1]["value"].startswith(("https://", "http://"))
 
-    @parameterized.expand([(prefix,) for prefix in CLIENT_ENV_PREFIXES])
+    @parameterized.expand([(prefix,) for prefix in EXPECTED_PREFIXES])
     def test_build_secrets_injects_framework_prefixed_aliases(self, prefix: str):
         team = Team.objects.create(organization=self.organization, name="Test Team", api_token="test_api_token")
         secrets = {secret["name"]: secret["value"] for secret in VercelIntegration._build_secrets(team)}
@@ -621,7 +624,7 @@ class TestVercelIntegration(TestCase):
         secrets = VercelIntegration._build_secrets(team)
 
         names = [secret["name"] for secret in secrets]
-        assert len(names) == len(set(names)) == 2 * len(CLIENT_ENV_PREFIXES)
+        assert len(names) == len(set(names)) == 2 * len(EXPECTED_PREFIXES)
 
     @parameterized.expand(
         [
@@ -1282,8 +1285,8 @@ class TestPushSecretsToVercel(TestCase):
         assert call_args[1]["resource_id"] == str(self.resource.pk)
 
         secrets = call_args[1]["secrets"]
-        assert len(secrets) == 2 * len(CLIENT_ENV_PREFIXES)
-        for prefix in CLIENT_ENV_PREFIXES:
+        assert len(secrets) == 2 * len(EXPECTED_PREFIXES)
+        for prefix in EXPECTED_PREFIXES:
             assert any(s["name"] == f"{prefix}POSTHOG_PROJECT_TOKEN" for s in secrets)
             assert any(s["name"] == f"{prefix}POSTHOG_HOST" for s in secrets)
 


### PR DESCRIPTION
## Problem

The Vercel marketplace integration injects `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` / `NEXT_PUBLIC_POSTHOG_HOST` into connected projects. A framework only exposes an env var to its client bundle if the var carries that framework's prefix, so any customer deploying a non-Next.js frontend on Vercel (Vite, Nuxt, SvelteKit, Astro) never sees these vars in the browser. The integration reads as connected, but PostHog silently receives nothing in production because the token never reaches the client.

## Changes

- `_build_secrets` now emits the same two values under every supported client prefix: `NEXT_PUBLIC_`, `VITE_`, `NUXT_PUBLIC_`, `PUBLIC_` (8 secrets total). `NEXT_PUBLIC_` stays first — it's the existing contract for already-installed users.
- The connect/account-linking flow's secret builder (`vercel_connect.py`) emits the same aliases, preserving its per-environment token overrides — previously it would have kept shipping only the `NEXT_PUBLIC_` pair.
- Adds a `backfill_vercel_secrets` management command that enqueues a `push_vercel_secrets` Celery task per team with a linked Vercel resource (with `--dry-run`, enqueues staggered at ~2/s, enqueue failures reported via `capture_exception`), so existing installations receive the new aliases. New installs and token rotations already pick them up via the existing push paths. Installation-missing skips in the push path now log at info instead of debug so a prod backfill's no-ops are visible.

## How did you test this code?

Automated: `pytest ee/vercel/test/test_backfill_vercel_secrets.py ee/vercel/test/test_integration.py ee/api/vercel/test/test_vercel_connect.py` — 134 tests pass, including new tests for the alias set (hardcoded expected names, so dropping a prefix fails), the connect flow's 8-secret shape with and without environment overrides, the backfill command's staggering, and its failure reporting. `ruff` and `mypy` clean on changed files.

Manual, against the real Vercel marketplace API (dev integration + local stack over ngrok):

- Backfill: `backfill_vercel_secrets --dry-run` listed the expected teams; the real run pushed all 8 secrets to the live dev installation's resource, verified in the Vercel dashboard (correct names, identical values per pair, upserted with no duplicates).
- Stale rows: teams whose org has no live installation were skipped without halting the sweep.
- Rotation: rotating a team's API token triggered the existing push path and all 8 values updated on Vercel.

Notes for reviewers:

- `POSTHOG_HOST` is built from `absolute_uri()` (the app host), same as the pre-existing `NEXT_PUBLIC_` pair — this PR replicates that behavior under the new prefixes rather than switching to the dedicated ingest host.
- Left as-is deliberately: `_get_vercel_resource_for_team` uses `.get()` and would raise on a hypothetical multi-resource team (not producible via current creation paths), and the `push_vercel_secrets` task has no retry semantics — both pre-existing, flagged here rather than expanding scope.
- `PUBLIC_` is the least namespaced of the four prefixes; collision with a customer's own `PUBLIC_POSTHOG_*` vars seems implausible but is worth a beat of thought.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The Vercel marketplace docs list the injected env vars; they should mention the new aliases once this ships.
