### PR TITLE
feat(insights): redrawn insight type icon set with chart-true colors

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -401,9 +401,9 @@ snapshots:
     components-editable-field--multiline-with-markdown--light:
         hash: v1.k794b7964.e62e904dc93d9cd9d1d51bb8014642a210dffae5b048c667f960fd09d8079825.azh8AGX7ymJHdgxzuJOKXLEyHoXdLW0YBRTVe7Ha-Ms
     components-editorfilters--with-long-filter-value--dark:
-        hash: v1.k794b7964.f3b5749291626b56591c641ee1a8b95fcac49e222928969f1b8edf8b0b538633.jgWlK6apybkKZcYZ0gQohMJDij8HWbwMnkdXNPmabvw
+        hash: v1.k794b7964.2934bf1fa859b4f10011e2cdeac8f54868eed3cf2b82b0bea7a28a8ab3e18fe2.e9kU80ang16DT44L82fuciH5d1X7SwiwjQDifYN3ibg
     components-editorfilters--with-long-filter-value--light:
-        hash: v1.k794b7964.37b4299abd8d1d46ef429ed321e337bcd0e8247e243a8c15b0651ee921668084.O5jywlI9T7O5mW7J_yt2lEvhd0IkfBc-wMruFQFfOJY
+        hash: v1.k794b7964.250984777a5e7f15e2fb91bacd52416d73678c05e328d8d1b7e57296cafb8f92.PBQ1L5prNwRc042lo12y5Xs4qsG0B6VkL9xU8PmayLQ
     components-empty-message--empty-message--dark:
         hash: v1.k794b7964.b98036b313efce67327df1499b6583b55f482ca3aca5320b255280d601bab8f6.VSqEn95sY0Q1aSYbP1-TlEXjQMJqBJDyo8KouaEHpnA
     components-empty-message--empty-message--light:
@@ -1721,9 +1721,9 @@ snapshots:
     components-search--product-recents-and-starred--light:
         hash: v1.k794b7964.5df9ac27e8f914736f6fc30fbe27aba42d686145e0f06982dfe1050b74931081.9snshG25bFXRzfMF4nFJgaB7uHRXkt-2Du2b_Qoi9Lw
     components-search--searching--dark:
-        hash: v1.k794b7964.290bfa4a2a6e49770661d45646711b5755aea5d9b89ae5196c21e217dc8f8e82.QuKpgiWzYoz9LP7dmTh1ha4v5i-dFSI5fMpLWTGtVi0
+        hash: v1.k794b7964.85766b937eb3e2cb31d77d0fc3d3270ea92b5a4c51577cddc5de92649787d1ac.TQ8fgQkYMWRzITSkjwIDMOahzlPUZXGugRI2b-7Q7Rs
     components-search--searching--light:
-        hash: v1.k794b7964.24bc3ddb258e9a945dc9162929f53a48995d937d8ae69abff655145321bd190a.JCxCMyMt3v-oFLNXFgr_mHYfpz_lWSQc6vNy9Dz_enI
+        hash: v1.k794b7964.f7ed712a72accf99484489415f30aa0d1931f75806b0522e6ac88bfef3eff899.HKpJ3OTjiZbPtkMvpTjami0t7I5d-odknNJ_0-antHE
     components-sentencelist--full-sentence--dark:
         hash: v1.k794b7964.7e8e5dd2e09d246cc3668f362f2391fe67618bd1143aa393832297f5dc30e558.yptEWKc5RAUY613Fwd5cQ0VIinMvpdoI6cuKgagAGxk
     components-sentencelist--full-sentence--light:
@@ -3153,9 +3153,9 @@ snapshots:
     lemon-ui-icons1--shelf-a--light:
         hash: v1.k794b7964.5ac03ce003c333375b716362f03c7692bca611adffe6be6ef9be3b007e3b2595.YDFXw5WBfM-Nw2sTc3wVkST_yw3Ov7ZZshM8qFYuf-M
     lemon-ui-icons1--shelf-b--dark:
-        hash: v1.k794b7964.c7547d871ddbf17a4f99d32c466878c8757d27cf0f22ec6bc8e43ef87c399182.L89ECBrJOTmw8Exi6IL6Hr8id1ix59nzKurtIQ7KHRw
+        hash: v1.k794b7964.c2c95a8a61bb792c13779dc5f22c1e121ad9ae7af8351b30a9ac17b81c291e86.uJxk1G4ss-OPMH5YoVtM8YhU64L_66iieFCsezOpyew
     lemon-ui-icons1--shelf-b--light:
-        hash: v1.k794b7964.8b727af713dae6ff6e31145bdc8366e139ee55c4d714edb1116a3dce8a76c320.RRDoV57noSzwfHYAdS7_PREQ_Vq_mj8htal3TSvLZ1E
+        hash: v1.k794b7964.076c78450d15324c056a0d2797d9540f66d94674478877cb30f641e89960ba73.OVINaoLosPw8FuQQt8HVE9Vb05cIWy4eyYblTAFu3Q8
     lemon-ui-icons1--shelf-c--dark:
         hash: v1.k794b7964.fa38008cc14dfc8829a27ae05a420e0330024a81d22e8cf6c0955c0cd720d06d.0v0ZiDwGLHBsy_I3t3yYKrc-3iWi75dosJJEVP3dldo
     lemon-ui-icons1--shelf-c--light:
@@ -3181,9 +3181,9 @@ snapshots:
     lemon-ui-icons1--shelf-h--light:
         hash: v1.k794b7964.3c9870edcee498ad6947444be87ef3f85e90d82192b4fd22f2cde84db48e86f2.QQnFYrSO2Xfc4I_B3I5cVZaH-4Q1fr08QodV0PyJBCk
     lemon-ui-icons1--shelf-i--dark:
-        hash: v1.k794b7964.8297200812d946bc3a10745c77f19f5a2ddee96e763024265d81253e10fd76e6.9gh8BqMzdk5glx3S0fRDj8FIKDaAlOESdr2f7FQpMfI
+        hash: v1.k794b7964.a83c90e27dd8557efb82de3661184e4755a4380c84dac1fe777dc6baac7fc359.zukSzeHos2m1Sb3_zAKpUIxAFgcDyxSQgh3wOBFc__k
     lemon-ui-icons1--shelf-i--light:
-        hash: v1.k794b7964.69086b2ff6b18e808ad3c6594d5989c405e28db613751e36fc9c8f7162a80fc9.mGdV4gTlyPaEBryMd_o4rzAMfteZdIF0DDb2GPnmWZo
+        hash: v1.k794b7964.aa2eb9ceb9808fd0828a257b8b1b99aa3f3321ec994ec36eb68028558bd5ebfc.7UHzhHJ-xB7MPtHPpp9NnHEPrLtgq7QGg44YAbbFhNQ
     lemon-ui-icons2--shelf-j--dark:
         hash: v1.k794b7964.033611afdd5888be217968d1dcd15e873afd918d808d5c426fedaa3438f92a9f.vgOx8gXP6B3-wYG_JPG-BIvxybLW38je2SE1cl8jV48
     lemon-ui-icons2--shelf-j--light:
@@ -6317,7 +6317,7 @@ snapshots:
     scenes-app-insights-side-panel-actions--saved-trends-insight--dark:
         hash: v1.k794b7964.e236a1e99e95775e1e69c07f4c336f58ebc7d2a25a557271638d225368ca081a.CgTT0P5qfYJ-wavjUYdmYjcc7vrm_ZiXNjlkaEyDuKg
     scenes-app-insights-side-panel-actions--saved-trends-insight--light:
-        hash: v1.k794b7964.8b3c5b3a6d6c40c1deffcc9295215757184925243f0ec4f1e5360947645dfe63.l8Ld6syBbfnl46gqKDLV8JMhS8G-76BsrG9ztylWhRM
+        hash: v1.k794b7964.a100083fa940e2a324d9dcc970e9923aa3c21739f4b957769321f3cda6b1fbf8.fzAHIvBjqv21xju0NyoS77W2CdhYWK8kSeGuAAKtdbA
     scenes-app-insights-side-panel-actions--unsaved-insight--dark:
         hash: v1.k794b7964.d4921e1d896775d1f98056f5bc1c57c9b7ca0be8951e14a0f3229e7b77dc2472.W3I3GvNATojXlZJp04S-XFH3DfLBUNb7lJ1-lr-rW9g
     scenes-app-insights-side-panel-actions--unsaved-insight--light:
@@ -6931,7 +6931,7 @@ snapshots:
     scenes-app-saved-insights-new-insight-menu--chips-overlay--light:
         hash: v1.k794b7964.734bf73c0aacf34fa60365106192d1a705ce2470faccd609b493bc6013427bff.DlKlVXWYBikhZE9lb-F8QKKTFPHVLET5XZdYeS0GRH4
     scenes-app-saved-insights-new-insight-menu--grouped-overlay--dark:
