### PR TITLE
chore(conversations): rename user-facing copy from Conversations to Support

### DIFF
--- a/frontend/src/scenes/inbox/components/badges/sourceProductIcons.tsx
+++ b/frontend/src/scenes/inbox/components/badges/sourceProductIcons.tsx
@@ -72,7 +72,7 @@ export const SOURCE_PRODUCT_META: Partial<Record<SignalSourceProduct, SourceProd
     [SignalSourceProduct.Conversations]: {
         Icon: IconSupport,
         color: 'var(--blue)',
-        label: 'Conversations',
+        label: 'Support',
     },
     [SignalSourceProduct.Pganalyze]: {
         Icon: IconDatabase,

--- a/frontend/src/scenes/inbox/filterOptions.tsx
+++ b/frontend/src/scenes/inbox/filterOptions.tsx
@@ -86,7 +86,7 @@ export const INBOX_SOURCE_OPTIONS: { value: string; label: string; icon: JSX.Ele
     { value: 'github', label: 'GitHub', icon: <IconGithub /> },
     { value: 'linear', label: 'Linear', icon: <IconStack /> },
     { value: 'zendesk', label: 'Zendesk', icon: <IconReceipt /> },
-    { value: 'conversations', label: 'Conversations', icon: <IconSupport /> },
+    { value: 'conversations', label: 'Support', icon: <IconSupport /> },
     { value: 'pganalyze', label: 'pganalyze', icon: <IconDatabase /> },
     { value: 'analytics', label: 'Product analytics', icon: <IconGraph /> },
     { value: 'signals_scout', label: 'Scout', icon: <IconCompass /> },

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1194,7 +1194,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                         </LemonTag>
                     </>
                 ),
-                description: 'Import historical support data from external tools into Conversations.',
+                description: 'Import historical support data from external tools into Support.',
                 component: <ZendeskImportSection />,
                 flag: 'PRODUCT_SUPPORT_IMPORT_TICKETS',
                 allowForTeam: (t) => !!t?.conversations_enabled,

--- a/products/conversations/backend/api/email_settings.py
+++ b/products/conversations/backend/api/email_settings.py
@@ -374,7 +374,7 @@ class EmailSendTestView(APIView):
         from_addr = formataddr((config.from_name, config.from_email))
 
         email_message = mail.EmailMultiAlternatives(
-            subject="Test email from PostHog Conversations",
+            subject="Test email from PostHog Support",
             body="This is a test email to confirm your outbound email is working correctly.",
             from_email=from_addr,
             to=[user.email],
@@ -393,7 +393,7 @@ class EmailSendTestView(APIView):
         except MailgunNotConfigured:
             logger.exception("email_send_test_not_configured", team_id=team.id, config_id=config.id)
             return Response(
-                {"error": "Conversations email not configured on this instance"},
+                {"error": "Support email not configured on this instance"},
                 status=500,
             )
         except MailgunDomainNotRegistered:

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1149,7 +1149,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
 
         if not self.team.conversations_enabled:
             return Response(
-                {"detail": "Conversations is not enabled."},
+                {"detail": "Support is not enabled."},
                 status=drf_status.HTTP_400_BAD_REQUEST,
             )
 
@@ -1243,7 +1243,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
 
         if not team.conversations_enabled:
             return Response(
-                {"detail": "Conversations is not enabled."},
+                {"detail": "Support is not enabled."},
                 status=drf_status.HTTP_400_BAD_REQUEST,
             )
 

--- a/products/conversations/backend/api/zendesk_import.py
+++ b/products/conversations/backend/api/zendesk_import.py
@@ -141,7 +141,7 @@ class ZendeskImportViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         team_id = self.team_id
         if not self.team.conversations_enabled:
             return Response(
-                {"detail": "Conversations is not enabled for this team"}, status=drf_status.HTTP_400_BAD_REQUEST
+                {"detail": "Support is not enabled for this team"}, status=drf_status.HTTP_400_BAD_REQUEST
             )
 
         serializer = ZendeskImportStartSerializer(data=request.data)

--- a/products/conversations/backend/api/zendesk_import.py
+++ b/products/conversations/backend/api/zendesk_import.py
@@ -140,9 +140,7 @@ class ZendeskImportViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def create(self, request: Request, *args, **kwargs) -> Response:
         team_id = self.team_id
         if not self.team.conversations_enabled:
-            return Response(
-                {"detail": "Support is not enabled for this team"}, status=drf_status.HTTP_400_BAD_REQUEST
-            )
+            return Response({"detail": "Support is not enabled for this team"}, status=drf_status.HTTP_400_BAD_REQUEST)
 
         serializer = ZendeskImportStartSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/products/conversations/backend/apps.py
+++ b/products/conversations/backend/apps.py
@@ -5,7 +5,7 @@ class ConversationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "products.conversations.backend"
     label = "conversations"
-    verbose_name = "Conversations"
+    verbose_name = "Support"
 
     def ready(self):
         from . import signals  # noqa: F401

--- a/products/conversations/frontend/components/ComposeTicket/ComposeTicketButton.tsx
+++ b/products/conversations/frontend/components/ComposeTicket/ComposeTicketButton.tsx
@@ -48,7 +48,7 @@ export function ComposeTicketButton({
                 overlay={
                     <div className="p-3 max-w-xs flex flex-col gap-2">
                         <p className="m-0 text-sm">
-                            Conversations are not enabled for this project. Enable them in settings to start writing to
+                            Support is not enabled for this project. Enable it in settings to start writing to
                             customers.
                         </p>
                         <LemonButton

--- a/products/conversations/frontend/components/SidePanel/TicketsList.tsx
+++ b/products/conversations/frontend/components/SidePanel/TicketsList.tsx
@@ -20,7 +20,7 @@ export function TicketsList(): JSX.Element {
     if (!hasIdentityMode && (!posthog.conversations || !posthog.conversations.isAvailable())) {
         return (
             <div className="text-center text-muted-alt py-8">
-                <p>Conversations are not available for this team.</p>
+                <p>Support is not available for this team.</p>
             </div>
         )
     }

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -89,8 +89,8 @@ export function WidgetSection(): JSX.Element {
                     <>
                         <LemonDivider />
                         <LemonBanner type="info" className="my-2">
-                            Allowed domains for the widget are managed under the <strong>Direct API</strong>{' '}
-                            section — they apply to both the widget and direct API calls.
+                            Allowed domains for the widget are managed under the <strong>Direct API</strong> section —
+                            they apply to both the widget and direct API calls.
                         </LemonBanner>
                         <SceneSection title="Visual settings" className="mt-8" titleSize="sm">
                             <LemonCard hoverEffect={false} className="px-4 py-3">

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -89,7 +89,7 @@ export function WidgetSection(): JSX.Element {
                     <>
                         <LemonDivider />
                         <LemonBanner type="info" className="my-2">
-                            Allowed domains for the widget are managed under the <strong>Conversations API</strong>{' '}
+                            Allowed domains for the widget are managed under the <strong>Direct API</strong>{' '}
                             section — they apply to both the widget and direct API calls.
                         </LemonBanner>
                         <SceneSection title="Visual settings" className="mt-8" titleSize="sm">

--- a/products/conversations/frontend/scenes/settings/ZendeskImportSection.tsx
+++ b/products/conversations/frontend/scenes/settings/ZendeskImportSection.tsx
@@ -39,7 +39,7 @@ export function ZendeskImportSection(): JSX.Element {
     return (
         <SceneSection
             title="Zendesk import"
-            description="Import historical Zendesk Support tickets and message threads into Conversations. Already-synced tickets are skipped on re-run."
+            description="Import historical Zendesk Support tickets and message threads into Support. Already-synced tickets are skipped on re-run."
         >
             <LemonCard hoverEffect={false} className="flex flex-col gap-y-3 max-w-[800px] px-4 py-3">
                 <ZendeskImportForm />

--- a/products/conversations/manifest.tsx
+++ b/products/conversations/manifest.tsx
@@ -5,7 +5,7 @@ import { ProductItemCategory, ProductKey } from '~/queries/schema/schema-general
 import { FileSystemIconColor, ProductManifest } from '../../frontend/src/types'
 
 export const manifest: ProductManifest = {
-    name: 'Conversations',
+    name: 'Support',
     scenes: {
         SupportTickets: {
             name: 'Ticket list',


### PR DESCRIPTION
## Problem

The product that lives in code under the `products/conversations/` namespace is user-facing named **Support**. A handful of user-visible strings still said "Conversations", which is inconsistent with the nav entry, settings section, side panel, and docs (which all say "Support"). Raised in a Slack thread.

## Changes

Renamed user-facing copy from "Conversations" to "Support". The internal `conversations` code namespace, module paths, API route slugs, kea logic keys and enum values are intentionally left untouched — only strings a user actually sees are changed:

- Frontend: compose-ticket disabled popover, side-panel unavailable state, Zendesk import description, widget-settings banner (also fixes a stale cross-reference: the section is titled "Direct API"), inbox source filter option + source badge label, settings imports description.
- Backend strings that surface in the UI: test-email subject line, and the "not enabled"/"not configured" API error messages.
- Django `AppConfig.verbose_name` (Django admin) and the product manifest `name`.

## How did you test this code?

Copy-only changes. No tests assert on these strings (verified). No serializer/schema changes, so no OpenAPI regeneration needed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app after a Slack thread asked to confirm nothing user-facing still says "Conversations". An Explore subagent audited the repo and categorized findings into user-facing vs internal; this PR fixes only the user-facing set and deliberately leaves the internal `conversations` namespace alone. Lowercase "conversation(s)" that refers to an individual message thread within the product (domain terminology) was left as-is. No skills were required (pure copy changes; no viewset/serializer schema edits).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1784652337773889?thread_ts=1784652337.773889&cid=C08S2L0S5MZ)*
