### PR TITLE
chore(agents): route security fixes to posthog-private, never public

### DIFF
--- a/.agents/security.md
+++ b/.agents/security.md
@@ -1,5 +1,17 @@
 # Security guidelines for agents
 
+## Routing security fixes
+
+**Security fixes are developed in private, never in this public repo.** Opening a public PR, branch, or issue for a vulnerability discloses it before the fix is deployed — so it must not happen.
+
+- **Where:** open the change against the private mirror **`PostHog/posthog-private`**, not `PostHog/posthog`.
+- **Branch name:** start it with **`security/`** (e.g. `security/idor-dashboards`).
+- **Never on public `PostHog/posthog`:** do not open a PR, push a branch, or file an issue there that fixes or describes a security weakness — not even a "small" or "obvious" one, and not a test that demonstrates the exploit.
+- **What counts as a security fix** (route any of these to `PostHog/posthog-private`): closing an access-control / IDOR gap, an injection (SQL/HogQL/command/path), SSRF, an auth / session / token weakness, secret exposure, an XSS / CSRF / open-redirect issue, or any change whose purpose is to close an exploitable hole. **If unsure, treat it as a security fix** and route it privately.
+- **Reporting (audits / reviews):** keep findings in the session or private channels; do not paste exploit details or vulnerable-path specifics into a public PR, issue, or comment.
+
+This is about _where the fix lands_ — the rest of this doc is about writing secure code.
+
 ## Principle of Least Privilege
 
 Default to the smallest permission, narrowest field set, and shortest scope that still works. If a change needs more access than what's already in place, stop and reconsider the design before widening it.

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -222,7 +222,7 @@ Once the report is delivered, ask the user whether they want the findings fixed.
 - Run any adjacent existing tests for the affected module to catch regressions.
 - Report back which findings were fixed, which tests pass, and anything that needs follow-up.
 
-Do not start fixing without explicit approval — the user may want to triage, file tickets, or fix in a separate branch.
+Do not start fixing without explicit approval — the user may want to triage, file tickets, or fix in `PostHog/posthog-private` on a `security/<topic>` branch.
 
 ## Output format
 


### PR DESCRIPTION
## Problem

Agent instructions don't say where a security fix should land. An agent that fixes a vulnerability could open the PR against this public repo, which discloses the issue before the fix is deployed.

## Changes

Document the routing rule in the security guidelines so agents follow it:

- A security fix, and any PR/branch/issue describing one, goes to the private mirror **`PostHog/posthog-private`**, never public `PostHog/posthog`.
- The branch must start with **`security/`**.
- Added a "Routing security fixes" section to `.agents/security.md` (with a "what counts as a security fix" list and "if unsure, route privately"), and applied it in the `security-audit` skill's "After reporting" step so a fix from an audit, and its reproducer test, is routed privately.

Docs/instructions only. No code or workflow changes.

This is a redo of #63503 with the hard-wrapped markdown removed, following the repo's semantic-line-breaks convention. The `AGENTS.md` pointer from the original is dropped because master already broadened that line.

## How did you test this code?

I'm an agent (Claude Code). Docs-only change, so no automated tests apply. Markdown is auto-formatted by the repo's lint-staged hook, which ran on commit and left the prose unwrapped.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

This PR is the docs update (agent instructions).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by the PR assignee. Recreates the closed #63503 with hard-wrapped lines removed per the semantic-line-breaks rule. Keeps the detail in one place (`.agents/security.md`) with the security-audit skill pointing to it. No skills were invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
