### PR TITLE
ci: make Container Images CD idempotent so ECR sha tags aren't overwritten

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -59,8 +59,39 @@ jobs:
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            # Idempotency preflight. If this commit's image is already in ECR (a manual
+            # re-run, or an earlier attempt that pushed to ECR before failing on another
+            # registry) do NOT rebuild: a rebuild yields a new digest and would overwrite
+            # the immutable sha-<short>/<full-sha> tags. We reconcile from the existing
+            # digest instead (see "Reconcile tags from existing image" below). Uses
+            # batch-get-image because the ECR publish role has ecr:BatchGetImage but not
+            # ecr:DescribeImages.
+            - name: Check for existing image in ECR
+              id: preflight
+              env:
+                  ECR_REPO: posthog-cloud
+                  SHA: ${{ github.sha }}
+              run: |
+                  set -euo pipefail
+                  digest="$(aws ecr batch-get-image \
+                      --repository-name "$ECR_REPO" \
+                      --image-ids imageTag="$SHA" \
+                      --accepted-media-types \
+                          "application/vnd.oci.image.index.v1+json" \
+                          "application/vnd.docker.distribution.manifest.list.v2+json" \
+                          "application/vnd.oci.image.manifest.v1+json" \
+                          "application/vnd.docker.distribution.manifest.v2+json" \
+                      --query 'images[0].imageId.imageDigest' \
+                      --output text 2>/dev/null || true)"
+                  [ "$digest" = "None" ] && digest=""
+                  echo "digest=$digest" >> "$GITHUB_OUTPUT"
+                  if [ -n "$digest" ]; then
+                      echo "Image for $SHA already present in ECR ($digest); skipping build." >&2
+                  fi
+
             - name: Build and push container image
               id: build
+              if: steps.preflight.outputs.digest == ''
               continue-on-error: true
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
@@ -101,9 +132,33 @@ jobs:
               if: steps.build.outcome == 'failure'
               uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
+            # Attempt 1 may have pushed to ECR before failing on another registry. Re-check
+            # so the retry reconciles from that digest instead of rebuilding (which would
+            # overwrite the immutable sha-* tags with a new digest).
+            - name: Re-check for existing image in ECR (retry)
+              id: preflight_retry
+              if: steps.build.outcome == 'failure'
+              env:
+                  ECR_REPO: posthog-cloud
+                  SHA: ${{ github.sha }}
+              run: |
+                  set -euo pipefail
+                  digest="$(aws ecr batch-get-image \
+                      --repository-name "$ECR_REPO" \
+                      --image-ids imageTag="$SHA" \
+                      --accepted-media-types \
+                          "application/vnd.oci.image.index.v1+json" \
+                          "application/vnd.docker.distribution.manifest.list.v2+json" \
+                          "application/vnd.oci.image.manifest.v1+json" \
+                          "application/vnd.docker.distribution.manifest.v2+json" \
+                      --query 'images[0].imageId.imageDigest' \
+                      --output text 2>/dev/null || true)"
+                  [ "$digest" = "None" ] && digest=""
+                  echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
             - name: Build and push container image (retry)
               id: build_retry
-              if: steps.build.outcome == 'failure'
+              if: steps.build.outcome == 'failure' && steps.preflight_retry.outputs.digest == ''
               continue-on-error: true
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
@@ -118,21 +173,51 @@ jobs:
                   secrets: |
                       posthog_upload_sourcemaps_cli_api_key=${{ secrets.POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY }}
 
-            - name: Fail if both build attempts failed
-              if: steps.build.outcome == 'failure' && steps.build_retry.outcome != 'success'
+            # Reconcile every tag from the already-present digest (preflight skip, or a retry
+            # where attempt 1 had already reached ECR). imagetools copies the manifest
+            # server-side by digest: multi-arch is preserved, the immutable sha-* tags keep
+            # their digest (same-digest re-tag is a no-op), and any registry a partial push
+            # missed is completed. No rebuild, so the digest never drifts.
+            - name: Reconcile tags from existing image
+              id: reconcile
+              if: steps.preflight.outputs.digest != '' || steps.preflight_retry.outputs.digest != ''
+              env:
+                  SRC: ${{ steps.docker-meta.outputs.ecr-registry }}/posthog-cloud@${{ steps.preflight.outputs.digest || steps.preflight_retry.outputs.digest }}
+                  TAGS: ${{ steps.docker-meta.outputs.tags }}
               run: |
