### PR TITLE
fix(vercel): treat billing_charges 404 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
@@ -96,6 +96,12 @@ To sync resources owned by a team, also enter the team's ID (found under **Team 
             # stable status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://api.vercel.com": "Your Vercel access token is invalid or has been revoked. Create a new token in your Vercel account settings, then reconnect.",
             "403 Client Error: Forbidden for url: https://api.vercel.com": "Your Vercel access token is not authorized for this resource. Check the token's scope (and team access), then reconnect.",
+            # Vercel's FOCUS billing endpoint 404s when the configured team can't be resolved for
+            # this token (wrong/missing Team ID, or the token's user no longer belongs to that
+            # team) rather than the 403 it returns for a role that lacks billing access. Retrying
+            # never resolves a bad team reference, so stop the sync. Match the stable path, not the
+            # query string (it carries the per-request date window and team id).
+            "404 Client Error: Not Found for url: https://api.vercel.com/v1/billing/charges": "Vercel couldn't find billing data for the configured team. Check that the Team ID is correct and that your access token's user still belongs to that team, then reconnect.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
@@ -102,6 +102,10 @@ class TestVercelSource:
         [
             ("unauthorized", "401 Client Error: Unauthorized for url: https://api.vercel.com/v6/deployments?limit=100"),
             ("forbidden", "403 Client Error: Forbidden for url: https://api.vercel.com/v9/projects?limit=100"),
+            (
+                "billing_charges_team_not_found",
+                "404 Client Error: Not Found for url: https://api.vercel.com/v1/billing/charges?from=2026-01-01T00%3A00%3A00.000Z&to=2026-02-01T00%3A00%3A00.000Z&teamId=team_abc",
+            ),
         ]
     )
     def test_credential_errors_are_non_retryable(self, _name: str, observed_error: str) -> None:
@@ -113,6 +117,9 @@ class TestVercelSource:
             ("rate_limit", "429 Client Error: Too Many Requests for url: https://api.vercel.com/v6/deployments"),
             ("server_error", "500 Server Error: Internal Server Error for url: https://api.vercel.com/v6/deployments"),
             ("read_timeout", "HTTPSConnectionPool(host='api.vercel.com', port=443): Read timed out."),
+            # Not-found on a non-billing endpoint is unrelated to the billing_charges team-lookup
+            # failure, so the match must stay scoped to that path rather than any 404 on the host.
+            ("not_found_other_endpoint", "404 Client Error: Not Found for url: https://api.vercel.com/v6/deployments"),
         ]
     )
     def test_transient_errors_remain_retryable(self, _name: str, other_error: str) -> None:


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` from the Vercel data warehouse source, raised in `_open_billing_stream` (`products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py`):

```
404 Client Error: Not Found for url: https://api.vercel.com/v1/billing/charges?from=...&to=...&teamId=...
```

Vercel's [FOCUS billing charges API](https://vercel.com/docs/rest-api/billing/list-focus-billing-charges) documents separate `401`/`403`/`404` responses. The source already treats 401/403 (bad or unauthorized token) as non-retryable. A 404 here means the configured team can't be resolved for the token at all — a wrong/missing Team ID, or a token whose user no longer belongs to that team — which is a customer-side configuration issue, not something retrying can fix. Without this, the sync kept retrying the same 404 on every activity attempt.

## Changes

Added the billing_charges 404 to `VercelSource.get_non_retryable_errors()`, matching on the stable endpoint path (not the query string, which carries the per-request date window and team id) so the sync stops and surfaces an actionable message instead of retrying indefinitely.

## How did you test this code?

Extended the existing parameterized coverage in `test_vercel_source.py`:
- Added a `billing_charges_team_not_found` case to `test_credential_errors_are_non_retryable`, asserting the new 404 message is recognized as non-retryable.
- Added a `not_found_other_endpoint` case to `test_transient_errors_remain_retryable`, asserting a 404 on an unrelated endpoint (e.g. `/v6/deployments`) is *not* matched — guarding against the match being widened to any 404 on the host.

Ran the full `test_vercel_source.py` suite locally (`uv run pytest ... -q`): 18 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing behavior or documented workflow changed beyond the error message shown when this sync fails.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) triaged a live error-tracking issue for the Vercel warehouse source. I confirmed the stack trace originates in `vercel.py`'s `_open_billing_stream`, read Vercel's REST API docs for the endpoint to confirm 404 is a documented-but-undescribed response distinct from 401/403, and mirrored the existing Stripe/Vercel `get_non_retryable_errors` pattern. No skills were invoked (no migration, DRF, or frontend surface touched). I searched open PRs for duplicates (by exception type, message phrase, module path, and the author's own open PRs) and found none addressing this issue.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*