-        hash: v1.k794b7964.0308bca93f90618e10d9c366f0e18c7ec79cdb295320d278de5b584d2394c42c.4ik9p5vbMBj6F6CSkRUKx7ZpeBDanxMa0xSC4VC3QxI
+        hash: v1.k794b7964.5a65f3fe94b288f66e436ecd8677bc2d1b3fe08ca885f03eae64bc8847b783ee.Rbg5_4VnhqIM110O92Rsb0SKEPt3aFNSAEDRY-msHPc
     scenes-app-saved-insights-new-insight-menu--grouped-overlay--light:
         hash: v1.k794b7964.1ed49ef01f24d1bf519ec7a184b4ae9a809705421510221f60fe5d22ab5052f7.FTV3mfkHio4riI82tiGFRA4e-rcdasqh62XJtba9AXU
     scenes-app-sessionattributionexplorer--session-attribution-explorer--dark:

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -4,7 +4,6 @@ import {
     IconApp,
     IconApps,
     IconBook,
-    IconBrackets,
     IconBug,
     IconCircleDashed,
     IconClock,
@@ -65,7 +64,7 @@ import {
     IconWarning,
 } from '@posthog/icons'
 
-import { IconStamphog } from 'lib/lemon-ui/icons'
+import { IconBracketsChart, IconStamphog } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
 import {
@@ -281,7 +280,7 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
         iconColor: ['var(--color-insight-stickiness-light)'],
     },
     'insight/hog': {
-        icon: <IconBrackets />,
+        icon: <IconBracketsChart />,
         iconColor: ['var(--color-insight-sql-light)'],
     },
     team_activity: {

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -20,11 +20,9 @@ import {
     IconFlask,
     IconFolder,
     IconFolderOpen,
-    IconFunnels,
     IconGear,
     IconGraph,
     IconHome,
-    IconLifecycle,
     IconList,
     IconListCheck,
     IconListTree,
@@ -45,7 +43,6 @@ import {
     IconPlug,
     IconPullRequest,
     IconReceipt,
-    IconRetention,
     IconRewindPlay,
     IconRocket,
     IconScatter,
@@ -53,18 +50,24 @@ import {
     IconServer,
     IconSpotlight,
     IconStethoscope,
-    IconStickiness,
     IconSupport,
     IconToggle,
     IconToggleOff,
     IconToolbar,
-    IconTrends,
     IconUser,
-    IconUserPaths,
     IconWarning,
 } from '@posthog/icons'
 
-import { IconBracketsChart, IconStamphog } from 'lib/lemon-ui/icons'
+import {
+    IconBracketsChart,
+    IconInsightFunnels,
+    IconInsightLifecycle,
+    IconInsightRetention,
+    IconInsightStickiness,
+    IconInsightTrends,
+    IconInsightUserPaths,
+    IconStamphog,
+} from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
 import {
@@ -256,27 +259,27 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
         icon: <IconPeople />,
     },
     'insight/funnels': {
-        icon: <IconFunnels />,
+        icon: <IconInsightFunnels />,
         iconColor: ['var(--color-insight-funnel-light)'],
     },
     'insight/trends': {
-        icon: <IconTrends />,
+        icon: <IconInsightTrends />,
         iconColor: ['var(--color-insight-trends-light)'],
     },
     'insight/retention': {
-        icon: <IconRetention />,
+        icon: <IconInsightRetention />,
         iconColor: ['var(--color-insight-retention-light)'],
     },
     'insight/paths': {
-        icon: <IconUserPaths />,
+        icon: <IconInsightUserPaths />,
         iconColor: ['var(--color-insight-user-paths-light)', 'var(--color-user-paths-dark)'],
     },
     'insight/lifecycle': {
-        icon: <IconLifecycle />,
+        icon: <IconInsightLifecycle />,
         iconColor: ['var(--color-insight-lifecycle-light)'],
     },
     'insight/stickiness': {
-        icon: <IconStickiness />,
+        icon: <IconInsightStickiness />,
         iconColor: ['var(--color-insight-stickiness-light)'],
     },
     'insight/hog': {

--- a/frontend/src/lib/lemon-ui/icons/icons.scss
+++ b/frontend/src/lib/lemon-ui/icons/icons.scss
@@ -3,3 +3,26 @@
     width: 1em;
     vertical-align: -0.15em; // -0.15em ensures vertical centering in inline contexts
 }
+
+// Insight type icon palette (the IconInsight* glyphs in icons.tsx). Light mode uses the
+// charts' real series hexes; dark mode brightens them, since the chart hexes are too dark
+// to read at icon size on dark surfaces. The plain declarations double as the fallback for
+// browsers without light-dark().
+:root {
+    --insight-icon-blue: #1d4aff; // --data-color-1
+    --insight-icon-purple: #7f26d9; // --data-color-2 (dark variant, the more vivid purple)
+    --insight-icon-green: #42827e; // --data-color-3
+    --insight-icon-lifecycle-returning: #388600; // --color-lifecycle-returning
+    --insight-icon-lifecycle-dormant: #db3707; // --color-lifecycle-dormant
+    --insight-icon-lifecycle-resurrecting: #a56eff; // --color-lifecycle-resurrecting, bright enough for both modes
+}
+
+@supports (color: light-dark(#000, #fff)) {
+    :root {
+        --insight-icon-blue: light-dark(#1d4aff, #5c7aff);
+        --insight-icon-purple: light-dark(#7f26d9, #a56eff);
+        --insight-icon-green: light-dark(#42827e, #58b5ad);
+        --insight-icon-lifecycle-returning: light-dark(#388600, #7bbc4e);
+        --insight-icon-lifecycle-dormant: light-dark(#db3707, #f95e2f);
+    }
+}

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -429,13 +429,15 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
 
 /*
  * Insight type icon set. Drawn at the same visual weight as the left-nav icon family
- * (~1.5-1.75 unit strokes, slim bars) and colored the way each insight's chart actually renders:
- * series blue `--data-color-1` (#1d4aff) for most, the real lifecycle status colors for Lifecycle,
- * and the PostHog brand trio for SQL. Colors are fixed hex on purpose (the glyphs stay chart-true
- * rather than following `currentColor`); structural parts (SQL brackets, lifecycle axis) still
- * follow `currentColor` so they theme.
+ * (~1.5-1.75 unit strokes, slim bars). Series blue is the base color; glyphs with several
+ * series step through the first data colors (blue, purple, green), and Lifecycle keeps its
+ * chart's real status colors. Colors are fixed hex on purpose (the glyphs stay chart-true
+ * rather than following `currentColor`); structural parts (SQL brackets, lifecycle axis)
+ * still follow `currentColor` so they theme.
  */
 const INSIGHT_BLUE = '#1d4aff' // --data-color-1, the default series color
+const INSIGHT_PURPLE = '#7f26d9' // --data-color-2 (dark variant, the more vivid purple)
+const INSIGHT_GREEN = '#42827e' // --data-color-3
 
 /** SQL insights: curly brackets (matching `IconBrackets` from `@posthog/icons`) wrapping a bar chart. */
 export function IconBracketsChart(props: LemonIconProps): JSX.Element {
@@ -447,8 +449,8 @@ export function IconBracketsChart(props: LemonIconProps): JSX.Element {
                 d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75Z"
                 fill="currentColor"
             />
-            <rect x="6.75" y="13.5" width="3" height="4" rx="0.5" fill="#f9bd2b" />
-            <rect x="10.5" y="10.5" width="3" height="7" rx="0.5" fill="#f54e00" />
+            <rect x="6.75" y="13.5" width="3" height="4" rx="0.5" fill={INSIGHT_GREEN} />
+            <rect x="10.5" y="10.5" width="3" height="7" rx="0.5" fill={INSIGHT_PURPLE} />
             <rect x="14.25" y="7.5" width="3" height="10" rx="0.5" fill={INSIGHT_BLUE} />
         </LemonIconBase>
     )
@@ -459,7 +461,6 @@ export function IconInsightTrends(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase stroke={INSIGHT_BLUE} strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" {...props}>
             <path d="M3.75 17 8.75 10.75l4.25 3 7.25-7.75" />
-            <path d="M16.75 6h3.5v3.5" />
         </LemonIconBase>
     )
 }
@@ -469,21 +470,21 @@ export function IconInsightFunnels(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <rect x="3.75" y="4.25" width="16.5" height="4.25" rx="0.75" fill={INSIGHT_BLUE} />
-            <rect x="3.75" y="9.9" width="11" height="4.25" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="3.75" y="15.55" width="5.75" height="4.25" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="3.75" y="9.9" width="11" height="4.25" rx="0.75" fill={INSIGHT_PURPLE} />
+            <rect x="3.75" y="15.55" width="5.75" height="4.25" rx="0.75" fill={INSIGHT_GREEN} />
         </LemonIconBase>
     )
 }
 
-/** Retention insights: the cohort triangle, fading as periods pass. */
+/** Retention insights: the cohort triangle, the first cohort row purple over blue return rows. */
 export function IconInsightRetention(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.75" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
-            <rect x="9.3" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="14.85" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="3.75" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
+            <rect x="9.3" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
+            <rect x="14.85" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
             <rect x="3.75" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
-            <rect x="9.3" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="9.3" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
             <rect x="3.75" y="14.85" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
         </LemonIconBase>
     )
@@ -527,22 +528,22 @@ export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
     )
 }
 
-/** Calendar heatmap insights: a day-by-hour intensity matrix. */
+/** Calendar heatmap insights: a day-by-hour matrix, intensity stepping through the first data colors (blue hottest). */
 export function IconInsightCalendarHeatmap(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
-            <rect x="8.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="3.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_GREEN} />
+            <rect x="8.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
             <rect x="12.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="17.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="3.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="17.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
+            <rect x="3.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
             <rect x="8.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="12.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="17.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="12.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
+            <rect x="17.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_GREEN} />
             <rect x="3.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="8.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="12.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
-            <rect x="17.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="8.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
+            <rect x="12.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_GREEN} />
+            <rect x="17.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
         </LemonIconBase>
     )
 }
@@ -560,26 +561,26 @@ export function IconInsightNumber(props: LemonIconProps): JSX.Element {
     )
 }
 
-/** Table insights: a solid header row above label/value rows fading down the ranking. */
+/** Table insights: a solid header row above label/value rows stepping through the first data colors. */
 export function IconInsightTable(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <rect x="3.75" y="4.5" width="16.5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} />
-            <rect x="3.75" y="10" width="5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="10.25" y="10" width="10" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="3.75" y="15.5" width="5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
-            <rect x="10.25" y="15.5" width="10" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="3.75" y="10" width="5" height="3.6" rx="0.75" fill={INSIGHT_PURPLE} />
+            <rect x="10.25" y="10" width="10" height="3.6" rx="0.75" fill={INSIGHT_PURPLE} />
+            <rect x="3.75" y="15.5" width="5" height="3.6" rx="0.75" fill={INSIGHT_GREEN} />
+            <rect x="10.25" y="15.5" width="10" height="3.6" rx="0.75" fill={INSIGHT_GREEN} />
         </LemonIconBase>
     )
 }
 
-/** Pie insights: breakdown slices fading like the chart's series shades. */
+/** Pie insights: breakdown slices in the first series colors, largest slice blue. */
 export function IconInsightPie(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <path d="M12 12 L12 3.75 A8.25 8.25 0 0 1 12 20.25 Z" fill={INSIGHT_BLUE} />
-            <path d="M12 12 L12 20.25 A8.25 8.25 0 0 1 4.16 9.44 Z" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <path d="M12 12 L4.16 9.44 A8.25 8.25 0 0 1 12 3.75 Z" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <path d="M12 12 L12 20.25 A8.25 8.25 0 0 1 4.16 9.44 Z" fill={INSIGHT_PURPLE} />
+            <path d="M12 12 L4.16 9.44 A8.25 8.25 0 0 1 12 3.75 Z" fill={INSIGHT_GREEN} />
         </LemonIconBase>
     )
 }

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -427,12 +427,17 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
     )
 }
 
