### PR TITLE
fix(frontend): apply system theme changes without a page refresh

### DIFF
--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -3,7 +3,7 @@ import './Exporter.scss'
 
 import clsx from 'clsx'
 import { BindLogic, useValues } from 'kea'
-import { Suspense, useEffect } from 'react'
+import { Suspense, useEffect, useSyncExternalStore } from 'react'
 
 import { Logo } from 'lib/brand'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
@@ -38,16 +38,28 @@ function ExportedSceneSkeleton(): JSX.Element {
     )
 }
 
-function resolveForcedTheme(theme?: 'light' | 'dark' | 'system'): 'light' | 'dark' | null {
+const PREFERS_DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)'
+
+function subscribeToColorSchemeChanges(onChange: () => void): () => void {
+    const media = window.matchMedia?.(PREFERS_DARK_MEDIA_QUERY)
+    media?.addEventListener('change', onChange)
+    return () => media?.removeEventListener('change', onChange)
+}
+
+function getSystemPrefersDark(): boolean {
+    return typeof window !== 'undefined' && !!window.matchMedia?.(PREFERS_DARK_MEDIA_QUERY)?.matches
+}
+
+function useResolvedForcedTheme(theme?: 'light' | 'dark' | 'system'): 'light' | 'dark' | null {
+    // Subscribe so a shared page left open follows system light/dark switches without a reload
+    const systemPrefersDark = useSyncExternalStore(subscribeToColorSchemeChanges, getSystemPrefersDark)
     if (theme === 'light' || theme === 'dark') {
         return theme
     }
     if (theme !== 'system') {
         return null
     }
-    return typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)')?.matches
-        ? 'dark'
-        : 'light'
+    return systemPrefersDark ? 'dark' : 'light'
 }
 
 export function Exporter(props: ExportedData): JSX.Element {
@@ -66,7 +78,7 @@ export function Exporter(props: ExportedData): JSX.Element {
         ...exportOptions
     } = props
     const { whitelabel, showInspector = false } = exportOptions
-    const forcedTheme = resolveForcedTheme(exportOptions.theme)
+    const forcedTheme = useResolvedForcedTheme(exportOptions.theme)
 
     // A metric insight sizes to a square card rather than filling the viewport, so drop the 100vh floor
     // that would otherwise leave empty space below it (see Exporter.scss and ExportedInsight.scss).

--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -42,8 +42,17 @@ const PREFERS_DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)'
 
 function subscribeToColorSchemeChanges(onChange: () => void): () => void {
     const media = window.matchMedia?.(PREFERS_DARK_MEDIA_QUERY)
-    media?.addEventListener('change', onChange)
-    return () => media?.removeEventListener('change', onChange)
+    if (!media) {
+        return () => {}
+    }
+    // Shared/embedded pages are viewed from browsers we don't control; old WebKit (Safari < 14)
+    // only implements the legacy listener API, and throwing here would crash the whole page
+    if (typeof media.addEventListener !== 'function') {
+        media.addListener(onChange)
+        return () => media.removeListener(onChange)
+    }
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
 }
 
 function getSystemPrefersDark(): boolean {

--- a/frontend/src/lib/logic/themeLogic.test.ts
+++ b/frontend/src/lib/logic/themeLogic.test.ts
@@ -1,0 +1,68 @@
+import { themeLogic } from 'lib/logic/themeLogic'
+
+import { initKeaTests } from '~/test/init'
+
+// Trigger visibilitychange after mutating document.hidden, so the kea disposables
+// plugin pauses/resumes listeners exactly as it does in the browser
+const setHidden = (hidden: boolean): void => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+    Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => (hidden ? 'hidden' : 'visible'),
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('themeLogic', () => {
+    let systemPrefersDark: boolean
+    let changeListeners: Set<(e: MediaQueryListEvent) => void>
+
+    const emitSystemThemeChange = (dark: boolean): void => {
+        systemPrefersDark = dark
+        changeListeners.forEach((listener) => listener({ matches: dark } as MediaQueryListEvent))
+    }
+
+    beforeEach(() => {
+        systemPrefersDark = false
+        changeListeners = new Set()
+        window.matchMedia = jest.fn(
+            (query: string) =>
+                ({
+                    get matches() {
+                        return systemPrefersDark
+                    },
+                    media: query,
+                    addEventListener: (_type: string, listener: (e: MediaQueryListEvent) => void): void => {
+                        changeListeners.add(listener)
+                    },
+                    removeEventListener: (_type: string, listener: (e: MediaQueryListEvent) => void): void => {
+                        changeListeners.delete(listener)
+                    },
+                }) as unknown as MediaQueryList
+        )
+        initKeaTests()
+        setHidden(false)
+        themeLogic.mount()
+    })
+
+    afterEach(() => {
+        setHidden(false)
+    })
+
+    it('syncs darkModeSystemPreference when the system theme changes while the tab is visible', () => {
+        expect(themeLogic.values.darkModeSystemPreference).toBe(false)
+        emitSystemThemeChange(true)
+        expect(themeLogic.values.darkModeSystemPreference).toBe(true)
+    })
+
+    it('picks up a system theme change that happened while the tab was hidden', () => {
+        setHidden(true)
+        emitSystemThemeChange(true) // the paused listener misses this; only the resume re-read can catch it
+        setHidden(false)
+        expect(themeLogic.values.darkModeSystemPreference).toBe(true)
+
+        // The change listener must be re-attached after resume, so live changes still apply
+        emitSystemThemeChange(false)
+        expect(themeLogic.values.darkModeSystemPreference).toBe(false)
+    })
+})

--- a/frontend/src/lib/logic/themeLogic.ts
+++ b/frontend/src/lib/logic/themeLogic.ts
@@ -180,6 +180,10 @@ export const themeLogic = kea<themeLogicType>([
         afterMount() {
             cache.disposables.add(() => {
                 const prefersColorSchemeMedia = window.matchMedia('(prefers-color-scheme: dark)')
+                // This setup re-runs whenever the tab becomes visible again (disposables pause on hidden
+                // tabs, detaching the listener), so re-read the preference to catch a system theme change
+                // that happened while the tab was hidden and fired no observable `change` event
+                actions.syncDarkModePreference(prefersColorSchemeMedia.matches)
                 const onPrefersColorSchemeChange = (e: MediaQueryListEvent): void =>
                     actions.syncDarkModePreference(e.matches)
                 prefersColorSchemeMedia.addEventListener('change', onPrefersColorSchemeChange)


### PR DESCRIPTION
## TL;DR

If your computer switches between light and dark mode while the PostHog tab is hidden, PostHog misses the switch and keeps the old colors until you reload the page. Now it catches up the moment you return to the tab.

## Problem

With the theme set to "Sync with system", the app listens for `prefers-color-scheme` changes. The kea disposables plugin detaches that listener while the tab is hidden. That is exactly when theme switches happen: you are in the OS settings, or the OS switches at sunset. On return the plugin re-runs the listener setup, but nothing re-read the preference, so the stale theme stuck until a full reload.

**Why:** switching the OS between light and dark mode only took effect in PostHog after a page refresh.

## Changes

- `themeLogic`: the listener setup now re-reads the media query each time it runs. The disposables plugin re-runs setup when the tab becomes visible, so a switch missed while hidden applies as soon as you return. Switches while the tab is visible worked before and still do.
- `Exporter`: shared and embedded pages with `theme=system` read the preference once per render. They now subscribe via `useSyncExternalStore`, so a shared dashboard left open follows the OS switch too.

No screenshots: the change has no new UI, it makes the existing theme apply without a reload.

## How did you test this code?

- New `themeLogic.test.ts` with two cases. The hidden-tab case catches the regression this PR fixes and fails without the fix: flip the system preference while the tab is hidden, then show the tab and assert the logic syncs. No existing test covered this listener at all.
- Ran `Exporter.test.tsx` and `kea-disposables.test.ts`: pass.
- `pnpm --filter=@posthog/frontend fix` and `tsgo --noEmit`: no errors in the changed files (the checkout has pre-existing errors elsewhere, untouched here). `hogli ci:preflight --fix`: clean.
- I (the agent) did not verify by hand in a browser; the jest test simulates the exact visibility sequence.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc changes needed. "Sync with system" behaves as documented; this fixes it applying without a reload.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) authored this from Thomas's bug report. Skills invoked: `/using-kea-disposables`, `/writing-tests`.

Decisions:

- Re-read the preference in the disposable setup instead of opting the listener out of pause with `pauseOnPageHidden: false`. Browsers do not reliably fire `change` on hidden tabs, so keeping the listener attached would not be enough. Re-reading on resume covers both gaps and keeps the power-saving pause.
- The setup dispatches unconditionally instead of diffing against `values`: reading `values` in a resumed setup throws for stale logic instances in the jest harness, and the reducer dedupes anyway.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
