### PR TITLE
feat(dashboards): allow excluding tiles from dashboard filters

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -184,10 +184,6 @@ export interface InsightCardProps extends Resizeable {
     rename?: () => void
     duplicate?: () => void
     setOverride?: () => void
-    /** Toggle whether this tile ignores dashboard-level filters. */
-    toggleIgnoreDashboardFilters?: () => void
-    /** True while the ignore-dashboard-filters toggle for this tile is saving. */
-    ignoreDashboardFiltersSaving?: boolean
     moveToDashboard?: (target: Pick<DashboardType, 'id' | 'name'>) => void
     /** Copy this insight tile to another dashboard (same insight; requires editor on destination). */
     copyToDashboard?: (dashboard: DashboardBasicType) => void
@@ -245,8 +241,6 @@ function InsightCardInternal(
         rename,
         duplicate,
         setOverride,
-        toggleIgnoreDashboardFilters,
-        ignoreDashboardFiltersSaving,
         moveToDashboard,
         copyToDashboard,
         className,
@@ -448,8 +442,6 @@ function InsightCardInternal(
                         rename={rename}
                         duplicate={duplicate}
                         setOverride={setOverride}
-                        toggleIgnoreDashboardFilters={toggleIgnoreDashboardFilters}
-                        ignoreDashboardFiltersSaving={ignoreDashboardFiltersSaving}
                         moveToDashboard={moveToDashboard}
                         copyToDashboard={copyToDashboard}
                         areDetailsShown={areDetailsShown}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -184,6 +184,10 @@ export interface InsightCardProps extends Resizeable {
     rename?: () => void
     duplicate?: () => void
     setOverride?: () => void
+    /** Toggle whether this tile ignores dashboard-level filters. */
+    toggleIgnoreDashboardFilters?: () => void
+    /** True while the ignore-dashboard-filters toggle for this tile is saving. */
+    ignoreDashboardFiltersSaving?: boolean
     moveToDashboard?: (target: Pick<DashboardType, 'id' | 'name'>) => void
     /** Copy this insight tile to another dashboard (same insight; requires editor on destination). */
     copyToDashboard?: (dashboard: DashboardBasicType) => void
@@ -241,6 +245,8 @@ function InsightCardInternal(
         rename,
         duplicate,
         setOverride,
+        toggleIgnoreDashboardFilters,
+        ignoreDashboardFiltersSaving,
         moveToDashboard,
         copyToDashboard,
         className,
@@ -442,6 +448,8 @@ function InsightCardInternal(
                         rename={rename}
                         duplicate={duplicate}
                         setOverride={setOverride}
+                        toggleIgnoreDashboardFilters={toggleIgnoreDashboardFilters}
+                        ignoreDashboardFiltersSaving={ignoreDashboardFiltersSaving}
                         moveToDashboard={moveToDashboard}
                         copyToDashboard={copyToDashboard}
                         areDetailsShown={areDetailsShown}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.test.tsx
@@ -227,5 +227,33 @@ describe('InsightDetails', () => {
             expect(result.filterTestAccounts).toEqual({ value: true, source: 'dashboard' })
             expect(result.interval).toEqual({ value: 'week', source: 'dashboard' })
         })
+
+        it('drops the whole dashboard layer when the tile ignores dashboard filters (raw-props fallback)', () => {
+            const result = getEffectiveFilterOverrides(
+                undefined,
+                { properties: [countryUS], filterTestAccounts: true, interval: 'month' } as any,
+                { ignoreDashboardFilters: true, properties: [browserChrome] } as any
+            )
+
+            expect(result.ignoresDashboardFilters).toBe(true)
+            expect(result.propertyGroups).toEqual([{ properties: [browserChrome], source: 'tile' }])
+            expect(result.filterTestAccounts).toBeNull()
+            expect(result.interval).toBeNull()
+        })
+
+        it('reports the ignore flag from the backend context tile layer', () => {
+            const result = getEffectiveFilterOverrides(
+                {
+                    dashboard: null,
+                    tile: { ignoreDashboardFilters: true },
+                    overridden_dashboard: { filterTestAccounts: true },
+                } as any,
+                { filterTestAccounts: true } as any,
+                undefined
+            )
+
+            expect(result.ignoresDashboardFilters).toBe(true)
+            expect(result.filterTestAccounts).toBeNull()
+        })
     })
 })

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -713,6 +713,7 @@ export const InsightDetails = React.memo(
             breakdown: overrideBreakdown,
             interval: overrideInterval,
             filterTestAccounts: overrideFilterTestAccounts,
+            ignoresDashboardFilters,
         } = getEffectiveFilterOverrides(filterOverrideContext, filtersOverride, tileFiltersOverride)
         const insightDateRange = isInsightVizNode(query) ? query.source.dateRange : undefined
         const dateOverride = getDateRangeOverrideDisplay(
@@ -741,6 +742,11 @@ export const InsightDetails = React.memo(
                             variables={isHogQLQuery(query.source) ? query.source.variables : undefined}
                             variablesOverride={variablesOverride}
                         />
+                        {ignoresDashboardFilters && (
+                            <InsightDetailSectionDisplay icon={<IconFilter />} label="Dashboard filters">
+                                <span>Ignored for this insight</span>
+                            </InsightDetailSectionDisplay>
+                        )}
                         {dateOverride && (
                             <DateRangeSummary
                                 dateFrom={dateOverride.dateFrom}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconInfo, IconPulse, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { IconCheck, IconInfo, IconPulse, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { CardMeta } from 'lib/components/Cards/CardMeta'
@@ -81,6 +81,8 @@ interface InsightMetaProps extends Pick<
     | 'loadingQueued'
     | 'rename'
     | 'setOverride'
+    | 'toggleIgnoreDashboardFilters'
+    | 'ignoreDashboardFiltersSaving'
     | 'duplicate'
     | 'dashboardId'
     | 'moveToDashboard'
@@ -111,7 +113,13 @@ export function getEffectiveDateOverride(
     filtersOverride: DashboardFilter | undefined,
     tileFiltersOverride: TileFilters | undefined
 ): { dateFromOverride: string | null | undefined; dateToOverride: string | null | undefined } {
-    const dashboardFilters = filterOverrideContext ? filterOverrideContext.dashboard : filtersOverride
+    // The backend context already resolves the ignore flag into an empty dashboard layer; the raw-props
+    // fallback has to apply it itself.
+    const dashboardFilters = filterOverrideContext
+        ? filterOverrideContext.dashboard
+        : tileFiltersOverride?.ignoreDashboardFilters
+          ? undefined
+          : filtersOverride
     const tileFilters = filterOverrideContext ? filterOverrideContext.tile : tileFiltersOverride
     const tileHasDate = tileFilters?.date_from != null || tileFilters?.date_to != null
     const source = tileHasDate ? tileFilters : dashboardFilters
@@ -135,6 +143,8 @@ export function InsightMeta({
     rename,
     duplicate,
     setOverride,
+    toggleIgnoreDashboardFilters,
+    ignoreDashboardFiltersSaving,
     moveToDashboard,
     copyToDashboard,
     areDetailsShown,
@@ -198,12 +208,15 @@ export function InsightMeta({
     const isSqlInsight = isDataVisualizationNode(insight.query)
     const showCompactHeading = !showCompactTile || !isSqlInsight
 
-    const hasTileOverrides = Object.keys(tileFiltersOverride ?? {}).length > 0
+    const ignoresDashboardFilters = !!tileFiltersOverride?.ignoreDashboardFilters
+    // The ignore flag is surfaced by its own notice, so it alone shouldn't trigger the overrides warning.
+    const hasTileOverrides = Object.keys(tileFiltersOverride ?? {}).some((key) => key !== 'ignoreDashboardFilters')
     const dateOverride = getEffectiveDateOverride(insight.filter_override_context, filtersOverride, tileFiltersOverride)
     const topHeadingProps = {
         query: insight.query,
         lastRefresh: insight.last_refresh,
         hasTileOverrides,
+        ignoresDashboardFilters,
         resolvedDateRange: insightData?.resolved_date_range,
         ...dateOverride,
     }
@@ -465,6 +478,19 @@ export function InsightMeta({
                                 {tile && (
                                     <LemonButton onClick={setOverride} fullWidth>
                                         Set override
+                                    </LemonButton>
+                                )}
+                                {tile && toggleIgnoreDashboardFilters && (
+                                    <LemonButton
+                                        onClick={toggleIgnoreDashboardFilters}
+                                        fullWidth
+                                        loading={ignoreDashboardFiltersSaving}
+                                        active={ignoresDashboardFilters}
+                                        sideIcon={ignoresDashboardFilters ? <IconCheck /> : null}
+                                        tooltip="When on, none of the dashboard's filters apply to this insight. Tile overrides still do."
+                                        data-attr="toggle-tile-ignore-dashboard-filters"
+                                    >
+                                        Ignore dashboard filters
                                     </LemonButton>
                                 )}
                             </>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconCheck, IconInfo, IconPulse, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { IconInfo, IconPulse, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { CardMeta } from 'lib/components/Cards/CardMeta'
@@ -81,8 +81,6 @@ interface InsightMetaProps extends Pick<
     | 'loadingQueued'
     | 'rename'
     | 'setOverride'
-    | 'toggleIgnoreDashboardFilters'
-    | 'ignoreDashboardFiltersSaving'
     | 'duplicate'
     | 'dashboardId'
     | 'moveToDashboard'
@@ -143,8 +141,6 @@ export function InsightMeta({
     rename,
     duplicate,
     setOverride,
-    toggleIgnoreDashboardFilters,
-    ignoreDashboardFiltersSaving,
     moveToDashboard,
     copyToDashboard,
     areDetailsShown,
@@ -478,19 +474,6 @@ export function InsightMeta({
                                 {tile && (
                                     <LemonButton onClick={setOverride} fullWidth>
                                         Set override
-                                    </LemonButton>
-                                )}
-                                {tile && toggleIgnoreDashboardFilters && (
-                                    <LemonButton
-                                        onClick={toggleIgnoreDashboardFilters}
-                                        fullWidth
-                                        loading={ignoreDashboardFiltersSaving}
-                                        active={ignoresDashboardFilters}
-                                        sideIcon={ignoresDashboardFilters ? <IconCheck /> : null}
-                                        tooltip="When on, none of the dashboard's filters apply to this insight. Tile overrides still do."
-                                        data-attr="toggle-tile-ignore-dashboard-filters"
-                                    >
-                                        Ignore dashboard filters
                                     </LemonButton>
                                 )}
                             </>

--- a/frontend/src/lib/components/Cards/InsightCard/TileOverridesWarning.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/TileOverridesWarning.tsx
@@ -1,4 +1,4 @@
-import { IconWarning } from '@posthog/icons'
+import { IconFilter, IconWarning } from '@posthog/icons'
 
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
@@ -13,6 +13,16 @@ export function TileOverridesWarning(): JSX.Element | null {
         >
             <div className="flex items-center gap-1 text-warning">
                 <IconWarning /> Tile filters applied
+            </div>
+        </Tooltip>
+    )
+}
+
+export function IgnoresDashboardFiltersNotice(): JSX.Element | null {
+    return (
+        <Tooltip title="None of the dashboard's filters apply to this insight. Its own tile overrides still do.">
+            <div className="flex items-center gap-1 text-muted-alt">
+                <IconFilter /> Ignores dashboard filters
             </div>
         </Tooltip>
     )

--- a/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
@@ -14,7 +14,7 @@ import {
 } from '~/queries/utils'
 
 import { InsightFreshness } from './InsightFreshness'
-import { TileOverridesWarning } from './TileOverridesWarning'
+import { IgnoresDashboardFiltersNotice, TileOverridesWarning } from './TileOverridesWarning'
 
 function getInsightType(query: Node | null): InsightTypeMetadata {
     if (query?.kind) {
@@ -30,6 +30,7 @@ export function TopHeading({
     query,
     lastRefresh,
     hasTileOverrides,
+    ignoresDashboardFilters,
     resolvedDateRange,
     showInsightType = true,
     showDate = true,
@@ -39,6 +40,7 @@ export function TopHeading({
     query: Node | null
     lastRefresh?: string | null
     hasTileOverrides?: boolean | null
+    ignoresDashboardFilters?: boolean | null
     resolvedDateRange?: ResolvedDateRangeResponse | null
     showInsightType?: boolean
     showDate?: boolean
@@ -85,6 +87,7 @@ export function TopHeading({
             {/* Freshness clock lives in the date row — without a date it would hold the row open on its own. */}
             {dateLabel && lastRefresh ? <InsightFreshness lastRefresh={lastRefresh} /> : null}
             {hasTileOverrides ? <TileOverridesWarning /> : null}
+            {ignoresDashboardFilters ? <IgnoresDashboardFiltersNotice /> : null}
         </CardTopHeadingRow>
     )
 }

--- a/frontend/src/lib/components/Cards/InsightCard/insightDetailsFilterOverrides.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/insightDetailsFilterOverrides.ts
@@ -9,6 +9,13 @@ export interface EffectiveFilterOverrides {
     breakdown: { breakdownFilter: NonNullable<DashboardFilter['breakdown_filter']>; source: OverrideSource } | null
     interval: { value: IntervalType; source: OverrideSource } | null
     filterTestAccounts: { value: boolean; source: OverrideSource } | null
+    ignoresDashboardFilters: boolean
+}
+
+// The generated context type lags behind TileFilters until the OpenAPI types are rebuilt, so read the
+// flag through the schema type.
+function ignoresDashboardFilters(tileFilters: unknown): boolean {
+    return !!(tileFilters as TileFilters | null | undefined)?.ignoreDashboardFilters
 }
 
 // Tile beats dashboard; `!= null` (not truthiness) so a force-off `filterTestAccounts: false` still counts.
@@ -28,8 +35,15 @@ export function getEffectiveFilterOverrides(
     filtersOverride: DashboardFilter | undefined,
     tileFiltersOverride: TileFilters | null | undefined
 ): EffectiveFilterOverrides {
-    const dashboardFilters = filterOverrideContext ? filterOverrideContext.dashboard : filtersOverride
     const tileFilters = filterOverrideContext ? filterOverrideContext.tile : tileFiltersOverride
+    const tileIgnoresDashboard = ignoresDashboardFilters(tileFilters)
+    // The backend context already resolves the ignore flag into an empty dashboard layer; the raw-props
+    // fallback has to apply it itself.
+    const dashboardFilters = filterOverrideContext
+        ? filterOverrideContext.dashboard
+        : tileIgnoresDashboard
+          ? undefined
+          : filtersOverride
     const dashboardProperties = (dashboardFilters?.properties ?? []) as AnyPropertyFilter[]
     const tileProperties = (tileFilters?.properties ?? []) as AnyPropertyFilter[]
     const overriddenByTile = (filterOverrideContext?.overridden_dashboard?.properties ?? []) as AnyPropertyFilter[]
@@ -55,7 +69,14 @@ export function getEffectiveFilterOverrides(
         dashboardFilters?.filterTestAccounts
     )
 
-    return { propertyGroups, overriddenByTile, breakdown, interval, filterTestAccounts }
+    return {
+        propertyGroups,
+        overriddenByTile,
+        breakdown,
+        interval,
+        filterTestAccounts,
+        ignoresDashboardFilters: tileIgnoresDashboard,
+    }
 }
 
 interface DateRangeSource {
@@ -88,8 +109,12 @@ export function getDateRangeOverrideDisplay(
     filtersOverride: DashboardFilter | undefined,
     tileFiltersOverride: TileFilters | null | undefined
 ): EffectiveDateOverride | null {
-    const dashboardFilters = filterOverrideContext ? filterOverrideContext.dashboard : filtersOverride
     const tileFilters = filterOverrideContext ? filterOverrideContext.tile : tileFiltersOverride
+    const dashboardFilters = filterOverrideContext
+        ? filterOverrideContext.dashboard
+        : ignoresDashboardFilters(tileFilters)
+          ? undefined
+          : filtersOverride
     let winner: {
         source: OverrideSource
         dateFrom: string | null | undefined

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -600,6 +600,15 @@ export interface eventUsageLogicActions {
         dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null
         properties: Record<string, boolean | number | string | null | undefined>
     }
+    reportDashboardTileIgnoreDashboardFiltersToggled: (
+        dashboardId: number | undefined,
+        insightId: number | null,
+        ignored: boolean
+    ) => {
+        dashboardId: number | undefined
+        ignored: boolean
+        insightId: number | null
+    }
     reportDashboardFrontEndUpdate: (
         dashboardId: number | undefined,
         attribute: 'description' | 'name' | 'tags',
@@ -2095,6 +2104,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             changeType: DashboardFilterChangeType,
             properties: Record<string, string | number | boolean | null | undefined>
         ) => ({ dashboard, changeType, properties }),
+        reportDashboardTileIgnoreDashboardFiltersToggled: (
+            dashboardId: number | undefined,
+            insightId: number | null,
+            ignored: boolean
+        ) => ({ dashboardId, insightId, ignored }),
         reportDashboardLayoutZoomChanged: (
             dashboard: DashboardType<QueryBasedInsightModel> | null,
             layoutZoom: number,
@@ -3036,6 +3050,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 dashboard_id: dashboard?.id,
                 change_type: changeType,
                 ...properties,
+            })
+        },
+        reportDashboardTileIgnoreDashboardFiltersToggled: async ({ dashboardId, insightId, ignored }) => {
+            posthog.capture('dashboard tile ignore dashboard filters toggled', {
+                dashboard_id: dashboardId,
+                insight_id: insightId,
+                ignored,
             })
         },
         reportDashboardLayoutZoomChanged: async ({ dashboard, layoutZoom, source }) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -600,15 +600,6 @@ export interface eventUsageLogicActions {
         dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null
         properties: Record<string, boolean | number | string | null | undefined>
     }
-    reportDashboardTileIgnoreDashboardFiltersToggled: (
-        dashboardId: number | undefined,
-        insightId: number | null,
-        ignored: boolean
-    ) => {
-        dashboardId: number | undefined
-        ignored: boolean
-        insightId: number | null
-    }
     reportDashboardFrontEndUpdate: (
         dashboardId: number | undefined,
         attribute: 'description' | 'name' | 'tags',
@@ -770,6 +761,15 @@ export interface eventUsageLogicActions {
     ) => {
         dashboardId: number | undefined
         isShared: boolean
+    }
+    reportDashboardTileIgnoreDashboardFiltersToggled: (
+        dashboardId: number | undefined,
+        insightId: number | null,
+        ignored: boolean
+    ) => {
+        dashboardId: number | undefined
+        ignored: boolean
+        insightId: number | null
     }
     reportDashboardTileInsertedInline: (
         tileType: DashboardAddTileType,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -49792,6 +49792,10 @@
                 "filterTestAccounts": {
                     "type": ["boolean", "null"]
                 },
+                "ignoreDashboardFilters": {
+                    "description": "When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply.",
+                    "type": ["boolean", "null"]
+                },
                 "interval": {
                     "anyOf": [
                         {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5397,6 +5397,8 @@ export interface TileFilters {
     explicitDate?: boolean | undefined
     interval?: IntervalType | null | undefined
     filterTestAccounts?: boolean | null | undefined
+    /** When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply. */
+    ignoreDashboardFilters?: boolean | null | undefined
 }
 
 export interface InsightsThresholdBounds {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -93,6 +93,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         widgetResultsByTileId,
         widgetRefreshStatus,
         scrollToBottomSignal,
+        tileIgnoreDashboardFiltersSavingIds,
     } = useValues(dashboardLogic)
     const { layoutZoom = 1 } = useValues(dashboardLogic)
     const {
@@ -109,6 +110,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         moveToDashboard,
         copyToDashboard,
         setTileOverride,
+        toggleTileIgnoreDashboardFilters,
         setDashboardMode,
         setAddWidgetModalOpen,
         setPendingInsertion,
@@ -573,6 +575,10 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         rename={() => renameInsight(insight)}
                                         duplicate={() => duplicateTile(tile)}
                                         setOverride={() => setTileOverride(tile)}
+                                        toggleIgnoreDashboardFilters={() => toggleTileIgnoreDashboardFilters(tile)}
+                                        ignoreDashboardFiltersSaving={tileIgnoreDashboardFiltersSavingIds.includes(
+                                            tile.id
+                                        )}
                                         showDetailsControls={showDetailsControls}
                                         placement={placement}
                                         loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -93,7 +93,6 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         widgetResultsByTileId,
         widgetRefreshStatus,
         scrollToBottomSignal,
-        tileIgnoreDashboardFiltersSavingIds,
     } = useValues(dashboardLogic)
     const { layoutZoom = 1 } = useValues(dashboardLogic)
     const {
@@ -110,7 +109,6 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         moveToDashboard,
         copyToDashboard,
         setTileOverride,
-        toggleTileIgnoreDashboardFilters,
         setDashboardMode,
         setAddWidgetModalOpen,
         setPendingInsertion,
@@ -575,10 +573,6 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                                         rename={() => renameInsight(insight)}
                                         duplicate={() => duplicateTile(tile)}
                                         setOverride={() => setTileOverride(tile)}
-                                        toggleIgnoreDashboardFilters={() => toggleTileIgnoreDashboardFilters(tile)}
-                                        ignoreDashboardFiltersSaving={tileIgnoreDashboardFiltersSavingIds.includes(
-                                            tile.id
-                                        )}
                                         showDetailsControls={showDetailsControls}
                                         placement={placement}
                                         loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}

--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -4,7 +4,7 @@ import './TileFiltersOverride.scss'
 import { useActions, useValues } from 'kea'
 
 import { IconCalendar } from '@posthog/icons'
-import '@posthog/lemon-ui'
+import { LemonSwitch } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -18,7 +18,7 @@ import { tileLogic } from './tileLogic'
 
 export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedInsightModel> }): JSX.Element {
     const { overrides } = useValues(tileLogic)
-    const { setDates, setProperties } = useActions(tileLogic)
+    const { setDates, setProperties, setIgnoreDashboardFilters } = useActions(tileLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const { hasPageview, hasScreen } = getProjectEventExistence()
@@ -33,6 +33,20 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
             </div>
 
             <div className="space-y-4">
+                <div>
+                    <LemonSwitch
+                        checked={!!overrides.ignoreDashboardFilters}
+                        onChange={setIgnoreDashboardFilters}
+                        label="Ignore dashboard filters"
+                        bordered
+                        fullWidth
+                        data-attr="tile-ignore-dashboard-filters"
+                    />
+                    <p className="text-xs text-muted mt-1 mb-0">
+                        When on, none of the dashboard's filters apply to this insight. The overrides below still do.
+                    </p>
+                </div>
+
                 <div>
                     <label className="text-sm font-medium mb-2 block">Date Range</label>
                     <DateFilter

--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
@@ -12,6 +12,7 @@ describe('isDashboardFilterEmpty', () => {
         ['null date fields + explicitDate false', { date_from: null, date_to: null, explicitDate: false }],
         ['empty properties array', { properties: [] }],
         ['filterTestAccounts null', { filterTestAccounts: null }],
+        ['ignoreDashboardFilters false', { ignoreDashboardFilters: false }],
     ]
 
     test.each(emptyCases)('returns true for %s', (_, filter) => {
@@ -38,6 +39,7 @@ describe('isDashboardFilterEmpty', () => {
         ['interval set', { interval: 'week' }],
         ['filterTestAccounts forced on', { filterTestAccounts: true }],
         ['filterTestAccounts forced off', { filterTestAccounts: false }],
+        ['ignoreDashboardFilters set', { ignoreDashboardFilters: true }],
     ]
 
     test.each(nonEmptyCases)('returns false for %s', (_, filter) => {

--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
@@ -9,6 +9,7 @@ export function isDashboardFilterEmpty(filter: DashboardFilter | TileFilters | n
             (filter.properties == null || (Array.isArray(filter.properties) && filter.properties.length === 0)) &&
             filter.breakdown_filter == null &&
             filter.interval == null &&
-            filter.filterTestAccounts == null)
+            filter.filterTestAccounts == null &&
+            !(filter as TileFilters).ignoreDashboardFilters)
     )
 }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -84,6 +84,7 @@ import {
     HogQLVariable,
     NodeKind,
     RefreshType,
+    TileFilters,
 } from '~/queries/schema/schema-general'
 import {
     AccessControlLevel,
@@ -333,6 +334,7 @@ export interface dashboardLogicValues {
     terraformModalOpen: boolean
     textTileId: number | 'new' | null
     textTiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
+    tileIgnoreDashboardFiltersSavingIds: number[]
     tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
     urlFilters: DashboardFilter
     urlSearchParamsAtEditModeEntry: {
@@ -787,6 +789,13 @@ export interface dashboardLogicActions {
     setTextTileId: (textTileId: number | 'new' | null) => {
         textTileId: number | 'new' | null
     }
+    setTileIgnoreDashboardFiltersSaving: (
+        tileId: number,
+        saving: boolean
+    ) => {
+        saving: boolean
+        tileId: number
+    }
     setTileOverride: (tile: DashboardTile<QueryBasedInsightModel>) => {
         tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
     }
@@ -832,6 +841,9 @@ export interface dashboardLogicActions {
     }
     toggleTileDescription: (tileId: number) => {
         tileId: number
+    }
+    toggleTileIgnoreDashboardFilters: (tile: DashboardTile<QueryBasedInsightModel>) => {
+        tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
     }
     triggerDashboardRefresh: () => {
         value: true
@@ -1293,6 +1305,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setTextTileId: (textTileId: number | 'new' | null) => ({ textTileId }),
         setButtonTileId: (buttonTileId: number | 'new' | null) => ({ buttonTileId }),
         setTileOverride: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
+        toggleTileIgnoreDashboardFilters: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
+        setTileIgnoreDashboardFiltersSaving: (tileId: number, saving: boolean) => ({ tileId, saving }),
 
         /**
          * Usage tracking.
@@ -2100,6 +2114,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
             null as number | 'new' | null,
             {
                 setButtonTileId: (_, { buttonTileId }) => buttonTileId,
+            },
+        ],
+
+        tileIgnoreDashboardFiltersSavingIds: [
+            [] as number[],
+            {
+                setTileIgnoreDashboardFiltersSaving: (state, { tileId, saving }) =>
+                    saving ? [...state, tileId] : state.filter((id) => id !== tileId),
             },
         ],
 
@@ -4112,6 +4134,41 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     lemonToast.success('Tile filters saved')
                 },
             })
+        },
+        toggleTileIgnoreDashboardFilters: async ({ tile }) => {
+            if (values.tileIgnoreDashboardFiltersSavingIds.includes(tile.id)) {
+                return
+            }
+            const nextIgnored = !tile.filters_overrides?.ignoreDashboardFilters
+            const nextOverrides: TileFilters = { ...tile.filters_overrides }
+            if (nextIgnored) {
+                nextOverrides.ignoreDashboardFilters = true
+            } else {
+                delete nextOverrides.ignoreDashboardFilters
+            }
+
+            actions.setTileIgnoreDashboardFiltersSaving(tile.id, true)
+            try {
+                await api.update(`api/environments/${teamLogic.values.currentTeamId}/dashboards/${props.id}`, {
+                    tiles: [{ id: tile.id, filters_overrides: nextOverrides }],
+                })
+                tile.filters_overrides = nextOverrides
+                eventUsageLogic.actions.reportDashboardTileIgnoreDashboardFiltersToggled(
+                    props.id,
+                    tile.insight?.id ?? null,
+                    nextIgnored
+                )
+                actions.refreshDashboardItem({ tile })
+                lemonToast.success(
+                    nextIgnored
+                        ? 'This insight now ignores dashboard filters'
+                        : 'This insight follows dashboard filters again'
+                )
+            } catch {
+                lemonToast.error('Could not update the tile. Please try again.')
+            } finally {
+                actions.setTileIgnoreDashboardFiltersSaving(tile.id, false)
+            }
         },
     })),
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -84,7 +84,6 @@ import {
     HogQLVariable,
     NodeKind,
     RefreshType,
-    TileFilters,
 } from '~/queries/schema/schema-general'
 import {
     AccessControlLevel,
@@ -334,7 +333,6 @@ export interface dashboardLogicValues {
     terraformModalOpen: boolean
     textTileId: number | 'new' | null
     textTiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
-    tileIgnoreDashboardFiltersSavingIds: number[]
     tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
     urlFilters: DashboardFilter
     urlSearchParamsAtEditModeEntry: {
@@ -789,13 +787,6 @@ export interface dashboardLogicActions {
     setTextTileId: (textTileId: number | 'new' | null) => {
         textTileId: number | 'new' | null
     }
-    setTileIgnoreDashboardFiltersSaving: (
-        tileId: number,
-        saving: boolean
-    ) => {
-        saving: boolean
-        tileId: number
-    }
     setTileOverride: (tile: DashboardTile<QueryBasedInsightModel>) => {
         tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
     }
@@ -841,9 +832,6 @@ export interface dashboardLogicActions {
     }
     toggleTileDescription: (tileId: number) => {
         tileId: number
-    }
-    toggleTileIgnoreDashboardFilters: (tile: DashboardTile<QueryBasedInsightModel>) => {
-        tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
     }
     triggerDashboardRefresh: () => {
         value: true
@@ -1305,8 +1293,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setTextTileId: (textTileId: number | 'new' | null) => ({ textTileId }),
         setButtonTileId: (buttonTileId: number | 'new' | null) => ({ buttonTileId }),
         setTileOverride: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
-        toggleTileIgnoreDashboardFilters: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
-        setTileIgnoreDashboardFiltersSaving: (tileId: number, saving: boolean) => ({ tileId, saving }),
 
         /**
          * Usage tracking.
@@ -2114,14 +2100,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             null as number | 'new' | null,
             {
                 setButtonTileId: (_, { buttonTileId }) => buttonTileId,
-            },
-        ],
-
-        tileIgnoreDashboardFiltersSavingIds: [
-            [] as number[],
-            {
-                setTileIgnoreDashboardFiltersSaving: (state, { tileId, saving }) =>
-                    saving ? [...state, tileId] : state.filter((id) => id !== tileId),
             },
         ],
 
@@ -4124,51 +4102,25 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 },
                 onSubmit: async () => {
                     const tileFilterOverrides = logic.values.overrides
+                    const wasIgnored = !!tile.filters_overrides?.ignoreDashboardFilters
+                    const isIgnored = !!tileFilterOverrides.ignoreDashboardFilters
 
                     await api.update(`api/environments/${teamLogic.values.currentTeamId}/dashboards/${props.id}`, {
                         tiles: [{ id: tile.id, filters_overrides: tileFilterOverrides }],
                     })
 
                     tile.filters_overrides = tileFilterOverrides
+                    if (wasIgnored !== isIgnored) {
+                        eventUsageLogic.actions.reportDashboardTileIgnoreDashboardFiltersToggled(
+                            props.id,
+                            tile.insight?.id ?? null,
+                            isIgnored
+                        )
+                    }
                     actions.refreshDashboardItem({ tile })
                     lemonToast.success('Tile filters saved')
                 },
             })
-        },
-        toggleTileIgnoreDashboardFilters: async ({ tile }) => {
-            if (values.tileIgnoreDashboardFiltersSavingIds.includes(tile.id)) {
-                return
-            }
-            const nextIgnored = !tile.filters_overrides?.ignoreDashboardFilters
-            const nextOverrides: TileFilters = { ...tile.filters_overrides }
-            if (nextIgnored) {
-                nextOverrides.ignoreDashboardFilters = true
-            } else {
-                delete nextOverrides.ignoreDashboardFilters
-            }
-
-            actions.setTileIgnoreDashboardFiltersSaving(tile.id, true)
-            try {
-                await api.update(`api/environments/${teamLogic.values.currentTeamId}/dashboards/${props.id}`, {
-                    tiles: [{ id: tile.id, filters_overrides: nextOverrides }],
-                })
-                tile.filters_overrides = nextOverrides
-                eventUsageLogic.actions.reportDashboardTileIgnoreDashboardFiltersToggled(
-                    props.id,
-                    tile.insight?.id ?? null,
-                    nextIgnored
-                )
-                actions.refreshDashboardItem({ tile })
-                lemonToast.success(
-                    nextIgnored
-                        ? 'This insight now ignores dashboard filters'
-                        : 'This insight follows dashboard filters again'
-                )
-            } catch {
-                lemonToast.error('Could not update the tile. Please try again.')
-            } finally {
-                actions.setTileIgnoreDashboardFiltersSaving(tile.id, false)
-            }
         },
     })),
 

--- a/frontend/src/scenes/dashboard/tileLogic.tsx
+++ b/frontend/src/scenes/dashboard/tileLogic.tsx
@@ -31,6 +31,9 @@ export interface tileLogicActions {
         date_to: string | null | undefined
         explicitDate: boolean | undefined
     }
+    setIgnoreDashboardFilters: (ignoreDashboardFilters: boolean) => {
+        ignoreDashboardFilters: boolean
+    }
     setProperties: (properties: AnyPropertyFilter[] | null | undefined) => {
         properties: AnyPropertyFilter[] | null | undefined
     }
@@ -60,6 +63,7 @@ export const tileLogic = kea<tileLogicType>([
         }),
         setProperties: (properties: AnyPropertyFilter[] | null | undefined) => ({ properties }),
         setBreakdown: (breakdown_filter: BreakdownFilter | null | undefined) => ({ breakdown_filter }),
+        setIgnoreDashboardFilters: (ignoreDashboardFilters: boolean) => ({ ignoreDashboardFilters }),
         resetOverrides: true,
     })),
 
@@ -96,6 +100,15 @@ export const tileLogic = kea<tileLogicType>([
                     return newState
                 },
                 setBreakdown: (state, { breakdown_filter }) => ({ ...state, breakdown_filter }),
+                setIgnoreDashboardFilters: (state, { ignoreDashboardFilters }) => {
+                    const newState = { ...state }
+                    if (ignoreDashboardFilters) {
+                        newState.ignoreDashboardFilters = true
+                    } else {
+                        delete newState.ignoreDashboardFilters
+                    }
+                    return newState
+                },
                 resetOverrides: () => ({}),
             },
         ],

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -14,6 +14,18 @@ _DATA_WAREHOUSE_NODE_KINDS = {"DataWarehouseNode", "FunnelsDataWarehouseNode", "
 # when set. Property filters are handled separately (stacked unless they contradict).
 _SCALAR_OVERRIDE_FIELDS = ["breakdown_filter", "interval", "filterTestAccounts"]
 
+# Tile-only flag, not a filter value: it must never reach DashboardFilter(**effective_filters)
+# (extra="forbid"), so every merged output strips it.
+_IGNORE_DASHBOARD_FILTERS = "ignoreDashboardFilters"
+
+
+def _ignores_dashboard_filters(filters: dict | None) -> bool:
+    return bool(filters and filters.get(_IGNORE_DASHBOARD_FILTERS))
+
+
+def _without_ignore_flag(filters: dict) -> dict:
+    return {key: value for key, value in filters.items() if key != _IGNORE_DASHBOARD_FILTERS}
+
 
 class FilterLayerResolution(TypedDict):
     dashboard: dict
@@ -26,6 +38,17 @@ def resolve_filter_layers_by_priority(
 ) -> FilterLayerResolution:
     base = base_filters or {}
     override = override_filters or {}
+
+    if _ignores_dashboard_filters(override):
+        overridden_base = {key: value for key, value in base.items() if value is not None}
+        if overridden_base.get("properties") is not None:
+            overridden_base["properties"] = flatten_property_leaves(overridden_base["properties"])
+        return {
+            "dashboard": {},
+            "tile": override,
+            "overridden_dashboard": overridden_base,
+        }
+
     effective_base = {**base}
     overridden_base: dict = {}
 
@@ -87,11 +110,22 @@ def merge_filters_by_priority(base_filters: dict | None, override_filters: dict 
 
     Overriding the insight's own base filters (not just the lower-priority layer's) is handled separately
     by `remove_query_properties_overridden_by`, which the override-aware call sites apply to the query.
+
+    An override with `ignoreDashboardFilters` drops the base layer entirely: only the override's own
+    values apply. The flag itself is stripped from every merged result, since the output feeds
+    `DashboardFilter(**...)` which forbids extra keys.
     """
+    if override_filters:
+        if override_filters.get(_IGNORE_DASHBOARD_FILTERS):
+            effective = _without_ignore_flag(override_filters)
+            if effective.get("properties") is not None:
+                effective["properties"] = flatten_property_leaves(effective["properties"])
+            return effective
+        override_filters = _without_ignore_flag(override_filters)
     if not override_filters:
         return base_filters or {}
     if not base_filters:
-        return override_filters or {}
+        return override_filters
 
     resolved_layers = resolve_filter_layers_by_priority(base_filters, override_filters)
     merged = {**resolved_layers["dashboard"]}

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -15,7 +15,9 @@ _DATA_WAREHOUSE_NODE_KINDS = {"DataWarehouseNode", "FunnelsDataWarehouseNode", "
 _SCALAR_OVERRIDE_FIELDS = ["breakdown_filter", "interval", "filterTestAccounts"]
 
 # Tile-only flag, not a filter value: it must never reach DashboardFilter(**effective_filters)
-# (extra="forbid"), so every merged output strips it.
+# (extra="forbid"), so every merged output strips it. It only acts on the override (tile) layer;
+# in the base layer (e.g. smuggled in via the `filters_override` query param) it is stripped
+# without effect, since a dashboard-layer "ignore dashboard filters" has no meaning.
 _IGNORE_DASHBOARD_FILTERS = "ignoreDashboardFilters"
 
 
@@ -36,7 +38,7 @@ class FilterLayerResolution(TypedDict):
 def resolve_filter_layers_by_priority(
     base_filters: dict | None, override_filters: dict | None
 ) -> FilterLayerResolution:
-    base = base_filters or {}
+    base = _without_ignore_flag(base_filters or {})
     override = override_filters or {}
 
     if _ignores_dashboard_filters(override):
@@ -113,8 +115,12 @@ def merge_filters_by_priority(base_filters: dict | None, override_filters: dict 
 
     An override with `ignoreDashboardFilters` drops the base layer entirely: only the override's own
     values apply. The flag itself is stripped from every merged result, since the output feeds
-    `DashboardFilter(**...)` which forbids extra keys.
+    `DashboardFilter(**...)` which forbids extra keys. In the base layer the flag is stripped without
+    acting — it is tile-only, but clients can place it in `base_filters` via the `filters_override`
+    query param.
     """
+    if base_filters:
+        base_filters = _without_ignore_flag(base_filters)
     if override_filters:
         if override_filters.get(_IGNORE_DASHBOARD_FILTERS):
             effective = _without_ignore_flag(override_filters)
@@ -263,7 +269,9 @@ def resolve_effective_dashboard_filters(
 ) -> tuple[dict, dict]:
     """Combine dashboard and tile filters for query execution and display reconstruction."""
     effective_filters = (
-        merge_filters_by_priority(base_filters, tile_filters_override) if tile_filters_override else base_filters or {}
+        merge_filters_by_priority(base_filters, tile_filters_override)
+        if tile_filters_override
+        else _without_ignore_flag(base_filters or {})
     )
     # `merge_filters_by_priority` can early-return a raw layer (and a single layer is unmerged), so
     # `properties` may still be a group dict here — normalize before it reaches `DashboardFilter`.
@@ -275,6 +283,10 @@ def resolve_effective_dashboard_filters(
 
 def dashboard_filter_from_dict(filters: dict) -> DashboardFilter:
     """Build a dashboard filter while tolerating legacy grouped properties."""
+    # Final guard: callers like Insight.get_effective_query pass client-supplied filter dicts
+    # here without going through the merge functions, and the tile-only flag would trip
+    # DashboardFilter's extra="forbid".
+    filters = _without_ignore_flag(filters)
     if isinstance(filters.get("properties"), dict):
         filters = {**filters, "properties": flatten_property_leaves(filters["properties"])}
     return DashboardFilter(**filters)

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -42,7 +42,7 @@ def resolve_filter_layers_by_priority(
     override = override_filters or {}
 
     if _ignores_dashboard_filters(override):
-        overridden_base = {key: value for key, value in base.items() if value is not None}
+        overridden_base: dict = {key: value for key, value in base.items() if value is not None}
         if overridden_base.get("properties") is not None:
             overridden_base["properties"] = flatten_property_leaves(overridden_base["properties"])
         return {
@@ -52,7 +52,7 @@ def resolve_filter_layers_by_priority(
         }
 
     effective_base = {**base}
-    overridden_base: dict = {}
+    overridden_base = {}
 
     for field in _SCALAR_OVERRIDE_FIELDS:
         if override.get(field) is not None:

--- a/posthog/hogql_queries/test/test_merge_filters_by_priority.py
+++ b/posthog/hogql_queries/test/test_merge_filters_by_priority.py
@@ -2,6 +2,8 @@ from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
+from posthog.schema import DashboardFilter
+
 from posthog.hogql_queries.apply_dashboard_filters import (
     dashboard_filter_from_dict,
     flatten_property_leaves,
@@ -209,6 +211,65 @@ class TestResolveEffectiveDashboardFilters(SimpleTestCase):
         )
         assert effective["properties"] == [prop]
         assert effective["date_from"] == "-7d"
+
+
+class TestIgnoreDashboardFilters(SimpleTestCase):
+    _DASHBOARD = {
+        "date_from": "-30d",
+        "properties": [{"key": "$browser", "value": "Chrome", "type": "event"}],
+        "interval": "day",
+        "filterTestAccounts": True,
+    }
+
+    @parameterized.expand(
+        [
+            ("dashboard has filters", _DASHBOARD),
+            ("dashboard empty", None),
+        ]
+    )
+    def test_flag_drops_dashboard_layer_and_keeps_tile_values(self, _name, dashboard):
+        merged = merge_filters_by_priority(dashboard, {"ignoreDashboardFilters": True, "date_from": "-7d"})
+
+        assert merged == {"date_from": "-7d"}
+        DashboardFilter(**merged)  # the flag must never reach the extra="forbid" model
+
+    def test_flag_only_tile_yields_empty_effective_filters(self):
+        merged = merge_filters_by_priority(self._DASHBOARD, {"ignoreDashboardFilters": True})
+
+        assert merged == {}
+
+    def test_flag_with_property_group_tile_filters_flattens_for_query_application(self):
+        merged = merge_filters_by_priority(
+            self._DASHBOARD,
+            {
+                "ignoreDashboardFilters": True,
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "AND", "values": [{"key": "$browser", "value": "Chrome", "type": "event"}]}],
+                },
+            },
+        )
+
+        assert merged == {"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]}
+
+    def test_false_flag_merges_normally_and_is_stripped(self):
+        merged = merge_filters_by_priority({"date_from": "-30d"}, {"ignoreDashboardFilters": False, "interval": "week"})
+
+        assert merged == {"date_from": "-30d", "interval": "week"}
+        DashboardFilter(**merged)
+
+    def test_resolve_layers_reports_dashboard_as_fully_overridden(self):
+        tile_prop = {"key": "$country", "value": "US", "type": "event"}
+
+        resolved = resolve_filter_layers_by_priority(
+            self._DASHBOARD, {"ignoreDashboardFilters": True, "properties": [tile_prop]}
+        )
+
+        assert resolved == {
+            "dashboard": {},
+            "tile": {"ignoreDashboardFilters": True, "properties": [tile_prop]},
+            "overridden_dashboard": self._DASHBOARD,
+        }
 
 
 class TestRemoveQueryPropertiesOverriddenBy(SimpleTestCase):

--- a/posthog/hogql_queries/test/test_merge_filters_by_priority.py
+++ b/posthog/hogql_queries/test/test_merge_filters_by_priority.py
@@ -258,6 +258,39 @@ class TestIgnoreDashboardFilters(SimpleTestCase):
         assert merged == {"date_from": "-30d", "interval": "week"}
         DashboardFilter(**merged)
 
+    @parameterized.expand(
+        [
+            ("no tile override", None, {"date_from": "-30d"}),
+            (
+                "tile override present",
+                {"interval": "week"},
+                {"date_from": "-30d", "interval": "week"},
+            ),
+        ]
+    )
+    def test_flag_in_base_layer_is_stripped_without_dropping_the_layer(self, _name, tile, expected):
+        base = {"ignoreDashboardFilters": True, "date_from": "-30d"}
+
+        merged = merge_filters_by_priority(base, tile)
+
+        assert merged == expected
+        DashboardFilter(**merged)
+
+    def test_flag_in_base_layer_does_not_reach_effective_filters(self):
+        query = {"kind": "TrendsQuery", "series": []}
+
+        _, effective = resolve_effective_dashboard_filters(
+            query, {"ignoreDashboardFilters": True, "date_from": "-30d"}, None
+        )
+
+        assert effective == {"date_from": "-30d"}
+        DashboardFilter(**effective)
+
+    def test_dashboard_filter_from_dict_strips_flag(self):
+        assert dashboard_filter_from_dict({"ignoreDashboardFilters": True, "date_from": "-30d"}) == DashboardFilter(
+            date_from="-30d"
+        )
+
     def test_resolve_layers_reports_dashboard_as_fully_overridden(self):
         tile_prop = {"key": "$country", "value": "US", "type": "event"}
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -23969,6 +23969,12 @@ class TileFilters(BaseModel):
     date_to: str | None = None
     explicitDate: bool | None = None
     filterTestAccounts: bool | None = None
+    ignoreDashboardFilters: bool | None = Field(
+        default=None,
+        description=(
+            "When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply."
+        ),
+    )
     interval: IntervalType | None = None
     properties: (
         list[

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -8351,11 +8351,49 @@ export interface DashboardFilterApi {
         | null
 }
 
+export interface TileFiltersApi {
+    breakdown_filter?: BreakdownFilterApi | null
+    date_from?: string | null
+    date_to?: string | null
+    explicitDate?: boolean | null
+    filterTestAccounts?: boolean | null
+    /** When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply. */
+    ignoreDashboardFilters?: boolean | null
+    interval?: IntervalTypeApi | null
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | PersonMetadataPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | MetricPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | AccountCustomPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+}
+
 export interface InsightFilterOverrideContextApi {
     /** Dashboard filters that remain active after applying tile precedence. */
     dashboard?: DashboardFilterApi | null
     /** Tile filters applied above the dashboard filters. */
-    tile?: DashboardFilterApi | null
+    tile?: TileFiltersApi | null
     /** Dashboard filters replaced by the tile filters. */
     overridden_dashboard?: DashboardFilterApi | null
 }

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -556,7 +556,7 @@ class InsightFilterOverrideContext(BaseModel):
     dashboard: schema.DashboardFilter | None = PydanticField(
         default=None, description="Dashboard filters that remain active after applying tile precedence."
     )
-    tile: schema.DashboardFilter | None = PydanticField(
+    tile: schema.TileFilters | None = PydanticField(
         default=None, description="Tile filters applied above the dashboard filters."
     )
     overridden_dashboard: schema.DashboardFilter | None = PydanticField(

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -4388,6 +4388,52 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             },
         }
 
+    def test_tile_ignoring_dashboard_filters_keeps_insight_query_untouched(self) -> None:
+        # The tile opts out of dashboard filters entirely, so neither the dashboard's date range nor its
+        # properties may reach the returned query; the tile's own overrides still apply.
+        insight = Insight.objects.create(
+            query={
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"event": "$pageview", "kind": "EventsNode"}],
+                    "dateRange": {"date_from": "-90d"},
+                },
+            },
+            team=self.team,
+        )
+        dashboard = Dashboard.objects.create(team=self.team, name="dashboard 1", created_by=self.user)
+        DashboardTile.objects.create(
+            dashboard=dashboard,
+            insight=insight,
+            filters_overrides={
+                "ignoreDashboardFilters": True,
+                "properties": [{"key": "$browser", "type": "event", "operator": "exact", "value": ["Firefox"]}],
+            },
+        )
+        dashboard_filters = {
+            "date_from": "-7d",
+            "properties": [{"key": "$country", "type": "event", "operator": "exact", "value": ["US"]}],
+        }
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/{insight.pk}",
+            data={"from_dashboard": str(dashboard.pk), "filters_override": json.dumps(dashboard_filters)},
+        ).json()
+
+        source = response["query"]["source"]
+        assert source["dateRange"]["date_from"] == "-90d"
+        assert self._collect_property_values(source.get("properties"), "$country") == []
+        assert self._collect_property_values(source.get("properties"), "$browser") == [["Firefox"]]
+        assert response["filter_override_context"] == {
+            "dashboard": None,
+            "tile": {
+                "ignoreDashboardFilters": True,
+                "properties": [{"key": "$browser", "type": "event", "operator": "exact", "value": ["Firefox"]}],
+            },
+            "overridden_dashboard": dashboard_filters,
+        }
+
     def test_dashboard_property_override_replaces_insight_on_same_key(self) -> None:
         # Insight and dashboard both filter $browser, no tile. The dashboard must win on that key —
         # over the insight's own filter — instead of AND-ing (Chrome AND Safari would return nothing).

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7745,11 +7745,49 @@ export interface DashboardFilterApi {
         | null
 }
 
+export interface TileFiltersApi {
+    breakdown_filter?: BreakdownFilterApi | null
+    date_from?: string | null
+    date_to?: string | null
+    explicitDate?: boolean | null
+    filterTestAccounts?: boolean | null
+    /** When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply. */
+    ignoreDashboardFilters?: boolean | null
+    interval?: IntervalTypeApi | null
+    properties?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | PersonMetadataPropertyFilterApi
+              | ElementPropertyFilterApi
+              | EventMetadataPropertyFilterApi
+              | SessionPropertyFilterApi
+              | CohortPropertyFilterApi
+              | RecordingPropertyFilterApi
+              | LogEntryPropertyFilterApi
+              | GroupPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | FlagPropertyFilterApi
+              | HogQLPropertyFilterApi
+              | EmptyPropertyFilterApi
+              | DataWarehousePropertyFilterApi
+              | DataWarehousePersonPropertyFilterApi
+              | ErrorTrackingIssueFilterApi
+              | LogPropertyFilterApi
+              | MetricPropertyFilterApi
+              | SpanPropertyFilterApi
+              | RevenueAnalyticsPropertyFilterApi
+              | AccountCustomPropertyFilterApi
+              | WorkflowVariablePropertyFilterApi
+          )[]
+        | null
+}
+
 export interface InsightFilterOverrideContextApi {
     /** Dashboard filters that remain active after applying tile precedence. */
     dashboard?: DashboardFilterApi | null
     /** Tile filters applied above the dashboard filters. */
-    tile?: DashboardFilterApi | null
+    tile?: TileFiltersApi | null
     /** Dashboard filters replaced by the tile filters. */
     overridden_dashboard?: DashboardFilterApi | null
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7935,11 +7935,23 @@ export namespace Schemas {
       properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
     }
 
+    export interface TileFilters {
+      breakdown_filter?: BreakdownFilter | null;
+      date_from?: string | null;
+      date_to?: string | null;
+      explicitDate?: boolean | null;
+      filterTestAccounts?: boolean | null;
+      /** When true, this tile ignores every dashboard-level filter; the tile's own overrides still apply. */
+      ignoreDashboardFilters?: boolean | null;
+      interval?: IntervalType | null;
+      properties?: (EventPropertyFilter | PersonPropertyFilter | PersonMetadataPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | MetricPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | AccountCustomPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+    }
+
     export interface InsightFilterOverrideContext {
       /** Dashboard filters that remain active after applying tile precedence. */
       dashboard?: DashboardFilter | null;
       /** Tile filters applied above the dashboard filters. */
-      tile?: DashboardFilter | null;
+      tile?: TileFilters | null;
       /** Dashboard filters replaced by the tile filters. */
       overridden_dashboard?: DashboardFilter | null;
     }


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/23762

## TL;DR

ELI5: a dashboard's filters normally apply to every insight on it. This adds a per-tile switch, "Ignore dashboard filters". Flip it on and that insight keeps showing its own data, whatever the dashboard filters say. The tile's own overrides still work.

## Problem

Dashboard filters (date, properties, breakdown, interval, and the test-account override from #68612) apply to every tile. A tile can replace a dashboard value with its own, but it cannot opt out. A pinned KPI tile on a filtered dashboard has no way to stay untouched.

Builds on #68612 (merged).

## Changes

- New `ignoreDashboardFilters` flag on `TileFilters`, stored in the existing `DashboardTile.filters_overrides` JSON. No migration; it rides the existing tiles PATCH, copy, and query-param paths.
- Backend: `resolve_filter_layers_by_priority` and `merge_filters_by_priority` drop the dashboard layer when the flag is set, and always strip the flag before filters reach `DashboardFilter(**...)`, which forbids extra keys. This covers dashboard view, previews, shared dashboards, exports, and subscriptions, since they all resolve through the same functions.
- Excluded-tile properties go through the same `flatten_property_leaves` normalization as the normal merge path, so property-group payloads behave the same with and without the flag (aligns with #72328).
- The "Override Tile Filters" modal gets an "Ignore dashboard filters" switch. (An earlier revision also had a toggle in the tile "more" menu; it was removed on request so the modal is the single place to set the flag.)
- Excluded tiles show an "Ignores dashboard filters" notice in the card heading and a "Dashboard filters: ignored" line in the insight details popover.
- Dashboard variables still apply; exclusion covers filters only.
- `InsightFilterOverrideContext.tile` is now typed as `TileFilters` (was `DashboardFilter`).

`hogli build:openapi` needs a database and could not run in this environment, so generated API types are not refreshed in this commit; CI regenerates them.

## How did you test this code?

- `test_merge_filters_by_priority.py`, 6 new cases: catch the flag leaking into the `extra="forbid"` `DashboardFilter` (which would break every excluded tile's compute), the exclusion branch being dropped, property groups skipping flattening on the ignore path, and the display context misreporting layers. All 34 pass locally.
- `test_insight.py`, 1 new end-to-end case: an excluded tile's query keeps its own date range and properties when `filters_override` is passed, and the response context reports the layers. Catches a call-site reordering the unit tests cannot see. It needs Postgres, which this environment lacks, so CI runs it.
- Jest: new cases in `dashboardFilterEmpty.test.ts` (a flag-only override must not be dropped as "empty") and `InsightDetails.test.tsx` (the popover must not show dashboard layers for excluded tiles). Both suites pass locally.
- Repo-wide mypy: one error, pre-existing in an untouched file (also present without this diff). TypeScript check: no errors in touched files.
- Not done: no browser or manual testing in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover tile overrides today; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in a PostHog Code cloud task. Skills invoked: /grill-me (design interview), /writing-tests, /improving-drf-endpoints. Decisions settled with the requester before coding: exclusion covers all dashboard filter types rather than per-type or test-accounts-only; tile-level overrides still apply; the flag lives in `filters_overrides` instead of a new column; the switch lives in the override modal (a menu toggle was added, then removed on follow-up request); the indicator always shows on excluded tiles; variables stay out of scope. The work started stacked on #68612; that PR squash-merged mid-task, so the branch was rebased onto master (picking up the #72328 flattening) and now carries a single commit. The commit was created through GitHub's commit API because the signed-commit tool's credential expired mid-task; the commit is Verified.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