-/**
- * In-house draft icon for SQL insights: curly brackets wrapping an ascending bar chart.
- * Brackets match `IconBrackets` from `@posthog/icons` and follow `currentColor`; the bars are
- * solid pills (the `IconGraph` shape language) in fixed PostHog brand colors (yellow, red, blue),
- * so this icon is intentionally not monochrome.
+/*
+ * Insight type icon set. Drawn at the same visual weight as the left-nav icon family
+ * (~1.5-1.75 unit strokes, slim bars) and colored the way each insight's chart actually renders:
+ * series blue `--data-color-1` (#1d4aff) for most, the real lifecycle status colors for Lifecycle,
+ * and the PostHog brand trio for SQL. Colors are fixed hex on purpose (the glyphs stay chart-true
+ * rather than following `currentColor`); structural parts (SQL brackets, lifecycle axis) still
+ * follow `currentColor` so they theme.
  */
+const INSIGHT_BLUE = '#1d4aff' // --data-color-1, the default series color
+
+/** SQL insights: curly brackets (matching `IconBrackets` from `@posthog/icons`) wrapping a bar chart. */
 export function IconBracketsChart(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
@@ -442,9 +447,100 @@ export function IconBracketsChart(props: LemonIconProps): JSX.Element {
                 d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75Z"
                 fill="currentColor"
             />
-            <rect x="6.75" y="13.5" width="3" height="4" rx="1.5" fill="#f9bd2b" />
-            <rect x="10.5" y="10.5" width="3" height="7" rx="1.5" fill="#f54e00" />
-            <rect x="14.25" y="7.5" width="3" height="10" rx="1.5" fill="#1d4aff" />
+            <rect x="6.75" y="13.5" width="3" height="4" rx="0.5" fill="#f9bd2b" />
+            <rect x="10.5" y="10.5" width="3" height="7" rx="0.5" fill="#f54e00" />
+            <rect x="14.25" y="7.5" width="3" height="10" rx="0.5" fill={INSIGHT_BLUE} />
+        </LemonIconBase>
+    )
+}
+
+/** Trends insights: a rising series line. */
+export function IconInsightTrends(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase stroke={INSIGHT_BLUE} strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M3.75 17 8.75 10.75l4.25 3 7.25-7.75" />
+            <path d="M16.75 6h3.5v3.5" />
+        </LemonIconBase>
+    )
+}
+
+/** Funnel insights: steps narrowing as users drop off. */
+export function IconInsightFunnels(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <rect x="3.75" y="4.25" width="16.5" height="4.25" rx="0.75" fill={INSIGHT_BLUE} />
+            <rect x="3.75" y="9.9" width="11" height="4.25" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="3.75" y="15.55" width="5.75" height="4.25" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+        </LemonIconBase>
+    )
+}
+
+/** Retention insights: the cohort triangle, fading as periods pass. */
+export function IconInsightRetention(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <rect x="3.75" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
+            <rect x="9.3" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="14.85" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="3.75" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
+            <rect x="9.3" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="3.75" y="14.85" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
+        </LemonIconBase>
+    )
+}
+
+/** User paths insights: a flow branching off, some of it dropping off. */
+export function IconInsightUserPaths(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase stroke={INSIGHT_BLUE} strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M3.75 12h3.5c3.8 0 3.2-6.25 7-6.25h6" />
+            <path d="M7.25 12h5.5" opacity="0.6" />
+            <path d="M3.75 12h3.5c3.8 0 3.2 6.25 7 6.25h6" opacity="0.4" />
+        </LemonIconBase>
+    )
+}
+
+/** Stickiness insights: the "n days or more" histogram tailing off. */
+export function IconInsightStickiness(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="8.4" y="9" width="2.9" height="10.5" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="13.05" y="12.5" width="2.9" height="7" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="17.7" y="15.5" width="2.9" height="4" rx="0.7" fill={INSIGHT_BLUE} />
+        </LemonIconBase>
+    )
+}
+
+/** Lifecycle insights: new/returning/resurrecting above the axis, dormant below, in the chart's real status colors. */
+export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <path d="M3.75 12.1h16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" fill="#1d4aff" />
+            <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" fill="#388600" />
+            <rect x="12.7" y="13" width="2.6" height="4.5" rx="0.65" fill="#db3707" />
+            <rect x="17.1" y="5.75" width="2.6" height="5.5" rx="0.65" fill="#a56eff" />
+        </LemonIconBase>
+    )
+}
+
+/** Calendar heatmap insights: a day-by-hour intensity matrix. */
+export function IconInsightCalendarHeatmap(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <rect x="3.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="8.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="12.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
+            <rect x="17.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="3.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="8.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
+            <rect x="12.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="17.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="3.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
+            <rect x="8.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="12.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="17.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
         </LemonIconBase>
     )
 }

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -489,13 +489,15 @@ export function IconInsightRetention(props: LemonIconProps): JSX.Element {
     )
 }
 
-/** User paths insights: a flow branching off, some of it dropping off. */
+/** User paths insights: a sankey — a source node splitting into two flows. */
 export function IconInsightUserPaths(props: LemonIconProps): JSX.Element {
     return (
-        <LemonIconBase stroke={INSIGHT_BLUE} strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" {...props}>
-            <path d="M3.75 12h3.5c3.8 0 3.2-6.25 7-6.25h6" />
-            <path d="M7.25 12h5.5" opacity="0.6" />
-            <path d="M3.75 12h3.5c3.8 0 3.2 6.25 7 6.25h6" opacity="0.4" />
+        <LemonIconBase {...props}>
+            <path d="M6.6 8.25 C10.5 8.25 12 7.6 17.4 7.6" stroke={INSIGHT_BLUE} strokeWidth="4.5" opacity="0.4" />
+            <path d="M6.6 15 C10.5 15 12.5 16.4 17.4 16.4" stroke={INSIGHT_BLUE} strokeWidth="3.25" opacity="0.25" />
+            <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="17.35" y="4.5" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="17.35" y="13.25" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_BLUE} />
         </LemonIconBase>
     )
 }

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -427,6 +427,20 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
     )
 }
 
