### PR TITLE
fix(monday): retry monday.com internal server errors instead of failing the sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/monday/monday.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/monday/monday.py
@@ -148,9 +148,13 @@ def _execute(
     errors = body.get("errors")
     if errors:
         message = "; ".join(str(error.get("message", error)) for error in errors)
-        # Complexity-budget exhaustion comes back as a GraphQL error, not a 429.
-        if "complexity" in message.lower():
+        message_lower = message.lower()
+        # Complexity-budget exhaustion and transient backend failures both come back
+        # as a 200 with a GraphQL error, not a 429/5xx status.
+        if "complexity" in message_lower:
             raise MondayRetryableError(f"monday.com complexity budget exhausted: {message}")
+        if "internal server error" in message_lower:
+            raise MondayRetryableError(f"monday.com internal server error (retryable): {message}")
         raise MondayGraphQLError(f"monday.com GraphQL error: {message}")
 
     return body.get("data") or {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/monday/tests/test_monday.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/monday/tests/test_monday.py
@@ -7,6 +7,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.monday.mon
     ITEMS_PAGE_SIZE,
     PAGE_SIZE,
     MondayGraphQLError,
+    MondayRetryableError,
     get_rows,
     monday_source,
     validate_credentials,
@@ -71,6 +72,27 @@ class TestGetRowsPaged:
         mock_session.return_value.post.return_value = _response({}, errors=[{"message": "Field not found"}])
 
         with pytest.raises(MondayGraphQLError):
+            list(get_rows("token", "users", mock.MagicMock()))
+
+    @mock.patch("time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_internal_server_error_is_retried_then_succeeds(self, mock_session, _mock_sleep):
+        mock_session.return_value.post.side_effect = [
+            _response({}, errors=[{"message": "Internal Server Error"}]),
+            _response({"users": [{"id": "1"}]}),
+        ]
+
+        batches = list(get_rows("token", "users", mock.MagicMock()))
+
+        assert batches == [[{"id": "1"}]]
+        assert mock_session.return_value.post.call_count == 2
+
+    @mock.patch("time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_internal_server_error_raises_retryable_when_exhausted(self, mock_session, _mock_sleep):
+        mock_session.return_value.post.return_value = _response({}, errors=[{"message": "Internal Server Error"}])
+
+        with pytest.raises(MondayRetryableError):
             list(get_rows("token", "users", mock.MagicMock()))
 
     @mock.patch(f"{_MODULE}.make_tracked_session")


### PR DESCRIPTION
## Problem

monday.com error tracking surfaced [`MondayGraphQLError: monday.com GraphQL error: Internal Server Error`](https://us.posthog.com/project/2/error_tracking/019f85ce-e568-7843-9f55-29dfca78b4ff), raised from `_execute` in the monday.com data warehouse source.

monday.com's GraphQL API sometimes returns HTTP 200 with an "Internal Server Error" message inside the GraphQL `errors` array instead of a proper 5xx status. `_execute` treated this the same as any genuine GraphQL error (bad query, unsupported field, auth failure), raising a fatal `MondayGraphQLError`. That type isn't in the tenacity `retry_if_exception_type` set, so it skips the fast in-process retry and instead forces the whole sync activity to fail and restart from scratch via Temporal's activity-level retry - wasteful for a full-refresh-only source that re-fetches every board and item from page one.

## Changes

- In `monday.py`, classify a GraphQL error whose message contains "internal server error" as retryable (`MondayRetryableError`), the same way complexity-budget exhaustion is already handled - both are monday.com's way of reporting transient failures through the GraphQL body instead of the HTTP status.
- No change to `NonRetryableErrors`: this is a transient upstream failure, not a credential/config problem, so it should keep retrying rather than get permanently disabled.

## How did you test this code?

Added two cases to `test_monday.py`:
- `test_internal_server_error_is_retried_then_succeeds` - a GraphQL "Internal Server Error" followed by a clean response now succeeds via retry, where before it would have raised immediately. Guards the exact regression this PR fixes.
- `test_internal_server_error_raises_retryable_when_exhausted` - confirms retries are exhausted as `MondayRetryableError`, not silently swallowed.

Ran the full `monday` source test suite (31 tests) plus `ruff check`/`ruff format --check` on the changed files - all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal retry classification, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tools: Claude Code, triggered by a PostHog error tracking webhook for this issue.
- Skills invoked: `/writing-tests` before adding the regression tests.
- Decisions: confirmed the stack trace originates in this source's `_execute` (not a downstream dependency); classified the error as a transient upstream/infrastructure failure per the triage criteria rather than a user/credential error, so it was fixed as retryable behavior instead of added to `get_non_retryable_errors`. Checked open PRs (including the repo's own recent Monday-adjacent PRs) for overlap - found none.