### PR TITLE
fix(braintree): send non-null search input to avoid GraphQL validation error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
@@ -70,8 +70,10 @@ def _format_created_at(value: Any) -> str:
 
 
 def _build_query(config: BraintreeEndpointConfig) -> str:
+    # Braintree's search fields require a non-null input (e.g. `TransactionSearchInput!`);
+    # a nullable declaration fails GraphQL validation even when a value is always supplied.
     return f"""
-query ($input: {config.input_type}, $first: Int!, $after: String) {{
+query ($input: {config.input_type}!, $first: Int!, $after: String) {{
   search {{
     {config.search_field} (input: $input, first: $first, after: $after) {{
       pageInfo {{ hasNextPage }}
@@ -164,7 +166,7 @@ def get_rows(
         return _execute(session, url, query, variables, logger)
 
     while True:
-        data = execute({"input": search_input or None, "first": PAGE_SIZE, "after": after})
+        data = execute({"input": search_input, "first": PAGE_SIZE, "after": after})
         connection = ((data.get("search") or {}).get(config.search_field)) or {}
         edges = connection.get("edges") or []
         items = [edge.get("node") for edge in edges if edge.get("node")]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
@@ -68,7 +68,9 @@ class TestBuildQuery:
     )
     def test_query_uses_correct_input_type(self, endpoint, input_type):
         query = _build_query(BRAINTREE_ENDPOINTS[endpoint])
-        assert f"$input: {input_type}" in query
+        # Braintree's search fields require a non-null input; a nullable declaration
+        # fails GraphQL validation (VariableTypeMismatch) regardless of the value sent.
+        assert f"$input: {input_type}!" in query
         assert BRAINTREE_ENDPOINTS[endpoint].search_field in query
 
 
@@ -154,14 +156,16 @@ class TestGetRows:
         assert variables["input"] == {"createdAt": {"greaterThanOrEqualTo": "2024-01-02T00:00:00Z"}}
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_full_scan_has_null_input(self, mock_session):
+    def test_full_scan_has_empty_input(self, mock_session):
         mock_session.return_value.post.return_value = _search_response("transactions", [])
 
         manager = _make_manager()
         list(get_rows("production", "pub", "priv", "transactions", _VERSION, mock.MagicMock(), manager))
 
         variables = mock_session.return_value.post.call_args.kwargs["json"]["variables"]
-        assert variables["input"] is None
+        # Must stay non-null: the query declares `$input` as non-null (e.g. `TransactionSearchInput!`),
+        # so a `None` value here reproduces the Braintree VariableTypeMismatch validation error.
+        assert variables["input"] == {}
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_resumes_from_saved_cursor(self, mock_session):


### PR DESCRIPTION
## Problem

Braintree's GraphQL error tracking surfaced a `BraintreeGraphQLError` firing on the `transactions` endpoint: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019f860b-318c-7371-8629-603502f43a20).

```
Braintree GraphQL error: Validation error (VariableTypeMismatch@[search/transactions]) : Variable 'input' of type 'TransactionSearchInput' used in position expecting type 'TransactionSearchInput!'
```

This is a genuine bug in our code, not a user/upstream error. Braintree's `search.transactions` field requires a non-null `TransactionSearchInput!` argument (this matches Braintree's own documented GraphQL query examples), but our generated query always declared the `$input` variable as nullable. On a full, non-incremental sync, `braintree.py` also sent `null` as the value (`search_input or None`), which is exactly the combination GraphQL validation rejects — it fails before the request is even executed against Braintree, on every first sync of the `transactions` endpoint.

## Changes

- `_build_query` now declares `$input` as non-null (`{input_type}!`), matching Braintree's documented query pattern for all three search endpoints (transactions, refunds, disputes).
- `get_rows` now always sends the search input object (`{}` on a full scan) instead of coercing an empty dict to `None`.

## How did you test this code?

Ran the existing unit test suite for this source (all pass), and updated two tests to reflect the corrected behavior:
- `test_query_uses_correct_input_type` now asserts the non-null `!` suffix is present in the generated query.
- Renamed `test_full_scan_has_null_input` → `test_full_scan_has_empty_input`, asserting the full-scan variables payload is `{}` rather than `None` — this guards against reintroducing the `null` value that triggers the GraphQL validation error.

```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py -q
22 passed
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal source implementation fix, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored autonomously by Claude Code, triggered by a webhook-delivered error tracking alert for the `BraintreeGraphQLError` issue above. No `/writing-tests`-flagged anti-patterns were introduced — the test skill was consulted before editing the two affected tests, and the change updates existing coverage rather than adding redundant cases.