+/** In-house draft icon for SQL insights: curly brackets wrapping a bar chart. Brackets match `IconBrackets` from `@posthog/icons`. */
+export function IconBracketsChart(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75ZM8.5 13.5a1 1 0 0 1 2 0v2.75a1 1 0 0 1-2 0V13.5ZM11 7.75a1 1 0 0 1 2 0v8.5a1 1 0 0 1-2 0v-8.5ZM13.5 10.5a1 1 0 0 1 2 0v5.75a1 1 0 0 1-2 0V10.5Z"
+                fill="currentColor"
+            />
+        </LemonIconBase>
+    )
+}
+
 /** Material Design 123 icon. */
 export function Icon123(props: LemonIconProps): JSX.Element {
     return (

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -435,8 +435,8 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
  * the charts' real hexes in light mode, brightened equivalents in dark mode, where the chart
  * hexes are too dark to read at icon size. The vars must be applied via `style` (SVG
  * presentation attributes can't resolve `var()`). The SQL brackets follow `currentColor`
- * like a regular icon; the lifecycle axis uses the border color so it stays a quiet
- * divider instead of competing with the bars.
+ * like a regular icon; the lifecycle axis follows it at half opacity, visible in both
+ * themes without competing with the bars.
  */
 const INSIGHT_BLUE = 'var(--insight-icon-blue)'
 const INSIGHT_PURPLE = 'var(--insight-icon-purple)'
@@ -537,9 +537,10 @@ export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
         <LemonIconBase {...props}>
             <path
                 d="M3.75 12.1h16.5"
+                stroke="currentColor"
+                strokeOpacity="0.5"
                 strokeWidth="1.5"
                 strokeLinecap="round"
-                style={{ stroke: 'var(--color-border-primary)' }}
             />
             <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" style={{ fill: INSIGHT_BLUE }} />
             <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" style={{ fill: LIFECYCLE_RETURNING }} />

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -434,9 +434,8 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
  * chart's real status colors. The palette lives in `--insight-icon-*` variables (icons.scss):
  * the charts' real hexes in light mode, brightened equivalents in dark mode, where the chart
  * hexes are too dark to read at icon size. The vars must be applied via `style` (SVG
- * presentation attributes can't resolve `var()`). The SQL brackets follow `currentColor`
- * like a regular icon; the lifecycle axis follows it at half opacity, visible in both
- * themes without competing with the bars.
+ * presentation attributes can't resolve `var()`). Structural parts (SQL brackets,
+ * lifecycle axis) follow `currentColor` like regular icons.
  */
 const INSIGHT_BLUE = 'var(--insight-icon-blue)'
 const INSIGHT_PURPLE = 'var(--insight-icon-purple)'
@@ -535,13 +534,7 @@ export function IconInsightStickiness(props: LemonIconProps): JSX.Element {
 export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <path
-                d="M3.75 12.1h16.5"
-                stroke="currentColor"
-                strokeOpacity="0.5"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-            />
+            <path d="M3.75 12.1h16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
             <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" style={{ fill: INSIGHT_BLUE }} />
             <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" style={{ fill: LIFECYCLE_RETURNING }} />
             <rect x="12.7" y="13" width="2.6" height="4.5" rx="0.65" style={{ fill: LIFECYCLE_DORMANT }} />

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -429,8 +429,9 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
 
 /**
  * In-house draft icon for SQL insights: curly brackets wrapping an ascending bar chart.
- * Brackets match `IconBrackets` from `@posthog/icons` and follow `currentColor`; the bars
- * are fixed PostHog brand colors (yellow, red, blue), so this icon is intentionally not monochrome.
+ * Brackets match `IconBrackets` from `@posthog/icons` and follow `currentColor`; the bars are
+ * solid pills (the `IconGraph` shape language) in fixed PostHog brand colors (yellow, red, blue),
+ * so this icon is intentionally not monochrome.
  */
 export function IconBracketsChart(props: LemonIconProps): JSX.Element {
     return (
@@ -441,39 +442,9 @@ export function IconBracketsChart(props: LemonIconProps): JSX.Element {
                 d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75Z"
                 fill="currentColor"
             />
-            <rect
-                x="7"
-                y="14"
-                width="2.8"
-                height="3.5"
-                rx="0.75"
-                fill="#f9bd2b"
-                fillOpacity="0.25"
-                stroke="#f9bd2b"
-                strokeWidth="1.5"
-            />
-            <rect
-                x="10.5"
-                y="11"
-                width="2.8"
-                height="6.5"
-                rx="0.75"
-                fill="#f54e00"
-                fillOpacity="0.25"
-                stroke="#f54e00"
-                strokeWidth="1.5"
-            />
-            <rect
-                x="14"
-                y="7.75"
-                width="2.8"
-                height="9.75"
-                rx="0.75"
-                fill="#1d4aff"
-                fillOpacity="0.25"
-                stroke="#1d4aff"
-                strokeWidth="1.5"
-            />
+            <rect x="6.75" y="13.5" width="3" height="4" rx="1.5" fill="#f9bd2b" />
+            <rect x="10.5" y="10.5" width="3" height="7" rx="1.5" fill="#f54e00" />
+            <rect x="14.25" y="7.5" width="3" height="10" rx="1.5" fill="#1d4aff" />
         </LemonIconBase>
     )
 }

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -431,13 +431,18 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
  * Insight type icon set. Drawn at the same visual weight as the left-nav icon family
  * (~1.5-1.75 unit strokes, slim bars). Series blue is the base color; glyphs with several
  * series step through the first data colors (blue, purple, green), and Lifecycle keeps its
- * chart's real status colors. Colors are fixed hex on purpose (the glyphs stay chart-true
- * rather than following `currentColor`); structural parts (SQL brackets, lifecycle axis)
- * still follow `currentColor` so they theme.
+ * chart's real status colors. The palette lives in `--insight-icon-*` variables (icons.scss):
+ * the charts' real hexes in light mode, brightened equivalents in dark mode, where the chart
+ * hexes are too dark to read at icon size. The vars must be applied via `style` (SVG
+ * presentation attributes can't resolve `var()`); structural parts (SQL brackets, lifecycle
+ * axis) follow `currentColor` so they theme with the surrounding text.
  */
-const INSIGHT_BLUE = '#1d4aff' // --data-color-1, the default series color
-const INSIGHT_PURPLE = '#7f26d9' // --data-color-2 (dark variant, the more vivid purple)
-const INSIGHT_GREEN = '#42827e' // --data-color-3
+const INSIGHT_BLUE = 'var(--insight-icon-blue)'
+const INSIGHT_PURPLE = 'var(--insight-icon-purple)'
+const INSIGHT_GREEN = 'var(--insight-icon-green)'
+const LIFECYCLE_RETURNING = 'var(--insight-icon-lifecycle-returning)'
+const LIFECYCLE_DORMANT = 'var(--insight-icon-lifecycle-dormant)'
+const LIFECYCLE_RESURRECTING = 'var(--insight-icon-lifecycle-resurrecting)'
 
 /** SQL insights: curly brackets (matching `IconBrackets` from `@posthog/icons`) wrapping a bar chart. */
 export function IconBracketsChart(props: LemonIconProps): JSX.Element {
@@ -449,9 +454,9 @@ export function IconBracketsChart(props: LemonIconProps): JSX.Element {
                 d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75Z"
                 fill="currentColor"
             />
-            <rect x="6.75" y="13.5" width="3" height="4" rx="0.5" fill={INSIGHT_GREEN} />
-            <rect x="10.5" y="10.5" width="3" height="7" rx="0.5" fill={INSIGHT_PURPLE} />
-            <rect x="14.25" y="7.5" width="3" height="10" rx="0.5" fill={INSIGHT_BLUE} />
+            <rect x="6.75" y="13.5" width="3" height="4" rx="0.5" style={{ fill: INSIGHT_GREEN }} />
+            <rect x="10.5" y="10.5" width="3" height="7" rx="0.5" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="14.25" y="7.5" width="3" height="10" rx="0.5" style={{ fill: INSIGHT_BLUE }} />
         </LemonIconBase>
     )
 }
@@ -459,8 +464,8 @@ export function IconBracketsChart(props: LemonIconProps): JSX.Element {
 /** Trends insights: a rising series line. */
 export function IconInsightTrends(props: LemonIconProps): JSX.Element {
     return (
-        <LemonIconBase stroke={INSIGHT_BLUE} strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" {...props}>
-            <path d="M3.75 17 8.75 10.75l4.25 3 7.25-7.75" />
+        <LemonIconBase strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M3.75 17 8.75 10.75l4.25 3 7.25-7.75" style={{ stroke: INSIGHT_BLUE }} />
         </LemonIconBase>
     )
 }
@@ -469,9 +474,9 @@ export function IconInsightTrends(props: LemonIconProps): JSX.Element {
 export function IconInsightFunnels(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.75" y="4.25" width="16.5" height="4.25" rx="0.75" fill={INSIGHT_BLUE} />
-            <rect x="3.75" y="9.9" width="11" height="4.25" rx="0.75" fill={INSIGHT_PURPLE} />
-            <rect x="3.75" y="15.55" width="5.75" height="4.25" rx="0.75" fill={INSIGHT_GREEN} />
+            <rect x="3.75" y="4.25" width="16.5" height="4.25" rx="0.75" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="3.75" y="9.9" width="11" height="4.25" rx="0.75" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="3.75" y="15.55" width="5.75" height="4.25" rx="0.75" style={{ fill: INSIGHT_GREEN }} />
         </LemonIconBase>
     )
 }
@@ -480,12 +485,12 @@ export function IconInsightFunnels(props: LemonIconProps): JSX.Element {
 export function IconInsightRetention(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.75" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
-            <rect x="9.3" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
-            <rect x="14.85" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
-            <rect x="3.75" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
-            <rect x="9.3" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
-            <rect x="3.75" y="14.85" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
+            <rect x="3.75" y="3.75" width="4.4" height="4.4" rx="1" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="9.3" y="3.75" width="4.4" height="4.4" rx="1" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="14.85" y="3.75" width="4.4" height="4.4" rx="1" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="3.75" y="9.3" width="4.4" height="4.4" rx="1" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="9.3" y="9.3" width="4.4" height="4.4" rx="1" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="3.75" y="14.85" width="4.4" height="4.4" rx="1" style={{ fill: INSIGHT_BLUE }} />
         </LemonIconBase>
     )
 }
@@ -494,11 +499,21 @@ export function IconInsightRetention(props: LemonIconProps): JSX.Element {
 export function IconInsightUserPaths(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <path d="M6.6 8.25 C10.5 8.25 12 7.6 17.4 7.6" stroke={INSIGHT_BLUE} strokeWidth="4.5" opacity="0.4" />
-            <path d="M6.6 15 C10.5 15 12.5 16.4 17.4 16.4" stroke={INSIGHT_BLUE} strokeWidth="3.25" opacity="0.25" />
-            <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="17.35" y="4.5" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="17.35" y="13.25" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_BLUE} />
+            <path
+                d="M6.6 8.25 C10.5 8.25 12 7.6 17.4 7.6"
+                strokeWidth="4.5"
+                opacity="0.4"
+                style={{ stroke: INSIGHT_BLUE }}
+            />
+            <path
+                d="M6.6 15 C10.5 15 12.5 16.4 17.4 16.4"
+                strokeWidth="3.25"
+                opacity="0.25"
+                style={{ stroke: INSIGHT_BLUE }}
+            />
+            <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="17.35" y="4.5" width="2.9" height="6.25" rx="0.7" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="17.35" y="13.25" width="2.9" height="6.25" rx="0.7" style={{ fill: INSIGHT_BLUE }} />
         </LemonIconBase>
     )
 }
@@ -507,10 +522,10 @@ export function IconInsightUserPaths(props: LemonIconProps): JSX.Element {
 export function IconInsightStickiness(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="8.4" y="9" width="2.9" height="10.5" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="13.05" y="12.5" width="2.9" height="7" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="17.7" y="15.5" width="2.9" height="4" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="8.4" y="9" width="2.9" height="10.5" rx="0.7" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="13.05" y="12.5" width="2.9" height="7" rx="0.7" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="17.7" y="15.5" width="2.9" height="4" rx="0.7" style={{ fill: INSIGHT_BLUE }} />
         </LemonIconBase>
     )
 }
@@ -520,10 +535,10 @@ export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <path d="M3.75 12.1h16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" fill="#1d4aff" />
-            <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" fill="#388600" />
-            <rect x="12.7" y="13" width="2.6" height="4.5" rx="0.65" fill="#db3707" />
-            <rect x="17.1" y="5.75" width="2.6" height="5.5" rx="0.65" fill="#a56eff" />
+            <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" style={{ fill: LIFECYCLE_RETURNING }} />
+            <rect x="12.7" y="13" width="2.6" height="4.5" rx="0.65" style={{ fill: LIFECYCLE_DORMANT }} />
+            <rect x="17.1" y="5.75" width="2.6" height="5.5" rx="0.65" style={{ fill: LIFECYCLE_RESURRECTING }} />
         </LemonIconBase>
     )
 }
@@ -532,18 +547,18 @@ export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
 export function IconInsightCalendarHeatmap(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_GREEN} />
-            <rect x="8.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
-            <rect x="12.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="17.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
-            <rect x="3.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
-            <rect x="8.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="12.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
-            <rect x="17.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_GREEN} />
-            <rect x="3.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="8.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
-            <rect x="12.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_GREEN} />
-            <rect x="17.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
+            <rect x="3.55" y="5.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_GREEN }} />
+            <rect x="8.05" y="5.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="12.55" y="5.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="17.05" y="5.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="3.55" y="9.85" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="8.05" y="9.85" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="12.55" y="9.85" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="17.05" y="9.85" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_GREEN }} />
+            <rect x="3.55" y="14.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="8.05" y="14.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="12.55" y="14.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_GREEN }} />
+            <rect x="17.05" y="14.35" width="3.4" height="3.4" rx="0.9" style={{ fill: INSIGHT_PURPLE }} />
         </LemonIconBase>
     )
 }
