### PR TITLE
feat(cohorts): backfill reconcile snapshot

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
@@ -11,7 +11,6 @@ import { resetBehavioralCohortsDatabase } from '../../../tests/helpers/sql'
 import { Hub } from '../../types'
 import { createCohortMembershipEvent, createCohortMembershipEvents, createKafkaMessage } from '../_tests/fixtures'
 import { CdpCohortMembershipConsumer } from './cdp-cohort-membership.consumer'
-import { counterCohortMembershipControlMessageSkipped } from './metrics'
 
 jest.setTimeout(20_000)
 
@@ -30,7 +29,6 @@ describe('CdpCohortMembershipConsumer', () => {
     afterEach(async () => {
         await consumer.stop()
         await closeHub(hub)
-        jest.restoreAllMocks()
     })
 
     describe('end-to-end cohort membership processing', () => {
@@ -214,60 +212,6 @@ describe('CdpCohortMembershipConsumer', () => {
             expect(result.rows[0].in_cohort).toBe(false)
         })
 
-        it('should skip typed control messages while persisting membership changes', async () => {
-            const skippedControlMessageCounter = jest.spyOn(counterCohortMembershipControlMessageSkipped, 'inc')
-            const messages = [
-                createKafkaMessage(
-                    createCohortMembershipEvent({
-                        person_id: personId1,
-                        cohort_id: 456,
-                        team_id: 1,
-                        status: 'entered',
-                    }),
-                    { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 0 }
-                ),
-                createKafkaMessage(
-                    {
-                        type: 'reconcile_complete',
-                        team_id: 1,
-                        cohort_id: 456,
-                        partition: 7,
-                        run_id: new UUIDT().toString(),
-                        last_updated: '2026-05-26 12:34:56.789123',
-                    },
-                    { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 1 }
-                ),
-                createKafkaMessage(
-                    createCohortMembershipEvent({
-                        person_id: personId2,
-                        cohort_id: 456,
-                        team_id: 1,
-                        status: 'left',
-                    }),
-                    { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 2 }
-                ),
-            ]
-
-            const cohortMembershipChanges = consumer['_parseAndValidateBatch'](messages)
-            await consumer['persistCohortMembershipChanges'](cohortMembershipChanges)
-
-            const result = await hub.postgres.query(
-                PostgresUse.BEHAVIORAL_COHORTS_RW,
-                'SELECT person_id, in_cohort FROM cohort_membership WHERE team_id = $1 ORDER BY person_id',
-                [1],
-                'testQuery'
-            )
-
-            expect(result.rows).toHaveLength(2)
-            expect(result.rows).toEqual(
-                expect.arrayContaining([
-                    { person_id: personId1, in_cohort: true },
-                    { person_id: personId2, in_cohort: false },
-                ])
-            )
-            expect(skippedControlMessageCounter).toHaveBeenCalledTimes(1)
-        })
-
         it('should reject entire batch when invalid messages are present', async () => {
             const validEvent = {
                 person_id: personId1,
@@ -276,11 +220,8 @@ describe('CdpCohortMembershipConsumer', () => {
                 status: 'entered',
             }
 
-            const validMessage = createKafkaMessage(validEvent, {
-                topic: KAFKA_COHORT_MEMBERSHIP_CHANGED,
-                offset: 0,
-            })
-            const invalidMessages: Message[] = [
+            const messages: Message[] = [
+                createKafkaMessage(validEvent, { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 0 }),
                 {
                     value: Buffer.from('invalid json'),
                     topic: KAFKA_COHORT_MEMBERSHIP_CHANGED,
@@ -302,9 +243,7 @@ describe('CdpCohortMembershipConsumer', () => {
                 },
             ]
 
-            for (const invalidMessage of invalidMessages) {
-                expect(() => consumer['_parseAndValidateBatch']([validMessage, invalidMessage])).toThrow()
-            }
+            expect(() => consumer['_parseAndValidateBatch'](messages)).toThrow()
 
             const result = await hub.postgres.query(
                 PostgresUse.BEHAVIORAL_COHORTS_RW,

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
@@ -11,6 +11,7 @@ import { resetBehavioralCohortsDatabase } from '../../../tests/helpers/sql'
 import { Hub } from '../../types'
 import { createCohortMembershipEvent, createCohortMembershipEvents, createKafkaMessage } from '../_tests/fixtures'
 import { CdpCohortMembershipConsumer } from './cdp-cohort-membership.consumer'
+import { counterCohortMembershipControlMessageSkipped } from './metrics'
 
 jest.setTimeout(20_000)
 
@@ -29,6 +30,7 @@ describe('CdpCohortMembershipConsumer', () => {
     afterEach(async () => {
         await consumer.stop()
         await closeHub(hub)
+        jest.restoreAllMocks()
     })
 
     describe('end-to-end cohort membership processing', () => {
@@ -212,6 +214,60 @@ describe('CdpCohortMembershipConsumer', () => {
             expect(result.rows[0].in_cohort).toBe(false)
         })
 
+        it('should skip typed control messages while persisting membership changes', async () => {
+            const skippedControlMessageCounter = jest.spyOn(counterCohortMembershipControlMessageSkipped, 'inc')
+            const messages = [
+                createKafkaMessage(
+                    createCohortMembershipEvent({
+                        person_id: personId1,
+                        cohort_id: 456,
+                        team_id: 1,
+                        status: 'entered',
+                    }),
+                    { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 0 }
+                ),
+                createKafkaMessage(
+                    {
+                        type: 'reconcile_complete',
+                        team_id: 1,
+                        cohort_id: 456,
+                        partition: 7,
+                        run_id: new UUIDT().toString(),
+                        last_updated: '2026-05-26 12:34:56.789123',
+                    },
+                    { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 1 }
+                ),
+                createKafkaMessage(
+                    createCohortMembershipEvent({
+                        person_id: personId2,
+                        cohort_id: 456,
+                        team_id: 1,
+                        status: 'left',
+                    }),
+                    { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 2 }
+                ),
+            ]
+
+            const cohortMembershipChanges = consumer['_parseAndValidateBatch'](messages)
+            await consumer['persistCohortMembershipChanges'](cohortMembershipChanges)
+
+            const result = await hub.postgres.query(
+                PostgresUse.BEHAVIORAL_COHORTS_RW,
+                'SELECT person_id, in_cohort FROM cohort_membership WHERE team_id = $1 ORDER BY person_id',
+                [1],
+                'testQuery'
+            )
+
+            expect(result.rows).toHaveLength(2)
+            expect(result.rows).toEqual(
+                expect.arrayContaining([
+                    { person_id: personId1, in_cohort: true },
+                    { person_id: personId2, in_cohort: false },
+                ])
+            )
+            expect(skippedControlMessageCounter).toHaveBeenCalledTimes(1)
+        })
+
         it('should reject entire batch when invalid messages are present', async () => {
             const validEvent = {
                 person_id: personId1,
@@ -220,8 +276,11 @@ describe('CdpCohortMembershipConsumer', () => {
                 status: 'entered',
             }
 
-            const messages: Message[] = [
-                createKafkaMessage(validEvent, { topic: KAFKA_COHORT_MEMBERSHIP_CHANGED, offset: 0 }),
+            const validMessage = createKafkaMessage(validEvent, {
+                topic: KAFKA_COHORT_MEMBERSHIP_CHANGED,
+                offset: 0,
+            })
+            const invalidMessages: Message[] = [
                 {
                     value: Buffer.from('invalid json'),
                     topic: KAFKA_COHORT_MEMBERSHIP_CHANGED,
@@ -243,7 +302,9 @@ describe('CdpCohortMembershipConsumer', () => {
                 },
             ]
 
-            expect(() => consumer['_parseAndValidateBatch'](messages)).toThrow()
+            for (const invalidMessage of invalidMessages) {
+                expect(() => consumer['_parseAndValidateBatch']([validMessage, invalidMessage])).toThrow()
+            }
 
             const result = await hub.postgres.query(
                 PostgresUse.BEHAVIORAL_COHORTS_RW,

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
@@ -10,13 +10,8 @@ import { logger } from '~/common/utils/logger'
 
 import { HealthCheckResult } from '../../types'
 import { CdpConsumerBase, CdpConsumerBaseConfig, CdpConsumerBaseDeps } from './cdp-base.consumer'
-import { counterCohortMembershipControlMessageSkipped } from './metrics'
 
-// Zod schema for validation.
-// Invariant: a membership row must never carry a `type` field. Control messages (e.g. reconcile
-// completion markers) are the only shape with `type`, and `isTypedControlMessage` skips any object
-// that defines one *before* this schema runs — so adding `type` to a membership row would make the
-// consumer silently drop it.
+// Zod schema for validation
 const CohortMembershipChangeSchema = z.object({
     person_id: z.guid(),
     cohort_id: z.number(),
@@ -26,12 +21,6 @@ const CohortMembershipChangeSchema = z.object({
 })
 
 export type CohortMembershipChange = z.infer<typeof CohortMembershipChangeSchema>
-
-type TypedControlMessage = { type: unknown }
-
-function isTypedControlMessage(message: unknown): message is TypedControlMessage {
-    return typeof message === 'object' && message !== null && 'type' in message && message.type !== undefined
-}
 
 export class CdpCohortMembershipConsumer extends CdpConsumerBase {
     protected name = 'CdpCohortMembershipConsumer'
@@ -107,16 +96,7 @@ export class CdpCohortMembershipConsumer extends CdpConsumerBase {
                     throw new Error('Empty message received')
                 }
 
-                const parsedMessage: unknown = parseJSON(messageValue)
-
-                if (isTypedControlMessage(parsedMessage)) {
-                    counterCohortMembershipControlMessageSkipped.inc()
-                    logger.info('Skipping typed cohort membership control message', {
-                        messageType:
-                            typeof parsedMessage.type === 'string' ? parsedMessage.type : typeof parsedMessage.type,
-                    })
-                    continue
-                }
+                const parsedMessage = parseJSON(messageValue)
 
                 // Validate using Zod schema
                 const validationResult = CohortMembershipChangeSchema.safeParse(parsedMessage)

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
@@ -12,7 +12,11 @@ import { HealthCheckResult } from '../../types'
 import { CdpConsumerBase, CdpConsumerBaseConfig, CdpConsumerBaseDeps } from './cdp-base.consumer'
 import { counterCohortMembershipControlMessageSkipped } from './metrics'
 
-// Zod schema for validation
+// Zod schema for validation.
+// Invariant: a membership row must never carry a `type` field. Control messages (e.g. reconcile
+// completion markers) are the only shape with `type`, and `isTypedControlMessage` skips any object
+// that defines one *before* this schema runs — so adding `type` to a membership row would make the
+// consumer silently drop it.
 const CohortMembershipChangeSchema = z.object({
     person_id: z.guid(),
     cohort_id: z.number(),

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
@@ -10,6 +10,7 @@ import { logger } from '~/common/utils/logger'
 
 import { HealthCheckResult } from '../../types'
 import { CdpConsumerBase, CdpConsumerBaseConfig, CdpConsumerBaseDeps } from './cdp-base.consumer'
+import { counterCohortMembershipControlMessageSkipped } from './metrics'
 
 // Zod schema for validation
 const CohortMembershipChangeSchema = z.object({
@@ -21,6 +22,12 @@ const CohortMembershipChangeSchema = z.object({
 })
 
 export type CohortMembershipChange = z.infer<typeof CohortMembershipChangeSchema>
+
+type TypedControlMessage = { type: unknown }
+
+function isTypedControlMessage(message: unknown): message is TypedControlMessage {
+    return typeof message === 'object' && message !== null && 'type' in message && message.type !== undefined
+}
 
 export class CdpCohortMembershipConsumer extends CdpConsumerBase {
     protected name = 'CdpCohortMembershipConsumer'
@@ -96,7 +103,16 @@ export class CdpCohortMembershipConsumer extends CdpConsumerBase {
                     throw new Error('Empty message received')
                 }
 
-                const parsedMessage = parseJSON(messageValue)
+                const parsedMessage: unknown = parseJSON(messageValue)
+
+                if (isTypedControlMessage(parsedMessage)) {
+                    counterCohortMembershipControlMessageSkipped.inc()
+                    logger.info('Skipping typed cohort membership control message', {
+                        messageType:
+                            typeof parsedMessage.type === 'string' ? parsedMessage.type : typeof parsedMessage.type,
+                    })
+                    continue
+                }
 
                 // Validate using Zod schema
                 const validationResult = CohortMembershipChangeSchema.safeParse(parsedMessage)

--- a/nodejs/src/cdp/consumers/metrics.ts
+++ b/nodejs/src/cdp/consumers/metrics.ts
@@ -23,8 +23,3 @@ export const counterBatchHogFlowTriggerFailed = new Counter({
     help: 'A batch hog flow run failed during audience resolution and was skipped',
     labelNames: ['hog_flow_id', 'reason'],
 })
-
-export const counterCohortMembershipControlMessageSkipped = new Counter({
-    name: 'cdp_cohort_membership_control_message_skipped',
-    help: 'A typed cohort membership control message was skipped',
-})

--- a/nodejs/src/cdp/consumers/metrics.ts
+++ b/nodejs/src/cdp/consumers/metrics.ts
@@ -23,3 +23,8 @@ export const counterBatchHogFlowTriggerFailed = new Counter({
     help: 'A batch hog flow run failed during audience resolution and was skipped',
     labelNames: ['hog_flow_id', 'reason'],
 })
+
+export const counterCohortMembershipControlMessageSkipped = new Counter({
+    name: 'cdp_cohort_membership_control_message_skipped',
+    help: 'A typed cohort membership control message was skipped',
+})

--- a/products/cohorts/backend/management/commands/compare_cohort_membership.py
+++ b/products/cohorts/backend/management/commands/compare_cohort_membership.py
@@ -178,7 +178,8 @@ class Command(BaseCommand):
         log(
             f"drained {drain_stats.consumed} messages from {drain_stats.partitions_read}/{drain_stats.partitions} "
             f"partitions; folded {fold_stats.folded} for team {team_id} across {len(fold_stats.cohorts_seen)} cohorts "
-            f"(dropped: {fold_stats.dropped_wrong_team} wrong-team, {fold_stats.dropped_before_since} pre-since, "
+            f"({fold_stats.reconcile_markers_recorded} reconcile markers; "
+            f"dropped: {fold_stats.dropped_wrong_team} wrong-team, {fold_stats.dropped_before_since} pre-since, "
             f"{fold_stats.dropped_malformed} malformed, {drain_stats.undecodable} undecodable; "
             f"by origin: {dict(sorted(fold_stats.folded_by_origin.items()))})"
         )

--- a/products/cohorts/backend/management/commands/compare_cohort_membership.py
+++ b/products/cohorts/backend/management/commands/compare_cohort_membership.py
@@ -24,9 +24,15 @@ from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from products.cohorts.backend.parity.classifier import ClassifierConfig, CohortComparison, classify_cohort, summarize
 from products.cohorts.backend.parity.eligibility import EMITTING_CLASSES, screen_team
-from products.cohorts.backend.parity.fold import fold_membership_changes
+from products.cohorts.backend.parity.fold import fold_membership_changes, reconcile_completeness
 from products.cohorts.backend.parity.kafka_io import DEFAULT_SHADOW_TOPIC, DrainStats, consumer_config, drain_topic
-from products.cohorts.backend.parity.report import format_notes, format_summary, format_table, to_json
+from products.cohorts.backend.parity.report import (
+    format_notes,
+    format_reconcile_notes,
+    format_summary,
+    format_table,
+    to_json,
+)
 from products.cohorts.backend.parity.snapshots import load_old_membership, load_realtime_cohorts, make_activity_probe
 
 SHADOW_TOPIC_RETENTION_DAYS = 7
@@ -173,7 +179,8 @@ class Command(BaseCommand):
             f"drained {drain_stats.consumed} messages from {drain_stats.partitions_read}/{drain_stats.partitions} "
             f"partitions; folded {fold_stats.folded} for team {team_id} across {len(fold_stats.cohorts_seen)} cohorts "
             f"(dropped: {fold_stats.dropped_wrong_team} wrong-team, {fold_stats.dropped_before_since} pre-since, "
-            f"{fold_stats.dropped_malformed} malformed, {drain_stats.undecodable} undecodable)"
+            f"{fold_stats.dropped_malformed} malformed, {drain_stats.undecodable} undecodable; "
+            f"by origin: {dict(sorted(fold_stats.folded_by_origin.items()))})"
         )
 
         warnings, infos = _collect_warnings(drain_stats, fold_stats.cohorts_seen - set(screened), since, now)
@@ -201,6 +208,7 @@ class Command(BaseCommand):
                     new_state=new_state.get(cid, {}),
                     last_realtime_calculation_at=last_calc[cid],
                     config=classifier_config,
+                    notes=format_reconcile_notes(reconcile_completeness(fold_stats, cid)),
                 )
             )
 

--- a/products/cohorts/backend/parity/classifier.py
+++ b/products/cohorts/backend/parity/classifier.py
@@ -5,8 +5,8 @@ emitted a decision for since the store wipe (fold.py:observed). Within O both pi
 have weighed in, so the diff is sound; each rule explains (removes) part of it and the
 remainder is the gated residual:
 
-- R-EXCLUDE: persons in `old - O` are excluded from the diff entirely (the new pipeline
-  never evaluated them — flip-only emission means a never-member emits nothing).
+- R-EXCLUDE: persons in `old - O` are excluded from the diff entirely because the new
+  pipeline has not emitted a decision for them.
 - R-FRESH:  `only_new` entries whose flip is newer than the old side's last recompute —
   the old pipeline simply hasn't caught up yet (expected, not over-inclusion).
 - R-STALE:  the mirror on `only_old` — the new pipeline already flipped a person to
@@ -115,6 +115,7 @@ def classify_cohort(
     new_state: dict[str, MembershipRecord],
     last_realtime_calculation_at: Optional[datetime],
     config: ClassifierConfig,
+    notes: Sequence[str] = (),
 ) -> CohortComparison:
     if not screened.emits:
         return CohortComparison(
@@ -122,7 +123,10 @@ def classify_cohort(
             name=name,
             eligibility=screened.eligibility,
             verdict=VERDICT_SKIP,
-            notes=("not emit-eligible: " + ", ".join(screened.drop_reasons or (screened.eligibility,)),),
+            notes=(
+                *notes,
+                "not emit-eligible: " + ", ".join(screened.drop_reasons or (screened.eligibility,)),
+            ),
         )
 
     obs = observed(new_state)
@@ -133,7 +137,7 @@ def classify_cohort(
     unobserved = old_members - obs  # excluded from the diff (R-EXCLUDE)
     union_size = len(both) + len(only_old) + len(only_new)
     raw_pct = _pct(len(only_old) + len(only_new), union_size)
-    notes: list[str] = []
+    comparison_notes = list(notes)
 
     fresh = 0
     stale = 0
@@ -144,7 +148,7 @@ def classify_cohort(
             fresh = len(only_new)
             # stale stays 0: a never-recomputed old side has no entered rows to be stale.
             if fresh:
-                notes.append("old side never recomputed this cohort; all only_new counted fresh")
+                comparison_notes.append("old side never recomputed this cohort; all only_new counted fresh")
         else:
             fresh = sum(1 for p in only_new if new_state[p].last_updated > last_realtime_calculation_at)
             stale = sum(1 for p in only_old if new_state[p].last_updated > last_realtime_calculation_at)
@@ -160,11 +164,11 @@ def classify_cohort(
             sample_suspect = sum(1 for p in sample if p in active)
             suspect_missing = round(sample_suspect / len(sample) * len(unobserved))
             if len(sample) < len(unobserved):
-                notes.append(f"suspect_missing extrapolated from sample {len(sample)}/{len(unobserved)}")
+                comparison_notes.append(f"suspect_missing extrapolated from sample {len(sample)}/{len(unobserved)}")
             if window == 0:
-                notes.append("minute/hour window: probe cutoff is now, suspect≈0 by construction")
+                comparison_notes.append("minute/hour window: probe cutoff is now, suspect≈0 by construction")
         elif unobserved and config.warmup_sample <= 0:
-            notes.append("suspect check skipped (--warmup-sample 0); unobserved population unprobed")
+            comparison_notes.append("suspect check skipped (--warmup-sample 0); unobserved population unprobed")
 
     residual_old = max(len(only_old) - stale, 0)
     residual_new = max(len(only_new) - fresh, 0)
@@ -205,7 +209,7 @@ def classify_cohort(
         dormant=dormant,
         suspect_pct=suspect_pct,
         verdict=verdict,
-        notes=tuple(notes),
+        notes=tuple(comparison_notes),
     )
 
 

--- a/products/cohorts/backend/parity/fold.py
+++ b/products/cohorts/backend/parity/fold.py
@@ -51,6 +51,10 @@ class FoldStats:
     dropped_malformed: int = 0
     cohorts_seen: set[int] = field(default_factory=set)
     reconcile_markers: dict[tuple[str, int], set[int]] = field(default_factory=dict)
+    # Count of accepted marker messages, incl. duplicates — the reconcile_markers set dedups by
+    # partition, so it undercounts. This keeps folded + drops + markers == total (markers land in
+    # neither the folded nor the dropped buckets).
+    reconcile_markers_recorded: int = 0
     folded_by_origin: dict[str, int] = field(default_factory=dict)
 
 
@@ -122,6 +126,7 @@ def fold_membership_changes(
                 stats.dropped_before_since += 1
                 continue
             stats.reconcile_markers.setdefault((run_id, cohort_id), set()).add(partition)
+            stats.reconcile_markers_recorded += 1
             stats.cohorts_seen.add(cohort_id)
             continue
 

--- a/products/cohorts/backend/parity/fold.py
+++ b/products/cohorts/backend/parity/fold.py
@@ -12,12 +12,34 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Optional
+from uuid import UUID
+
+RECONCILE_COMPLETE_TYPE = "reconcile_complete"
+RECONCILE_PARTITION_COUNT = 64
+LIVE_ORIGIN = "live"
 
 
 @dataclass(frozen=True)
 class MembershipRecord:
     status: str  # "entered" | "left"
     last_updated: datetime
+    origin: Optional[str] = None
+    run_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ReconcileRunCompleteness:
+    run_id: str
+    cohort_id: int
+    partitions_seen: int
+
+    @property
+    def expected_partitions(self) -> int:
+        return RECONCILE_PARTITION_COUNT
+
+    @property
+    def complete(self) -> bool:
+        return self.partitions_seen == RECONCILE_PARTITION_COUNT
 
 
 @dataclass
@@ -28,6 +50,8 @@ class FoldStats:
     dropped_before_since: int = 0
     dropped_malformed: int = 0
     cohorts_seen: set[int] = field(default_factory=set)
+    reconcile_markers: dict[tuple[str, int], set[int]] = field(default_factory=dict)
+    folded_by_origin: dict[str, int] = field(default_factory=dict)
 
 
 def parse_last_updated(raw: Any) -> Optional[datetime]:
@@ -45,6 +69,19 @@ def parse_last_updated(raw: Any) -> Optional[datetime]:
     return None
 
 
+def _parse_marker_run_id(raw: Any) -> Optional[str]:
+    if not isinstance(raw, str):
+        return None
+    try:
+        return str(UUID(raw))
+    except ValueError:
+        return None
+
+
+def _optional_string(raw: Any) -> Optional[str]:
+    return raw if isinstance(raw, str) and raw else None
+
+
 def fold_membership_changes(
     messages: Iterable[dict[str, Any]],
     *,
@@ -57,13 +94,39 @@ def fold_membership_changes(
     state: dict[int, dict[str, MembershipRecord]] = {}
     for message in messages:
         stats.total += 1
-        if message.get("team_id") != team_id:
+        message_team_id = message.get("team_id")
+        if not isinstance(message_team_id, int) or isinstance(message_team_id, bool):
+            stats.dropped_malformed += 1
+            continue
+        if message_team_id != team_id:
             stats.dropped_wrong_team += 1
             continue
         cohort_id = message.get("cohort_id")
+        last_updated = parse_last_updated(message.get("last_updated"))
+
+        if message.get("type") == RECONCILE_COMPLETE_TYPE:
+            run_id = _parse_marker_run_id(message.get("run_id"))
+            partition = message.get("partition")
+            if (
+                run_id is None
+                or not isinstance(cohort_id, int)
+                or isinstance(cohort_id, bool)
+                or not isinstance(partition, int)
+                or isinstance(partition, bool)
+                or not 0 <= partition < RECONCILE_PARTITION_COUNT
+                or last_updated is None
+            ):
+                stats.dropped_malformed += 1
+                continue
+            if last_updated < since:
+                stats.dropped_before_since += 1
+                continue
+            stats.reconcile_markers.setdefault((run_id, cohort_id), set()).add(partition)
+            stats.cohorts_seen.add(cohort_id)
+            continue
+
         person_id = message.get("person_id")
         status = message.get("status")
-        last_updated = parse_last_updated(message.get("last_updated"))
         if (
             not isinstance(cohort_id, int)
             or isinstance(cohort_id, bool)
@@ -84,11 +147,28 @@ def fold_membership_changes(
         # its boundary (here and both readers in snapshots.py) or the sets stop matching.
         key = person_id.lower()
         prior = bucket.get(key)
+        origin = _optional_string(message.get("origin"))
+        run_id = _optional_string(message.get("run_id"))
         if prior is None or last_updated >= prior.last_updated:
-            bucket[key] = MembershipRecord(status=status, last_updated=last_updated)
+            bucket[key] = MembershipRecord(status=status, last_updated=last_updated, origin=origin, run_id=run_id)
         stats.cohorts_seen.add(cohort_id)
         stats.folded += 1
+        origin_key = origin or LIVE_ORIGIN
+        stats.folded_by_origin[origin_key] = stats.folded_by_origin.get(origin_key, 0) + 1
     return state, stats
+
+
+def reconcile_completeness(stats: FoldStats, cohort_id: int) -> tuple[ReconcileRunCompleteness, ...]:
+    """Return deterministic per-run marker completeness for one cohort."""
+    return tuple(
+        ReconcileRunCompleteness(
+            run_id=run_id,
+            cohort_id=marker_cohort_id,
+            partitions_seen=len(partitions),
+        )
+        for (run_id, marker_cohort_id), partitions in sorted(stats.reconcile_markers.items())
+        if marker_cohort_id == cohort_id
+    )
 
 
 def members(state: dict[str, MembershipRecord]) -> set[str]:
@@ -99,8 +179,8 @@ def members(state: dict[str, MembershipRecord]) -> set[str]:
 def observed(state: dict[str, MembershipRecord]) -> set[str]:
     """Every person the new pipeline emitted a decision for in this cohort.
 
-    Emission is flip-only (see the Rust processor's stage1/transition + stage2/evaluator),
-    so a first emission is always `entered`: the presence of a key means both pipelines
-    have weighed in on that person, which is the universe the membership diff is bounded to.
+    Live and seed processing can be flip-only, while reconcile snapshots emit every current
+    decision. In either case, the presence of a key means the new pipeline has weighed in on
+    that person, which is the universe the membership diff is bounded to.
     """
     return set(state.keys())

--- a/products/cohorts/backend/parity/report.py
+++ b/products/cohorts/backend/parity/report.py
@@ -14,6 +14,7 @@ from products.cohorts.backend.parity.classifier import (
     AggregateSummary,
     CohortComparison,
 )
+from products.cohorts.backend.parity.fold import ReconcileRunCompleteness
 
 _VERDICT_ORDER = {VERDICT_FAIL: 0, VERDICT_WARMUP: 1, VERDICT_PASS: 2, VERDICT_SKIP: 3}
 
@@ -47,6 +48,18 @@ def format_notes(rows: Sequence[CohortComparison]) -> str:
         for note in r.notes:
             lines.append(f"  cohort {r.cohort_id}: {note}")
     return "\n".join(lines)
+
+
+def format_reconcile_notes(completeness: Sequence[ReconcileRunCompleteness]) -> tuple[str, ...]:
+    notes: list[str] = []
+    for run in sorted(completeness, key=lambda item: (item.run_id, item.cohort_id)):
+        partition_summary = (
+            f"{run.partitions_seen}/{run.expected_partitions}"
+            if run.complete
+            else f"partial {run.partitions_seen}/{run.expected_partitions}"
+        )
+        notes.append(f"reconcile run {run.run_id}: {partition_summary}")
+    return tuple(notes)
 
 
 def format_summary(summary: AggregateSummary) -> str:

--- a/products/cohorts/backend/parity/test/test_classifier.py
+++ b/products/cohorts/backend/parity/test/test_classifier.py
@@ -1,4 +1,5 @@
 import math
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 from django.test import SimpleTestCase
@@ -49,9 +50,33 @@ class TestClassifier(SimpleTestCase):
             new_state={},
             last_realtime_calculation_at=LAST_CALC,
             config=_config(),
+            notes=("reconcile run r: partial 1/64",),
         )
         self.assertEqual(row.verdict, VERDICT_SKIP)
         self.assertFalse(row.gated)
+        self.assertEqual(row.notes[0], "reconcile run r: partial 1/64")
+
+    def test_reconcile_note_does_not_change_classification_fields(self) -> None:
+        baseline = classify_cohort(
+            screened=_screened(),
+            name="x",
+            old_members={"a"},
+            new_state=_entered(["a"], at=NOW),
+            last_realtime_calculation_at=LAST_CALC,
+            config=_config(),
+        )
+        with_reconcile_note = classify_cohort(
+            screened=_screened(),
+            name="x",
+            old_members={"a"},
+            new_state=_entered(["a"], at=NOW),
+            last_realtime_calculation_at=LAST_CALC,
+            config=_config(),
+            notes=("reconcile run r: 64/64",),
+        )
+
+        self.assertEqual(replace(with_reconcile_note, notes=()), baseline)
+        self.assertEqual(with_reconcile_note.notes, ("reconcile run r: 64/64",))
 
     def test_fresh_rule_explains_new_entries_after_last_recompute(self) -> None:
         new_state = _entered(["a", "b"], at=NOW - timedelta(minutes=45)) | _entered(

--- a/products/cohorts/backend/parity/test/test_fold.py
+++ b/products/cohorts/backend/parity/test/test_fold.py
@@ -158,6 +158,10 @@ class TestFold(SimpleTestCase):
             [(run.run_id, run.partitions_seen, run.complete) for run in completeness],
             [(RUN_1, 41, False), (RUN_2, 64, True)],
         )
+        # Counts every accepted marker message, including the RUN_1 partition-0 duplicate — 106,
+        # not the 105 distinct partitions the completeness sets hold. Keeps the summary's
+        # folded + drops + markers == total accounting exact.
+        self.assertEqual(stats.reconcile_markers_recorded, 106)
 
     @parameterized.expand(
         [

--- a/products/cohorts/backend/parity/test/test_fold.py
+++ b/products/cohorts/backend/parity/test/test_fold.py
@@ -4,9 +4,18 @@ from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
-from products.cohorts.backend.parity.fold import fold_membership_changes, members, observed, parse_last_updated
+from products.cohorts.backend.parity.fold import (
+    LIVE_ORIGIN,
+    fold_membership_changes,
+    members,
+    observed,
+    parse_last_updated,
+    reconcile_completeness,
+)
 
 SINCE = datetime(2026, 7, 7, 19, 0, tzinfo=UTC)
+RUN_1 = "00000000-0000-0000-0000-000000000001"
+RUN_2 = "00000000-0000-0000-0000-000000000002"
 
 
 def _msg(status: str, ts: str, *, cohort_id: int | None = 10, person_id: str = "P1", team_id: int = 2) -> dict:
@@ -16,6 +25,24 @@ def _msg(status: str, ts: str, *, cohort_id: int | None = 10, person_id: str = "
         "person_id": person_id,
         "last_updated": ts,
         "status": status,
+    }
+
+
+def _marker(
+    partition: int,
+    *,
+    run_id: str = RUN_1,
+    cohort_id: int = 10,
+    team_id: int = 2,
+    ts: str = "2026-07-07 19:05:00.000001",
+) -> dict:
+    return {
+        "type": "reconcile_complete",
+        "team_id": team_id,
+        "cohort_id": cohort_id,
+        "partition": partition,
+        "run_id": run_id,
+        "last_updated": ts,
     }
 
 
@@ -85,6 +112,75 @@ class TestFold(SimpleTestCase):
         )
         self.assertEqual(members(state[10]), {"p2"})
         self.assertEqual(stats.dropped_wrong_team, 1)
+
+    def test_reconcile_marker_is_recorded_before_membership_validation(self) -> None:
+        state, stats = fold_membership_changes(
+            [
+                _marker(7),
+                _msg("entered", "2026-07-07 19:06:00.000001") | {"origin": "reconcile", "run_id": RUN_1},
+            ],
+            team_id=2,
+            since=SINCE,
+        )
+
+        self.assertEqual(stats.reconcile_markers, {(RUN_1, 10): {7}})
+        self.assertEqual(stats.dropped_malformed, 0)
+        self.assertEqual(stats.cohorts_seen, {10})
+        self.assertEqual(state[10]["p1"].origin, "reconcile")
+        self.assertEqual(state[10]["p1"].run_id, RUN_1)
+
+    def test_membership_provenance_follows_lww_and_counts_every_folded_origin(self) -> None:
+        state, stats = fold_membership_changes(
+            [
+                _msg("entered", "2026-07-07 19:01:00.000001", person_id="P1"),
+                _msg("entered", "2026-07-07 19:02:00.000001", person_id="P2") | {"origin": "seed", "run_id": RUN_1},
+                _msg("left", "2026-07-07 19:03:00.000001", person_id="P1") | {"origin": "reconcile", "run_id": RUN_2},
+            ],
+            team_id=2,
+            since=SINCE,
+        )
+
+        self.assertEqual(stats.folded_by_origin, {LIVE_ORIGIN: 1, "seed": 1, "reconcile": 1})
+        self.assertEqual(
+            (state[10]["p1"].status, state[10]["p1"].origin, state[10]["p1"].run_id), ("left", "reconcile", RUN_2)
+        )
+        self.assertEqual((state[10]["p2"].origin, state[10]["p2"].run_id), ("seed", RUN_1))
+
+    def test_reconcile_completeness_is_per_run_and_counts_distinct_partitions(self) -> None:
+        messages = [*(_marker(partition, run_id=RUN_2) for partition in range(64))]
+        messages.extend(_marker(partition, run_id=RUN_1) for partition in range(41))
+        messages.append(_marker(0, run_id=RUN_1))
+
+        _state, stats = fold_membership_changes(messages, team_id=2, since=SINCE)
+
+        completeness = reconcile_completeness(stats, cohort_id=10)
+        self.assertEqual(
+            [(run.run_id, run.partitions_seen, run.complete) for run in completeness],
+            [(RUN_1, 41, False), (RUN_2, 64, True)],
+        )
+
+    @parameterized.expand(
+        [
+            ("bad_run_id", _marker(1, run_id="not-a-uuid"), 2, 1, 0),
+            ("out_of_range_partition", _marker(64), 2, 1, 0),
+            ("float_team_id", _marker(1) | {"team_id": 2.0}, 2, 1, 0),
+            ("boolean_team_id", _marker(1, team_id=True), 1, 1, 0),
+            ("before_since", _marker(1, ts="2026-07-07 18:59:59.999999"), 2, 0, 1),
+        ]
+    )
+    def test_invalid_or_stale_markers_cannot_certify_reconcile(
+        self,
+        _name: str,
+        marker: dict,
+        team_id: int,
+        expected_malformed: int,
+        expected_before_since: int,
+    ) -> None:
+        _state, stats = fold_membership_changes([marker], team_id=team_id, since=SINCE)
+
+        self.assertEqual(stats.reconcile_markers, {})
+        self.assertEqual(stats.dropped_malformed, expected_malformed)
+        self.assertEqual(stats.dropped_before_since, expected_before_since)
 
     @parameterized.expand(
         [

--- a/products/cohorts/backend/parity/test/test_report.py
+++ b/products/cohorts/backend/parity/test/test_report.py
@@ -8,12 +8,23 @@ from products.cohorts.backend.parity.classifier import (
     AggregateSummary,
     CohortComparison,
 )
-from products.cohorts.backend.parity.report import to_json
+from products.cohorts.backend.parity.fold import ReconcileRunCompleteness
+from products.cohorts.backend.parity.report import format_notes, format_reconcile_notes, to_json
 
 
-def _row(cohort_id: int, verdict: str, residual_pct: float = 0.0) -> CohortComparison:
+def _row(
+    cohort_id: int,
+    verdict: str,
+    residual_pct: float = 0.0,
+    notes: tuple[str, ...] = (),
+) -> CohortComparison:
     return CohortComparison(
-        cohort_id=cohort_id, name=f"c{cohort_id}", eligibility="single_leaf", verdict=verdict, residual_pct=residual_pct
+        cohort_id=cohort_id,
+        name=f"c{cohort_id}",
+        eligibility="single_leaf",
+        verdict=verdict,
+        residual_pct=residual_pct,
+        notes=notes,
     )
 
 
@@ -32,3 +43,20 @@ class TestReport(SimpleTestCase):
             [(5, VERDICT_FAIL), (3, VERDICT_FAIL), (4, VERDICT_WARMUP), (2, VERDICT_PASS), (1, VERDICT_SKIP)],
         )
         self.assertEqual(document["meta"], {"team_id": 2})
+
+    def test_reconcile_completeness_is_rendered_as_complete_or_partial_notes(self) -> None:
+        notes = format_reconcile_notes(
+            [
+                ReconcileRunCompleteness(run_id="run-b", cohort_id=10, partitions_seen=41),
+                ReconcileRunCompleteness(run_id="run-a", cohort_id=10, partitions_seen=64),
+            ]
+        )
+
+        self.assertEqual(notes, ("reconcile run run-a: 64/64", "reconcile run run-b: partial 41/64"))
+        row = _row(10, VERDICT_PASS, notes=notes)
+        self.assertEqual(
+            format_notes([row]),
+            "  cohort 10: reconcile run run-a: 64/64\n  cohort 10: reconcile run run-b: partial 41/64",
+        )
+        document = to_json([row], AggregateSummary(), {"team_id": 2})
+        self.assertEqual(document["cohorts"][0]["notes"], notes)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2239,6 +2239,7 @@ dependencies = [
  "axum 0.7.9",
  "chrono",
  "chrono-tz",
+ "clap",
  "clickhouse",
  "cohort-core",
  "common-alloc",

--- a/rust/cohort-core/src/eligibility.rs
+++ b/rust/cohort-core/src/eligibility.rs
@@ -83,6 +83,12 @@ impl CohortEligibility {
     pub fn writes_cf_stage2(self) -> bool {
         matches!(self, Self::Stage2Composable | Self::Stage2ComposableRef)
     }
+
+    /// Whether this class persists membership in `cf_stage2`. Single-leaf cohorts register their
+    /// leaf membership directly; composable cohorts persist the result of Boolean composition.
+    pub fn registers_membership(self) -> bool {
+        !matches!(self, Self::Excluded(_))
+    }
 }
 
 /// Whether a tree's root condition is negated: AND requires all children negated, OR requires any.
@@ -904,6 +910,12 @@ mod tests {
             "a still-excluded ref cohort persists no cf_stage2 row",
         );
         assert!(!CohortEligibility::Excluded(ExcludedReason::CycleDetected).writes_cf_stage2());
+
+        assert!(CohortEligibility::Stage2Composable.registers_membership());
+        assert!(CohortEligibility::Stage2ComposableRef.registers_membership());
+        assert!(CohortEligibility::SingleLeaf(LeafStateKey(HASH_A)).registers_membership());
+        assert!(!CohortEligibility::Excluded(ExcludedReason::HasCohortRef).registers_membership(),);
+        assert!(!CohortEligibility::Excluded(ExcludedReason::CycleDetected).registers_membership(),);
     }
 
     #[test]

--- a/rust/cohort-core/src/eligibility.rs
+++ b/rust/cohort-core/src/eligibility.rs
@@ -86,8 +86,15 @@ impl CohortEligibility {
 
     /// Whether this class persists membership in `cf_stage2`. Single-leaf cohorts register their
     /// leaf membership directly; composable cohorts persist the result of Boolean composition.
+    ///
+    /// Enumerated positively — the reconcile scan domain and the orphan-GC keep-predicate both read
+    /// this, so a new eligibility variant must opt in here rather than default into membership
+    /// registration and reconcile emission.
     pub fn registers_membership(self) -> bool {
-        !matches!(self, Self::Excluded(_))
+        matches!(
+            self,
+            Self::SingleLeaf(_) | Self::Stage2Composable | Self::Stage2ComposableRef
+        )
     }
 }
 

--- a/rust/cohort-core/src/filters/loader.rs
+++ b/rust/cohort-core/src/filters/loader.rs
@@ -12,7 +12,10 @@ use tracing::warn;
 use crate::filters::catalog::FilterCatalog;
 use crate::filters::reverse_index::TeamFiltersBuilder;
 use crate::filters::{CohortId, FilterError, TeamId};
-use crate::metrics::{FILTER_CATALOG_COHORT_PARSE_ERRORS, FILTER_CATALOG_TZ_FALLBACK};
+use crate::metrics::{
+    FILTER_CATALOG_COHORT_PARSE_ERRORS, FILTER_CATALOG_INVALID_SHAPE_HASH,
+    FILTER_CATALOG_TZ_FALLBACK,
+};
 use crate::seed::BehavioralShapeHash;
 
 /// Realtime cohorts to load, mirroring the Node filter manager's predicate, joined to
@@ -66,12 +69,15 @@ pub fn build_catalog_from_rows(rows: Vec<CohortRow>, cascade_enabled: bool) -> F
                     Some(raw_hash) if raw_hash.is_empty() => {}
                     Some(raw_hash) => match BehavioralShapeHash::parse(&raw_hash) {
                         Ok(hash) => builder.set_behavioral_shape_hash(cohort_id, hash),
-                        Err(error) => warn!(
-                            cohort_id = cohort_id.0,
-                            team_id = team_id.0,
-                            error = %error,
-                            "ignoring invalid persisted behavioral shape hash",
-                        ),
+                        Err(error) => {
+                            counter!(FILTER_CATALOG_INVALID_SHAPE_HASH).increment(1);
+                            warn!(
+                                cohort_id = cohort_id.0,
+                                team_id = team_id.0,
+                                error = %error,
+                                "ignoring invalid persisted behavioral shape hash",
+                            );
+                        }
                     },
                 }
             }

--- a/rust/cohort-core/src/filters/loader.rs
+++ b/rust/cohort-core/src/filters/loader.rs
@@ -13,10 +13,12 @@ use crate::filters::catalog::FilterCatalog;
 use crate::filters::reverse_index::TeamFiltersBuilder;
 use crate::filters::{CohortId, FilterError, TeamId};
 use crate::metrics::{FILTER_CATALOG_COHORT_PARSE_ERRORS, FILTER_CATALOG_TZ_FALLBACK};
+use crate::seed::BehavioralShapeHash;
 
 /// Realtime cohorts to load, mirroring the Node filter manager's predicate, joined to
 /// `posthog_team` for the team timezone the bucket variants use for calendar-day computation.
-pub const REALTIME_COHORTS_SQL: &str = "SELECT c.id, c.team_id, c.filters, t.timezone \
+pub const REALTIME_COHORTS_SQL: &str = "SELECT c.id, c.team_id, c.filters, \
+            c.behavioral_filters_shape_hash, t.timezone \
      FROM posthog_cohort c \
      JOIN posthog_team t ON t.id = c.team_id \
      WHERE c.cohort_type = 'realtime' AND c.deleted = false AND c.filters IS NOT NULL";
@@ -27,6 +29,7 @@ pub struct CohortRow {
     pub id: i32,
     pub team_id: i32,
     pub filters: Value,
+    pub behavioral_filters_shape_hash: Option<String>,
     /// `posthog_team.timezone` — a non-null IANA zone name (default `"UTC"`).
     pub timezone: String,
 }
@@ -54,14 +57,33 @@ pub fn build_catalog_from_rows(rows: Vec<CohortRow>, cascade_enabled: bool) -> F
             )
         });
 
-        if let Err(err) = builder.add_cohort(cohort_id, team_id, &row.filters) {
-            counter!(FILTER_CATALOG_COHORT_PARSE_ERRORS).increment(1);
-            warn!(
-                cohort_id = cohort_id.0,
-                team_id = team_id.0,
-                error = %err,
-                "skipping cohort that failed to parse",
-            );
+        match builder.add_cohort(cohort_id, team_id, &row.filters) {
+            Ok(()) => {
+                match row.behavioral_filters_shape_hash {
+                    // Python's canonical extractor returns an empty string when a cohort has no
+                    // behavioral leaves. It is an expected unknown guard, not malformed data.
+                    None => {}
+                    Some(raw_hash) if raw_hash.is_empty() => {}
+                    Some(raw_hash) => match BehavioralShapeHash::parse(&raw_hash) {
+                        Ok(hash) => builder.set_behavioral_shape_hash(cohort_id, hash),
+                        Err(error) => warn!(
+                            cohort_id = cohort_id.0,
+                            team_id = team_id.0,
+                            error = %error,
+                            "ignoring invalid persisted behavioral shape hash",
+                        ),
+                    },
+                }
+            }
+            Err(err) => {
+                counter!(FILTER_CATALOG_COHORT_PARSE_ERRORS).increment(1);
+                warn!(
+                    cohort_id = cohort_id.0,
+                    team_id = team_id.0,
+                    error = %err,
+                    "skipping cohort that failed to parse",
+                );
+            }
         }
     }
 
@@ -92,6 +114,8 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    const SHAPE_HASH: &str = "persisted-authoritative-hash";
+
     fn row(id: i32, team_id: i32, filters: Value) -> CohortRow {
         row_with_tz(id, team_id, filters, "UTC")
     }
@@ -101,8 +125,15 @@ mod tests {
             id,
             team_id,
             filters,
+            behavioral_filters_shape_hash: None,
             timezone: timezone.to_string(),
         }
+    }
+
+    fn row_with_shape_hash(id: i32, team_id: i32, shape_hash: Option<&str>) -> CohortRow {
+        let mut row = row(id, team_id, behavioral_cohort());
+        row.behavioral_filters_shape_hash = shape_hash.map(str::to_string);
+        row
     }
 
     fn behavioral_cohort() -> Value {
@@ -126,6 +157,42 @@ mod tests {
     fn empty_rows_build_an_empty_catalog() {
         let catalog = build_catalog_from_rows(vec![], false);
         assert_eq!(catalog.team_count(), 0);
+    }
+
+    #[test]
+    fn build_catalog_carries_only_valid_persisted_behavioral_shape_hashes() {
+        assert!(REALTIME_COHORTS_SQL.contains("c.behavioral_filters_shape_hash"));
+        let mut malformed = row(5, 7, json!({ "bogus": true }));
+        malformed.behavioral_filters_shape_hash = Some(SHAPE_HASH.to_string());
+        let catalog = build_catalog_from_rows(
+            vec![
+                row_with_shape_hash(1, 7, Some(SHAPE_HASH)),
+                row_with_shape_hash(2, 7, None),
+                row_with_shape_hash(3, 7, Some("")),
+                row_with_shape_hash(4, 7, Some("non-ascii-é")),
+                malformed,
+            ],
+            false,
+        );
+
+        let team = catalog.team(TeamId(7)).expect("team present");
+        assert_eq!(
+            team.behavioral_shape_hashes[&CohortId(1)].as_str(),
+            SHAPE_HASH,
+        );
+        assert!(!team.behavioral_shape_hashes.contains_key(&CohortId(2)));
+        assert!(!team.behavioral_shape_hashes.contains_key(&CohortId(3)));
+        assert!(!team.behavioral_shape_hashes.contains_key(&CohortId(4)));
+        assert!(!team.behavioral_shape_hashes.contains_key(&CohortId(5)));
+        assert!(team.cohorts.contains_key(&CohortId(3)));
+        assert!(
+            team.cohorts.contains_key(&CohortId(4)),
+            "only the bad hash is ignored"
+        );
+        assert!(
+            !team.cohorts.contains_key(&CohortId(5)),
+            "the malformed cohort is skipped"
+        );
     }
 
     #[test]

--- a/rust/cohort-core/src/filters/reverse_index.rs
+++ b/rust/cohort-core/src/filters/reverse_index.rs
@@ -23,6 +23,7 @@ use crate::leaf_state::variant::StateVariant;
 use crate::metrics::{
     COHORT_ELIGIBILITY_TOTAL, COHORT_IN_CYCLE_TOTAL, FILTER_CATALOG_SKIPPED_LEAVES,
 };
+use crate::seed::BehavioralShapeHash;
 
 #[derive(Debug, Clone, Copy)]
 pub struct LeafStateMeta {
@@ -70,6 +71,8 @@ pub struct TeamFilters {
     pub eligibility: HashMap<CohortId, CohortEligibility>,
     /// Parsed trees by cohort, retained for the Stage 2 re-walk.
     pub cohorts: HashMap<CohortId, CohortTree>,
+    /// Persisted behavioral leaf-shape hashes used to fence reconcile work from cohort edits.
+    pub behavioral_shape_hashes: HashMap<CohortId, BehavioralShapeHash>,
     /// The team's resolved IANA timezone, used by bucket variants for calendar-day computation.
     pub timezone: Tz,
 }
@@ -94,6 +97,7 @@ impl Default for TeamFilters {
             by_referenced_cohort: HashMap::new(),
             eligibility: HashMap::new(),
             cohorts: HashMap::new(),
+            behavioral_shape_hashes: HashMap::new(),
             timezone: UTC,
         }
     }
@@ -118,6 +122,7 @@ pub struct TeamFiltersBuilder {
     cohorts: HashMap<CohortId, CohortTree>,
     /// Per-cohort eligibility signals captured during parse.
     flags: HashMap<CohortId, CohortParseFlags>,
+    behavioral_shape_hashes: HashMap<CohortId, BehavioralShapeHash>,
 }
 
 impl LeafSink for TeamFiltersBuilder {
@@ -156,6 +161,12 @@ impl LeafSink for TeamFiltersBuilder {
 }
 
 impl TeamFiltersBuilder {
+    /// Attach the persisted behavioral shape guard for `cohort_id`. Freeze discards the value when
+    /// no cohort with that id parsed successfully.
+    pub fn set_behavioral_shape_hash(&mut self, cohort_id: CohortId, hash: BehavioralShapeHash) {
+        self.behavioral_shape_hashes.insert(cohort_id, hash);
+    }
+
     pub fn add_cohort(
         &mut self,
         cohort_id: CohortId,
@@ -277,6 +288,8 @@ impl TeamFiltersBuilder {
                 (name, hashes)
             })
             .collect();
+        let mut behavioral_shape_hashes = self.behavioral_shape_hashes;
+        behavioral_shape_hashes.retain(|cohort_id, _| self.cohorts.contains_key(cohort_id));
 
         TeamFilters {
             by_condition_to_lsk: sorted_vec_map(self.by_condition_to_lsk),
@@ -294,6 +307,7 @@ impl TeamFiltersBuilder {
             by_referenced_cohort,
             eligibility,
             cohorts: self.cohorts,
+            behavioral_shape_hashes,
             timezone,
         }
     }
@@ -503,6 +517,31 @@ mod tests {
             UTC,
             "an empty filter set defaults to UTC",
         );
+    }
+
+    #[test]
+    fn freeze_retains_behavioral_shape_hashes_only_for_parsed_cohorts() {
+        let mut builder = TeamFiltersBuilder::default();
+        builder.set_behavioral_shape_hash(
+            CohortId(1),
+            BehavioralShapeHash::parse("persisted").unwrap(),
+        );
+        builder
+            .set_behavioral_shape_hash(CohortId(99), BehavioralShapeHash::parse("orphan").unwrap());
+        builder
+            .add_cohort(
+                CohortId(1),
+                TeamId(7),
+                &wrap(vec![behavioral_performed_event(7)]),
+            )
+            .unwrap();
+
+        let frozen = builder.freeze(UTC);
+        assert_eq!(
+            frozen.behavioral_shape_hashes[&CohortId(1)].as_str(),
+            "persisted",
+        );
+        assert!(!frozen.behavioral_shape_hashes.contains_key(&CohortId(99)));
     }
 
     #[test]

--- a/rust/cohort-core/src/metrics.rs
+++ b/rust/cohort-core/src/metrics.rs
@@ -10,6 +10,10 @@ pub const FILTER_CATALOG_SKIPPED_LEAVES: &str = "filter_catalog_skipped_leaves_t
 pub const FILTER_CATALOG_COHORT_PARSE_ERRORS: &str = "filter_catalog_cohort_parse_errors_total";
 /// Teams whose timezone did not parse as an IANA zone and fell back to UTC (counter).
 pub const FILTER_CATALOG_TZ_FALLBACK: &str = "filter_catalog_tz_fallback_total";
+/// Cohorts whose persisted `behavioral_filters_shape_hash` failed to parse (counter). The cohort
+/// loads but reads as `HashUnknown`, so every reconcile for it discards — **alert on a sustained
+/// non-zero level**, it signals drift between the Python hash extractor and the Rust bounds.
+pub const FILTER_CATALOG_INVALID_SHAPE_HASH: &str = "filter_catalog_invalid_shape_hash_total";
 /// Cohorts classified by composition eligibility at freeze, labelled by `class` (counter).
 pub const COHORT_ELIGIBILITY_TOTAL: &str = "cohort_eligibility_total";
 /// Cohorts excluded because they sit in a cohort-reference cycle (counter).

--- a/rust/cohort-core/src/seed/decode.rs
+++ b/rust/cohort-core/src/seed/decode.rs
@@ -1,19 +1,20 @@
 //! Tolerant two-stage decode of a seed-topic payload: a cheap kind/schema probe, then the full
-//! [`SeedTile`] parse only for a supported combination. The consumer's policy is skip-and-count
-//! (never wedge a partition): unknown kinds and newer schemas are data for later slices'
+//! the full wire type parse only for a supported combination. The consumer's policy is
+//! skip-and-count (never wedge a partition): unknown kinds and newer schemas are data for later
 //! consumers, and a malformed payload is deterministic bytes that would fail identically on every
 //! redelivery.
 
 use serde::Deserialize;
 
+use super::reconcile::{ReconcileTile, RECONCILE_KIND, RECONCILE_SCHEMA_VERSION};
 use super::tile::{SeedTile, SCHEMA_VERSION, TILE_KIND};
 
-/// The probe outcome for a supported-or-not payload. `UnknownKind` covers kinds this consumer
-/// does not handle (e.g. a reconcile control tile before its slice ships); `UnsupportedSchema`
-/// covers a known kind at a newer schema version.
+/// The probe outcome for a supported-or-not payload. `UnknownKind` covers kinds this consumer does
+/// not handle; `UnsupportedSchema` covers a known kind at a newer schema version.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DecodedSeed {
     Tile(SeedTile),
+    Reconcile(ReconcileTile),
     UnknownKind { kind: String, schema_version: u32 },
     UnsupportedSchema { kind: String, schema_version: u32 },
 }
@@ -26,19 +27,22 @@ struct SeedProbe {
 
 pub fn decode_seed(payload: &[u8]) -> Result<DecodedSeed, serde_json::Error> {
     let probe: SeedProbe = serde_json::from_slice(payload)?;
-    if probe.kind != TILE_KIND {
-        return Ok(DecodedSeed::UnknownKind {
+    match probe.kind.as_str() {
+        TILE_KIND if probe.schema_version == SCHEMA_VERSION => {
+            Ok(DecodedSeed::Tile(serde_json::from_slice(payload)?))
+        }
+        RECONCILE_KIND if probe.schema_version == RECONCILE_SCHEMA_VERSION => {
+            Ok(DecodedSeed::Reconcile(serde_json::from_slice(payload)?))
+        }
+        TILE_KIND | RECONCILE_KIND => Ok(DecodedSeed::UnsupportedSchema {
             kind: probe.kind,
             schema_version: probe.schema_version,
-        });
-    }
-    if probe.schema_version != SCHEMA_VERSION {
-        return Ok(DecodedSeed::UnsupportedSchema {
+        }),
+        _ => Ok(DecodedSeed::UnknownKind {
             kind: probe.kind,
             schema_version: probe.schema_version,
-        });
+        }),
     }
-    Ok(DecodedSeed::Tile(serde_json::from_slice(payload)?))
 }
 
 #[cfg(test)]
@@ -48,7 +52,9 @@ mod tests {
     use uuid::Uuid;
 
     use crate::filters::TeamId;
-    use crate::seed::{ClaimEpoch, ConditionHash, RunId, SChunkMs};
+    use crate::seed::{
+        BehavioralShapeHash, ClaimEpoch, ConditionHash, ReconcileTile, RunId, SChunkMs,
+    };
 
     use super::*;
 
@@ -66,6 +72,19 @@ mod tests {
         .unwrap()
     }
 
+    fn reconcile_json() -> serde_json::Value {
+        serde_json::to_value(ReconcileTile::new(
+            TeamId(2),
+            crate::filters::CohortId(42),
+            BehavioralShapeHash::parse(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+            .unwrap(),
+            RunId(Uuid::nil()),
+        ))
+        .unwrap()
+    }
+
     #[test]
     fn decode_probes_kind_and_schema_before_the_full_parse() {
         let tile = tile_json();
@@ -73,14 +92,20 @@ mod tests {
 
         assert!(matches!(decode(&tile).unwrap(), DecodedSeed::Tile(_)));
 
-        let mut reconcile = tile.clone();
-        reconcile["kind"] = serde_json::json!("reconcile");
+        let reconcile = reconcile_json();
         assert_eq!(
             decode(&reconcile).unwrap(),
+            DecodedSeed::Reconcile(serde_json::from_value(reconcile.clone()).unwrap()),
+        );
+
+        let mut unknown = tile.clone();
+        unknown["kind"] = serde_json::json!("future_control");
+        assert_eq!(
+            decode(&unknown).unwrap(),
             DecodedSeed::UnknownKind {
-                kind: "reconcile".to_string(),
+                kind: "future_control".to_string(),
                 schema_version: 1,
-            }
+            },
         );
 
         let mut newer = tile.clone();
@@ -93,11 +118,26 @@ mod tests {
             }
         );
 
+        let mut newer_reconcile = reconcile.clone();
+        newer_reconcile["schema_version"] = serde_json::json!(2);
+        newer_reconcile["filters_hash"] = serde_json::json!("");
+        assert_eq!(
+            decode(&newer_reconcile).unwrap(),
+            DecodedSeed::UnsupportedSchema {
+                kind: "reconcile".to_string(),
+                schema_version: 2,
+            },
+        );
+
         // A supported kind/schema with a malformed body is a decode error, not a skip: the probe
         // admits it, the full parse rejects it (zero count here).
         let mut zero_count = tile.clone();
         zero_count["count"] = serde_json::json!(0);
         assert!(decode(&zero_count).is_err());
+
+        let mut empty_hash = reconcile;
+        empty_hash["filters_hash"] = serde_json::json!("");
+        assert!(decode(&empty_hash).is_err());
 
         let mut kindless = tile;
         kindless.as_object_mut().unwrap().remove("kind");

--- a/rust/cohort-core/src/seed/mod.rs
+++ b/rust/cohort-core/src/seed/mod.rs
@@ -1,16 +1,20 @@
 //! The seed wire contract shared by the backfill seeder (producer) and the stream processor
-//! (consumer): the [`SeedTile`] day-tile, its id newtypes, and the tolerant [`decode_seed`] entry
-//! point. Lives here — not in the seeder crate — for the same reason as [`crate::events`]: both
-//! processes must agree on these bytes, and the processor cannot depend on the seeder.
+//! (consumer): the [`SeedTile`] day-tile, [`ReconcileTile`] control tile, their newtypes, and the
+//! tolerant [`decode_seed`] entry point. Lives here — not in the seeder crate — for the same reason
+//! as [`crate::events`]: both processes must agree on these bytes, and the processor cannot depend
+//! on the seeder.
 //!
-//! The JSON layout is frozen; the golden test in [`tile`] is the byte-level regression gate. New
-//! fields must be additive and skipped when absent-equivalent (see `redirect_hops`) so tiles
-//! produced by older seeders keep parsing and older consumers keep ignoring newer producers.
+//! The JSON layouts are frozen; the golden tests in [`tile`] and [`reconcile`] are the byte-level
+//! regression gates. New fields must be additive and skipped when absent-equivalent (see
+//! `redirect_hops`) so tiles produced by older seeders keep parsing and older consumers keep
+//! ignoring newer producers.
 
 pub mod decode;
 pub mod ids;
+pub mod reconcile;
 pub mod tile;
 
 pub use decode::{decode_seed, DecodedSeed};
 pub use ids::{ClaimEpoch, ConditionHash, ConditionHashError, RunId, SChunkMs};
+pub use reconcile::{BehavioralShapeHash, BehavioralShapeHashError, ReconcileTile};
 pub use tile::SeedTile;

--- a/rust/cohort-core/src/seed/reconcile.rs
+++ b/rust/cohort-core/src/seed/reconcile.rs
@@ -1,0 +1,275 @@
+//! Wire contract for one partition-targeted reconcile control tile.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::de::{Deserializer, Error as DeError, Unexpected};
+use serde::ser::Serializer;
+use serde::{Deserialize, Serialize};
+
+use crate::filters::{CohortId, TeamId};
+
+use super::ids::RunId;
+
+pub(super) const RECONCILE_SCHEMA_VERSION: u32 = 1;
+pub(super) const RECONCILE_KIND: &str = "reconcile";
+
+/// The persisted behavioral filter-shape fingerprint that fences a reconcile job from cohort edits.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BehavioralShapeHash(Box<str>);
+
+impl BehavioralShapeHash {
+    pub fn parse(value: &str) -> Result<Self, BehavioralShapeHashError> {
+        if value.is_empty() {
+            return Err(BehavioralShapeHashError::Empty);
+        }
+        if value.len() > 64 {
+            return Err(BehavioralShapeHashError::TooLong(value.len()));
+        }
+        if !value.is_ascii() {
+            return Err(BehavioralShapeHashError::NonAscii);
+        }
+        Ok(Self(value.into()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for BehavioralShapeHash {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for BehavioralShapeHash {
+    type Err = BehavioralShapeHashError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl Serialize for BehavioralShapeHash {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for BehavioralShapeHash {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(&value).map_err(|_| {
+            DeError::invalid_value(
+                Unexpected::Str(&value),
+                &"a non-empty ASCII behavioral shape hash of at most 64 bytes",
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum BehavioralShapeHashError {
+    #[error("behavioral shape hash must not be empty")]
+    Empty,
+    #[error("behavioral shape hash must be at most 64 bytes, got {0}")]
+    TooLong(usize),
+    #[error("behavioral shape hash must contain only ASCII characters")]
+    NonAscii,
+}
+
+/// A control tile that requests one partition's full current snapshot for one behavioral cohort.
+/// Field order is the wire order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconcileTile {
+    #[serde(deserialize_with = "deserialize_schema_version")]
+    schema_version: u32,
+    kind: ReconcileKind,
+    #[serde(
+        serialize_with = "serialize_team_id",
+        deserialize_with = "deserialize_team_id"
+    )]
+    team_id: TeamId,
+    #[serde(
+        serialize_with = "serialize_cohort_id",
+        deserialize_with = "deserialize_cohort_id"
+    )]
+    cohort_id: CohortId,
+    filters_hash: BehavioralShapeHash,
+    run_id: RunId,
+}
+
+impl ReconcileTile {
+    pub fn new(
+        team_id: TeamId,
+        cohort_id: CohortId,
+        filters_hash: BehavioralShapeHash,
+        run_id: RunId,
+    ) -> Self {
+        Self {
+            schema_version: RECONCILE_SCHEMA_VERSION,
+            kind: ReconcileKind,
+            team_id,
+            cohort_id,
+            filters_hash,
+            run_id,
+        }
+    }
+
+    pub const fn team_id(&self) -> TeamId {
+        self.team_id
+    }
+
+    pub const fn cohort_id(&self) -> CohortId {
+        self.cohort_id
+    }
+
+    pub fn filters_hash(&self) -> &BehavioralShapeHash {
+        &self.filters_hash
+    }
+
+    pub const fn run_id(&self) -> RunId {
+        self.run_id
+    }
+}
+
+/// A zero-sized discriminant proven to be [`RECONCILE_KIND`] during deserialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReconcileKind;
+
+impl Serialize for ReconcileKind {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(RECONCILE_KIND)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReconcileKind {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        if value != RECONCILE_KIND {
+            return Err(DeError::invalid_value(
+                Unexpected::Str(&value),
+                &"seed kind \"reconcile\"",
+            ));
+        }
+        Ok(Self)
+    }
+}
+
+fn serialize_team_id<S: Serializer>(value: &TeamId, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_i32(value.0)
+}
+
+fn deserialize_team_id<'de, D: Deserializer<'de>>(deserializer: D) -> Result<TeamId, D::Error> {
+    i32::deserialize(deserializer).map(TeamId)
+}
+
+fn serialize_cohort_id<S: Serializer>(value: &CohortId, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_i32(value.0)
+}
+
+fn deserialize_cohort_id<'de, D: Deserializer<'de>>(deserializer: D) -> Result<CohortId, D::Error> {
+    i32::deserialize(deserializer).map(CohortId)
+}
+
+fn deserialize_schema_version<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
+    let value = u32::deserialize(deserializer)?;
+    if value != RECONCILE_SCHEMA_VERSION {
+        return Err(DeError::invalid_value(
+            Unexpected::Unsigned(u64::from(value)),
+            &"reconcile schema version 1",
+        ));
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+
+    // `extract_behavioral_leaf_shape_hash` for the canonical Python behavioral-leaf fixture.
+    const SHA256: &str = "9efcd8a99c5334a19b52f6a7b990e3b862ad116031a0b47481f8bbb09e54a7de";
+
+    fn tile() -> ReconcileTile {
+        ReconcileTile::new(
+            TeamId(2),
+            CohortId(42),
+            BehavioralShapeHash::parse(SHA256).unwrap(),
+            RunId(Uuid::nil()),
+        )
+    }
+
+    #[test]
+    fn reconcile_wire_contract_is_fixed() {
+        let tile = tile();
+        assert_eq!(
+            serde_json::to_value(&tile).unwrap(),
+            serde_json::json!({
+                "schema_version": 1,
+                "kind": "reconcile",
+                "team_id": 2,
+                "cohort_id": 42,
+                "filters_hash": SHA256,
+                "run_id": "00000000-0000-0000-0000-000000000000",
+            })
+        );
+        assert_eq!(
+            serde_json::to_string(&tile).unwrap(),
+            r#"{"schema_version":1,"kind":"reconcile","team_id":2,"cohort_id":42,"filters_hash":"9efcd8a99c5334a19b52f6a7b990e3b862ad116031a0b47481f8bbb09e54a7de","run_id":"00000000-0000-0000-0000-000000000000"}"#
+        );
+    }
+
+    #[test]
+    fn reconcile_roundtrips_and_rejects_foreign_kind_schema_and_hash() {
+        let tile = tile();
+        let bytes = serde_json::to_vec(&tile).unwrap();
+        assert_eq!(
+            serde_json::from_slice::<ReconcileTile>(&bytes).unwrap(),
+            tile
+        );
+
+        let golden = serde_json::to_value(&tile).unwrap();
+        let mut extended = golden.clone();
+        extended["future_metadata"] = serde_json::json!({ "source": "scheduler" });
+        assert_eq!(
+            serde_json::from_value::<ReconcileTile>(extended).unwrap(),
+            tile
+        );
+
+        for (field, value) in [
+            ("kind", serde_json::json!("behavioral_tile")),
+            ("schema_version", serde_json::json!(2)),
+            ("filters_hash", serde_json::json!("")),
+            ("filters_hash", serde_json::json!("x".repeat(65))),
+            ("filters_hash", serde_json::json!("non-ascii-é")),
+        ] {
+            let mut broken = golden.clone();
+            broken[field] = value;
+            assert!(
+                serde_json::from_value::<ReconcileTile>(broken).is_err(),
+                "accepted a reconcile tile with mutated {field}",
+            );
+        }
+    }
+
+    #[test]
+    fn behavioral_shape_hash_matches_the_persisted_output_bounds() {
+        assert_eq!(BehavioralShapeHash::parse(SHA256).unwrap().as_str(), SHA256,);
+        assert_eq!(BehavioralShapeHash::parse("a").unwrap().as_str(), "a",);
+        assert_eq!(
+            BehavioralShapeHash::parse(""),
+            Err(BehavioralShapeHashError::Empty),
+        );
+        assert_eq!(
+            BehavioralShapeHash::parse(&"x".repeat(65)),
+            Err(BehavioralShapeHashError::TooLong(65)),
+        );
+        assert_eq!(
+            BehavioralShapeHash::parse("é"),
+            Err(BehavioralShapeHashError::NonAscii),
+        );
+    }
+}

--- a/rust/cohort-seeder/Cargo.toml
+++ b/rust/cohort-seeder/Cargo.toml
@@ -9,11 +9,16 @@ workspace = true
 [features]
 pg-test-support = []
 
+[[bin]]
+name = "reconcile_dispatch"
+path = "src/bin/reconcile_dispatch.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
+clap = { workspace = true }
 clickhouse = { workspace = true }
 cohort-core = { path = "../cohort-core" }
 common-alloc = { path = "../common/alloc" }

--- a/rust/cohort-seeder/src/app/mod.rs
+++ b/rust/cohort-seeder/src/app/mod.rs
@@ -5,6 +5,7 @@ mod deliver;
 mod execute;
 mod orchestrator;
 mod prepare;
+pub mod reconcile_dispatch;
 pub mod settings;
 
 pub use orchestrator::{SeederOrchestrator, ORCHESTRATOR_LIVENESS_DEADLINE};

--- a/rust/cohort-seeder/src/app/reconcile_dispatch.rs
+++ b/rust/cohort-seeder/src/app/reconcile_dispatch.rs
@@ -1,0 +1,636 @@
+//! Manual reconcile dispatch orchestration. Database validation and partition-layout verification
+//! finish before the first control tile is enqueued; all enqueued deliveries are drained before an
+//! error is returned.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::time::Duration;
+
+use cohort_core::partitioner::COHORT_PARTITION_COUNT;
+use rdkafka::error::KafkaError;
+use sqlx::PgPool;
+
+use crate::domain::{ReconcileTile, RunId};
+use crate::kafka::producer::{
+    EnqueueError, PartitionCountError, SeedPartition, SeedPartitionCountError, SeedTileProducer,
+};
+use crate::store::chunks::{ChunkStoreError, PgChunkStore};
+use crate::store::runs::{load_reconcile_run, ReconcileRun, ReconcileRunError, RunStatus};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionRequirement {
+    Complete,
+    AllowIncomplete,
+}
+
+/// Operator attestation that this run's data tiles were seeded or replayed after membership-register
+/// writers were deployed.
+///
+/// The database does not persist a writer-version boundary, so pre-register runs cannot prove that
+/// their Stage 2 scan domain is complete. Requiring this capability at the dispatch boundary keeps
+/// that residual explicit instead of emitting a false completion certificate.
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisterBackfillConfirmation(());
+
+impl RegisterBackfillConfirmation {
+    pub const fn confirmed_by_operator() -> Self {
+        Self(())
+    }
+}
+
+/// A run capability minted only after its status, active participations, hashes, and chunk ledger
+/// satisfy the operator's completion requirement.
+#[derive(Debug)]
+pub struct PreparedReconcileDispatch {
+    run: ReconcileRun,
+    total_chunks: u64,
+    remaining_chunks: u64,
+}
+
+impl PreparedReconcileDispatch {
+    pub const fn run_id(&self) -> RunId {
+        self.run.run_id()
+    }
+
+    pub fn cohort_count(&self) -> usize {
+        self.run.cohort_count()
+    }
+
+    pub const fn total_chunks(&self) -> u64 {
+        self.total_chunks
+    }
+
+    pub const fn remaining_chunks(&self) -> u64 {
+        self.remaining_chunks
+    }
+}
+
+pub async fn prepare_reconcile_dispatch(
+    pool: &PgPool,
+    run_id: RunId,
+    completion: CompletionRequirement,
+    _register_backfill: RegisterBackfillConfirmation,
+) -> Result<PreparedReconcileDispatch, PrepareReconcileDispatchError> {
+    let run = load_reconcile_run(pool, run_id).await?;
+    let progress = PgChunkStore::new(pool.clone())
+        .chunk_progress(run_id)
+        .await?;
+    validate_completion(
+        run_id,
+        run.status(),
+        progress.total(),
+        progress.remaining(),
+        completion,
+    )?;
+    Ok(PreparedReconcileDispatch {
+        run,
+        total_chunks: progress.total(),
+        remaining_chunks: progress.remaining(),
+    })
+}
+
+fn validate_completion(
+    run_id: RunId,
+    status: RunStatus,
+    total_chunks: u64,
+    remaining_chunks: u64,
+    completion: CompletionRequirement,
+) -> Result<(), PrepareReconcileDispatchError> {
+    if completion == CompletionRequirement::Complete {
+        if remaining_chunks != 0 {
+            return Err(PrepareReconcileDispatchError::Incomplete {
+                run_id,
+                remaining_chunks,
+            });
+        }
+        if total_chunks == 0 && status == RunStatus::Seeding {
+            return Err(PrepareReconcileDispatchError::EmptyChunkLedger(run_id));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrepareReconcileDispatchError {
+    #[error(transparent)]
+    Run(#[from] ReconcileRunError),
+    #[error("reading the run's chunk ledger")]
+    Chunks(#[from] ChunkStoreError),
+    #[error("run {run_id:?} still has {remaining_chunks} unconfirmed chunks")]
+    Incomplete {
+        run_id: RunId,
+        remaining_chunks: u64,
+    },
+    #[error(
+        "seeding run {0:?} has no chunk rows, so dispatch cannot prove planning has completed; use --allow-incomplete to override"
+    )]
+    EmptyChunkLedger(RunId),
+}
+
+/// Highest acknowledged reconcile-control offset for every seed partition. A team-wide run may
+/// enqueue several cohorts to one partition, so the maximum is the run's useful partition HWM.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReconcileDispatchReceipt {
+    offsets: BTreeMap<SeedPartition, i64>,
+}
+
+impl ReconcileDispatchReceipt {
+    pub fn offsets(&self) -> impl ExactSizeIterator<Item = (SeedPartition, i64)> + '_ {
+        self.offsets
+            .iter()
+            .map(|(partition, offset)| (*partition, *offset))
+    }
+
+    fn observe(&mut self, partition: SeedPartition, offset: i64) {
+        self.offsets
+            .entry(partition)
+            .and_modify(|current| *current = (*current).max(offset))
+            .or_insert(offset);
+    }
+}
+
+pub async fn execute_reconcile_dispatch(
+    prepared: PreparedReconcileDispatch,
+    producer: &SeedTileProducer,
+    max_inflight: NonZeroUsize,
+    metadata_timeout: Duration,
+) -> Result<ReconcileDispatchReceipt, ReconcileDispatchError> {
+    let partitions = SeedPartition::all(COHORT_PARTITION_COUNT)?.collect::<Vec<_>>();
+    let verify_producer = producer.clone();
+    tokio::task::spawn_blocking(move || {
+        verify_producer.verify_partition_count(COHORT_PARTITION_COUNT, metadata_timeout)
+    })
+    .await
+    .map_err(ReconcileDispatchError::PartitionVerificationTask)??;
+
+    let tiles = prepared.run.tiles().collect::<Vec<_>>();
+    produce_reconcile_tiles(tiles, producer, &partitions, max_inflight).await
+}
+
+type ReconcileDelivery =
+    Pin<Box<dyn Future<Output = Result<(i32, i64), KafkaError>> + Send + 'static>>;
+
+trait ReconcileProducer {
+    fn enqueue(
+        &self,
+        tile: &ReconcileTile,
+        partition: SeedPartition,
+    ) -> Result<ReconcileDelivery, EnqueueError>;
+}
+
+impl ReconcileProducer for SeedTileProducer {
+    fn enqueue(
+        &self,
+        tile: &ReconcileTile,
+        partition: SeedPartition,
+    ) -> Result<ReconcileDelivery, EnqueueError> {
+        let delivery = SeedTileProducer::enqueue_reconcile(self, tile, partition)?;
+        Ok(Box::pin(async move {
+            match delivery.await {
+                Ok(Ok(coordinates)) => Ok(coordinates),
+                Ok(Err((error, _))) => Err(error),
+                Err(_) => Err(KafkaError::Canceled),
+            }
+        }))
+    }
+}
+
+async fn produce_reconcile_tiles<P: ReconcileProducer>(
+    tiles: impl IntoIterator<Item = ReconcileTile>,
+    producer: &P,
+    partitions: &[SeedPartition],
+    max_inflight: NonZeroUsize,
+) -> Result<ReconcileDispatchReceipt, ReconcileDispatchError> {
+    let mut pending = VecDeque::new();
+    let mut receipt = ReconcileDispatchReceipt::default();
+    let mut failures = DeliveryFailures::default();
+    let mut enqueue_error = None;
+
+    'tiles: for tile in tiles {
+        for partition in partitions.iter().copied() {
+            loop {
+                match producer.enqueue(&tile, partition) {
+                    Ok(delivery) => {
+                        pending.push_back(PendingDelivery {
+                            partition,
+                            delivery,
+                        });
+                        break;
+                    }
+                    Err(EnqueueError::QueueFull) if !pending.is_empty() => {
+                        observe_next(&mut pending, &mut receipt, &mut failures).await;
+                    }
+                    Err(error) => {
+                        enqueue_error = Some(error);
+                        break 'tiles;
+                    }
+                }
+            }
+
+            if pending.len() >= max_inflight.get() {
+                observe_next(&mut pending, &mut receipt, &mut failures).await;
+            }
+        }
+    }
+
+    while !pending.is_empty() {
+        observe_next(&mut pending, &mut receipt, &mut failures).await;
+    }
+
+    if let Some(error) = enqueue_error {
+        return Err(ReconcileDispatchError::Enqueue(error));
+    }
+    if let Some(error) = failures.into_error() {
+        return Err(ReconcileDispatchError::Delivery(error));
+    }
+    Ok(receipt)
+}
+
+struct PendingDelivery {
+    partition: SeedPartition,
+    delivery: ReconcileDelivery,
+}
+
+async fn observe_next(
+    pending: &mut VecDeque<PendingDelivery>,
+    receipt: &mut ReconcileDispatchReceipt,
+    failures: &mut DeliveryFailures,
+) {
+    let pending = pending
+        .pop_front()
+        .expect("observe_next is only called for a non-empty delivery queue");
+    let expected_partition = i32::from(pending.partition.as_u16());
+    match pending.delivery.await {
+        Ok((actual_partition, offset)) if actual_partition == expected_partition && offset >= 0 => {
+            receipt.observe(pending.partition, offset);
+        }
+        Ok((actual_partition, _)) if actual_partition != expected_partition => {
+            failures.record(ReconcileDeliveryFailure::UnexpectedPartition {
+                expected: pending.partition,
+                actual: actual_partition,
+            });
+        }
+        Ok((_, offset)) => {
+            failures.record(ReconcileDeliveryFailure::NegativeOffset {
+                partition: pending.partition,
+                offset,
+            });
+        }
+        Err(error) => failures.record(ReconcileDeliveryFailure::Kafka(error)),
+    }
+}
+
+#[derive(Debug, Default)]
+struct DeliveryFailures {
+    count: usize,
+    first: Option<ReconcileDeliveryFailure>,
+}
+
+impl DeliveryFailures {
+    fn record(&mut self, failure: ReconcileDeliveryFailure) {
+        self.count += 1;
+        if self.first.is_none() {
+            self.first = Some(failure);
+        }
+    }
+
+    fn into_error(self) -> Option<ReconcileDeliveryFailures> {
+        self.first.map(|first| ReconcileDeliveryFailures {
+            count: self.count,
+            first,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReconcileDispatchError {
+    #[error(transparent)]
+    InvalidPartitionCount(#[from] SeedPartitionCountError),
+    #[error("joining the seed-topic partition verification task")]
+    PartitionVerificationTask(#[source] tokio::task::JoinError),
+    #[error("verifying the seed-topic partition count")]
+    PartitionCount(#[from] PartitionCountError),
+    #[error("enqueuing a reconcile control tile")]
+    Enqueue(#[source] EnqueueError),
+    #[error(transparent)]
+    Delivery(#[from] ReconcileDeliveryFailures),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{count} reconcile control tile deliveries failed; first failure: {first}")]
+pub struct ReconcileDeliveryFailures {
+    count: usize,
+    #[source]
+    first: ReconcileDeliveryFailure,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ReconcileDeliveryFailure {
+    #[error("Kafka rejected the delivery: {0}")]
+    Kafka(#[source] KafkaError),
+    #[error("partition {expected} was acknowledged as partition {actual}")]
+    UnexpectedPartition {
+        expected: SeedPartition,
+        actual: i32,
+    },
+    #[error("partition {partition} was acknowledged with invalid offset {offset}")]
+    NegativeOffset {
+        partition: SeedPartition,
+        offset: i64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use cohort_core::filters::{CohortId, TeamId};
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn completion_requirement_fails_closed_for_unplanned_seeding_runs() {
+        let run_id = RunId(Uuid::nil());
+        assert!(validate_completion(
+            run_id,
+            RunStatus::Seeding,
+            3,
+            0,
+            CompletionRequirement::Complete,
+        )
+        .is_ok());
+        assert!(validate_completion(
+            run_id,
+            RunStatus::Reconciling,
+            0,
+            0,
+            CompletionRequirement::Complete,
+        )
+        .is_ok());
+        assert!(validate_completion(
+            run_id,
+            RunStatus::Seeding,
+            0,
+            0,
+            CompletionRequirement::AllowIncomplete,
+        )
+        .is_ok());
+        assert!(matches!(
+            validate_completion(
+                run_id,
+                RunStatus::Seeding,
+                3,
+                2,
+                CompletionRequirement::Complete,
+            ),
+            Err(PrepareReconcileDispatchError::Incomplete {
+                remaining_chunks: 2,
+                ..
+            })
+        ));
+        assert!(matches!(
+            validate_completion(
+                run_id,
+                RunStatus::Seeding,
+                0,
+                0,
+                CompletionRequirement::Complete,
+            ),
+            Err(PrepareReconcileDispatchError::EmptyChunkLedger(id)) if id == run_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispatch_covers_every_cohort_partition_and_reports_bounded_hwm() {
+        let partitions = SeedPartition::all(64).unwrap().collect::<Vec<_>>();
+        let producer = FakeProducer::new([]);
+        let receipt = produce_reconcile_tiles(
+            [tile(41), tile(42)],
+            &producer,
+            &partitions,
+            NonZeroUsize::new(5).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let calls = producer.calls();
+        assert_eq!(calls.len(), 128);
+        assert_eq!(
+            calls
+                .iter()
+                .map(|call| (call.cohort_id, call.partition))
+                .collect::<HashSet<_>>()
+                .len(),
+            128,
+        );
+        assert_eq!(producer.deliveries.resolved.load(Ordering::SeqCst), 128);
+        assert_eq!(producer.deliveries.current.load(Ordering::SeqCst), 0);
+        assert_eq!(producer.deliveries.maximum.load(Ordering::SeqCst), 5);
+
+        assert_eq!(
+            receipt
+                .offsets()
+                .map(|(partition, offset)| (partition.as_u16(), offset))
+                .collect::<Vec<_>>(),
+            (0_u16..64)
+                .map(|partition| (partition, i64::from(partition) + 1_000))
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    #[tokio::test]
+    async fn queue_full_drains_one_delivery_then_retries_the_same_target() {
+        let partitions = SeedPartition::all(2).unwrap().collect::<Vec<_>>();
+        let producer = FakeProducer::new([
+            ScriptedOutcome::Ack,
+            ScriptedOutcome::QueueFull,
+            ScriptedOutcome::Ack,
+        ]);
+
+        let receipt = produce_reconcile_tiles(
+            [tile(41)],
+            &producer,
+            &partitions,
+            NonZeroUsize::new(10).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(producer.calls().len(), 3);
+        assert_eq!(producer.deliveries.resolved.load(Ordering::SeqCst), 2);
+        assert_eq!(receipt.offsets().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn nack_and_fatal_enqueue_drain_every_already_enqueued_delivery() {
+        let partitions = SeedPartition::all(3).unwrap().collect::<Vec<_>>();
+        let nack = FakeProducer::new([
+            ScriptedOutcome::Nack,
+            ScriptedOutcome::Ack,
+            ScriptedOutcome::Ack,
+        ]);
+        let nack_error = produce_reconcile_tiles(
+            [tile(41)],
+            &nack,
+            &partitions,
+            NonZeroUsize::new(3).unwrap(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            nack_error,
+            ReconcileDispatchError::Delivery(ReconcileDeliveryFailures { count: 1, .. })
+        ));
+        assert_eq!(nack.deliveries.resolved.load(Ordering::SeqCst), 3);
+
+        let fatal = FakeProducer::new([ScriptedOutcome::Ack, ScriptedOutcome::Fatal]);
+        let fatal_error = produce_reconcile_tiles(
+            [tile(41)],
+            &fatal,
+            &partitions,
+            NonZeroUsize::new(3).unwrap(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(fatal_error, ReconcileDispatchError::Enqueue(_)));
+        assert_eq!(fatal.calls().len(), 2);
+        assert_eq!(fatal.deliveries.resolved.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_delivery_coordinates_fail_the_dispatch() {
+        let partition = SeedPartition::all(1).unwrap().collect::<Vec<_>>();
+        for outcome in [
+            ScriptedOutcome::UnexpectedPartition,
+            ScriptedOutcome::NegativeOffset,
+        ] {
+            let producer = FakeProducer::new([outcome]);
+            assert!(matches!(
+                produce_reconcile_tiles([tile(41)], &producer, &partition, NonZeroUsize::MIN,)
+                    .await,
+                Err(ReconcileDispatchError::Delivery(
+                    ReconcileDeliveryFailures { count: 1, .. }
+                ))
+            ));
+            assert_eq!(producer.deliveries.resolved.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    fn tile(cohort_id: i32) -> ReconcileTile {
+        ReconcileTile::new(
+            TeamId(2),
+            CohortId(cohort_id),
+            crate::domain::BehavioralShapeHash::parse("behavioral-shape").unwrap(),
+            RunId(Uuid::nil()),
+        )
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ScriptedOutcome {
+        Ack,
+        QueueFull,
+        Fatal,
+        Nack,
+        UnexpectedPartition,
+        NegativeOffset,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct RecordedEnqueue {
+        cohort_id: CohortId,
+        partition: SeedPartition,
+    }
+
+    #[derive(Debug, Default)]
+    struct DeliveryStats {
+        current: AtomicUsize,
+        maximum: AtomicUsize,
+        resolved: AtomicUsize,
+    }
+
+    #[derive(Debug, Default)]
+    struct FakeState {
+        scripts: VecDeque<ScriptedOutcome>,
+        calls: Vec<RecordedEnqueue>,
+        next_offsets: HashMap<SeedPartition, i64>,
+    }
+
+    #[derive(Debug)]
+    struct FakeProducer {
+        state: Mutex<FakeState>,
+        deliveries: Arc<DeliveryStats>,
+    }
+
+    impl FakeProducer {
+        fn new(scripts: impl IntoIterator<Item = ScriptedOutcome>) -> Self {
+            Self {
+                state: Mutex::new(FakeState {
+                    scripts: scripts.into_iter().collect(),
+                    ..FakeState::default()
+                }),
+                deliveries: Arc::new(DeliveryStats::default()),
+            }
+        }
+
+        fn calls(&self) -> Vec<RecordedEnqueue> {
+            self.state.lock().unwrap().calls.clone()
+        }
+
+        fn delivery(&self, result: Result<(i32, i64), KafkaError>) -> ReconcileDelivery {
+            let deliveries = Arc::clone(&self.deliveries);
+            let current = deliveries.current.fetch_add(1, Ordering::SeqCst) + 1;
+            deliveries.maximum.fetch_max(current, Ordering::SeqCst);
+            Box::pin(async move {
+                deliveries.current.fetch_sub(1, Ordering::SeqCst);
+                deliveries.resolved.fetch_add(1, Ordering::SeqCst);
+                result
+            })
+        }
+    }
+
+    impl ReconcileProducer for FakeProducer {
+        fn enqueue(
+            &self,
+            tile: &ReconcileTile,
+            partition: SeedPartition,
+        ) -> Result<ReconcileDelivery, EnqueueError> {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push(RecordedEnqueue {
+                cohort_id: tile.cohort_id(),
+                partition,
+            });
+            let outcome = state.scripts.pop_front().unwrap_or(ScriptedOutcome::Ack);
+            match outcome {
+                ScriptedOutcome::QueueFull => return Err(EnqueueError::QueueFull),
+                ScriptedOutcome::Fatal => {
+                    return Err(EnqueueError::Fatal(KafkaError::Canceled));
+                }
+                _ => {}
+            }
+
+            let next_offset = state
+                .next_offsets
+                .entry(partition)
+                .or_insert_with(|| i64::from(partition.as_u16()));
+            let offset = *next_offset;
+            *next_offset += 1_000;
+            drop(state);
+
+            let expected_partition = i32::from(partition.as_u16());
+            let result = match outcome {
+                ScriptedOutcome::Ack => Ok((expected_partition, offset)),
+                ScriptedOutcome::Nack => Err(KafkaError::Canceled),
+                ScriptedOutcome::UnexpectedPartition => Ok((expected_partition + 1, offset)),
+                ScriptedOutcome::NegativeOffset => Ok((expected_partition, -1)),
+                ScriptedOutcome::QueueFull | ScriptedOutcome::Fatal => unreachable!(),
+            };
+            Ok(self.delivery(result))
+        }
+    }
+}

--- a/rust/cohort-seeder/src/bin/reconcile_dispatch.rs
+++ b/rust/cohort-seeder/src/bin/reconcile_dispatch.rs
@@ -1,0 +1,152 @@
+//! Operator-invoked reconcile control-tile dispatcher.
+
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use cohort_core::partitioner::COHORT_PARTITION_COUNT;
+use cohort_seeder::app::reconcile_dispatch::{
+    execute_reconcile_dispatch, prepare_reconcile_dispatch, CompletionRequirement,
+    RegisterBackfillConfirmation,
+};
+use cohort_seeder::config::Config;
+use cohort_seeder::domain::RunId;
+use cohort_seeder::kafka::producer::SeedTileProducer;
+use common_database::get_pool_with_config;
+use envconfig::Envconfig;
+use uuid::Uuid;
+
+common_alloc::used!();
+
+const PARTITION_VERIFY_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "reconcile_dispatch",
+    about = "Dispatch partition-targeted reconcile snapshots for one behavioral cohort backfill run"
+)]
+struct Args {
+    /// Behavioral cohort backfill run UUID.
+    run_id: Uuid,
+
+    /// Dispatch while the run still has unconfirmed data chunks. Intended for development only.
+    #[arg(long)]
+    allow_incomplete: bool,
+
+    /// Confirm that this run's data tiles were seeded or replayed after membership-register writers
+    /// were deployed. Required because older runs cannot provide a complete reconcile scan domain.
+    #[arg(long, required = true)]
+    confirm_register_backfilled: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let config = Config::init_from_env().context("loading cohort-seeder configuration")?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")?;
+    runtime.block_on(async_main(args, config))
+}
+
+async fn async_main(args: Args, config: Config) -> Result<()> {
+    validate_partition_count(config.cohort_partition_count)?;
+    let run_id = RunId(args.run_id);
+    let pool = get_pool_with_config(&config.database_url, config.pool_config())
+        .context("creating cohort-seeder PostgreSQL pool")?;
+    let completion = if args.allow_incomplete {
+        CompletionRequirement::AllowIncomplete
+    } else {
+        CompletionRequirement::Complete
+    };
+    let register_backfill = args
+        .confirm_register_backfilled
+        .then_some(RegisterBackfillConfirmation::confirmed_by_operator())
+        .expect("clap requires --confirm-register-backfilled");
+    let prepared = prepare_reconcile_dispatch(&pool, run_id, completion, register_backfill)
+        .await
+        .context("validating reconcile dispatch")?;
+    if prepared.remaining_chunks() != 0 {
+        eprintln!(
+            "Warning: dispatching run {} with {} unconfirmed chunks because --allow-incomplete was set.",
+            prepared.run_id().0,
+            prepared.remaining_chunks(),
+        );
+    } else if args.allow_incomplete && prepared.total_chunks() == 0 {
+        eprintln!(
+            "Warning: dispatching run {} with an empty chunk ledger because --allow-incomplete was set.",
+            prepared.run_id().0,
+        );
+    }
+    eprintln!(
+        "Dispatching {} active cohorts across {} seed partitions for run {}.",
+        prepared.cohort_count(),
+        COHORT_PARTITION_COUNT,
+        prepared.run_id().0,
+    );
+
+    let producer = SeedTileProducer::new(
+        &config.build_kafka_config(),
+        config.seed_events_topic.clone(),
+    )
+    .await
+    .context("creating seed tile producer")?;
+    let max_inflight = NonZeroUsize::new(config.seeder_max_inflight_tiles)
+        .context("SEEDER_MAX_INFLIGHT_TILES must be greater than zero")?;
+    let receipt =
+        execute_reconcile_dispatch(prepared, &producer, max_inflight, PARTITION_VERIFY_TIMEOUT)
+            .await
+            .context("dispatching reconcile control tiles")?;
+
+    for (partition, offset) in receipt.offsets() {
+        println!("partition {}: {}", partition.as_u16(), offset);
+    }
+    Ok(())
+}
+
+fn validate_partition_count(configured: u32) -> Result<()> {
+    anyhow::ensure!(
+        configured == COHORT_PARTITION_COUNT,
+        "COHORT_PARTITION_COUNT must be {COHORT_PARTITION_COUNT} for reconcile dispatch, got {}",
+        configured,
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RUN_ID: &str = "0190f909-a2c1-7000-8000-000000000001";
+
+    #[test]
+    fn cli_requires_register_backfill_confirmation() {
+        let args = Args::try_parse_from([
+            "reconcile_dispatch",
+            RUN_ID,
+            "--allow-incomplete",
+            "--confirm-register-backfilled",
+        ])
+        .unwrap();
+        assert_eq!(args.run_id, Uuid::parse_str(RUN_ID).unwrap());
+        assert!(args.allow_incomplete);
+        assert!(args.confirm_register_backfilled);
+
+        assert!(Args::try_parse_from(["reconcile_dispatch"]).is_err());
+        assert!(Args::try_parse_from(["reconcile_dispatch", RUN_ID]).is_err());
+        assert!(Args::try_parse_from([
+            "reconcile_dispatch",
+            RUN_ID,
+            RUN_ID,
+            "--confirm-register-backfilled",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn cli_rejects_a_noncontract_partition_count() {
+        assert!(validate_partition_count(COHORT_PARTITION_COUNT).is_ok());
+        assert!(validate_partition_count(8).is_err());
+    }
+}

--- a/rust/cohort-seeder/src/domain/mod.rs
+++ b/rust/cohort-seeder/src/domain/mod.rs
@@ -22,7 +22,9 @@ pub use chunk::{
     ClaimKind, ClaimedChunk, EnqueuedChunk, HaltReason, Halted, ProduceHwms, ProducedChunk,
     ScannedChunk, UnknownChunkStatus,
 };
-pub use cohort_core::seed::SeedTile;
+pub use cohort_core::seed::{
+    BehavioralShapeHash, BehavioralShapeHashError, ReconcileTile, SeedTile,
+};
 pub use condition::{EventNameSet, Lookback, PinnedCondition};
 pub use ids::{
     Band, ChunkId, ClaimEpoch, ConditionHash, ConditionHashError, DayIdx, RunId, SChunkMs,

--- a/rust/cohort-seeder/src/kafka/producer.rs
+++ b/rust/cohort-seeder/src/kafka/producer.rs
@@ -4,6 +4,7 @@
 //! (pacing, in-flight bound, mark-produced, delivery acks) lives above, in the orchestrator, so this
 //! module carries no PostgreSQL dependency.
 
+use std::fmt;
 use std::time::Duration;
 
 use common_kafka::config::KafkaConfig;
@@ -12,7 +13,79 @@ use common_liveness::SyncLivenessReporter;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord, Producer};
 
-use crate::domain::SeedTile;
+use crate::domain::{ReconcileTile, SeedTile};
+
+const MAX_SEED_PARTITION_COUNT: u32 = 65_536;
+
+/// A seed-topic partition proven to fit both Kafka's signed partition field and this service's
+/// compact partition representation. Values can only be minted by [`SeedPartition::all`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SeedPartition(u16);
+
+impl SeedPartition {
+    pub fn all(count: u32) -> Result<SeedPartitions, SeedPartitionCountError> {
+        if count == 0 {
+            return Err(SeedPartitionCountError::Zero);
+        }
+        if count > MAX_SEED_PARTITION_COUNT {
+            return Err(SeedPartitionCountError::TooLarge(count));
+        }
+        Ok(SeedPartitions { next: 0, count })
+    }
+
+    pub const fn as_u16(self) -> u16 {
+        self.0
+    }
+
+    const fn as_i32(self) -> i32 {
+        self.0 as i32
+    }
+}
+
+impl fmt::Display for SeedPartition {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// The exact sequence `0..count` returned after [`SeedPartition::all`] proves every index fits.
+#[derive(Debug, Clone)]
+pub struct SeedPartitions {
+    next: u32,
+    count: u32,
+}
+
+impl Iterator for SeedPartitions {
+    type Item = SeedPartition;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next == self.count {
+            return None;
+        }
+        let partition = u16::try_from(self.next)
+            .expect("partition count validation proves every partition index fits u16");
+        self.next += 1;
+        Some(SeedPartition(partition))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = usize::try_from(self.count - self.next)
+            .expect("a u32 partition count fits usize on supported targets");
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for SeedPartitions {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum SeedPartitionCountError {
+    #[error("seed partition count must be greater than zero")]
+    Zero,
+    #[error(
+        "seed partition count {0} exceeds the largest u16-indexed partition set ({MAX_SEED_PARTITION_COUNT})"
+    )]
+    TooLarge(u32),
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum EnqueueError {
@@ -92,6 +165,22 @@ impl SeedTileProducer {
             .map_err(|(error, _)| error.into())
     }
 
+    pub fn enqueue_reconcile(
+        &self,
+        tile: &ReconcileTile,
+        partition: SeedPartition,
+    ) -> Result<DeliveryFuture, EnqueueError> {
+        let payload = serde_json::to_vec(tile).expect("ReconcileTile serialization cannot fail");
+        let key = reconcile_partition_key(tile);
+        let record = FutureRecord::to(&self.topic)
+            .partition(partition.as_i32())
+            .key(&key)
+            .payload(&payload);
+        self.producer
+            .send_result(record)
+            .map_err(|(error, _)| error.into())
+    }
+
     pub fn flush(&self, timeout: Duration) -> Result<(), KafkaError> {
         self.producer.flush(timeout)
     }
@@ -130,9 +219,62 @@ impl SyncLivenessReporter for AlwaysHealthy {
     fn report_unhealthy(&self) {}
 }
 
+fn reconcile_partition_key(tile: &ReconcileTile) -> String {
+    format!(
+        "{}:{}:{}",
+        tile.team_id().0,
+        tile.cohort_id().0,
+        tile.run_id().0
+    )
+}
+
 #[cfg(test)]
 mod tests {
+    use cohort_core::filters::{CohortId, TeamId};
+    use uuid::Uuid;
+
     use super::*;
+
+    #[test]
+    fn seed_partitions_cover_exactly_the_valid_partition_domain() {
+        let partitions = SeedPartition::all(64).unwrap().collect::<Vec<_>>();
+        assert_eq!(partitions.len(), 64);
+        assert_eq!(partitions.first().unwrap().as_u16(), 0);
+        assert_eq!(partitions.last().unwrap().as_u16(), 63);
+
+        assert_eq!(
+            SeedPartition::all(MAX_SEED_PARTITION_COUNT)
+                .unwrap()
+                .last()
+                .unwrap()
+                .as_u16(),
+            u16::MAX,
+        );
+        assert!(matches!(
+            SeedPartition::all(0),
+            Err(SeedPartitionCountError::Zero)
+        ));
+        assert!(matches!(
+            SeedPartition::all(MAX_SEED_PARTITION_COUNT + 1),
+            Err(SeedPartitionCountError::TooLarge(count))
+                if count == MAX_SEED_PARTITION_COUNT + 1
+        ));
+    }
+
+    #[test]
+    fn reconcile_key_identifies_the_run_and_cohort() {
+        let tile = ReconcileTile::new(
+            TeamId(2),
+            CohortId(42),
+            crate::domain::BehavioralShapeHash::parse("shape").unwrap(),
+            crate::domain::RunId(Uuid::nil()),
+        );
+
+        assert_eq!(
+            reconcile_partition_key(&tile),
+            "2:42:00000000-0000-0000-0000-000000000000"
+        );
+    }
 
     #[test]
     fn enqueue_error_splits_queue_full_from_fatal() {

--- a/rust/cohort-seeder/src/store/chunks.rs
+++ b/rust/cohort-seeder/src/store/chunks.rs
@@ -284,6 +284,32 @@ impl PgChunkStore {
         u64::try_from(count).map_err(|_| ChunkStoreError::InvalidRemainingCount(count))
     }
 
+    pub async fn chunk_progress(&self, run_id: RunId) -> Result<ChunkProgress, ChunkStoreError> {
+        let row = sqlx::query_as::<_, ChunkProgressRow>(
+            r#"
+            SELECT count(*)::bigint AS total,
+                   count(*) FILTER (WHERE status <> $2)::bigint AS remaining
+            FROM cohort_backfill_chunks
+            WHERE run_id = $1
+            "#,
+        )
+        .bind(run_id)
+        .bind(ChunkStatus::Confirmed.as_str())
+        .fetch_one(&self.pool)
+        .await?;
+        let total = u64::try_from(row.total)
+            .map_err(|_| ChunkStoreError::InvalidChunkProgress(row.total, row.remaining))?;
+        let remaining = u64::try_from(row.remaining)
+            .map_err(|_| ChunkStoreError::InvalidChunkProgress(row.total, row.remaining))?;
+        if remaining > total {
+            return Err(ChunkStoreError::InvalidChunkProgress(
+                row.total,
+                row.remaining,
+            ));
+        }
+        Ok(ChunkProgress { total, remaining })
+    }
+
     pub(crate) async fn heartbeat(
         &self,
         lease: ChunkLease,
@@ -439,6 +465,24 @@ pub enum ChunkStoreError {
     InvalidInsertedCount(i64),
     #[error("chunk counter returned invalid remaining count {0}")]
     InvalidRemainingCount(i64),
+    #[error("chunk counter returned invalid progress total={0}, remaining={1}")]
+    InvalidChunkProgress(i64, i64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkProgress {
+    total: u64,
+    remaining: u64,
+}
+
+impl ChunkProgress {
+    pub const fn total(self) -> u64 {
+        self.total
+    }
+
+    pub const fn remaining(self) -> u64 {
+        self.remaining
+    }
 }
 
 #[derive(Debug, FromRow)]
@@ -458,6 +502,12 @@ struct ClaimedRow {
 struct PlanRow {
     run_seeding: bool,
     inserted: i64,
+}
+
+#[derive(Debug, FromRow)]
+struct ChunkProgressRow {
+    total: i64,
+    remaining: i64,
 }
 
 fn fenced(

--- a/rust/cohort-seeder/src/store/runs.rs
+++ b/rust/cohort-seeder/src/store/runs.rs
@@ -11,8 +11,9 @@ use sqlx::types::Json;
 use sqlx::{FromRow, PgPool};
 
 use crate::domain::{
-    PinnedError, PinnedParticipation, PinnedParticipationState, PinnedRun, PinnedRunSnapshot,
-    RunId, TriggerKind, UtcMillis, ValidatedPinnedRun,
+    BehavioralShapeHash, BehavioralShapeHashError, PinnedError, PinnedParticipation,
+    PinnedParticipationState, PinnedRun, PinnedRunSnapshot, ReconcileTile, RunId, TriggerKind,
+    UtcMillis, ValidatedPinnedRun,
 };
 
 use super::{RenderedError, PERSISTED_ERROR_LIMIT};
@@ -51,6 +52,13 @@ const READ_RUN: &str = concat!(
     "\n    FROM cohort_backfill_runs",
     "\n    WHERE id = $1 AND backfill_kind = 'behavioral'\n"
 );
+
+const READ_ACTIVE_RECONCILE_PARTICIPATIONS: &str = r#"
+    SELECT team_id, cohort_id, behavioral_filters_shape_hash
+    FROM cohort_backfill_run_cohorts
+    WHERE run_id = $1 AND superseded_at IS NULL
+    ORDER BY cohort_id
+"#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunWarningNote {
@@ -180,9 +188,9 @@ impl SeedableRun {
     }
 
     pub async fn load_pinned(&self, pool: &PgPool) -> Result<ValidatedPinnedRun, RunError> {
-        let rows = sqlx::query_as::<_, ParticipationRow>(
+        let rows = sqlx::query_as::<_, PinnedParticipationRow>(
             r#"
-            SELECT team_id, cohort_id, filters_shape_hash, pinned_filters, superseded_at
+            SELECT team_id, cohort_id, pinned_filters, superseded_at
             FROM cohort_backfill_run_cohorts
             WHERE run_id = $1
             ORDER BY cohort_id
@@ -223,6 +231,75 @@ impl SeedableRun {
         };
         Ok(PinnedRun::validate(snapshot)?)
     }
+}
+
+/// A behavioral run proven safe to expand into reconcile control tiles. Construction validates
+/// the run state, tenant boundary, active participation set, and every persisted behavioral hash.
+#[derive(Debug, Clone)]
+pub struct ReconcileRun {
+    run_id: RunId,
+    status: RunStatus,
+    team_id: TeamId,
+    participations: Vec<ReconcileParticipation>,
+}
+
+impl ReconcileRun {
+    pub const fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    pub const fn status(&self) -> RunStatus {
+        self.status
+    }
+
+    pub fn cohort_count(&self) -> usize {
+        self.participations.len()
+    }
+
+    pub fn tiles(&self) -> impl ExactSizeIterator<Item = ReconcileTile> + '_ {
+        self.participations.iter().map(|participation| {
+            ReconcileTile::new(
+                self.team_id,
+                participation.cohort_id,
+                participation.behavioral_filters_shape_hash.clone(),
+                self.run_id,
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReconcileParticipation {
+    cohort_id: CohortId,
+    behavioral_filters_shape_hash: BehavioralShapeHash,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReconcileRunError {
+    #[error(transparent)]
+    Run(#[from] RunError),
+    #[error(
+        "run {run_id:?} has status {status:?}; reconcile dispatch requires seeding or reconciling"
+    )]
+    Status { run_id: RunId, status: RunStatus },
+    #[error("run {0:?} has no active cohort participations to reconcile")]
+    NoActiveParticipations(RunId),
+    #[error("run {run_id:?} cohort {cohort_id:?} has an invalid behavioral shape hash")]
+    InvalidBehavioralShapeHash {
+        run_id: RunId,
+        cohort_id: CohortId,
+        #[source]
+        source: BehavioralShapeHashError,
+    },
+    #[error(
+        "run {run_id:?} team {expected_team_id} has cohort {cohort_id:?} stored under team {actual_team_id}"
+    )]
+    CrossTeamParticipation {
+        run_id: RunId,
+        cohort_id: CohortId,
+        expected_team_id: i32,
+        actual_team_id: i32,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -361,16 +438,18 @@ mod tests {
 }
 
 #[derive(Debug, FromRow)]
+struct PinnedParticipationRow {
+    team_id: i32,
+    cohort_id: i32,
+    pinned_filters: Json<Value>,
+    superseded_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, FromRow)]
 struct ParticipationRow {
     team_id: i32,
     cohort_id: i32,
-    /// B5 CAS-readiness / reconcile seam: the filters shape hash read from
-    /// `cohort_backfill_run_cohorts` for a future reconcile slice. Populated by Q1 (whose SQL stays
-    /// frozen) but not yet read, so the attr suppresses the dead-field lint until that slice lands.
-    #[allow(dead_code)]
-    filters_shape_hash: String,
-    pinned_filters: Json<Value>,
-    superseded_at: Option<DateTime<Utc>>,
+    behavioral_filters_shape_hash: String,
 }
 
 #[derive(Debug, FromRow)]
@@ -398,6 +477,60 @@ pub async fn discover_runs(
         }
     };
     rows.into_iter().map(DiscoveredRun::try_from).collect()
+}
+
+pub async fn load_reconcile_run(
+    pool: &PgPool,
+    run_id: RunId,
+) -> Result<ReconcileRun, ReconcileRunError> {
+    let run = read_run(pool, run_id).await?;
+    if !matches!(run.status, RunStatus::Seeding | RunStatus::Reconciling) {
+        return Err(ReconcileRunError::Status {
+            run_id,
+            status: run.status,
+        });
+    }
+
+    let rows = sqlx::query_as::<_, ParticipationRow>(READ_ACTIVE_RECONCILE_PARTICIPATIONS)
+        .bind(run_id)
+        .fetch_all(pool)
+        .await
+        .map_err(RunError::from)?;
+    if rows.is_empty() {
+        return Err(ReconcileRunError::NoActiveParticipations(run_id));
+    }
+
+    let mut participations = Vec::with_capacity(rows.len());
+    for row in rows {
+        let cohort_id = CohortId(row.cohort_id);
+        if row.team_id != run.team_id.0 {
+            return Err(ReconcileRunError::CrossTeamParticipation {
+                run_id,
+                cohort_id,
+                expected_team_id: run.team_id.0,
+                actual_team_id: row.team_id,
+            });
+        }
+        let behavioral_filters_shape_hash =
+            BehavioralShapeHash::parse(&row.behavioral_filters_shape_hash).map_err(|source| {
+                ReconcileRunError::InvalidBehavioralShapeHash {
+                    run_id,
+                    cohort_id,
+                    source,
+                }
+            })?;
+        participations.push(ReconcileParticipation {
+            cohort_id,
+            behavioral_filters_shape_hash,
+        });
+    }
+
+    Ok(ReconcileRun {
+        run_id,
+        status: run.status,
+        team_id: run.team_id,
+        participations,
+    })
 }
 
 pub async fn establish_boundary(

--- a/rust/cohort-seeder/tests/fixtures/cohort_backfill_0004.sql
+++ b/rust/cohort-seeder/tests/fixtures/cohort_backfill_0004.sql
@@ -62,6 +62,7 @@ CREATE INDEX cohort_bfc_run_status_day_idx ON cohort_backfill_chunks(run_id, sta
 CREATE TABLE cohort_backfill_run_cohorts (
     id uuid PRIMARY KEY,
     filters_shape_hash varchar(64) NOT NULL,
+    behavioral_filters_shape_hash varchar(64) NOT NULL DEFAULT '',
     pinned_filters jsonb NOT NULL,
     stamped_at timestamptz,
     superseded_at timestamptz,

--- a/rust/cohort-seeder/tests/pg_chunks.rs
+++ b/rust/cohort-seeder/tests/pg_chunks.rs
@@ -11,13 +11,17 @@ use std::num::NonZeroU16;
 use std::time::Duration;
 
 use anyhow::{bail, ensure, Context, Result};
-use cohort_core::filters::CohortId;
+use cohort_core::filters::{CohortId, TeamId};
+use cohort_seeder::app::reconcile_dispatch::{
+    prepare_reconcile_dispatch, CompletionRequirement, PrepareReconcileDispatchError,
+    RegisterBackfillConfirmation,
+};
 use cohort_seeder::domain::{ClaimEpoch, PinnedWarning, ProduceHwms};
 use cohort_seeder::store::chunks::{ChunkStoreError, PgChunkStore, PlanOutcome};
 use cohort_seeder::store::lease::LeaseFailure;
 use cohort_seeder::store::runs::{
-    discover_runs, establish_boundary, fail_run, record_run_warning, BoundaryOutcome, RunError,
-    RunStatus, RunWarningNote,
+    discover_runs, establish_boundary, fail_run, load_reconcile_run, record_run_warning,
+    BoundaryOutcome, ReconcileRunError, RunError, RunStatus, RunWarningNote,
 };
 use cohort_seeder::store::{Claimant, LeaseDuration, MaxAttempts, RenderedError};
 use cohort_seeder::test_support;
@@ -299,6 +303,158 @@ async fn load_pinned_drops_superseded_and_rejects_cross_team_and_dr() -> Result<
     .await
 }
 
+/// Manual dispatch reads only active participations, carries the behavioral-only shape hash onto
+/// the control tile, and refuses stale run states or malformed tenant/hash data before Kafka.
+#[tokio::test]
+async fn reconcile_run_load_is_fail_closed_and_behavioral_hash_scoped() -> Result<()> {
+    with_db(|pool| async move {
+        let run_id = insert_run(
+            &pool,
+            20,
+            "team_enablement",
+            "seeding",
+            true,
+            empty_pinned(),
+        )
+        .await?;
+        insert_participation(
+            &pool,
+            run_id,
+            20,
+            201,
+            false,
+            behavioral_filter(ACTIVE_HASH, "active-event"),
+        )
+        .await?;
+        insert_participation(
+            &pool,
+            run_id,
+            20,
+            202,
+            true,
+            behavioral_filter(SUPERSEDED_HASH, "superseded-event"),
+        )
+        .await?;
+
+        let register_backfill = RegisterBackfillConfirmation::confirmed_by_operator();
+        ensure!(matches!(
+            prepare_reconcile_dispatch(
+                &pool,
+                run_id,
+                CompletionRequirement::Complete,
+                register_backfill,
+            )
+            .await,
+            Err(PrepareReconcileDispatchError::EmptyChunkLedger(id)) if id == run_id
+        ));
+        let overridden = prepare_reconcile_dispatch(
+            &pool,
+            run_id,
+            CompletionRequirement::AllowIncomplete,
+            register_backfill,
+        )
+        .await?;
+        ensure!(overridden.total_chunks() == 0);
+        ensure!(overridden.remaining_chunks() == 0);
+
+        let reconcile = load_reconcile_run(&pool, run_id).await?;
+        ensure!(reconcile.run_id() == run_id);
+        ensure!(reconcile.status() == RunStatus::Seeding);
+        ensure!(reconcile.cohort_count() == 1);
+        let tile = reconcile
+            .tiles()
+            .next()
+            .context("missing active cohort tile")?;
+        ensure!(tile.team_id() == TeamId(20));
+        ensure!(tile.cohort_id() == CohortId(201));
+        ensure!(tile.filters_hash().as_str() == "behavioral-shape");
+        ensure!(tile.run_id() == run_id);
+
+        sqlx::query("UPDATE cohort_backfill_runs SET status = 'reconciling' WHERE id = $1")
+            .bind(run_id)
+            .execute(&pool)
+            .await?;
+        ensure!(load_reconcile_run(&pool, run_id).await?.status() == RunStatus::Reconciling);
+        ensure!(prepare_reconcile_dispatch(
+            &pool,
+            run_id,
+            CompletionRequirement::Complete,
+            register_backfill,
+        )
+        .await
+        .is_ok());
+
+        sqlx::query(
+            "UPDATE cohort_backfill_run_cohorts SET behavioral_filters_shape_hash = '' \
+             WHERE run_id = $1 AND cohort_id = 201",
+        )
+        .bind(run_id)
+        .execute(&pool)
+        .await?;
+        ensure!(matches!(
+            load_reconcile_run(&pool, run_id).await,
+            Err(ReconcileRunError::InvalidBehavioralShapeHash { cohort_id, .. })
+                if cohort_id == CohortId(201)
+        ));
+
+        sqlx::query(
+            "UPDATE cohort_backfill_run_cohorts \
+             SET behavioral_filters_shape_hash = 'behavioral-shape', team_id = 999 \
+             WHERE run_id = $1 AND cohort_id = 201",
+        )
+        .bind(run_id)
+        .execute(&pool)
+        .await?;
+        ensure!(matches!(
+            load_reconcile_run(&pool, run_id).await,
+            Err(ReconcileRunError::CrossTeamParticipation {
+                expected_team_id: 20,
+                actual_team_id: 999,
+                ..
+            })
+        ));
+
+        sqlx::query(
+            "UPDATE cohort_backfill_run_cohorts SET superseded_at = now() WHERE run_id = $1",
+        )
+        .bind(run_id)
+        .execute(&pool)
+        .await?;
+        ensure!(matches!(
+            load_reconcile_run(&pool, run_id).await,
+            Err(ReconcileRunError::NoActiveParticipations(id)) if id == run_id
+        ));
+
+        let completed_run = insert_run(
+            &pool,
+            21,
+            "team_enablement",
+            "completed",
+            true,
+            empty_pinned(),
+        )
+        .await?;
+        insert_participation(
+            &pool,
+            completed_run,
+            21,
+            211,
+            false,
+            behavioral_filter(ACTIVE_HASH, "active-event"),
+        )
+        .await?;
+        ensure!(matches!(
+            load_reconcile_run(&pool, completed_run).await,
+            Err(ReconcileRunError::Status {
+                status: RunStatus::Completed,
+                ..
+            })
+        ));
+        Ok(())
+    })
+    .await
+}
+
 /// Planning a seeding run's days is idempotent (re-planning inserts nothing), stamps the run's team
 /// onto every chunk, and reports `RunNotSeeding` for a run that is not seeding.
 #[tokio::test]
@@ -310,6 +466,9 @@ async fn planning_is_idempotent_scopes_team_and_gates_on_seeding() -> Result<()>
 
         ensure!(planned_count(store.plan_chunks(seeding_run, [100, 101], ONE_BAND).await?)? == 2);
         ensure!(planned_count(store.plan_chunks(seeding_run, [100, 101], ONE_BAND).await?)? == 0);
+        let progress = store.chunk_progress(seeding_run).await?;
+        ensure!(progress.total() == 2);
+        ensure!(progress.remaining() == 2);
         let chunk_teams_match: bool = sqlx::query_scalar(
             "SELECT bool_and(team_id = 2) FROM cohort_backfill_chunks WHERE run_id = $1",
         )

--- a/rust/cohort-seeder/tests/support/mod.rs
+++ b/rust/cohort-seeder/tests/support/mod.rs
@@ -145,8 +145,10 @@ pub async fn insert_participation(
     sqlx::query(
         r#"
         INSERT INTO cohort_backfill_run_cohorts
-            (id, run_id, team_id, cohort_id, filters_shape_hash, pinned_filters, superseded_at)
-        VALUES ($1, $2, $3, $4, 'shape', $5, CASE WHEN $6 THEN now() ELSE NULL END)
+            (id, run_id, team_id, cohort_id, filters_shape_hash,
+             behavioral_filters_shape_hash, pinned_filters, superseded_at)
+        VALUES ($1, $2, $3, $4, 'full-shape', 'behavioral-shape', $5,
+                CASE WHEN $6 THEN now() ELSE NULL END)
         "#,
     )
     .bind(Uuid::now_v7())

--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -243,6 +243,22 @@ pub struct Config {
     )]
     pub cohort_seed_watermark_idle_probe_interval_ms: u64,
 
+    /// Admit and drain reconcile controls and permit cross-partition membership-register transfer.
+    /// Local register writers and transfer receivers are always active. Default off for a
+    /// receiver-first rollout; enable promptly after every processor pod understands the additive
+    /// transfer payload and every downstream consumer tolerates completion markers. Until enabled,
+    /// a cross-partition merge carrying register rows retains its source offset for retry.
+    #[envconfig(from = "COHORT_SEED_RECONCILE_ENABLED", default = "false")]
+    pub cohort_seed_reconcile_enabled: bool,
+
+    /// Maximum Stage 2 rows one partition worker evaluates per reconcile tick.
+    #[envconfig(from = "COHORT_SEED_RECONCILE_SCAN_PAGE", default = "256")]
+    pub cohort_seed_reconcile_scan_page: usize,
+
+    /// Cadence for routing one bounded reconcile-drain tick to each active partition worker.
+    #[envconfig(from = "COHORT_SEED_RECONCILE_TICK_INTERVAL_MS", default = "2000")]
+    pub cohort_seed_reconcile_tick_interval_ms: u64,
+
     /// Stable per-pod identity for `group.instance.id` + `client.id`, enabling static membership.
     /// Read from `POD_NAME`, else `HOSTNAME`. Absent means no static membership.
     #[envconfig(from = "POD_NAME")]
@@ -598,6 +614,10 @@ impl Config {
             .max(Duration::from_secs(1))
     }
 
+    pub fn reconcile_tick_interval(&self) -> Duration {
+        Duration::from_millis(self.cohort_seed_reconcile_tick_interval_ms)
+    }
+
     pub fn checkpoint_interval(&self) -> Duration {
         Duration::from_millis(self.checkpoint_interval_ms)
     }
@@ -636,11 +656,29 @@ impl Config {
     /// Refuse unsafe durability startup combinations. Pure (no I/O), so unit-testable without a broker.
     ///
     /// Guards:
+    /// - Reconcile scan and tick limits must be non-zero; a zero page would falsely certify an
+    ///   unscanned snapshot, while Tokio rejects a zero timer interval.
     /// - `checkpoint_enabled` requires `durable_restore_enabled`: without it the restored DB is wiped
     ///   on open, silently discarding the restore.
     /// - `durable_restore_enabled` + `cohort_cascade_enabled` requires `durable_restore_single_pod`
     ///   and a pod identity: `pod_identity()` alone is not a single-pod signal (set on every k8s pod).
     pub fn validate_durability_startup(&self) -> anyhow::Result<()> {
+        ensure!(
+            self.cohort_seed_reconcile_scan_page > 0,
+            "COHORT_SEED_RECONCILE_SCAN_PAGE must be greater than zero.",
+        );
+        ensure!(
+            self.cohort_seed_reconcile_tick_interval_ms > 0,
+            "COHORT_SEED_RECONCILE_TICK_INTERVAL_MS must be greater than zero.",
+        );
+
+        if self.cohort_seed_reconcile_enabled && !self.cohort_seed_consumer_enabled {
+            warn!(
+                "COHORT_SEED_RECONCILE_ENABLED without COHORT_SEED_CONSUMER_ENABLED: no reconcile \
+                 controls can be consumed; enable the seed consumer or turn reconcile off.",
+            );
+        }
+
         ensure!(
             !self.checkpoint_enabled || self.durable_restore_enabled,
             "CHECKPOINT_ENABLED requires DURABLE_RESTORE_ENABLED: restoring a checkpoint without \
@@ -967,6 +1005,9 @@ mod tests {
             kafka_seed_consumer_group: "cohort-stream-seeds".to_string(),
             cohort_seed_fence_margin_ms: 600_000,
             cohort_seed_watermark_idle_probe_interval_ms: 30_000,
+            cohort_seed_reconcile_enabled: false,
+            cohort_seed_reconcile_scan_page: 256,
+            cohort_seed_reconcile_tick_interval_ms: 2_000,
         }
     }
 
@@ -981,6 +1022,58 @@ mod tests {
             config.filter_catalog_refresh_jitter(),
             Duration::from_secs(60)
         );
+    }
+
+    #[test]
+    fn reconcile_knobs_default_dark_and_override_from_env() {
+        let defaults = Config::init_from_hashmap(&std::collections::HashMap::new()).unwrap();
+        assert!(!defaults.cohort_seed_reconcile_enabled);
+        assert_eq!(defaults.cohort_seed_reconcile_scan_page, 256);
+        assert_eq!(
+            defaults.reconcile_tick_interval(),
+            Duration::from_millis(2_000)
+        );
+
+        let env: std::collections::HashMap<String, String> = [
+            ("COHORT_SEED_RECONCILE_ENABLED", "true"),
+            ("COHORT_SEED_RECONCILE_SCAN_PAGE", "17"),
+            ("COHORT_SEED_RECONCILE_TICK_INTERVAL_MS", "345"),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect();
+        let config = Config::init_from_hashmap(&env).unwrap();
+        assert!(config.cohort_seed_reconcile_enabled);
+        assert_eq!(config.cohort_seed_reconcile_scan_page, 17);
+        assert_eq!(config.reconcile_tick_interval(), Duration::from_millis(345));
+    }
+
+    #[test]
+    fn reconcile_startup_validation_rejects_zero_work_limits() {
+        let mut config = test_config();
+        config.cohort_seed_reconcile_scan_page = 0;
+        assert!(config
+            .validate_durability_startup()
+            .unwrap_err()
+            .to_string()
+            .contains("COHORT_SEED_RECONCILE_SCAN_PAGE"),);
+
+        config.cohort_seed_reconcile_scan_page = 1;
+        config.cohort_seed_reconcile_tick_interval_ms = 0;
+        assert!(config
+            .validate_durability_startup()
+            .unwrap_err()
+            .to_string()
+            .contains("COHORT_SEED_RECONCILE_TICK_INTERVAL_MS"),);
+    }
+
+    #[test]
+    fn reconcile_without_the_seed_consumer_warns_but_starts() {
+        let mut config = test_config();
+        config.cohort_seed_reconcile_enabled = true;
+        config.cohort_seed_consumer_enabled = false;
+
+        assert!(config.validate_durability_startup().is_ok());
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -82,12 +82,19 @@ pub struct ConsumedEvent {
     pub broker_ts_ms: Option<i64>,
 }
 
+/// A partition entry remains present while its old worker drains. That sentinel serializes worker
+/// replacement with tracker-tenure reset during a rapid revoke/reassign.
+enum WorkerSlot {
+    Running(Stage1Worker),
+    Draining,
+}
+
 /// The Kafka-free routing core: dispatches consumed batches to per-partition workers, tracks
 /// processed offsets, and owns the partition lifecycle the rebalance handler drives.
 pub struct EventDispatcher {
     router: Arc<PartitionRouter>,
     tracker: Arc<OffsetTracker>,
-    workers: Arc<DashMap<i32, Stage1Worker>>,
+    workers: Arc<DashMap<i32, WorkerSlot>>,
     /// Partitions currently assigned to this consumer.
     owned: Arc<DashSet<i32>>,
     handle: StoreHandle,
@@ -237,8 +244,8 @@ impl EventDispatcher {
     }
 
     /// Retry-send held sub-batches, raising the ceiling for any that flush. Returns the partitions
-    /// still full (retained holdover) to keep paused; a flushed or worker-gone one is absent, so the
-    /// caller resumes it.
+    /// still unavailable (full, missing, or closed) to keep paused; only a flushed partition is
+    /// absent, so the caller resumes it.
     pub fn redispatch_held(
         &self,
         held: Vec<(i32, Vec<ShuffleMessage>)>,
@@ -246,6 +253,7 @@ impl EventDispatcher {
         // Each partition's Vec stays contiguous, so the regrouped route keeps offset order.
         let mut messages: Vec<(i32, ShuffleMessage)> = Vec::new();
         for (partition, batch) in held {
+            self.ensure_worker(partition);
             for message in batch {
                 messages.push((partition, message));
             }
@@ -282,7 +290,10 @@ impl EventDispatcher {
                 SendOutcome::Full(returned) => {
                     full.entry(partition).or_default().extend(returned);
                 }
-                SendOutcome::NoWorker | SendOutcome::ChannelClosed => route_errors += 1,
+                SendOutcome::NoWorker(returned) | SendOutcome::ChannelClosed(returned) => {
+                    full.entry(partition).or_default().extend(returned);
+                    route_errors += 1;
+                }
             }
         }
         if dispatched > 0 {
@@ -423,7 +434,14 @@ impl EventDispatcher {
                             .filter_map(|message| ConsumedSeed::from_message(partition, message)),
                     );
                 }
-                SendOutcome::NoWorker | SendOutcome::ChannelClosed => route_errors += 1,
+                SendOutcome::NoWorker(returned) | SendOutcome::ChannelClosed(returned) => {
+                    full.entry(partition).or_default().extend(
+                        returned
+                            .into_iter()
+                            .filter_map(|message| ConsumedSeed::from_message(partition, message)),
+                    );
+                    route_errors += 1;
+                }
             }
         }
         if route_errors > 0 {
@@ -470,7 +488,14 @@ impl EventDispatcher {
     /// partition is unowned. The ownership check and insert are atomic under the DashMap shard guard.
     fn ensure_worker(&self, partition: i32) {
         match self.workers.entry(partition) {
-            Entry::Occupied(_) => {}
+            Entry::Occupied(slot) => {
+                if matches!(slot.get(), WorkerSlot::Draining) {
+                    debug!(
+                        partition,
+                        "worker replacement waits for the revoked worker to finish draining"
+                    );
+                }
+            }
             Entry::Vacant(slot) => {
                 // No `.await` in this arm — the DashMap shard guard is held.
                 if !self.owned.contains(&partition) {
@@ -500,7 +525,7 @@ impl EventDispatcher {
                             self.durable_restore_enabled(),
                             self.event_name_gating(),
                         );
-                        slot.insert(worker);
+                        slot.insert(WorkerSlot::Running(worker));
                         counter!(COHORT_STREAM_WORKERS_SPAWNED).increment(1);
                         info!(
                             partition,
@@ -560,6 +585,11 @@ impl EventDispatcher {
         .await;
     }
 
+    /// Route one bounded reconcile-drain tick to each owned partition with a live worker.
+    pub async fn route_reconcile_drain(&self) {
+        self.route_to_owned(|| ShuffleMessage::ReconcileDrain).await;
+    }
+
     /// Owned partitions that currently have a live worker channel — the only partitions a maintenance
     /// tick can reach. An owned partition that never received an event has no worker, so a tick to it
     /// is a guaranteed `no_worker` no-op (no in-memory state to evict, redrive, or GC); skipping it
@@ -616,8 +646,24 @@ impl EventDispatcher {
             return;
         }
 
+        let worker = match self.workers.entry(partition) {
+            Entry::Occupied(mut slot) => {
+                if matches!(slot.get(), WorkerSlot::Draining) {
+                    debug!(partition, "revoke cleanup is already draining this worker");
+                    return;
+                }
+                match slot.insert(WorkerSlot::Draining) {
+                    WorkerSlot::Running(worker) => Some(worker),
+                    WorkerSlot::Draining => unreachable!("the occupied slot was checked above"),
+                }
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(WorkerSlot::Draining);
+                None
+            }
+        };
         self.router.remove_partition(partition);
-        if let Some((_, worker)) = self.workers.remove(&partition) {
+        if let Some(worker) = worker {
             let started = Instant::now();
             if let Err(err) = worker.join().await {
                 warn!(partition, error = %err, "stage 1 worker panicked during revoke drain");
@@ -626,7 +672,12 @@ impl EventDispatcher {
         }
 
         if self.owned.contains(&partition) {
-            // re-acquired during the join — skip cleanup
+            // The draining sentinel prevents an in-flight follower batch from spawning a replacement
+            // worker before the old in-memory reconcile queue is gone and its tracker tenure resets.
+            // The rebalance worker then rewinds the follower, so anything dropped against the
+            // sentinel is replayed into the fresh tenure.
+            self.merge.seed_tracker.forget_partition(partition);
+            self.finish_worker_drain(partition);
             counter!(REBALANCE_CLEANUP_SKIPPED_TOTAL, "phase" => "post_join").increment(1);
             debug!(
                 partition,
@@ -656,6 +707,7 @@ impl EventDispatcher {
                 partition,
                 "revoked partition out of u16 range; skipping state delete"
             );
+            self.finish_worker_drain(partition);
             return;
         };
         match self.handle.delete_partition(partition_id).await {
@@ -664,6 +716,12 @@ impl EventDispatcher {
                 warn!(partition, error = %err, "failed to delete revoked partition state")
             }
         }
+        self.finish_worker_drain(partition);
+    }
+
+    fn finish_worker_drain(&self, partition: i32) {
+        self.workers
+            .remove_if(&partition, |_, slot| matches!(slot, WorkerSlot::Draining));
     }
 
     /// Delete a moving-in partition's stale on-disk slice so the worker cold-rebuilds from the
@@ -886,7 +944,7 @@ impl EventDispatcher {
         self.router.clear();
         let partitions: Vec<i32> = self.workers.iter().map(|entry| *entry.key()).collect();
         for partition in partitions {
-            if let Some((_, worker)) = self.workers.remove(&partition) {
+            if let Some((_, WorkerSlot::Running(worker))) = self.workers.remove(&partition) {
                 if let Err(err) = worker.join().await {
                     warn!(partition, error = %err, "stage 1 worker panicked during shutdown drain");
                 }
@@ -1409,10 +1467,14 @@ pub(crate) async fn run_pauser_loop(
 mod tests {
     use super::*;
     use chrono_tz::UTC;
+    use common_kafka::kafka_producer::KafkaProduceError;
     use serde_json::json;
     use tempfile::TempDir;
     use uuid::Uuid;
 
+    use cohort_core::seed::{BehavioralShapeHash, ReconcileTile, RunId};
+
+    use crate::consumers::seeds::SeedWork;
     use crate::filters::{CohortId, FilterCatalog, TeamFiltersBuilder, TeamId};
     use crate::merge::transfer::{
         MergeStateTransfer, PendingTransfer, PersonMergeEvent, Tombstone, TransferLeaf,
@@ -1421,7 +1483,8 @@ mod tests {
     use crate::partitions::offset_tracker::MarkOutcome;
     use crate::partitions::partitioner::{partition_of, COHORT_PARTITION_COUNT};
     use crate::producer::{
-        CaptureSink, CaptureStreamEventSink, CaptureTransferSink, MembershipStatus,
+        CaptureSink, CaptureStreamEventSink, CaptureTransferSink, CohortMembershipChange,
+        MembershipStatus, ReconcileCompleteMarker,
     };
     use crate::stage1::state::AppliedOffsets;
     use crate::stage1::{Stage1State, StatefulRecord};
@@ -1434,6 +1497,43 @@ mod tests {
     const TEAM: i32 = 7;
     const BEHAVIORAL_HASH: [u8; 16] = *b"0123456789abcdef";
     const BASE_TS: &str = "2026-05-26 12:34:56.789000";
+
+    struct BlockingMembershipSink {
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+        block_first: AtomicBool,
+    }
+
+    impl BlockingMembershipSink {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                entered: tokio::sync::Notify::new(),
+                release: tokio::sync::Notify::new(),
+                block_first: AtomicBool::new(true),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MembershipSink for BlockingMembershipSink {
+        async fn produce(
+            &self,
+            changes: Vec<CohortMembershipChange>,
+        ) -> Vec<Result<(), KafkaProduceError>> {
+            if self.block_first.swap(false, Ordering::SeqCst) {
+                self.entered.notify_one();
+                self.release.notified().await;
+            }
+            changes.into_iter().map(|_| Ok(())).collect()
+        }
+
+        async fn produce_markers(
+            &self,
+            markers: Vec<ReconcileCompleteMarker>,
+        ) -> Vec<Result<(), KafkaProduceError>> {
+            markers.into_iter().map(|_| Ok(())).collect()
+        }
+    }
 
     /// Wrap a test store in the `All` operating point so the dispatcher runs on the blocking pool.
     fn test_handle(store: &CohortStore) -> StoreHandle {
@@ -1770,6 +1870,10 @@ mod tests {
         let sink = Arc::new(sink);
         let transfer_sink = Arc::new(transfer_sink);
         let transfer_sink_dyn: Arc<dyn crate::producer::TransferSink> = transfer_sink.clone();
+        let reconcile = crate::workers::ReconcileDeps {
+            enabled: true,
+            ..crate::workers::ReconcileDeps::default()
+        };
         let merge = Arc::new(MergeWorkerDeps {
             transfer_sink: transfer_sink_dyn,
             stream_event_sink: Arc::new(CaptureStreamEventSink::new()),
@@ -1785,6 +1889,7 @@ mod tests {
             seed_tile_sink: Arc::new(crate::producer::CaptureSeedTileSink::new()),
             seed_tracker: Arc::new(crate::partitions::offset_tracker::OffsetTracker::new()),
             live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+            reconcile,
         });
         let dispatcher = EventDispatcher::new(
             PartitionRouter::new(64),
@@ -2469,6 +2574,164 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn post_join_reacquire_starts_a_fresh_seed_tenure_for_reconcile_replay() {
+        let (_dir, store) = temp_store();
+        let sink = BlockingMembershipSink::new();
+        let reconcile = crate::workers::ReconcileDeps {
+            enabled: true,
+            ..crate::workers::ReconcileDeps::default()
+        };
+        let merge = Arc::new(MergeWorkerDeps {
+            transfer_sink: Arc::new(CaptureTransferSink::new()),
+            stream_event_sink: Arc::new(CaptureStreamEventSink::new()),
+            merge_tracker: Arc::new(OffsetTracker::new()),
+            transfer_tracker: Arc::new(OffsetTracker::new()),
+            retry: TransferRetryPolicy::default(),
+            gc_scan_limit: crate::workers::DEFAULT_MERGE_GC_SCAN_LIMIT,
+            stage2_orphan_gc_enabled: true,
+            cascade_sink: Arc::new(crate::producer::CaptureCascadeSink::new()),
+            cascade_tracker: Arc::new(OffsetTracker::new()),
+            cascade: crate::workers::CascadeConfig::default(),
+            partition_count: COHORT_PARTITION_COUNT,
+            seed_tile_sink: Arc::new(crate::producer::CaptureSeedTileSink::new()),
+            seed_tracker: Arc::new(OffsetTracker::new()),
+            live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+            reconcile,
+        });
+        let dispatcher = Arc::new(EventDispatcher::new(
+            PartitionRouter::new(64),
+            Arc::new(OffsetTracker::new()),
+            test_handle(&store),
+            behavioral_catalog(),
+            sink.clone(),
+            merge.clone(),
+        ));
+        dispatcher.assign_partition(0);
+
+        let tile = ReconcileTile::new(
+            TeamId(TEAM),
+            CohortId(1),
+            BehavioralShapeHash::parse("0123456789abcdef").unwrap(),
+            RunId(Uuid::from_u128(1)),
+        );
+        let held = dispatcher.dispatch_seeds(vec![ConsumedSeed {
+            work: SeedWork::Reconcile(tile.clone()),
+            partition: 0,
+            offset: 5,
+        }]);
+        assert!(held.is_empty());
+        for _ in 0..10_000 {
+            if merge.reconcile.backlog.len() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(merge.reconcile.backlog.len(), 1, "reconcile was admitted");
+
+        dispatcher.dispatch(vec![consumed(person(1), 0, 6)]).await;
+        sink.entered.notified().await;
+
+        dispatcher.revoke_partition_sync(0);
+        let drain = {
+            let dispatcher = dispatcher.clone();
+            tokio::spawn(async move { dispatcher.revoke_partition_drain(0).await })
+        };
+        for _ in 0..10_000 {
+            if dispatcher
+                .workers
+                .get(&0)
+                .is_some_and(|slot| matches!(slot.value(), WorkerSlot::Draining))
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            dispatcher
+                .workers
+                .get(&0)
+                .is_some_and(|slot| matches!(slot.value(), WorkerSlot::Draining)),
+            "the old worker was replaced by a draining sentinel before its blocked join",
+        );
+
+        dispatcher.assign_partition(0);
+        let held_events = dispatcher
+            .dispatch_events_nonblocking(vec![consumed(person(2), 0, 7)], &HashSet::new());
+        assert_eq!(
+            held_offsets(
+                held_events
+                    .get(&0)
+                    .expect("a primary event is held behind the draining worker"),
+            ),
+            vec![7],
+        );
+        let mut held = dispatcher.dispatch_seeds(vec![ConsumedSeed {
+            work: SeedWork::Reconcile(tile.clone()),
+            partition: 0,
+            offset: 5,
+        }]);
+        assert_eq!(
+            held_seed_offsets(held.get(&0).expect("the draining route is held")),
+            vec![5],
+        );
+        assert!(
+            dispatcher
+                .workers
+                .get(&0)
+                .is_some_and(|slot| matches!(slot.value(), WorkerSlot::Draining)),
+            "an in-flight follower batch cannot replace the draining worker",
+        );
+
+        sink.release.notify_one();
+        drain.await.unwrap();
+
+        assert!(dispatcher.owns(0));
+        assert!(merge.reconcile.backlog.is_empty());
+        assert!(dispatcher.workers.is_empty(), "the sentinel was released");
+
+        let still_held = dispatcher.redispatch_held(held_events.into_iter().collect());
+        assert!(
+            still_held.is_empty(),
+            "the primary event routes after the draining sentinel is released",
+        );
+        let held = dispatcher.dispatch_seeds(
+            held.remove(&0)
+                .expect("the held follower batch is retried after the drain"),
+        );
+        assert!(held.is_empty());
+        for _ in 0..10_000 {
+            if merge.reconcile.backlog.len() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(merge.reconcile.backlog.len(), 1, "replay was re-admitted");
+        assert_eq!(
+            merge.seed_tracker.mark_processed(0, 6),
+            MarkOutcome::WithinDispatch,
+            "worker receipt raises the fresh tenure's seed ceiling before admission",
+        );
+        assert_eq!(
+            merge.seed_tracker.committable_offsets().get(&0),
+            Some(&5),
+            "the replayed reconcile owns the fresh tenure's commit floor",
+        );
+        for _ in 0..10_000 {
+            if dispatcher.tracker().committable_offsets().get(&0) == Some(&8) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            dispatcher.tracker().committable_offsets().get(&0),
+            Some(&8),
+            "the held primary event is processed after worker replacement",
+        );
+
+        dispatcher.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn revoke_then_shutdown_drain_each_worker_exactly_once() {
         let (_dir, store) = temp_store();
         let (dispatcher, sink) = dispatcher_and_sink(&store, behavioral_catalog());
@@ -2605,6 +2868,24 @@ mod tests {
                 ShuffleMessage::Sweep { due_before_ms } => assert_eq!(*due_before_ms, cutoff),
                 other => panic!("expected Sweep, got {other:?}"),
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn route_reconcile_drain_delivers_one_tick_to_each_active_worker() {
+        let (_dir, store) = temp_store();
+        let dispatcher = dispatcher_with(&store, behavioral_catalog());
+
+        dispatcher.assign_partition(0);
+        dispatcher.assign_partition(1);
+        let mut rx0 = dispatcher.router.add_partition(0).unwrap();
+        let mut rx1 = dispatcher.router.add_partition(1).unwrap();
+
+        dispatcher.route_reconcile_drain().await;
+
+        for receiver in [&mut rx0, &mut rx1] {
+            let batch = receiver.recv().await.expect("a reconcile tick was routed");
+            assert!(matches!(batch.as_slice(), [ShuffleMessage::ReconcileDrain]));
         }
     }
 
@@ -2950,6 +3231,7 @@ mod tests {
             source_partition: source.0,
             source_offset: source.1,
             leaves,
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,

--- a/rust/cohort-stream-processor/src/consumers/merges.rs
+++ b/rust/cohort-stream-processor/src/consumers/merges.rs
@@ -396,6 +396,7 @@ mod tests {
                     AppliedOffsets::default(),
                 ),
             )],
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,

--- a/rust/cohort-stream-processor/src/consumers/seeds.rs
+++ b/rust/cohort-stream-processor/src/consumers/seeds.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use cohort_core::seed::{decode_seed, DecodedSeed, SChunkMs, SeedTile};
+use cohort_core::seed::{decode_seed, DecodedSeed, ReconcileTile, SChunkMs, SeedTile};
 use lifecycle::Handle;
 use metrics::{counter, gauge, histogram};
 use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
@@ -41,7 +41,7 @@ const PROBE_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 /// Why a consumed seed payload is skipped rather than applied.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SeedSkipReason {
-    /// A kind this consumer does not handle (e.g. a `reconcile` control tile).
+    /// A kind the current worker path does not handle.
     UnknownKind,
     /// A newer schema version. The skip commits and never replays, so this consumer must be
     /// upgraded before any seeder emits a new schema.
@@ -64,6 +64,7 @@ impl SeedSkipReason {
 #[derive(Debug)]
 pub enum SeedWork {
     Tile(SeedTile),
+    Reconcile(ReconcileTile),
     Skip(SeedSkipReason),
 }
 
@@ -95,11 +96,11 @@ impl ConsumedSeed {
         }
     }
 
-    /// The fence input; `None` for skips.
+    /// The fence input; control messages and skips are fence-open.
     fn s_chunk_ms(&self) -> Option<SChunkMs> {
         match &self.work {
             SeedWork::Tile(tile) => Some(tile.s_chunk_ms()),
-            SeedWork::Skip(_) => None,
+            SeedWork::Reconcile(_) | SeedWork::Skip(_) => None,
         }
     }
 }
@@ -423,8 +424,7 @@ impl SeedFollowerConsumer {
     }
 }
 
-/// Decode one payload; every non-tile outcome is a channel-riding skip so its offset marks in
-/// order.
+/// Decode one payload into channel-riding work so every outcome retains its in-order offset.
 fn decode_payload(payload: Option<&[u8]>, partition: i32, offset: i64) -> SeedWork {
     let Some(payload) = payload else {
         debug!(
@@ -435,6 +435,7 @@ fn decode_payload(payload: Option<&[u8]>, partition: i32, offset: i64) -> SeedWo
     };
     match decode_seed(payload) {
         Ok(DecodedSeed::Tile(tile)) => SeedWork::Tile(tile),
+        Ok(DecodedSeed::Reconcile(tile)) => SeedWork::Reconcile(tile),
         Ok(DecodedSeed::UnknownKind { kind, .. }) => {
             debug!(partition, offset, kind, "skipping seed of unknown kind");
             SeedWork::Skip(SeedSkipReason::UnknownKind)
@@ -603,10 +604,12 @@ fn frontier_is_caught_up(frontier: Option<i64>, low: i64, high: i64) -> bool {
 mod tests {
     use std::num::NonZeroU32;
 
-    use cohort_core::seed::{ClaimEpoch, ConditionHash, RunId, SChunkMs};
+    use cohort_core::seed::{
+        BehavioralShapeHash, ClaimEpoch, ConditionHash, ReconcileTile, RunId, SChunkMs,
+    };
     use uuid::Uuid;
 
-    use crate::filters::TeamId;
+    use crate::filters::{CohortId, TeamId};
     use crate::partitions::watermarks::LiveWatermarks;
 
     use super::*;
@@ -781,12 +784,19 @@ mod tests {
             SeedWork::Tile(decoded) if decoded == tile,
         ));
 
-        let mut reconcile = serde_json::to_value(&tile).unwrap();
-        reconcile["kind"] = serde_json::json!("reconcile");
+        let reconcile = ReconcileTile::new(
+            TeamId(2),
+            CohortId(42),
+            BehavioralShapeHash::parse(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+            .unwrap(),
+            RunId(Uuid::nil()),
+        );
         let bytes = serde_json::to_vec(&reconcile).unwrap();
         assert!(matches!(
             decode_payload(Some(&bytes), 0, 0),
-            SeedWork::Skip(SeedSkipReason::UnknownKind),
+            SeedWork::Reconcile(decoded) if decoded == reconcile,
         ));
 
         let mut newer = serde_json::to_value(&tile).unwrap();
@@ -817,8 +827,56 @@ mod tests {
         assert_eq!(back.offset, 42);
         assert!(matches!(back.work, SeedWork::Tile(tile) if tile.s_chunk_ms() == SChunkMs(123)));
 
+        let reconcile = ReconcileTile::new(
+            TeamId(2),
+            CohortId(42),
+            BehavioralShapeHash::parse("0123456789abcdef").unwrap(),
+            RunId(Uuid::nil()),
+        );
+        let consumed = ConsumedSeed {
+            work: SeedWork::Reconcile(reconcile.clone()),
+            partition: 9,
+            offset: 43,
+        };
+        let back = ConsumedSeed::from_message(9, consumed.into_message()).unwrap();
+        assert_eq!(back.offset, 43);
+        assert!(matches!(back.work, SeedWork::Reconcile(tile) if tile == reconcile));
+
         let not_seed = ShuffleMessage::RedrivePendingTransfers;
         assert!(ConsumedSeed::from_message(9, not_seed).is_none());
+    }
+
+    #[test]
+    fn reconcile_is_fence_open_but_never_leapfrogs_a_closed_tile() {
+        let reconcile = ReconcileTile::new(
+            TeamId(2),
+            CohortId(42),
+            BehavioralShapeHash::parse("0123456789abcdef").unwrap(),
+            RunId(Uuid::nil()),
+        );
+        let reconcile_seed = |offset| ConsumedSeed {
+            work: SeedWork::Reconcile(reconcile.clone()),
+            partition: 3,
+            offset,
+        };
+
+        let open_prefix = split_at_fence(
+            vec![reconcile_seed(1), seed(3, 2, 0)],
+            &HashSet::new(),
+            MARGIN_MS,
+            |_| None,
+        );
+        assert_eq!(offsets(&open_prefix.admitted), vec![1]);
+        assert_eq!(offsets(&open_prefix.held[&3]), vec![2]);
+
+        let closed_prefix = split_at_fence(
+            vec![seed(3, 3, 0), reconcile_seed(4)],
+            &HashSet::new(),
+            MARGIN_MS,
+            |_| None,
+        );
+        assert!(closed_prefix.admitted.is_empty());
+        assert_eq!(offsets(&closed_prefix.held[&3]), vec![3, 4]);
     }
 
     /// A wrong `true` declares a partition with unfolded live events idle — the fence's

--- a/rust/cohort-stream-processor/src/filters/manager.rs
+++ b/rust/cohort-stream-processor/src/filters/manager.rs
@@ -219,6 +219,7 @@ mod tests {
             id,
             team_id,
             filters: serde_json::Value::Null,
+            behavioral_filters_shape_hash: None,
             timezone: "UTC".to_string(),
         }
     }

--- a/rust/cohort-stream-processor/src/main.rs
+++ b/rust/cohort-stream-processor/src/main.rs
@@ -40,8 +40,10 @@ use cohort_stream_processor::store::durability::{
     S3Uploader, TrackedTopic, CHECKPOINT_LOOP_NAME,
 };
 use cohort_stream_processor::store::{CohortStore, StoreHandle};
-use cohort_stream_processor::sweep::{run_sweep_loop, run_sweep_loop_delayed, DispatchSweeper};
-use cohort_stream_processor::workers::MergeWorkerDeps;
+use cohort_stream_processor::sweep::{
+    run_sweep_loop, run_sweep_loop_delayed, DispatchSweeper, ReconcileDrainSweeper,
+};
+use cohort_stream_processor::workers::{MergeWorkerDeps, ReconcileBacklog, ReconcileDeps};
 
 common_alloc::used!();
 
@@ -216,6 +218,7 @@ async fn async_main(config: Config) -> Result<()> {
     } else {
         Arc::new(NoopSeedTileSink)
     };
+    let reconcile_backlog = Arc::new(ReconcileBacklog::default());
     let merge_deps = Arc::new(MergeWorkerDeps {
         transfer_sink,
         stream_event_sink,
@@ -232,6 +235,11 @@ async fn async_main(config: Config) -> Result<()> {
         seed_tracker: Arc::new(OffsetTracker::new()),
         // Unconditional (cheap): the event path observes regardless of the seed gate.
         live_watermarks: Arc::new(LiveWatermarks::new()),
+        reconcile: ReconcileDeps {
+            enabled: config.cohort_seed_reconcile_enabled,
+            scan_page: config.cohort_seed_reconcile_scan_page,
+            backlog: reconcile_backlog.clone(),
+        },
     });
 
     // Cheap `Arc` clones taken before the originals move into the dispatcher: the checkpoint sweeper
@@ -479,6 +487,15 @@ async fn async_main(config: Config) -> Result<()> {
         "merge_gc",
         consumer_handle.shutdown_token(),
     ));
+
+    if config.cohort_seed_reconcile_enabled {
+        tokio::spawn(run_sweep_loop(
+            ReconcileDrainSweeper::new(dispatcher.clone(), reconcile_backlog),
+            config.reconcile_tick_interval(),
+            "reconcile",
+            consumer_handle.shutdown_token(),
+        ));
+    }
 
     // Publish store cache/size metrics via the sweep machinery, and Tokio runtime metrics via a
     // separate monitor.
@@ -772,6 +789,9 @@ fn log_startup(config: &Config) {
         seed_topic = %config.cohort_stream_seed_events_topic,
         seed_consumer_group = %config.kafka_seed_consumer_group,
         seed_fence_margin_ms = config.cohort_seed_fence_margin_ms,
+        cohort_seed_reconcile_enabled = config.cohort_seed_reconcile_enabled,
+        cohort_seed_reconcile_scan_page = config.cohort_seed_reconcile_scan_page,
+        cohort_seed_reconcile_tick_interval_ms = config.cohort_seed_reconcile_tick_interval_ms,
         "starting cohort-stream-processor",
     );
 }

--- a/rust/cohort-stream-processor/src/merge/apply_handler.rs
+++ b/rust/cohort-stream-processor/src/merge/apply_handler.rs
@@ -11,14 +11,19 @@
 //! state to the live survivor instead — inline when the survivor co-resides on this partition,
 //! forwarded on `cohort_merge_state_transfer` when it lives on another.
 
+use std::collections::BTreeMap;
+
 use metrics::counter;
 use uuid::Uuid;
 
 use crate::filters::reverse_index::TeamFilters;
-use crate::filters::TeamId;
+use crate::filters::{CohortId, TeamId};
 use crate::merge::rules::merge_records;
 use crate::merge::tombstone_redirect::{resolve, Resolution};
-use crate::merge::transfer::{ApplyStamp, MergeStateTransfer};
+use crate::merge::transfer::{
+    ApplyStamp, MergeStateTransfer, TransferMembershipRegister, TransferMembershipRegisterKind,
+    TransferredRegisterProvenance,
+};
 use crate::observability::metrics::{
     MERGE_APPLIES_SKIPPED_REPLAY_TOTAL, MERGE_FORWARD_HOP_CAPPED_TOTAL, MERGE_LEAVES_DROPPED_TOTAL,
     MERGE_TRANSFER_FORWARDS_TOTAL,
@@ -27,9 +32,12 @@ use crate::stage1::key::LeafStateKey;
 use crate::stage1::person_record::{PersonDedup, PersonRecord};
 use crate::stage1::state::StatefulRecord;
 use crate::stage1::transition::LeafTransition;
+use crate::stage2::{
+    leaf_membership, single_leaf_register_writes, MembershipRegisterSource, Stage2State,
+};
 use crate::store::{
     Behavioral, BehavioralKey, CohortStore, MergeAppliedKey, PersonPrefix, PersonRecords,
-    StoreError,
+    Stage2Key, Stage2TransferredRegisterKey, StoreError,
 };
 use crate::sweep::EvictionQueue;
 use crate::workers::event_path::schedule_deadline;
@@ -228,9 +236,42 @@ fn apply_into(
     let stamp = ApplyStamp {
         applied_at_ms: transfer.merged_at_ms,
     };
+    let fallback_register_writes = missing_transferred_register_writes(
+        partition_id,
+        store,
+        filters,
+        transfer.team_id,
+        target,
+        &transfer.membership_registers,
+        transfer.merged_at_ms,
+    )?;
     store.write_batch(|batch| {
-        for (key, bytes) in &apply.puts {
-            batch.put::<Behavioral>(key, bytes);
+        for write in &fallback_register_writes {
+            if let Some(state) = &write.state {
+                batch.put_stage2(&write.key, &state.encode_transferred_fallback());
+            }
+            if let Some(provenance) = &write.provenance {
+                batch.put_stage2_transferred_register(
+                    &Stage2TransferredRegisterKey::new(write.key),
+                    &provenance.encode(),
+                );
+            }
+        }
+        for leaf in &apply.puts {
+            batch.put::<Behavioral>(&leaf.key, &leaf.bytes);
+            for write in single_leaf_register_writes(
+                filters,
+                MembershipRegisterSource {
+                    partition_id,
+                    team_id: TeamId(transfer.team_id),
+                    person_id: target,
+                    leaf_state_key: leaf.key.lsk(),
+                },
+                leaf.in_cohort,
+                transfer.merged_at_ms,
+            ) {
+                batch.put_stage2(&write.key, &write.state.encode());
+            }
         }
         if let Some(bytes) = &record_put {
             batch.put::<PersonRecords>(&target_prefix.record_key(), bytes);
@@ -292,13 +333,121 @@ pub(crate) fn merge_person_records(
     }
 }
 
+/// One merge-carried register settlement. The logical state and person-first provenance are
+/// fill-only. A decoded existing state may be rewritten only to mark its ownership as transferred,
+/// preserving its bit and timestamp so a later receiver evaluation can settle the provenance.
+pub(crate) struct TransferredRegisterWrite {
+    pub key: Stage2Key,
+    pub state: Option<Stage2State>,
+    pub provenance: Option<TransferredRegisterProvenance>,
+}
+
+/// Fill only missing survivor rows from transferred membership registers. A recognized receiver
+/// shape chooses the conservative local bit (so a real single-leaf-to-composable edit starts false);
+/// otherwise the self-describing wire kind does. Source kind + bit remain in person-first provenance
+/// for another catalogless hop. Applied leaf evaluation remains authoritative and is staged later.
+#[allow(clippy::too_many_arguments, clippy::disallowed_methods)]
+pub(crate) fn missing_transferred_register_writes(
+    partition_id: u16,
+    store: &CohortStore,
+    filters: &TeamFilters,
+    team_id: i32,
+    person_id: Uuid,
+    registers: &[TransferMembershipRegister],
+    last_evaluated_at_ms: i64,
+) -> Result<Vec<TransferredRegisterWrite>, StoreError> {
+    let registers_by_cohort: BTreeMap<CohortId, TransferMembershipRegister> = registers
+        .iter()
+        .map(|register| (CohortId(register.cohort_id), *register))
+        .collect();
+    let keys: Vec<Stage2Key> = registers_by_cohort
+        .keys()
+        .map(|cohort_id| Stage2Key {
+            partition_id,
+            team_id: team_id as u64,
+            cohort_id: cohort_id.0 as u64,
+            person_id,
+        })
+        .collect();
+    let existing = store.multi_get_stage2(&keys)?;
+    let inventory_keys: Vec<Stage2TransferredRegisterKey> = keys
+        .iter()
+        .copied()
+        .map(Stage2TransferredRegisterKey::new)
+        .collect();
+    let existing_provenance = store.multi_get_stage2_transferred_registers(&inventory_keys)?;
+
+    Ok(keys
+        .into_iter()
+        .zip(registers_by_cohort.into_values())
+        .zip(existing)
+        .zip(existing_provenance)
+        .map(|(((key, register), existing), existing_provenance)| {
+            let receiver_kind =
+                TransferMembershipRegisterKind::from_filters(filters, CohortId(register.cohort_id));
+            let primary_missing = existing.is_none();
+            let existing_state = existing
+                .as_deref()
+                .and_then(|bytes| Stage2State::decode(bytes).ok());
+            let existing_bit = existing_state.as_ref().map(|state| state.in_cohort);
+            let materialized_kind = receiver_kind.unwrap_or(register.kind);
+            let install_existing_provenance =
+                !primary_missing && existing_provenance.is_none() && receiver_kind.is_none();
+            let state = if primary_missing {
+                Some(Stage2State {
+                    in_cohort: materialized_kind.materialized_bit(register.in_cohort),
+                    last_evaluated_at_ms,
+                })
+            } else if install_existing_provenance {
+                // A corrupt primary has no fill-only bit to preserve. Repair it with the same
+                // conservative source fallback used for a missing catalogless primary.
+                Some(existing_state.unwrap_or(Stage2State {
+                    in_cohort: register.kind.materialized_bit(register.in_cohort),
+                    last_evaluated_at_ms,
+                }))
+            } else {
+                None
+            };
+            let provenance = (primary_missing || install_existing_provenance).then(|| {
+                let source = TransferMembershipRegister {
+                    // The survivor's existing primary is fill-only and therefore owns the bit. The
+                    // incoming register supplies only the otherwise-unavailable kind clue.
+                    in_cohort: existing_bit.unwrap_or(register.in_cohort),
+                    ..register
+                };
+                let encoded_state = state.as_ref().map(Stage2State::encode_transferred_fallback);
+                let expected_primary = encoded_state.as_deref().expect(
+                    "installing provenance always materializes explicit fallback ownership",
+                );
+                TransferredRegisterProvenance::new(source, expected_primary)
+            });
+            TransferredRegisterWrite {
+                key,
+                state,
+                // Fill-only applies to provenance too: an existing survivor inventory wins. If
+                // neither inventory nor catalog can enumerate an existing row, the incoming
+                // source is the only safe person-first provenance to install.
+                provenance,
+            }
+        })
+        .collect())
+}
+
 /// Computed writes from applying P_old's leaves into P_new, uncommitted so the caller can compose
 /// the final batch.
 #[derive(Debug, Default)]
 pub(crate) struct LeafApply {
-    pub puts: Vec<(BehavioralKey, Vec<u8>)>,
+    pub puts: Vec<AppliedLeafWrite>,
     pub transitions: Vec<LeafTransition>,
     pub schedules: Vec<(BehavioralKey, i64)>,
+}
+
+/// One survivor leaf write coupled to the membership derived from those exact post-merge bytes.
+#[derive(Debug)]
+pub(crate) struct AppliedLeafWrite {
+    pub key: BehavioralKey,
+    pub bytes: Vec<u8>,
+    pub in_cohort: bool,
 }
 
 /// Merge each of P_old's `leaves` into P_new's state on `partition_new`. Pure reads only — the
@@ -349,7 +498,11 @@ pub(crate) fn apply_leaves(
             if let Some(deadline) = schedule_deadline(&record.state) {
                 out.schedules.push((p_new_key, deadline));
             }
-            out.puts.push((p_new_key, record.encode()));
+            out.puts.push(AppliedLeafWrite {
+                key: p_new_key,
+                bytes: record.encode(),
+                in_cohort: leaf_membership(Some(&record.state), meta),
+            });
         }
         if let Some(kind) = merged.flip {
             out.transitions.push(LeafTransition {

--- a/rust/cohort-stream-processor/src/merge/drain_handler.rs
+++ b/rust/cohort-stream-processor/src/merge/drain_handler.rs
@@ -77,9 +77,16 @@ pub enum DrainSkip {
 
 /// Whether a cross-partition drain may emit the additive membership-register payload.
 ///
-/// Local register writes and receiver application are unconditional. Only the sender is gated so
-/// a mixed-version fleet cannot acknowledge a transfer on an old receiver and delete the sole copy
-/// of its reconcile scan domain.
+/// Local register writes and receiver application are unconditional; only the sender is gated, on
+/// `reconcile_enabled`. While the gate is off, a register-owning cross-partition merge never ships a
+/// transfer — it fail-stops via [`DrainOutcome::AwaitingRegisterTransferEnablement`] (sticky hold,
+/// zero mutation) — so a receiver that cannot apply the payload never acks a transfer and deletes the
+/// sole copy of its reconcile scan domain.
+///
+/// Once the gate is on the sender emits, and a receiver that does not understand `membership_registers`
+/// (no `deny_unknown_fields`) silently drops it, deleting the survivor's only register row. The gate
+/// alone therefore does not make a mixed-version fleet safe: enable `COHORT_SEED_RECONCILE_ENABLED`
+/// only once every pod can apply the transfer, and disable it before rolling the image back.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MembershipRegisterTransferMode {
     Disabled,

--- a/rust/cohort-stream-processor/src/merge/drain_handler.rs
+++ b/rust/cohort-stream-processor/src/merge/drain_handler.rs
@@ -10,31 +10,39 @@
 //!   the transfer for the caller to produce.
 //!
 //! The drain emits no `Left` for P_old — it silently reclaims P_old's `cf_behavioral` slice with one
-//! range delete over its person prefix. P_old's `cf_stage2` keys are built from the catalog (no
-//! reads needed; deleting an absent key is a no-op).
+//! range delete over its person prefix. P_old's `cf_stage2` keys are built from the catalog; existing
+//! membership rows ride the cross-partition transfer so a no-op merge or catalog refresh cannot
+//! strand the survivor outside the reconcile scan domain.
+
+use std::collections::BTreeMap;
 
 use metrics::{counter, histogram};
 use uuid::Uuid;
 
 use crate::filters::reverse_index::TeamFilters;
 use crate::filters::{CohortId, TeamId};
-use crate::merge::apply_handler::{apply_leaves, merge_person_records, QueueEffects};
+use crate::merge::apply_handler::{
+    apply_leaves, merge_person_records, missing_transferred_register_writes, QueueEffects,
+};
 use crate::merge::tombstone_redirect::{resolve, Resolution};
 use crate::merge::transfer::{
     DrainStamp, MergeStateTransfer, PendingTransfer, PersonMergeEvent, Tombstone, TransferLeaf,
+    TransferMembershipRegister, TransferMembershipRegisterKind, TransferredRegisterProvenance,
 };
 use crate::observability::metrics::{
     MERGE_DRAINS_SKIPPED_REPLAY_TOTAL, MERGE_DRAIN_LEAVES_SCANNED, MERGE_HANDLED_TOTAL,
-    MERGE_LEAVES_DROPPED_TOTAL,
+    MERGE_LEAVES_DROPPED_TOTAL, STAGE2_STATE_DECODE_ERROR,
 };
 use crate::partitions::partitioner::partition_of;
 use crate::stage1::key::LeafStateKey;
 use crate::stage1::person_record::{PersonDedup, PersonRecord};
 use crate::stage1::state::StatefulRecord;
 use crate::stage1::transition::LeafTransition;
+use crate::stage2::{single_leaf_register_writes, MembershipRegisterSource, Stage2State};
 use crate::store::{
     Behavioral, BehavioralKey, CohortStore, MergeDrainKey, PendingTransferKey, PersonPrefix,
-    PersonRecords, Stage2Key, StoreError, TombstoneKey,
+    PersonRecords, Stage2Key, Stage2TransferredRegisterKey, Stage2TransferredRegisterPersonPrefix,
+    StoreError, TombstoneKey,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -46,13 +54,16 @@ pub enum DrainOutcome {
         effects: QueueEffects,
     },
     /// Cross-partition slow path: state drained into `transfer`, staged in `cf_pending_transfers`.
-    /// A transfer with no leaves and no person-record dedup is not staged; the caller skips the produce
-    /// and commits directly. `effects` cancels P_old's now-deleted keys (no schedules — the state left
-    /// this partition).
+    /// A transfer with no payload is not staged; the caller skips the produce and commits directly.
+    /// `effects` cancels P_old's now-deleted keys (no schedules — the state left this partition).
     Drained {
         transfer: MergeStateTransfer,
         effects: QueueEffects,
     },
+    /// A cross-partition merge owns Stage 2 register rows, but transfer emission is still disabled
+    /// for the receiver-first rollout. Nothing was mutated; the caller must retain the source
+    /// offset and retry after the gate is enabled.
+    AwaitingRegisterTransferEnablement,
     /// Idempotence hit — already drained. The caller re-produces any still-staged pending transfer.
     AlreadyDrained,
     /// Skipped before any state change (validation failure).
@@ -62,6 +73,31 @@ pub enum DrainOutcome {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DrainSkip {
     SamePerson,
+}
+
+/// Whether a cross-partition drain may emit the additive membership-register payload.
+///
+/// Local register writes and receiver application are unconditional. Only the sender is gated so
+/// a mixed-version fleet cannot acknowledge a transfer on an old receiver and delete the sole copy
+/// of its reconcile scan domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MembershipRegisterTransferMode {
+    Disabled,
+    Enabled,
+}
+
+impl MembershipRegisterTransferMode {
+    pub(crate) const fn from_reconcile_enabled(enabled: bool) -> Self {
+        if enabled {
+            Self::Enabled
+        } else {
+            Self::Disabled
+        }
+    }
+
+    const fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
 }
 
 /// Drain the merge `event` on P_old's worker (`partition_id` owns P_old).
@@ -79,6 +115,28 @@ pub fn handle_merge_event(
     event: &PersonMergeEvent,
     msg_coords: (i32, i64),
     partition_count: u32,
+) -> Result<DrainOutcome, StoreError> {
+    handle_merge_event_with_transfer_mode(
+        partition_id,
+        store,
+        filters,
+        event,
+        msg_coords,
+        partition_count,
+        MembershipRegisterTransferMode::Enabled,
+    )
+}
+
+/// Production entry with rollout-safe cross-partition register transfer.
+#[allow(clippy::disallowed_methods)]
+pub(crate) fn handle_merge_event_with_transfer_mode(
+    partition_id: u16,
+    store: &CohortStore,
+    filters: &TeamFilters,
+    event: &PersonMergeEvent,
+    msg_coords: (i32, i64),
+    partition_count: u32,
+    register_transfer_mode: MembershipRegisterTransferMode,
 ) -> Result<DrainOutcome, StoreError> {
     let team_id = event.team_id;
     let team_u64 = team_id as u64;
@@ -146,14 +204,63 @@ pub fn handle_merge_event(
         team_id: team_u64,
         person: old_person,
     };
-    let old_stage2_keys: Vec<Stage2Key> = composable_cohort_ids(filters)
-        .map(|cohort_id| Stage2Key {
+    let transferred_inventory = store.scan_stage2_transferred_registers(
+        Stage2TransferredRegisterPersonPrefix::new(partition_id, team_u64, old_person),
+    )?;
+    let old_transferred_register_keys: Vec<Stage2TransferredRegisterKey> = transferred_inventory
+        .iter()
+        .map(|(key, _value)| *key)
+        .collect();
+    let mut registering_cohorts: BTreeMap<CohortId, DrainRegisterSource> =
+        membership_registering_cohorts(filters)
+            .map(|(cohort_id, kind)| {
+                (
+                    cohort_id,
+                    DrainRegisterSource {
+                        catalog_kind: Some(kind),
+                        provenance: None,
+                    },
+                )
+            })
+            .collect();
+    for (key, value) in &transferred_inventory {
+        let Ok(cohort_id) = i32::try_from(key.stage2_key().cohort_id) else {
+            counter!(MERGE_LEAVES_DROPPED_TOTAL, "reason" => "register_inventory_cohort")
+                .increment(1);
+            continue;
+        };
+        let source =
+            registering_cohorts
+                .entry(CohortId(cohort_id))
+                .or_insert(DrainRegisterSource {
+                    catalog_kind: None,
+                    provenance: None,
+                });
+        match TransferredRegisterProvenance::decode(value) {
+            Some(provenance) => source.provenance = Some(provenance),
+            None => {
+                counter!(MERGE_LEAVES_DROPPED_TOTAL, "reason" => "register_inventory_decode")
+                    .increment(1);
+                // The person-first key still proves that a register exists. Composable is the
+                // conservative kind when neither the inventory value nor the catalog can name it.
+                source
+                    .catalog_kind
+                    .get_or_insert(TransferMembershipRegisterKind::Composable);
+            }
+        }
+    }
+    let registering_cohorts: Vec<_> = registering_cohorts.into_iter().collect();
+    let old_stage2_keys: Vec<Stage2Key> = registering_cohorts
+        .iter()
+        .map(|(cohort_id, _source)| Stage2Key {
             partition_id,
             team_id: team_u64,
             cohort_id: cohort_id.0 as u64,
             person_id: old_person,
         })
         .collect();
+    let old_membership_registers =
+        read_membership_registers(store, &registering_cohorts, &old_stage2_keys)?;
 
     // Same-slice assist: if P_new is itself tombstoned in *this* slice, drain straight to the live
     // survivor, skipping a hop the apply-side resolution would otherwise take. Only the routing/apply
@@ -188,9 +295,15 @@ pub fn handle_merge_event(
             &old_keys,
             &old_prefix,
             &old_stage2_keys,
+            &old_transferred_register_keys,
+            &old_membership_registers,
             &present_leaves,
             person_dedup.as_ref(),
         );
+    }
+
+    if !register_transfer_mode.is_enabled() && !old_membership_registers.is_empty() {
+        return Ok(DrainOutcome::AwaitingRegisterTransferEnablement);
     }
 
     slow_path(
@@ -206,6 +319,8 @@ pub fn handle_merge_event(
         &old_keys,
         &old_prefix,
         &old_stage2_keys,
+        &old_transferred_register_keys,
+        old_membership_registers,
         &present_leaves,
         person_dedup,
     )
@@ -226,6 +341,8 @@ fn fast_path(
     old_keys: &[BehavioralKey],
     old_prefix: &PersonPrefix,
     old_stage2_keys: &[Stage2Key],
+    old_transferred_register_keys: &[Stage2TransferredRegisterKey],
+    old_membership_registers: &[TransferMembershipRegister],
     present_leaves: &[(LeafStateKey, StatefulRecord)],
     person_dedup: Option<&PersonDedup>,
 ) -> Result<DrainOutcome, StoreError> {
@@ -249,17 +366,52 @@ fn fast_path(
         Some(dedup) => merge_person_records(store, &new_prefix, event.old_person_uuid, dedup)?,
         None => None,
     };
-
+    let fallback_register_writes = missing_transferred_register_writes(
+        partition_id,
+        store,
+        filters,
+        event.team_id,
+        effective_new_person,
+        old_membership_registers,
+        event.merged_at_ms,
+    )?;
     store.write_batch(|batch| {
         batch.delete_behavioral_prefix(old_prefix);
         batch.delete::<PersonRecords>(&old_prefix.record_key());
         for key in old_stage2_keys {
             batch.delete_stage2(key);
         }
+        for key in old_transferred_register_keys {
+            batch.delete_stage2_transferred_register(key);
+        }
         batch.put_tombstone(tombstone_key, &tombstone.encode());
         batch.put_merge_drain_applied(drain_key, &drain_stamp.encode());
-        for (key, bytes) in &apply.puts {
-            batch.put::<Behavioral>(key, bytes);
+        for write in &fallback_register_writes {
+            if let Some(state) = &write.state {
+                batch.put_stage2(&write.key, &state.encode_transferred_fallback());
+            }
+            if let Some(provenance) = &write.provenance {
+                batch.put_stage2_transferred_register(
+                    &Stage2TransferredRegisterKey::new(write.key),
+                    &provenance.encode(),
+                );
+            }
+        }
+        for leaf in &apply.puts {
+            batch.put::<Behavioral>(&leaf.key, &leaf.bytes);
+            for write in single_leaf_register_writes(
+                filters,
+                MembershipRegisterSource {
+                    partition_id,
+                    team_id: TeamId(event.team_id),
+                    person_id: effective_new_person,
+                    leaf_state_key: leaf.key.lsk(),
+                },
+                leaf.in_cohort,
+                event.merged_at_ms,
+            ) {
+                batch.put_stage2(&write.key, &write.state.encode());
+            }
         }
         if let Some(bytes) = &record_put {
             batch.put::<PersonRecords>(&new_prefix.record_key(), bytes);
@@ -290,6 +442,8 @@ fn slow_path(
     old_keys: &[BehavioralKey],
     old_prefix: &PersonPrefix,
     old_stage2_keys: &[Stage2Key],
+    old_transferred_register_keys: &[Stage2TransferredRegisterKey],
+    old_membership_registers: Vec<TransferMembershipRegister>,
     present_leaves: &[(LeafStateKey, StatefulRecord)],
     person_dedup: Option<PersonDedup>,
 ) -> Result<DrainOutcome, StoreError> {
@@ -307,14 +461,13 @@ fn slow_path(
             .iter()
             .map(|(lsk, record)| TransferLeaf::new(*lsk, record.clone()))
             .collect(),
+        membership_registers: old_membership_registers,
         forward_hops: 0,
         person_dedup,
     };
-    // Stage iff the transfer carries leaves or a person-record dedup; a record-only person would
-    // otherwise lose its straggler-dedup ancestry. A truly empty transfer is never staged — a duplicate
+    // Stage iff the transfer carries state. A truly empty transfer is never staged — a duplicate
     // merge event at fresh coordinates could overwrite a still-pending, never-produced transfer.
-    let has_payload = !transfer.leaves.is_empty() || transfer.person_dedup.is_some();
-    let pending = has_payload.then(|| PendingTransfer {
+    let pending = transfer.has_payload().then(|| PendingTransfer {
         transfer: transfer.clone(),
         merge_msg_partition: msg_coords.0,
         merge_msg_offset: msg_coords.1,
@@ -335,6 +488,9 @@ fn slow_path(
         for key in old_stage2_keys {
             batch.delete_stage2(key);
         }
+        for key in old_transferred_register_keys {
+            batch.delete_stage2_transferred_register(key);
+        }
         batch.put_tombstone(tombstone_key, &tombstone.encode());
     })?;
 
@@ -347,23 +503,79 @@ fn slow_path(
     })
 }
 
-/// The team's cohort ids that write `cf_stage2` rows (both composable classes). See
-/// [`writes_cf_stage2`](crate::stage2::CohortEligibility::writes_cf_stage2).
-fn composable_cohort_ids(filters: &TeamFilters) -> impl Iterator<Item = CohortId> + '_ {
-    filters
-        .eligibility
+/// The team's cohorts that persist membership in `cf_stage2`, coupled to the source semantics a
+/// receiver needs when its own catalog is missing or stale.
+fn membership_registering_cohorts(
+    filters: &TeamFilters,
+) -> impl Iterator<Item = (CohortId, TransferMembershipRegisterKind)> + '_ {
+    filters.eligibility.keys().filter_map(|&cohort_id| {
+        TransferMembershipRegisterKind::from_filters(filters, cohort_id)
+            .map(|kind| (cohort_id, kind))
+    })
+}
+
+#[derive(Debug, Clone)]
+struct DrainRegisterSource {
+    catalog_kind: Option<TransferMembershipRegisterKind>,
+    provenance: Option<TransferredRegisterProvenance>,
+}
+
+#[allow(clippy::disallowed_methods)]
+fn read_membership_registers(
+    store: &CohortStore,
+    cohorts: &[(CohortId, DrainRegisterSource)],
+    keys: &[Stage2Key],
+) -> Result<Vec<TransferMembershipRegister>, StoreError> {
+    debug_assert_eq!(cohorts.len(), keys.len());
+    Ok(cohorts
         .iter()
-        .filter_map(|(&cohort_id, eligibility)| eligibility.writes_cf_stage2().then_some(cohort_id))
+        .zip(store.multi_get_stage2(keys)?)
+        .filter_map(|((cohort_id, source), bytes)| {
+            let bytes = bytes?;
+            let active_provenance = source
+                .provenance
+                .as_ref()
+                .filter(|provenance| provenance.matches_primary(&bytes));
+            let kind = active_provenance
+                .map(|provenance| provenance.kind)
+                .or(source.catalog_kind)
+                .or_else(|| source.provenance.as_ref().map(|provenance| provenance.kind))
+                .unwrap_or(TransferMembershipRegisterKind::Composable);
+            let materialized_bit = match Stage2State::decode(&bytes) {
+                Ok(state) => Some(state.in_cohort),
+                Err(_) => {
+                    counter!(STAGE2_STATE_DECODE_ERROR).increment(1);
+                    None
+                }
+            };
+            Some(TransferMembershipRegister {
+                cohort_id: cohort_id.0,
+                // An exact fingerprint means the receiver has not evaluated this register since
+                // transfer, so retain the source bit. Otherwise the current primary row wins.
+                in_cohort: active_provenance
+                    .map(|provenance| provenance.in_cohort)
+                    .or(materialized_bit)
+                    .unwrap_or(false),
+                kind,
+            })
+        })
+        .collect())
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use chrono_tz::UTC;
     use serde_json::{json, Value};
+    use tempfile::TempDir;
 
     use crate::filters::TeamFiltersBuilder;
+    use crate::merge::apply_handler::{handle_transfer, ApplyOutcome};
+    use crate::partitions::partitioner::COHORT_PARTITION_COUNT;
+    use crate::stage2::state::Stage2Ownership;
     use crate::stage2::CohortEligibility;
+    use crate::store::StoreConfig;
 
     fn behavioral(time_value: i64) -> Value {
         json!({
@@ -391,9 +603,9 @@ mod tests {
     }
 
     #[test]
-    fn composable_cohort_ids_enumerates_both_composable_classes_for_row_deletion() {
+    fn membership_registering_cohorts_enumerates_single_leaf_and_composable_classes() {
         let mut builder = TeamFiltersBuilder::default();
-        // 2: single-leaf referent — does NOT write cf_stage2.
+        // 2: single-leaf referent — writes its direct membership register.
         builder
             .add_cohort(CohortId(2), TeamId(7), &cohort(vec![behavioral(7)]))
             .unwrap();
@@ -419,17 +631,19 @@ mod tests {
             filters.eligibility[&CohortId(1)],
             CohortEligibility::Stage2ComposableRef,
         );
-        let mut ids: Vec<i32> = composable_cohort_ids(&filters).map(|c| c.0).collect();
+        let mut ids: Vec<i32> = membership_registering_cohorts(&filters)
+            .map(|(cohort_id, _kind)| cohort_id.0)
+            .collect();
         ids.sort_unstable();
         assert_eq!(
             ids,
-            vec![1, 3],
-            "a Stage2ComposableRef writer is enumerated alongside Stage2Composable; the SingleLeaf referent is not",
+            vec![1, 2, 3],
+            "all membership-registering classes are reclaimed for the merged-away person",
         );
     }
 
     #[test]
-    fn composable_cohort_ids_gate_off_drops_the_still_excluded_ref_cohort() {
+    fn membership_registering_cohorts_excludes_a_ref_cohort_when_the_gate_is_off() {
         let mut builder = TeamFiltersBuilder::default();
         builder
             .add_cohort(CohortId(2), TeamId(7), &cohort(vec![behavioral(7)]))
@@ -443,10 +657,535 @@ mod tests {
             .unwrap();
         let filters = builder.freeze_with(UTC, false);
 
-        let ids: Vec<i32> = composable_cohort_ids(&filters).map(|c| c.0).collect();
-        assert!(
-            ids.is_empty(),
-            "gate off keeps the ref cohort Excluded(HasCohortRef), which writes no cf_stage2 row",
+        let ids: Vec<i32> = membership_registering_cohorts(&filters)
+            .map(|(cohort_id, _kind)| cohort_id.0)
+            .collect();
+        assert_eq!(
+            ids,
+            vec![2],
+            "gate off excludes the ref cohort but retains its single-leaf referent's register",
         );
+    }
+
+    #[test]
+    fn disabled_register_transfer_retains_the_cross_partition_merge_for_retry() {
+        let mut builder = TeamFiltersBuilder::default();
+        builder
+            .add_cohort(CohortId(1), TeamId(7), &cohort(vec![behavioral(7)]))
+            .unwrap();
+        let filters = builder.freeze(UTC);
+        let old_person = Uuid::from_u128(1);
+        let old_partition = partition_of(TeamId(7), &old_person, COHORT_PARTITION_COUNT) as u16;
+        let new_person = (2u128..)
+            .map(Uuid::from_u128)
+            .find(|person| {
+                partition_of(TeamId(7), person, COHORT_PARTITION_COUNT) as u16 != old_partition
+            })
+            .unwrap();
+        let register_key = Stage2Key {
+            partition_id: old_partition,
+            team_id: 7,
+            cohort_id: 1,
+            person_id: old_person,
+        };
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(
+                    &register_key,
+                    &Stage2State {
+                        in_cohort: true,
+                        last_evaluated_at_ms: 1,
+                    }
+                    .encode(),
+                )
+            })
+            .unwrap();
+
+        let outcome = handle_merge_event_with_transfer_mode(
+            old_partition,
+            &store,
+            &filters,
+            &PersonMergeEvent {
+                team_id: 7,
+                old_person_uuid: old_person,
+                new_person_uuid: new_person,
+                merged_at_ms: 2,
+                schema_version: crate::merge::transfer::MERGE_EVENT_SCHEMA_VERSION,
+            },
+            (3, 4),
+            COHORT_PARTITION_COUNT,
+            MembershipRegisterTransferMode::Disabled,
+        )
+        .unwrap();
+
+        assert_eq!(outcome, DrainOutcome::AwaitingRegisterTransferEnablement);
+        assert!(
+            store.get_stage2(&register_key).unwrap().is_some(),
+            "the source register remains until a compatible receiver can accept it",
+        );
+    }
+
+    #[test]
+    fn catalogless_existing_row_seeds_provenance_from_the_survivor_bit() {
+        let person = Uuid::from_u128(1);
+        let partition = partition_of(TeamId(7), &person, COHORT_PARTITION_COUNT) as u16;
+        let key = Stage2Key {
+            partition_id: partition,
+            team_id: 7,
+            cohort_id: 1,
+            person_id: person,
+        };
+        let inventory = Stage2TransferredRegisterKey::new(key);
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(
+                    &key,
+                    &Stage2State {
+                        in_cohort: true,
+                        last_evaluated_at_ms: 1,
+                    }
+                    .encode(),
+                );
+            })
+            .unwrap();
+
+        handle_transfer(
+            partition,
+            &store,
+            &TeamFilters::default(),
+            &MergeStateTransfer {
+                team_id: 7,
+                old_person_uuid: Uuid::from_u128(99),
+                new_person_uuid: person,
+                merged_at_ms: 2,
+                source_partition: 3,
+                source_offset: 4,
+                leaves: Vec::new(),
+                membership_registers: vec![TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: false,
+                    kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                }],
+                forward_hops: 0,
+                person_dedup: None,
+            },
+            (partition.into(), 5),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap();
+
+        assert!(
+            Stage2State::decode(&store.get_stage2(&key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort
+        );
+        assert_eq!(
+            TransferredRegisterProvenance::decode(
+                &store
+                    .get_stage2_transferred_register(&inventory)
+                    .unwrap()
+                    .unwrap(),
+            ),
+            Some(TransferredRegisterProvenance::new(
+                TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                },
+                &Stage2State {
+                    in_cohort: true,
+                    last_evaluated_at_ms: 1,
+                }
+                .encode_transferred_fallback(),
+            )),
+        );
+    }
+
+    #[test]
+    fn catalogless_corrupt_existing_row_is_repaired_as_an_owned_fallback() {
+        let person = Uuid::from_u128(1);
+        let partition = partition_of(TeamId(7), &person, COHORT_PARTITION_COUNT) as u16;
+        let key = Stage2Key {
+            partition_id: partition,
+            team_id: 7,
+            cohort_id: 1,
+            person_id: person,
+        };
+        let inventory = Stage2TransferredRegisterKey::new(key);
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        store
+            .write_batch(|batch| batch.put_stage2(&key, b"corrupt"))
+            .unwrap();
+
+        let source_register = TransferMembershipRegister {
+            cohort_id: 1,
+            in_cohort: true,
+            kind: TransferMembershipRegisterKind::Composable,
+        };
+        handle_transfer(
+            partition,
+            &store,
+            &TeamFilters::default(),
+            &MergeStateTransfer {
+                team_id: 7,
+                old_person_uuid: Uuid::from_u128(99),
+                new_person_uuid: person,
+                merged_at_ms: 2,
+                source_partition: 3,
+                source_offset: 4,
+                leaves: Vec::new(),
+                membership_registers: vec![source_register],
+                forward_hops: 0,
+                person_dedup: None,
+            },
+            (partition.into(), 5),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap();
+
+        let primary = store.get_stage2(&key).unwrap().unwrap();
+        assert_eq!(
+            Stage2State::decode_with_ownership(&primary).unwrap(),
+            (
+                Stage2State {
+                    in_cohort: false,
+                    last_evaluated_at_ms: 2,
+                },
+                Stage2Ownership::TransferredFallback,
+            ),
+        );
+        let provenance = TransferredRegisterProvenance::decode(
+            &store
+                .get_stage2_transferred_register(&inventory)
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(provenance.kind, source_register.kind);
+        assert_eq!(provenance.in_cohort, source_register.in_cohort);
+        assert!(provenance.matches_primary(&primary));
+    }
+
+    #[test]
+    fn local_noop_stage2_update_supersedes_transfer_provenance_before_gc() {
+        let old_person = Uuid::from_u128(1);
+        let old_partition = partition_of(TeamId(7), &old_person, COHORT_PARTITION_COUNT) as u16;
+        let new_person = (2u128..)
+            .map(Uuid::from_u128)
+            .find(|person| {
+                partition_of(TeamId(7), person, COHORT_PARTITION_COUNT) as u16 != old_partition
+            })
+            .unwrap();
+        let register_key = Stage2Key {
+            partition_id: old_partition,
+            team_id: 7,
+            cohort_id: 1,
+            person_id: old_person,
+        };
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let mut current_filters = TeamFilters::default();
+        current_filters
+            .eligibility
+            .insert(CohortId(1), CohortEligibility::Stage2Composable);
+
+        handle_transfer(
+            old_partition,
+            &store,
+            &current_filters,
+            &MergeStateTransfer {
+                team_id: 7,
+                old_person_uuid: Uuid::from_u128(99),
+                new_person_uuid: old_person,
+                merged_at_ms: 1,
+                source_partition: 3,
+                source_offset: 4,
+                leaves: Vec::new(),
+                membership_registers: vec![TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                }],
+                forward_hops: 0,
+                person_dedup: None,
+            },
+            (old_partition.into(), 5),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap();
+
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(
+                    &register_key,
+                    &Stage2State {
+                        in_cohort: false,
+                        last_evaluated_at_ms: 1,
+                    }
+                    .encode(),
+                );
+            })
+            .unwrap();
+
+        let outcome = handle_merge_event_with_transfer_mode(
+            old_partition,
+            &store,
+            &current_filters,
+            &PersonMergeEvent {
+                team_id: 7,
+                old_person_uuid: old_person,
+                new_person_uuid: new_person,
+                merged_at_ms: 3,
+                schema_version: crate::merge::transfer::MERGE_EVENT_SCHEMA_VERSION,
+            },
+            (old_partition.into(), 6),
+            COHORT_PARTITION_COUNT,
+            MembershipRegisterTransferMode::Enabled,
+        )
+        .unwrap();
+
+        let DrainOutcome::Drained { transfer, .. } = outcome else {
+            panic!("the ownership-settled register should drain");
+        };
+        assert_eq!(
+            transfer.membership_registers,
+            vec![TransferMembershipRegister {
+                cohort_id: 1,
+                in_cohort: false,
+                kind: TransferMembershipRegisterKind::Composable,
+            }],
+            "removing only fallback ownership makes the current primary and catalog authoritative",
+        );
+    }
+
+    #[test]
+    fn catalogless_register_survives_disabled_sender_and_a_second_transfer_hop() {
+        let middle_person = Uuid::from_u128(1);
+        let middle_partition =
+            partition_of(TeamId(7), &middle_person, COHORT_PARTITION_COUNT) as u16;
+        let final_person = (2u128..)
+            .map(Uuid::from_u128)
+            .find(|person| {
+                partition_of(TeamId(7), person, COHORT_PARTITION_COUNT) as u16 != middle_partition
+            })
+            .unwrap();
+        let register_key = Stage2Key {
+            partition_id: middle_partition,
+            team_id: 7,
+            cohort_id: 1,
+            person_id: middle_person,
+        };
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+
+        let mut stale_receiver_filters = TeamFilters::default();
+        stale_receiver_filters.eligibility.insert(
+            CohortId(1),
+            crate::stage2::CohortEligibility::Excluded(crate::stage2::ExcludedReason::NotMultiLeaf),
+        );
+        let applied = handle_transfer(
+            middle_partition,
+            &store,
+            &stale_receiver_filters,
+            &MergeStateTransfer {
+                team_id: 7,
+                old_person_uuid: Uuid::from_u128(99),
+                new_person_uuid: middle_person,
+                merged_at_ms: 1,
+                source_partition: 3,
+                source_offset: 4,
+                leaves: Vec::new(),
+                membership_registers: vec![TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                }],
+                forward_hops: 0,
+                person_dedup: None,
+            },
+            (middle_partition.into(), 5),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap();
+        assert!(matches!(applied, ApplyOutcome::Applied { .. }));
+        assert!(
+            Stage2State::decode(&store.get_stage2(&register_key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort,
+            "the wire register survives a stale receiver catalog that excludes the cohort",
+        );
+        let register_inventory = Stage2TransferredRegisterKey::new(register_key);
+        assert_eq!(
+            TransferredRegisterProvenance::decode(
+                &store
+                    .get_stage2_transferred_register(&register_inventory)
+                    .unwrap()
+                    .unwrap(),
+            ),
+            Some(TransferredRegisterProvenance::new(
+                TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                },
+                &Stage2State {
+                    in_cohort: true,
+                    last_evaluated_at_ms: 1,
+                }
+                .encode_transferred_fallback(),
+            )),
+        );
+
+        // A second catalogless source collides with the survivor. Both the primary bit and the
+        // existing survivor provenance are fill-only; the incoming composable sentinel cannot
+        // rewrite either one.
+        handle_transfer(
+            middle_partition,
+            &store,
+            &TeamFilters::default(),
+            &MergeStateTransfer {
+                team_id: 7,
+                old_person_uuid: Uuid::from_u128(98),
+                new_person_uuid: middle_person,
+                merged_at_ms: 1,
+                source_partition: 30,
+                source_offset: 40,
+                leaves: Vec::new(),
+                membership_registers: vec![TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::Composable,
+                }],
+                forward_hops: 0,
+                person_dedup: None,
+            },
+            (middle_partition.into(), 41),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap();
+        assert!(
+            Stage2State::decode(&store.get_stage2(&register_key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort,
+        );
+        assert_eq!(
+            TransferredRegisterProvenance::decode(
+                &store
+                    .get_stage2_transferred_register(&register_inventory)
+                    .unwrap()
+                    .unwrap(),
+            ),
+            Some(TransferredRegisterProvenance::new(
+                TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                },
+                &Stage2State {
+                    in_cohort: true,
+                    last_evaluated_at_ms: 1,
+                }
+                .encode_transferred_fallback(),
+            )),
+        );
+
+        let empty_filters = TeamFilters::default();
+        let second_event = PersonMergeEvent {
+            team_id: 7,
+            old_person_uuid: middle_person,
+            new_person_uuid: final_person,
+            merged_at_ms: 2,
+            schema_version: crate::merge::transfer::MERGE_EVENT_SCHEMA_VERSION,
+        };
+        let second = handle_merge_event_with_transfer_mode(
+            middle_partition,
+            &store,
+            &empty_filters,
+            &second_event,
+            (middle_partition.into(), 6),
+            COHORT_PARTITION_COUNT,
+            MembershipRegisterTransferMode::Disabled,
+        )
+        .unwrap();
+
+        assert_eq!(second, DrainOutcome::AwaitingRegisterTransferEnablement);
+        assert!(
+            store.get_stage2(&register_key).unwrap().is_some(),
+            "a disabled second sender retains the register that its receiver understood",
+        );
+
+        let drained = handle_merge_event_with_transfer_mode(
+            middle_partition,
+            &store,
+            &empty_filters,
+            &second_event,
+            (middle_partition.into(), 6),
+            COHORT_PARTITION_COUNT,
+            MembershipRegisterTransferMode::Enabled,
+        )
+        .unwrap();
+        let DrainOutcome::Drained { transfer, .. } = drained else {
+            panic!("the enabled second hop should drain the catalogless register");
+        };
+        assert_eq!(
+            transfer.membership_registers,
+            vec![TransferMembershipRegister {
+                cohort_id: 1,
+                in_cohort: true,
+                kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+            }],
+        );
+        assert!(store.get_stage2(&register_key).unwrap().is_none());
+
+        let final_partition = partition_of(TeamId(7), &final_person, COHORT_PARTITION_COUNT) as u16;
+        let applied = handle_transfer(
+            final_partition,
+            &store,
+            &empty_filters,
+            &transfer,
+            (final_partition.into(), 7),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap();
+        assert!(matches!(applied, ApplyOutcome::Applied { .. }));
+        let final_key = Stage2Key {
+            partition_id: final_partition,
+            person_id: final_person,
+            ..register_key
+        };
+        assert!(
+            Stage2State::decode(&store.get_stage2(&final_key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort,
+        );
+        assert!(store
+            .get_stage2_transferred_register(&Stage2TransferredRegisterKey::new(final_key))
+            .unwrap()
+            .is_some());
     }
 }

--- a/rust/cohort-stream-processor/src/merge/transfer.rs
+++ b/rust/cohort-stream-processor/src/merge/transfer.rs
@@ -9,9 +9,11 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::filters::reverse_index::TeamFilters;
+use crate::filters::CohortId;
 use crate::stage1::key::LeafStateKey;
 use crate::stage1::person_record::PersonDedup;
-use crate::stage1::state::StatefulRecord;
+use crate::stage1::state::{StateVariant, StatefulRecord};
 
 pub const MERGE_EVENT_SCHEMA_VERSION: u32 = 1;
 
@@ -31,6 +33,124 @@ pub struct TransferLeaf {
     /// 16-byte `LeafStateKey` as 32 lowercase hex chars (human-readable on the wire).
     pub leaf_state_key: String,
     pub record: StatefulRecord,
+}
+
+/// One persisted membership register carried alongside P_old's leaf state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferMembershipRegister {
+    pub cohort_id: i32,
+    pub in_cohort: bool,
+    /// Enough source semantics for a receiver to materialize the scan register without consulting
+    /// a potentially older or not-yet-loaded filter catalog.
+    #[serde(default)]
+    pub kind: TransferMembershipRegisterKind,
+}
+
+/// Source semantics for a transferred membership register.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferMembershipRegisterKind {
+    SingleLeafBehavioral,
+    SingleLeafPersonProperty,
+    #[default]
+    Composable,
+}
+
+/// Persisted source provenance for a merge-carried register. The local Stage 2 row may use a
+/// conservative bit from the receiver's current catalog shape; this value keeps the original wire
+/// bit and kind available for another catalogless hop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransferredRegisterProvenance {
+    pub kind: TransferMembershipRegisterKind,
+    pub in_cohort: bool,
+    expected_primary: Vec<u8>,
+}
+
+impl TransferredRegisterProvenance {
+    pub fn new(register: TransferMembershipRegister, expected_primary: &[u8]) -> Self {
+        Self {
+            kind: register.kind,
+            in_cohort: register.in_cohort,
+            expected_primary: expected_primary.to_vec(),
+        }
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(2 + self.expected_primary.len());
+        encoded.push(self.kind.encode()[0]);
+        encoded.push(self.in_cohort as u8);
+        encoded.extend_from_slice(&self.expected_primary);
+        encoded
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        let [kind, in_cohort, expected_primary @ ..] = bytes else {
+            return None;
+        };
+        Some(Self {
+            kind: TransferMembershipRegisterKind::decode(&[*kind])?,
+            in_cohort: match *in_cohort {
+                0 => false,
+                1 => true,
+                _ => return None,
+            },
+            expected_primary: expected_primary.to_vec(),
+        })
+    }
+
+    pub fn matches_primary(&self, primary: &[u8]) -> bool {
+        self.expected_primary == primary
+    }
+}
+
+impl TransferMembershipRegisterKind {
+    /// The safe initial value for a missing survivor register. Behavioral single-leaf state carries
+    /// its exact bit; person-property and composable state must be recomputed for the survivor.
+    pub const fn materialized_bit(self, transferred_bit: bool) -> bool {
+        match self {
+            Self::SingleLeafBehavioral => transferred_bit,
+            Self::SingleLeafPersonProperty | Self::Composable => false,
+        }
+    }
+
+    /// Compact persisted form used by the catalog-independent Stage 2 transfer inventory.
+    pub const fn encode(self) -> [u8; 1] {
+        [match self {
+            Self::SingleLeafBehavioral => 1,
+            Self::SingleLeafPersonProperty => 2,
+            Self::Composable => 3,
+        }]
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        match bytes {
+            [1] => Some(Self::SingleLeafBehavioral),
+            [2] => Some(Self::SingleLeafPersonProperty),
+            [3] => Some(Self::Composable),
+            _ => None,
+        }
+    }
+
+    /// Derive the register semantics from one catalog snapshot. `None` means the cohort does not
+    /// currently register membership.
+    pub(crate) fn from_filters(filters: &TeamFilters, cohort_id: CohortId) -> Option<Self> {
+        match filters.eligibility.get(&cohort_id)? {
+            crate::stage2::CohortEligibility::SingleLeaf(lsk) => {
+                Some(match filters.by_lsk.get(lsk).map(|meta| meta.variant) {
+                    Some(StateVariant::PersonProperty) => Self::SingleLeafPersonProperty,
+                    Some(
+                        StateVariant::BehavioralSingle
+                        | StateVariant::BehavioralDailyBuckets
+                        | StateVariant::BehavioralCompressedHistory,
+                    ) => Self::SingleLeafBehavioral,
+                    None => Self::Composable,
+                })
+            }
+            crate::stage2::CohortEligibility::Stage2Composable
+            | crate::stage2::CohortEligibility::Stage2ComposableRef => Some(Self::Composable),
+            crate::stage2::CohortEligibility::Excluded(_) => None,
+        }
+    }
 }
 
 impl TransferLeaf {
@@ -59,6 +179,12 @@ pub struct MergeStateTransfer {
     pub source_partition: i32,
     pub source_offset: i64,
     pub leaves: Vec<TransferLeaf>,
+    /// P_old's materialized behavioral membership rows. Carrying these preserves the reconcile scan
+    /// domain when no leaf transition recreates a composable row, and across catalog refreshes
+    /// between drain and apply. An apply uses them only to fill a missing survivor register;
+    /// post-merge evaluation remains authoritative.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub membership_registers: Vec<TransferMembershipRegister>,
     /// Cross-partition forward hops taken so far when `new_person_uuid` was itself tombstoned at
     /// apply time (chained merge `A → B → C` where `B → C` drained before `A → B` applied). Bounded
     /// by [`crate::merge::apply_handler::MAX_TRANSFER_FORWARD_HOPS`]. `#[serde(default)]`: a message
@@ -72,6 +198,15 @@ pub struct MergeStateTransfer {
     /// field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub person_dedup: Option<PersonDedup>,
+}
+
+impl MergeStateTransfer {
+    /// Whether applying this transfer can change survivor state.
+    pub fn has_payload(&self) -> bool {
+        !self.leaves.is_empty()
+            || !self.membership_registers.is_empty()
+            || self.person_dedup.is_some()
+    }
 }
 
 /// Staged transfer in `cf_pending_transfers`. Survives a crash between the drain batch and the
@@ -204,6 +339,61 @@ mod tests {
     }
 
     #[test]
+    fn membership_register_kind_inventory_codec_is_closed() {
+        for kind in [
+            TransferMembershipRegisterKind::SingleLeafBehavioral,
+            TransferMembershipRegisterKind::SingleLeafPersonProperty,
+            TransferMembershipRegisterKind::Composable,
+        ] {
+            assert_eq!(
+                TransferMembershipRegisterKind::decode(&kind.encode()),
+                Some(kind)
+            );
+        }
+        assert_eq!(TransferMembershipRegisterKind::decode(&[]), None);
+        assert_eq!(TransferMembershipRegisterKind::decode(&[0]), None);
+        assert_eq!(TransferMembershipRegisterKind::decode(&[1, 2]), None);
+    }
+
+    #[test]
+    fn transferred_register_provenance_codec_preserves_kind_and_bit() {
+        for provenance in [
+            TransferredRegisterProvenance::new(
+                TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                },
+                b"primary-a",
+            ),
+            TransferredRegisterProvenance::new(
+                TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: false,
+                    kind: TransferMembershipRegisterKind::SingleLeafPersonProperty,
+                },
+                b"primary-b",
+            ),
+            TransferredRegisterProvenance::new(
+                TransferMembershipRegister {
+                    cohort_id: 1,
+                    in_cohort: true,
+                    kind: TransferMembershipRegisterKind::Composable,
+                },
+                b"primary-c",
+            ),
+        ] {
+            assert_eq!(
+                TransferredRegisterProvenance::decode(&provenance.encode()),
+                Some(provenance.clone()),
+            );
+            assert!(provenance.matches_primary(&provenance.expected_primary));
+        }
+        assert_eq!(TransferredRegisterProvenance::decode(&[1]), None);
+        assert_eq!(TransferredRegisterProvenance::decode(&[1, 2]), None);
+    }
+
+    #[test]
     fn person_merge_event_shape_is_pinned() {
         let event = PersonMergeEvent {
             team_id: 42,
@@ -244,17 +434,52 @@ mod tests {
             source_partition: 17,
             source_offset: 12_345,
             leaves: vec![TransferLeaf::new(LeafStateKey([0xAB; 16]), single_record())],
+            membership_registers: vec![TransferMembershipRegister {
+                cohort_id: 9,
+                in_cohort: false,
+                kind: TransferMembershipRegisterKind::Composable,
+            }],
             forward_hops: 0,
 
             person_dedup: None,
         };
         let decoded = MergeStateTransfer::decode(&transfer.encode()).unwrap();
         assert_eq!(decoded, transfer);
+        let wire: serde_json::Value = serde_json::from_slice(&transfer.encode()).unwrap();
+        assert_eq!(
+            wire["membership_registers"][0]["kind"],
+            serde_json::json!("composable"),
+            "the self-describing register kind is pinned on the wire",
+        );
         assert_eq!(
             decoded.leaves[0].record,
             single_record(),
             "the leaf's StatefulRecord transfers whole, so redirect_dedup chains for free",
         );
+        assert_eq!(decoded.membership_registers, transfer.membership_registers);
+        assert!(decoded.has_payload());
+    }
+
+    #[test]
+    fn register_only_transfer_is_not_empty() {
+        let transfer = MergeStateTransfer {
+            team_id: 7,
+            old_person_uuid: uuid(0xAAAA),
+            new_person_uuid: uuid(0xBBBB),
+            merged_at_ms: 1,
+            source_partition: 3,
+            source_offset: 4,
+            leaves: vec![],
+            membership_registers: vec![TransferMembershipRegister {
+                cohort_id: 9,
+                in_cohort: false,
+                kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+            }],
+            forward_hops: 0,
+            person_dedup: None,
+        };
+
+        assert!(transfer.has_payload());
     }
 
     #[test]
@@ -276,6 +501,7 @@ mod tests {
             source_partition: 17,
             source_offset: 12_345,
             leaves: vec![],
+            membership_registers: vec![],
             forward_hops: 0,
             person_dedup: Some(PersonDedup {
                 applied_offsets: AppliedOffsets::from_sorted_entries(vec![(1, 100), (2, 200)]),
@@ -306,6 +532,21 @@ mod tests {
             decoded.forward_hops, 0,
             "missing forward_hops defaults to 0"
         );
+        assert!(
+            decoded.membership_registers.is_empty(),
+            "older transfers default to no carried register rows",
+        );
+    }
+
+    #[test]
+    fn register_without_kind_defaults_to_safe_composable_semantics() {
+        let register: TransferMembershipRegister = serde_json::from_value(serde_json::json!({
+            "cohort_id": 9,
+            "in_cohort": true,
+        }))
+        .unwrap();
+        assert_eq!(register.kind, TransferMembershipRegisterKind::Composable);
+        assert!(!register.kind.materialized_bit(register.in_cohort));
     }
 
     #[test]
@@ -318,6 +559,7 @@ mod tests {
             source_partition: 3,
             source_offset: 4,
             leaves: vec![],
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,

--- a/rust/cohort-stream-processor/src/merge/transfer.rs
+++ b/rust/cohort-stream-processor/src/merge/transfer.rs
@@ -539,6 +539,36 @@ mod tests {
     }
 
     #[test]
+    fn transfer_tolerates_unknown_fields_so_a_new_sender_cannot_poison_an_old_receiver() {
+        // A sender may add fields to the transfer wire; a receiver that does not know them must
+        // ignore them, not reject the whole message. This pins the absence of
+        // `#[serde(deny_unknown_fields)]` on MergeStateTransfer — adding it would silently drop every
+        // cross-partition merge whose transfer carries an unknown field.
+        let json = serde_json::json!({
+            "team_id": 7,
+            "old_person_uuid": uuid(0xAAAA).to_string(),
+            "new_person_uuid": uuid(0xBBBB).to_string(),
+            "merged_at_ms": 1_716_800_000_000_i64,
+            "source_partition": 17,
+            "source_offset": 12_345,
+            "leaves": [],
+            "membership_registers": [{ "cohort_id": 9, "in_cohort": false, "kind": "composable" }],
+            "some_future_field": { "added": "by a newer sender" },
+        });
+        let decoded = MergeStateTransfer::decode(&serde_json::to_vec(&json).unwrap())
+            .expect("an unknown extra field must not fail the decode");
+        assert_eq!(
+            decoded.membership_registers,
+            vec![TransferMembershipRegister {
+                cohort_id: 9,
+                in_cohort: false,
+                kind: TransferMembershipRegisterKind::Composable,
+            }],
+            "the known additive field still round-trips alongside the ignored unknown one",
+        );
+    }
+
+    #[test]
     fn register_without_kind_defaults_to_safe_composable_semantics() {
         let register: TransferMembershipRegister = serde_json::from_value(serde_json::json!({
             "cohort_id": 9,

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -5,8 +5,8 @@ use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 // The `cohort-core`-owned metric names this binary emits: its metric-surface manifest.
 pub use cohort_core::metrics::{
     COHORT_ELIGIBILITY_TOTAL, COHORT_IN_CYCLE_TOTAL, FILTER_CATALOG_COHORT_PARSE_ERRORS,
-    FILTER_CATALOG_SKIPPED_LEAVES, FILTER_CATALOG_TZ_FALLBACK, STAGE1_GLOBALS_PARSE_ERROR,
-    STAGE1_HOGVM_ERROR, STAGE1_HOGVM_UNKNOWN_FUNCTION,
+    FILTER_CATALOG_INVALID_SHAPE_HASH, FILTER_CATALOG_SKIPPED_LEAVES, FILTER_CATALOG_TZ_FALLBACK,
+    STAGE1_GLOBALS_PARSE_ERROR, STAGE1_HOGVM_ERROR, STAGE1_HOGVM_UNKNOWN_FUNCTION,
 };
 
 /// Teams with ≥1 realtime cohort in the current catalog snapshot (gauge).
@@ -390,6 +390,14 @@ pub const MERGE_TRANSFER_PRODUCE_FAILURE_TOTAL: &str = "merge_transfer_produce_f
 pub const MERGE_OUTBOX_CLEAR_FAILURE_TOTAL: &str = "merge_outbox_clear_failure_total";
 /// Cross-partition drains whose packaged transfer carried no leaves (counter).
 pub const MERGE_TRANSFERS_SKIPPED_EMPTY_TOTAL: &str = "merge_transfers_skipped_empty_total";
+/// Cross-partition merges retained (sticky-held, no mutation) because the membership-register
+/// transfer is still disabled — i.e. `COHORT_SEED_RECONCILE_ENABLED` is off while a merged person
+/// owns register rows (counter). Each retry of the held offset re-counts, so this is a stall *rate*.
+/// A sustained non-zero level means merge consumption is wedged on that partition: reconcile must be
+/// enabled before the merge producer (`PERSON_MERGE_EVENTS_ENABLED`). **Alert on a sustained
+/// non-zero level.**
+pub const MERGE_TRANSFERS_HELD_AWAITING_ENABLEMENT_TOTAL: &str =
+    "merge_transfers_held_awaiting_enablement_total";
 /// Entries currently staged in a partition's `cf_pending_transfers` outbox, labelled by `partition`
 /// (gauge). A sustained non-zero level means the transfer topic keeps refusing produces.
 pub const MERGE_PENDING_TRANSFERS_GAUGE: &str = "merge_pending_transfers";
@@ -475,9 +483,11 @@ pub const RECONCILE_JOBS_COMPLETED_TOTAL: &str = "cohort_reconcile_jobs_complete
 pub const RECONCILE_JOBS_SUPERSEDED_TOTAL: &str = "cohort_reconcile_jobs_superseded_total";
 /// Reconcile jobs invalidated by a drain-time guard, labelled by bounded `reason` (counter).
 pub const RECONCILE_JOBS_DISCARDED_TOTAL: &str = "cohort_reconcile_jobs_discarded_total";
-/// Stage 2 rows read by reconcile scan attempts (counter).
+/// Stage 2 rows read by reconcile and durably settled, counted once per committed page (counter). A
+/// page that fails its produce or commit and retries is not double-counted.
 pub const RECONCILE_ROWS_SCANNED_TOTAL: &str = "cohort_reconcile_rows_scanned_total";
-/// Snapshot membership rows acknowledged by Kafka, labelled by `status` (counter).
+/// Snapshot membership rows acknowledged by Kafka and durably settled, labelled by `status`, counted
+/// once per committed page (counter).
 pub const RECONCILE_ROWS_EMITTED_TOTAL: &str = "cohort_reconcile_rows_emitted_total";
 /// Stale Stage 2 bits durably fixed, labelled by `direction` (counter).
 pub const RECONCILE_BITS_FIXED_TOTAL: &str = "cohort_reconcile_bits_fixed_total";
@@ -787,5 +797,17 @@ mod tests {
             "store_schema_mismatch_wipes_total",
         );
         assert_eq!(MERGE_DRAIN_LEAVES_SCANNED, "merge_drain_leaves_scanned");
+    }
+
+    #[test]
+    fn catalog_and_merge_hold_metric_names_are_stable() {
+        assert_eq!(
+            FILTER_CATALOG_INVALID_SHAPE_HASH,
+            "filter_catalog_invalid_shape_hash_total",
+        );
+        assert_eq!(
+            MERGE_TRANSFERS_HELD_AWAITING_ENABLEMENT_TOTAL,
+            "merge_transfers_held_awaiting_enablement_total",
+        );
     }
 }

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -426,6 +426,8 @@ pub const STAGE2_ORPHAN_GC_SKIPPED_TOTAL: &str = "stage2_orphan_gc_skipped_total
 /// `cf_stage2` keys the orphan GC could not classify and left in place (counter): a key the decoder
 /// rejected, or an id that overflows `i32`.
 pub const STAGE2_ORPHAN_GC_UNDECODABLE_KEYS_TOTAL: &str = "stage2_orphan_gc_undecodable_keys_total";
+/// `cf_stage2` keys a cohort-prefix scan could not decode and skipped (counter).
+pub const STAGE2_SCAN_UNDECODABLE_KEYS_TOTAL: &str = "stage2_scan_undecodable_keys_total";
 
 /// Keys the sweep popped but did not evict, labelled by `reason` (counter). Conservation:
 /// `popped == evicted + dropped`.
@@ -465,6 +467,24 @@ pub const SEED_FENCED_PARTITIONS: &str = "cohort_seed_fenced_partitions";
 pub const SEED_FENCE_DEFICIT_MS: &str = "cohort_seed_fence_deficit_ms";
 /// Age of each owned partition's live watermark, labelled by `partition` (gauge, ms).
 pub const LIVE_WATERMARK_AGE_MS: &str = "cohort_live_watermark_age_ms";
+/// Reconcile jobs admitted to partition-local queues (counter).
+pub const RECONCILE_JOBS_ENQUEUED_TOTAL: &str = "cohort_reconcile_jobs_enqueued_total";
+/// Reconcile jobs that emitted their completion marker and released their seed floor (counter).
+pub const RECONCILE_JOBS_COMPLETED_TOTAL: &str = "cohort_reconcile_jobs_completed_total";
+/// Queued jobs replaced by a higher Kafka offset for the same team and cohort (counter).
+pub const RECONCILE_JOBS_SUPERSEDED_TOTAL: &str = "cohort_reconcile_jobs_superseded_total";
+/// Reconcile jobs invalidated by a drain-time guard, labelled by bounded `reason` (counter).
+pub const RECONCILE_JOBS_DISCARDED_TOTAL: &str = "cohort_reconcile_jobs_discarded_total";
+/// Stage 2 rows read by reconcile scan attempts (counter).
+pub const RECONCILE_ROWS_SCANNED_TOTAL: &str = "cohort_reconcile_rows_scanned_total";
+/// Snapshot membership rows acknowledged by Kafka, labelled by `status` (counter).
+pub const RECONCILE_ROWS_EMITTED_TOTAL: &str = "cohort_reconcile_rows_emitted_total";
+/// Stale Stage 2 bits durably fixed, labelled by `direction` (counter).
+pub const RECONCILE_BITS_FIXED_TOTAL: &str = "cohort_reconcile_bits_fixed_total";
+/// Reconcile completion markers acknowledged by Kafka (counter).
+pub const RECONCILE_MARKERS_EMITTED_TOTAL: &str = "cohort_reconcile_markers_emitted_total";
+/// Partition-local reconcile queue depth, labelled by `partition` (gauge).
+pub const RECONCILE_QUEUE_DEPTH: &str = "cohort_reconcile_queue_depth";
 
 /// Install the global Prometheus recorder. Call once at startup.
 ///
@@ -668,6 +688,10 @@ mod tests {
             STAGE2_ORPHAN_GC_UNDECODABLE_KEYS_TOTAL,
             "stage2_orphan_gc_undecodable_keys_total",
         );
+        assert_eq!(
+            STAGE2_SCAN_UNDECODABLE_KEYS_TOTAL,
+            "stage2_scan_undecodable_keys_total",
+        );
     }
 
     #[test]
@@ -708,7 +732,52 @@ mod tests {
         assert_eq!(SEED_HELD_OFFSET_GAUGE, "seed_held_offset");
         assert_eq!(SEED_FENCED_PARTITIONS, "cohort_seed_fenced_partitions");
         assert_eq!(SEED_FENCE_DEFICIT_MS, "cohort_seed_fence_deficit_ms");
+        assert_eq!(
+            RECONCILE_JOBS_ENQUEUED_TOTAL,
+            "cohort_reconcile_jobs_enqueued_total"
+        );
+        assert_eq!(
+            RECONCILE_JOBS_SUPERSEDED_TOTAL,
+            "cohort_reconcile_jobs_superseded_total"
+        );
         assert_eq!(LIVE_WATERMARK_AGE_MS, "cohort_live_watermark_age_ms");
+    }
+
+    #[test]
+    fn reconcile_metric_names_are_stable() {
+        assert_eq!(
+            RECONCILE_JOBS_ENQUEUED_TOTAL,
+            "cohort_reconcile_jobs_enqueued_total",
+        );
+        assert_eq!(
+            RECONCILE_JOBS_COMPLETED_TOTAL,
+            "cohort_reconcile_jobs_completed_total",
+        );
+        assert_eq!(
+            RECONCILE_JOBS_SUPERSEDED_TOTAL,
+            "cohort_reconcile_jobs_superseded_total",
+        );
+        assert_eq!(
+            RECONCILE_JOBS_DISCARDED_TOTAL,
+            "cohort_reconcile_jobs_discarded_total",
+        );
+        assert_eq!(
+            RECONCILE_ROWS_SCANNED_TOTAL,
+            "cohort_reconcile_rows_scanned_total",
+        );
+        assert_eq!(
+            RECONCILE_ROWS_EMITTED_TOTAL,
+            "cohort_reconcile_rows_emitted_total",
+        );
+        assert_eq!(
+            RECONCILE_BITS_FIXED_TOTAL,
+            "cohort_reconcile_bits_fixed_total",
+        );
+        assert_eq!(
+            RECONCILE_MARKERS_EMITTED_TOTAL,
+            "cohort_reconcile_markers_emitted_total",
+        );
+        assert_eq!(RECONCILE_QUEUE_DEPTH, "cohort_reconcile_queue_depth");
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/partitions/mod.rs
+++ b/rust/cohort-stream-processor/src/partitions/mod.rs
@@ -20,7 +20,7 @@ pub use cohort_core::partitioner;
 pub use backpressure::{Backpressure, PartitionHoldover};
 pub use follower::{Follower, FollowerSet, PartitionMirror};
 pub use intake::{Admission, MeteredReceiver, PartitionIntake};
-pub use offset_tracker::{MarkOutcome, OffsetTracker};
+pub use offset_tracker::{DeferredOffset, MarkOutcome, OffsetTracker};
 pub use partitioner::{
     merge_partition_key, murmur2, partition_for, partition_of, COHORT_PARTITION_COUNT,
 };

--- a/rust/cohort-stream-processor/src/partitions/offset_tracker.rs
+++ b/rust/cohort-stream-processor/src/partitions/offset_tracker.rs
@@ -6,13 +6,17 @@
 //! Per-key replay dedup is a separate concern, owned by
 //! [`AppliedOffsets`](crate::stage1::state::AppliedOffsets) on each `cf_behavioral` record.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
 
 use dashmap::DashMap;
 
 /// Per-partition consume/commit progress.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default)]
 struct PartitionProgress {
+    /// Identity for one partition tenure. A deferred token from a forgotten tenure must not release
+    /// an equal offset deferred by a later owner.
+    tenure: Arc<()>,
     /// Next offset to consume (highest processed `+ 1`), the value committed to Kafka. Monotonic.
     /// `0` is the "never processed" sentinel; a real mark is always `≥ 1`, so
     /// [`committable_offsets`](OffsetTracker::committable_offsets) treats `0` as nothing to commit.
@@ -35,9 +39,57 @@ struct PartitionProgress {
     /// persistent store error a *visible* commit-stall (lag grows; emit the `held_offset` gauge and
     /// alert) rather than a silent state loss — the intended fail-stop for a correctness-critical pipeline.
     held_offset: Option<i64>,
+    /// Releasable commit floors owned by in-flight work that outlives its consumed message. Unlike
+    /// [`held_offset`](Self::held_offset), each floor is removed explicitly when that work finishes.
+    deferred: BTreeSet<i64>,
     /// Last offset Kafka acked as committed. The gap to `processed_offset` is the window Kafka
     /// replays after a crash.
     committed_offset: i64,
+}
+
+impl PartitionProgress {
+    fn mark_processed(&mut self, next_offset: i64) -> MarkOutcome {
+        let capped = next_offset.min(self.dispatched_offset);
+        self.processed_offset = self.processed_offset.max(capped);
+        if capped < next_offset {
+            MarkOutcome::CappedAheadOfDispatch
+        } else {
+            MarkOutcome::WithinDispatch
+        }
+    }
+
+    fn committable_offset(&self) -> Option<i64> {
+        let committable = [
+            Some(self.processed_offset),
+            self.held_offset,
+            self.deferred.first().copied(),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .expect("processed offset always supplies a commit candidate");
+
+        (self.processed_offset > 0 && committable > 0).then_some(committable)
+    }
+}
+
+/// Ownership token for a releasable commit floor created by [`OffsetTracker::defer`].
+///
+/// The token is deliberately non-`Clone`: one in-flight operation owns one completion. Dropping it
+/// leaves the floor pinned until the partition is forgotten, so a lost job fails closed and Kafka
+/// replays the message on the next tenure.
+#[derive(Debug)]
+#[must_use = "a deferred offset must be completed after its durable work finishes"]
+pub struct DeferredOffset {
+    partition: i32,
+    offset: i64,
+    tenure: Arc<()>,
+}
+
+impl DeferredOffset {
+    pub(crate) fn offset(&self) -> i64 {
+        self.offset
+    }
 }
 
 /// What [`OffsetTracker::mark_processed`] did with a mark — returned so the worker can emit a metric
@@ -82,13 +134,72 @@ impl OffsetTracker {
     #[must_use = "a CappedAheadOfDispatch outcome is an F1 invariant violation the worker must surface"]
     pub fn mark_processed(&self, partition: i32, next_offset: i64) -> MarkOutcome {
         let mut progress = self.partitions.entry(partition).or_default();
-        let capped = next_offset.min(progress.dispatched_offset);
-        progress.processed_offset = progress.processed_offset.max(capped);
-        if capped < next_offset {
-            MarkOutcome::CappedAheadOfDispatch
-        } else {
-            MarkOutcome::WithinDispatch
+        progress.mark_processed(next_offset)
+    }
+
+    /// Pin this partition's committable offset at the consumed message's own `offset` until the
+    /// returned token is passed to [`complete_deferred`](Self::complete_deferred).
+    ///
+    /// This is for durable work that continues after the message handler returns. Later processed
+    /// marks may advance normally, but Kafka cannot commit past the earliest deferred offset. The
+    /// serial partition worker must defer each consumed offset at most once per tenure.
+    pub fn defer(&self, partition: i32, offset: i64) -> DeferredOffset {
+        let mut progress = self.partitions.entry(partition).or_default();
+        assert!(
+            progress.deferred.insert(offset),
+            "partition {partition} offset {offset} was deferred twice in one tenure",
+        );
+        DeferredOffset {
+            partition,
+            offset,
+            tenure: Arc::clone(&progress.tenure),
         }
+    }
+
+    /// Release a deferred floor and mark its consumed message processed (`offset + 1`).
+    ///
+    /// Returns `None` when the partition was forgotten or the token no longer belongs to its
+    /// current progress. This makes late completion after a rebalance harmless and avoids
+    /// recreating tracking state for a revoked partition.
+    pub fn complete_deferred(&self, deferred: DeferredOffset) -> Option<MarkOutcome> {
+        let mut progress = self.partitions.get_mut(&deferred.partition)?;
+        if !Arc::ptr_eq(&progress.tenure, &deferred.tenure)
+            || !progress.deferred.remove(&deferred.offset)
+        {
+            return None;
+        }
+        Some(progress.mark_processed(deferred.offset + 1))
+    }
+
+    /// Atomically replace one deferred floor with another and mark the superseded message processed.
+    ///
+    /// Keeping both mutations under the partition lock matters when the replacement reuses an
+    /// offset after a follower rewind: a concurrent commit snapshot must never observe the old floor
+    /// removed before the replacement is installed. Returns `None` when the token belongs to a
+    /// forgotten tenure or no longer owns its floor.
+    pub fn replace_deferred(
+        &self,
+        deferred: DeferredOffset,
+        replacement_offset: i64,
+    ) -> Option<(DeferredOffset, MarkOutcome)> {
+        let mut progress = self.partitions.get_mut(&deferred.partition)?;
+        if !Arc::ptr_eq(&progress.tenure, &deferred.tenure)
+            || !progress.deferred.remove(&deferred.offset)
+        {
+            return None;
+        }
+        assert!(
+            progress.deferred.insert(replacement_offset),
+            "partition {} offset {replacement_offset} was deferred twice in one tenure",
+            deferred.partition,
+        );
+        let outcome = progress.mark_processed(deferred.offset + 1);
+        let replacement = DeferredOffset {
+            partition: deferred.partition,
+            offset: replacement_offset,
+            tenure: Arc::clone(&progress.tenure),
+        };
+        Some((replacement, outcome))
     }
 
     /// Pin the partition's commit floor at `offset` (the failed message's *own* offset `K`, **not**
@@ -120,27 +231,24 @@ impl OffsetTracker {
     }
 
     /// Snapshot of `partition → next-offset-to-consume` for every partition with a *processed*
-    /// offset, **capped at any [`hold`](Self::hold) floor**. Partitions tracked only because they were
-    /// dispatched carry the `processed_offset == 0` sentinel and are excluded — nothing safe to
-    /// commit, so Kafka replays them. A real mark is always `≥ 1`, so the filter never drops a
-    /// committable offset.
+    /// offset, capped at the earliest sticky [`hold`](Self::hold) or releasable
+    /// [`defer`](Self::defer) floor. Partitions tracked only because they were dispatched or deferred
+    /// carry the `processed_offset == 0` sentinel and are excluded — nothing safe to commit, so
+    /// Kafka replays them. A real mark is always `≥ 1`, so the filter never drops a committable
+    /// offset.
     ///
-    /// The hold cap is applied to the *value*, not the filter: a hold pinned at the message's own
-    /// offset `K` makes the committable value `min(processed, K)` so a later success cannot leapfrog
-    /// the failed message. A hold at `0` (or a hold while `processed == 0`) yields a value of `0`,
-    /// which the `> 0` filter then excludes — Kafka replays the partition from the start of its
-    /// uncommitted range, redelivering the held message rather than skipping it.
+    /// Floors cap the *value*, not the filter: a floor pinned at the message's own offset `K` makes
+    /// the committable value `min(processed, K)` so a later success cannot leapfrog the unfinished
+    /// message. A floor at `0` (or any floor while `processed == 0`) yields no committable value, so
+    /// Kafka replays from the start of the uncommitted range.
     pub fn committable_offsets(&self) -> HashMap<i32, i64> {
         self.partitions
             .iter()
-            .filter(|entry| entry.value().processed_offset > 0)
             .filter_map(|entry| {
-                let progress = entry.value();
-                let committable = match progress.held_offset {
-                    Some(held) => progress.processed_offset.min(held),
-                    None => progress.processed_offset,
-                };
-                (committable > 0).then_some((*entry.key(), committable))
+                entry
+                    .value()
+                    .committable_offset()
+                    .map(|offset| (*entry.key(), offset))
             })
             .collect()
     }
@@ -150,8 +258,9 @@ impl OffsetTracker {
     }
 
     /// Drop all tracking for a revoked partition. Its offset should already be committed. Removing the
-    /// whole entry also clears any [`hold`](Self::hold), so the next tenure starts unheld and replays
-    /// from the committed offset — the only way a sticky hold is released.
+    /// whole entry also clears any [`hold`](Self::hold) and [`defer`](Self::defer) floors, so the next
+    /// tenure starts unheld and replays from the committed offset — the only way a sticky hold is
+    /// released.
     pub fn forget_partition(&self, partition: i32) {
         self.partitions.remove(&partition);
     }
@@ -350,5 +459,185 @@ mod tests {
 
         assert_eq!(tracker.committable_offsets().get(&4), None);
         assert_eq!(tracker.partition_count(), 1);
+    }
+
+    #[test]
+    fn later_processed_marks_cannot_leapfrog_a_deferred_offset() {
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 100);
+        let deferred = tracker.defer(4, 41);
+
+        assert_eq!(tracker.mark_processed(4, 80), MarkOutcome::WithinDispatch);
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&41));
+
+        assert_eq!(
+            tracker.complete_deferred(deferred),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&80));
+    }
+
+    #[test]
+    fn completing_a_deferred_offset_zero_marks_next_offset_one() {
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 1);
+        let deferred = tracker.defer(4, 0);
+
+        assert_eq!(tracker.committable_offsets().get(&4), None);
+        assert_eq!(
+            tracker.complete_deferred(deferred),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&1));
+    }
+
+    #[test]
+    fn multiple_deferred_offsets_reveal_the_next_lowest_floor() {
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 100);
+        let first = tracker.defer(4, 20);
+        let second = tracker.defer(4, 40);
+        let _ = tracker.mark_processed(4, 80);
+
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&20));
+        assert_eq!(
+            tracker.complete_deferred(first),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&40));
+        assert_eq!(
+            tracker.complete_deferred(second),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&80));
+
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 100);
+        let first = tracker.defer(4, 20);
+        let second = tracker.defer(4, 40);
+        let _ = tracker.mark_processed(4, 80);
+
+        assert_eq!(
+            tracker.complete_deferred(second),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&20));
+        assert_eq!(
+            tracker.complete_deferred(first),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&80));
+    }
+
+    #[test]
+    fn replacing_a_deferred_offset_never_exposes_an_unpinned_commit() {
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 100);
+        let original = tracker.defer(4, 20);
+        let _ = tracker.mark_processed(4, 80);
+
+        let (replacement, outcome) = tracker
+            .replace_deferred(original, 20)
+            .expect("the current tenure owns the original floor");
+
+        assert_eq!(outcome, MarkOutcome::WithinDispatch);
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&20));
+        assert_eq!(
+            tracker.complete_deferred(replacement),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&80));
+    }
+
+    #[test]
+    fn replacing_a_deferred_offset_moves_the_floor_atomically() {
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 100);
+        let original = tracker.defer(4, 40);
+        let _ = tracker.mark_processed(4, 80);
+
+        let (replacement, _) = tracker
+            .replace_deferred(original, 20)
+            .expect("the current tenure owns the original floor");
+
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&20));
+        assert_eq!(
+            tracker.complete_deferred(replacement),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&80));
+    }
+
+    #[test]
+    fn deferred_and_sticky_floors_compose_by_minimum() {
+        for (partition, held, deferred_offset, expected_before, expected_after) in
+            [(1, 30, 40, 30, 30), (2, 50, 40, 40, 50)]
+        {
+            let tracker = OffsetTracker::new();
+            tracker.mark_dispatched(partition, 100);
+            tracker.hold(partition, held);
+            let deferred = tracker.defer(partition, deferred_offset);
+            let _ = tracker.mark_processed(partition, 80);
+
+            assert_eq!(
+                tracker.committable_offsets().get(&partition),
+                Some(&expected_before),
+            );
+            assert_eq!(
+                tracker.complete_deferred(deferred),
+                Some(MarkOutcome::WithinDispatch),
+            );
+            assert_eq!(
+                tracker.committable_offsets().get(&partition),
+                Some(&expected_after),
+            );
+        }
+    }
+
+    #[test]
+    fn forgetting_a_partition_invalidates_its_deferred_tokens() {
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 100);
+        let stale = tracker.defer(4, 40);
+        let _ = tracker.mark_processed(4, 80);
+        tracker.forget_partition(4);
+
+        // Recreate the same offset in a new tenure to pin the ABA case: the stale token cannot
+        // release work now owned by the new partition worker.
+        tracker.mark_dispatched(4, 100);
+        let current = tracker.defer(4, 40);
+        let _ = tracker.mark_processed(4, 80);
+        assert_eq!(tracker.complete_deferred(stale), None);
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&40));
+
+        assert_eq!(
+            tracker.complete_deferred(current),
+            Some(MarkOutcome::WithinDispatch),
+        );
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&80));
+    }
+
+    #[test]
+    fn dropping_a_deferred_token_pins_until_the_partition_is_forgotten() {
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(4, 100);
+        let deferred = tracker.defer(4, 40);
+        let _ = tracker.mark_processed(4, 80);
+
+        drop(deferred);
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&40));
+
+        tracker.forget_partition(4);
+        tracker.mark_dispatched(4, 100);
+        let _ = tracker.mark_processed(4, 80);
+        assert_eq!(tracker.committable_offsets().get(&4), Some(&80));
+    }
+
+    #[test]
+    #[should_panic(expected = "offset 40 was deferred twice in one tenure")]
+    fn deferring_the_same_offset_twice_fails_closed() {
+        let tracker = OffsetTracker::new();
+        let _first = tracker.defer(4, 40);
+        let _second = tracker.defer(4, 40);
     }
 }

--- a/rust/cohort-stream-processor/src/partitions/router.rs
+++ b/rust/cohort-stream-processor/src/partitions/router.rs
@@ -53,10 +53,12 @@ pub enum SendOutcome {
     },
     /// Channel full: carries the un-sent sub-batch to hold, pause, and redispatch. No drop recorded.
     Full(Vec<ShuffleMessage>),
-    /// No worker registered (never assigned, or revoked): dropped and recorded; Kafka replays.
-    NoWorker,
-    /// Worker channel closed (worker exited): dropped and recorded; Kafka replays.
-    ChannelClosed,
+    /// No worker registered (never assigned, or revoked). The caller may hold the returned batch;
+    /// otherwise Kafka replays it.
+    NoWorker(Vec<ShuffleMessage>),
+    /// Worker channel closed (worker exited). The caller may hold the returned batch; otherwise Kafka
+    /// replays it.
+    ChannelClosed(Vec<ShuffleMessage>),
 }
 
 /// A registered worker channel: the sender and the per-partition event-intake budget its
@@ -237,8 +239,7 @@ impl PartitionRouter {
 
     fn try_send_to_partition(&self, partition: i32, batch: Vec<ShuffleMessage>) -> SendOutcome {
         let Some(channel) = self.channel_for(partition) else {
-            self.record_drop(partition, batch.len(), REASON_NO_WORKER);
-            return SendOutcome::NoWorker;
+            return SendOutcome::NoWorker(batch);
         };
         let count = batch.len();
         // `None` for an event-less batch — carried through, not defaulted to 0, so a non-Event caller
@@ -267,8 +268,7 @@ impl PartitionRouter {
             }
             Err(TrySendError::Closed(returned)) => {
                 channel.intake.release(counted);
-                self.record_drop(partition, returned.len(), REASON_CHANNEL_CLOSED);
-                SendOutcome::ChannelClosed
+                SendOutcome::ChannelClosed(returned)
             }
         }
     }
@@ -350,6 +350,7 @@ mod tests {
                 | ShuffleMessage::Cascade { .. }
                 | ShuffleMessage::RedrivePendingTransfers
                 | ShuffleMessage::MergeCfGc { .. }
+                | ShuffleMessage::ReconcileDrain
                 | ShuffleMessage::Seed { .. } => {
                     unreachable!("router tests route only events")
                 }
@@ -592,17 +593,17 @@ mod tests {
     #[tokio::test]
     async fn try_route_batch_reports_no_worker_and_channel_closed() {
         let router = PartitionRouter::new(16);
-        assert!(matches!(
-            router.try_route_batch(vec![(9, event_off(1))]).remove(&9),
-            Some(SendOutcome::NoWorker),
-        ));
+        match router.try_route_batch(vec![(9, event_off(1))]).remove(&9) {
+            Some(SendOutcome::NoWorker(returned)) => assert_eq!(tags(&returned), vec![1]),
+            other => panic!("expected NoWorker, got {other:?}"),
+        }
 
         let rx = router.add_partition(3).unwrap();
         drop(rx);
-        assert!(matches!(
-            router.try_route_batch(vec![(3, event_off(1))]).remove(&3),
-            Some(SendOutcome::ChannelClosed),
-        ));
+        match router.try_route_batch(vec![(3, event_off(1))]).remove(&3) {
+            Some(SendOutcome::ChannelClosed(returned)) => assert_eq!(tags(&returned), vec![1]),
+            other => panic!("expected ChannelClosed, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
+++ b/rust/cohort-stream-processor/src/partitions/shuffle_message.rs
@@ -51,6 +51,8 @@ pub enum ShuffleMessage {
         marker_cutoff_ms: i64,
         tombstone_cutoff_ms: i64,
     },
+    /// Periodic bounded-progress tick for the partition's reconcile queue.
+    ReconcileDrain,
     /// A backfill day-tile (or its consume-side skip), paired with its topic offset. Marked on
     /// the seed tracker, never the events tracker. Boxed so the tile doesn't inflate every
     /// `ShuffleMessage`.
@@ -69,6 +71,7 @@ impl ShuffleMessage {
             | ShuffleMessage::Cascade { .. }
             | ShuffleMessage::RedrivePendingTransfers
             | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain
             | ShuffleMessage::Seed { .. } => None,
         }
     }
@@ -83,7 +86,8 @@ impl ShuffleMessage {
             | ShuffleMessage::Transfer { .. }
             | ShuffleMessage::Cascade { .. }
             | ShuffleMessage::RedrivePendingTransfers
-            | ShuffleMessage::MergeCfGc { .. } => None,
+            | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain => None,
         }
     }
 
@@ -97,7 +101,8 @@ impl ShuffleMessage {
             | ShuffleMessage::Transfer { .. }
             | ShuffleMessage::Cascade { .. }
             | ShuffleMessage::RedrivePendingTransfers
-            | ShuffleMessage::MergeCfGc { .. } => false,
+            | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain => false,
         }
     }
 }
@@ -164,6 +169,7 @@ mod tests {
             source_partition: 3,
             source_offset: 9,
             leaves: vec![],
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,
@@ -195,6 +201,7 @@ mod tests {
             | ShuffleMessage::Transfer { .. }
             | ShuffleMessage::RedrivePendingTransfers
             | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain
             | ShuffleMessage::Seed { .. }
             | ShuffleMessage::Cascade { .. } => unreachable!("constructed an Event"),
         }
@@ -240,6 +247,9 @@ mod tests {
         assert_eq!(event.seed_offset(), None);
         assert!(event.counts_toward_intake());
         assert!(!ShuffleMessage::RedrivePendingTransfers.counts_toward_intake());
+        assert!(!ShuffleMessage::ReconcileDrain.counts_toward_intake());
+        assert_eq!(ShuffleMessage::ReconcileDrain.event_offset(), None);
+        assert_eq!(ShuffleMessage::ReconcileDrain.seed_offset(), None);
     }
 
     #[test]
@@ -254,6 +264,7 @@ mod tests {
             | ShuffleMessage::Transfer { .. }
             | ShuffleMessage::RedrivePendingTransfers
             | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain
             | ShuffleMessage::Seed { .. }
             | ShuffleMessage::Cascade { .. } => unreachable!("constructed a Sweep"),
         }
@@ -278,6 +289,7 @@ mod tests {
             | ShuffleMessage::Merge { .. }
             | ShuffleMessage::Transfer { .. }
             | ShuffleMessage::RedrivePendingTransfers
+            | ShuffleMessage::ReconcileDrain
             | ShuffleMessage::Seed { .. }
             | ShuffleMessage::Cascade { .. } => unreachable!("constructed a MergeCfGc"),
         }
@@ -299,6 +311,7 @@ mod tests {
             | ShuffleMessage::Transfer { .. }
             | ShuffleMessage::RedrivePendingTransfers
             | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain
             | ShuffleMessage::Seed { .. }
             | ShuffleMessage::Cascade { .. } => unreachable!("constructed a Merge"),
         }
@@ -317,6 +330,7 @@ mod tests {
             | ShuffleMessage::Merge { .. }
             | ShuffleMessage::RedrivePendingTransfers
             | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain
             | ShuffleMessage::Seed { .. }
             | ShuffleMessage::Cascade { .. } => unreachable!("constructed a Transfer"),
         }
@@ -341,6 +355,7 @@ mod tests {
             | ShuffleMessage::Transfer { .. }
             | ShuffleMessage::RedrivePendingTransfers
             | ShuffleMessage::MergeCfGc { .. }
+            | ShuffleMessage::ReconcileDrain
             | ShuffleMessage::Seed { .. } => unreachable!("constructed a Cascade"),
         }
     }

--- a/rust/cohort-stream-processor/src/producer/kafka.rs
+++ b/rust/cohort-stream-processor/src/producer/kafka.rs
@@ -9,7 +9,7 @@ use common_kafka::kafka_producer::{
 use common_liveness::SyncLivenessReporter;
 use rdkafka::producer::FutureProducer;
 
-use crate::producer::{CohortMembershipChange, MembershipSink};
+use crate::producer::{CohortMembershipChange, MembershipSink, ReconcileCompleteMarker};
 
 /// No-op liveness reporter — producer stalls are surfaced by the consumer's liveness deadline.
 #[derive(Clone, Copy)]
@@ -49,16 +49,42 @@ impl MembershipSink for KafkaMembershipSink {
         )
         .await
     }
+
+    async fn produce_markers(
+        &self,
+        markers: Vec<ReconcileCompleteMarker>,
+    ) -> Vec<Result<(), KafkaProduceError>> {
+        send_keyed_iter_to_kafka_with_headers(
+            &self.producer,
+            &self.topic,
+            reconcile_complete_key,
+            |_| None,
+            markers,
+        )
+        .await
+    }
 }
 
 fn membership_key(change: &CohortMembershipChange) -> Option<String> {
     Some(change.person_id.clone())
 }
 
+fn reconcile_complete_key(marker: &ReconcileCompleteMarker) -> Option<String> {
+    Some(format!(
+        "{}:{}:{}",
+        marker.team_id().0,
+        marker.cohort_id().0,
+        marker.run_id().0
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::filters::{CohortId, TeamId};
     use crate::producer::MembershipStatus;
+    use cohort_core::seed::RunId;
+    use uuid::Uuid;
 
     #[test]
     fn membership_key_is_the_person_id() {
@@ -72,5 +98,34 @@ mod tests {
             run_id: None,
         };
         assert_eq!(membership_key(&change), Some(change.person_id.clone()));
+    }
+
+    #[test]
+    fn reconcile_complete_key_identifies_the_run_without_the_partition() {
+        let run_id = RunId(Uuid::nil());
+        let marker = ReconcileCompleteMarker::new(
+            TeamId(42),
+            CohortId(91204),
+            63,
+            run_id,
+            "2026-05-26 12:34:56.789123".to_string(),
+        );
+        let other_partition = ReconcileCompleteMarker::new(
+            TeamId(42),
+            CohortId(91204),
+            0,
+            run_id,
+            "2026-05-26 12:34:56.789123".to_string(),
+        );
+
+        assert_eq!(
+            reconcile_complete_key(&marker),
+            Some("42:91204:00000000-0000-0000-0000-000000000000".to_string())
+        );
+        assert_eq!(
+            reconcile_complete_key(&marker),
+            reconcile_complete_key(&other_partition),
+            "all partition markers for one run share the same Kafka key",
+        );
     }
 }

--- a/rust/cohort-stream-processor/src/producer/merge.rs
+++ b/rust/cohort-stream-processor/src/producer/merge.rs
@@ -260,6 +260,7 @@ mod tests {
                     AppliedOffsets::default(),
                 ),
             )],
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,

--- a/rust/cohort-stream-processor/src/producer/mod.rs
+++ b/rust/cohort-stream-processor/src/producer/mod.rs
@@ -16,12 +16,14 @@ use async_trait::async_trait;
 use chrono::Utc;
 use common_kafka::kafka_producer::KafkaProduceError;
 use metrics::counter;
+use serde::de::{Deserializer, Error as DeError, Unexpected};
+use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
 use cohort_core::seed::RunId;
 
 use crate::filters::reverse_index::TeamFilters;
-use crate::filters::CohortId;
+use crate::filters::{CohortId, TeamId};
 use crate::observability::metrics::OUTPUT_TRANSITIONS_UNMAPPED;
 use crate::stage1::transition::{LeafTransition, TransitionKind};
 
@@ -60,6 +62,85 @@ pub struct CohortMembershipChange {
 #[serde(rename_all = "snake_case")]
 pub enum ChangeOrigin {
     Seed,
+    Reconcile,
+}
+
+const RECONCILE_COMPLETE_KIND: &str = "reconcile_complete";
+
+/// A completion certificate emitted after one partition's reconcile snapshot is durable.
+/// Field order is the wire order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconcileCompleteMarker {
+    #[serde(rename = "type")]
+    kind: ReconcileCompleteKind,
+    team_id: i32,
+    cohort_id: i32,
+    partition: u16,
+    run_id: RunId,
+    /// ClickHouse `DateTime64(6)` wire format.
+    last_updated: String,
+}
+
+impl ReconcileCompleteMarker {
+    pub fn new(
+        team_id: TeamId,
+        cohort_id: CohortId,
+        partition: u16,
+        run_id: RunId,
+        last_updated: String,
+    ) -> Self {
+        Self {
+            kind: ReconcileCompleteKind,
+            team_id: team_id.0,
+            cohort_id: cohort_id.0,
+            partition,
+            run_id,
+            last_updated,
+        }
+    }
+
+    pub const fn team_id(&self) -> TeamId {
+        TeamId(self.team_id)
+    }
+
+    pub const fn cohort_id(&self) -> CohortId {
+        CohortId(self.cohort_id)
+    }
+
+    pub const fn partition(&self) -> u16 {
+        self.partition
+    }
+
+    pub const fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    pub fn last_updated(&self) -> &str {
+        &self.last_updated
+    }
+}
+
+/// A zero-sized discriminant proven to be [`RECONCILE_COMPLETE_KIND`] during deserialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReconcileCompleteKind;
+
+impl Serialize for ReconcileCompleteKind {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(RECONCILE_COMPLETE_KIND)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReconcileCompleteKind {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        if value != RECONCILE_COMPLETE_KIND {
+            return Err(DeError::invalid_value(
+                Unexpected::Str(&value),
+                &"marker type \"reconcile_complete\"",
+            ));
+        }
+        Ok(Self)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -122,7 +203,35 @@ pub fn map_transition<'a>(
 
 /// Current UTC time as a ClickHouse `DateTime64(6)` string (microseconds).
 pub fn now_last_updated() -> String {
-    Utc::now().format("%Y-%m-%d %H:%M:%S%.6f").to_string()
+    format_last_updated(Utc::now().timestamp_micros())
+}
+
+/// Per-partition output-version allocator. Wall time supplies the normal value; the local floor
+/// makes every later worker message strictly newer even if the clock stalls or moves backward.
+#[derive(Debug, Default)]
+pub(crate) struct LastUpdatedClock {
+    last_micros: Option<i64>,
+}
+
+impl LastUpdatedClock {
+    pub fn next(&mut self) -> String {
+        self.next_at(Utc::now().timestamp_micros())
+    }
+
+    fn next_at(&mut self, observed_micros: i64) -> String {
+        let next_micros = self.last_micros.map_or(observed_micros, |last_micros| {
+            observed_micros.max(last_micros.saturating_add(1))
+        });
+        self.last_micros = Some(next_micros);
+        format_last_updated(next_micros)
+    }
+}
+
+fn format_last_updated(timestamp_micros: i64) -> String {
+    chrono::DateTime::<Utc>::from_timestamp_micros(timestamp_micros)
+        .expect("current UTC timestamps fit Chrono's supported range")
+        .format("%Y-%m-%d %H:%M:%S%.6f")
+        .to_string()
 }
 
 #[async_trait]
@@ -131,11 +240,17 @@ pub trait MembershipSink: Send + Sync {
         &self,
         changes: Vec<CohortMembershipChange>,
     ) -> Vec<Result<(), KafkaProduceError>>;
+
+    async fn produce_markers(
+        &self,
+        markers: Vec<ReconcileCompleteMarker>,
+    ) -> Vec<Result<(), KafkaProduceError>>;
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct CaptureSink {
     changes: Arc<Mutex<Vec<CohortMembershipChange>>>,
+    markers: Arc<Mutex<Vec<ReconcileCompleteMarker>>>,
     fail_remaining: Arc<AtomicUsize>,
 }
 
@@ -147,6 +262,7 @@ impl CaptureSink {
     pub fn failing_first(n: usize) -> Self {
         Self {
             changes: Arc::default(),
+            markers: Arc::default(),
             fail_remaining: Arc::new(AtomicUsize::new(n)),
         }
     }
@@ -157,6 +273,21 @@ impl CaptureSink {
             .expect("CaptureSink mutex poisoned")
             .clone()
     }
+
+    pub fn markers(&self) -> Vec<ReconcileCompleteMarker> {
+        self.markers
+            .lock()
+            .expect("CaptureSink mutex poisoned")
+            .clone()
+    }
+
+    fn should_fail(&self) -> bool {
+        self.fail_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                (n > 0).then(|| n - 1)
+            })
+            .is_ok()
+    }
 }
 
 #[async_trait]
@@ -165,13 +296,7 @@ impl MembershipSink for CaptureSink {
         &self,
         changes: Vec<CohortMembershipChange>,
     ) -> Vec<Result<(), KafkaProduceError>> {
-        let should_fail = self
-            .fail_remaining
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
-                (n > 0).then(|| n - 1)
-            })
-            .is_ok();
-        if should_fail {
+        if self.should_fail() {
             return changes
                 .into_iter()
                 .map(|_| Err(KafkaProduceError::KafkaProduceCanceled))
@@ -182,6 +307,24 @@ impl MembershipSink for CaptureSink {
             .lock()
             .expect("CaptureSink mutex poisoned")
             .extend(changes);
+        acks
+    }
+
+    async fn produce_markers(
+        &self,
+        markers: Vec<ReconcileCompleteMarker>,
+    ) -> Vec<Result<(), KafkaProduceError>> {
+        if self.should_fail() {
+            return markers
+                .into_iter()
+                .map(|_| Err(KafkaProduceError::KafkaProduceCanceled))
+                .collect();
+        }
+        let acks = (0..markers.len()).map(|_| Ok(())).collect();
+        self.markers
+            .lock()
+            .expect("CaptureSink mutex poisoned")
+            .extend(markers);
         acks
     }
 }
@@ -234,6 +377,16 @@ mod tests {
             condition_hash: HASH,
             kind,
         }
+    }
+
+    fn reconcile_complete_marker(partition: u16) -> ReconcileCompleteMarker {
+        ReconcileCompleteMarker::new(
+            TeamId(42),
+            CohortId(91204),
+            partition,
+            RunId(Uuid::nil()),
+            TS.to_string(),
+        )
     }
 
     #[test]
@@ -354,6 +507,38 @@ mod tests {
     }
 
     #[test]
+    fn reconcile_origin_serializes_snake_case() {
+        let value = serde_json::to_value(ChangeOrigin::Reconcile).unwrap();
+        assert_eq!(value, json!("reconcile"));
+    }
+
+    #[test]
+    fn reconcile_complete_marker_has_the_exact_wire_contract() {
+        let marker = reconcile_complete_marker(7);
+
+        assert_eq!(
+            serde_json::to_string(&marker).unwrap(),
+            r#"{"type":"reconcile_complete","team_id":42,"cohort_id":91204,"partition":7,"run_id":"00000000-0000-0000-0000-000000000000","last_updated":"2026-05-26 12:34:56.789123"}"#,
+        );
+        assert_eq!(
+            serde_json::from_str::<ReconcileCompleteMarker>(
+                &serde_json::to_string(&marker).unwrap()
+            )
+            .unwrap(),
+            marker
+        );
+    }
+
+    #[test]
+    fn reconcile_complete_marker_rejects_another_message_type() {
+        let payload = serde_json::to_string(&reconcile_complete_marker(7))
+            .unwrap()
+            .replace("reconcile_complete", "seed");
+
+        assert!(serde_json::from_str::<ReconcileCompleteMarker>(&payload).is_err());
+    }
+
+    #[test]
     fn live_path_change_stays_byte_identical_and_a_seed_tag_adds_only_the_two_keys() {
         let live = CohortMembershipChange {
             team_id: 42,
@@ -402,6 +587,21 @@ mod tests {
         assert_eq!(time.matches(':').count(), 2);
     }
 
+    #[test]
+    fn last_updated_clock_is_strictly_monotonic_when_wall_time_stalls_or_rewinds() {
+        let mut clock = LastUpdatedClock::default();
+
+        let first = clock.next_at(1_700_000_000_000_000);
+        let stalled = clock.next_at(1_700_000_000_000_000);
+        let rewound = clock.next_at(1_699_999_999_000_000);
+
+        assert!(first < stalled);
+        assert!(stalled < rewound);
+        assert_eq!(first, "2023-11-14 22:13:20.000000");
+        assert_eq!(stalled, "2023-11-14 22:13:20.000001");
+        assert_eq!(rewound, "2023-11-14 22:13:20.000002");
+    }
+
     #[tokio::test]
     async fn capture_sink_records_and_acks_in_order() {
         let sink = CaptureSink::new();
@@ -440,5 +640,42 @@ mod tests {
         let second = sink.produce(vec![change.clone()]).await;
         assert!(second.iter().all(Result::is_ok), "second flush succeeds");
         assert_eq!(sink.changes(), vec![change]);
+    }
+
+    #[tokio::test]
+    async fn capture_sink_records_markers_and_shares_failure_order_across_message_types() {
+        let sink = CaptureSink::failing_first(1);
+        let change = CohortMembershipChange {
+            team_id: 42,
+            cohort_id: 91204,
+            person_id: "p".to_string(),
+            last_updated: TS.to_string(),
+            status: MembershipStatus::Entered,
+            origin: Some(ChangeOrigin::Reconcile),
+            run_id: Some(RunId(Uuid::nil())),
+        };
+        let marker = reconcile_complete_marker(7);
+
+        let first = sink.produce(vec![change]).await;
+        assert!(first.iter().all(Result::is_err), "first flush fails");
+        assert!(sink.changes().is_empty(), "a failed flush records nothing");
+
+        let second = sink.produce_markers(vec![marker.clone()]).await;
+        assert!(second.iter().all(Result::is_ok), "second flush succeeds");
+        assert_eq!(sink.markers(), vec![marker]);
+    }
+
+    #[tokio::test]
+    async fn capture_sink_retries_a_failed_marker_without_recording_the_failed_attempt() {
+        let sink = CaptureSink::failing_first(1);
+        let marker = reconcile_complete_marker(7);
+
+        let first = sink.produce_markers(vec![marker.clone()]).await;
+        assert!(first.iter().all(Result::is_err), "first flush fails");
+        assert!(sink.markers().is_empty(), "a failed flush records nothing");
+
+        let second = sink.produce_markers(vec![marker.clone()]).await;
+        assert!(second.iter().all(Result::is_ok), "retry succeeds");
+        assert_eq!(sink.markers(), vec![marker]);
     }
 }

--- a/rust/cohort-stream-processor/src/stage2/mod.rs
+++ b/rust/cohort-stream-processor/src/stage2/mod.rs
@@ -1,9 +1,13 @@
 //! Stage 2: per-person Boolean composition of a cohort's leaves into membership flips.
 
 pub mod evaluator;
+mod register;
 pub mod state;
 
 pub use cohort_core::eligibility;
 pub use eligibility::{classify, CohortEligibility, CohortParseFlags, ExcludedReason};
 pub use evaluator::{evaluate_tree, leaf_membership};
+pub(crate) use register::{
+    single_leaf_register_writes, single_leaf_transition_register_writes, MembershipRegisterSource,
+};
 pub use state::Stage2State;

--- a/rust/cohort-stream-processor/src/stage2/register.rs
+++ b/rust/cohort-stream-processor/src/stage2/register.rs
@@ -1,0 +1,134 @@
+//! Typed writes for the persisted single-leaf membership register.
+
+use uuid::Uuid;
+
+use crate::filters::reverse_index::TeamFilters;
+use crate::filters::TeamId;
+use crate::stage1::key::LeafStateKey;
+use crate::stage1::transition::{LeafTransition, TransitionKind};
+use crate::store::Stage2Key;
+
+use super::Stage2State;
+
+/// One complete `cf_stage2` register write for a single-leaf cohort.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MembershipRegisterWrite {
+    pub key: Stage2Key,
+    pub state: Stage2State,
+}
+
+/// Person/leaf coordinates shared by every register write in one fan-out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MembershipRegisterSource {
+    pub partition_id: u16,
+    pub team_id: TeamId,
+    pub person_id: Uuid,
+    pub leaf_state_key: LeafStateKey,
+}
+
+/// Fan out one leaf's current membership to every single-leaf cohort backed by that leaf.
+pub(crate) fn single_leaf_register_writes(
+    filters: &TeamFilters,
+    source: MembershipRegisterSource,
+    in_cohort: bool,
+    last_evaluated_at_ms: i64,
+) -> Vec<MembershipRegisterWrite> {
+    filters
+        .by_lsk_to_single_leaf_cohorts
+        .get(&source.leaf_state_key)
+        .into_iter()
+        .flatten()
+        .map(|cohort_id| MembershipRegisterWrite {
+            key: Stage2Key {
+                partition_id: source.partition_id,
+                team_id: source.team_id.0 as u64,
+                cohort_id: cohort_id.0 as u64,
+                person_id: source.person_id,
+            },
+            state: Stage2State {
+                in_cohort,
+                last_evaluated_at_ms,
+            },
+        })
+        .collect()
+}
+
+/// Fan out a membership transition as a complete register overwrite, including explicit `false`.
+pub(crate) fn single_leaf_transition_register_writes(
+    filters: &TeamFilters,
+    partition_id: u16,
+    transition: &LeafTransition,
+    last_evaluated_at_ms: i64,
+) -> Vec<MembershipRegisterWrite> {
+    single_leaf_register_writes(
+        filters,
+        MembershipRegisterSource {
+            partition_id,
+            team_id: transition.team_id,
+            person_id: transition.person_id,
+            leaf_state_key: transition.leaf_state_key,
+        },
+        matches!(transition.kind, TransitionKind::Entered),
+        last_evaluated_at_ms,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono_tz::UTC;
+    use serde_json::json;
+
+    use super::*;
+    use crate::filters::{CohortId, TeamFiltersBuilder};
+
+    #[test]
+    fn fans_out_a_leaf_to_each_single_leaf_cohort_with_an_explicit_bit() {
+        let mut builder = TeamFiltersBuilder::default();
+        let cohort = json!({
+            "properties": {
+                "type": "AND",
+                "values": [{
+                    "type": "behavioral",
+                    "key": "purchase",
+                    "value": "performed_event",
+                    "time_value": 7,
+                    "time_interval": "day",
+                    "conditionHash": "0123456789abcdef",
+                    "bytecode": ["_H", 1, 32, "purchase", 32, "event", 1, 3, 11]
+                }]
+            }
+        });
+        builder.add_cohort(CohortId(1), TeamId(7), &cohort).unwrap();
+        builder.add_cohort(CohortId(2), TeamId(7), &cohort).unwrap();
+        let filters = builder.freeze(UTC);
+        let leaf_state_key = *filters.by_lsk_to_single_leaf_cohorts.keys().next().unwrap();
+        let person_id = Uuid::from_u128(42);
+
+        let mut writes = single_leaf_register_writes(
+            &filters,
+            MembershipRegisterSource {
+                partition_id: 3,
+                team_id: TeamId(7),
+                person_id,
+                leaf_state_key,
+            },
+            false,
+            1_700_000_000_123,
+        );
+        writes.sort_unstable_by_key(|write| write.key.cohort_id);
+
+        assert_eq!(writes.len(), 2);
+        assert_eq!(writes[0].key.cohort_id, 1);
+        assert_eq!(writes[1].key.cohort_id, 2);
+        assert!(writes.iter().all(|write| {
+            write.key.partition_id == 3
+                && write.key.team_id == 7
+                && write.key.person_id == person_id
+                && write.state
+                    == Stage2State {
+                        in_cohort: false,
+                        last_evaluated_at_ms: 1_700_000_000_123,
+                    }
+        }));
+    }
+}

--- a/rust/cohort-stream-processor/src/stage2/state.rs
+++ b/rust/cohort-stream-processor/src/stage2/state.rs
@@ -2,15 +2,41 @@
 
 use serde::{Deserialize, Serialize};
 
-/// The composed membership of one `(cohort, person)`: whether the person is in the cohort, and when
-/// that was last evaluated.
+/// The registered membership of one `(cohort, person)`: whether the person is in the cohort, and
+/// when that was last evaluated. Single-leaf cohorts write this directly from their leaf state;
+/// composable cohorts write it after Boolean composition.
 ///
-/// `last_evaluated_at_ms` is write-only for now (nothing reads it). It is the source event's
-/// timestamp, not a wall clock, so the value is replay-stable.
+/// `last_evaluated_at_ms` is write-only for now (nothing reads it). Writers use the timestamp of the
+/// operation that evaluated membership: event time for live/merge work, the sweep cutoff for
+/// evictions, and application time for seed work.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Stage2State {
     pub in_cohort: bool,
     pub last_evaluated_at_ms: i64,
+}
+
+/// Who last established the persisted bit. Transfer fallbacks are deliberately explicit so the
+/// first receiver-side evaluation can claim the row even when it computes identical membership.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Stage2Ownership {
+    #[default]
+    Local,
+    TransferredFallback,
+}
+
+impl Stage2Ownership {
+    const fn is_local(&self) -> bool {
+        matches!(self, Self::Local)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedStage2State {
+    in_cohort: bool,
+    last_evaluated_at_ms: i64,
+    #[serde(default, skip_serializing_if = "Stage2Ownership::is_local")]
+    ownership: Stage2Ownership,
 }
 
 /// A failure decoding a stored [`Stage2State`]; surfaced (never panicked) so a single corrupt row is
@@ -26,9 +52,33 @@ impl Stage2State {
         serde_json::to_vec(self).expect("Stage2State is plain data and always serializes")
     }
 
+    /// Encode a conservative merge-carried fallback. The additive ownership field is omitted from
+    /// ordinary rows, preserving their existing on-disk bytes.
+    pub(crate) fn encode_transferred_fallback(&self) -> Vec<u8> {
+        serde_json::to_vec(&PersistedStage2State {
+            in_cohort: self.in_cohort,
+            last_evaluated_at_ms: self.last_evaluated_at_ms,
+            ownership: Stage2Ownership::TransferredFallback,
+        })
+        .expect("PersistedStage2State is plain data and always serializes")
+    }
+
     /// Garbage bytes and missing fields both yield an [`Err`], never a panic.
     pub fn decode(bytes: &[u8]) -> Result<Self, Stage2CodecError> {
-        Ok(serde_json::from_slice(bytes)?)
+        Ok(Self::decode_with_ownership(bytes)?.0)
+    }
+
+    pub(crate) fn decode_with_ownership(
+        bytes: &[u8],
+    ) -> Result<(Self, Stage2Ownership), Stage2CodecError> {
+        let persisted: PersistedStage2State = serde_json::from_slice(bytes)?;
+        Ok((
+            Self {
+                in_cohort: persisted.in_cohort,
+                last_evaluated_at_ms: persisted.last_evaluated_at_ms,
+            },
+            persisted.ownership,
+        ))
     }
 }
 
@@ -62,6 +112,29 @@ mod tests {
                 in_cohort: true,
                 last_evaluated_at_ms: 1_700_000_000_123,
             },
+        );
+    }
+
+    #[test]
+    fn transferred_fallback_is_additive_and_decodes_through_the_normal_codec() {
+        let state = Stage2State {
+            in_cohort: false,
+            last_evaluated_at_ms: 1_700_000_000_123,
+        };
+        let bytes = state.encode_transferred_fallback();
+
+        assert_eq!(Stage2State::decode(&bytes).unwrap(), state);
+        assert_eq!(
+            Stage2State::decode_with_ownership(&bytes).unwrap(),
+            (state, Stage2Ownership::TransferredFallback),
+        );
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+            serde_json::json!({
+                "in_cohort": false,
+                "last_evaluated_at_ms": 1_700_000_000_123_i64,
+                "ownership": "transferred_fallback",
+            }),
         );
     }
 

--- a/rust/cohort-stream-processor/src/store/handle.rs
+++ b/rust/cohort-stream-processor/src/store/handle.rs
@@ -26,9 +26,13 @@ use metrics::{gauge, histogram};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinError;
 
-use super::keys::{PendingTransferKey, Stage2Key, TombstoneKey};
+use super::keys::{
+    PendingTransferKey, Stage2CohortPrefix, Stage2DirtyKey, Stage2Key, TombstoneKey,
+};
 use super::keyspace::{BehavioralKey, PersonPrefix, PersonRecordKey};
-use super::rocks::{CohortStore, EventSnapshotRaw, StoreError, StoreStats};
+use super::rocks::{
+    CohortStore, EventSnapshotRaw, Stage2DirtyTrackingGuard, StoreError, StoreStats,
+};
 use super::staged::StagedBatch;
 use crate::observability::metrics::{
     STORE_OFFLOAD_EXEC_DURATION_SECONDS, STORE_OFFLOAD_INFLIGHT,
@@ -337,6 +341,38 @@ impl StoreHandle {
             store.multi_get_stage2(&keys)
         })
         .await
+    }
+
+    /// Scan one bounded page of a partition/team/cohort `cf_stage2` slice on the maintenance lane.
+    pub async fn scan_stage2_cohort(
+        &self,
+        prefix: Stage2CohortPrefix,
+        start_after: Option<Vec<u8>>,
+        limit: usize,
+    ) -> Result<Vec<Stage2Key>, StoreError> {
+        self.read("scan_stage2_cohort", ReadLane::Maintenance, move |store| {
+            store.scan_stage2_cohort(prefix, start_after.as_deref(), limit)
+        })
+        .await
+    }
+
+    /// Scan one bounded page of a cohort's dirty-person markers on the maintenance lane.
+    pub async fn scan_stage2_dirty(
+        &self,
+        prefix: Stage2CohortPrefix,
+        start_after: Option<Vec<u8>>,
+        limit: usize,
+    ) -> Result<Vec<Stage2DirtyKey>, StoreError> {
+        self.read("scan_stage2_dirty", ReadLane::Maintenance, move |store| {
+            store.scan_stage2_dirty(prefix, start_after.as_deref(), limit)
+        })
+        .await
+    }
+
+    /// Start process-local dirty capture for one queued reconcile job. The returned lease owns the
+    /// registration and disables it on drop.
+    pub fn track_stage2_dirty(&self, prefix: Stage2CohortPrefix) -> Stage2DirtyTrackingGuard {
+        self.store.track_stage2_dirty(prefix)
     }
 
     /// Point-read one redirect tombstone.

--- a/rust/cohort-stream-processor/src/store/keys.rs
+++ b/rust/cohort-stream-processor/src/store/keys.rs
@@ -11,6 +11,19 @@ use super::rocks::StoreError;
 
 /// `[partition_id u16][team_id u64][cohort_id u64][person_id 16]`.
 pub const STAGE2_KEY_LEN: usize = 2 + 8 + 8 + 16;
+/// `[partition_id u16][team_id u64][cohort_id u64]`.
+pub const STAGE2_COHORT_PREFIX_LEN: usize = 2 + 8 + 8;
+/// `[partition_id u16][0xFF; 32][dirty discriminant][team_id u64][cohort_id u64]`.
+pub const STAGE2_DIRTY_COHORT_PREFIX_LEN: usize = STAGE2_KEY_LEN + 1 + 8 + 8;
+/// `[dirty cohort prefix][person_id 16]`.
+pub const STAGE2_DIRTY_KEY_LEN: usize = STAGE2_DIRTY_COHORT_PREFIX_LEN + 16;
+const STAGE2_DIRTY_DISCRIMINANT: u8 = 1;
+/// `[partition_id u16][0xFF; 32][transferred-register discriminant][team_id u64][person_id 16]`.
+pub const STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN: usize = STAGE2_KEY_LEN + 1 + 8 + 16;
+/// `[transferred-register person prefix][cohort_id u64]`.
+pub const STAGE2_TRANSFERRED_REGISTER_KEY_LEN: usize =
+    STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN + 8;
+const STAGE2_TRANSFERRED_REGISTER_DISCRIMINANT: u8 = 2;
 /// `[partition_id u16][team_id u64][old_person 16][merge_msg_partition u32][merge_msg_offset u64]`.
 pub const MERGE_DRAIN_KEY_LEN: usize = 2 + 8 + 16 + 4 + 8;
 /// `[partition_id u16][team_id u64][old_person 16]`.
@@ -26,6 +39,43 @@ pub struct Stage2Key {
     pub partition_id: u16,
     pub team_id: u64,
     pub cohort_id: u64,
+    pub person_id: Uuid,
+}
+
+/// Prefix selecting one cohort's membership rows in one partition.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Stage2CohortPrefix {
+    pub partition_id: u16,
+    pub team_id: u64,
+    pub cohort_id: u64,
+}
+
+/// Coalescing mutation marker for one Stage 2 person row.
+///
+/// Dirty keys sort after every valid [`Stage2Key`] in their partition. Their namespace starts with
+/// the partition's maximum 34-byte Stage 2 row, followed by a discriminant below `0xFF`; this keeps
+/// them inside the partition range without colliding with a row, including in partition `u16::MAX`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Stage2DirtyKey(Stage2Key);
+
+/// Prefix selecting one cohort's dirty-person markers.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Stage2DirtyPrefix(Stage2CohortPrefix);
+
+/// Catalog-independent inventory for a register received through the merge protocol.
+///
+/// The primary Stage 2 layout is cohort-first, so a merge drain cannot enumerate one person's rows
+/// when its local catalog has not learned the cohort yet. This person-first metadata key closes that
+/// gap. Its value carries the source transfer kind and bit plus the exact primary bytes they
+/// describe; the primary row remains the receiver's current materialized membership state.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Stage2TransferredRegisterKey(Stage2Key);
+
+/// Prefix selecting one person's transferred-register inventory entries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Stage2TransferredRegisterPersonPrefix {
+    pub partition_id: u16,
+    pub team_id: u64,
     pub person_id: Uuid,
 }
 
@@ -88,6 +138,229 @@ impl Stage2Key {
             cohort_id: u64::from_be_bytes(array8(&bytes[10..18])),
             person_id: Uuid::from_bytes(array16(&bytes[18..34])),
         })
+    }
+
+    pub fn cohort_prefix(&self) -> Stage2CohortPrefix {
+        Stage2CohortPrefix {
+            partition_id: self.partition_id,
+            team_id: self.team_id,
+            cohort_id: self.cohort_id,
+        }
+    }
+}
+
+impl Stage2CohortPrefix {
+    pub fn encode(&self) -> [u8; STAGE2_COHORT_PREFIX_LEN] {
+        let mut out = [0u8; STAGE2_COHORT_PREFIX_LEN];
+        out[0..2].copy_from_slice(&self.partition_id.to_be_bytes());
+        out[2..10].copy_from_slice(&self.team_id.to_be_bytes());
+        out[10..18].copy_from_slice(&self.cohort_id.to_be_bytes());
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, StoreError> {
+        check_len(bytes, STAGE2_COHORT_PREFIX_LEN, "stage2 cohort prefix")?;
+        Ok(Self {
+            partition_id: u16::from_be_bytes(array2(&bytes[0..2])),
+            team_id: u64::from_be_bytes(array8(&bytes[2..10])),
+            cohort_id: u64::from_be_bytes(array8(&bytes[10..18])),
+        })
+    }
+
+    /// Half-open byte range containing the matching [`Stage2Key`] values.
+    pub fn range(&self) -> (Vec<u8>, Vec<u8>) {
+        let start = self.encode().to_vec();
+        let mut end = start.clone();
+        for byte in end.iter_mut().rev() {
+            if let Some(next) = byte.checked_add(1) {
+                *byte = next;
+                return (start, end);
+            }
+            *byte = 0;
+        }
+
+        // The maximum valid Stage2 key is 34 bytes of 0xFF, so the same bytes plus one remain a
+        // strict exclusive upper bound when the 18-byte prefix itself has no successor.
+        (start, vec![0xFF; STAGE2_KEY_LEN + 1])
+    }
+
+    pub const fn dirty_prefix(self) -> Stage2DirtyPrefix {
+        Stage2DirtyPrefix(self)
+    }
+}
+
+impl Stage2DirtyKey {
+    pub const fn new(key: Stage2Key) -> Self {
+        Self(key)
+    }
+
+    pub const fn stage2_key(self) -> Stage2Key {
+        self.0
+    }
+
+    pub fn encode(self) -> [u8; STAGE2_DIRTY_KEY_LEN] {
+        let mut out = [0u8; STAGE2_DIRTY_KEY_LEN];
+        out[0..2].copy_from_slice(&self.0.partition_id.to_be_bytes());
+        out[2..STAGE2_KEY_LEN].fill(0xFF);
+        out[STAGE2_KEY_LEN] = STAGE2_DIRTY_DISCRIMINANT;
+        out[(STAGE2_KEY_LEN + 1)..(STAGE2_KEY_LEN + 9)]
+            .copy_from_slice(&self.0.team_id.to_be_bytes());
+        out[(STAGE2_KEY_LEN + 9)..STAGE2_DIRTY_COHORT_PREFIX_LEN]
+            .copy_from_slice(&self.0.cohort_id.to_be_bytes());
+        out[STAGE2_DIRTY_COHORT_PREFIX_LEN..].copy_from_slice(self.0.person_id.as_bytes());
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, StoreError> {
+        check_len(bytes, STAGE2_DIRTY_KEY_LEN, "stage2 dirty")?;
+        if bytes[2..STAGE2_KEY_LEN].iter().any(|byte| *byte != 0xFF)
+            || bytes[STAGE2_KEY_LEN] != STAGE2_DIRTY_DISCRIMINANT
+        {
+            return Err(StoreError::UnknownKey {
+                kind: "stage2 dirty",
+            });
+        }
+        Ok(Self(Stage2Key {
+            partition_id: u16::from_be_bytes(array2(&bytes[0..2])),
+            team_id: u64::from_be_bytes(array8(&bytes[(STAGE2_KEY_LEN + 1)..(STAGE2_KEY_LEN + 9)])),
+            cohort_id: u64::from_be_bytes(array8(
+                &bytes[(STAGE2_KEY_LEN + 9)..STAGE2_DIRTY_COHORT_PREFIX_LEN],
+            )),
+            person_id: Uuid::from_bytes(array16(&bytes[STAGE2_DIRTY_COHORT_PREFIX_LEN..])),
+        }))
+    }
+}
+
+impl Stage2DirtyPrefix {
+    pub fn encode(self) -> [u8; STAGE2_DIRTY_COHORT_PREFIX_LEN] {
+        let key = Stage2Key {
+            partition_id: self.0.partition_id,
+            team_id: self.0.team_id,
+            cohort_id: self.0.cohort_id,
+            person_id: Uuid::nil(),
+        };
+        let encoded = Stage2DirtyKey::new(key).encode();
+        let mut out = [0u8; STAGE2_DIRTY_COHORT_PREFIX_LEN];
+        out.copy_from_slice(&encoded[..STAGE2_DIRTY_COHORT_PREFIX_LEN]);
+        out
+    }
+
+    pub fn range(self) -> (Vec<u8>, Vec<u8>) {
+        let start = self.encode().to_vec();
+        let mut end = start.clone();
+        for byte in end.iter_mut().rev() {
+            if let Some(next) = byte.checked_add(1) {
+                *byte = next;
+                return (start, end);
+            }
+            *byte = 0;
+        }
+        unreachable!("the dirty discriminant has a lexicographic successor")
+    }
+}
+
+impl From<Stage2Key> for Stage2DirtyKey {
+    fn from(value: Stage2Key) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Stage2TransferredRegisterKey {
+    pub const fn new(key: Stage2Key) -> Self {
+        Self(key)
+    }
+
+    pub const fn stage2_key(self) -> Stage2Key {
+        self.0
+    }
+
+    pub fn encode(self) -> [u8; STAGE2_TRANSFERRED_REGISTER_KEY_LEN] {
+        let mut out = [0u8; STAGE2_TRANSFERRED_REGISTER_KEY_LEN];
+        out[0..2].copy_from_slice(&self.0.partition_id.to_be_bytes());
+        out[2..STAGE2_KEY_LEN].fill(0xFF);
+        out[STAGE2_KEY_LEN] = STAGE2_TRANSFERRED_REGISTER_DISCRIMINANT;
+        out[(STAGE2_KEY_LEN + 1)..(STAGE2_KEY_LEN + 9)]
+            .copy_from_slice(&self.0.team_id.to_be_bytes());
+        out[(STAGE2_KEY_LEN + 9)..STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN]
+            .copy_from_slice(self.0.person_id.as_bytes());
+        out[STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN..]
+            .copy_from_slice(&self.0.cohort_id.to_be_bytes());
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, StoreError> {
+        check_len(
+            bytes,
+            STAGE2_TRANSFERRED_REGISTER_KEY_LEN,
+            "stage2 transferred register",
+        )?;
+        if bytes[2..STAGE2_KEY_LEN].iter().any(|byte| *byte != 0xFF)
+            || bytes[STAGE2_KEY_LEN] != STAGE2_TRANSFERRED_REGISTER_DISCRIMINANT
+        {
+            return Err(StoreError::UnknownKey {
+                kind: "stage2 transferred register",
+            });
+        }
+        Ok(Self(Stage2Key {
+            partition_id: u16::from_be_bytes(array2(&bytes[0..2])),
+            team_id: u64::from_be_bytes(array8(&bytes[(STAGE2_KEY_LEN + 1)..(STAGE2_KEY_LEN + 9)])),
+            cohort_id: u64::from_be_bytes(array8(
+                &bytes[STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN..],
+            )),
+            person_id: Uuid::from_bytes(array16(
+                &bytes[(STAGE2_KEY_LEN + 9)..STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN],
+            )),
+        }))
+    }
+
+    pub const fn person_prefix(self) -> Stage2TransferredRegisterPersonPrefix {
+        Stage2TransferredRegisterPersonPrefix {
+            partition_id: self.0.partition_id,
+            team_id: self.0.team_id,
+            person_id: self.0.person_id,
+        }
+    }
+}
+
+impl Stage2TransferredRegisterPersonPrefix {
+    pub const fn new(partition_id: u16, team_id: u64, person_id: Uuid) -> Self {
+        Self {
+            partition_id,
+            team_id,
+            person_id,
+        }
+    }
+
+    pub fn encode(self) -> [u8; STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN] {
+        let key = Stage2Key {
+            partition_id: self.partition_id,
+            team_id: self.team_id,
+            cohort_id: 0,
+            person_id: self.person_id,
+        };
+        let encoded = Stage2TransferredRegisterKey::new(key).encode();
+        let mut out = [0u8; STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN];
+        out.copy_from_slice(&encoded[..STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN]);
+        out
+    }
+
+    pub fn range(self) -> (Vec<u8>, Vec<u8>) {
+        let start = self.encode().to_vec();
+        let mut end = start.clone();
+        for byte in end.iter_mut().rev() {
+            if let Some(next) = byte.checked_add(1) {
+                *byte = next;
+                return (start, end);
+            }
+            *byte = 0;
+        }
+        unreachable!("the transferred-register discriminant has a lexicographic successor")
+    }
+}
+
+impl From<Stage2Key> for Stage2TransferredRegisterKey {
+    fn from(value: Stage2Key) -> Self {
+        Self::new(value)
     }
 }
 
@@ -224,6 +497,8 @@ fn array16(s: &[u8]) -> [u8; 16] {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
     use crate::stage1::key::LeafStateKey;
     use crate::store::keyspace::BehavioralKey;
@@ -250,6 +525,42 @@ mod tests {
             34,
         );
         assert_eq!(STAGE2_KEY_LEN, 34);
+        assert_eq!(
+            Stage2CohortPrefix {
+                partition_id: 1,
+                team_id: 2,
+                cohort_id: 3,
+            }
+            .encode()
+            .len(),
+            18,
+        );
+        assert_eq!(STAGE2_COHORT_PREFIX_LEN, 18);
+        assert_eq!(
+            Stage2DirtyKey::new(Stage2Key {
+                partition_id: 1,
+                team_id: 2,
+                cohort_id: 3,
+                person_id: person(4),
+            })
+            .encode()
+            .len(),
+            STAGE2_DIRTY_KEY_LEN,
+        );
+        assert_eq!(STAGE2_DIRTY_KEY_LEN, 67);
+        assert_eq!(STAGE2_TRANSFERRED_REGISTER_PERSON_PREFIX_LEN, 59);
+        assert_eq!(
+            Stage2TransferredRegisterKey::new(Stage2Key {
+                partition_id: 1,
+                team_id: 2,
+                cohort_id: 3,
+                person_id: person(4),
+            })
+            .encode()
+            .len(),
+            STAGE2_TRANSFERRED_REGISTER_KEY_LEN,
+        );
+        assert_eq!(STAGE2_TRANSFERRED_REGISTER_KEY_LEN, 67);
     }
 
     #[test]
@@ -276,6 +587,280 @@ mod tests {
                 }
             ),
             "unexpected error: {err:?}",
+        );
+    }
+
+    #[test]
+    fn stage2_dirty_key_round_trips_without_colliding_with_a_person_row() {
+        let row = Stage2Key {
+            partition_id: 7,
+            team_id: 42,
+            cohort_id: 99,
+            person_id: person(123),
+        };
+        let dirty = Stage2DirtyKey::new(row);
+        let encoded = dirty.encode();
+        assert_eq!(Stage2DirtyKey::decode(&encoded).unwrap(), dirty);
+        assert!(Stage2Key::decode(&encoded).is_err());
+
+        let mut wrong_discriminant = encoded;
+        wrong_discriminant[STAGE2_KEY_LEN] = 2;
+        assert!(Stage2DirtyKey::decode(&wrong_discriminant).is_err());
+    }
+
+    #[test]
+    fn stage2_dirty_namespace_sorts_after_rows_and_inside_its_partition() {
+        for partition_id in [0, 7, u16::MAX] {
+            let row = Stage2Key {
+                partition_id,
+                team_id: u64::MAX,
+                cohort_id: u64::MAX,
+                person_id: person(u128::MAX),
+            };
+            let dirty = Stage2DirtyKey::new(row).encode();
+            assert!(row.encode().as_slice() < dirty.as_slice());
+            let (partition_start, partition_end) = partition_range(partition_id);
+            assert!(partition_start.as_slice() <= dirty.as_slice());
+            assert!(dirty.as_slice() < partition_end.as_slice());
+        }
+    }
+
+    #[test]
+    fn transferred_register_key_round_trips_and_groups_by_person() {
+        let row = Stage2Key {
+            partition_id: 7,
+            team_id: 42,
+            cohort_id: 99,
+            person_id: person(123),
+        };
+        let inventory = Stage2TransferredRegisterKey::new(row);
+        assert_eq!(
+            Stage2TransferredRegisterKey::decode(&inventory.encode()).unwrap(),
+            inventory,
+        );
+        assert_eq!(inventory.stage2_key(), row);
+        assert_eq!(
+            inventory.person_prefix(),
+            Stage2TransferredRegisterPersonPrefix::new(7, 42, person(123)),
+        );
+        assert!(Stage2Key::decode(&inventory.encode()).is_err());
+        assert!(Stage2DirtyKey::decode(&inventory.encode()).is_err());
+    }
+
+    #[test]
+    fn transferred_register_namespace_sorts_after_dirty_and_inside_partition() {
+        for partition_id in [0, 7, u16::MAX] {
+            let row = Stage2Key {
+                partition_id,
+                team_id: u64::MAX,
+                cohort_id: u64::MAX,
+                person_id: person(u128::MAX),
+            };
+            let dirty = Stage2DirtyKey::new(row).encode();
+            let inventory = Stage2TransferredRegisterKey::new(row).encode();
+            assert!(row.encode().as_slice() < dirty.as_slice());
+            assert!(dirty.as_slice() < inventory.as_slice());
+            let (partition_start, partition_end) = partition_range(partition_id);
+            assert!(partition_start.as_slice() <= inventory.as_slice());
+            assert!(inventory.as_slice() < partition_end.as_slice());
+        }
+    }
+
+    #[test]
+    fn transferred_register_person_prefix_selects_all_and_only_that_person() {
+        let prefix = Stage2TransferredRegisterPersonPrefix::new(7, 42, person(9));
+        let (start, end) = prefix.range();
+        for cohort_id in [0, 1, u64::MAX] {
+            let encoded = Stage2TransferredRegisterKey::new(Stage2Key {
+                partition_id: 7,
+                team_id: 42,
+                cohort_id,
+                person_id: person(9),
+            })
+            .encode();
+            assert!(start.as_slice() <= encoded.as_slice());
+            assert!(encoded.as_slice() < end.as_slice());
+        }
+        for foreign in [
+            Stage2Key {
+                partition_id: 8,
+                team_id: 42,
+                cohort_id: 1,
+                person_id: person(9),
+            },
+            Stage2Key {
+                partition_id: 7,
+                team_id: 43,
+                cohort_id: 1,
+                person_id: person(9),
+            },
+            Stage2Key {
+                partition_id: 7,
+                team_id: 42,
+                cohort_id: 1,
+                person_id: person(10),
+            },
+        ] {
+            let encoded = Stage2TransferredRegisterKey::new(foreign).encode();
+            assert!(encoded.as_slice() < start.as_slice() || encoded.as_slice() >= end.as_slice());
+        }
+    }
+
+    #[test]
+    fn stage2_dirty_prefix_selects_exactly_one_cohort() {
+        let prefix = Stage2CohortPrefix {
+            partition_id: 7,
+            team_id: 42,
+            cohort_id: 99,
+        }
+        .dirty_prefix();
+        let (start, end) = prefix.range();
+        for person_id in [0, 1, u128::MAX] {
+            let encoded = Stage2DirtyKey::new(Stage2Key {
+                partition_id: 7,
+                team_id: 42,
+                cohort_id: 99,
+                person_id: person(person_id),
+            })
+            .encode();
+            assert!(start.as_slice() <= encoded.as_slice());
+            assert!(encoded.as_slice() < end.as_slice());
+        }
+        for foreign in [
+            Stage2Key {
+                partition_id: 8,
+                team_id: 42,
+                cohort_id: 99,
+                person_id: person(1),
+            },
+            Stage2Key {
+                partition_id: 7,
+                team_id: 43,
+                cohort_id: 99,
+                person_id: person(1),
+            },
+            Stage2Key {
+                partition_id: 7,
+                team_id: 42,
+                cohort_id: 100,
+                person_id: person(1),
+            },
+        ] {
+            let encoded = Stage2DirtyKey::new(foreign).encode();
+            assert!(encoded.as_slice() < start.as_slice() || encoded.as_slice() >= end.as_slice());
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn stage2_cohort_prefix_range_contains_exactly_matching_keys(
+            partition_id in any::<u16>(),
+            team_id in any::<u64>(),
+            cohort_id in any::<u64>(),
+            person_id in any::<u128>(),
+            foreign_axis in 0u8..3,
+        ) {
+            let prefix = Stage2CohortPrefix {
+                partition_id,
+                team_id,
+                cohort_id,
+            };
+            let (start, end) = prefix.range();
+            let matching = Stage2Key {
+                partition_id,
+                team_id,
+                cohort_id,
+                person_id: person(person_id),
+            }
+            .encode();
+            prop_assert!(start.as_slice() <= matching.as_slice());
+            prop_assert!(matching.as_slice() < end.as_slice());
+
+            let (foreign_partition, foreign_team, foreign_cohort) = match foreign_axis {
+                0 => (partition_id.wrapping_add(1), team_id, cohort_id),
+                1 => (partition_id, team_id.wrapping_add(1), cohort_id),
+                _ => (partition_id, team_id, cohort_id.wrapping_add(1)),
+            };
+            let foreign = Stage2Key {
+                partition_id: foreign_partition,
+                team_id: foreign_team,
+                cohort_id: foreign_cohort,
+                person_id: person(person_id),
+            }
+            .encode();
+            prop_assert!(
+                foreign.as_slice() < start.as_slice() || foreign.as_slice() >= end.as_slice()
+            );
+        }
+    }
+
+    #[test]
+    fn stage2_cohort_prefix_range_carries_and_bounds_the_all_ones_key() {
+        for (prefix, expected_end) in [
+            (
+                Stage2CohortPrefix {
+                    partition_id: 1,
+                    team_id: 2,
+                    cohort_id: 3,
+                },
+                Stage2CohortPrefix {
+                    partition_id: 1,
+                    team_id: 2,
+                    cohort_id: 4,
+                }
+                .encode()
+                .to_vec(),
+            ),
+            (
+                Stage2CohortPrefix {
+                    partition_id: 1,
+                    team_id: 2,
+                    cohort_id: u64::MAX,
+                },
+                Stage2CohortPrefix {
+                    partition_id: 1,
+                    team_id: 3,
+                    cohort_id: 0,
+                }
+                .encode()
+                .to_vec(),
+            ),
+            (
+                Stage2CohortPrefix {
+                    partition_id: 1,
+                    team_id: u64::MAX,
+                    cohort_id: u64::MAX,
+                },
+                Stage2CohortPrefix {
+                    partition_id: 2,
+                    team_id: 0,
+                    cohort_id: 0,
+                }
+                .encode()
+                .to_vec(),
+            ),
+        ] {
+            assert_eq!(prefix.range().1, expected_end);
+        }
+
+        let max_prefix = Stage2CohortPrefix {
+            partition_id: u16::MAX,
+            team_id: u64::MAX,
+            cohort_id: u64::MAX,
+        };
+        let (start, end) = max_prefix.range();
+        assert_eq!(start, vec![0xFF; STAGE2_COHORT_PREFIX_LEN]);
+        assert_eq!(end, vec![0xFF; STAGE2_KEY_LEN + 1]);
+        assert!(
+            Stage2Key {
+                partition_id: u16::MAX,
+                team_id: u64::MAX,
+                cohort_id: u64::MAX,
+                person_id: person(u128::MAX),
+            }
+            .encode()
+            .as_slice()
+                < end.as_slice(),
         );
     }
 

--- a/rust/cohort-stream-processor/src/store/mod.rs
+++ b/rust/cohort-stream-processor/src/store/mod.rs
@@ -14,14 +14,18 @@ pub use column_families::{
     CF_META, CF_PENDING_TRANSFERS, CF_PERSON_RECORDS, CF_STAGE2,
 };
 pub use handle::{OffloadConfig, OffloadMode, ReadLane, StoreHandle};
-pub use keys::{MergeAppliedKey, MergeDrainKey, PendingTransferKey, Stage2Key, TombstoneKey};
+pub use keys::{
+    MergeAppliedKey, MergeDrainKey, PendingTransferKey, Stage2CohortPrefix, Stage2DirtyKey,
+    Stage2DirtyPrefix, Stage2Key, Stage2TransferredRegisterKey,
+    Stage2TransferredRegisterPersonPrefix, TombstoneKey,
+};
 pub use keyspace::{
     Behavioral, BehavioralKey, Keyspace, Meta, MetaKey, PersonPrefix, PersonRecordKey,
     PersonRecords,
 };
 pub use rocks::{
-    BatchBuilder, CfStats, CohortStore, EventSnapshotRaw, StoreConfig, StoreError, StoreStats,
-    STORE_SCHEMA_VERSION,
+    BatchBuilder, CfStats, CohortStore, EventSnapshotRaw, Stage2DirtyTrackingGuard, StoreConfig,
+    StoreError, StoreStats, STORE_SCHEMA_VERSION,
 };
 pub use staged::StagedBatch;
 

--- a/rust/cohort-stream-processor/src/store/rocks.rs
+++ b/rust/cohort-stream-processor/src/store/rocks.rs
@@ -6,8 +6,10 @@
 #![allow(clippy::disallowed_methods)]
 
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use metrics::{counter, histogram};
@@ -22,16 +24,18 @@ use tracing::warn;
 
 use super::column_families::{self, Cf, OpaqueCf};
 use super::keys::{
-    self, MergeAppliedKey, MergeDrainKey, PendingTransferKey, Stage2Key, TombstoneKey,
+    self, MergeAppliedKey, MergeDrainKey, PendingTransferKey, Stage2CohortPrefix, Stage2DirtyKey,
+    Stage2Key, Stage2TransferredRegisterKey, Stage2TransferredRegisterPersonPrefix, TombstoneKey,
 };
 use super::keyspace::{
     BehavioralKey, Keyspace, Meta, PersonPrefix, PersonRecordKey, META_SCHEMA_VERSION,
 };
 use super::staged::{StagedBatch, StagedOp};
 use crate::observability::metrics::{
-    CHECKPOINT_DURATION_SECONDS, STORE_ERRORS_TOTAL, STORE_READS_TOTAL,
-    STORE_READ_DURATION_SECONDS, STORE_SCHEMA_MISMATCH_WIPES_TOTAL, STORE_WRITE_BATCH_TOTAL,
-    STORE_WRITE_DURATION_SECONDS, WAL_FSYNC_DURATION_SECONDS, WAL_FSYNC_ERRORS_TOTAL,
+    CHECKPOINT_DURATION_SECONDS, STAGE2_SCAN_UNDECODABLE_KEYS_TOTAL, STORE_ERRORS_TOTAL,
+    STORE_READS_TOTAL, STORE_READ_DURATION_SECONDS, STORE_SCHEMA_MISMATCH_WIPES_TOTAL,
+    STORE_WRITE_BATCH_TOTAL, STORE_WRITE_DURATION_SECONDS, WAL_FSYNC_DURATION_SECONDS,
+    WAL_FSYNC_ERRORS_TOTAL,
 };
 
 /// On-disk store schema version, stamped into `cf_meta` at first open and checked on every reopen.
@@ -156,6 +160,13 @@ pub enum StoreError {
         actual: usize,
     },
 
+    #[error("decoding {kind} value: expected {expected} bytes, got {actual}")]
+    ValueDecode {
+        kind: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+
     /// A key of the right length that matches none of the keyspace's known literals (closed-set
     /// keyspaces like `cf_meta`). Distinct from [`Self::KeyDecode`], which reports a length mismatch.
     #[error("unknown {kind} key: matches no known literal")]
@@ -174,6 +185,74 @@ pub enum StoreError {
 /// One scanned key/value pair as raw bytes — the merge-CF GC decodes each per CF.
 pub type RawKv = (Vec<u8>, Vec<u8>);
 
+#[derive(Debug, Default)]
+struct Stage2DirtyTracking {
+    active: RwLock<HashMap<Stage2CohortPrefix, usize>>,
+    active_count: AtomicUsize,
+}
+
+impl Stage2DirtyTracking {
+    fn acquire(self: &Arc<Self>, prefix: Stage2CohortPrefix) -> Stage2DirtyTrackingGuard {
+        let mut active = self
+            .active
+            .write()
+            .expect("Stage 2 dirty-tracking lock is not held across fallible work");
+        *active.entry(prefix).or_default() += 1;
+        self.active_count.fetch_add(1, Ordering::Release);
+        Stage2DirtyTrackingGuard {
+            tracking: self.clone(),
+            prefix,
+        }
+    }
+
+    fn is_active(&self, prefix: Stage2CohortPrefix) -> bool {
+        if self.active_count.load(Ordering::Acquire) == 0 {
+            return false;
+        }
+        self.active
+            .read()
+            .expect("Stage 2 dirty-tracking lock is not held across fallible work")
+            .contains_key(&prefix)
+    }
+
+    fn release(&self, prefix: Stage2CohortPrefix) {
+        let mut active = self
+            .active
+            .write()
+            .expect("Stage 2 dirty-tracking lock is not held across fallible work");
+        let remove = {
+            let count = active
+                .get_mut(&prefix)
+                .expect("every dirty-tracking guard owns one active reference");
+            *count -= 1;
+            *count == 0
+        };
+        if remove {
+            active.remove(&prefix);
+        }
+        let previous = self.active_count.fetch_sub(1, Ordering::Release);
+        debug_assert!(previous > 0, "dirty-tracking reference count underflow");
+    }
+}
+
+/// In-memory lease enabling per-person dirty capture for one active reconcile cohort.
+///
+/// The lease is owned by the queued job. Dropping the job on completion, supersession, rebalance,
+/// or shutdown disables future capture. Already-written markers are safe for GC to reclaim because
+/// a replayed job starts from a full cohort scan.
+#[must_use]
+#[derive(Debug)]
+pub struct Stage2DirtyTrackingGuard {
+    tracking: Arc<Stage2DirtyTracking>,
+    prefix: Stage2CohortPrefix,
+}
+
+impl Drop for Stage2DirtyTrackingGuard {
+    fn drop(&mut self) {
+        self.tracking.release(self.prefix);
+    }
+}
+
 /// Handle to the per-process state store.
 ///
 /// Writes have two layers. The closure-based [`Self::write_batch`] is for synchronous callers that
@@ -190,6 +269,7 @@ pub struct CohortStore {
     db_opts: Arc<Options>,
     /// See [`StoreConfig::read_sample_ratio`]; `>= 1`.
     read_sample_ratio: u32,
+    dirty_tracking: Arc<Stage2DirtyTracking>,
 }
 
 impl CohortStore {
@@ -264,6 +344,7 @@ impl CohortStore {
             db_opts: Arc::new(db_opts.clone()),
             // Floor at 1: `next % ratio` must not divide by zero.
             read_sample_ratio: config.read_sample_ratio.max(1),
+            dirty_tracking: Arc::new(Stage2DirtyTracking::default()),
         })
     }
 
@@ -433,6 +514,58 @@ impl CohortStore {
         self.get(Cf::Stage2, &key.encode())
     }
 
+    /// Enable coalescing dirty-person capture for one active reconcile cohort until the returned
+    /// lease is dropped. This is process-local by design: a crash replays the held reconcile tile
+    /// and starts a fresh full scan, so correctness never depends on preserving an inactive marker.
+    pub fn track_stage2_dirty(&self, prefix: Stage2CohortPrefix) -> Stage2DirtyTrackingGuard {
+        self.dirty_tracking.acquire(prefix)
+    }
+
+    /// Whether this process currently owns a reconcile scan for `prefix`.
+    ///
+    /// Stage 2 GC uses this to distinguish live dirty work from metadata left by a completed,
+    /// discarded, or rebalanced job. Partition-worker serialization prevents a lease transition
+    /// from racing the corresponding GC tick.
+    pub(crate) fn is_stage2_dirty_tracking_active(&self, prefix: Stage2CohortPrefix) -> bool {
+        self.dirty_tracking.is_active(prefix)
+    }
+
+    pub fn get_stage2_transferred_register(
+        &self,
+        key: &Stage2TransferredRegisterKey,
+    ) -> Result<Option<Vec<u8>>, StoreError> {
+        self.get(Cf::Stage2, &key.encode())
+    }
+
+    /// Batch-read transferred-register inventory values, preserving input order.
+    pub fn multi_get_stage2_transferred_registers(
+        &self,
+        keys: &[Stage2TransferredRegisterKey],
+    ) -> Result<Vec<Option<Vec<u8>>>, StoreError> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let handle = self.cf(Cf::Stage2)?;
+        let encoded: Vec<_> = keys.iter().map(|key| key.encode()).collect();
+        let started = Instant::now();
+        let results = self
+            .db
+            .multi_get_cf(encoded.iter().map(|key| (handle, key.as_slice())));
+        record_multi_get(started, keys.len());
+        results
+            .into_iter()
+            .map(|result| {
+                result.map_err(|source| {
+                    counter!(STORE_ERRORS_TOTAL, "op" => OP_MULTI_GET).increment(1);
+                    StoreError::Backend {
+                        op: OP_MULTI_GET,
+                        source,
+                    }
+                })
+            })
+            .collect()
+    }
+
     /// Batch-read several `cf_stage2` values in one call, preserving input order.
     pub fn multi_get_stage2(&self, keys: &[Stage2Key]) -> Result<Vec<Option<Vec<u8>>>, StoreError> {
         // An empty batch is not a read: skip it so it records no phantom read-latency sample.
@@ -460,6 +593,148 @@ impl CohortStore {
             .collect()
     }
 
+    /// Scan up to `limit` keys in one partition/team/cohort slice of `cf_stage2`, in person order,
+    /// resuming strictly after `start_after` when it decodes as a key in that slice.
+    ///
+    /// Corrupt keys are counted and skipped. The scan continues until it collects `limit` valid
+    /// keys or exhausts the prefix, so a short result proves there are no later decodable rows.
+    pub fn scan_stage2_cohort(
+        &self,
+        prefix: Stage2CohortPrefix,
+        start_after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<Vec<Stage2Key>, StoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let (prefix_start, prefix_end) = prefix.range();
+        let begin = match start_after {
+            Some(cursor)
+                if cursor >= prefix_start.as_slice()
+                    && cursor < prefix_end.as_slice()
+                    && Stage2Key::decode(cursor).is_ok() =>
+            {
+                successor(cursor)
+            }
+            _ => prefix_start,
+        };
+        let handle = self.cf(Cf::Stage2)?;
+
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_iterate_upper_bound(prefix_end);
+        let iter = self.db.iterator_cf_opt(
+            handle,
+            read_opts,
+            IteratorMode::From(&begin, Direction::Forward),
+        );
+        let mut out = Vec::with_capacity(limit.min(1024));
+        for item in iter {
+            if out.len() == limit {
+                break;
+            }
+            let (key_bytes, _value) = item.map_err(|source| {
+                counter!(STORE_ERRORS_TOTAL, "op" => OP_SCAN).increment(1);
+                StoreError::Backend {
+                    op: OP_SCAN,
+                    source,
+                }
+            })?;
+            if Stage2DirtyKey::decode(&key_bytes).is_ok()
+                || Stage2TransferredRegisterKey::decode(&key_bytes).is_ok()
+            {
+                // Metadata is the partition tail, so no Stage 2 row can follow it. This is reachable
+                // only for the all-ones row prefix; ordinary cohort ranges end earlier.
+                break;
+            }
+            match Stage2Key::decode(&key_bytes) {
+                Ok(key) => out.push(key),
+                Err(_) => counter!(STAGE2_SCAN_UNDECODABLE_KEYS_TOTAL).increment(1),
+            }
+        }
+        Ok(out)
+    }
+
+    /// Scan up to `limit` dirty-person markers for one Stage 2 cohort, resuming strictly after a
+    /// marker in that same prefix. A malformed key inside the reserved namespace is an error: the
+    /// reconciler must stop rather than mistake corruption for an empty dirty set.
+    pub fn scan_stage2_dirty(
+        &self,
+        prefix: Stage2CohortPrefix,
+        start_after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<Vec<Stage2DirtyKey>, StoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let dirty_prefix = prefix.dirty_prefix();
+        let (prefix_start, prefix_end) = dirty_prefix.range();
+        let begin = match start_after {
+            Some(cursor)
+                if cursor >= prefix_start.as_slice()
+                    && cursor < prefix_end.as_slice()
+                    && Stage2DirtyKey::decode(cursor).is_ok() =>
+            {
+                successor(cursor)
+            }
+            _ => prefix_start,
+        };
+        let handle = self.cf(Cf::Stage2)?;
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_iterate_upper_bound(prefix_end);
+        let iter = self.db.iterator_cf_opt(
+            handle,
+            read_opts,
+            IteratorMode::From(&begin, Direction::Forward),
+        );
+
+        let mut out = Vec::with_capacity(limit.min(1024));
+        for item in iter.take(limit) {
+            let (key_bytes, _value) = item.map_err(|source| {
+                counter!(STORE_ERRORS_TOTAL, "op" => OP_SCAN).increment(1);
+                StoreError::Backend {
+                    op: OP_SCAN,
+                    source,
+                }
+            })?;
+            out.push(Stage2DirtyKey::decode(&key_bytes)?);
+        }
+        Ok(out)
+    }
+
+    /// Scan the catalog-independent transferred-register inventory for one person.
+    pub fn scan_stage2_transferred_registers(
+        &self,
+        prefix: Stage2TransferredRegisterPersonPrefix,
+    ) -> Result<Vec<(Stage2TransferredRegisterKey, Vec<u8>)>, StoreError> {
+        let (prefix_start, prefix_end) = prefix.range();
+        let handle = self.cf(Cf::Stage2)?;
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_iterate_upper_bound(prefix_end);
+        let iter = self.db.iterator_cf_opt(
+            handle,
+            read_opts,
+            IteratorMode::From(&prefix_start, Direction::Forward),
+        );
+
+        let mut out = Vec::new();
+        for item in iter {
+            let (key_bytes, value) = item.map_err(|source| {
+                counter!(STORE_ERRORS_TOTAL, "op" => OP_SCAN).increment(1);
+                StoreError::Backend {
+                    op: OP_SCAN,
+                    source,
+                }
+            })?;
+            out.push((
+                Stage2TransferredRegisterKey::decode(&key_bytes)?,
+                value.to_vec(),
+            ));
+        }
+        Ok(out)
+    }
+
     /// Apply writes across CFs in one atomic `WriteBatch`.
     pub fn write_batch<F>(&self, build: F) -> Result<(), StoreError>
     where
@@ -475,6 +750,7 @@ impl CohortStore {
             merge_applied: self.cf(Cf::MergeApplied)?,
             merge_tombstones: self.cf(Cf::MergeTombstones)?,
             meta: self.cf(Cf::Meta)?,
+            dirty_tracking: &self.dirty_tracking,
         };
         build(&mut builder);
         self.commit(builder.batch, OP_WRITE_BATCH)
@@ -491,13 +767,32 @@ impl CohortStore {
             match op {
                 StagedOp::Put { cf, key, value } => {
                     batch.put_cf(self.cf(*cf)?, key, value);
+                    self.mark_staged_stage2_dirty(&mut batch, *cf, key);
                 }
                 StagedOp::Delete { cf, key } => {
                     batch.delete_cf(self.cf(*cf)?, key);
+                    self.mark_staged_stage2_dirty(&mut batch, *cf, key);
                 }
             }
         }
         self.commit(batch, OP_WRITE_BATCH)
+    }
+
+    fn mark_staged_stage2_dirty(&self, batch: &mut WriteBatch, cf: Cf, encoded_key: &[u8]) {
+        if !matches!(cf, Cf::Stage2) {
+            return;
+        }
+        let Ok(key) = Stage2Key::decode(encoded_key) else {
+            return;
+        };
+        if self.dirty_tracking.is_active(key.cohort_prefix()) {
+            batch.put_cf(
+                self.cf(Cf::Stage2)
+                    .expect("the Stage 2 CF was opened before applying a batch"),
+                Stage2DirtyKey::new(key).encode(),
+                [],
+            );
+        }
     }
 
     pub fn get_merge_drain_applied(
@@ -906,6 +1201,7 @@ pub struct BatchBuilder<'db> {
     merge_applied: &'db ColumnFamily,
     merge_tombstones: &'db ColumnFamily,
     meta: &'db ColumnFamily,
+    dirty_tracking: &'db Stage2DirtyTracking,
 }
 
 impl<'db> BatchBuilder<'db> {
@@ -947,9 +1243,29 @@ impl<'db> BatchBuilder<'db> {
 
     pub fn put_stage2(&mut self, key: &Stage2Key, value: &[u8]) {
         self.batch.put_cf(self.stage2, key.encode(), value);
+        self.mark_stage2_dirty(key);
     }
 
     pub fn delete_stage2(&mut self, key: &Stage2Key) {
+        self.batch.delete_cf(self.stage2, key.encode());
+        self.mark_stage2_dirty(key);
+    }
+
+    /// Clear a reconcile dirty marker without creating another marker.
+    pub fn delete_stage2_dirty(&mut self, key: &Stage2DirtyKey) {
+        self.batch.delete_cf(self.stage2, key.encode());
+    }
+
+    /// Preserve a merge-carried register independently of the receiver's current catalog.
+    pub fn put_stage2_transferred_register(
+        &mut self,
+        key: &Stage2TransferredRegisterKey,
+        value: &[u8],
+    ) {
+        self.batch.put_cf(self.stage2, key.encode(), value);
+    }
+
+    pub fn delete_stage2_transferred_register(&mut self, key: &Stage2TransferredRegisterKey) {
         self.batch.delete_cf(self.stage2, key.encode());
     }
 
@@ -1000,6 +1316,18 @@ impl<'db> BatchBuilder<'db> {
     /// Raw put by pre-encoded key bytes. Restricted to [`OpaqueCf`].
     pub fn put_raw(&mut self, cf: OpaqueCf, key: &[u8], value: &[u8]) {
         self.batch.put_cf(self.handle(cf.cf()), key, value);
+        if matches!(cf, OpaqueCf::Stage2) {
+            if let Ok(key) = Stage2Key::decode(key) {
+                self.mark_stage2_dirty(&key);
+            }
+        }
+    }
+
+    fn mark_stage2_dirty(&mut self, key: &Stage2Key) {
+        if self.dirty_tracking.is_active(key.cohort_prefix()) {
+            self.batch
+                .put_cf(self.stage2, Stage2DirtyKey::new(*key).encode(), []);
+        }
     }
 }
 
@@ -1426,6 +1754,333 @@ mod tests {
         assert!(
             store.multi_get_stage2(&[]).unwrap().is_empty(),
             "an empty key set reads no values",
+        );
+    }
+
+    #[test]
+    fn stage2_mutations_atomically_coalesce_one_dirty_marker_per_person() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let key = |person_id: u128, cohort_id: u64| Stage2Key {
+            partition_id: 3,
+            team_id: 7,
+            cohort_id,
+            person_id: Uuid::from_u128(person_id),
+        };
+        let watched = key(1, 100);
+        let prefix = watched.cohort_prefix();
+        let _tracking = store.track_stage2_dirty(prefix);
+        assert!(store
+            .scan_stage2_dirty(prefix, None, 10)
+            .unwrap()
+            .is_empty());
+
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(&watched, b"member");
+                batch.put_stage2(&watched, b"member-again");
+                batch.put_stage2(&key(2, 100), b"second person");
+                batch.put_stage2(&key(1, 101), b"other cohort");
+            })
+            .unwrap();
+        assert_eq!(
+            store
+                .scan_stage2_dirty(prefix, None, 10)
+                .unwrap()
+                .into_iter()
+                .map(Stage2DirtyKey::stage2_key)
+                .collect::<Vec<_>>(),
+            vec![watched, key(2, 100)],
+            "repeated writes coalesce and another cohort stays outside the prefix",
+        );
+
+        let mut staged = StagedBatch::default();
+        staged.delete_stage2(&watched);
+        store.apply(&staged).unwrap();
+        assert!(store.get_stage2(&watched).unwrap().is_none());
+        assert_eq!(
+            store.scan_stage2_dirty(prefix, None, 10).unwrap().len(),
+            2,
+            "a delete retains the coalesced marker even though the row is gone",
+        );
+
+        store
+            .write_batch(|batch| {
+                batch.delete_stage2_dirty(&Stage2DirtyKey::new(watched));
+                batch.delete_stage2_dirty(&Stage2DirtyKey::new(key(2, 100)));
+            })
+            .unwrap();
+        assert!(store
+            .scan_stage2_dirty(prefix, None, 10)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn stage2_dirty_capture_is_scoped_to_the_tracking_lease() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let key = Stage2Key {
+            partition_id: 3,
+            team_id: 7,
+            cohort_id: 100,
+            person_id: Uuid::from_u128(1),
+        };
+        let prefix = key.cohort_prefix();
+
+        store
+            .write_batch(|batch| batch.put_stage2(&key, b"before"))
+            .unwrap();
+        assert!(store
+            .scan_stage2_dirty(prefix, None, 10)
+            .unwrap()
+            .is_empty());
+
+        let tracking = store.track_stage2_dirty(prefix);
+        let mut staged = StagedBatch::default();
+        staged.put_stage2(&key, b"during");
+        store.apply(&staged).unwrap();
+        assert_eq!(store.scan_stage2_dirty(prefix, None, 10).unwrap().len(), 1);
+        store
+            .write_batch(|batch| batch.delete_stage2_dirty(&Stage2DirtyKey::new(key)))
+            .unwrap();
+        drop(tracking);
+
+        store
+            .write_batch(|batch| batch.put_stage2(&key, b"after"))
+            .unwrap();
+        assert!(
+            store
+                .scan_stage2_dirty(prefix, None, 10)
+                .unwrap()
+                .is_empty(),
+            "idle Stage 2 writes do not accumulate permanent dirty metadata",
+        );
+    }
+
+    #[test]
+    fn scan_stage2_dirty_is_bounded_and_resumable() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let key = |person_id: u128| Stage2Key {
+            partition_id: 3,
+            team_id: 7,
+            cohort_id: 100,
+            person_id: Uuid::from_u128(person_id),
+        };
+        let prefix = key(1).cohort_prefix();
+        let _tracking = store.track_stage2_dirty(prefix);
+        store
+            .write_batch(|batch| {
+                for person_id in 1..=4 {
+                    batch.put_stage2(&key(person_id), b"member");
+                }
+            })
+            .unwrap();
+
+        let first = store.scan_stage2_dirty(prefix, None, 2).unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|dirty| dirty.stage2_key().person_id)
+                .collect::<Vec<_>>(),
+            vec![Uuid::from_u128(1), Uuid::from_u128(2)],
+        );
+        let cursor = first.last().unwrap().encode();
+        let second = store.scan_stage2_dirty(prefix, Some(&cursor), 2).unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|dirty| dirty.stage2_key().person_id)
+                .collect::<Vec<_>>(),
+            vec![Uuid::from_u128(3), Uuid::from_u128(4)],
+        );
+        let cursor = second.last().unwrap().encode();
+        assert!(store
+            .scan_stage2_dirty(prefix, Some(&cursor), 2)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn transferred_register_inventory_scans_one_person_in_cohort_order() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("transferred-register-scan"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let person_id = Uuid::from_u128(7);
+        let prefix = Stage2TransferredRegisterPersonPrefix::new(3, 7, person_id);
+        store
+            .write_batch(|batch| {
+                for cohort_id in [9, 2, 5] {
+                    batch.put_stage2_transferred_register(
+                        &Stage2TransferredRegisterKey::new(Stage2Key {
+                            partition_id: 3,
+                            team_id: 7,
+                            cohort_id,
+                            person_id,
+                        }),
+                        &[cohort_id as u8],
+                    );
+                }
+                batch.put_stage2_transferred_register(
+                    &Stage2TransferredRegisterKey::new(Stage2Key {
+                        partition_id: 3,
+                        team_id: 7,
+                        cohort_id: 1,
+                        person_id: Uuid::from_u128(8),
+                    }),
+                    b"foreign",
+                );
+            })
+            .unwrap();
+
+        let rows = store.scan_stage2_transferred_registers(prefix).unwrap();
+        assert_eq!(
+            rows.iter()
+                .map(|(key, value)| (key.stage2_key().cohort_id, value.clone()))
+                .collect::<Vec<_>>(),
+            vec![(2, vec![2]), (5, vec![5]), (9, vec![9])],
+        );
+    }
+
+    #[test]
+    fn scan_stage2_cohort_is_bounded_resumable_and_skips_corrupt_keys() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let prefix = Stage2CohortPrefix {
+            partition_id: 3,
+            team_id: 7,
+            cohort_id: 100,
+        };
+        let key = |partition_id: u16, team_id: u64, cohort_id: u64, person: u128| Stage2Key {
+            partition_id,
+            team_id,
+            cohort_id,
+            person_id: Uuid::from_u128(person),
+        };
+
+        store
+            .write_batch(|batch| {
+                for person in 1..=4 {
+                    batch.put_stage2(&key(3, 7, 100, person), b"member");
+                }
+                batch.put_stage2(&key(3, 7, 101, 1), b"other-cohort");
+                batch.put_stage2(&key(3, 8, 100, 1), b"other-team");
+                batch.put_stage2(&key(4, 7, 100, 1), b"other-partition");
+            })
+            .unwrap();
+
+        // This malformed key is inside the prefix range and sorts before person 1. It must not
+        // consume the valid-key page limit or make the scan fail.
+        let mut malformed = prefix.encode().to_vec();
+        malformed.extend_from_slice(&[0; 15]);
+        store
+            .db
+            .put_cf(store.cf(Cf::Stage2).unwrap(), malformed, b"corrupt-prefix")
+            .unwrap();
+        let mut malformed_tail = prefix.encode().to_vec();
+        malformed_tail.extend_from_slice(Uuid::from_u128(5).as_bytes());
+        malformed_tail.push(0);
+        store
+            .db
+            .put_cf(
+                store.cf(Cf::Stage2).unwrap(),
+                &malformed_tail,
+                b"corrupt-tail",
+            )
+            .unwrap();
+
+        let first = store.scan_stage2_cohort(prefix, None, 2).unwrap();
+        assert_eq!(
+            first.iter().map(|key| key.person_id).collect::<Vec<_>>(),
+            vec![Uuid::from_u128(1), Uuid::from_u128(2)],
+        );
+
+        let cursor = first.last().unwrap().encode().to_vec();
+        let second = store.scan_stage2_cohort(prefix, Some(&cursor), 2).unwrap();
+        assert_eq!(
+            second.iter().map(|key| key.person_id).collect::<Vec<_>>(),
+            vec![Uuid::from_u128(3), Uuid::from_u128(4)],
+        );
+
+        let last = second.last().unwrap().encode().to_vec();
+        assert!(
+            store
+                .scan_stage2_cohort(prefix, Some(&last), 10)
+                .unwrap()
+                .is_empty(),
+            "the cohort prefix is exhausted after person 4",
+        );
+
+        assert_eq!(
+            store
+                .scan_stage2_cohort(prefix, Some(&malformed_tail), 10)
+                .unwrap()
+                .len(),
+            4,
+            "an in-prefix cursor must decode before it can skip rows",
+        );
+
+        let foreign_cursor = key(3, 7, 101, 1).encode();
+        assert_eq!(
+            store
+                .scan_stage2_cohort(prefix, Some(&foreign_cursor), 10)
+                .unwrap()
+                .len(),
+            4,
+            "an out-of-prefix cursor starts a fresh scan",
+        );
+        assert!(store
+            .scan_stage2_cohort(prefix, None, 0)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn scan_stage2_cohort_includes_the_all_ones_key() {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let prefix = Stage2CohortPrefix {
+            partition_id: u16::MAX,
+            team_id: u64::MAX,
+            cohort_id: u64::MAX,
+        };
+        let key = Stage2Key {
+            partition_id: u16::MAX,
+            team_id: u64::MAX,
+            cohort_id: u64::MAX,
+            person_id: Uuid::from_u128(u128::MAX),
+        };
+        store
+            .write_batch(|batch| batch.put_stage2(&key, b"max"))
+            .unwrap();
+
+        assert_eq!(
+            store.scan_stage2_cohort(prefix, None, 1).unwrap(),
+            vec![key]
         );
     }
 

--- a/rust/cohort-stream-processor/src/store/staged.rs
+++ b/rust/cohort-stream-processor/src/store/staged.rs
@@ -11,7 +11,10 @@
 //! that sequence built through `BatchBuilder` and committed through `write_batch`.
 
 use super::column_families::{Cf, OpaqueCf};
-use super::keys::{MergeAppliedKey, MergeDrainKey, PendingTransferKey, Stage2Key, TombstoneKey};
+use super::keys::{
+    MergeAppliedKey, MergeDrainKey, PendingTransferKey, Stage2DirtyKey, Stage2Key,
+    Stage2TransferredRegisterKey, TombstoneKey,
+};
 use super::keyspace::Keyspace;
 
 /// One staged RocksDB operation with owned bytes, so the batch is `Send + 'static`.
@@ -79,6 +82,33 @@ impl StagedBatch {
     }
 
     pub fn delete_stage2(&mut self, key: &Stage2Key) {
+        self.ops.push(StagedOp::Delete {
+            cf: Cf::Stage2,
+            key: key.encode().to_vec(),
+        });
+    }
+
+    /// Clear a reconcile dirty marker without creating another marker.
+    pub fn delete_stage2_dirty(&mut self, key: &Stage2DirtyKey) {
+        self.ops.push(StagedOp::Delete {
+            cf: Cf::Stage2,
+            key: key.encode().to_vec(),
+        });
+    }
+
+    pub fn put_stage2_transferred_register(
+        &mut self,
+        key: &Stage2TransferredRegisterKey,
+        value: &[u8],
+    ) {
+        self.ops.push(StagedOp::Put {
+            cf: Cf::Stage2,
+            key: key.encode().to_vec(),
+            value: value.to_vec(),
+        });
+    }
+
+    pub fn delete_stage2_transferred_register(&mut self, key: &Stage2TransferredRegisterKey) {
         self.ops.push(StagedOp::Delete {
             cf: Cf::Stage2,
             key: key.encode().to_vec(),
@@ -176,6 +206,7 @@ mod tests {
     use crate::stage1::key::LeafStateKey;
     use crate::store::keyspace::{Behavioral, BehavioralKey};
     use crate::store::rocks::{BatchBuilder, CohortStore, StoreConfig};
+    use crate::store::Stage2DirtyKey;
 
     const PARTITION: u16 = 3;
     const TEAM: u64 = 7;
@@ -253,6 +284,13 @@ mod tests {
         b.put_stage2(&stage2_key(1, 100), b"s2-put");
         b.put_stage2(&stage2_key(2, 200), b"s2-doomed");
         b.delete_stage2(&stage2_key(2, 200));
+        b.put_stage2_transferred_register(
+            &Stage2TransferredRegisterKey::new(stage2_key(1, 100)),
+            b"kind",
+        );
+        b.delete_stage2_transferred_register(&Stage2TransferredRegisterKey::new(stage2_key(
+            2, 200,
+        )));
 
         b.put_merge_drain_applied(&merge_drain_key(1), b"drain-put");
         b.delete_merge_drain_applied(&merge_drain_key(2));
@@ -283,6 +321,13 @@ mod tests {
         s.put_stage2(&stage2_key(1, 100), b"s2-put");
         s.put_stage2(&stage2_key(2, 200), b"s2-doomed");
         s.delete_stage2(&stage2_key(2, 200));
+        s.put_stage2_transferred_register(
+            &Stage2TransferredRegisterKey::new(stage2_key(1, 100)),
+            b"kind",
+        );
+        s.delete_stage2_transferred_register(&Stage2TransferredRegisterKey::new(stage2_key(
+            2, 200,
+        )));
 
         s.put_merge_drain_applied(&merge_drain_key(1), b"drain-put");
         s.delete_merge_drain_applied(&merge_drain_key(2));
@@ -309,13 +354,15 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let via_builder = open_store(&dir, "builder");
         let via_staged = open_store(&dir, "staged");
+        let _builder_tracking = via_builder.track_stage2_dirty(stage2_key(1, 100).cohort_prefix());
+        let _staged_tracking = via_staged.track_stage2_dirty(stage2_key(1, 100).cohort_prefix());
 
         via_builder.write_batch(drive_batch_builder).unwrap();
 
         let mut staged = StagedBatch::default();
         drive_staged_batch(&mut staged);
         assert!(!staged.is_empty());
-        assert_eq!(staged.len(), 16);
+        assert_eq!(staged.len(), 18);
         via_staged.apply(&staged).unwrap();
 
         // `scan_merge_cf` is CF-generic and all keys carry the partition prefix, so it enumerates any
@@ -348,6 +395,13 @@ mod tests {
             via_staged.get_behavioral(&behavioral_key(2, 0xA1)).unwrap(),
             None,
         );
+        assert!(via_staged
+            .get(
+                Cf::Stage2,
+                &Stage2DirtyKey::new(stage2_key(1, 100)).encode()
+            )
+            .unwrap()
+            .is_some());
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/sweep/mod.rs
+++ b/rust/cohort-stream-processor/src/sweep/mod.rs
@@ -11,8 +11,10 @@
 
 pub mod dispatch;
 pub mod eviction_queue;
+pub mod reconcile;
 pub mod scheduler;
 
 pub use dispatch::DispatchSweeper;
 pub use eviction_queue::EvictionQueue;
+pub use reconcile::ReconcileDrainSweeper;
 pub use scheduler::{due_before_ms, run_sweep_loop, run_sweep_loop_delayed, Sweeper};

--- a/rust/cohort-stream-processor/src/sweep/reconcile.rs
+++ b/rust/cohort-stream-processor/src/sweep/reconcile.rs
@@ -1,0 +1,113 @@
+//! Periodic bounded-progress ticks for admitted reconcile snapshots.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::consumers::events::EventDispatcher;
+use crate::sweep::Sweeper;
+use crate::workers::ReconcileBacklog;
+
+/// Routes one reconcile page to each active partition only while this pod owns queued work.
+pub struct ReconcileDrainSweeper {
+    dispatcher: Arc<EventDispatcher>,
+    backlog: Arc<ReconcileBacklog>,
+}
+
+impl ReconcileDrainSweeper {
+    pub fn new(dispatcher: Arc<EventDispatcher>, backlog: Arc<ReconcileBacklog>) -> Self {
+        Self {
+            dispatcher,
+            backlog,
+        }
+    }
+
+    fn has_work(&self) -> bool {
+        !self.backlog.is_empty()
+    }
+}
+
+#[async_trait]
+impl Sweeper for ReconcileDrainSweeper {
+    async fn run_once(&self) {
+        if !self.has_work() {
+            return;
+        }
+        // B6's live-lag pause belongs here, before fan-out, so admitted jobs keep their deferred
+        // offsets while maintenance reads are paused without waking every partition worker.
+        self.dispatcher.route_reconcile_drain().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use cohort_core::filters::{CohortId, TeamId};
+    use cohort_core::seed::{BehavioralShapeHash, ReconcileTile, RunId};
+
+    use crate::filters::{CatalogHandle, FilterCatalog};
+    use crate::partitions::{OffsetTracker, PartitionRouter};
+    use crate::producer::{CaptureSink, MembershipSink};
+    use crate::store::{CohortStore, OffloadConfig, OffloadMode, StoreConfig, StoreHandle};
+    use crate::workers::reconcile::ReconcileQueue;
+    use crate::workers::MergeWorkerDeps;
+
+    use super::*;
+
+    fn dispatcher() -> (TempDir, Arc<EventDispatcher>, StoreHandle) {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        let handle = StoreHandle::new(
+            store,
+            OffloadConfig {
+                mode: OffloadMode::All,
+                event_read_permits: 16,
+                maintenance_permits: 6,
+            },
+        );
+        let catalog = Arc::new(CatalogHandle::from_catalog(FilterCatalog::from_teams([])));
+        let sink: Arc<dyn MembershipSink> = Arc::new(CaptureSink::new());
+        let dispatcher = EventDispatcher::new(
+            PartitionRouter::new(64),
+            Arc::new(OffsetTracker::new()),
+            handle.clone(),
+            catalog,
+            sink,
+            MergeWorkerDeps::capture(),
+        );
+        (dir, Arc::new(dispatcher), handle)
+    }
+
+    #[tokio::test]
+    async fn idle_short_circuit_arms_only_while_a_job_is_owned() {
+        let (_dir, dispatcher, handle) = dispatcher();
+        let backlog = Arc::new(ReconcileBacklog::default());
+        let sweeper = ReconcileDrainSweeper::new(dispatcher, backlog.clone());
+        assert!(!sweeper.has_work());
+        sweeper.run_once().await;
+
+        let tracker = OffsetTracker::new();
+        tracker.mark_dispatched(0, 6);
+        let mut queue = ReconcileQueue::new(0, backlog, handle);
+        queue.enqueue(
+            ReconcileTile::new(
+                TeamId(7),
+                CohortId(1),
+                BehavioralShapeHash::parse("shape-v1").unwrap(),
+                RunId(Uuid::nil()),
+            ),
+            tracker.defer(0, 5),
+        );
+
+        assert!(sweeper.has_work());
+        sweeper.run_once().await;
+        drop(queue);
+        assert!(!sweeper.has_work());
+    }
+}

--- a/rust/cohort-stream-processor/src/sweep/scheduler.rs
+++ b/rust/cohort-stream-processor/src/sweep/scheduler.rs
@@ -36,8 +36,9 @@ pub fn due_before_ms(now_ms: i64, safety_margin_ms: i64) -> i64 {
 /// Drive the periodic sweep until `cancel` fires, invoking `sweeper.run_once()` once per tick and
 /// recording [`SWEEP_CYCLES_TOTAL`] + [`SWEEP_CYCLE_DURATION_SECONDS`], both labelled by `loop_name`.
 ///
-/// `loop_name` (`eviction`|`redrive`|`merge_gc`|`checkpoint`|`store_stats`) labels the cycle metrics
-/// so the concurrent loops — same timer machinery, different cadences — stay distinguishable.
+/// `loop_name` (`eviction`|`redrive`|`merge_gc`|`reconcile`|`checkpoint`|`store_stats`) labels the
+/// cycle metrics so the concurrent loops — same timer machinery, different cadences — stay
+/// distinguishable.
 ///
 /// - **`MissedTickBehavior::Skip`**: if a sweep runs long or the task is starved, the timer drops the
 ///   ticks it slept through rather than firing a catch-up burst — one sweep then resumes on the

--- a/rust/cohort-stream-processor/src/workers/cascade_path.rs
+++ b/rust/cohort-stream-processor/src/workers/cascade_path.rs
@@ -129,6 +129,15 @@ pub(crate) async fn handle_cascade(
                 return;
             }
         };
+        if diff.requires_write() {
+            writes.push((
+                diff.stage2_key,
+                Stage2State {
+                    in_cohort: diff.new_bit,
+                    last_evaluated_at_ms: evaluated_at_ms,
+                },
+            ));
+        }
         if !diff.flipped() {
             continue;
         }
@@ -142,13 +151,6 @@ pub(crate) async fn handle_cascade(
             origin: None,
             run_id: None,
         });
-        writes.push((
-            diff.stage2_key,
-            Stage2State {
-                in_cohort: diff.new_bit,
-                last_evaluated_at_ms: evaluated_at_ms,
-            },
-        ));
         // The external flip above is unconditional; only the onward hop is depth/cycle bounded.
         match should_emit(
             message,
@@ -180,31 +182,33 @@ pub(crate) async fn handle_cascade(
         }
     }
 
-    if changes.is_empty() {
+    if changes.is_empty() && writes.is_empty() {
         mark_processed(&merge.cascade_tracker, partition_id, offset);
         return;
     }
 
-    // Produce-before-state: both legs must ack before the bits commit (see the module doc).
-    let membership_errors = produce_membership(sink, changes).await;
-    if membership_errors > 0 {
-        warn!(
-            partition_id,
-            errors = membership_errors,
-            "cascade membership produce failed; holding the cascade offset for redelivery",
-        );
-        hold(&merge.cascade_tracker, partition_id, offset);
-        return;
-    }
-    let cascade_errors = produce_cascades(merge, outgoing).await;
-    if cascade_errors > 0 {
-        warn!(
-            partition_id,
-            errors = cascade_errors,
-            "cascade onward produce failed; holding the cascade offset for redelivery",
-        );
-        hold(&merge.cascade_tracker, partition_id, offset);
-        return;
+    if !changes.is_empty() {
+        // Produce-before-state: both legs must ack before flipped bits commit (see the module doc).
+        let membership_errors = produce_membership(sink, changes).await;
+        if membership_errors > 0 {
+            warn!(
+                partition_id,
+                errors = membership_errors,
+                "cascade membership produce failed; holding the cascade offset for redelivery",
+            );
+            hold(&merge.cascade_tracker, partition_id, offset);
+            return;
+        }
+        let cascade_errors = produce_cascades(merge, outgoing).await;
+        if cascade_errors > 0 {
+            warn!(
+                partition_id,
+                errors = cascade_errors,
+                "cascade onward produce failed; holding the cascade offset for redelivery",
+            );
+            hold(&merge.cascade_tracker, partition_id, offset);
+            return;
+        }
     }
 
     let mut staged = StagedBatch::default();
@@ -272,6 +276,7 @@ mod tests {
     use crate::stage1::key::LeafStateKey;
     use crate::stage1::person_record::{MatchedSet, PersonRecord};
     use crate::stage1::state::{AppliedOffsets, Stage1State, StatefulRecord};
+    use crate::stage2::state::Stage2Ownership;
     use crate::store::{
         Behavioral, BehavioralKey, CohortStore, OffloadConfig, OffloadMode, PersonRecordKey,
         PersonRecords, StoreConfig,
@@ -441,6 +446,7 @@ mod tests {
             seed_tile_sink: Arc::new(crate::producer::CaptureSeedTileSink::new()),
             seed_tracker: Arc::new(crate::partitions::offset_tracker::OffsetTracker::new()),
             live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+            reconcile: crate::workers::ReconcileDeps::default(),
         };
         // The cascade was dispatched this tenure, so its ceiling is raised — mirrors the dispatcher.
         deps.cascade_tracker
@@ -562,6 +568,70 @@ mod tests {
         assert!(membership.changes().is_empty(), "no flip, no membership");
         assert!(cascade.messages().is_empty(), "no flip, no onward cascade");
         assert_eq!(committed(&deps), Some(OFFSET + 1), "still advances");
+    }
+
+    #[tokio::test]
+    async fn cascade_noop_claims_a_transferred_fallback_without_emitting() {
+        let (_dir, store) = temp_store();
+        let catalog = catalog(
+            vec![
+                (2, vec![behavioral_leaf()]),
+                (1, vec![person_leaf(), cohort_ref(2)]),
+            ],
+            true,
+        );
+        let alice = person(1);
+        write_behavioral(&store, behavioral_lsk(&catalog), alice, behavioral_match());
+        write_person_record(&store, alice, &[PERSON_HASH]);
+        let key = Stage2Key {
+            partition_id: PARTITION,
+            team_id: TEAM as u64,
+            cohort_id: 1,
+            person_id: alice,
+        };
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(
+                    &key,
+                    &Stage2State {
+                        in_cohort: true,
+                        last_evaluated_at_ms: 0,
+                    }
+                    .encode_transferred_fallback(),
+                );
+            })
+            .unwrap();
+
+        let membership = CaptureSink::new();
+        let cascade = CaptureCascadeSink::new();
+        let (sink, deps) = deps(&membership, &cascade, true, 1000);
+        let msg = first_cascade(incoming(2, alice, 1, vec![2]).change, 99);
+
+        handle_cascade(
+            PARTITION,
+            &handle(&store),
+            &catalog,
+            &sink,
+            &deps,
+            TS,
+            &msg,
+            OFFSET,
+        )
+        .await;
+
+        let bytes = store.get_stage2(&key).unwrap().unwrap();
+        let (state, ownership) = Stage2State::decode_with_ownership(&bytes).unwrap();
+        assert!(state.in_cohort);
+        assert_eq!(ownership, Stage2Ownership::Local);
+        assert!(
+            membership.changes().is_empty(),
+            "ownership settlement is not a flip"
+        );
+        assert!(
+            cascade.messages().is_empty(),
+            "ownership settlement does not cascade"
+        );
+        assert_eq!(committed(&deps), Some(OFFSET + 1));
     }
 
     #[tokio::test]

--- a/rust/cohort-stream-processor/src/workers/event_path.rs
+++ b/rust/cohort-stream-processor/src/workers/event_path.rs
@@ -45,6 +45,7 @@ use crate::stage1::state::{
 };
 use crate::stage1::time::clickhouse_timestamp_to_millis;
 use crate::stage1::transition::{LeafTransition, TransitionKind};
+use crate::stage2::single_leaf_transition_register_writes;
 use crate::store::{
     Behavioral, BehavioralKey, CohortStore, EventSnapshotRaw, PersonPrefix, PersonRecords,
     StagedBatch, StoreError, StoreHandle,
@@ -537,6 +538,16 @@ pub(crate) fn fold_event(
     if let Some(bytes) = record_put {
         write_stats.record_size = Some(bytes.len());
         staged.put::<PersonRecords>(&prefix.record_key(), &bytes);
+    }
+    for transition in &transitions {
+        for write in single_leaf_transition_register_writes(
+            filters,
+            prefix.partition_id,
+            transition,
+            event_ms,
+        ) {
+            staged.put_stage2(&write.key, &write.state.encode());
+        }
     }
 
     FoldResult::Folded(FoldOutput {

--- a/rust/cohort-stream-processor/src/workers/merge_path.rs
+++ b/rust/cohort-stream-processor/src/workers/merge_path.rs
@@ -16,7 +16,7 @@ use crate::filters::manager::CatalogHandle;
 use crate::filters::reverse_index::TeamFilters;
 use crate::filters::{TeamFiltersBuilder, TeamId};
 use crate::merge::apply_handler::{handle_transfer, ApplyOutcome};
-use crate::merge::drain_handler::{handle_merge_event, DrainOutcome};
+use crate::merge::drain_handler::{handle_merge_event_with_transfer_mode, DrainOutcome};
 use crate::merge::transfer::{MergeStateTransfer, PendingTransfer, PersonMergeEvent};
 use crate::observability::metrics::{
     COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH, MERGE_APPLY_DURATION_SECONDS,
@@ -39,6 +39,7 @@ use crate::workers::stage2_path::compose_stage2;
 use crate::workers::worker::{
     affected_leaves, first_cascades, produce_cascades, produce_membership, transition_metric_label,
 };
+use crate::workers::ReconcileDeps;
 
 /// Inline bounded backoff for the transfer produce.
 ///
@@ -127,6 +128,8 @@ pub struct MergeWorkerDeps {
     pub seed_tracker: Arc<OffsetTracker>,
     /// Fold-frontier watermarks the seed fence reads; the worker advances them post-mark.
     pub live_watermarks: Arc<LiveWatermarks>,
+    /// Reconcile admission and the pod-wide scheduler wake-up count.
+    pub reconcile: ReconcileDeps,
 }
 
 impl MergeWorkerDeps {
@@ -146,6 +149,7 @@ impl MergeWorkerDeps {
             seed_tile_sink: Arc::new(CaptureSeedTileSink::new()),
             seed_tracker: Arc::new(OffsetTracker::new()),
             live_watermarks: Arc::new(LiveWatermarks::new()),
+            reconcile: ReconcileDeps::default(),
         })
     }
 }
@@ -173,6 +177,7 @@ pub(crate) async fn handle_merge(
         let snapshot = snapshot.clone();
         let event_owned = event.clone();
         let partition_count = merge.partition_count;
+        let register_transfer_mode = merge.reconcile.register_transfer_mode();
         handle
             .run_section("merge_drain", move |store| {
                 let fallback: TeamFilters;
@@ -186,13 +191,14 @@ pub(crate) async fn handle_merge(
                 // Timed inside the section so the histogram keeps measuring drain execution only;
                 // permit and pool-queue waits are on `store_offload_*{op="merge_drain"}`.
                 let started = Instant::now();
-                let outcome = handle_merge_event(
+                let outcome = handle_merge_event_with_transfer_mode(
                     partition_id,
                     store,
                     filters,
                     &event_owned,
                     msg_coords,
                     partition_count,
+                    register_transfer_mode,
                 );
                 histogram!(MERGE_DRAIN_DURATION_SECONDS).record(started.elapsed().as_secs_f64());
                 outcome
@@ -252,14 +258,23 @@ pub(crate) async fn handle_merge(
         }
         Ok(DrainOutcome::Drained { transfer, effects }) => {
             effects.apply_to(queue);
-            // Nothing to apply without leaves or a person-record dedup — skip the produce. A record-only
-            // transfer still produces so P_new absorbs the ancestry (matches the drain's staging).
-            if transfer.leaves.is_empty() && transfer.person_dedup.is_none() {
+            // Nothing to apply — skip the produce. The transfer type owns this predicate so drain
+            // staging and worker settlement cannot disagree about new payload classes.
+            if !transfer.has_payload() {
                 counter!(MERGE_TRANSFERS_SKIPPED_EMPTY_TOTAL).increment(1);
                 mark_processed(&merge.merge_tracker, partition_id, offset);
                 return;
             }
             produce_and_settle(partition_id, handle, merge, &transfer, &pending_key, offset).await;
+        }
+        Ok(DrainOutcome::AwaitingRegisterTransferEnablement) => {
+            warn!(
+                partition_id,
+                team_id = event.team_id,
+                old_person = %event.old_person_uuid,
+                "cross-partition merge retained until membership-register transfer is enabled",
+            );
+            hold(&merge.merge_tracker, partition_id, offset);
         }
         Ok(DrainOutcome::AlreadyDrained) => {
             match handle.get_pending_transfer(&pending_key).await {
@@ -818,6 +833,7 @@ mod tests {
             source_partition: 0,
             source_offset: 0,
             leaves: vec![],
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,
@@ -846,6 +862,7 @@ mod tests {
             source_partition: 0,
             source_offset: 0,
             leaves: vec![],
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,
@@ -886,6 +903,7 @@ mod tests {
             seed_tile_sink: Arc::new(crate::producer::CaptureSeedTileSink::new()),
             seed_tracker: Arc::new(crate::partitions::offset_tracker::OffsetTracker::new()),
             live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+            reconcile: ReconcileDeps::default(),
         }
     }
 
@@ -908,6 +926,7 @@ mod tests {
                     AppliedOffsets::default(),
                 ),
             )],
+            membership_registers: vec![],
             forward_hops: 0,
 
             person_dedup: None,
@@ -1095,6 +1114,7 @@ mod tests {
             source_partition: 9,
             source_offset: 100,
             leaves: vec![],
+            membership_registers: vec![],
             forward_hops: 1,
 
             person_dedup: None,

--- a/rust/cohort-stream-processor/src/workers/merge_path.rs
+++ b/rust/cohort-stream-processor/src/workers/merge_path.rs
@@ -21,8 +21,9 @@ use crate::merge::transfer::{MergeStateTransfer, PendingTransfer, PersonMergeEve
 use crate::observability::metrics::{
     COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH, MERGE_APPLY_DURATION_SECONDS,
     MERGE_DRAIN_DURATION_SECONDS, MERGE_HELD_OFFSET_GAUGE, MERGE_OUTBOX_CLEAR_FAILURE_TOTAL,
-    MERGE_PENDING_TRANSFERS_GAUGE, MERGE_TRANSFERS_SKIPPED_EMPTY_TOTAL,
-    MERGE_TRANSFER_FORWARDS_TOTAL, MERGE_TRANSFER_PRODUCE_FAILURE_TOTAL, STAGE1_TRANSITIONS,
+    MERGE_PENDING_TRANSFERS_GAUGE, MERGE_TRANSFERS_HELD_AWAITING_ENABLEMENT_TOTAL,
+    MERGE_TRANSFERS_SKIPPED_EMPTY_TOTAL, MERGE_TRANSFER_FORWARDS_TOTAL,
+    MERGE_TRANSFER_PRODUCE_FAILURE_TOTAL, STAGE1_TRANSITIONS,
 };
 use crate::partitions::offset_tracker::{MarkOutcome, OffsetTracker};
 use crate::partitions::partitioner::COHORT_PARTITION_COUNT;
@@ -268,6 +269,12 @@ pub(crate) async fn handle_merge(
             produce_and_settle(partition_id, handle, merge, &transfer, &pending_key, offset).await;
         }
         Ok(DrainOutcome::AwaitingRegisterTransferEnablement) => {
+            // A cross-partition merge of a person that owns membership-register rows cannot ship its
+            // register payload until reconcile is enabled, so it sticky-holds — a visible commit-stall
+            // in place of silent register loss. Reconcile must be enabled before the merge producer
+            // (`PERSON_MERGE_EVENTS_ENABLED`), or merge consumption on this partition wedges for the
+            // tenure.
+            counter!(MERGE_TRANSFERS_HELD_AWAITING_ENABLEMENT_TOTAL).increment(1);
             warn!(
                 partition_id,
                 team_id = event.team_id,

--- a/rust/cohort-stream-processor/src/workers/mod.rs
+++ b/rust/cohort-stream-processor/src/workers/mod.rs
@@ -4,6 +4,7 @@ pub mod cascade_path;
 pub mod event_path;
 pub mod merge_gc;
 pub mod merge_path;
+pub mod reconcile;
 pub mod seed_path;
 pub mod stage2_gc;
 pub mod stage2_path;
@@ -17,6 +18,7 @@ pub use merge_gc::{handle_merge_gc, MergeGcCursor};
 pub use merge_path::{
     CascadeConfig, MergeWorkerDeps, TransferRetryPolicy, DEFAULT_MERGE_GC_SCAN_LIMIT,
 };
+pub use reconcile::{ReconcileBacklog, ReconcileDeps, DEFAULT_RECONCILE_SCAN_PAGE};
 pub use stage2_gc::{handle_stage2_orphan_gc, Stage2GcCursor};
 pub use stage2_path::compose_stage2;
 pub use worker::Stage1Worker;

--- a/rust/cohort-stream-processor/src/workers/reconcile.rs
+++ b/rust/cohort-stream-processor/src/workers/reconcile.rs
@@ -687,7 +687,6 @@ async fn settle_reconcile_page(
     source_offset: i64,
     last_updated: &str,
 ) -> Option<PageProgress> {
-    counter!(RECONCILE_ROWS_SCANNED_TOTAL).increment(page.len() as u64);
     let evaluated_at_ms = clickhouse_timestamp_to_millis(last_updated)
         .expect("worker-generated last_updated timestamps always parse");
     let mut changes = Vec::with_capacity(page.len());
@@ -769,12 +768,6 @@ async fn settle_reconcile_page(
         );
         return None;
     }
-    if entered > 0 {
-        counter!(RECONCILE_ROWS_EMITTED_TOTAL, "status" => "entered").increment(entered);
-    }
-    if left > 0 {
-        counter!(RECONCILE_ROWS_EMITTED_TOTAL, "status" => "left").increment(left);
-    }
 
     let cascade_errors = produce_cascades(merge, cascades).await;
     if cascade_errors > 0 {
@@ -810,6 +803,16 @@ async fn settle_reconcile_page(
             );
             return None;
         }
+    }
+    // Count only durably-settled pages: membership produce, cascade produce, and commit have all
+    // succeeded here. Any earlier failure returns `None` above and retries the whole page, so
+    // incrementing here keeps a retry from double-counting.
+    counter!(RECONCILE_ROWS_SCANNED_TOTAL).increment(page.len() as u64);
+    if entered > 0 {
+        counter!(RECONCILE_ROWS_EMITTED_TOTAL, "status" => "entered").increment(entered);
+    }
+    if left > 0 {
+        counter!(RECONCILE_ROWS_EMITTED_TOTAL, "status" => "left").increment(left);
     }
     if fixed_entered > 0 {
         counter!(RECONCILE_BITS_FIXED_TOTAL, "direction" => "entered").increment(fixed_entered);

--- a/rust/cohort-stream-processor/src/workers/reconcile.rs
+++ b/rust/cohort-stream-processor/src/workers/reconcile.rs
@@ -1,0 +1,1707 @@
+//! In-memory reconcile work admitted by the seed consumer.
+//!
+//! The queue belongs to one partition worker. Its deferred offsets deliberately die with the
+//! worker without completing; partition teardown then forgets the tracker tenure so Kafka replays
+//! every unfinished reconcile from the beginning.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+
+use metrics::{counter, gauge};
+use tracing::{debug, info, warn};
+
+use cohort_core::clickhouse_timestamp_to_millis;
+use cohort_core::filters::{CohortId, TeamId};
+use cohort_core::seed::ReconcileTile;
+#[cfg(test)]
+use cohort_core::seed::RunId;
+
+use crate::filters::manager::CatalogHandle;
+use crate::filters::reverse_index::TeamFilters;
+use crate::merge::drain_handler::MembershipRegisterTransferMode;
+use crate::observability::metrics::{
+    COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH, RECONCILE_BITS_FIXED_TOTAL,
+    RECONCILE_JOBS_COMPLETED_TOTAL, RECONCILE_JOBS_DISCARDED_TOTAL,
+    RECONCILE_MARKERS_EMITTED_TOTAL, RECONCILE_QUEUE_DEPTH, RECONCILE_ROWS_EMITTED_TOTAL,
+    RECONCILE_ROWS_SCANNED_TOTAL,
+};
+use crate::partitions::offset_tracker::{DeferredOffset, MarkOutcome, OffsetTracker};
+use crate::producer::{
+    ChangeOrigin, CohortMembershipChange, MembershipSink, ReconcileCompleteMarker,
+};
+use crate::stage2::Stage2State;
+use crate::store::{
+    ReadLane, Stage2CohortPrefix, Stage2DirtyKey, Stage2Key, StagedBatch, StoreHandle,
+};
+use crate::workers::merge_path::MergeWorkerDeps;
+use crate::workers::stage2_path::recompute_and_diff;
+use crate::workers::worker::{
+    count_by_status, first_cascades, produce_cascades, produce_membership,
+};
+
+/// Default number of Stage 2 rows one reconcile drain tick may scan.
+pub const DEFAULT_RECONCILE_SCAN_PAGE: usize = 256;
+
+/// Pod-wide count of admitted jobs still owned by partition queues.
+#[derive(Debug, Default)]
+pub struct ReconcileBacklog(AtomicI64);
+
+impl ReconcileBacklog {
+    pub fn len(&self) -> i64 {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn add(&self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn done(&self, count: usize) {
+        let count = i64::try_from(count).expect("an in-memory queue cannot exceed i64::MAX jobs");
+        let updated = self
+            .0
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_sub(count).filter(|next| *next >= 0)
+            });
+        debug_assert!(updated.is_ok(), "reconcile backlog ownership underflow");
+    }
+}
+
+/// Runtime dependencies shared by every partition's reconcile queue.
+#[derive(Debug, Clone)]
+pub struct ReconcileDeps {
+    pub enabled: bool,
+    pub scan_page: usize,
+    pub backlog: Arc<ReconcileBacklog>,
+}
+
+impl Default for ReconcileDeps {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            scan_page: DEFAULT_RECONCILE_SCAN_PAGE,
+            backlog: Arc::new(ReconcileBacklog::default()),
+        }
+    }
+}
+
+impl ReconcileDeps {
+    /// Register rows are written unconditionally. The reconcile gate only permits moving them
+    /// across partitions after every receiver understands the additive transfer payload.
+    pub(crate) const fn register_transfer_mode(&self) -> MembershipRegisterTransferMode {
+        MembershipRegisterTransferMode::from_reconcile_enabled(self.enabled)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ScanPhase {
+    Scanning { cursor: Option<Vec<u8>> },
+    DrainingDirty { cursor: Option<Vec<u8>> },
+    MarkerReady,
+}
+
+#[derive(Debug)]
+struct ReconcileJob {
+    tile: ReconcileTile,
+    offset: DeferredOffset,
+    dirty_tracking: Option<crate::store::Stage2DirtyTrackingGuard>,
+    phase: ScanPhase,
+    rows_scanned: u64,
+    bits_fixed: u64,
+}
+
+pub(crate) enum SupersedeOutcome {
+    NoQueuedJob,
+    Replaced(DeferredOffset),
+    RetainedNewerOrEqual,
+}
+
+/// FIFO reconcile work for one partition worker.
+pub(crate) struct ReconcileQueue {
+    jobs: VecDeque<ReconcileJob>,
+    backlog: Arc<ReconcileBacklog>,
+    partition_label: Arc<str>,
+    handle: StoreHandle,
+}
+
+impl ReconcileQueue {
+    pub(crate) fn new(
+        partition_id: u16,
+        backlog: Arc<ReconcileBacklog>,
+        handle: StoreHandle,
+    ) -> Self {
+        let queue = Self {
+            jobs: VecDeque::new(),
+            backlog,
+            partition_label: Arc::from(partition_id.to_string()),
+            handle,
+        };
+        queue.record_depth();
+        queue
+    }
+
+    pub(crate) fn enqueue(&mut self, tile: ReconcileTile, offset: DeferredOffset) {
+        self.jobs.push_back(ReconcileJob {
+            tile,
+            offset,
+            dirty_tracking: None,
+            phase: ScanPhase::Scanning { cursor: None },
+            rows_scanned: 0,
+            bits_fixed: 0,
+        });
+        self.backlog.add();
+        self.record_depth();
+    }
+
+    /// Start dirty capture only for the queue head, immediately before its first scan. Mutations
+    /// while a job waits behind another snapshot are covered by its future full scan and need no
+    /// per-person metadata.
+    fn activate_front_tracking(&mut self, prefix: Stage2CohortPrefix) {
+        if self
+            .jobs
+            .front()
+            .is_some_and(|job| job.dirty_tracking.is_none())
+        {
+            let tracking = self.handle.track_stage2_dirty(prefix);
+            self.jobs
+                .front_mut()
+                .expect("the queue head was present before acquiring its tracking lease")
+                .dirty_tracking = Some(tracking);
+        }
+    }
+
+    /// Replace a queued job only when the incoming Kafka offset is newer. A follower rewind may
+    /// replay an older job while a newer run is still queued; that replay must never evict the newer
+    /// snapshot.
+    pub(crate) fn supersede_if_newer(
+        &mut self,
+        team_id: TeamId,
+        cohort_id: CohortId,
+        incoming_offset: i64,
+    ) -> SupersedeOutcome {
+        let Some(position) = self
+            .jobs
+            .iter()
+            .position(|job| job.tile.team_id() == team_id && job.tile.cohort_id() == cohort_id)
+        else {
+            return SupersedeOutcome::NoQueuedJob;
+        };
+        if incoming_offset <= self.jobs[position].offset.offset() {
+            return SupersedeOutcome::RetainedNewerOrEqual;
+        }
+        let job = self
+            .jobs
+            .remove(position)
+            .expect("position came from the same queue");
+        self.backlog.done(1);
+        self.record_depth();
+        SupersedeOutcome::Replaced(job.offset)
+    }
+
+    fn front(&self) -> Option<&ReconcileJob> {
+        self.jobs.front()
+    }
+
+    fn front_mut(&mut self) -> Option<&mut ReconcileJob> {
+        self.jobs.front_mut()
+    }
+
+    fn finish_front(&mut self) -> Option<ReconcileJob> {
+        let job = self.jobs.pop_front()?;
+        self.backlog.done(1);
+        self.record_depth();
+        Some(job)
+    }
+
+    fn record_depth(&self) {
+        gauge!(RECONCILE_QUEUE_DEPTH, "partition" => self.partition_label.clone())
+            .set(self.jobs.len() as f64);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.jobs.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn front_run_id(&self) -> Option<RunId> {
+        self.jobs.front().map(|job| job.tile.run_id())
+    }
+}
+
+impl Drop for ReconcileQueue {
+    fn drop(&mut self) {
+        self.backlog.done(self.jobs.len());
+        gauge!(RECONCILE_QUEUE_DEPTH, "partition" => self.partition_label.clone()).set(0.0);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileRetryReason {
+    CatalogNotLoaded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileDiscardReason {
+    TeamAbsent,
+    CohortAbsent,
+    NotEmitting,
+    HashMismatch,
+    HashUnknown,
+}
+
+impl ReconcileDiscardReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::TeamAbsent => "team_absent",
+            Self::CohortAbsent => "cohort_absent",
+            Self::NotEmitting => "not_emitting",
+            Self::HashMismatch => "hash_mismatch",
+            Self::HashUnknown => "hash_unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileGuard {
+    Proceed,
+    Retry(ReconcileRetryReason),
+    Discard(ReconcileDiscardReason),
+}
+
+fn evaluate_guard(
+    catalog_loaded: bool,
+    filters: Option<&TeamFilters>,
+    tile: &ReconcileTile,
+) -> ReconcileGuard {
+    if !catalog_loaded {
+        return ReconcileGuard::Retry(ReconcileRetryReason::CatalogNotLoaded);
+    }
+    let Some(filters) = filters else {
+        return ReconcileGuard::Discard(ReconcileDiscardReason::TeamAbsent);
+    };
+    if !filters.cohorts.contains_key(&tile.cohort_id()) {
+        return ReconcileGuard::Discard(ReconcileDiscardReason::CohortAbsent);
+    }
+    let Some(eligibility) = filters.eligibility.get(&tile.cohort_id()) else {
+        return ReconcileGuard::Discard(ReconcileDiscardReason::CohortAbsent);
+    };
+    if !eligibility.registers_membership() {
+        return ReconcileGuard::Discard(ReconcileDiscardReason::NotEmitting);
+    }
+    let Some(actual_hash) = filters.behavioral_shape_hashes.get(&tile.cohort_id()) else {
+        return ReconcileGuard::Discard(ReconcileDiscardReason::HashUnknown);
+    };
+    if actual_hash != tile.filters_hash() {
+        return ReconcileGuard::Discard(ReconcileDiscardReason::HashMismatch);
+    }
+    ReconcileGuard::Proceed
+}
+
+/// Advance at most one scan page for the queue head. Guard-discarded jobs are drained in the same
+/// tick; a successfully completed job stops the tick so the next queued snapshot gets its own page
+/// budget.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_reconcile_drain(
+    partition_id: u16,
+    handle: &StoreHandle,
+    catalog: &CatalogHandle,
+    sink: &Arc<dyn MembershipSink>,
+    merge: &MergeWorkerDeps,
+    queue: &mut ReconcileQueue,
+    last_updated: &str,
+) {
+    loop {
+        let Some(job) = queue.front() else {
+            return;
+        };
+        let tile = job.tile.clone();
+        let phase = job.phase.clone();
+        let source_offset = job.offset.offset();
+
+        // Read the release-published loaded flag before the ArcSwap. On the first refresh, that
+        // ordering prevents observing `loaded = true` alongside the pre-refresh empty snapshot.
+        let catalog_loaded = catalog.is_loaded();
+        let catalog_snapshot = catalog.load_full();
+        let filters = catalog_snapshot.team(tile.team_id()).map(Arc::as_ref);
+        match evaluate_guard(catalog_loaded, filters, &tile) {
+            ReconcileGuard::Retry(ReconcileRetryReason::CatalogNotLoaded) => {
+                debug!(
+                    partition_id,
+                    team_id = tile.team_id().0,
+                    cohort_id = tile.cohort_id().0,
+                    run_id = %tile.run_id().0,
+                    "reconcile drain waiting for the first filter catalog load",
+                );
+                return;
+            }
+            ReconcileGuard::Discard(reason) => {
+                let discarded = queue
+                    .finish_front()
+                    .expect("the guarded queue head is still present");
+                complete_offset(
+                    &merge.seed_tracker,
+                    partition_id,
+                    discarded.offset,
+                    "discarded reconcile",
+                );
+                counter!(RECONCILE_JOBS_DISCARDED_TOTAL, "reason" => reason.as_str()).increment(1);
+                warn!(
+                    partition_id,
+                    team_id = tile.team_id().0,
+                    cohort_id = tile.cohort_id().0,
+                    run_id = %tile.run_id().0,
+                    reason = reason.as_str(),
+                    "discarding reconcile job without a completion marker",
+                );
+                continue;
+            }
+            ReconcileGuard::Proceed => {}
+        }
+
+        let filters = filters.expect("the proceed guard proved the team exists");
+        let tree = filters
+            .cohorts
+            .get(&tile.cohort_id())
+            .expect("the proceed guard proved the cohort exists");
+        let eligibility = filters
+            .eligibility
+            .get(&tile.cohort_id())
+            .copied()
+            .expect("the proceed guard proved eligibility exists");
+
+        let prefix = Stage2CohortPrefix {
+            partition_id,
+            team_id: tile.team_id().0 as u64,
+            cohort_id: tile.cohort_id().0 as u64,
+        };
+        queue.activate_front_tracking(prefix);
+
+        match phase {
+            ScanPhase::Scanning { cursor } => {
+                let page = match handle
+                    .scan_stage2_cohort(prefix, cursor, merge.reconcile.scan_page)
+                    .await
+                {
+                    Ok(page) => page,
+                    Err(error) => {
+                        warn!(
+                            partition_id,
+                            team_id = tile.team_id().0,
+                            cohort_id = tile.cohort_id().0,
+                            run_id = %tile.run_id().0,
+                            error = %error,
+                            "reconcile Stage 2 scan failed; retrying this page on the next tick",
+                        );
+                        return;
+                    }
+                };
+                if page.is_empty() {
+                    queue
+                        .front_mut()
+                        .expect("the scanned queue head is still present")
+                        .phase = ScanPhase::DrainingDirty { cursor: None };
+                    continue;
+                }
+
+                let dirty_to_clear: Vec<Stage2DirtyKey> =
+                    page.iter().copied().map(Stage2DirtyKey::new).collect();
+                let Some(progress) = settle_reconcile_page(
+                    partition_id,
+                    handle,
+                    sink,
+                    merge,
+                    &tile,
+                    filters,
+                    tree,
+                    eligibility.writes_cf_stage2(),
+                    &page,
+                    &dirty_to_clear,
+                    source_offset,
+                    last_updated,
+                )
+                .await
+                else {
+                    return;
+                };
+
+                let short_page = page.len() < merge.reconcile.scan_page;
+                let next_cursor = page
+                    .last()
+                    .expect("a non-empty page has a final key")
+                    .encode()
+                    .to_vec();
+                let job = queue
+                    .front_mut()
+                    .expect("the advanced queue head is still present");
+                job.rows_scanned = job.rows_scanned.saturating_add(progress.rows_scanned);
+                job.bits_fixed = job.bits_fixed.saturating_add(progress.bits_fixed);
+                job.phase = if short_page {
+                    ScanPhase::DrainingDirty { cursor: None }
+                } else {
+                    ScanPhase::Scanning {
+                        cursor: Some(next_cursor),
+                    }
+                };
+                // One non-empty settlement page is the tick's work budget. Even a short final main
+                // page leaves dirty verification for the next tick, so mutations behind the cursor
+                // cannot silently double the configured per-tick ceiling.
+                return;
+            }
+            ScanPhase::DrainingDirty { cursor } => {
+                let page = match handle
+                    .scan_stage2_dirty(prefix, cursor.clone(), merge.reconcile.scan_page)
+                    .await
+                {
+                    Ok(page) => page,
+                    Err(error) => {
+                        warn!(
+                            partition_id,
+                            team_id = tile.team_id().0,
+                            cohort_id = tile.cohort_id().0,
+                            run_id = %tile.run_id().0,
+                            error = %error,
+                            "reconcile dirty scan failed; retrying this page on the next tick",
+                        );
+                        return;
+                    }
+                };
+                if page.is_empty() {
+                    let job = queue
+                        .front_mut()
+                        .expect("the dirty-scanning queue head is still present");
+                    if cursor.is_some() {
+                        // Verify once more from the prefix so a marker inserted behind the cursor
+                        // between ticks cannot be missed.
+                        job.phase = ScanPhase::DrainingDirty { cursor: None };
+                    } else {
+                        job.phase = ScanPhase::MarkerReady;
+                    }
+                    continue;
+                }
+
+                let stage2_keys: Vec<Stage2Key> =
+                    page.iter().map(|dirty| dirty.stage2_key()).collect();
+                let current_rows = match handle
+                    .multi_get_stage2(stage2_keys.clone(), ReadLane::Maintenance)
+                    .await
+                {
+                    Ok(rows) => rows,
+                    Err(error) => {
+                        warn!(
+                            partition_id,
+                            team_id = tile.team_id().0,
+                            cohort_id = tile.cohort_id().0,
+                            run_id = %tile.run_id().0,
+                            error = %error,
+                            "reconcile dirty-row read failed; retrying this page on the next tick",
+                        );
+                        return;
+                    }
+                };
+                let existing_keys: Vec<Stage2Key> = stage2_keys
+                    .into_iter()
+                    .zip(current_rows)
+                    .filter_map(|(key, value)| value.is_some().then_some(key))
+                    .collect();
+                let Some(progress) = settle_reconcile_page(
+                    partition_id,
+                    handle,
+                    sink,
+                    merge,
+                    &tile,
+                    filters,
+                    tree,
+                    eligibility.writes_cf_stage2(),
+                    &existing_keys,
+                    &page,
+                    source_offset,
+                    last_updated,
+                )
+                .await
+                else {
+                    return;
+                };
+
+                let short_page = page.len() < merge.reconcile.scan_page;
+                let next_cursor = page
+                    .last()
+                    .expect("a non-empty dirty page has a final key")
+                    .encode()
+                    .to_vec();
+                let job = queue
+                    .front_mut()
+                    .expect("the advanced dirty queue head is still present");
+                job.rows_scanned = job.rows_scanned.saturating_add(progress.rows_scanned);
+                job.bits_fixed = job.bits_fixed.saturating_add(progress.bits_fixed);
+                job.phase = ScanPhase::DrainingDirty {
+                    cursor: Some(next_cursor.clone()),
+                };
+
+                // A full page does not prove exhaustion, so first look strictly after it. This is
+                // verification only: if another page exists, the next tick settles it.
+                if !short_page {
+                    match handle.scan_stage2_dirty(prefix, Some(next_cursor), 1).await {
+                        Ok(remaining) if !remaining.is_empty() => return,
+                        Ok(_) => {}
+                        Err(error) => {
+                            warn!(
+                                partition_id,
+                                team_id = tile.team_id().0,
+                                cohort_id = tile.cohort_id().0,
+                                run_id = %tile.run_id().0,
+                                error = %error,
+                                "reconcile dirty tail verification failed; retrying next tick",
+                            );
+                            return;
+                        }
+                    }
+                }
+
+                // Verify once from the prefix to catch work inserted behind an earlier cursor. The
+                // worker owns this partition serially, so an empty result immediately after the
+                // settlement closes the hot-single-key case even when page size is one. Never
+                // settle a second nonempty page in this tick.
+                queue
+                    .front_mut()
+                    .expect("the verified dirty queue head is still present")
+                    .phase = ScanPhase::DrainingDirty { cursor: None };
+                match handle.scan_stage2_dirty(prefix, None, 1).await {
+                    Ok(remaining) if !remaining.is_empty() => return,
+                    Ok(_) => {
+                        queue
+                            .front_mut()
+                            .expect("the verified dirty queue head is still present")
+                            .phase = ScanPhase::MarkerReady;
+                        continue;
+                    }
+                    Err(error) => {
+                        warn!(
+                            partition_id,
+                            team_id = tile.team_id().0,
+                            cohort_id = tile.cohort_id().0,
+                            run_id = %tile.run_id().0,
+                            error = %error,
+                            "reconcile dirty prefix verification failed; retrying next tick",
+                        );
+                        return;
+                    }
+                }
+            }
+            ScanPhase::MarkerReady => {
+                // A marker produce may have failed on a prior tick. Recheck the dirty prefix before
+                // every retry so newly arrived work is settled first without rescanning the cohort.
+                let pending_dirty = match handle.scan_stage2_dirty(prefix, None, 1).await {
+                    Ok(page) => page,
+                    Err(error) => {
+                        warn!(
+                            partition_id,
+                            team_id = tile.team_id().0,
+                            cohort_id = tile.cohort_id().0,
+                            run_id = %tile.run_id().0,
+                            error = %error,
+                            "reconcile dirty verification failed before marker; retrying on the next tick",
+                        );
+                        return;
+                    }
+                };
+                if !pending_dirty.is_empty() {
+                    queue
+                        .front_mut()
+                        .expect("the marker-ready queue head is still present")
+                        .phase = ScanPhase::DrainingDirty { cursor: None };
+                    continue;
+                }
+                let marker = ReconcileCompleteMarker::new(
+                    tile.team_id(),
+                    tile.cohort_id(),
+                    partition_id,
+                    tile.run_id(),
+                    last_updated.to_string(),
+                );
+                let acks = sink.produce_markers(vec![marker]).await;
+                let marker_errors =
+                    acks.iter().filter(|ack| ack.is_err()).count() + acks.len().abs_diff(1);
+                if marker_errors > 0 {
+                    warn!(
+                        partition_id,
+                        team_id = tile.team_id().0,
+                        cohort_id = tile.cohort_id().0,
+                        run_id = %tile.run_id().0,
+                        errors = marker_errors,
+                        "reconcile completion-marker produce failed; rechecking dirty work before retry",
+                    );
+                    return;
+                }
+
+                counter!(RECONCILE_MARKERS_EMITTED_TOTAL).increment(1);
+                let completed = queue
+                    .finish_front()
+                    .expect("the marker-producing queue head is still present");
+                complete_offset(
+                    &merge.seed_tracker,
+                    partition_id,
+                    completed.offset,
+                    "completed reconcile",
+                );
+                counter!(RECONCILE_JOBS_COMPLETED_TOTAL).increment(1);
+                info!(
+                    partition_id,
+                    team_id = tile.team_id().0,
+                    cohort_id = tile.cohort_id().0,
+                    run_id = %tile.run_id().0,
+                    rows_scanned = completed.rows_scanned,
+                    bits_fixed = completed.bits_fixed,
+                    "reconcile job completed",
+                );
+                return;
+            }
+        }
+    }
+}
+
+struct PageProgress {
+    rows_scanned: u64,
+    bits_fixed: u64,
+}
+
+/// Emit one current reconcile page, then atomically commit any corrected bits and clear the exact
+/// dirty markers covered by that evaluation. Returning `None` leaves the queue phase unchanged so
+/// the same page is retried on the next tick.
+#[allow(clippy::too_many_arguments)]
+async fn settle_reconcile_page(
+    partition_id: u16,
+    handle: &StoreHandle,
+    sink: &Arc<dyn MembershipSink>,
+    merge: &MergeWorkerDeps,
+    tile: &ReconcileTile,
+    filters: &TeamFilters,
+    tree: &crate::filters::tree::CohortTree,
+    cascades_flips: bool,
+    page: &[Stage2Key],
+    dirty_to_clear: &[Stage2DirtyKey],
+    source_offset: i64,
+    last_updated: &str,
+) -> Option<PageProgress> {
+    counter!(RECONCILE_ROWS_SCANNED_TOTAL).increment(page.len() as u64);
+    let evaluated_at_ms = clickhouse_timestamp_to_millis(last_updated)
+        .expect("worker-generated last_updated timestamps always parse");
+    let mut changes = Vec::with_capacity(page.len());
+    let mut cascade_changes = Vec::new();
+    let mut writes: Vec<(Stage2Key, Stage2State)> = Vec::new();
+    let mut fixed_entered = 0u64;
+    let mut fixed_left = 0u64;
+    for key in page {
+        let diff = match recompute_and_diff(
+            partition_id,
+            key.person_id,
+            tree,
+            filters,
+            handle,
+            ReadLane::Maintenance,
+        )
+        .await
+        {
+            Ok(diff) => diff,
+            Err(error) => {
+                warn!(
+                    partition_id,
+                    team_id = tile.team_id().0,
+                    cohort_id = tile.cohort_id().0,
+                    run_id = %tile.run_id().0,
+                    person_id = %key.person_id,
+                    error = %error,
+                    "reconcile recompute failed; retrying this page on the next tick",
+                );
+                return None;
+            }
+        };
+        let change = CohortMembershipChange {
+            team_id: tile.team_id().0,
+            cohort_id: tile.cohort_id().0,
+            person_id: key.person_id.to_string(),
+            last_updated: last_updated.to_string(),
+            status: diff.status(),
+            origin: Some(ChangeOrigin::Reconcile),
+            run_id: Some(tile.run_id()),
+        };
+        if diff.requires_write() {
+            writes.push((
+                diff.stage2_key,
+                Stage2State {
+                    in_cohort: diff.new_bit,
+                    last_evaluated_at_ms: evaluated_at_ms,
+                },
+            ));
+        }
+        if diff.flipped() {
+            if diff.new_bit {
+                fixed_entered += 1;
+            } else {
+                fixed_left += 1;
+            }
+            if cascades_flips {
+                cascade_changes.push(change.clone());
+            }
+        }
+        changes.push(change);
+    }
+
+    let cascades = first_cascades(merge, &cascade_changes, source_offset);
+    let (entered, left) = count_by_status(&changes);
+    let membership_errors = if changes.is_empty() {
+        0
+    } else {
+        produce_membership(sink, changes).await
+    };
+    if membership_errors > 0 {
+        warn!(
+            partition_id,
+            team_id = tile.team_id().0,
+            cohort_id = tile.cohort_id().0,
+            run_id = %tile.run_id().0,
+            errors = membership_errors,
+            "reconcile membership produce failed; retrying this page on the next tick",
+        );
+        return None;
+    }
+    if entered > 0 {
+        counter!(RECONCILE_ROWS_EMITTED_TOTAL, "status" => "entered").increment(entered);
+    }
+    if left > 0 {
+        counter!(RECONCILE_ROWS_EMITTED_TOTAL, "status" => "left").increment(left);
+    }
+
+    let cascade_errors = produce_cascades(merge, cascades).await;
+    if cascade_errors > 0 {
+        warn!(
+            partition_id,
+            team_id = tile.team_id().0,
+            cohort_id = tile.cohort_id().0,
+            run_id = %tile.run_id().0,
+            errors = cascade_errors,
+            "reconcile cascade produce failed; retrying this page on the next tick",
+        );
+        return None;
+    }
+
+    let mut staged = StagedBatch::default();
+    for (key, state) in &writes {
+        staged.put_stage2(key, &state.encode());
+    }
+    // These deletes are deliberately staged after the puts. A fix marks its row dirty through the
+    // normal typed write path, then this page-clear consumes that marker in the same atomic batch.
+    for dirty in dirty_to_clear {
+        staged.delete_stage2_dirty(dirty);
+    }
+    if !staged.is_empty() {
+        if let Err(error) = handle.commit(staged).await {
+            warn!(
+                partition_id,
+                team_id = tile.team_id().0,
+                cohort_id = tile.cohort_id().0,
+                run_id = %tile.run_id().0,
+                error = %error,
+                "reconcile Stage 2 settlement failed; retrying this page on the next tick",
+            );
+            return None;
+        }
+    }
+    if fixed_entered > 0 {
+        counter!(RECONCILE_BITS_FIXED_TOTAL, "direction" => "entered").increment(fixed_entered);
+    }
+    if fixed_left > 0 {
+        counter!(RECONCILE_BITS_FIXED_TOTAL, "direction" => "left").increment(fixed_left);
+    }
+
+    Some(PageProgress {
+        rows_scanned: page.len() as u64,
+        bits_fixed: fixed_entered + fixed_left,
+    })
+}
+
+fn complete_offset(
+    tracker: &OffsetTracker,
+    partition_id: u16,
+    offset: DeferredOffset,
+    operation: &'static str,
+) {
+    match tracker.complete_deferred(offset) {
+        Some(MarkOutcome::WithinDispatch) => {}
+        Some(MarkOutcome::CappedAheadOfDispatch) => {
+            counter!(COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH).increment(1);
+            warn!(
+                partition_id,
+                operation, "reconcile completion exceeded the seed dispatch ceiling",
+            );
+        }
+        None => warn!(
+            partition_id,
+            operation, "reconcile completion belonged to an expired seed-tracker tenure",
+        ),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use async_trait::async_trait;
+    use chrono_tz::UTC;
+    use common_kafka::kafka_producer::KafkaProduceError;
+    use serde_json::{json, Value};
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use cohort_core::seed::BehavioralShapeHash;
+    use cohort_core::{CohortEligibility, ExcludedReason, FilterCatalog, LeafStateKey};
+
+    use crate::filters::tree::{CohortTree, FilterNode};
+    use crate::filters::{BoolOp, TeamFiltersBuilder};
+    use crate::partitions::offset_tracker::OffsetTracker;
+    use crate::producer::{CaptureCascadeSink, CaptureSink, MembershipStatus};
+    use crate::stage1::person_record::{MatchedSet, PersonRecord};
+    use crate::stage1::state::{AppliedOffsets, Stage1State, StatefulRecord};
+    use crate::stage2::state::Stage2Ownership;
+    use crate::store::{
+        Behavioral, BehavioralKey, CohortStore, OffloadConfig, OffloadMode, PersonRecordKey,
+        PersonRecords, StoreConfig,
+    };
+
+    use super::*;
+
+    const TEAM: i32 = 7;
+    const COHORT: i32 = 1;
+    const PARTITION: u16 = 0;
+    const BEHAVIORAL_HASH: [u8; 16] = *b"0123456789abcdef";
+    const PERSON_HASH: [u8; 16] = *b"fedcba9876543210";
+    const SHAPE_HASH: &str = "shape-v1";
+    const TS: &str = "2026-05-26 12:34:56.789123";
+
+    fn temp_store() -> (TempDir, CohortStore) {
+        let dir = TempDir::new().unwrap();
+        let store = CohortStore::open(&StoreConfig {
+            path: dir.path().join("db"),
+            ..StoreConfig::default()
+        })
+        .unwrap();
+        (dir, store)
+    }
+
+    fn store_handle(store: &CohortStore) -> StoreHandle {
+        StoreHandle::new(
+            store.clone(),
+            OffloadConfig {
+                mode: OffloadMode::All,
+                event_read_permits: 16,
+                maintenance_permits: 6,
+            },
+        )
+    }
+
+    fn behavioral_leaf() -> Value {
+        json!({
+            "type": "behavioral", "value": "performed_event", "key": "$pageview",
+            "time_value": 7, "time_interval": "day",
+            "conditionHash": "0123456789abcdef",
+            "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
+        })
+    }
+
+    fn person_leaf() -> Value {
+        json!({
+            "type": "person", "key": "email", "value": "u@p.com", "operator": "exact",
+            "conditionHash": "fedcba9876543210",
+            "bytecode": ["_H", 1, 32, "u@p.com", 32, "email", 32, "properties", 32, "person", 1, 3, 11],
+        })
+    }
+
+    fn catalog(single_leaf: bool) -> (CatalogHandle, LeafStateKey) {
+        let values = if single_leaf {
+            vec![behavioral_leaf()]
+        } else {
+            vec![behavioral_leaf(), person_leaf()]
+        };
+        let cohort = json!({ "properties": { "type": "AND", "values": values } });
+        let mut builder = TeamFiltersBuilder::default();
+        builder
+            .add_cohort(CohortId(COHORT), TeamId(TEAM), &cohort)
+            .unwrap();
+        builder.set_behavioral_shape_hash(
+            CohortId(COHORT),
+            BehavioralShapeHash::parse(SHAPE_HASH).unwrap(),
+        );
+        let filters = builder.freeze(UTC);
+        let lsk = filters.by_condition_to_lsk[&BEHAVIORAL_HASH][0];
+        (
+            CatalogHandle::from_catalog(FilterCatalog::from_teams([(TeamId(TEAM), filters)])),
+            lsk,
+        )
+    }
+
+    struct DrainShell {
+        _dir: TempDir,
+        store: CohortStore,
+        handle: StoreHandle,
+        catalog: CatalogHandle,
+        sink: Arc<dyn MembershipSink>,
+        deps: MergeWorkerDeps,
+        queue: ReconcileQueue,
+        lsk: LeafStateKey,
+    }
+
+    impl DrainShell {
+        fn new(
+            single_leaf: bool,
+            sink: Arc<dyn MembershipSink>,
+            cascade_sink: CaptureCascadeSink,
+            scan_page: usize,
+        ) -> Self {
+            let (_dir, store) = temp_store();
+            let handle = store_handle(&store);
+            let (catalog, lsk) = catalog(single_leaf);
+            let mut deps = Arc::try_unwrap(MergeWorkerDeps::capture())
+                .unwrap_or_else(|_| panic!("test owns the only dependency Arc"));
+            deps.reconcile.enabled = true;
+            deps.reconcile.scan_page = scan_page;
+            deps.cascade.enabled = true;
+            deps.cascade_sink = Arc::new(cascade_sink);
+            let queue =
+                ReconcileQueue::new(PARTITION, deps.reconcile.backlog.clone(), handle.clone());
+            Self {
+                _dir,
+                store,
+                handle,
+                catalog,
+                sink,
+                deps,
+                queue,
+                lsk,
+            }
+        }
+
+        fn write_current(&self, person: Uuid, behavioral: bool, person_match: bool, prior: bool) {
+            if behavioral {
+                let key = BehavioralKey::new(PARTITION, TEAM as u64, person, self.lsk);
+                let state = Stage1State::BehavioralSingle {
+                    has_match: true,
+                    last_event_at_ms: 1_700_000_000_000,
+                    earliest_eviction_at_ms: i64::MAX,
+                };
+                let record = StatefulRecord::new(state, AppliedOffsets::default());
+                self.store
+                    .write_batch(|batch| batch.put::<Behavioral>(&key, &record.encode()))
+                    .unwrap();
+            }
+            if person_match {
+                let key = PersonRecordKey::new(PARTITION, TEAM as u64, person);
+                let mut record = PersonRecord::absent();
+                record.matched = MatchedSet::from_iter([PERSON_HASH]);
+                self.store
+                    .write_batch(|batch| batch.put::<PersonRecords>(&key, &record.encode()))
+                    .unwrap();
+            }
+            let key = Stage2Key {
+                partition_id: PARTITION,
+                team_id: TEAM as u64,
+                cohort_id: COHORT as u64,
+                person_id: person,
+            };
+            let state = Stage2State {
+                in_cohort: prior,
+                last_evaluated_at_ms: 1,
+            };
+            self.store
+                .write_batch(|batch| batch.put_stage2(&key, &state.encode()))
+                .unwrap();
+        }
+
+        fn stage2_bit(&self, person: Uuid) -> bool {
+            let key = Stage2Key {
+                partition_id: PARTITION,
+                team_id: TEAM as u64,
+                cohort_id: COHORT as u64,
+                person_id: person,
+            };
+            Stage2State::decode(&self.store.get_stage2(&key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort
+        }
+
+        fn enqueue(&mut self, tile: ReconcileTile, offset: i64) {
+            self.deps
+                .seed_tracker
+                .mark_dispatched(PARTITION as i32, offset + 1);
+            if self.committable().is_none() {
+                assert_eq!(
+                    self.deps
+                        .seed_tracker
+                        .mark_processed(PARTITION as i32, offset),
+                    MarkOutcome::WithinDispatch,
+                );
+            }
+            let deferred = self.deps.seed_tracker.defer(PARTITION as i32, offset);
+            self.queue.enqueue(tile, deferred);
+        }
+
+        async fn tick(&mut self) {
+            handle_reconcile_drain(
+                PARTITION,
+                &self.handle,
+                &self.catalog,
+                &self.sink,
+                &self.deps,
+                &mut self.queue,
+                TS,
+            )
+            .await;
+        }
+
+        fn committable(&self) -> Option<i64> {
+            self.deps
+                .seed_tracker
+                .committable_offsets()
+                .get(&(PARTITION as i32))
+                .copied()
+        }
+    }
+
+    fn tile(team_id: i32, cohort_id: i32, run_id: u128) -> ReconcileTile {
+        ReconcileTile::new(
+            TeamId(team_id),
+            CohortId(cohort_id),
+            BehavioralShapeHash::parse(SHAPE_HASH).unwrap(),
+            RunId(Uuid::from_u128(run_id)),
+        )
+    }
+
+    #[test]
+    fn queue_tracks_backlog_and_drop_releases_only_the_backlog_count() {
+        let (_dir, store) = temp_store();
+        let tracker = OffsetTracker::new();
+        let backlog = Arc::new(ReconcileBacklog::default());
+        tracker.mark_dispatched(3, 11);
+
+        {
+            let mut queue = ReconcileQueue::new(3, backlog.clone(), store_handle(&store));
+            queue.enqueue(tile(1, 7, 1), tracker.defer(3, 10));
+            assert_eq!(queue.len(), 1);
+            assert_eq!(backlog.len(), 1);
+        }
+
+        assert!(backlog.is_empty());
+        assert_eq!(
+            tracker.mark_processed(3, 11),
+            crate::partitions::offset_tracker::MarkOutcome::WithinDispatch,
+        );
+        assert_eq!(
+            tracker.committable_offsets().get(&3),
+            Some(&10),
+            "dropping a queued job does not complete its deferred offset",
+        );
+    }
+
+    #[test]
+    fn only_the_active_queue_head_tracks_dirty_people() {
+        let (_dir, store) = temp_store();
+        let tracker = OffsetTracker::new();
+        let backlog = Arc::new(ReconcileBacklog::default());
+        tracker.mark_dispatched(PARTITION as i32, 12);
+        let mut queue = ReconcileQueue::new(PARTITION, backlog, store_handle(&store));
+        queue.enqueue(tile(TEAM, COHORT, 1), tracker.defer(PARTITION as i32, 10));
+        queue.enqueue(
+            tile(TEAM, COHORT + 1, 2),
+            tracker.defer(PARTITION as i32, 11),
+        );
+        let head_prefix = Stage2CohortPrefix {
+            partition_id: PARTITION,
+            team_id: TEAM as u64,
+            cohort_id: COHORT as u64,
+        };
+        let waiting_prefix = Stage2CohortPrefix {
+            cohort_id: (COHORT + 1) as u64,
+            ..head_prefix
+        };
+
+        // Enqueue alone captures nothing: a future full scan covers these writes.
+        for (prefix, person) in [(head_prefix, 1), (waiting_prefix, 2)] {
+            let key = Stage2Key {
+                partition_id: prefix.partition_id,
+                team_id: prefix.team_id,
+                cohort_id: prefix.cohort_id,
+                person_id: Uuid::from_u128(person),
+            };
+            store
+                .write_batch(|batch| batch.put_stage2(&key, b"before"))
+                .unwrap();
+            assert!(store
+                .scan_stage2_dirty(prefix, None, 10)
+                .unwrap()
+                .is_empty());
+        }
+
+        queue.activate_front_tracking(head_prefix);
+        for (prefix, person) in [(head_prefix, 3), (waiting_prefix, 4)] {
+            let key = Stage2Key {
+                partition_id: prefix.partition_id,
+                team_id: prefix.team_id,
+                cohort_id: prefix.cohort_id,
+                person_id: Uuid::from_u128(person),
+            };
+            store
+                .write_batch(|batch| batch.put_stage2(&key, b"during"))
+                .unwrap();
+        }
+
+        assert_eq!(
+            store
+                .scan_stage2_dirty(head_prefix, None, 10)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(store
+            .scan_stage2_dirty(waiting_prefix, None, 10)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn supersede_matches_team_and_cohort_and_preserves_other_jobs() {
+        let (_dir, store) = temp_store();
+        let tracker = OffsetTracker::new();
+        let backlog = Arc::new(ReconcileBacklog::default());
+        tracker.mark_dispatched(3, 14);
+        let mut queue = ReconcileQueue::new(3, backlog.clone(), store_handle(&store));
+        queue.enqueue(tile(1, 7, 1), tracker.defer(3, 10));
+        queue.enqueue(tile(1, 8, 2), tracker.defer(3, 11));
+        queue.enqueue(tile(2, 7, 3), tracker.defer(3, 12));
+
+        let SupersedeOutcome::Replaced(superseded) =
+            queue.supersede_if_newer(TeamId(1), CohortId(7), 13)
+        else {
+            panic!("the newer run should supersede team 1 cohort 7");
+        };
+
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.front_run_id(), Some(RunId(Uuid::from_u128(2))));
+        assert_eq!(backlog.len(), 2);
+        assert_eq!(
+            tracker.complete_deferred(superseded),
+            Some(crate::partitions::offset_tracker::MarkOutcome::WithinDispatch),
+        );
+        assert!(matches!(
+            queue.supersede_if_newer(TeamId(2), CohortId(7), 12),
+            SupersedeOutcome::RetainedNewerOrEqual,
+        ));
+    }
+
+    #[test]
+    fn older_or_duplicate_replay_never_evicts_the_queued_run() {
+        let (_dir, store) = temp_store();
+        let tracker = OffsetTracker::new();
+        let backlog = Arc::new(ReconcileBacklog::default());
+        tracker.mark_dispatched(3, 20);
+        let mut queue = ReconcileQueue::new(3, backlog.clone(), store_handle(&store));
+        queue.enqueue(tile(1, 7, 2), tracker.defer(3, 15));
+
+        for replayed_offset in [10, 15] {
+            assert!(matches!(
+                queue.supersede_if_newer(TeamId(1), CohortId(7), replayed_offset),
+                SupersedeOutcome::RetainedNewerOrEqual,
+            ));
+            assert_eq!(queue.front_run_id(), Some(RunId(Uuid::from_u128(2))));
+            assert_eq!(backlog.len(), 1);
+            assert_eq!(tracker.committable_offsets().get(&3), None);
+        }
+    }
+
+    fn guard_filters(eligibility: Option<CohortEligibility>, hash: Option<&str>) -> TeamFilters {
+        let mut filters = TeamFilters::default();
+        filters.cohorts.insert(
+            CohortId(COHORT),
+            CohortTree {
+                cohort_id: CohortId(COHORT),
+                team_id: TeamId(TEAM),
+                root: FilterNode::Group {
+                    op: BoolOp::And,
+                    children: Vec::new(),
+                },
+            },
+        );
+        if let Some(eligibility) = eligibility {
+            filters.eligibility.insert(CohortId(COHORT), eligibility);
+        }
+        if let Some(hash) = hash {
+            filters
+                .behavioral_shape_hashes
+                .insert(CohortId(COHORT), BehavioralShapeHash::parse(hash).unwrap());
+        }
+        filters
+    }
+
+    #[test]
+    fn drain_guard_classifies_every_retry_discard_and_proceed_state() {
+        let reconcile = tile(TEAM, COHORT, 1);
+
+        assert_eq!(
+            evaluate_guard(false, None, &reconcile),
+            ReconcileGuard::Retry(ReconcileRetryReason::CatalogNotLoaded),
+        );
+        assert_eq!(
+            evaluate_guard(true, None, &reconcile),
+            ReconcileGuard::Discard(ReconcileDiscardReason::TeamAbsent),
+        );
+        assert_eq!(
+            evaluate_guard(true, Some(&TeamFilters::default()), &reconcile),
+            ReconcileGuard::Discard(ReconcileDiscardReason::CohortAbsent),
+        );
+
+        let missing_eligibility = guard_filters(None, Some(SHAPE_HASH));
+        assert_eq!(
+            evaluate_guard(true, Some(&missing_eligibility), &reconcile),
+            ReconcileGuard::Discard(ReconcileDiscardReason::CohortAbsent),
+        );
+        let excluded = guard_filters(
+            Some(CohortEligibility::Excluded(ExcludedReason::HasDroppedLeaf)),
+            Some(SHAPE_HASH),
+        );
+        assert_eq!(
+            evaluate_guard(true, Some(&excluded), &reconcile),
+            ReconcileGuard::Discard(ReconcileDiscardReason::NotEmitting),
+        );
+        let hash_unknown = guard_filters(Some(CohortEligibility::Stage2Composable), None);
+        assert_eq!(
+            evaluate_guard(true, Some(&hash_unknown), &reconcile),
+            ReconcileGuard::Discard(ReconcileDiscardReason::HashUnknown),
+        );
+        let hash_mismatch =
+            guard_filters(Some(CohortEligibility::Stage2Composable), Some("shape-v2"));
+        assert_eq!(
+            evaluate_guard(true, Some(&hash_mismatch), &reconcile),
+            ReconcileGuard::Discard(ReconcileDiscardReason::HashMismatch),
+        );
+
+        for eligibility in [
+            CohortEligibility::SingleLeaf(LeafStateKey(BEHAVIORAL_HASH)),
+            CohortEligibility::Stage2Composable,
+            CohortEligibility::Stage2ComposableRef,
+        ] {
+            let filters = guard_filters(Some(eligibility), Some(SHAPE_HASH));
+            assert_eq!(
+                evaluate_guard(true, Some(&filters), &reconcile),
+                ReconcileGuard::Proceed,
+                "{eligibility:?} registers membership",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_emits_the_full_snapshot_fixes_only_flips_and_paginates() {
+        let sink = CaptureSink::new();
+        let cascades = CaptureCascadeSink::new();
+        let mut shell = DrainShell::new(false, Arc::new(sink.clone()), cascades.clone(), 2);
+        let alice = Uuid::from_u128(1);
+        let bob = Uuid::from_u128(2);
+        let charlie = Uuid::from_u128(3);
+        shell.write_current(alice, true, true, false);
+        shell.write_current(bob, false, false, true);
+        shell.write_current(charlie, true, true, true);
+        shell.enqueue(tile(TEAM, COHORT, 11), 5);
+
+        shell.tick().await;
+
+        assert_eq!(sink.changes().len(), 2, "one bounded page was emitted");
+        assert!(sink.markers().is_empty());
+        assert_eq!(shell.committable(), Some(5));
+        assert!(matches!(
+            shell.queue.front().map(|job| &job.phase),
+            Some(ScanPhase::Scanning {
+                cursor: Some(_),
+                ..
+            }),
+        ));
+
+        shell.tick().await;
+
+        let changes = sink.changes();
+        assert_eq!(changes.len(), 3, "unchanged rows are emitted too");
+        assert_eq!(
+            changes
+                .iter()
+                .map(|change| change.status)
+                .collect::<Vec<_>>(),
+            vec![
+                MembershipStatus::Entered,
+                MembershipStatus::Left,
+                MembershipStatus::Entered,
+            ],
+        );
+        assert!(changes.iter().all(|change| {
+            change.origin == Some(ChangeOrigin::Reconcile)
+                && change.run_id == Some(RunId(Uuid::from_u128(11)))
+        }));
+        assert!(shell.stage2_bit(alice));
+        assert!(!shell.stage2_bit(bob));
+        assert!(shell.stage2_bit(charlie));
+
+        let cascade_messages = cascades.messages();
+        assert_eq!(cascade_messages.len(), 2, "only flipped bits cascade");
+        assert_eq!(cascade_messages[0].change.person_id, alice.to_string());
+        assert_eq!(cascade_messages[1].change.person_id, bob.to_string());
+        shell.tick().await;
+        assert_eq!(sink.markers().len(), 1);
+        assert!(shell.queue.front().is_none());
+        assert!(shell.deps.reconcile.backlog.is_empty());
+        assert_eq!(shell.committable(), Some(6));
+    }
+
+    #[tokio::test]
+    async fn noop_reconcile_claims_a_transferred_fallback() {
+        let sink = CaptureSink::new();
+        let cascades = CaptureCascadeSink::new();
+        let mut shell = DrainShell::new(false, Arc::new(sink.clone()), cascades.clone(), 2);
+        let person = Uuid::from_u128(1);
+        let key = Stage2Key {
+            partition_id: PARTITION,
+            team_id: TEAM as u64,
+            cohort_id: COHORT as u64,
+            person_id: person,
+        };
+        let fallback = Stage2State {
+            in_cohort: false,
+            last_evaluated_at_ms: 1,
+        };
+        shell
+            .store
+            .write_batch(|batch| {
+                batch.put_stage2(&key, &fallback.encode_transferred_fallback());
+            })
+            .unwrap();
+        shell.enqueue(tile(TEAM, COHORT, 12), 5);
+
+        shell.tick().await;
+
+        let bytes = shell.store.get_stage2(&key).unwrap().unwrap();
+        let (state, ownership) = Stage2State::decode_with_ownership(&bytes).unwrap();
+        assert!(!state.in_cohort);
+        assert_eq!(ownership, Stage2Ownership::Local);
+        assert_eq!(
+            sink.changes().len(),
+            1,
+            "the full snapshot still emits the row"
+        );
+        assert_eq!(sink.changes()[0].status, MembershipStatus::Left);
+        assert!(
+            cascades.messages().is_empty(),
+            "ownership settlement is not a flip"
+        );
+    }
+
+    #[tokio::test]
+    async fn paged_scan_drains_a_row_inserted_behind_its_cursor_without_restarting() {
+        let sink = CaptureSink::new();
+        let mut shell = DrainShell::new(true, Arc::new(sink.clone()), CaptureCascadeSink::new(), 1);
+        let later_key = Uuid::from_u128(2);
+        let inserted_behind_cursor = Uuid::from_u128(1);
+        shell.write_current(later_key, true, false, true);
+        shell.enqueue(tile(TEAM, COHORT, 111), 5);
+
+        shell.tick().await;
+        assert_eq!(sink.changes().len(), 1);
+        assert_eq!(sink.changes()[0].person_id, later_key.to_string());
+        assert!(sink.markers().is_empty());
+
+        shell.write_current(inserted_behind_cursor, true, false, true);
+        shell.tick().await;
+
+        assert_eq!(
+            sink.changes()[1].person_id,
+            inserted_behind_cursor.to_string(),
+            "the dirty-person pass catches a row inserted behind the main cursor",
+        );
+        assert_eq!(
+            sink.changes()
+                .iter()
+                .map(|change| change.person_id.clone())
+                .collect::<Vec<_>>(),
+            vec![later_key.to_string(), inserted_behind_cursor.to_string(),],
+            "the main cohort page is not rescanned because another person changed",
+        );
+        assert_eq!(sink.markers().len(), 1);
+        assert_eq!(shell.committable(), Some(6));
+    }
+
+    #[tokio::test]
+    async fn repeatedly_mutated_hot_person_does_not_restart_main_scan() {
+        let sink = CaptureSink::new();
+        let mut shell = DrainShell::new(true, Arc::new(sink.clone()), CaptureCascadeSink::new(), 1);
+        let hot = Uuid::from_u128(10);
+        let second = Uuid::from_u128(20);
+        let third = Uuid::from_u128(30);
+        for person in [hot, second, third] {
+            shell.write_current(person, true, false, true);
+        }
+        shell.enqueue(tile(TEAM, COHORT, 112), 5);
+
+        for expected in [hot, second, third] {
+            shell.tick().await;
+            assert_eq!(
+                sink.changes().last().unwrap().person_id,
+                expected.to_string(),
+                "the main cursor advances despite a mutation behind it",
+            );
+            shell.write_current(hot, true, false, true);
+        }
+
+        shell.tick().await;
+        assert_eq!(sink.changes().last().unwrap().person_id, hot.to_string());
+        assert_eq!(
+            sink.markers().len(),
+            1,
+            "the job completes in the same tick that settles the full hot-person page",
+        );
+        assert_eq!(shell.committable(), Some(6));
+    }
+
+    #[tokio::test]
+    async fn deleted_dirty_row_is_cleared_without_being_resurrected_or_emitted_again() {
+        let sink = CaptureSink::new();
+        let mut shell = DrainShell::new(true, Arc::new(sink.clone()), CaptureCascadeSink::new(), 1);
+        let alice = Uuid::from_u128(1);
+        let bob = Uuid::from_u128(2);
+        shell.write_current(alice, true, false, true);
+        shell.write_current(bob, true, false, true);
+        shell.enqueue(tile(TEAM, COHORT, 113), 5);
+
+        shell.tick().await;
+        let deleted_key = Stage2Key {
+            partition_id: PARTITION,
+            team_id: TEAM as u64,
+            cohort_id: COHORT as u64,
+            person_id: alice,
+        };
+        shell
+            .store
+            .write_batch(|batch| batch.delete_stage2(&deleted_key))
+            .unwrap();
+
+        shell.tick().await;
+        shell.tick().await;
+        shell.tick().await;
+
+        assert_eq!(
+            sink.changes()
+                .iter()
+                .map(|change| change.person_id.clone())
+                .collect::<Vec<_>>(),
+            vec![alice.to_string(), bob.to_string()],
+            "the tombstoned scan row is not evaluated or emitted from its dirty marker",
+        );
+        assert!(shell.store.get_stage2(&deleted_key).unwrap().is_none());
+        assert_eq!(sink.markers().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn single_leaf_fix_never_cascades() {
+        let sink = CaptureSink::new();
+        let cascades = CaptureCascadeSink::new();
+        let mut shell = DrainShell::new(true, Arc::new(sink.clone()), cascades.clone(), 8);
+        let alice = Uuid::from_u128(1);
+        shell.write_current(alice, true, false, false);
+        shell.enqueue(tile(TEAM, COHORT, 12), 5);
+
+        shell.tick().await;
+
+        assert_eq!(sink.changes().len(), 1);
+        assert_eq!(sink.changes()[0].status, MembershipStatus::Entered);
+        assert!(shell.stage2_bit(alice));
+        assert!(cascades.messages().is_empty());
+        shell.tick().await;
+        assert_eq!(sink.markers().len(), 1);
+        assert_eq!(shell.committable(), Some(6));
+    }
+
+    #[tokio::test]
+    async fn discard_continues_to_a_zero_row_job_and_emits_only_its_marker() {
+        let sink = CaptureSink::new();
+        let mut shell =
+            DrainShell::new(false, Arc::new(sink.clone()), CaptureCascadeSink::new(), 8);
+        shell.enqueue(tile(999, COHORT, 1), 5);
+        shell.enqueue(tile(TEAM, COHORT, 2), 6);
+
+        shell.tick().await;
+
+        assert!(sink.changes().is_empty());
+        let markers = sink.markers();
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].run_id(), RunId(Uuid::from_u128(2)));
+        assert!(shell.queue.front().is_none());
+        assert!(shell.deps.reconcile.backlog.is_empty());
+        assert_eq!(shell.committable(), Some(7));
+    }
+
+    #[tokio::test]
+    async fn membership_failure_retries_the_same_page_without_advancing() {
+        let sink = CaptureSink::failing_first(1);
+        let mut shell = DrainShell::new(true, Arc::new(sink.clone()), CaptureCascadeSink::new(), 8);
+        let alice = Uuid::from_u128(1);
+        shell.write_current(alice, true, false, false);
+        shell.enqueue(tile(TEAM, COHORT, 13), 5);
+
+        shell.tick().await;
+
+        assert!(sink.changes().is_empty());
+        assert!(sink.markers().is_empty());
+        assert!(!shell.stage2_bit(alice));
+        assert!(matches!(
+            shell.queue.front().map(|job| &job.phase),
+            Some(ScanPhase::Scanning { cursor: None }),
+        ));
+
+        shell.tick().await;
+
+        assert_eq!(sink.changes().len(), 1);
+        assert!(shell.stage2_bit(alice));
+        shell.tick().await;
+        assert_eq!(sink.markers().len(), 1);
+        assert_eq!(shell.committable(), Some(6));
+    }
+
+    #[tokio::test]
+    async fn cascade_failure_retries_before_committing_or_advancing() {
+        let sink = CaptureSink::new();
+        let cascades = CaptureCascadeSink::failing_first(1);
+        let mut shell = DrainShell::new(false, Arc::new(sink.clone()), cascades.clone(), 8);
+        let alice = Uuid::from_u128(1);
+        shell.write_current(alice, true, true, false);
+        shell.enqueue(tile(TEAM, COHORT, 14), 5);
+
+        shell.tick().await;
+
+        assert_eq!(sink.changes().len(), 1, "the membership leg acked");
+        assert!(sink.markers().is_empty());
+        assert!(!shell.stage2_bit(alice));
+        assert!(matches!(
+            shell.queue.front().map(|job| &job.phase),
+            Some(ScanPhase::Scanning { cursor: None }),
+        ));
+
+        shell.tick().await;
+
+        assert_eq!(sink.changes().len(), 2, "the page was emitted again");
+        assert_eq!(cascades.messages().len(), 1);
+        assert!(shell.stage2_bit(alice));
+        shell.tick().await;
+        assert_eq!(sink.markers().len(), 1);
+        assert_eq!(shell.committable(), Some(6));
+    }
+
+    struct FailFirstMarkerSink {
+        capture: CaptureSink,
+        fail_marker: AtomicBool,
+    }
+
+    impl FailFirstMarkerSink {
+        fn new() -> Self {
+            Self {
+                capture: CaptureSink::new(),
+                fail_marker: AtomicBool::new(true),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MembershipSink for FailFirstMarkerSink {
+        async fn produce(
+            &self,
+            changes: Vec<CohortMembershipChange>,
+        ) -> Vec<Result<(), KafkaProduceError>> {
+            self.capture.produce(changes).await
+        }
+
+        async fn produce_markers(
+            &self,
+            markers: Vec<ReconcileCompleteMarker>,
+        ) -> Vec<Result<(), KafkaProduceError>> {
+            if self.fail_marker.swap(false, Ordering::SeqCst) {
+                return markers
+                    .into_iter()
+                    .map(|_| Err(KafkaProduceError::KafkaProduceCanceled))
+                    .collect();
+            }
+            self.capture.produce_markers(markers).await
+        }
+    }
+
+    #[tokio::test]
+    async fn marker_failure_retries_only_the_marker_phase() {
+        let sink = Arc::new(FailFirstMarkerSink::new());
+        let mut shell = DrainShell::new(true, sink.clone(), CaptureCascadeSink::new(), 8);
+        let alice = Uuid::from_u128(1);
+        shell.write_current(alice, true, false, false);
+        shell.enqueue(tile(TEAM, COHORT, 15), 5);
+
+        shell.tick().await;
+        shell.tick().await;
+
+        assert_eq!(sink.capture.changes().len(), 1);
+        assert!(sink.capture.markers().is_empty());
+        assert!(shell.stage2_bit(alice), "the page committed before marker");
+        assert!(matches!(
+            shell.queue.front().map(|job| &job.phase),
+            Some(ScanPhase::MarkerReady),
+        ));
+        assert_eq!(shell.committable(), Some(5));
+
+        shell.tick().await;
+
+        assert_eq!(
+            sink.capture.changes().len(),
+            1,
+            "the page was not rescanned"
+        );
+        assert_eq!(sink.capture.markers().len(), 1);
+        assert!(shell.queue.front().is_none());
+        assert_eq!(shell.committable(), Some(6));
+    }
+
+    #[tokio::test]
+    async fn marker_retry_drains_new_dirty_work_without_rescanning_clean_rows() {
+        let sink = Arc::new(FailFirstMarkerSink::new());
+        let mut shell = DrainShell::new(true, sink.clone(), CaptureCascadeSink::new(), 8);
+        let alice = Uuid::from_u128(2);
+        let bob = Uuid::from_u128(1);
+        shell.write_current(alice, true, false, true);
+        shell.enqueue(tile(TEAM, COHORT, 16), 5);
+
+        shell.tick().await;
+        shell.tick().await;
+        assert_eq!(sink.capture.changes().len(), 1);
+        assert!(sink.capture.markers().is_empty());
+        assert!(matches!(
+            shell.queue.front().map(|job| &job.phase),
+            Some(ScanPhase::MarkerReady),
+        ));
+
+        shell.write_current(bob, true, false, true);
+        shell.tick().await;
+
+        assert_eq!(
+            sink.capture
+                .changes()
+                .iter()
+                .map(|change| change.person_id.clone())
+                .collect::<Vec<_>>(),
+            vec![alice.to_string(), bob.to_string()],
+            "a failed marker drains only the person that changed while the marker was pending",
+        );
+        assert_eq!(sink.capture.markers().len(), 1);
+        assert_eq!(shell.committable(), Some(6));
+    }
+}

--- a/rust/cohort-stream-processor/src/workers/seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_path.rs
@@ -11,10 +11,10 @@ use std::sync::Arc;
 use chrono::Utc;
 use chrono_tz::Tz;
 use metrics::{counter, gauge};
-use tracing::warn;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
-use cohort_core::seed::{RunId, SeedTile};
+use cohort_core::seed::{ReconcileTile, RunId, SeedTile};
 
 use crate::consumers::seeds::SeedWork;
 use crate::filters::manager::CatalogHandle;
@@ -22,7 +22,8 @@ use crate::filters::reverse_index::{LeafStateMeta, TeamFilters};
 use crate::filters::TeamId;
 use crate::merge::tombstone_redirect::{self, Resolution, MAX_CROSS_PARTITION_REDIRECT_HOPS};
 use crate::observability::metrics::{
-    COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH, SEED_HELD_OFFSET_GAUGE, SEED_REKEYED_TOTAL,
+    COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH, RECONCILE_JOBS_ENQUEUED_TOTAL,
+    RECONCILE_JOBS_SUPERSEDED_TOTAL, SEED_HELD_OFFSET_GAUGE, SEED_REKEYED_TOTAL,
     SEED_REKEY_HOP_CAPPED_TOTAL, SEED_REKEY_PRODUCE_FAILURE_TOTAL, SEED_TILES_APPLIED_TOTAL,
     SEED_TILES_DROPPED_TOTAL, SEED_TILES_SKIPPED_TOTAL, SEED_TILES_UNCHANGED_TOTAL,
     STAGE1_STATE_DECODE_ERROR, STAGE1_TRANSITIONS,
@@ -39,9 +40,11 @@ use crate::stage1::pick_state::{EvictionWindow, PredicateOp};
 use crate::stage1::predicate::{compressed_predicate, daily_predicate, predicate};
 use crate::stage1::state::{Stage1State, StateVariant, StatefulRecord};
 use crate::stage1::transition::{LeafTransition, TransitionKind};
+use crate::stage2::{leaf_membership, single_leaf_register_writes, MembershipRegisterSource};
 use crate::store::{Behavioral, BehavioralKey, PersonPrefix, ReadLane, StagedBatch, StoreHandle};
 use crate::sweep::EvictionQueue;
 use crate::workers::merge_path::MergeWorkerDeps;
+use crate::workers::reconcile::{ReconcileQueue, SupersedeOutcome};
 use crate::workers::stage2_path::{commit_stage2_writes, recompute_stage2};
 use crate::workers::worker::{
     first_cascades, produce_cascades, produce_membership, transition_metric_label,
@@ -107,8 +110,8 @@ impl SeedDropReason {
     }
 }
 
-/// One leaf's merge outcome; `Unchanged` (byte-identical post-merge record) is the tile
-/// idempotency.
+/// One leaf's merge outcome; `Unchanged` carries the post-merge record so idempotent seed delivery
+/// can still repair the single-leaf membership register.
 #[must_use]
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum LeafMergeOutcome {
@@ -118,7 +121,9 @@ pub(crate) enum LeafMergeOutcome {
         /// The recomputed eviction deadline ([`i64::MAX`] = permanent, never scheduled).
         deadline_ms: i64,
     },
-    Unchanged,
+    Unchanged {
+        record: StatefulRecord,
+    },
     Dropped(SeedDropReason),
 }
 
@@ -445,7 +450,7 @@ fn finish(
     deadline_ms: i64,
 ) -> LeafMergeOutcome {
     if prev_state.as_ref() == Some(&record.state) {
-        return LeafMergeOutcome::Unchanged;
+        return LeafMergeOutcome::Unchanged { record };
     }
     let kind = match (predicate_before, predicate_after) {
         (false, true) => Some(TransitionKind::Entered),
@@ -468,6 +473,7 @@ pub(crate) async fn handle_seed(
     sink: &Arc<dyn MembershipSink>,
     merge: &MergeWorkerDeps,
     queue: &mut EvictionQueue<BehavioralKey>,
+    reconcile_queue: &mut ReconcileQueue,
     last_updated: &str,
     work: &SeedWork,
     offset: i64,
@@ -476,6 +482,10 @@ pub(crate) async fn handle_seed(
         SeedWork::Skip(reason) => {
             counter!(SEED_TILES_SKIPPED_TOTAL, "reason" => reason.as_str()).increment(1);
             mark_processed(&merge.seed_tracker, partition_id, offset);
+            return;
+        }
+        SeedWork::Reconcile(tile) => {
+            admit_reconcile(partition_id, merge, reconcile_queue, tile, offset);
             return;
         }
         SeedWork::Tile(tile) => tile,
@@ -689,6 +699,65 @@ pub(crate) async fn handle_seed(
     mark_processed(&merge.seed_tracker, partition_id, offset);
 }
 
+fn admit_reconcile(
+    partition_id: u16,
+    merge: &MergeWorkerDeps,
+    queue: &mut ReconcileQueue,
+    tile: &ReconcileTile,
+    offset: i64,
+) {
+    if !merge.reconcile.enabled {
+        counter!(SEED_TILES_SKIPPED_TOTAL, "reason" => "reconcile_disabled").increment(1);
+        warn!(
+            partition_id,
+            team_id = tile.team_id().0,
+            cohort_id = tile.cohort_id().0,
+            run_id = %tile.run_id().0,
+            "reconcile seed skipped while reconcile is disabled; re-dispatch after enabling",
+        );
+        mark_processed(&merge.seed_tracker, partition_id, offset);
+        return;
+    }
+
+    let deferred = match queue.supersede_if_newer(tile.team_id(), tile.cohort_id(), offset) {
+        SupersedeOutcome::NoQueuedJob => merge.seed_tracker.defer(partition_id as i32, offset),
+        SupersedeOutcome::Replaced(superseded) => {
+            let (replacement, outcome) = merge
+                .seed_tracker
+                .replace_deferred(superseded, offset)
+                .expect("a queued reconcile must retain its deferred offset in the current tenure");
+            match outcome {
+                MarkOutcome::WithinDispatch => {}
+                MarkOutcome::CappedAheadOfDispatch => {
+                    counter!(COHORT_STREAM_OFFSET_AHEAD_OF_DISPATCH).increment(1);
+                    warn!(
+                        partition_id,
+                        "superseded reconcile completion exceeded the seed dispatch ceiling",
+                    );
+                }
+            }
+            counter!(RECONCILE_JOBS_SUPERSEDED_TOTAL).increment(1);
+            replacement
+        }
+        SupersedeOutcome::RetainedNewerOrEqual => {
+            counter!(SEED_TILES_SKIPPED_TOTAL, "reason" => "reconcile_stale_replay").increment(1);
+            debug!(
+                partition_id,
+                team_id = tile.team_id().0,
+                cohort_id = tile.cohort_id().0,
+                run_id = %tile.run_id().0,
+                offset,
+                "replayed reconcile seed retained the newer or equal queued job",
+            );
+            mark_processed(&merge.seed_tracker, partition_id, offset);
+            return;
+        }
+    };
+
+    queue.enqueue(tile.clone(), deferred);
+    counter!(RECONCILE_JOBS_ENQUEUED_TOTAL).increment(1);
+}
+
 /// What one tile staged across its referencing leaves.
 #[derive(Default)]
 struct TileApplication {
@@ -755,6 +824,19 @@ fn apply_tile_to_leaves(
                 counter!(SEED_TILES_APPLIED_TOTAL, "variant" => record.state.variant().as_str())
                     .increment(1);
                 let key = prefix.behavioral_key(lsk);
+                stage_seed_membership_registers(
+                    &mut application.staged,
+                    filters,
+                    MembershipRegisterSource {
+                        partition_id: prefix.partition_id,
+                        team_id: identity.team_id,
+                        person_id: identity.person_id,
+                        leaf_state_key: identity.lsk,
+                    },
+                    meta,
+                    &record.state,
+                    now_ms,
+                );
                 application.staged.put::<Behavioral>(&key, &record.encode());
                 application.stage2_leaves.push((lsk, person));
                 if let Some(transition) = transition {
@@ -764,9 +846,22 @@ fn apply_tile_to_leaves(
                     application.schedules.push((key, deadline_ms));
                 }
             }
-            LeafMergeOutcome::Unchanged => {
+            LeafMergeOutcome::Unchanged { record } => {
                 counter!(SEED_TILES_UNCHANGED_TOTAL, "variant" => meta.variant.as_str())
                     .increment(1);
+                stage_seed_membership_registers(
+                    &mut application.staged,
+                    filters,
+                    MembershipRegisterSource {
+                        partition_id: prefix.partition_id,
+                        team_id: identity.team_id,
+                        person_id: identity.person_id,
+                        leaf_state_key: identity.lsk,
+                    },
+                    meta,
+                    &record.state,
+                    now_ms,
+                );
                 application.stage2_leaves.push((lsk, person));
             }
             LeafMergeOutcome::Dropped(reason) => {
@@ -775,6 +870,20 @@ fn apply_tile_to_leaves(
         }
     }
     application
+}
+
+fn stage_seed_membership_registers(
+    staged: &mut StagedBatch,
+    filters: &TeamFilters,
+    source: MembershipRegisterSource,
+    meta: &LeafStateMeta,
+    state: &Stage1State,
+    now_ms: i64,
+) {
+    let in_cohort = leaf_membership(Some(state), meta);
+    for write in single_leaf_register_writes(filters, source, in_cohort, now_ms) {
+        staged.put_stage2(&write.key, &write.state.encode());
+    }
 }
 
 fn tag_seed(changes: &mut [CohortMembershipChange], run_id: RunId) {
@@ -817,7 +926,9 @@ mod tests {
     use serde_json::{json, Value};
     use tempfile::TempDir;
 
-    use cohort_core::seed::{ClaimEpoch, ConditionHash, SChunkMs, SeedTile};
+    use cohort_core::seed::{
+        BehavioralShapeHash, ClaimEpoch, ConditionHash, ReconcileTile, SChunkMs, SeedTile,
+    };
 
     use crate::consumers::seeds::SeedSkipReason;
     use crate::filters::{CohortId, FilterCatalog, TeamFiltersBuilder};
@@ -931,9 +1042,11 @@ mod tests {
             EvictionWindow::RelativeDays { days: 7 }.earliest_eviction_at_ms(NOW_MS, UTC),
         );
 
-        assert_eq!(
-            merge(&meta, now_day(), 1, Some(record)),
-            LeafMergeOutcome::Unchanged,
+        assert!(
+            matches!(
+                merge(&meta, now_day(), 1, Some(record)),
+                LeafMergeOutcome::Unchanged { .. }
+            ),
             "re-delivery is a structural no-op",
         );
     }
@@ -1115,10 +1228,10 @@ mod tests {
         let (live, _, _) = merged(merge(&meta, now_day(), 3, None));
 
         // A tile counting a subset (late-arrival overlap) is absorbed: max(3, 2) = 3 → Unchanged.
-        assert_eq!(
+        assert!(matches!(
             merge(&meta, now_day(), 2, Some(live.clone())),
-            LeafMergeOutcome::Unchanged,
-        );
+            LeafMergeOutcome::Unchanged { .. }
+        ));
         // A tile counting a superset raises the bucket to the absolute count, never the sum.
         let (after, _, _) = merged(merge(&meta, now_day(), 5, Some(live)));
         let Stage1State::BehavioralDailyBuckets { ref buckets, .. } = after.state else {
@@ -1148,10 +1261,10 @@ mod tests {
             start_of_day_ms_in_tz(now_day() - 30 + 365 + 1, UTC)
         );
 
-        assert_eq!(
+        assert!(matches!(
             merge(&meta, now_day() - 30, 2, Some(record)),
-            LeafMergeOutcome::Unchanged,
-        );
+            LeafMergeOutcome::Unchanged { .. }
+        ));
     }
 
     #[test]
@@ -1616,6 +1729,15 @@ mod tests {
         )
     }
 
+    fn reconcile_for(cohort_id: i32, run_id: u128) -> ReconcileTile {
+        ReconcileTile::new(
+            TEAM,
+            CohortId(cohort_id),
+            BehavioralShapeHash::parse("0123456789abcdef").unwrap(),
+            RunId(Uuid::from_u128(run_id)),
+        )
+    }
+
     struct Shell {
         _dir: TempDir,
         store: CohortStore,
@@ -1626,6 +1748,7 @@ mod tests {
         cascade_sink: crate::producer::CaptureCascadeSink,
         deps: MergeWorkerDeps,
         queue: EvictionQueue<BehavioralKey>,
+        reconcile_queue: ReconcileQueue,
     }
 
     impl Shell {
@@ -1692,7 +1815,10 @@ mod tests {
                 seed_tile_sink: Arc::new(seed_sink.clone()),
                 seed_tracker: Arc::new(OffsetTracker::new()),
                 live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+                reconcile: crate::workers::ReconcileDeps::default(),
             };
+            let reconcile_queue =
+                ReconcileQueue::new(0, deps.reconcile.backlog.clone(), handle.clone());
             Self {
                 _dir,
                 store,
@@ -1703,6 +1829,7 @@ mod tests {
                 cascade_sink,
                 deps,
                 queue: EvictionQueue::new(),
+                reconcile_queue,
             }
         }
 
@@ -1718,6 +1845,7 @@ mod tests {
                 &sink,
                 &self.deps,
                 &mut self.queue,
+                &mut self.reconcile_queue,
                 "2026-06-15 12:00:00.000000",
                 &work,
                 offset,
@@ -1749,6 +1877,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_reconcile_skips_and_commits_without_enqueuing() {
+        let mut shell = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+
+        shell
+            .run(0, SeedWork::Reconcile(reconcile_for(1, 1)), 5)
+            .await;
+
+        assert_eq!(shell.committable(0), Some(6));
+        assert_eq!(shell.reconcile_queue.len(), 0);
+        assert!(shell.deps.reconcile.backlog.is_empty());
+        assert!(shell.sink.changes().is_empty());
+        assert!(shell.sink.markers().is_empty());
+    }
+
+    #[tokio::test]
+    async fn enabled_reconcile_enqueues_and_pins_later_seed_progress() {
+        let mut shell = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+        shell.deps.reconcile.enabled = true;
+
+        shell
+            .run(0, SeedWork::Reconcile(reconcile_for(1, 1)), 5)
+            .await;
+        shell
+            .run(0, SeedWork::Skip(SeedSkipReason::UnknownKind), 6)
+            .await;
+
+        assert_eq!(shell.committable(0), Some(5));
+        assert_eq!(shell.reconcile_queue.len(), 1);
+        assert_eq!(shell.deps.reconcile.backlog.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn newer_reconcile_supersedes_the_same_cohort_and_completes_the_old_floor() {
+        let mut shell = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+        shell.deps.reconcile.enabled = true;
+
+        shell
+            .run(0, SeedWork::Reconcile(reconcile_for(1, 1)), 5)
+            .await;
+        shell
+            .run(0, SeedWork::Reconcile(reconcile_for(1, 2)), 6)
+            .await;
+
+        assert_eq!(shell.committable(0), Some(6));
+        assert_eq!(shell.reconcile_queue.len(), 1);
+        assert_eq!(shell.deps.reconcile.backlog.len(), 1);
+        assert_eq!(
+            shell.reconcile_queue.front_run_id(),
+            Some(RunId(Uuid::from_u128(2))),
+        );
+    }
+
+    #[tokio::test]
+    async fn older_reconcile_replay_cannot_evict_a_newer_queued_run() {
+        let mut shell = Shell::new(vec![(1, wrap(vec![single_leaf_json(7)]))]);
+        shell.deps.reconcile.enabled = true;
+
+        shell
+            .run(0, SeedWork::Reconcile(reconcile_for(1, 2)), 6)
+            .await;
+        shell
+            .run(0, SeedWork::Reconcile(reconcile_for(1, 1)), 5)
+            .await;
+        shell
+            .run(0, SeedWork::Skip(SeedSkipReason::UnknownKind), 7)
+            .await;
+
+        assert_eq!(shell.committable(0), Some(6));
+        assert_eq!(shell.reconcile_queue.len(), 1);
+        assert_eq!(shell.deps.reconcile.backlog.len(), 1);
+        assert_eq!(
+            shell.reconcile_queue.front_run_id(),
+            Some(RunId(Uuid::from_u128(2))),
+        );
+    }
+
+    #[tokio::test]
     async fn tile_flip_emits_an_origin_tagged_change_and_schedules_eviction() {
         let person = Uuid::from_u128(0x5EED);
         let partition_id = partition_of(TEAM, &person, COHORT_PARTITION_COUNT) as u16;
@@ -1768,10 +1973,80 @@ mod tests {
         assert_eq!(shell.committable(partition_id), Some(10));
         assert_eq!(shell.queue.len(), 1, "the leaf's eviction was scheduled");
 
-        // Re-delivery: max-merge no-op, no duplicate emission, offset still advances.
+        let register_key = Stage2Key {
+            partition_id,
+            team_id: TEAM.0 as u64,
+            cohort_id: 1,
+            person_id: person,
+        };
+        assert!(
+            Stage2State::decode(&shell.store.get_stage2(&register_key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort,
+            "the seed apply materializes the single-leaf register",
+        );
+
+        shell
+            .store
+            .write_batch(|batch| batch.delete_stage2(&register_key))
+            .unwrap();
+
+        // Re-delivery: max-merge no-op, no duplicate emission, and the missing register self-heals.
         shell.run(partition_id, SeedWork::Tile(tile), 10).await;
         assert_eq!(shell.sink.changes().len(), 1);
         assert_eq!(shell.committable(partition_id), Some(11));
+        assert!(
+            Stage2State::decode(&shell.store.get_stage2(&register_key).unwrap().unwrap())
+                .unwrap()
+                .in_cohort,
+            "an Unchanged seed replay restores the register from its post-merge record",
+        );
+    }
+
+    #[tokio::test]
+    async fn unchanged_non_member_seed_restores_an_explicit_false_register_without_emission() {
+        let person = Uuid::from_u128(0x5EED);
+        let partition_id = partition_of(TEAM, &person, COHORT_PARTITION_COUNT) as u16;
+        let mut shell = Shell::new(vec![(1, wrap(vec![multiple_leaf_json(7, "gte", 3)]))]);
+        let tile = tile_for(person, today(), 1);
+        let register_key = Stage2Key {
+            partition_id,
+            team_id: TEAM.0 as u64,
+            cohort_id: 1,
+            person_id: person,
+        };
+
+        shell
+            .run(partition_id, SeedWork::Tile(tile.clone()), 0)
+            .await;
+        let registered = Stage2State::decode(
+            &shell
+                .store
+                .get_stage2(&register_key)
+                .unwrap()
+                .expect("seeded non-member has a register row"),
+        )
+        .unwrap();
+        assert!(!registered.in_cohort);
+        assert!(shell.sink.changes().is_empty());
+
+        shell
+            .store
+            .write_batch(|batch| batch.delete_stage2(&register_key))
+            .unwrap();
+        shell.run(partition_id, SeedWork::Tile(tile), 1).await;
+
+        let restored = Stage2State::decode(
+            &shell
+                .store
+                .get_stage2(&register_key)
+                .unwrap()
+                .expect("Unchanged replay restores the false register"),
+        )
+        .unwrap();
+        assert!(!restored.in_cohort);
+        assert!(shell.sink.changes().is_empty());
+        assert_eq!(shell.committable(partition_id), Some(2));
     }
 
     #[tokio::test]

--- a/rust/cohort-stream-processor/src/workers/stage2_gc.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_gc.rs
@@ -1,15 +1,15 @@
 //! Worker-side `cf_stage2` orphan garbage collection.
 //!
-//! [`handle_stage2_orphan_gc`] reclaims `cf_stage2` rows whose cohort is no longer composable, on the
-//! same [`ShuffleMessage::MergeCfGc`](crate::partitions::shuffle_message::ShuffleMessage::MergeCfGc)
+//! [`handle_stage2_orphan_gc`] reclaims `cf_stage2` rows whose cohort no longer registers membership,
+//! on the same
+//! [`ShuffleMessage::MergeCfGc`](crate::partitions::shuffle_message::ShuffleMessage::MergeCfGc)
 //! tick as [`handle_merge_gc`](crate::workers::merge_gc::handle_merge_gc). Two paths strand such rows:
-//! an absent-team merge drain (the drain deletes via the catalog's composable cohorts, empty when the
-//! team is absent) and a cohort reclassified out of the composable set (`Stage2Composable` →
-//! `SingleLeaf`, deleted, or made non-realtime).
+//! an absent-team merge drain (the catalog provides no ids to delete) and a cohort deleted or made
+//! non-realtime.
 //!
 //! The victim decision is **catalog absence, not a timestamp**: a `cf_stage2` value's
-//! `last_evaluated_at_ms` is the replay-stable source event time, so a time cutoff would evict a
-//! still-live dormant member.
+//! `last_evaluated_at_ms` records its latest evaluation, not its retention lifetime, so a time cutoff
+//! would evict a still-live dormant member.
 //!
 //! Two gates keep the pass from deleting live state on an untrustworthy snapshot — a successful
 //! *empty* refresh is indistinguishable from "every cohort vanished":
@@ -23,11 +23,12 @@ use tracing::warn;
 
 use crate::filters::manager::CatalogHandle;
 use crate::filters::{CohortId, FilterCatalog, TeamId};
+use crate::merge::transfer::{TransferMembershipRegisterKind, TransferredRegisterProvenance};
 use crate::observability::metrics::{
     STAGE2_ORPHAN_GC_KEYS_DELETED_TOTAL, STAGE2_ORPHAN_GC_KEYS_SCANNED_TOTAL,
     STAGE2_ORPHAN_GC_SKIPPED_TOTAL, STAGE2_ORPHAN_GC_UNDECODABLE_KEYS_TOTAL,
 };
-use crate::store::{Cf, CohortStore, Stage2Key};
+use crate::store::{Cf, CohortStore, Stage2DirtyKey, Stage2Key, Stage2TransferredRegisterKey};
 
 /// Per-worker resume cursor: the raw last-key scanned in this partition's `cf_stage2` slice; `None`
 /// restarts at the prefix start. Loss on a rebalance is benign — a fresh tenure rescans and
@@ -35,9 +36,12 @@ use crate::store::{Cf, CohortStore, Stage2Key};
 #[derive(Default)]
 pub struct Stage2GcCursor(Option<Vec<u8>>);
 
-/// GC one partition's `cf_stage2` orphans for one tick: scan up to `scan_limit` rows, delete every
-/// row whose cohort is no longer composable in `catalog`, and advance the cursor (wrapping on
-/// exhaustion). A no-op before the first catalog load or against an empty catalog (the two safety gates).
+/// GC one partition's `cf_stage2` orphans for one tick: inspect at most `scan_limit` raw keys,
+/// delete every Stage 2 row whose cohort no longer registers membership in `catalog`, and advance
+/// the raw cursor (wrapping on exhaustion). Dirty and transferred-register metadata count against
+/// the hard per-tick budget but are not membership rows. Inactive dirty metadata is reclaimed;
+/// transferred-register metadata protects a catalog-skewed row until the catalog recognizes it. A
+/// no-op before the first catalog load or against an empty catalog (the two safety gates).
 // Sync GC core; runs on the blocking pool inside `StoreHandle::run_section`, so its direct
 // `CohortStore` I/O is already off the runtime threads.
 #[allow(clippy::disallowed_methods)]
@@ -61,9 +65,9 @@ pub fn handle_stage2_orphan_gc(
         return;
     }
 
-    let page = match store.scan_merge_cf(Cf::Stage2, partition_id, cursor.0.as_deref(), scan_limit)
+    let rows = match store.scan_merge_cf(Cf::Stage2, partition_id, cursor.0.as_deref(), scan_limit)
     {
-        Ok(page) => page,
+        Ok(rows) => rows,
         Err(error) => {
             warn!(
                 partition_id,
@@ -74,21 +78,81 @@ pub fn handle_stage2_orphan_gc(
         }
     };
 
-    if page.is_empty() {
-        // Slice exhausted — wrap the cursor to the prefix start.
+    if rows.is_empty() {
         cursor.0 = None;
         return;
     }
 
-    counter!(STAGE2_ORPHAN_GC_KEYS_SCANNED_TOTAL).increment(page.len() as u64);
+    counter!(STAGE2_ORPHAN_GC_KEYS_SCANNED_TOTAL).increment(rows.len() as u64);
+    let next_cursor = (rows.len() == scan_limit).then(|| {
+        rows.last()
+            .expect("a full raw page has a final key")
+            .0
+            .clone()
+    });
 
     // Decode and classify before opening the batch, since the batch closure is infallible.
     let mut undecodable = 0u64;
     let mut victims: Vec<Stage2Key> = Vec::new();
-    for (key_bytes, _value) in &page {
+    let mut stale_dirty: Vec<Stage2DirtyKey> = Vec::new();
+    let mut settled_transferred: Vec<Stage2TransferredRegisterKey> = Vec::new();
+    for (key_bytes, value) in &rows {
+        if let Ok(dirty) = Stage2DirtyKey::decode(key_bytes) {
+            if !store.is_stage2_dirty_tracking_active(dirty.stage2_key().cohort_prefix()) {
+                stale_dirty.push(dirty);
+            }
+            continue;
+        }
+        if let Ok(transferred) = Stage2TransferredRegisterKey::decode(key_bytes) {
+            let stage2_key = transferred.stage2_key();
+            let primary = match store.get_stage2(&stage2_key) {
+                Ok(row) => row,
+                Err(error) => {
+                    warn!(
+                        partition_id,
+                        error = %error,
+                        "cf_stage2 orphan GC inventory read failed; retrying this page next tick",
+                    );
+                    return;
+                }
+            };
+            // Exact primary bytes tie provenance to the receiver fallback it describes. A later
+            // local evaluation supersedes that fallback without requiring an extra tombstone on
+            // every Stage 2 write. Matching catalog semantics also make person-first enumeration
+            // redundant. Missing primaries always leave stale inventory.
+            let settled = match (
+                primary.as_deref(),
+                TransferredRegisterProvenance::decode(value),
+            ) {
+                (None, _) => true,
+                (Some(primary), Some(provenance)) => {
+                    !provenance.matches_primary(primary)
+                        || Some(provenance.kind) == catalog_register_kind(&snapshot, &stage2_key)
+                }
+                (Some(_), None) => false,
+            };
+            if settled {
+                settled_transferred.push(transferred);
+            }
+            continue;
+        }
         match Stage2Key::decode(key_bytes) {
             Ok(key) => match is_orphan(&snapshot, &key) {
-                Some(true) => victims.push(key),
+                Some(true) => {
+                    let inventory = Stage2TransferredRegisterKey::new(key);
+                    match store.get_stage2_transferred_register(&inventory) {
+                        Ok(Some(_)) => {}
+                        Ok(None) => victims.push(key),
+                        Err(error) => {
+                            warn!(
+                                partition_id,
+                                error = %error,
+                                "cf_stage2 orphan GC protection read failed; retrying this page next tick",
+                            );
+                            return;
+                        }
+                    }
+                }
                 Some(false) => {}
                 // An id outside `i32` can't be classified — leave it in place (not corruption).
                 None => undecodable += 1,
@@ -104,10 +168,19 @@ pub fn handle_stage2_orphan_gc(
         }
     }
 
-    if !victims.is_empty() {
+    if !victims.is_empty() || !stale_dirty.is_empty() || !settled_transferred.is_empty() {
         let result = store.write_batch(|batch| {
             for key in &victims {
                 batch.delete_stage2(key);
+                // Orphan deletion does not need reconcile coverage. Clear both a pre-existing dirty
+                // marker and the one `delete_stage2` just staged, in the same atomic batch.
+                batch.delete_stage2_dirty(&Stage2DirtyKey::new(*key));
+            }
+            for key in &stale_dirty {
+                batch.delete_stage2_dirty(key);
+            }
+            for key in &settled_transferred {
+                batch.delete_stage2_transferred_register(key);
             }
         });
         match result {
@@ -130,16 +203,12 @@ pub fn handle_stage2_orphan_gc(
         counter!(STAGE2_ORPHAN_GC_UNDECODABLE_KEYS_TOTAL).increment(undecodable);
     }
 
-    // Full page → resume after the last key; short page → wrap. The cursor is the last *scanned* key
-    // (survivors included), so a mostly-live slice still advances over successive ticks.
-    cursor.0 = (page.len() == scan_limit)
-        .then(|| page.last().expect("non-empty by the guard above").0.clone());
+    cursor.0 = next_cursor;
 }
 
-/// Whether a `cf_stage2` row is an orphan: its cohort is not a composable cohort in `snapshot`
-/// (`writes_cf_stage2()` is `true` only for the two composable classes, so team-absent, cohort-absent,
-/// and reclassified-out all resolve to orphan). `None` when the id can't be classified (outside `i32`),
-/// which the caller leaves in place.
+/// Whether a `cf_stage2` row is an orphan: its cohort does not register membership in `snapshot`.
+/// Team-absent, cohort-absent, and excluded cohorts resolve to orphan. `None` when the id can't be
+/// classified (outside `i32`), which the caller leaves in place.
 fn is_orphan(snapshot: &FilterCatalog, key: &Stage2Key) -> Option<bool> {
     // Keys store `u64`; `TeamId`/`CohortId` are `i32`, so an overflowing id can't be matched.
     let team_id = i32::try_from(key.team_id).ok()?;
@@ -147,8 +216,18 @@ fn is_orphan(snapshot: &FilterCatalog, key: &Stage2Key) -> Option<bool> {
     let live = snapshot
         .team(TeamId(team_id))
         .and_then(|team_filters| team_filters.eligibility.get(&CohortId(cohort_id)))
-        .is_some_and(|eligibility| eligibility.writes_cf_stage2());
+        .is_some_and(|eligibility| eligibility.registers_membership());
     Some(!live)
+}
+
+/// Catalog semantics for a register, when both ids are representable and the cohort is live.
+fn catalog_register_kind(
+    snapshot: &FilterCatalog,
+    key: &Stage2Key,
+) -> Option<TransferMembershipRegisterKind> {
+    let team_id = TeamId(i32::try_from(key.team_id).ok()?);
+    let cohort_id = CohortId(i32::try_from(key.cohort_id).ok()?);
+    TransferMembershipRegisterKind::from_filters(snapshot.team(team_id)?, cohort_id)
 }
 
 // Tests seed and read stage-2 rows directly against the store.
@@ -160,6 +239,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::filters::reverse_index::TeamFilters;
+    use crate::merge::transfer::TransferMembershipRegister;
     use crate::stage1::key::LeafStateKey;
     use crate::stage2::state::Stage2State;
     use crate::stage2::{CohortEligibility, ExcludedReason};
@@ -251,9 +331,9 @@ mod tests {
     }
 
     #[test]
-    fn orphan_row_for_a_cohort_reclassified_out_of_composable_is_deleted() {
+    fn single_leaf_register_is_kept_while_an_absent_cohort_is_deleted() {
         let (_dir, store) = temp_store();
-        // Team present, but cohort 1 is now SingleLeaf and cohort 2 absent — both left the composable set.
+        // Team present: cohort 1 still registers membership, while cohort 2 is absent.
         let reclassified = stage2_key(LIVE_TEAM, 1, 100);
         let deleted_cohort = stage2_key(LIVE_TEAM, 2, 100);
         put_row(&store, &reclassified);
@@ -264,8 +344,8 @@ mod tests {
         handle_stage2_orphan_gc(PARTITION, &store, &catalog, &mut cursor, NO_CAP);
 
         assert!(
-            !exists(&store, &reclassified),
-            "a SingleLeaf reclassification leaves the cf_stage2 row an orphan",
+            exists(&store, &reclassified),
+            "a SingleLeaf row is a live membership register",
         );
         assert!(
             !exists(&store, &deleted_cohort),
@@ -418,6 +498,166 @@ mod tests {
     }
 
     #[test]
+    fn dirty_metadata_consumes_the_raw_per_tick_budget() {
+        let (_dir, store) = temp_store();
+        let live = stage2_key(LIVE_TEAM, 1, 100);
+        let _tracking = store.track_stage2_dirty(live.cohort_prefix());
+        put_row(&store, &live);
+        let dirty = Stage2DirtyKey::new(live).encode().to_vec();
+        let catalog = loaded(&[(LIVE_TEAM as i32, &[(1, single_leaf())])]);
+        let mut cursor = Stage2GcCursor::default();
+
+        handle_stage2_orphan_gc(PARTITION, &store, &catalog, &mut cursor, 1);
+        assert_eq!(cursor.0, Some(live.encode().to_vec()));
+
+        handle_stage2_orphan_gc(PARTITION, &store, &catalog, &mut cursor, 1);
+        assert_eq!(
+            cursor.0,
+            Some(dirty),
+            "one dirty marker consumes the entire one-key tick budget",
+        );
+        assert!(exists(&store, &live));
+
+        handle_stage2_orphan_gc(PARTITION, &store, &catalog, &mut cursor, 1);
+        assert!(cursor.0.is_none(), "the following empty tick wraps");
+    }
+
+    #[test]
+    fn inactive_dirty_only_marker_is_reclaimed() {
+        let (_dir, store) = temp_store();
+        let deleted = stage2_key(ABSENT_TEAM, 1, 100);
+        {
+            let _tracking = store.track_stage2_dirty(deleted.cohort_prefix());
+            store
+                .write_batch(|batch| batch.delete_stage2(&deleted))
+                .unwrap();
+            assert!(store
+                .get(Cf::Stage2, &Stage2DirtyKey::new(deleted).encode())
+                .unwrap()
+                .is_some());
+        }
+
+        let mut cursor = Stage2GcCursor::default();
+        handle_stage2_orphan_gc(PARTITION, &store, &live_team_only(), &mut cursor, NO_CAP);
+
+        assert!(store
+            .get(Cf::Stage2, &Stage2DirtyKey::new(deleted).encode())
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn transferred_register_survives_gc_until_catalog_refresh() {
+        let (_dir, store) = temp_store();
+        let transferred = stage2_key(ABSENT_TEAM, 17, 100);
+        let inventory = Stage2TransferredRegisterKey::new(transferred);
+        let state = Stage2State {
+            in_cohort: true,
+            last_evaluated_at_ms: 1,
+        };
+        let provenance = TransferredRegisterProvenance::new(
+            TransferMembershipRegister {
+                cohort_id: 17,
+                in_cohort: true,
+                kind: TransferMembershipRegisterKind::Composable,
+            },
+            &state.encode_transferred_fallback(),
+        );
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(&transferred, &state.encode_transferred_fallback());
+                batch.put_stage2_transferred_register(&inventory, &provenance.encode());
+            })
+            .unwrap();
+
+        let mut cursor = Stage2GcCursor::default();
+        handle_stage2_orphan_gc(PARTITION, &store, &live_team_only(), &mut cursor, NO_CAP);
+        assert!(exists(&store, &transferred));
+        assert!(store
+            .get_stage2_transferred_register(&inventory)
+            .unwrap()
+            .is_some());
+
+        // A later catalog snapshot recognizes the cohort. The ordinary keep predicate now protects
+        // the row and GC retires only the temporary person-first inventory.
+        let refreshed = loaded(&[(
+            ABSENT_TEAM as i32,
+            &[(17, CohortEligibility::Stage2Composable)],
+        )]);
+        cursor.0 = None;
+        handle_stage2_orphan_gc(PARTITION, &store, &refreshed, &mut cursor, NO_CAP);
+        assert!(exists(&store, &transferred));
+        assert!(store
+            .get_stage2_transferred_register(&inventory)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn stale_catalog_shape_cannot_retire_wire_inventory() {
+        let (_dir, store) = temp_store();
+        let transferred = stage2_key(LIVE_TEAM, 17, 100);
+        let inventory = Stage2TransferredRegisterKey::new(transferred);
+        let transferred_state = Stage2State {
+            in_cohort: true,
+            last_evaluated_at_ms: 1,
+        };
+        let provenance = TransferredRegisterProvenance::new(
+            TransferMembershipRegister {
+                cohort_id: 17,
+                in_cohort: true,
+                kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+            },
+            &transferred_state.encode_transferred_fallback(),
+        );
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(
+                    &transferred,
+                    &transferred_state.encode_transferred_fallback(),
+                );
+                batch.put_stage2_transferred_register(&inventory, &provenance.encode());
+            })
+            .unwrap();
+        let stale_shape = loaded(&[(
+            LIVE_TEAM as i32,
+            &[(17, CohortEligibility::Stage2Composable)],
+        )]);
+        let mut cursor = Stage2GcCursor::default();
+
+        handle_stage2_orphan_gc(PARTITION, &store, &stale_shape, &mut cursor, NO_CAP);
+        assert!(store
+            .get_stage2_transferred_register(&inventory)
+            .unwrap()
+            .is_some());
+
+        // A later normal evaluation write supersedes the exact fallback fingerprint. GC can retire
+        // the provenance without adding a second write to the evaluation hot path.
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(
+                    &transferred,
+                    &Stage2State {
+                        in_cohort: false,
+                        last_evaluated_at_ms: 2,
+                    }
+                    .encode(),
+                );
+            })
+            .unwrap();
+        assert!(store
+            .get_stage2_transferred_register(&inventory)
+            .unwrap()
+            .is_some());
+        cursor.0 = None;
+        handle_stage2_orphan_gc(PARTITION, &store, &stale_shape, &mut cursor, NO_CAP);
+        assert!(store
+            .get_stage2_transferred_register(&inventory)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
     fn undecodable_or_impossible_key_is_left_in_place() {
         let (_dir, store) = temp_store();
 
@@ -476,10 +716,10 @@ mod tests {
             is_orphan(&catalog, &stage2_key(LIVE_TEAM, 2, 0)),
             Some(false)
         );
-        // SingleLeaf / Excluded no longer write cf_stage2 → orphan.
+        // SingleLeaf registers membership; Excluded persists no row.
         assert_eq!(
             is_orphan(&catalog, &stage2_key(LIVE_TEAM, 3, 0)),
-            Some(true)
+            Some(false)
         );
         assert_eq!(
             is_orphan(&catalog, &stage2_key(LIVE_TEAM, 4, 0)),

--- a/rust/cohort-stream-processor/src/workers/stage2_path.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_path.rs
@@ -21,7 +21,7 @@ use crate::stage1::key::LeafStateKey;
 use crate::stage1::person_record::PersonRecord;
 use crate::stage1::state::{Stage1State, StateVariant, StatefulRecord};
 use crate::stage2::evaluator::{evaluate_tree, leaf_membership};
-use crate::stage2::state::Stage2State;
+use crate::stage2::state::{Stage2Ownership, Stage2State};
 use crate::stage2::CohortEligibility;
 use crate::store::{
     BehavioralKey, PersonRecordKey, ReadLane, Stage2Key, StagedBatch, StoreError, StoreHandle,
@@ -102,27 +102,28 @@ pub(crate) async fn recompute_stage2(
 
         let diff = recompute_and_diff(partition_id, person_id, tree, filters, handle, lane).await?;
         evaluated += 1;
-        if !diff.flipped() {
-            continue;
+        if diff.flipped() {
+            changes.push(CohortMembershipChange {
+                team_id: tree.team_id.0,
+                cohort_id: cohort_id.0,
+                person_id: person_id.to_string(),
+                last_updated: last_updated.to_string(),
+                status: diff.status(),
+                origin: None,
+                run_id: None,
+            });
         }
-
-        changes.push(CohortMembershipChange {
-            team_id: tree.team_id.0,
-            cohort_id: cohort_id.0,
-            person_id: person_id.to_string(),
-            last_updated: last_updated.to_string(),
-            status: diff.status(),
-            origin: None,
-            run_id: None,
-        });
-        // Write `false` rather than deleting so absence means "never evaluated".
-        writes.push((
-            diff.stage2_key,
-            Stage2State {
-                in_cohort: diff.new_bit,
-                last_evaluated_at_ms: event_ms,
-            },
-        ));
+        if diff.requires_write() {
+            // Write `false` rather than deleting so absence means "never evaluated". A no-flip
+            // transferred fallback is rewritten once so receiver evaluation claims ownership.
+            writes.push((
+                diff.stage2_key,
+                Stage2State {
+                    in_cohort: diff.new_bit,
+                    last_evaluated_at_ms: event_ms,
+                },
+            ));
+        }
     }
 
     Ok(Stage2Recompute {
@@ -153,6 +154,7 @@ pub(crate) struct RecomputeDiff {
     pub new_bit: bool,
     pub prior_bit: bool,
     pub stage2_key: Stage2Key,
+    settles_transfer_fallback: bool,
 }
 
 impl RecomputeDiff {
@@ -166,6 +168,12 @@ impl RecomputeDiff {
         } else {
             MembershipStatus::Left
         }
+    }
+
+    /// A receiver evaluation must rewrite a transferred fallback even when the logical bit is
+    /// unchanged, making source provenance observably stale without touching ordinary no-flip rows.
+    pub fn requires_write(&self) -> bool {
+        self.flipped() || self.settles_transfer_fallback
     }
 }
 
@@ -196,11 +204,12 @@ pub(crate) async fn recompute_and_diff(
         cohort_id: tree.cohort_id.0 as u64,
         person_id,
     };
-    let prior_bit = read_stage2_bit(handle, &stage2_key, lane).await?;
+    let prior = read_prior_stage2_state(handle, &stage2_key, lane).await?;
     Ok(RecomputeDiff {
         new_bit,
-        prior_bit,
+        prior_bit: prior.in_cohort,
         stage2_key,
+        settles_transfer_fallback: prior.ownership == Stage2Ownership::TransferredFallback,
     })
 }
 
@@ -433,13 +442,37 @@ fn decode_stage1_state(bytes: Option<Vec<u8>>) -> Option<Stage1State> {
     }
 }
 
-/// The stored `cf_stage2` membership bit for `key`, `false` when absent or undecodable.
-async fn read_stage2_bit(
+struct PriorStage2State {
+    in_cohort: bool,
+    ownership: Stage2Ownership,
+}
+
+/// Decode both the logical prior bit and its ownership. Missing or corrupt rows keep the existing
+/// fail-closed `false` behavior and are never mistaken for a transferred fallback.
+async fn read_prior_stage2_state(
     handle: &StoreHandle,
     key: &Stage2Key,
     lane: ReadLane,
-) -> Result<bool, StoreError> {
-    Ok(decode_stage2_bit(handle.get_stage2(key, lane).await?))
+) -> Result<PriorStage2State, StoreError> {
+    let Some(bytes) = handle.get_stage2(key, lane).await? else {
+        return Ok(PriorStage2State {
+            in_cohort: false,
+            ownership: Stage2Ownership::Local,
+        });
+    };
+    match Stage2State::decode_with_ownership(&bytes) {
+        Ok((state, ownership)) => Ok(PriorStage2State {
+            in_cohort: state.in_cohort,
+            ownership,
+        }),
+        Err(_) => {
+            counter!(STAGE2_STATE_DECODE_ERROR).increment(1);
+            Ok(PriorStage2State {
+                in_cohort: false,
+                ownership: Stage2Ownership::Local,
+            })
+        }
+    }
 }
 
 /// Decode a `cf_stage2` value into its membership bit, `false` when absent or undecodable.
@@ -814,6 +847,18 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(first.len(), 1, "the first evaluation enters");
+        let key = Stage2Key {
+            partition_id: PARTITION,
+            team_id: TEAM,
+            cohort_id: 1,
+            person_id: alice,
+        };
+        let current = Stage2State::decode(&store.get_stage2(&key).unwrap().unwrap()).unwrap();
+        store
+            .write_batch(|batch| {
+                batch.put_stage2(&key, &current.encode_transferred_fallback());
+            })
+            .unwrap();
 
         let second = compose_stage2(
             PARTITION,
@@ -829,6 +874,12 @@ mod tests {
         assert!(
             second.is_empty(),
             "a re-evaluation with no change emits nothing"
+        );
+        let bytes = store.get_stage2(&key).unwrap().unwrap();
+        assert_eq!(
+            Stage2State::decode_with_ownership(&bytes).unwrap().1,
+            Stage2Ownership::Local,
+            "the no-op evaluation still claims a transferred fallback",
         );
     }
 

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -32,12 +32,13 @@ use crate::partitions::intake::MeteredReceiver;
 use crate::partitions::offset_tracker::{MarkOutcome, OffsetTracker};
 use crate::partitions::shuffle_message::ShuffleMessage;
 use crate::producer::{
-    map_transition, now_last_updated, CohortMembershipChange, MembershipSink, MembershipStatus,
+    map_transition, CohortMembershipChange, LastUpdatedClock, MembershipSink, MembershipStatus,
     OutputBuffer,
 };
 use crate::stage1::key::LeafStateKey;
 use crate::stage1::state::{StateVariant, StatefulRecord};
 use crate::stage1::transition::{LeafTransition, TransitionKind};
+use crate::stage2::single_leaf_transition_register_writes;
 use crate::store::{Behavioral, BehavioralKey, ReadLane, StagedBatch, StoreHandle};
 use crate::sweep::EvictionQueue;
 use crate::workers::cascade_path::handle_cascade;
@@ -46,6 +47,7 @@ use crate::workers::event_path::{
 };
 use crate::workers::merge_gc::{handle_merge_gc, MergeGcCursor};
 use crate::workers::merge_path::{handle_apply, handle_merge, handle_redrive, MergeWorkerDeps};
+use crate::workers::reconcile::{handle_reconcile_drain, ReconcileQueue};
 use crate::workers::seed_path::handle_seed;
 use crate::workers::stage2_gc::{handle_stage2_orphan_gc, Stage2GcCursor};
 use crate::workers::stage2_path::compose_stage2;
@@ -154,6 +156,11 @@ async fn run_worker(
     info!(partition_id, "stage 1 worker started");
 
     let mut queue = EvictionQueue::<BehavioralKey>::new();
+    let mut reconcile_queue = ReconcileQueue::new(
+        partition_id,
+        merge.reconcile.backlog.clone(),
+        handle.clone(),
+    );
     // No-op for a cold partition (bloom-filtered scan finds nothing to schedule).
     if durable_restore {
         rebuild_eviction_queue(partition_id, &handle, &mut queue).await;
@@ -164,8 +171,8 @@ async fn run_worker(
 
     // Persists across batches so a stream of buffered batches still yields on the wall-clock interval.
     let mut last_yield = Instant::now();
+    let mut last_updated_clock = LastUpdatedClock::default();
     while let Some(batch) = receiver.recv().await {
-        let last_updated = now_last_updated();
         let mut buffer = OutputBuffer::new();
         let mut re_keys: Vec<CohortStreamEvent> = Vec::new();
         let mut max_offset: Option<i64> = None;
@@ -176,6 +183,7 @@ async fn run_worker(
         let mut held = false;
 
         for message in batch {
+            let last_updated = last_updated_clock.next();
             match message {
                 ShuffleMessage::Event {
                     event,
@@ -296,6 +304,13 @@ async fn run_worker(
                     .await;
                 }
                 ShuffleMessage::Seed { work, offset } => {
+                    // Worker receipt is the first point that both proves this exact seed landed and
+                    // orders its ceiling before even a zero-work handler can mark it processed.
+                    // The dispatcher also records the delivered batch maximum, but that post-send
+                    // accounting can race a fast worker on a multithreaded runtime.
+                    merge
+                        .seed_tracker
+                        .mark_dispatched(partition_id as i32, offset + 1);
                     if flush_event_changes_before_inline(
                         &sink,
                         &mut buffer,
@@ -313,6 +328,7 @@ async fn run_worker(
                         &sink,
                         &merge,
                         &mut queue,
+                        &mut reconcile_queue,
                         &last_updated,
                         &work,
                         offset,
@@ -362,6 +378,28 @@ async fn run_worker(
                             .await
                             .unwrap_or_default();
                     }
+                }
+                ShuffleMessage::ReconcileDrain => {
+                    if flush_event_changes_before_inline(
+                        &sink,
+                        &mut buffer,
+                        partition_id,
+                        &mut held,
+                    )
+                    .await
+                    {
+                        break;
+                    }
+                    handle_reconcile_drain(
+                        partition_id,
+                        &handle,
+                        &catalog,
+                        &sink,
+                        &merge,
+                        &mut reconcile_queue,
+                        &last_updated,
+                    )
+                    .await;
                 }
             }
 
@@ -482,15 +520,18 @@ pub(crate) fn count_by_status(changes: &[CohortMembershipChange]) -> (u64, u64) 
         })
 }
 
-/// Produce membership `changes`, await acks, and record metrics. Returns the failed-ack count
-/// (`0` = fully acked). The caller owns the per-site warn and recovery action.
+/// Produce membership `changes`, await one ack per change, and record metrics. Returns the failed
+/// or missing/extra-ack count (`0` = fully acked). The caller owns the per-site warn and recovery
+/// action.
 pub(crate) async fn produce_membership(
     sink: &Arc<dyn MembershipSink>,
     changes: Vec<CohortMembershipChange>,
 ) -> usize {
     let (entered, left) = count_by_status(&changes);
+    let expected_acks = changes.len();
     let acks = sink.produce(changes).await;
-    let errors = acks.iter().filter(|result| result.is_err()).count();
+    let errors =
+        acks.iter().filter(|result| result.is_err()).count() + acks.len().abs_diff(expected_acks);
     if errors > 0 {
         counter!(OUTPUT_PRODUCE_ERRORS).increment(errors as u64);
         return errors;
@@ -523,9 +564,10 @@ pub(crate) fn first_cascades(
         .collect()
 }
 
-/// Produce cascade messages and await acks. Returns the failed-ack count (`0` when empty or fully
-/// acked). The caller owns the recovery posture: the event path holds the offset; the sweep/merge
-/// paths drop (at-most-once). Shared by the first-hop leg and onward-hop consumer legs.
+/// Produce cascade messages and await one ack per message. Returns the failed or
+/// missing/extra-ack count (`0` when empty or fully acked). The caller owns the recovery posture:
+/// the event path holds the offset; the sweep/merge paths drop (at-most-once). Shared by the
+/// first-hop leg and onward-hop consumer legs.
 pub(crate) async fn produce_cascades(
     merge: &MergeWorkerDeps,
     cascades: Vec<CascadeMessage>,
@@ -533,8 +575,10 @@ pub(crate) async fn produce_cascades(
     if cascades.is_empty() {
         return 0;
     }
+    let expected_acks = cascades.len();
     let acks = merge.cascade_sink.produce(cascades).await;
-    let errors = acks.iter().filter(|result| result.is_err()).count();
+    let errors =
+        acks.iter().filter(|result| result.is_err()).count() + acks.len().abs_diff(expected_acks);
     if errors > 0 {
         counter!(CASCADE_PRODUCE_ERRORS_TOTAL).increment(errors as u64);
     }
@@ -808,6 +852,18 @@ async fn handle_sweep(
                 EvictionAction::Write(bytes) => staged.put::<Behavioral>(&result.key, bytes),
                 EvictionAction::Delete => staged.delete::<Behavioral>(&result.key),
             }
+            if let Some(transition) = &result.transition {
+                if let Some(filters) = snapshot.team(transition.team_id) {
+                    for write in single_leaf_transition_register_writes(
+                        filters,
+                        partition_id,
+                        transition,
+                        due_before_ms,
+                    ) {
+                        staged.put_stage2(&write.key, &write.state.encode());
+                    }
+                }
+            }
         }
         let written = handle.commit(staged).await;
         if let Err(error) = written {
@@ -1011,6 +1067,9 @@ mod tombstone_redirect_tests {
     use tempfile::TempDir;
     use tokio::sync::mpsc;
 
+    use cohort_core::seed::{BehavioralShapeHash, ReconcileTile, RunId};
+
+    use crate::consumers::seeds::SeedWork;
     use crate::filters::{CohortId, FilterCatalog, TeamFiltersBuilder};
     use crate::merge::transfer::Tombstone;
     use crate::partitions::partitioner::{partition_of, COHORT_PARTITION_COUNT};
@@ -1063,6 +1122,27 @@ mod tombstone_redirect_tests {
         builder
             .add_cohort(CohortId(1), TeamId(TEAM), &cohort)
             .unwrap();
+        Arc::new(CatalogHandle::from_catalog(FilterCatalog::from_teams([(
+            TeamId(TEAM),
+            builder.freeze(UTC),
+        )])))
+    }
+
+    fn reconcile_catalog(filters_hash: &str) -> Arc<CatalogHandle> {
+        let leaf = json!({
+            "type": "person", "key": "email", "value": "u@p.com", "operator": "exact",
+            "conditionHash": "fedcba9876543210",
+            "bytecode": ["_H", 1, 32, "u@p.com", 32, "email", 32, "properties", 32, "person", 1, 3, 11],
+        });
+        let cohort = json!({ "properties": { "type": "AND", "values": [leaf] } });
+        let mut builder = TeamFiltersBuilder::default();
+        builder
+            .add_cohort(CohortId(1), TeamId(TEAM), &cohort)
+            .unwrap();
+        builder.set_behavioral_shape_hash(
+            CohortId(1),
+            BehavioralShapeHash::parse(filters_hash).unwrap(),
+        );
         Arc::new(CatalogHandle::from_catalog(FilterCatalog::from_teams([(
             TeamId(TEAM),
             builder.freeze(UTC),
@@ -1126,7 +1206,16 @@ mod tombstone_redirect_tests {
             seed_tile_sink: Arc::new(crate::producer::CaptureSeedTileSink::new()),
             seed_tracker: Arc::new(crate::partitions::offset_tracker::OffsetTracker::new()),
             live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+            reconcile: crate::workers::ReconcileDeps::default(),
         })
+    }
+
+    fn reconcile_deps() -> Arc<MergeWorkerDeps> {
+        let mut deps = Arc::try_unwrap(merge_deps_with(CaptureStreamEventSink::new()))
+            .unwrap_or_else(|_| panic!("test owns the only dependency Arc"));
+        deps.reconcile.enabled = true;
+        deps.reconcile.scan_page = 2;
+        Arc::new(deps)
     }
 
     /// Deps with the `stage2_orphan_gc_enabled` kill-switch set to `stage2_orphan_gc_enabled`.
@@ -1146,6 +1235,7 @@ mod tombstone_redirect_tests {
             seed_tile_sink: Arc::new(crate::producer::CaptureSeedTileSink::new()),
             seed_tracker: Arc::new(crate::partitions::offset_tracker::OffsetTracker::new()),
             live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+            reconcile: crate::workers::ReconcileDeps::default(),
         })
     }
 
@@ -1170,6 +1260,7 @@ mod tombstone_redirect_tests {
             seed_tile_sink: Arc::new(crate::producer::CaptureSeedTileSink::new()),
             seed_tracker: Arc::new(crate::partitions::offset_tracker::OffsetTracker::new()),
             live_watermarks: Arc::new(crate::partitions::watermarks::LiveWatermarks::new()),
+            reconcile: crate::workers::ReconcileDeps::default(),
         })
     }
 
@@ -1198,6 +1289,124 @@ mod tombstone_redirect_tests {
         )
         .await;
         (partition_id, tracker)
+    }
+
+    #[tokio::test]
+    async fn seed_receipt_raises_the_ceiling_before_a_disabled_reconcile_skip() {
+        let (_dir, store) = temp_store();
+        let membership = CaptureSink::new();
+        let merge = merge_deps_with(CaptureStreamEventSink::new());
+        let seed_tracker = merge.seed_tracker.clone();
+        let events_tracker = Arc::new(OffsetTracker::new());
+        let tile = ReconcileTile::new(
+            TeamId(TEAM),
+            CohortId(1),
+            BehavioralShapeHash::parse("0123456789abcdef").unwrap(),
+            RunId(Uuid::from_u128(1)),
+        );
+
+        // Bypass EventDispatcher's post-send seed ceiling accounting. The worker must establish the
+        // ceiling from receipt before the disabled fast path can mark the offset processed.
+        run_batch(
+            0,
+            &store,
+            person_catalog(),
+            &membership,
+            &events_tracker,
+            merge,
+            0,
+            vec![ShuffleMessage::Seed {
+                work: Box::new(SeedWork::Reconcile(tile)),
+                offset: 5,
+            }],
+        )
+        .await;
+
+        assert_eq!(seed_tracker.committable_offsets().get(&0), Some(&6));
+    }
+
+    #[tokio::test]
+    async fn worker_admits_and_drains_a_zero_row_reconcile_before_releasing_its_offset() {
+        const FILTERS_HASH: &str = "shape-v1";
+
+        let (_dir, store) = temp_store();
+        let membership = CaptureSink::new();
+        let merge = reconcile_deps();
+        let seed_tracker = merge.seed_tracker.clone();
+        let backlog = merge.reconcile.backlog.clone();
+        let events_tracker = Arc::new(OffsetTracker::new());
+        let tile = ReconcileTile::new(
+            TeamId(TEAM),
+            CohortId(1),
+            BehavioralShapeHash::parse(FILTERS_HASH).unwrap(),
+            RunId(Uuid::from_u128(7)),
+        );
+
+        run_batch(
+            0,
+            &store,
+            reconcile_catalog(FILTERS_HASH),
+            &membership,
+            &events_tracker,
+            merge,
+            0,
+            vec![
+                ShuffleMessage::Seed {
+                    work: Box::new(SeedWork::Reconcile(tile)),
+                    offset: 5,
+                },
+                ShuffleMessage::ReconcileDrain,
+            ],
+        )
+        .await;
+
+        assert!(membership.changes().is_empty());
+        let markers = membership.markers();
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].partition(), 0);
+        assert_eq!(markers[0].run_id(), RunId(Uuid::from_u128(7)));
+        assert_eq!(seed_tracker.committable_offsets().get(&0), Some(&6));
+        assert!(backlog.is_empty());
+    }
+
+    #[tokio::test]
+    async fn maintenance_boundary_keeps_later_live_output_strictly_newer_in_one_batch() {
+        let (_dir, store) = temp_store();
+        let membership = CaptureSink::new();
+        let tracker = Arc::new(OffsetTracker::new());
+        let person = Uuid::from_u128(0x71AE);
+        let mut leaves = person_event(person, "other@p.com", 5, 1);
+        leaves.timestamp = "2026-05-26 12:34:56.790000".to_string();
+
+        run_batch(
+            0,
+            &store,
+            person_catalog(),
+            &membership,
+            &tracker,
+            merge_deps_with(CaptureStreamEventSink::new()),
+            2,
+            vec![
+                ShuffleMessage::Event {
+                    event: Box::new(person_event(person, "u@p.com", 5, 0)),
+                    cse_offset: 0,
+                    broker_ts_ms: None,
+                },
+                ShuffleMessage::ReconcileDrain,
+                ShuffleMessage::Event {
+                    event: Box::new(leaves),
+                    cse_offset: 1,
+                    broker_ts_ms: None,
+                },
+            ],
+        )
+        .await;
+
+        let changes = membership.changes();
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0].status, MembershipStatus::Entered);
+        assert_eq!(changes[1].status, MembershipStatus::Left);
+        assert!(changes[0].last_updated < changes[1].last_updated);
     }
 
     #[tokio::test]
@@ -1764,7 +1973,7 @@ mod tombstone_redirect_tests {
     }
 
     /// The `MergeCfGc` arm runs the `cf_stage2` orphan GC only when `stage2_orphan_gc_enabled`: a
-    /// SingleLeaf cohort's row (an orphan) survives with the kill-switch off and is reclaimed with it on.
+    /// catalog-absent cohort's row survives with the kill-switch off and is reclaimed with it on.
     #[tokio::test]
     async fn merge_cf_gc_arm_runs_stage2_orphan_gc_only_when_enabled() {
         for (enabled, expect_present) in [(false, true), (true, false)] {
@@ -1774,7 +1983,7 @@ mod tombstone_redirect_tests {
             let orphan = Stage2Key {
                 partition_id,
                 team_id: TEAM as u64,
-                cohort_id: 1, // SingleLeaf in person_catalog → an orphan
+                cohort_id: 99,
                 person_id: person,
             };
             store

--- a/rust/cohort-stream-processor/tests/cascade_consumer.rs
+++ b/rust/cohort-stream-processor/tests/cascade_consumer.rs
@@ -465,6 +465,7 @@ async fn spawn_instance(
         live_watermarks: Arc::new(
             cohort_stream_processor::partitions::watermarks::LiveWatermarks::new(),
         ),
+        reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/events_consumer.rs
+++ b/rust/cohort-stream-processor/tests/events_consumer.rs
@@ -45,6 +45,7 @@ use cohort_stream_processor::partitions::{
 };
 use cohort_stream_processor::producer::{
     CaptureSink, CohortMembershipChange, KafkaMembershipSink, MembershipSink, MembershipStatus,
+    ReconcileCompleteMarker,
 };
 use cohort_stream_processor::stage1::{Stage1State, StatefulRecord};
 use cohort_stream_processor::store::durability::{
@@ -729,6 +730,16 @@ impl MembershipSink for BarrierSink {
             .expect("BarrierSink poisoned")
             .extend(changes);
         acks
+    }
+
+    async fn produce_markers(
+        &self,
+        markers: Vec<ReconcileCompleteMarker>,
+    ) -> Vec<Result<(), KafkaProduceError>> {
+        markers
+            .into_iter()
+            .map(|_| Err(KafkaProduceError::KafkaProduceCanceled))
+            .collect()
     }
 }
 

--- a/rust/cohort-stream-processor/tests/filter_catalog.rs
+++ b/rust/cohort-stream-processor/tests/filter_catalog.rs
@@ -19,6 +19,7 @@ fn row(id: i32, team_id: i32, filters: Value) -> CohortRow {
         id,
         team_id,
         filters,
+        behavioral_filters_shape_hash: None,
         timezone: "UTC".to_string(),
     }
 }

--- a/rust/cohort-stream-processor/tests/merge_consumer.rs
+++ b/rust/cohort-stream-processor/tests/merge_consumer.rs
@@ -621,6 +621,7 @@ async fn spawn_instance(
         live_watermarks: Arc::new(
             cohort_stream_processor::partitions::watermarks::LiveWatermarks::new(),
         ),
+        reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(
@@ -768,6 +769,7 @@ async fn keyed_produces_agree_with_partition_of_live() {
                 source_partition: 0,
                 source_offset: n as i64,
                 leaves: vec![],
+                membership_registers: vec![],
                 forward_hops: 0,
                 person_dedup: None,
             })

--- a/rust/cohort-stream-processor/tests/merge_durability.rs
+++ b/rust/cohort-stream-processor/tests/merge_durability.rs
@@ -719,6 +719,7 @@ async fn spawn_instance(
         live_watermarks: Arc::new(
             cohort_stream_processor::partitions::watermarks::LiveWatermarks::new(),
         ),
+        reconcile: cohort_stream_processor::workers::ReconcileDeps::default(),
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(

--- a/rust/cohort-stream-processor/tests/merge_protocol.rs
+++ b/rust/cohort-stream-processor/tests/merge_protocol.rs
@@ -18,7 +18,8 @@ use cohort_stream_processor::merge::apply_handler::{
 use cohort_stream_processor::merge::drain_handler::{handle_merge_event, DrainOutcome};
 use cohort_stream_processor::merge::tombstone_redirect::{resolve, Resolution};
 use cohort_stream_processor::merge::transfer::{
-    MergeStateTransfer, PendingTransfer, PersonMergeEvent, Tombstone, MERGE_EVENT_SCHEMA_VERSION,
+    MergeStateTransfer, PendingTransfer, PersonMergeEvent, Tombstone, TransferMembershipRegister,
+    TransferMembershipRegisterKind, MERGE_EVENT_SCHEMA_VERSION,
 };
 use cohort_stream_processor::partitions::{partition_of, COHORT_PARTITION_COUNT};
 use cohort_stream_processor::producer::{now_last_updated, MembershipStatus};
@@ -128,6 +129,14 @@ fn build_filters() -> TeamFilters {
             TeamId(TEAM),
             &cohort(vec![daily_leaf(), person_leaf()]),
         )
+        .unwrap();
+    builder.freeze(UTC)
+}
+
+fn false_single_leaf_filters() -> TeamFilters {
+    let mut builder = TeamFiltersBuilder::default();
+    builder
+        .add_cohort(CohortId(1), TeamId(TEAM), &cohort(vec![daily_leaf()]))
         .unwrap();
     builder.freeze(UTC)
 }
@@ -262,6 +271,357 @@ fn behavioral_states(
     )
 }
 
+fn membership_register_key(partition_id: u16, cohort_id: u64, person: Uuid) -> Stage2Key {
+    Stage2Key {
+        partition_id,
+        team_id: TEAM as u64,
+        cohort_id,
+        person_id: person,
+    }
+}
+
+fn membership_register_bit(
+    store: &CohortStore,
+    partition_id: u16,
+    cohort_id: u64,
+    person: Uuid,
+) -> Option<bool> {
+    store
+        .get_stage2(&membership_register_key(partition_id, cohort_id, person))
+        .unwrap()
+        .map(|bytes| Stage2State::decode(&bytes).unwrap().in_cohort)
+}
+
+fn put_membership_register(
+    store: &CohortStore,
+    partition_id: u16,
+    cohort_id: u64,
+    person: Uuid,
+    in_cohort: bool,
+) {
+    store
+        .write_batch(|batch| {
+            batch.put_stage2(
+                &membership_register_key(partition_id, cohort_id, person),
+                &Stage2State {
+                    in_cohort,
+                    last_evaluated_at_ms: 1,
+                }
+                .encode(),
+            )
+        })
+        .unwrap();
+}
+
+#[test]
+fn merge_preserves_a_false_single_leaf_register_with_or_without_leaf_state() {
+    for same_partition in [false, true] {
+        for leaf_state_present in [false, true] {
+            let dir = TempDir::new().unwrap();
+            let store = temp_store_in(&dir);
+            let filters = false_single_leaf_filters();
+            let p_old = Uuid::from_u128(0xA11CE);
+            let p_old_part = part(p_old);
+            let p_new = if same_partition {
+                person_on(p_old_part)
+            } else {
+                person_not_on(p_old_part)
+            };
+            let p_new_part = part(p_new);
+
+            if leaf_state_present {
+                fold_pageview(&store, &filters, p_old_part, p_old, 10, 0);
+            }
+            put_membership_register(&store, p_old_part, 1, p_old, false);
+
+            let drained = handle_merge_event(
+                p_old_part,
+                &store,
+                &filters,
+                &merge_event(p_old, p_new),
+                (5, 100),
+                COHORT_PARTITION_COUNT,
+            )
+            .unwrap();
+            match drained {
+                DrainOutcome::FastPath { .. } if same_partition => {}
+                DrainOutcome::Drained { transfer, .. } if !same_partition => {
+                    assert_eq!(
+                        transfer.membership_registers,
+                        vec![TransferMembershipRegister {
+                            cohort_id: 1,
+                            in_cohort: false,
+                            kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+                        }],
+                    );
+                    assert!(matches!(
+                        handle_transfer(
+                            p_new_part,
+                            &store,
+                            &filters,
+                            &transfer,
+                            (5, 7),
+                            COHORT_PARTITION_COUNT,
+                        )
+                        .unwrap(),
+                        ApplyOutcome::Applied { .. }
+                    ));
+                }
+                other => {
+                    panic!("unexpected merge path (same_partition={same_partition}): {other:?}")
+                }
+            }
+
+            assert_eq!(
+                membership_register_bit(&store, p_old_part, 1, p_old),
+                None,
+                "the merged-away identity is reclaimed",
+            );
+            assert_eq!(
+                membership_register_bit(&store, p_new_part, 1, p_new),
+                Some(false),
+                "the survivor stays in the reconcile scan domain (same_partition={same_partition}, leaf_state_present={leaf_state_present})",
+            );
+            assert_eq!(
+                leaf_state(
+                    &store,
+                    p_new_part,
+                    lsk_of(&filters, StateVariant::BehavioralDailyBuckets),
+                    p_new,
+                )
+                .is_some(),
+                leaf_state_present,
+            );
+        }
+    }
+}
+
+#[test]
+fn cross_partition_catalog_edit_preserves_the_register_scan_domain() {
+    let dir = TempDir::new().unwrap();
+    let store = temp_store_in(&dir);
+    let source_filters = false_single_leaf_filters();
+    let mut target_builder = TeamFiltersBuilder::default();
+    target_builder
+        .add_cohort(CohortId(1), TeamId(TEAM), &cohort(vec![single_leaf()]))
+        .unwrap();
+    let target_filters = target_builder.freeze(UTC);
+    let p_old = Uuid::from_u128(0xA11CE);
+    let p_old_part = part(p_old);
+    let p_new = person_not_on(p_old_part);
+    let p_new_part = part(p_new);
+
+    fold_pageview(&store, &source_filters, p_old_part, p_old, 10, 0);
+    put_membership_register(&store, p_old_part, 1, p_old, false);
+
+    let transfer = match handle_merge_event(
+        p_old_part,
+        &store,
+        &source_filters,
+        &merge_event(p_old, p_new),
+        (5, 100),
+        COHORT_PARTITION_COUNT,
+    )
+    .unwrap()
+    {
+        DrainOutcome::Drained { transfer, .. } => transfer,
+        other => panic!("expected a cross-partition transfer, got {other:?}"),
+    };
+    assert_eq!(
+        transfer.membership_registers,
+        vec![TransferMembershipRegister {
+            cohort_id: 1,
+            in_cohort: false,
+            kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+        }],
+    );
+
+    assert!(matches!(
+        handle_transfer(
+            p_new_part,
+            &store,
+            &target_filters,
+            &transfer,
+            (5, 7),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap(),
+        ApplyOutcome::Applied { .. }
+    ));
+    assert_eq!(
+        membership_register_bit(&store, p_new_part, 1, p_new),
+        Some(false),
+        "the transfer fallback keeps the survivor scannable across a single-leaf LSK edit",
+    );
+}
+
+#[test]
+fn cross_partition_single_leaf_to_composable_edit_materializes_a_false_sentinel() {
+    let dir = TempDir::new().unwrap();
+    let store = temp_store_in(&dir);
+    let source_filters = false_single_leaf_filters();
+    let mut target_builder = TeamFiltersBuilder::default();
+    target_builder
+        .add_cohort(
+            CohortId(1),
+            TeamId(TEAM),
+            &cohort(vec![single_leaf(), compressed_leaf()]),
+        )
+        .unwrap();
+    let target_filters = target_builder.freeze(UTC);
+    let p_old = Uuid::from_u128(0xA11CE);
+    let p_old_part = part(p_old);
+    let p_new = person_not_on(p_old_part);
+    let p_new_part = part(p_new);
+
+    put_membership_register(&store, p_old_part, 1, p_old, true);
+    let transfer = match handle_merge_event(
+        p_old_part,
+        &store,
+        &source_filters,
+        &merge_event(p_old, p_new),
+        (5, 100),
+        COHORT_PARTITION_COUNT,
+    )
+    .unwrap()
+    {
+        DrainOutcome::Drained { transfer, .. } => transfer,
+        other => panic!("expected a cross-partition transfer, got {other:?}"),
+    };
+    assert_eq!(
+        transfer.membership_registers,
+        vec![TransferMembershipRegister {
+            cohort_id: 1,
+            in_cohort: true,
+            kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+        }],
+    );
+
+    assert!(matches!(
+        handle_transfer(
+            p_new_part,
+            &store,
+            &target_filters,
+            &transfer,
+            (5, 7),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap(),
+        ApplyOutcome::Applied { .. }
+    ));
+    assert_eq!(
+        membership_register_bit(&store, p_new_part, 1, p_new),
+        Some(false),
+        "a newly composable row gains scan presence without changing its absent-is-false semantics",
+    );
+}
+
+#[test]
+fn cross_partition_merge_preserves_a_composable_false_row_without_leaf_state() {
+    let dir = TempDir::new().unwrap();
+    let store = temp_store_in(&dir);
+    let mut builder = TeamFiltersBuilder::default();
+    builder
+        .add_cohort(
+            CohortId(1),
+            TeamId(TEAM),
+            &cohort(vec![single_leaf(), compressed_leaf()]),
+        )
+        .unwrap();
+    let filters = builder.freeze(UTC);
+    let p_old = Uuid::from_u128(0xA11CE);
+    let p_old_part = part(p_old);
+    let p_new = person_not_on(p_old_part);
+    let p_new_part = part(p_new);
+
+    put_membership_register(&store, p_old_part, 1, p_old, false);
+    let transfer = match handle_merge_event(
+        p_old_part,
+        &store,
+        &filters,
+        &merge_event(p_old, p_new),
+        (5, 100),
+        COHORT_PARTITION_COUNT,
+    )
+    .unwrap()
+    {
+        DrainOutcome::Drained { transfer, .. } => transfer,
+        other => panic!("expected a cross-partition transfer, got {other:?}"),
+    };
+
+    assert!(matches!(
+        handle_transfer(
+            p_new_part,
+            &store,
+            &filters,
+            &transfer,
+            (5, 7),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap(),
+        ApplyOutcome::Applied { .. }
+    ));
+    assert_eq!(
+        membership_register_bit(&store, p_new_part, 1, p_new),
+        Some(false),
+        "the existing composable scan domain follows the survivor even without leaf transitions",
+    );
+}
+
+#[test]
+fn cross_partition_merge_preserves_the_domain_of_a_corrupt_register_row() {
+    let dir = TempDir::new().unwrap();
+    let store = temp_store_in(&dir);
+    let filters = false_single_leaf_filters();
+    let p_old = Uuid::from_u128(0xA11CE);
+    let p_old_part = part(p_old);
+    let p_new = person_not_on(p_old_part);
+    let p_new_part = part(p_new);
+    store
+        .write_batch(|batch| {
+            batch.put_stage2(&membership_register_key(p_old_part, 1, p_old), b"corrupt")
+        })
+        .unwrap();
+
+    let transfer = match handle_merge_event(
+        p_old_part,
+        &store,
+        &filters,
+        &merge_event(p_old, p_new),
+        (5, 100),
+        COHORT_PARTITION_COUNT,
+    )
+    .unwrap()
+    {
+        DrainOutcome::Drained { transfer, .. } => transfer,
+        other => panic!("expected a cross-partition transfer, got {other:?}"),
+    };
+    assert_eq!(
+        transfer.membership_registers,
+        vec![TransferMembershipRegister {
+            cohort_id: 1,
+            in_cohort: false,
+            kind: TransferMembershipRegisterKind::SingleLeafBehavioral,
+        }],
+    );
+    assert!(matches!(
+        handle_transfer(
+            p_new_part,
+            &store,
+            &filters,
+            &transfer,
+            (5, 7),
+            COHORT_PARTITION_COUNT,
+        )
+        .unwrap(),
+        ApplyOutcome::Applied { .. }
+    ));
+    assert_eq!(
+        membership_register_bit(&store, p_new_part, 1, p_new),
+        Some(false),
+    );
+}
+
 #[test]
 fn cross_partition_drain_transfer_apply_merges_all_variants_and_matches_the_oracle() {
     let dir = TempDir::new().unwrap();
@@ -279,6 +639,10 @@ fn cross_partition_drain_transfer_apply_merges_all_variants_and_matches_the_orac
 
     fold_pageview(&store, &filters, p_old_part, p_old, 10, 0);
     fold_pageview(&store, &filters, p_new_part, p_new, 20, 0);
+    // Model the complete seed-created register domain: these leaves have state but are not members
+    // until old and survivor state are combined by the merge.
+    put_membership_register(&store, p_old_part, 2, p_old, false);
+    put_membership_register(&store, p_old_part, 3, p_old, false);
 
     let drained = handle_merge_event(
         p_old_part,
@@ -299,6 +663,13 @@ fn cross_partition_drain_transfer_apply_merges_all_variants_and_matches_the_orac
         s.is_none() && d.is_none() && c.is_none(),
         "P_old's state was drained"
     );
+    for cohort_id in 1..=3 {
+        assert_eq!(
+            membership_register_bit(&store, p_old_part, cohort_id, p_old),
+            None,
+            "drain removes P_old's single-leaf register for cohort {cohort_id}",
+        );
+    }
     assert!(store
         .get_tombstone(&TombstoneKey {
             partition_id: p_old_part,
@@ -337,6 +708,13 @@ fn cross_partition_drain_transfer_apply_merges_all_variants_and_matches_the_orac
         "daily summed across both persons"
     );
     assert_eq!(compressed_sum(&compressed.clone().unwrap()), 2);
+    for cohort_id in 1..=3 {
+        assert_eq!(
+            membership_register_bit(&store, p_new_part, cohort_id, p_new),
+            Some(true),
+            "apply aligns the survivor's single-leaf register for cohort {cohort_id}",
+        );
+    }
 
     // Oracle: a person that received both events from the start, keyed to P_new's partition.
     let oracle = Uuid::from_u128(0xABCDE);
@@ -541,6 +919,8 @@ fn fast_path_equals_the_cross_partition_result() {
 
     fold_pageview(&store, &filters, p_old_part, p_old, 10, 0);
     fold_pageview(&store, &filters, p_old_part, p_new, 20, 0);
+    put_membership_register(&store, p_old_part, 2, p_old, false);
+    put_membership_register(&store, p_old_part, 3, p_old, false);
 
     let outcome = handle_merge_event(
         p_old_part,
@@ -573,6 +953,13 @@ fn fast_path_equals_the_cross_partition_result() {
 
     let (s, d, c) = behavioral_states(&store, &filters, p_old_part, p_old);
     assert!(s.is_none() && d.is_none() && c.is_none());
+    for cohort_id in 1..=3 {
+        assert_eq!(
+            membership_register_bit(&store, p_old_part, cohort_id, p_old),
+            None,
+            "fast-path drain removes P_old's register for cohort {cohort_id}",
+        );
+    }
     let (single, daily, compressed) = behavioral_states(&store, &filters, p_old_part, p_new);
     assert!(matches!(
         single,
@@ -583,6 +970,13 @@ fn fast_path_equals_the_cross_partition_result() {
     ));
     assert_eq!(daily_sum(&daily.unwrap()), 2);
     assert_eq!(compressed_sum(&compressed.unwrap()), 2);
+    for cohort_id in 1..=3 {
+        assert_eq!(
+            membership_register_bit(&store, p_old_part, cohort_id, p_new),
+            Some(true),
+            "fast-path apply aligns P_new's register for cohort {cohort_id}",
+        );
+    }
 }
 
 #[test]

--- a/rust/cohort-stream-processor/tests/seed_consumer.rs
+++ b/rust/cohort-stream-processor/tests/seed_consumer.rs
@@ -12,7 +12,7 @@
 //! cargo test -p cohort-stream-processor --test seed_consumer -- --ignored --test-threads=1
 //! ```
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::num::NonZeroU32;
 use std::panic::AssertUnwindSafe;
@@ -20,7 +20,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono_tz::UTC;
-use cohort_core::seed::{ClaimEpoch, ConditionHash, RunId, SChunkMs, SeedTile};
+use cohort_core::seed::{
+    BehavioralShapeHash, ClaimEpoch, ConditionHash, ReconcileTile, RunId, SChunkMs, SeedTile,
+};
 use cohort_stream_processor::consumers::{
     CascadeRoute, CohortStreamEventsConsumer, EventDispatcher, FollowerConsumer, MergeRoute,
     SeedFollowerConsumer, TransferRoute,
@@ -36,14 +38,17 @@ use cohort_stream_processor::partitions::{
 use cohort_stream_processor::producer::{
     CascadeSink, ChangeOrigin, CohortMembershipChange, KafkaCascadeSink, KafkaMembershipSink,
     KafkaSeedTileSink, KafkaStreamEventSink, KafkaTransferSink, MembershipSink, MembershipStatus,
-    SeedTileSink, StreamEventSink, TransferSink,
+    ReconcileCompleteMarker, SeedTileSink, StreamEventSink, TransferSink,
 };
 use cohort_stream_processor::stage1::bucket_tz::day_idx_in_tz;
+use cohort_stream_processor::stage2::state::Stage2State;
 use cohort_stream_processor::store::{
-    CohortStore, OffloadConfig, OffloadMode, StoreConfig, StoreHandle,
+    CohortStore, OffloadConfig, OffloadMode, ReadLane, Stage2Key, StagedBatch, StoreConfig,
+    StoreHandle,
 };
 use cohort_stream_processor::workers::{
-    CascadeConfig, MergeWorkerDeps, TransferRetryPolicy, DEFAULT_MERGE_GC_SCAN_LIMIT,
+    CascadeConfig, MergeWorkerDeps, ReconcileBacklog, ReconcileDeps, TransferRetryPolicy,
+    DEFAULT_MERGE_GC_SCAN_LIMIT,
 };
 use common_kafka::config::KafkaConfig;
 use futures::FutureExt;
@@ -62,6 +67,8 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 const TEAM: i32 = 7;
+const COHORT: i32 = 1;
+const FILTERS_HASH: &str = "0123456789abcdef";
 const NUM_PARTITIONS: i32 = COHORT_PARTITION_COUNT as i32;
 const COMMIT_INTERVAL: Duration = Duration::from_millis(250);
 const RECV_TIMEOUT: Duration = Duration::from_millis(200);
@@ -77,17 +84,21 @@ fn seed_catalog() -> CatalogHandle {
     let leaf = json!({
         "type": "behavioral", "value": "performed_event", "key": "$pageview",
         "time_value": 7, "time_interval": "day",
-        "conditionHash": "0123456789abcdef",
+        "conditionHash": FILTERS_HASH,
         "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
     });
     let mut builder = TeamFiltersBuilder::default();
     builder
         .add_cohort(
-            CohortId(1),
+            CohortId(COHORT),
             TeamId(TEAM),
             &json!({ "properties": { "type": "AND", "values": [leaf] } }),
         )
         .expect("add cohort");
+    builder.set_behavioral_shape_hash(
+        CohortId(COHORT),
+        BehavioralShapeHash::parse(FILTERS_HASH).expect("valid test behavioral hash"),
+    );
     CatalogHandle::from_catalog(FilterCatalog::from_teams([(
         TeamId(TEAM),
         builder.freeze(UTC),
@@ -281,22 +292,31 @@ fn part(person: Uuid) -> u16 {
 
 /// The seed group's committed next-offset for `partition`, read without joining the group.
 fn seed_group_committed(group: &str, topic: &str, partition: i32) -> Option<i64> {
+    seed_group_committed_offsets(group, topic)
+        .get(&partition)
+        .copied()
+}
+
+/// Every concrete committed next-offset for the seed topic, read in one coordinator request.
+fn seed_group_committed_offsets(group: &str, topic: &str) -> HashMap<i32, i64> {
     let consumer: StreamConsumer = follower_client_config(group)
         .create()
         .expect("create committed-offset verifier");
     let mut tpl = TopicPartitionList::new();
-    tpl.add_partition(topic, partition);
+    for partition in 0..NUM_PARTITIONS {
+        tpl.add_partition(topic, partition);
+    }
     let committed = consumer
         .committed_offsets(tpl, Duration::from_secs(10))
-        .ok()?;
+        .expect("query seed-group committed offsets");
     committed
         .elements_for_topic(topic)
         .iter()
-        .find(|elem| elem.partition() == partition)
-        .and_then(|elem| match elem.offset() {
-            Offset::Offset(next) => Some(next),
+        .filter_map(|elem| match elem.offset() {
+            Offset::Offset(next) => Some((elem.partition(), next)),
             _ => None,
         })
+        .collect()
 }
 
 /// A name-mismatched warm-up event: folds (advancing the watermark) without flipping anything.
@@ -317,12 +337,21 @@ fn warm_envelope(person: Uuid, source_offset: i64) -> Vec<u8> {
     .expect("serialize envelope")
 }
 
-async fn produce_warm_event(producer: &FutureProducer, topic: &str, person: Uuid, offset: i64) {
+async fn produce_warm_event(
+    producer: &FutureProducer,
+    topic: &str,
+    person: Uuid,
+    offset: i64,
+    broker_timestamp_ms: i64,
+) {
     let key = merge_partition_key(TeamId(TEAM), &person);
     let payload = warm_envelope(person, offset);
     let (partition, _) = producer
         .send(
-            FutureRecord::to(topic).key(&key).payload(&payload),
+            FutureRecord::to(topic)
+                .key(&key)
+                .payload(&payload)
+                .timestamp(broker_timestamp_ms),
             Timeout::After(Duration::from_secs(10)),
         )
         .await
@@ -347,6 +376,31 @@ fn tile(person: Uuid, s_chunk_ms: i64) -> SeedTile {
 async fn produce_tile(seed_sink: &KafkaSeedTileSink, produced: SeedTile) {
     let acks = seed_sink.produce(vec![produced]).await;
     assert!(acks.iter().all(Result::is_ok), "tile produce must ack");
+}
+
+async fn produce_reconcile(
+    producer: &FutureProducer,
+    topic: &str,
+    partition: i32,
+    tile: &ReconcileTile,
+) -> i64 {
+    let key = format!("reconcile:{TEAM}:{COHORT}:{partition}");
+    let payload = serde_json::to_vec(tile).expect("serialize reconcile control");
+    let (ack_partition, offset) = producer
+        .send(
+            FutureRecord::to(topic)
+                .partition(partition)
+                .key(&key)
+                .payload(&payload),
+            Timeout::After(Duration::from_secs(10)),
+        )
+        .await
+        .expect("produce reconcile control");
+    assert_eq!(
+        ack_partition, partition,
+        "broker acked the targeted partition"
+    );
+    offset
 }
 
 fn open_store(dir: &TempDir) -> CohortStore {
@@ -429,12 +483,64 @@ fn register_instance(manager: &mut Manager) -> [Handle; 5] {
 
 struct Instance {
     dispatcher: Arc<EventDispatcher>,
+    store: StoreHandle,
+    reconcile_backlog: Arc<ReconcileBacklog>,
+    seed_tracker: Arc<OffsetTracker>,
+    seed_consumer: Arc<StreamConsumer>,
+    live_watermarks: Arc<LiveWatermarks>,
     tasks: Vec<JoinHandle<()>>,
 }
 
 impl Instance {
     fn owned(&self) -> HashSet<i32> {
         self.dispatcher.owned_partitions().into_iter().collect()
+    }
+
+    async fn put_stage2(&self, key: &Stage2Key, state: &Stage2State) {
+        let mut staged = StagedBatch::default();
+        staged.put_stage2(key, &state.encode());
+        self.store
+            .commit(staged)
+            .await
+            .expect("write test Stage 2 state");
+    }
+
+    async fn stage2(&self, key: &Stage2Key) -> Stage2State {
+        let bytes = self
+            .store
+            .get_stage2(key, ReadLane::Maintenance)
+            .await
+            .expect("read test Stage 2 state")
+            .expect("test Stage 2 row exists");
+        Stage2State::decode(&bytes).expect("decode test Stage 2 state")
+    }
+
+    fn seed_committable(&self, partition: u16) -> Option<i64> {
+        self.seed_tracker
+            .committable_offsets()
+            .get(&(partition as i32))
+            .copied()
+    }
+
+    fn seed_position(&self, topic: &str, partition: u16) -> Option<i64> {
+        let positions = self
+            .seed_consumer
+            .position()
+            .expect("query seed-consumer positions");
+        positions
+            .elements_for_topic(topic)
+            .iter()
+            .find(|elem| elem.partition() == partition as i32)
+            .and_then(|elem| match elem.offset() {
+                Offset::Offset(next) => Some(next),
+                _ => None,
+            })
+    }
+
+    fn live_watermark(&self, partition: u16) -> Option<i64> {
+        self.live_watermarks
+            .get(partition as i32)
+            .map(|watermark| watermark.0)
     }
 
     async fn join(self) {
@@ -454,6 +560,17 @@ async fn spawn_instance(
 ) -> Instance {
     let [events_handle, merge_handle, transfer_handle, cascade_handle, seed_handle] = handles;
     let kafka_config = producer_kafka_config();
+    let store = StoreHandle::new(
+        store,
+        OffloadConfig {
+            mode: OffloadMode::All,
+            event_read_permits: 16,
+            maintenance_permits: 6,
+        },
+    );
+    let reconcile_backlog = Arc::new(ReconcileBacklog::default());
+    let seed_tracker = Arc::new(OffsetTracker::new());
+    let live_watermarks = Arc::new(LiveWatermarks::new());
 
     let transfer_sink: Arc<dyn TransferSink> = Arc::new(
         KafkaTransferSink::new(&kafka_config, topics.transfers.clone())
@@ -493,21 +610,19 @@ async fn spawn_instance(
         cascade: CascadeConfig::default(),
         partition_count: COHORT_PARTITION_COUNT,
         seed_tile_sink,
-        seed_tracker: Arc::new(OffsetTracker::new()),
-        live_watermarks: Arc::new(LiveWatermarks::new()),
+        seed_tracker: seed_tracker.clone(),
+        live_watermarks: live_watermarks.clone(),
+        reconcile: ReconcileDeps {
+            enabled: true,
+            scan_page: 1,
+            backlog: reconcile_backlog.clone(),
+        },
     });
 
     let dispatcher = Arc::new(EventDispatcher::new(
         PartitionRouter::new(64),
         Arc::new(OffsetTracker::new()),
-        StoreHandle::new(
-            store,
-            OffloadConfig {
-                mode: OffloadMode::All,
-                event_read_permits: 16,
-                maintenance_permits: 6,
-            },
-        ),
+        store.clone(),
         Arc::new(catalog),
         membership_sink,
         merge_deps,
@@ -596,7 +711,7 @@ async fn spawn_instance(
         topics.seeds.clone(),
     ));
     let seed_follower = SeedFollowerConsumer::new(
-        seeds_consumer,
+        seeds_consumer.clone(),
         topics.seeds.clone(),
         events_client.clone(),
         topics.events.clone(),
@@ -625,7 +740,15 @@ async fn spawn_instance(
     );
     tasks.push(tokio::spawn(events_consumer.process()));
 
-    Instance { dispatcher, tasks }
+    Instance {
+        dispatcher,
+        store,
+        reconcile_backlog,
+        seed_tracker,
+        seed_consumer: seeds_consumer,
+        live_watermarks,
+        tasks,
+    }
 }
 
 /// A tile lands on its owning worker via the 5-topic co-assignment, applies behind an open
@@ -666,7 +789,14 @@ async fn seed_tile_applies_on_the_owning_worker_and_commits_to_the_hwm() {
         let alice = Uuid::from_u128(0xA11CE);
         // One folded live event opens the fence for the hour-old scan point.
         let producer = murmur2_producer();
-        produce_warm_event(&producer, &topics.events, alice, 0).await;
+        produce_warm_event(
+            &producer,
+            &topics.events,
+            alice,
+            0,
+            chrono::Utc::now().timestamp_millis(),
+        )
+        .await;
 
         let seed_sink = KafkaSeedTileSink::new(&producer_kafka_config(), topics.seeds.clone())
             .await
@@ -714,6 +844,291 @@ async fn seed_tile_applies_on_the_owning_worker_and_commits_to_the_hwm() {
     .await;
 }
 
+/// Partition-targeted controls drain a full 64-partition snapshot, repair a stale membership bit,
+/// and release each seed offset only after that partition's completion marker is acknowledged.
+#[tokio::test]
+#[ignore = "requires a running Kafka broker (KAFKA_HOSTS); run with --ignored against a local stack"]
+async fn reconcile_snapshot_repairs_stale_state_and_commits_after_markers() {
+    let suffix = Uuid::new_v4();
+    let topics = Topics::unique(&suffix);
+    let groups = Groups::unique(&suffix);
+    with_topics_cleanup(&topics.names(), async {
+        topics.create().await;
+
+        let mut manager = Manager::builder("reconcile-e2e-itest")
+            .with_trap_signals(false)
+            .build();
+        let handles = register_instance(&mut manager);
+        let shutdown = handles[0].clone();
+        let _monitor = manager.monitor_background();
+
+        let dir = TempDir::new().unwrap();
+        let instance = spawn_instance(
+            &topics,
+            &groups,
+            open_store(&dir),
+            seed_catalog(),
+            handles,
+            2_000,
+        )
+        .await;
+        wait_for(
+            "the consumer to own every partition",
+            Duration::from_secs(30),
+            || instance.owned().len() == NUM_PARTITIONS as usize,
+        )
+        .await;
+
+        // This person has no leaf state, so current membership is false. The injected true
+        // register bit models an at-most-once output loss or an edit-path stale row.
+        let person = Uuid::from_u128(0xDEC0DE);
+        let person_partition = part(person);
+        let stage2_key = Stage2Key {
+            partition_id: person_partition,
+            team_id: TEAM as u64,
+            cohort_id: COHORT as u64,
+            person_id: person,
+        };
+        instance
+            .put_stage2(
+                &stage2_key,
+                &Stage2State {
+                    in_cohort: true,
+                    last_evaluated_at_ms: 1,
+                },
+            )
+            .await;
+        assert!(instance.stage2(&stage2_key).await.in_cohort);
+
+        let run_id = RunId(Uuid::from_u128(0xB4));
+        let reconcile = ReconcileTile::new(
+            TeamId(TEAM),
+            CohortId(COHORT),
+            BehavioralShapeHash::parse(FILTERS_HASH).unwrap(),
+            run_id,
+        );
+        let producer = murmur2_producer();
+
+        for partition in 0..NUM_PARTITIONS {
+            assert_eq!(
+                produce_reconcile(&producer, &topics.seeds, partition, &reconcile).await,
+                0,
+                "a unique topic starts every partition at offset zero",
+            );
+        }
+        wait_for(
+            "all partition-targeted reconcile controls to be admitted",
+            Duration::from_secs(30),
+            || instance.reconcile_backlog.len() == i64::from(NUM_PARTITIONS),
+        )
+        .await;
+        let before_first_tick = seed_group_committed_offsets(&groups.seeds, &topics.seeds);
+        assert!(
+            before_first_tick.is_empty(),
+            "no reconcile control commits before draining starts",
+        );
+        assert!((0..NUM_PARTITIONS)
+            .all(|partition| { instance.seed_committable(partition as u16).is_none() }));
+
+        // scan_page=1 makes the stale row consume a whole first page. Every empty partition can
+        // emit its marker immediately, while this partition remains pinned after emitting `left`.
+        instance.dispatcher.route_reconcile_drain().await;
+        wait_for(
+            "63 empty-partition markers and one stale-row repair",
+            Duration::from_secs(60),
+            || topic_message_count(&topics.shadow) == NUM_PARTITIONS as i64,
+        )
+        .await;
+        wait_for(
+            "only the stale-row partition to remain queued",
+            Duration::from_secs(30),
+            || instance.reconcile_backlog.len() == 1,
+        )
+        .await;
+        assert_ne!(
+            seed_group_committed(&groups.seeds, &topics.seeds, person_partition as i32),
+            Some(1),
+            "the reconcile seed offset stays pinned before its marker",
+        );
+        assert_eq!(
+            instance.seed_committable(person_partition),
+            None,
+            "the production tracker stays pinned immediately after the row and before its marker",
+        );
+        assert!(!instance.stage2(&stage2_key).await.in_cohort);
+
+        let first_page = consume_all(
+            &topics.shadow,
+            NUM_PARTITIONS as usize,
+            Duration::from_secs(30),
+        )
+        .await;
+        let mut first_changes = Vec::new();
+        let mut first_markers = Vec::new();
+        for (_, payload) in first_page {
+            let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+            if value.get("type").and_then(serde_json::Value::as_str) == Some("reconcile_complete") {
+                first_markers
+                    .push(serde_json::from_slice::<ReconcileCompleteMarker>(&payload).unwrap());
+            } else {
+                first_changes
+                    .push(serde_json::from_slice::<CohortMembershipChange>(&payload).unwrap());
+            }
+        }
+        assert_eq!(first_changes.len(), 1);
+        assert_eq!(first_changes[0].person_id, person.to_string());
+        assert_eq!(first_changes[0].status, MembershipStatus::Left);
+        assert_eq!(first_changes[0].origin, Some(ChangeOrigin::Reconcile));
+        assert_eq!(first_changes[0].run_id, Some(run_id));
+        assert_eq!(first_markers.len(), NUM_PARTITIONS as usize - 1);
+        assert!(!first_markers
+            .iter()
+            .any(|marker| marker.partition() == person_partition));
+
+        instance.dispatcher.route_reconcile_drain().await;
+        wait_for(
+            "the final partition marker",
+            Duration::from_secs(30),
+            || topic_message_count(&topics.shadow) == i64::from(NUM_PARTITIONS) + 1,
+        )
+        .await;
+        wait_for(
+            "all reconcile jobs to complete",
+            Duration::from_secs(30),
+            || instance.reconcile_backlog.is_empty(),
+        )
+        .await;
+        wait_for(
+            "every seed partition commit to advance past its marker",
+            Duration::from_secs(30),
+            || {
+                let offsets = seed_group_committed_offsets(&groups.seeds, &topics.seeds);
+                (0..NUM_PARTITIONS).all(|partition| offsets.get(&partition) == Some(&1))
+            },
+        )
+        .await;
+        assert!((0..NUM_PARTITIONS)
+            .all(|partition| { instance.seed_committable(partition as u16) == Some(1) }));
+
+        let first_snapshot = consume_all(
+            &topics.shadow,
+            NUM_PARTITIONS as usize + 1,
+            Duration::from_secs(30),
+        )
+        .await;
+        let mut marker_partitions = HashSet::new();
+        let mut snapshot_changes = Vec::new();
+        for (_, payload) in first_snapshot {
+            let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+            if value.get("type").and_then(serde_json::Value::as_str) == Some("reconcile_complete") {
+                let marker: ReconcileCompleteMarker = serde_json::from_slice(&payload).unwrap();
+                assert_eq!(marker.team_id(), TeamId(TEAM));
+                assert_eq!(marker.cohort_id(), CohortId(COHORT));
+                assert_eq!(marker.run_id(), run_id);
+                marker_partitions.insert(marker.partition());
+            } else {
+                snapshot_changes
+                    .push(serde_json::from_slice::<CohortMembershipChange>(&payload).unwrap());
+            }
+        }
+        let expected_marker_partitions: HashSet<u16> = (0..COHORT_PARTITION_COUNT)
+            .map(|partition| partition as u16)
+            .collect();
+        assert_eq!(marker_partitions, expected_marker_partitions);
+        assert_eq!(snapshot_changes.len(), 1);
+        assert_eq!(snapshot_changes[0].status, MembershipStatus::Left);
+
+        // A duplicate manual dispatch emits the same full snapshot and certificate set, leaves the
+        // repaired bit unchanged, and advances every partition by exactly one more seed offset.
+        for partition in 0..NUM_PARTITIONS {
+            assert_eq!(
+                produce_reconcile(&producer, &topics.seeds, partition, &reconcile).await,
+                1,
+            );
+        }
+        wait_for(
+            "the duplicate reconcile controls to be admitted",
+            Duration::from_secs(30),
+            || instance.reconcile_backlog.len() == i64::from(NUM_PARTITIONS),
+        )
+        .await;
+        instance.dispatcher.route_reconcile_drain().await;
+        wait_for(
+            "the duplicate snapshot first page",
+            Duration::from_secs(60),
+            || topic_message_count(&topics.shadow) == i64::from(NUM_PARTITIONS) * 2 + 1,
+        )
+        .await;
+        assert_eq!(
+            seed_group_committed(&groups.seeds, &topics.seeds, person_partition as i32),
+            Some(1),
+            "redispatch stays pinned at the prior next-offset until its new marker",
+        );
+        assert_eq!(
+            instance.seed_committable(person_partition),
+            Some(1),
+            "the production tracker stays at the prior next-offset before the new marker",
+        );
+        instance.dispatcher.route_reconcile_drain().await;
+        wait_for(
+            "the duplicate snapshot marker set",
+            Duration::from_secs(30),
+            || topic_message_count(&topics.shadow) == i64::from(NUM_PARTITIONS) * 2 + 2,
+        )
+        .await;
+        wait_for(
+            "every redispatched seed partition commit to advance",
+            Duration::from_secs(30),
+            || {
+                let offsets = seed_group_committed_offsets(&groups.seeds, &topics.seeds);
+                (0..NUM_PARTITIONS).all(|partition| offsets.get(&partition) == Some(&2))
+            },
+        )
+        .await;
+        assert!((0..NUM_PARTITIONS)
+            .all(|partition| { instance.seed_committable(partition as u16) == Some(2) }));
+        assert!(!instance.stage2(&stage2_key).await.in_cohort);
+
+        let converged = consume_all(
+            &topics.shadow,
+            (NUM_PARTITIONS as usize * 2) + 2,
+            Duration::from_secs(30),
+        )
+        .await;
+        let mut marker_counts = HashMap::<u16, usize>::new();
+        let mut reconcile_changes = Vec::new();
+        for (_, payload) in converged {
+            let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+            if value.get("type").and_then(serde_json::Value::as_str) == Some("reconcile_complete") {
+                let marker: ReconcileCompleteMarker = serde_json::from_slice(&payload).unwrap();
+                assert_eq!(marker.team_id(), TeamId(TEAM));
+                assert_eq!(marker.cohort_id(), CohortId(COHORT));
+                assert_eq!(marker.run_id(), run_id);
+                *marker_counts.entry(marker.partition()).or_default() += 1;
+            } else {
+                reconcile_changes
+                    .push(serde_json::from_slice::<CohortMembershipChange>(&payload).unwrap());
+            }
+        }
+        assert_eq!(
+            marker_counts.keys().copied().collect::<HashSet<_>>(),
+            expected_marker_partitions,
+        );
+        assert!(marker_counts.values().all(|count| *count == 2));
+        assert_eq!(reconcile_changes.len(), 2);
+        assert!(reconcile_changes.iter().all(|change| {
+            change.person_id == person.to_string()
+                && change.status == MembershipStatus::Left
+                && change.origin == Some(ChangeOrigin::Reconcile)
+                && change.run_id == Some(run_id)
+        }));
+
+        shutdown.request_shutdown();
+        instance.join().await;
+    })
+    .await;
+}
+
 /// A tile scanned "now" stays fenced until live consumption flows past `s_chunk + margin`.
 #[tokio::test]
 #[ignore = "requires a running Kafka broker (KAFKA_HOSTS); run with --ignored against a local stack"]
@@ -724,6 +1139,29 @@ async fn fence_holds_a_fresh_tile_until_live_consumption_passes_its_scan_point()
     with_topics_cleanup(&topics.names(), async {
         topics.create().await;
 
+        // Put both same-partition records on the broker before the follower starts so its first
+        // receive batch can observe the closed tile and the FIFO suffix together.
+        let alice = Uuid::from_u128(0xA11CE);
+        let fence_margin_ms = 5_000;
+        let producer = murmur2_producer();
+        let seed_sink = KafkaSeedTileSink::new(&producer_kafka_config(), topics.seeds.clone())
+            .await
+            .expect("create test seed sink");
+        let s_chunk = chrono::Utc::now().timestamp_millis();
+        produce_tile(&seed_sink, tile(alice, s_chunk)).await;
+        let run_id = RunId(Uuid::from_u128(0x0F3E_CEC0));
+        let reconcile = ReconcileTile::new(
+            TeamId(TEAM),
+            CohortId(COHORT),
+            BehavioralShapeHash::parse(FILTERS_HASH).unwrap(),
+            run_id,
+        );
+        assert_eq!(
+            produce_reconcile(&producer, &topics.seeds, part(alice) as i32, &reconcile,).await,
+            1,
+            "the reconcile control follows the closed data tile in the same partition",
+        );
+
         let mut manager = Manager::builder("seed-fence-itest")
             .with_trap_signals(false)
             .build();
@@ -731,7 +1169,6 @@ async fn fence_holds_a_fresh_tile_until_live_consumption_passes_its_scan_point()
         let shutdown = handles[0].clone();
         let _monitor = manager.monitor_background();
 
-        let fence_margin_ms = 5_000;
         let dir = TempDir::new().unwrap();
         let instance = spawn_instance(
             &topics,
@@ -749,15 +1186,15 @@ async fn fence_holds_a_fresh_tile_until_live_consumption_passes_its_scan_point()
         )
         .await;
 
-        let alice = Uuid::from_u128(0xA11CE);
-        let seed_sink = KafkaSeedTileSink::new(&producer_kafka_config(), topics.seeds.clone())
-            .await
-            .expect("create test seed sink");
-        let s_chunk = chrono::Utc::now().timestamp_millis();
-        produce_tile(&seed_sink, tile(alice, s_chunk)).await;
-
-        // No watermark at all: fail-closed, nothing applies, nothing commits.
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        // No watermark at all: wait until Kafka has delivered both records, then give the follower
+        // a full receive/commit cycle to expose any accidental reconcile admission.
+        wait_for(
+            "the seed consumer to fetch the closed tile and its FIFO suffix",
+            Duration::from_secs(30),
+            || instance.seed_position(&topics.seeds, part(alice)) == Some(2),
+        )
+        .await;
+        tokio::time::sleep(COMMIT_INTERVAL + RECV_TIMEOUT + Duration::from_millis(250)).await;
         assert_eq!(
             topic_message_count(&topics.shadow),
             0,
@@ -768,34 +1205,104 @@ async fn fence_holds_a_fresh_tile_until_live_consumption_passes_its_scan_point()
             None,
             "a held tile's offset must never commit",
         );
+        assert!(
+            instance.reconcile_backlog.is_empty(),
+            "reconcile must not leapfrog a closed data tile",
+        );
+        assert_eq!(instance.seed_committable(part(alice)), None);
 
-        // A live event folded before `s_chunk + margin` has elapsed still leaves the fence closed.
-        let producer = murmur2_producer();
-        produce_warm_event(&producer, &topics.events, alice, 0).await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        // A live event at the exact bound still leaves the fence closed. Its explicit broker
+        // timestamp makes the assertion independent of manager startup and machine speed.
+        let closed_watermark = s_chunk + fence_margin_ms;
+        produce_warm_event(&producer, &topics.events, alice, 0, closed_watermark).await;
+        wait_for(
+            "the below-threshold live watermark to fold",
+            Duration::from_secs(30),
+            || instance.live_watermark(part(alice)) == Some(closed_watermark),
+        )
+        .await;
         assert_eq!(
             topic_message_count(&topics.shadow),
             0,
             "a watermark below s_chunk + margin keeps the fence closed",
         );
+        assert!(instance.reconcile_backlog.is_empty());
 
-        // Past s_chunk + margin, a newer live fold opens the fence for the held tile.
-        tokio::time::sleep(Duration::from_millis(fence_margin_ms as u64 + 1_500)).await;
-        produce_warm_event(&producer, &topics.events, alice, 1).await;
+        // One millisecond past the bound, a newer live fold opens the fence for the tile and then
+        // admits the reconcile control behind it. The tile materializes the scan register first.
+        produce_warm_event(&producer, &topics.events, alice, 1, closed_watermark + 1).await;
         wait_for(
             "the fence to open and the held tile to apply",
             Duration::from_secs(60),
             || topic_message_count(&topics.shadow) == 1,
         )
         .await;
-        let (_, payload) = consume_all(&topics.shadow, 1, Duration::from_secs(30))
-            .await
-            .into_iter()
-            .next()
-            .expect("one membership change");
-        let change: CohortMembershipChange = serde_json::from_slice(&payload).unwrap();
-        assert_eq!(change.origin, Some(ChangeOrigin::Seed));
-        assert_eq!(change.person_id, alice.to_string());
+        wait_for(
+            "the reconcile control behind the opened tile to be admitted",
+            Duration::from_secs(30),
+            || instance.reconcile_backlog.len() == 1,
+        )
+        .await;
+        assert_eq!(
+            instance.seed_committable(part(alice)),
+            Some(1),
+            "the applied data tile advances to the following deferred control",
+        );
+
+        instance.dispatcher.route_reconcile_drain().await;
+        wait_for(
+            "the reconcile membership row",
+            Duration::from_secs(30),
+            || topic_message_count(&topics.shadow) == 2,
+        )
+        .await;
+        assert_eq!(instance.reconcile_backlog.len(), 1);
+        assert_eq!(
+            instance.seed_committable(part(alice)),
+            Some(1),
+            "the control remains deferred after its row and before its marker",
+        );
+
+        instance.dispatcher.route_reconcile_drain().await;
+        wait_for(
+            "the reconcile completion marker",
+            Duration::from_secs(30),
+            || topic_message_count(&topics.shadow) == 3,
+        )
+        .await;
+        assert!(instance.reconcile_backlog.is_empty());
+        assert_eq!(instance.seed_committable(part(alice)), Some(2));
+        wait_for(
+            "the seed group to commit both FIFO messages",
+            Duration::from_secs(30),
+            || seed_group_committed(&groups.seeds, &topics.seeds, part(alice) as i32) == Some(2),
+        )
+        .await;
+
+        let outputs = consume_all(&topics.shadow, 3, Duration::from_secs(30)).await;
+        let mut changes = Vec::new();
+        let mut markers = Vec::new();
+        for (_, payload) in outputs {
+            let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+            if value.get("type").and_then(serde_json::Value::as_str) == Some("reconcile_complete") {
+                markers.push(serde_json::from_slice::<ReconcileCompleteMarker>(&payload).unwrap());
+            } else {
+                changes.push(serde_json::from_slice::<CohortMembershipChange>(&payload).unwrap());
+            }
+        }
+        assert_eq!(changes.len(), 2);
+        assert!(changes.iter().any(|change| {
+            change.person_id == alice.to_string() && change.origin == Some(ChangeOrigin::Seed)
+        }));
+        assert!(changes.iter().any(|change| {
+            change.person_id == alice.to_string()
+                && change.status == MembershipStatus::Entered
+                && change.origin == Some(ChangeOrigin::Reconcile)
+                && change.run_id == Some(run_id)
+        }));
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].partition(), part(alice));
+        assert_eq!(markers[0].run_id(), run_id);
 
         shutdown.request_shutdown();
         instance.join().await;

--- a/rust/cohort-stream-processor/tests/stage1_worker.rs
+++ b/rust/cohort-stream-processor/tests/stage1_worker.rs
@@ -27,9 +27,10 @@ use cohort_stream_processor::stage1::{
     clickhouse_timestamp_to_millis, AppliedOffsets, LeafTransition, Stage1State, StateVariant,
     StatefulRecord, TransitionKind,
 };
+use cohort_stream_processor::stage2::Stage2State;
 use cohort_stream_processor::store::{
     Behavioral, BehavioralKey, CohortStore, LeafStateKey, OffloadConfig, OffloadMode, PersonPrefix,
-    PersonRecordKey, PersonRecords, StoreConfig, StoreHandle,
+    PersonRecordKey, PersonRecords, Stage2Key, StoreConfig, StoreHandle,
 };
 use cohort_stream_processor::workers::{process_event, MergeWorkerDeps, SkipReason, Stage1Worker};
 use serde_json::{json, Value};
@@ -248,6 +249,22 @@ fn person_leaves(store: &CohortStore, person: Uuid) -> Vec<LeafStateKey> {
 
 fn state_at(store: &CohortStore, lsk: LeafStateKey, person: Uuid) -> Option<Stage1State> {
     record_at(store, lsk, person).map(|record| record.state)
+}
+
+fn membership_register_at(
+    store: &CohortStore,
+    cohort_id: u64,
+    person: Uuid,
+) -> Option<Stage2State> {
+    store
+        .get_stage2(&Stage2Key {
+            partition_id: PARTITION_ID,
+            team_id: TEAM as u64,
+            cohort_id,
+            person_id: person,
+        })
+        .unwrap()
+        .map(|bytes| Stage2State::decode(&bytes).unwrap())
 }
 
 /// The full persisted record (state + per-source-partition applied offsets), for the cross-partition
@@ -1360,6 +1377,14 @@ async fn worker_produces_changes_and_advances_offset() {
     assert_eq!(changes[0].cohort_id, 1);
     assert_eq!(changes[0].status, MembershipStatus::Entered);
     assert_eq!(changes[0].person_id, person(1).to_string());
+    assert_eq!(
+        membership_register_at(&store, 1, person(1)),
+        Some(Stage2State {
+            in_cohort: true,
+            last_evaluated_at_ms: clickhouse_timestamp_to_millis(BASE_TS).unwrap(),
+        }),
+        "the event commit atomically materializes the single-leaf membership register",
+    );
 }
 
 #[tokio::test]
@@ -1913,6 +1938,15 @@ async fn daily_multiple_single_leaf_cohort_emits_entered_then_left_to_the_sink()
     assert_eq!(changes[0].status, MembershipStatus::Entered);
     assert_eq!(changes[0].person_id, alice.to_string());
     assert_eq!(changes[1].status, MembershipStatus::Left);
+    assert_eq!(
+        membership_register_at(&store, 1, alice),
+        Some(Stage2State {
+            in_cohort: false,
+            last_evaluated_at_ms: clickhouse_timestamp_to_millis("2026-05-28 10:00:00.000000")
+                .unwrap(),
+        }),
+        "a live-event Left persists an explicit false register row",
+    );
     assert_eq!(
         tracker.committable_offsets().get(&(PARTITION_ID as i32)),
         Some(&4),

--- a/rust/cohort-stream-processor/tests/sweep_worker.rs
+++ b/rust/cohort-stream-processor/tests/sweep_worker.rs
@@ -27,7 +27,7 @@ use cohort_stream_processor::partitions::{
     MeteredReceiver, OffsetTracker, PartitionRouter, ShuffleMessage,
 };
 use cohort_stream_processor::producer::{
-    CaptureSink, CohortMembershipChange, MembershipSink, MembershipStatus,
+    CaptureSink, CohortMembershipChange, MembershipSink, MembershipStatus, ReconcileCompleteMarker,
 };
 use cohort_stream_processor::stage1::bucket_tz::{day_idx_in_tz, start_of_day_ms_in_tz};
 use cohort_stream_processor::stage1::{
@@ -375,6 +375,11 @@ async fn sweep_evicts_a_single_leaf_member_emits_left_and_deletes() {
     assert!(
         state_at(&store, lsk, alice).is_none(),
         "a fully-expired single is deleted",
+    );
+    assert_eq!(
+        stage2_bit(&store, 1, alice),
+        Some(false),
+        "the sweep commit retains an explicit false membership register after deleting leaf state",
     );
 }
 
@@ -1234,6 +1239,16 @@ impl MembershipSink for FailNthSink {
         let acks = changes.iter().map(|_| Ok(())).collect();
         self.changes.lock().unwrap().extend(changes);
         acks
+    }
+
+    async fn produce_markers(
+        &self,
+        markers: Vec<ReconcileCompleteMarker>,
+    ) -> Vec<Result<(), KafkaProduceError>> {
+        markers
+            .into_iter()
+            .map(|_| Err(KafkaProduceError::KafkaProduceCanceled))
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Problem

The streaming cohort pipeline emits membership at most once, so a lost produce can leave stored membership correct while the downstream copy stays stale, and an edited cohort keeps its old members forever. Nothing emits the full current membership to heal that.

## Changes

Adds the reconcile snapshot, gated behind `COHORT_SEED_RECONCILE_ENABLED` (default off) and producing only to the shadow topic, so it does not affect production services.

Once a backfill run's data tiles confirm, a reconcile control tile per partition makes each worker scan its stored `cf_stage2` slice for the cohort, evaluate every person from current leaf state, emit the full current membership unconditionally tagged `origin: "reconcile"` with the `run_id`, fix any stale stored bits, and emit a `reconcile_complete` marker per partition. This heals the at most once output losses and the edit path stale membership.

Supporting pieces:

- Single leaf cohorts wrote no `cf_stage2` row, so the live, sweep, seed, and merge paths now write a membership register bit alongside their state commit so the reconcile scan can see them.
- Releasable deferred offset floors on the offset tracker, so a reconcile tile commits its offset only after its scan and marker finish.
- A `cf_stage2` cohort prefix store scan paced on the maintenance read lane, plus the persisted `behavioral_filters_shape_hash` loaded into the catalog as the drain time guard.
- A reconcile `ChangeOrigin` and the `reconcile_complete` marker on their own producer method, leaving the live membership wire contract byte identical.
- A `reconcile_dispatch` command in the seeder that produces reconcile tiles to each of the 64 partitions.
- The parity harness fold recognizes the marker and reports per run completeness (64 of 64 partitions).

## How did you test this code?

The branch's Rust tests cover the drain typestate and guard table, the deferred offset floors, the prefix scan, the register writes at every transition site, wire byte stability, and a worker loop that produces the tagged snapshot then the marker; I added a forward compat serde pin and a fold conservation assertion. I ran cargo test for `cohort-core` and `cohort-stream-processor` (including `merge_protocol`), clippy, and fmt, all green, plus the python parity suite, green. 


## Docs update

No.