### PR TITLE
fix(braintree): declare search input as non-null in GraphQL query

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
@@ -70,8 +70,10 @@ def _format_created_at(value: Any) -> str:
 
 
 def _build_query(config: BraintreeEndpointConfig) -> str:
+    # Braintree's search fields declare `input` as non-null, even though every
+    # field within the input type is optional (an empty object matches everything).
     return f"""
-query ($input: {config.input_type}, $first: Int!, $after: String) {{
+query ($input: {config.input_type}!, $first: Int!, $after: String) {{
   search {{
     {config.search_field} (input: $input, first: $first, after: $after) {{
       pageInfo {{ hasNextPage }}
@@ -164,7 +166,7 @@ def get_rows(
         return _execute(session, url, query, variables, logger)
 
     while True:
-        data = execute({"input": search_input or None, "first": PAGE_SIZE, "after": after})
+        data = execute({"input": search_input, "first": PAGE_SIZE, "after": after})
         connection = ((data.get("search") or {}).get(config.search_field)) or {}
         edges = connection.get("edges") or []
         items = [edge.get("node") for edge in edges if edge.get("node")]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
@@ -68,7 +68,9 @@ class TestBuildQuery:
     )
     def test_query_uses_correct_input_type(self, endpoint, input_type):
         query = _build_query(BRAINTREE_ENDPOINTS[endpoint])
-        assert f"$input: {input_type}" in query
+        # Braintree's search fields declare `input` as non-null; a nullable
+        # declaration here fails GraphQL validation (VariableTypeMismatch).
+        assert f"$input: {input_type}!" in query
         assert BRAINTREE_ENDPOINTS[endpoint].search_field in query
 
 
@@ -154,14 +156,16 @@ class TestGetRows:
         assert variables["input"] == {"createdAt": {"greaterThanOrEqualTo": "2024-01-02T00:00:00Z"}}
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_full_scan_has_null_input(self, mock_session):
+    def test_full_scan_has_empty_input(self, mock_session):
         mock_session.return_value.post.return_value = _search_response("transactions", [])
 
         manager = _make_manager()
         list(get_rows("production", "pub", "priv", "transactions", _VERSION, mock.MagicMock(), manager))
 
+        # `input` is declared non-null (see TestBuildQuery), so a full scan must
+        # send an empty object rather than null or Braintree rejects the query.
         variables = mock_session.return_value.post.call_args.kwargs["json"]["variables"]
-        assert variables["input"] is None
+        assert variables["input"] == {}
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_resumes_from_saved_cursor(self, mock_session):


### PR DESCRIPTION
## Problem

Every full sync of the Braintree `transactions`, `refunds`, and `disputes` streams was failing with:

```
Braintree GraphQL error: Validation error (VariableTypeMismatch@[search/<stream>]) : Variable 'input' of type '<Stream>SearchInput' used in position expecting type '<Stream>SearchInput!'
```

Braintree's GraphQL schema declares the `input` argument on `search.transactions`/`refunds`/`disputes` as non-null, but our generated query declared the `$input` variable as nullable and sent `null` when there was no incremental filter (i.e. on every full scan). GraphQL rejects this at query-validation time, before the request executes, so the sync fails immediately as a non-retryable error on first run.

## Changes

- `_build_query` now declares `$input` as `<InputType>!` to match Braintree's schema.
- `get_rows` sends an empty object instead of `null` for full scans — every field on the search input types is optional, so an empty object still means "no filters", and it satisfies the non-null variable type.

## How did you test this code?

Extended the existing unit tests in `test_braintree.py`:
- `test_query_uses_correct_input_type` now asserts the `!` non-null suffix on the declared variable type (previously only checked the base type name as a substring, which passed even with the bug).
- `test_full_scan_has_null_input` renamed to `test_full_scan_has_empty_input` and now asserts the full-scan request sends `{}` instead of `null` for `input` — this test previously locked in the exact buggy behavior being fixed here.

Ran the full `test_braintree.py` suite locally (22 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was produced end-to-end by an agent (Claude) triaging a live PostHog error tracking issue for the Braintree data warehouse source. No skills from `.agents/skills/` matched this specific fix, so none were invoked beyond the standard `/writing-tests` gate before altering test assertions.

Investigation: pulled the error tracking issue and confirmed the crashing frame is in `braintree.py`'s `_execute`/`execute`, tracing back to `_build_query` building a nullable `$input` variable used in a non-null argument position. Confirmed via the existing (now-updated) test that the `null`-on-full-scan behavior was intentional but incompatible with Braintree's actual schema.

Decision: treated as a fixable bug (our query is malformed for every full sync), not a user/upstream error, since nothing about customer credentials or config is involved — every account hitting a full sync of these streams would fail identically.