@@ -554,8 +569,8 @@ export function IconInsightNumber(props: LemonIconProps): JSX.Element {
         <LemonIconBase {...props}>
             <path
                 d="M7,15H5.5v-4.5H4V9h3V15z M13.5,13.5h-3v-1h2c0.55,0,1-0.45,1-1V10c0-0.55-0.45-1-1-1H9v1.5h3v1h-2c-0.55,0-1,0.45-1,1V15 h4.5V13.5z M19.5,14v-4c0-0.55-0.45-1-1-1H15v1.5h3v1h-2v1h2v1h-3V15h3.5C19.05,15,19.5,14.55,19.5,14z"
-                fill={INSIGHT_BLUE}
                 transform="translate(12 12) scale(1.3) translate(-12 -12)"
+                style={{ fill: INSIGHT_BLUE }}
             />
         </LemonIconBase>
     )
@@ -565,11 +580,11 @@ export function IconInsightNumber(props: LemonIconProps): JSX.Element {
 export function IconInsightTable(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.75" y="4.5" width="16.5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} />
-            <rect x="3.75" y="10" width="5" height="3.6" rx="0.75" fill={INSIGHT_PURPLE} />
-            <rect x="10.25" y="10" width="10" height="3.6" rx="0.75" fill={INSIGHT_PURPLE} />
-            <rect x="3.75" y="15.5" width="5" height="3.6" rx="0.75" fill={INSIGHT_GREEN} />
-            <rect x="10.25" y="15.5" width="10" height="3.6" rx="0.75" fill={INSIGHT_GREEN} />
+            <rect x="3.75" y="4.5" width="16.5" height="3.6" rx="0.75" style={{ fill: INSIGHT_BLUE }} />
+            <rect x="3.75" y="10" width="5" height="3.6" rx="0.75" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="10.25" y="10" width="10" height="3.6" rx="0.75" style={{ fill: INSIGHT_PURPLE }} />
+            <rect x="3.75" y="15.5" width="5" height="3.6" rx="0.75" style={{ fill: INSIGHT_GREEN }} />
+            <rect x="10.25" y="15.5" width="10" height="3.6" rx="0.75" style={{ fill: INSIGHT_GREEN }} />
         </LemonIconBase>
     )
 }
@@ -578,9 +593,9 @@ export function IconInsightTable(props: LemonIconProps): JSX.Element {
 export function IconInsightPie(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <path d="M12 12 L12 3.75 A8.25 8.25 0 0 1 12 20.25 Z" fill={INSIGHT_BLUE} />
-            <path d="M12 12 L12 20.25 A8.25 8.25 0 0 1 4.16 9.44 Z" fill={INSIGHT_PURPLE} />
-            <path d="M12 12 L4.16 9.44 A8.25 8.25 0 0 1 12 3.75 Z" fill={INSIGHT_GREEN} />
+            <path d="M12 12 L12 3.75 A8.25 8.25 0 0 1 12 20.25 Z" style={{ fill: INSIGHT_BLUE }} />
+            <path d="M12 12 L12 20.25 A8.25 8.25 0 0 1 4.16 9.44 Z" style={{ fill: INSIGHT_PURPLE }} />
+            <path d="M12 12 L4.16 9.44 A8.25 8.25 0 0 1 12 3.75 Z" style={{ fill: INSIGHT_GREEN }} />
         </LemonIconBase>
     )
 }
@@ -588,10 +603,10 @@ export function IconInsightPie(props: LemonIconProps): JSX.Element {
 /** World map insights: a globe stroked in series blue at the nav-icon line weight. */
 export function IconInsightWorldMap(props: LemonIconProps): JSX.Element {
     return (
-        <LemonIconBase stroke={INSIGHT_BLUE} strokeWidth="1.5" strokeLinecap="round" {...props}>
-            <circle cx="12" cy="12" r="8.25" strokeWidth="1.75" />
-            <ellipse cx="12" cy="12" rx="3.9" ry="8.25" />
-            <path d="M3.75 12h16.5" />
+        <LemonIconBase strokeWidth="1.5" strokeLinecap="round" {...props}>
+            <circle cx="12" cy="12" r="8.25" strokeWidth="1.75" style={{ stroke: INSIGHT_BLUE }} />
+            <ellipse cx="12" cy="12" rx="3.9" ry="8.25" style={{ stroke: INSIGHT_BLUE }} />
+            <path d="M3.75 12h16.5" style={{ stroke: INSIGHT_BLUE }} />
         </LemonIconBase>
     )
 }

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -547,6 +547,54 @@ export function IconInsightCalendarHeatmap(props: LemonIconProps): JSX.Element {
     )
 }
 