-                  echo "::error::Both build attempts failed. First attempt and retry both unsuccessful."
+                  set -euo pipefail
+                  args=()
+                  while IFS= read -r tag; do
+                      [ -n "$tag" ] && args+=( --tag "$tag" )
+                  done <<< "$TAGS"
+                  echo "Reconciling ${#args[@]} tag(s) from $SRC (no rebuild)"
+                  docker buildx imagetools create "${args[@]}" "$SRC"
+
+            # Single source of truth for the image digest the deploy dispatches consume,
+            # whichever path produced it: existing image, retry-reconciled, retry, or build.
+            - name: Resolve image digest
+              id: image
+              env:
+                  DIGEST: ${{ steps.preflight.outputs.digest || steps.preflight_retry.outputs.digest || steps.build_retry.outputs.digest || steps.build.outputs.digest }}
+              run: |
+                  set -euo pipefail
+                  echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+            - name: Fail if no image was produced
+              if: steps.image.outputs.digest == ''
+              run: |
+                  echo "::error::No image digest resolved: build and retry both failed and no existing image was found in ECR."
                   exit 1
 
             - name: report failure
-              if: always() && steps.build.outcome == 'failure' && steps.build_retry.outcome != 'success'
+              if: always() && steps.image.outputs.digest == ''
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
               with:
                   posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
                   event: 'posthog-image-build'
                   properties: '{"status": "failure", "commit_hash": "${{ github.sha }}"}'
             - name: report failure to DevEx PostHog
-              if: always() && steps.build.outcome == 'failure' && steps.build_retry.outcome != 'success'
+              if: always() && steps.image.outputs.digest == ''
               continue-on-error: true
               uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
               with:
@@ -188,7 +273,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "posthog",
@@ -218,7 +303,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "ingestion",
@@ -248,7 +333,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker",
@@ -269,7 +354,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-batch-exports",
@@ -299,7 +384,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-max-ai",
@@ -329,7 +414,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-tasks-agent",
@@ -476,7 +561,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-billing",
@@ -497,7 +582,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-video-export",
@@ -518,7 +603,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-session-replay",
@@ -539,7 +624,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-replay-vision",
@@ -560,7 +645,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-experiments-recalculation",
@@ -581,7 +666,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-error-tracking",
@@ -602,7 +687,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-weekly-digest",
@@ -623,7 +708,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-analytics-platform",
@@ -644,7 +729,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-general-purpose",
@@ -665,7 +750,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-signup-enrichment",
@@ -742,7 +827,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-health-check",
@@ -772,7 +857,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-llm-analytics-evals",
@@ -796,7 +881,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-messaging",
@@ -817,7 +902,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-mcp-analytics",
@@ -838,7 +923,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-logs-alerting",
@@ -859,7 +944,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-stamphog",
@@ -889,7 +974,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-ducklake",
@@ -919,7 +1004,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-data-warehouse",
@@ -940,7 +1025,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-data-warehouse-metadata",
@@ -970,7 +1055,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "warehouse-sources-load",
@@ -1000,7 +1085,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "warehouse-sources-duckgres-load",
@@ -1021,7 +1106,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-data-warehouse-cdp-producer",
@@ -1042,7 +1127,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ github.sha }}@${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "temporal-worker-data-modeling",
@@ -1062,7 +1147,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                            "sha": "${{ steps.image.outputs.digest }}"
                           }
                         },
                         "release": "dagster-code-location",

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -18,6 +18,15 @@ on:
             - 'livestream/**'
     workflow_dispatch:
 
+# Serialize runs for the same commit so a push racing a manual re-run/dispatch can't both
+# preflight "absent" and both rebuild, moving an immutable sha-* tag to a new digest. Keyed
+# on github.sha (not the ref) so it also covers push-vs-dispatch overlap; different master
+# commits keep distinct groups and still build in parallel. Never cancel — a queued same-SHA
+# run must run its preflight after the first finishes and reconcile instead of rebuilding.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.sha }}
+    cancel-in-progress: false
+
 jobs:
     posthog_build:
         name: Build and push PostHog