+/** Number (bold number) insights: the 123 glyph in series blue. */
+export function IconInsightNumber(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <path
+                d="M7,15H5.5v-4.5H4V9h3V15z M13.5,13.5h-3v-1h2c0.55,0,1-0.45,1-1V10c0-0.55-0.45-1-1-1H9v1.5h3v1h-2c-0.55,0-1,0.45-1,1V15 h4.5V13.5z M19.5,14v-4c0-0.55-0.45-1-1-1H15v1.5h3v1h-2v1h2v1h-3V15h3.5C19.05,15,19.5,14.55,19.5,14z"
+                fill={INSIGHT_BLUE}
+                transform="translate(12 12) scale(1.3) translate(-12 -12)"
+            />
+        </LemonIconBase>
+    )
+}
+
+/** Table insights: a solid header row above label/value rows fading down the ranking. */
+export function IconInsightTable(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <rect x="3.75" y="4.5" width="16.5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} />
+            <rect x="3.75" y="10" width="5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="10.25" y="10" width="10" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="3.75" y="15.5" width="5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="10.25" y="15.5" width="10" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+        </LemonIconBase>
+    )
+}
+
+/** Pie insights: breakdown slices fading like the chart's series shades. */
+export function IconInsightPie(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase {...props}>
+            <path d="M12 12 L12 3.75 A8.25 8.25 0 0 1 12 20.25 Z" fill={INSIGHT_BLUE} />
+            <path d="M12 12 L12 20.25 A8.25 8.25 0 0 1 4.16 9.44 Z" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <path d="M12 12 L4.16 9.44 A8.25 8.25 0 0 1 12 3.75 Z" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+        </LemonIconBase>
+    )
+}
+
+/** World map insights: a globe stroked in series blue at the nav-icon line weight. */
+export function IconInsightWorldMap(props: LemonIconProps): JSX.Element {
+    return (
+        <LemonIconBase stroke={INSIGHT_BLUE} strokeWidth="1.5" strokeLinecap="round" {...props}>
+            <circle cx="12" cy="12" r="8.25" strokeWidth="1.75" />
+            <ellipse cx="12" cy="12" rx="3.9" ry="8.25" />
+            <path d="M3.75 12h16.5" />
+        </LemonIconBase>
+    )
+}
+
 /** Material Design 123 icon. */
 export function Icon123(props: LemonIconProps): JSX.Element {
     return (

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -434,8 +434,9 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
  * chart's real status colors. The palette lives in `--insight-icon-*` variables (icons.scss):
  * the charts' real hexes in light mode, brightened equivalents in dark mode, where the chart
  * hexes are too dark to read at icon size. The vars must be applied via `style` (SVG
- * presentation attributes can't resolve `var()`); structural parts (SQL brackets, lifecycle
- * axis) follow `currentColor` so they theme with the surrounding text.
+ * presentation attributes can't resolve `var()`). The SQL brackets follow `currentColor`
+ * like a regular icon; the lifecycle axis uses the border color so it stays a quiet
+ * divider instead of competing with the bars.
  */
 const INSIGHT_BLUE = 'var(--insight-icon-blue)'
 const INSIGHT_PURPLE = 'var(--insight-icon-purple)'
@@ -534,7 +535,12 @@ export function IconInsightStickiness(props: LemonIconProps): JSX.Element {
 export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <path d="M3.75 12.1h16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <path
+                d="M3.75 12.1h16.5"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                style={{ stroke: 'var(--color-border-primary)' }}
+            />
             <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" style={{ fill: INSIGHT_BLUE }} />
             <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" style={{ fill: LIFECYCLE_RETURNING }} />
             <rect x="12.7" y="13" width="2.6" height="4.5" rx="0.65" style={{ fill: LIFECYCLE_DORMANT }} />

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -427,15 +427,52 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
     )
 }
 
-/** In-house draft icon for SQL insights: curly brackets wrapping a bar chart. Brackets match `IconBrackets` from `@posthog/icons`. */
+/**
+ * In-house draft icon for SQL insights: curly brackets wrapping an ascending bar chart.
+ * Brackets match `IconBrackets` from `@posthog/icons` and follow `currentColor`; the bars
+ * are fixed PostHog brand colors (yellow, red, blue), so this icon is intentionally not monochrome.
+ */
 export function IconBracketsChart(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
-                d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75ZM8.5 13.5a1 1 0 0 1 2 0v2.75a1 1 0 0 1-2 0V13.5ZM11 7.75a1 1 0 0 1 2 0v8.5a1 1 0 0 1-2 0v-8.5ZM13.5 10.5a1 1 0 0 1 2 0v5.75a1 1 0 0 1-2 0V10.5Z"
+                d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75Z"
                 fill="currentColor"
+            />
+            <rect
+                x="7"
+                y="14"
+                width="2.8"
+                height="3.5"
+                rx="0.75"
+                fill="#f9bd2b"
+                fillOpacity="0.25"
+                stroke="#f9bd2b"
+                strokeWidth="1.5"
+            />
+            <rect
+                x="10.5"
+                y="11"
+                width="2.8"
+                height="6.5"
+                rx="0.75"
+                fill="#f54e00"
+                fillOpacity="0.25"
+                stroke="#f54e00"
+                strokeWidth="1.5"
+            />
+            <rect
+                x="14"
+                y="7.75"
+                width="2.8"
+                height="9.75"
+                rx="0.75"
+                fill="#1d4aff"
+                fillOpacity="0.25"
+                stroke="#1d4aff"
+                strokeWidth="1.5"
             />
         </LemonIconBase>
     )

--- a/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.tsx
@@ -2,8 +2,7 @@ import { useActions, useValues } from 'kea'
 import { BindLogic } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconFunnels, IconRetention, IconTrends } from '@posthog/icons'
-
+import { IconInsightFunnels, IconInsightRetention, IconInsightTrends } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
@@ -19,9 +18,9 @@ import { addInsightToDashboardLogic } from '../addInsightToDashboardModalLogic'
 import { dashboardLogic } from '../dashboardLogic'
 
 const QUICK_CREATE_TYPES = [
-    { type: InsightType.TRENDS, icon: IconTrends, label: 'Trend' },
-    { type: InsightType.FUNNELS, icon: IconFunnels, label: 'Funnel' },
-    { type: InsightType.RETENTION, icon: IconRetention, label: 'Retention' },
+    { type: InsightType.TRENDS, icon: IconInsightTrends, label: 'Trend' },
+    { type: InsightType.FUNNELS, icon: IconInsightFunnels, label: 'Funnel' },
+    { type: InsightType.RETENTION, icon: IconInsightRetention, label: 'Retention' },
 ]
 
 export function AddInsightToDashboardModal(): JSX.Element {

--- a/frontend/src/scenes/notebooks/nodeIcons.tsx
+++ b/frontend/src/scenes/notebooks/nodeIcons.tsx
@@ -1,6 +1,5 @@
 import {
     IconAI,
-    IconBrackets,
     IconChat,
     IconCheckCircle,
     IconCode,
@@ -22,6 +21,8 @@ import {
     IconWarning,
 } from '@posthog/icons'
 
+import { IconBracketsChart } from 'lib/lemon-ui/icons'
+
 import { NotebookNodeType } from './types'
 
 // Single source of truth for icons that represent a notebook node type.
@@ -29,9 +30,9 @@ import { NotebookNodeType } from './types'
 // back to the generic notebook icon at the consumer site.
 export const NODE_ICONS: Partial<Record<NotebookNodeType, JSX.Element>> = {
     [NotebookNodeType.Query]: <IconGraph />,
-    [NotebookNodeType.HogQLSQL]: <IconBrackets />,
-    [NotebookNodeType.DuckSQL]: <IconBrackets />,
-    [NotebookNodeType.SQLV2]: <IconBrackets />,
+    [NotebookNodeType.HogQLSQL]: <IconBracketsChart />,
+    [NotebookNodeType.DuckSQL]: <IconBracketsChart />,
+    [NotebookNodeType.SQLV2]: <IconBracketsChart />,
     [NotebookNodeType.Python]: <IconPython />,
     [NotebookNodeType.PythonV2]: <IconPython />,
     [NotebookNodeType.Latex]: <IconSquareRoot />,

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
@@ -1,12 +1,12 @@
 import { useValues } from 'kea'
 
-import { IconGlobe, IconPieChart, IconPlusSmall, IconSparkles } from '@posthog/icons'
+import { IconPlusSmall, IconSparkles } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { Icon123, IconTableChart } from 'lib/lemon-ui/icons'
+import { IconInsightNumber, IconInsightPie, IconInsightTable, IconInsightWorldMap } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
@@ -131,7 +131,7 @@ const SUB_INSIGHT_CARDS: Record<'worldMap' | 'table' | 'number' | 'pie', NewInsi
         key: 'preset-world-map',
         name: 'World map',
         description: 'Unique users per country.',
-        icon: IconGlobe,
+        icon: IconInsightWorldMap,
         sketch: WorldMapSketch,
         to: TRENDS_PRESET_URLS.worldMap,
         dataAttr: 'new-insight-menu-preset-world-map',
@@ -141,7 +141,7 @@ const SUB_INSIGHT_CARDS: Record<'worldMap' | 'table' | 'number' | 'pie', NewInsi
         key: 'preset-table',
         name: 'Table',
         description: 'Totals ranked in a sortable table.',
-        icon: IconTableChart,
+        icon: IconInsightTable,
         sketch: TableSketch,
         to: TRENDS_PRESET_URLS.table,
         dataAttr: 'new-insight-menu-preset-table',
@@ -151,7 +151,7 @@ const SUB_INSIGHT_CARDS: Record<'worldMap' | 'table' | 'number' | 'pie', NewInsi
         key: 'preset-number',
         name: 'Number',
         description: 'One big number for a single metric.',
-        icon: Icon123,
+        icon: IconInsightNumber,
         sketch: NumberSketch,
         to: TRENDS_PRESET_URLS.number,
         dataAttr: 'new-insight-menu-preset-number',
@@ -161,7 +161,7 @@ const SUB_INSIGHT_CARDS: Record<'worldMap' | 'table' | 'number' | 'pie', NewInsi
         key: 'preset-pie',
         name: 'Pie chart',
         description: 'Share of a total, split by a breakdown.',
-        icon: IconPieChart,
+        icon: IconInsightPie,
         sketch: PieSketch,
         to: TRENDS_PRESET_URLS.pie,
         dataAttr: 'new-insight-menu-preset-pie',

--- a/frontend/src/scenes/saved-insights/insightTypesMetadata.tsx
+++ b/frontend/src/scenes/saved-insights/insightTypesMetadata.tsx
@@ -39,46 +39,64 @@ export interface InsightTypeMetadata {
     tooltipDocLink?: string
 }
 
+/**
+ * Wraps an insight type glyph so it always renders in that insight's color (adapting to dark mode
+ * via `light-dark()`), regardless of the text color it would otherwise inherit.
+ */
+function withIconColor(
+    Icon: React.ComponentType<any>,
+    lightVar: string,
+    darkVar: string = lightVar
+): React.ComponentType<any> {
+    return function ColoredInsightIcon({ style, ...props }: { style?: React.CSSProperties }): JSX.Element {
+        return <Icon {...props} style={{ color: `light-dark(var(${lightVar}), var(${darkVar}))`, ...style }} />
+    }
+}
+
 export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
     [NodeKind.CalendarHeatmapQuery]: {
         name: 'Calendar heatmap (BETA)',
         description: 'Visualize total or unique users broken down by day and hour.',
-        icon: IconRetentionHeatmap,
+        icon: withIconColor(
+            IconRetentionHeatmap,
+            '--color-insight-calendar-heatmap-light',
+            '--color-insight-calendar-heatmap-dark'
+        ),
         inMenu: true,
         // tooltipDescription TODO: Add tooltip description
     },
     [NodeKind.TrendsQuery]: {
         name: 'Trends',
         description: 'Visualize and break down how actions or events vary over time.',
-        icon: IconTrends,
+        icon: withIconColor(IconTrends, '--color-insight-trends-light'),
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/trends/overview',
     },
     [NodeKind.FunnelsQuery]: {
         name: 'Funnel',
         description: 'Discover how many users complete or drop out of a sequence of actions.',
-        icon: IconFunnels,
+        icon: withIconColor(IconFunnels, '--color-insight-funnel-light'),
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/funnels',
     },
     [NodeKind.RetentionQuery]: {
         name: 'Retention',
         description: 'See how many users return on subsequent days after an initial action.',
-        icon: IconRetention,
+        icon: withIconColor(IconRetention, '--color-insight-retention-light'),
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/retention',
     },
     [NodeKind.PathsQuery]: {
         name: 'Paths',
         description: 'Trace the journeys users take within your product and where they drop off.',
-        icon: IconUserPaths,
+        icon: withIconColor(IconUserPaths, '--color-insight-user-paths-light', '--color-user-paths-dark'),
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/paths',
     },
     [NodeKind.StickinessQuery]: {
         name: 'Stickiness',
         description: 'See what keeps users coming back by viewing the interval between repeated actions.',
-        icon: IconStickiness,
+        icon: withIconColor(IconStickiness, '--color-insight-stickiness-light'),
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/stickiness',
     },
@@ -86,7 +104,7 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         name: 'Lifecycle',
         description: 'Understand growth by breaking down new, resurrected, returning and dormant users.',
         tooltipDescription: 'Understand growth by breaking down new, resurrected, returning and dormant users.',
-        icon: IconLifecycle,
+        icon: withIconColor(IconLifecycle, '--color-insight-lifecycle-light'),
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/lifecycle',
     },

--- a/frontend/src/scenes/saved-insights/insightTypesMetadata.tsx
+++ b/frontend/src/scenes/saved-insights/insightTypesMetadata.tsx
@@ -4,27 +4,32 @@ import {
     IconCorrelationAnalysis,
     IconCursor,
     IconFlask,
-    IconFunnels,
     IconGraph,
     IconHogQL,
-    IconLifecycle,
     IconLineGraph,
     IconLive,
     IconLlmAnalytics,
     IconPerson,
     IconPieChart,
     IconPiggyBank,
-    IconRetention,
-    IconRetentionHeatmap,
-    IconStickiness,
     IconTrends,
-    IconUserPaths,
     IconVideoCamera,
     IconWarning,
 } from '@posthog/icons'
 import { LemonSelectOptions } from '@posthog/lemon-ui'
 
-import { IconAction, IconBracketsChart, IconTableChart } from 'lib/lemon-ui/icons'
+import {
+    IconAction,
+    IconBracketsChart,
+    IconInsightCalendarHeatmap,
+    IconInsightFunnels,
+    IconInsightLifecycle,
+    IconInsightRetention,
+    IconInsightStickiness,
+    IconInsightTrends,
+    IconInsightUserPaths,
+    IconTableChart,
+} from 'lib/lemon-ui/icons'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { InsightType } from '~/types'
@@ -39,64 +44,46 @@ export interface InsightTypeMetadata {
     tooltipDocLink?: string
 }
 
-/**
- * Wraps an insight type glyph so it always renders in that insight's color (adapting to dark mode
- * via `light-dark()`), regardless of the text color it would otherwise inherit.
- */
-function withIconColor(
-    Icon: React.ComponentType<any>,
-    lightVar: string,
-    darkVar: string = lightVar
-): React.ComponentType<any> {
-    return function ColoredInsightIcon({ style, ...props }: { style?: React.CSSProperties }): JSX.Element {
-        return <Icon {...props} style={{ color: `light-dark(var(${lightVar}), var(${darkVar}))`, ...style }} />
-    }
-}
-
 export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
     [NodeKind.CalendarHeatmapQuery]: {
         name: 'Calendar heatmap (BETA)',
         description: 'Visualize total or unique users broken down by day and hour.',
-        icon: withIconColor(
-            IconRetentionHeatmap,
-            '--color-insight-calendar-heatmap-light',
-            '--color-insight-calendar-heatmap-dark'
-        ),
+        icon: IconInsightCalendarHeatmap,
         inMenu: true,
         // tooltipDescription TODO: Add tooltip description
     },
     [NodeKind.TrendsQuery]: {
         name: 'Trends',
         description: 'Visualize and break down how actions or events vary over time.',
-        icon: withIconColor(IconTrends, '--color-insight-trends-light'),
+        icon: IconInsightTrends,
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/trends/overview',
     },
     [NodeKind.FunnelsQuery]: {
         name: 'Funnel',
         description: 'Discover how many users complete or drop out of a sequence of actions.',
-        icon: withIconColor(IconFunnels, '--color-insight-funnel-light'),
+        icon: IconInsightFunnels,
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/funnels',
     },
     [NodeKind.RetentionQuery]: {
         name: 'Retention',
         description: 'See how many users return on subsequent days after an initial action.',
-        icon: withIconColor(IconRetention, '--color-insight-retention-light'),
+        icon: IconInsightRetention,
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/retention',
     },
     [NodeKind.PathsQuery]: {
         name: 'Paths',
         description: 'Trace the journeys users take within your product and where they drop off.',
-        icon: withIconColor(IconUserPaths, '--color-insight-user-paths-light', '--color-user-paths-dark'),
+        icon: IconInsightUserPaths,
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/paths',
     },
     [NodeKind.StickinessQuery]: {
         name: 'Stickiness',
         description: 'See what keeps users coming back by viewing the interval between repeated actions.',
-        icon: withIconColor(IconStickiness, '--color-insight-stickiness-light'),
+        icon: IconInsightStickiness,
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/stickiness',
     },
@@ -104,7 +91,7 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         name: 'Lifecycle',
         description: 'Understand growth by breaking down new, resurrected, returning and dormant users.',
         tooltipDescription: 'Understand growth by breaking down new, resurrected, returning and dormant users.',
-        icon: withIconColor(IconLifecycle, '--color-insight-lifecycle-light'),
+        icon: IconInsightLifecycle,
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/product-analytics/lifecycle',
     },

--- a/frontend/src/scenes/saved-insights/insightTypesMetadata.tsx
+++ b/frontend/src/scenes/saved-insights/insightTypesMetadata.tsx
@@ -24,7 +24,7 @@ import {
 } from '@posthog/icons'
 import { LemonSelectOptions } from '@posthog/lemon-ui'
 
-import { IconAction, IconTableChart } from 'lib/lemon-ui/icons'
+import { IconAction, IconBracketsChart, IconTableChart } from 'lib/lemon-ui/icons'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { InsightType } from '~/types'
@@ -207,7 +207,7 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
     [NodeKind.DataVisualizationNode]: {
         name: 'SQL',
         description: 'Slice and dice your data in a table or chart.',
-        icon: IconBrackets,
+        icon: IconBracketsChart,
         inMenu: false,
     },
     [NodeKind.SavedInsightNode]: {
@@ -231,25 +231,25 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
     [NodeKind.HogQLQuery]: {
         name: 'SQL',
         description: 'Direct SQL query.',
-        icon: IconBrackets,
+        icon: IconBracketsChart,
         inMenu: true,
     },
     [NodeKind.HogQLMetadata]: {
         name: 'SQL Metadata',
         description: 'Metadata for a SQL query.',
-        icon: IconBrackets,
+        icon: IconBracketsChart,
         inMenu: true,
     },
     [NodeKind.HogQLAutocomplete]: {
         name: 'SQL Autocomplete',
         description: 'Autocomplete for the SQL query editor.',
-        icon: IconBrackets,
+        icon: IconBracketsChart,
         inMenu: false,
     },
     [NodeKind.DatabaseSchemaQuery]: {
         name: 'Database Schema',
         description: 'Introspect the PostHog database schema.',
-        icon: IconBrackets,
+        icon: IconBracketsChart,
         inMenu: true,
     },
     [NodeKind.RevenueAnalyticsMetricsQuery]: {
@@ -664,7 +664,7 @@ export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = 
     [InsightType.SQL]: {
         name: 'SQL',
         description: 'Use SQL to query your data.',
-        icon: IconBrackets,
+        icon: IconBracketsChart,
         inMenu: true,
         tooltipDocLink: 'https://posthog.com/docs/data-warehouse/sql',
     },

--- a/products/endpoints/frontend/InsightPickerEndpointModal.tsx
+++ b/products/endpoints/frontend/InsightPickerEndpointModal.tsx
@@ -1,8 +1,9 @@
 import { useActions, useValues } from 'kea'
 import { BindLogic } from 'kea'
 
-import { IconEndpoints, IconPlus, IconRetention, IconTrends } from '@posthog/icons'
+import { IconEndpoints, IconPlus } from '@posthog/icons'
 
+import { IconInsightRetention, IconInsightTrends } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { Popover } from 'lib/lemon-ui/Popover'
@@ -39,8 +40,8 @@ function isInsightSupported(insight: QueryBasedInsightModel): boolean {
 }
 
 const QUICK_CREATE_TYPES = [
-    { type: InsightType.TRENDS, icon: IconTrends, label: 'Trend' },
-    { type: InsightType.RETENTION, icon: IconRetention, label: 'Retention' },
+    { type: InsightType.TRENDS, icon: IconInsightTrends, label: 'Trend' },
+    { type: InsightType.RETENTION, icon: IconInsightRetention, label: 'Retention' },
 ]
 
 export function InsightPickerEndpointModal(): JSX.Element {

--- a/products/posthog_ai/frontend/messages/posthogProducts.ts
+++ b/products/posthog_ai/frontend/messages/posthogProducts.ts
@@ -1,14 +1,15 @@
 /**
  * PostHog product taxonomy for the sandbox resources bar. Ported from the agent's
  * `POSTHOG_PRODUCTS` (ids + labels are authoritative there) with icons sourced from
- * `@posthog/icons`. The `_posthog/resources_used` wire frame already carries `{id, label}`, so this
+ * `@posthog/icons` (plus the in-house SQL icon). The `_posthog/resources_used` wire frame already carries `{id, label}`, so this
  * map is the icon source plus a fallback label for any id the wire omits. Labels are NOT a
  * mechanical sentence-casing of the id (e.g. `llm_analytics → "AI observability"`,
  * `cdp → "Data pipelines"`, acronyms stay all-caps), so they are copied verbatim.
  */
+import { ComponentType } from 'react'
+
 import {
     IconAI,
-    IconBrackets,
     IconCursor,
     IconDatabase,
     IconFlask,
@@ -22,6 +23,8 @@ import {
     IconToggle,
     IconWarning,
 } from '@posthog/icons'
+
+import { IconBracketsChart } from 'lib/lemon-ui/icons'
 
 export type PostHogProductId =
     | 'product_analytics'
@@ -41,7 +44,8 @@ export type PostHogProductId =
 
 export interface PostHogProductMeta {
     label: string
-    Icon: typeof IconGraph
+    // wide enough for both @posthog/icons components and lemon-ui LemonIcons
+    Icon: ComponentType<{ className?: string }>
 }
 
 export const POSTHOG_PRODUCTS: Record<PostHogProductId, PostHogProductMeta> = {
@@ -57,7 +61,7 @@ export const POSTHOG_PRODUCTS: Record<PostHogProductId, PostHogProductMeta> = {
     cdp: { label: 'Data pipelines', Icon: IconPlug },
     logs: { label: 'Logs', Icon: IconServer },
     apm: { label: 'APM', Icon: IconCursor },
-    sql: { label: 'SQL', Icon: IconBrackets },
+    sql: { label: 'SQL', Icon: IconBracketsChart },
     posthog: { label: 'PostHog', Icon: IconLogomark },
 }
 


### PR DESCRIPTION
## TL;DR

Insight type icons get a full redesign: every type now has a glyph drawn at the same line weight as the left-nav icons. Series blue is the base color, multi-series glyphs step through the first data colors (blue, purple, green), and lifecycle keeps its chart's real status colors. The set is used everywhere an insight type shows an icon.

![icon-final](https://raw.githubusercontent.com/PostHog/pr-assets/a71278e22f12732cf20e7c2431a708b76bfee076/2026/07/00be2494-8c4a-4836-af8a-b3da69b0f8c4.png)

## Problem

Three things were off with insight type icons:

- SQL insights had no icon at all — menus showed a hedgehog, lists showed brackets, `DataVisualizationNode` showed a table.
- The `@posthog/icons` insight glyphs are heavy filled shapes, visibly out of step with the light outline style of the left-nav icons.
- The only per-insight colors in the app (`--color-insight-*`, used by the project tree) don't match what the charts look like: trends is orange there but renders blue, retention is red there but renders blue, and so on.

## Changes

**The icon set** — twelve components in `frontend/src/lib/lemon-ui/icons/icons.tsx`, drawn at the nav-icon weight (1.5–1.75 unit strokes, slim bars). One palette across the set: series blue (`#1d4aff`, `--data-color-1`) as the base, and multi-series glyphs stepping through the first data colors (blue, purple `#7f26d9`, green `#42827e`):

- Trends: rising series line, blue
- Funnel: narrowing steps in blue, purple, green
- Retention: the cohort triangle, first cohort row purple over blue return rows
- Paths: a sankey — a source node splitting into two flows, blue
- Stickiness: the "n days or more" histogram, blue
- Lifecycle: bars above/below the axis in the chart's real status colors (`--color-lifecycle-*`: blue/green/purple/red); axis follows `currentColor`
- Calendar heatmap: a day-by-hour matrix, intensity stepping through blue, purple, green
- SQL: `IconBrackets` braces (`currentColor`) wrapping bars in the funnel's colors, near-rectangular (`rx` 0.5, was fully rounded pills)
- Number, Table, Pie, World map: glyphs for the trends preset cards in the `new-insight-menu-experiment` grouped variant — blue digits and globe, table rows and pie slices stepping through the same first data colors

The palette lives in `--insight-icon-*` variables (`icons.scss`): light mode uses the charts' real hexes, dark mode gets brightened equivalents via `light-dark()` (the chart hexes are too dark to read at icon size on dark surfaces), with the plain hexes as fallback for browsers without `light-dark()`. The glyphs don't follow text color; structural parts (SQL brackets, lifecycle axis) still theme via `currentColor`.

**Used everywhere:**

- `QUERY_TYPES_METADATA` / `INSIGHT_TYPES_METADATA` (`SavedInsights.tsx`) — covers the "New insight" menu, insight type selector, type-filter dropdown, quick-start cards, dashboard and endpoint pickers, and every saved-insight list row. The `withIconColor` CSS wrapper from the previous revision is gone; color lives in the glyphs now.
- Project tree `insight/*` entries (`defaultTree.tsx`) — the "New" section in the left panel.
- Quick-create buttons in the dashboard "add insight" modal and the endpoint picker modal.
- Notebook SQL nodes and the PostHog AI resources bar (SQL icon, from earlier commits).
- The grouped "New" menu variant's preset cards (Number, Table, Pie, World map), which kept gray `currentColor` icons while every other card in that menu got a colored glyph.

Left alone: Hog-language kinds keep the hedgehog, Custom/JSON keeps plain `IconBrackets`, the SQL editor product entry keeps `IconServer`, and the `@posthog/icons` glyphs themselves are untouched (other products still use them).

> [!NOTE]
> This PR and [#72724](https://github.com/PostHog/posthog/pull/72724) retarget some of the same lines (#72724 standardizes SQL surfaces on plain `IconBrackets`). They are alternatives — pick one and close the other.

## How did you test this code?

No logic changes — icon components and reference swaps only. I (Claude via PostHog Code) designed the set by rendering it next to the real left-nav icons and the old set (image above: light, dark, and 16 px sizes) and iterated until the weights matched. oxlint and oxfmt are clean on all five touched files, and the full `tsgo --noEmit` run reports byte-identical error sets with and without the diff (195 pre-existing sandbox errors from unbuilt workspace packages, none in these files). The icons appear in the `Lemon UI/Icons` storybook automatically, so CI's visual snapshots will show them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed. No doc shows the insight type icons.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude), driven by Thomas across five revisions: monochrome SQL draft → outlined PostHog-color bars → wired into all SQL surfaces → colored the stock glyphs via CSS vars → this full redraw. The final brief: use the new icons everywhere, squarer SQL bars, colors true to each chart's implementation, and nav-icon line weight. Glyph geometry was iterated visually with headless-browser renders against the nav icon row; the image above is generated from the exact committed values.

The palette went through a review round: the first draft mixed blue opacity fades with a red/yellow/blue SQL icon, so two full-palette options were built as sibling PRs for comparison (brand trio [#73004](https://github.com/PostHog/posthog/pull/73004), blue-purple ramp [#73005](https://github.com/PostHog/posthog/pull/73005)). The final palette hand-picks per icon: data colors 1–3 for multi-series glyphs, purple-over-blue retention, plain blue paths/stickiness, chart-true lifecycle, no arrowhead on trends. Both option PRs are closed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*