@@ -65,7 +74,9 @@ jobs:
             # the immutable sha-<short>/<full-sha> tags. We reconcile from the existing
             # digest instead (see "Reconcile tags from existing image" below). Uses
             # batch-get-image because the ECR publish role has ecr:BatchGetImage but not
-            # ecr:DescribeImages.
+            # ecr:DescribeImages. A genuine miss exits 0 (a `None` result); a throttle,
+            # credential, or network error exits non-zero and must fail the step — we can't
+            # swallow it to an empty "absent" result and rebuild, which would overwrite the tags.
             - name: Check for existing image in ECR
               id: preflight
               env:
@@ -82,7 +93,7 @@ jobs:
                           "application/vnd.oci.image.manifest.v1+json" \
                           "application/vnd.docker.distribution.manifest.v2+json" \
                       --query 'images[0].imageId.imageDigest' \
-                      --output text 2>/dev/null || true)"
+                      --output text)"
                   [ "$digest" = "None" ] && digest=""
                   echo "digest=$digest" >> "$GITHUB_OUTPUT"
                   if [ -n "$digest" ]; then
@@ -134,7 +145,8 @@ jobs:
 
             # Attempt 1 may have pushed to ECR before failing on another registry. Re-check
             # so the retry reconciles from that digest instead of rebuilding (which would
-            # overwrite the immutable sha-* tags with a new digest).
+            # overwrite the immutable sha-* tags with a new digest). As in the preflight, a
+            # transient AWS error must fail the step rather than be swallowed to "absent".
             - name: Re-check for existing image in ECR (retry)
               id: preflight_retry
               if: steps.build.outcome == 'failure'
@@ -152,7 +164,7 @@ jobs:
                           "application/vnd.oci.image.manifest.v1+json" \
                           "application/vnd.docker.distribution.manifest.v2+json" \
                       --query 'images[0].imageId.imageDigest' \
-                      --output text 2>/dev/null || true)"
+                      --output text)"
                   [ "$digest" = "None" ] && digest=""
                   echo "digest=$digest" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

`Container Images CD` builds `posthog-cloud` once and pushes the **whole tag set** — including the immutable-intent `sha-<short>` and `<full-sha>` tags — to every registry. When the push half-fails (e.g. ECR succeeded, DockerHub flaked) the `continue-on-error` retry **rebuilds from scratch**, producing a *new digest*, and the sha tags get overwritten. Manual workflow re-runs do the same.

Over one sample week the root-account `posthog-cloud` ECR repo had **10 sha-tag overwrites** (same tag, different digest) — all from this workflow's publish role. One pair was pushed to the same tag **2 seconds apart** (the in-job retry after a partial push), so what briefly deployed is unreproducible.

This blocks turning on **ECR image tag immutability**, which we want so a commit's `sha-*` tag is a permanent, tamper-evident pointer to exactly one image.

## Fix

Make the job idempotent — never rebuild a commit that's already in ECR, and never overwrite an existing sha tag with a different digest:

1. **Preflight** (`batch-get-image`, since the publish role has `ecr:BatchGetImage` but not `ecr:DescribeImages`): if the commit's image is already in ECR, skip the build.
2. **Reconcile from the existing digest** with `docker buildx imagetools create` — a server-side copy by digest. Multi-arch is preserved, the immutable sha tags keep their digest (same-digest re-tag is a no-op), and any registry a partial push missed is completed. No rebuild ⇒ no digest drift.
3. **Retry re-checks ECR first**: if attempt 1 had already reached ECR, reconcile instead of rebuilding.
4. All deploy dispatches now consume one resolved digest output (`steps.image.outputs.digest`) instead of `build_retry || build`, so the skip/reconcile paths dispatch the correct digest.

### Control flow

| Scenario | Before | After |
|---|---|---|
| First build, success | build+push | unchanged |
| Manual re-run of a built commit | rebuild ⇒ **overwrites sha tags** | preflight skip → reconcile (no rebuild) |
| Attempt 1 partial (ECR ok, DockerHub flake) | rebuild ⇒ **new digest** | reconcile from attempt 1's digest → completes missing registries |
| Attempt 1 fails before any push | rebuild | rebuild (unchanged) |
| Build + retry both fail | fail | fail (`Fail if no image was produced`) |

> Draft for DevEx review — this is the prerequisite for enabling `IMMUTABLE_WITH_EXCLUSION` (excluding `latest`/`master`/`pr-*`) on the ECR repos.
