### PR TITLE
feat(data-warehouse): add source health reads to warehouse facade

### DIFF
--- a/ee/hogai/tools/execute_sql/mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/mcp_tool.py
@@ -10,7 +10,7 @@ from posthog.hogql.taxonomy_validation import validate_taxonomy_references
 
 from posthog.sync import database_sync_to_async
 
-from products.warehouse_sources.backend.facade.models import ExternalDataSource
+from products.warehouse_sources.backend.facade import api as warehouse_api
 
 from ee.hogai.chat_agent.schema_generator.parsers import PydanticOutputParserException
 from ee.hogai.chat_agent.sql.mixins import HogQLOutputParserMixin
@@ -101,11 +101,7 @@ class ExecuteSQLMCPTool(HogQLOutputParserMixin, MCPTool[ExecuteSQLMCPToolArgs]):
 
     @database_sync_to_async(thread_sensitive=False)
     def _existing_source_types(self) -> set[str]:
-        return set(
-            ExternalDataSource.objects.filter(team_id=self._team.pk, deleted=False).values_list(
-                "source_type", flat=True
-            )
-        )
+        return {source.source_type for source in warehouse_api.list_sources(self._team.pk)}
 
     @database_sync_to_async(thread_sensitive=False)
     def _get_taxonomy_warnings(self, query: str) -> list[HogQLNotice]:

--- a/products/marketing_analytics/backend/services/data_source_health.py
+++ b/products/marketing_analytics/backend/services/data_source_health.py
@@ -2,9 +2,6 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 from typing import Literal
 
-from django.db.models import Sum
-from django.utils import timezone
-
 import structlog
 
 from posthog.schema import NativeMarketingSource
@@ -20,7 +17,10 @@ from products.marketing_analytics.backend.services.native_integrations import (
     DISPLAY_NAMES,
     EXTERNAL_SOURCE_TYPE_TO_NATIVE,
 )
-from products.warehouse_sources.backend.facade.models import ExternalDataJob, ExternalDataSchema, ExternalDataSource
+from products.warehouse_sources.backend.facade import (
+    api as warehouse_api,
+    contracts as warehouse_contracts,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -127,16 +127,15 @@ async def get_data_source_health(
         targets = {k: v for k, v in targets.items() if k == source_type}
 
     config_sources_map = sources_map if sources_map is not None else await _get_sources_map(team)
-    sources_by_type = await _get_sources_by_type(team, list(targets.keys()))
+    health_by_type = await _get_health_by_type(team, targets)
 
     entries: list[DataSourceHealthEntry] = []
     for type_key, native in targets.items():
-        source = sources_by_type.get(type_key)
         entries.append(
-            await _build_entry(
+            _build_entry(
                 source_type=type_key,
                 native=native,
-                source=source,
+                health=health_by_type.get(type_key),
                 config_sources_map=config_sources_map,
             )
         )
@@ -160,28 +159,38 @@ def _get_sources_map(team: Team) -> dict[str, dict]:
 
 
 @database_sync_to_async
-def _get_sources_by_type(team: Team, source_types: list[str]) -> dict[str, ExternalDataSource]:
-    """Index live sources by source_type. We pick the most recently created if
-    the team has more than one of the same type — this is uncommon in practice."""
-    qs = ExternalDataSource.objects.filter(team=team, source_type__in=source_types, deleted=False).order_by(
-        "source_type", "-created_at"
+def _get_health_by_type(
+    team: Team, targets: dict[str, NativeMarketingSource]
+) -> dict[str, warehouse_contracts.SourceHealth]:
+    """Health for the newest source of each native type (more than one of the same
+    type is uncommon in practice). Sync status, last error, row counts, and required-
+    table states all come from the warehouse facade in one set-based call."""
+    required_by_type = {
+        type_key: list(NEEDED_FIELDS_FOR_NATIVE_MARKETING_ANALYTICS.get(native, []))
+        for type_key, native in targets.items()
+    }
+    healths = warehouse_api.list_source_health(
+        team.pk,
+        source_types=list(targets.keys()),
+        stale_threshold=STALE_THRESHOLD,
+        required_schema_names_by_type=required_by_type,
     )
-    by_type: dict[str, ExternalDataSource] = {}
-    for src in qs:
-        by_type.setdefault(src.source_type, src)
+    by_type: dict[str, warehouse_contracts.SourceHealth] = {}
+    for health in healths:  # ordered (source_type, -created_at) → first seen per type is newest
+        by_type.setdefault(health.source_type, health)
     return by_type
 
 
-async def _build_entry(
+def _build_entry(
     *,
     source_type: str,
     native: NativeMarketingSource,
-    source: ExternalDataSource | None,
+    health: warehouse_contracts.SourceHealth | None,
     config_sources_map: dict[str, dict],
 ) -> DataSourceHealthEntry:
     display_name = DISPLAY_NAMES[native]
 
-    if source is None:
+    if health is None:
         return DataSourceHealthEntry(
             source_type=source_type,
             is_native=True,
@@ -209,31 +218,32 @@ async def _build_entry(
             fix_suggestion=f"Connect {display_name} from {_MARKETING_SETTINGS_URL}.",
         )
 
-    last_completed_at, last_error_text = await _get_last_job_state(source)
-    rows_24h, rows_7d = await _get_rows_synced(source)
-    required_tables = await _get_required_tables_status(source, native)
+    required_tables = [
+        RequiredTableStatus(
+            table_name=s.schema_name,
+            present=s.present,
+            should_sync=s.should_sync,
+            status=s.status,
+            last_synced_at=s.last_synced_at,
+        )
+        for s in health.schemas
+    ]
 
-    source_id_str = str(source.id)
+    source_id_str = str(health.source_id)
     field_mapping = config_sources_map.get(source_id_str, {})
     mapped_keys = list(field_mapping.keys())
     # Native sources don't use sources_map for column mapping. Only non-native
     # (BigQuery, S3, self-managed) sources track per-column mappings here.
     missing_required: list[str] = []
 
-    last_sync_status = _resolve_sync_status(
-        last_completed_at=last_completed_at,
-        last_error_text=last_error_text,
-        required_tables=required_tables,
-    )
-
     diagnosis, fix_suggestion = _diagnose(
         display_name=display_name,
-        last_sync_status=last_sync_status,
-        last_completed_at=last_completed_at,
-        last_error_text=last_error_text,
+        last_sync_status=health.sync_status,
+        last_completed_at=health.last_completed_sync_at,
+        last_error_text=health.last_unresolved_error,
         sources_map_present=bool(field_mapping),
         missing_required=missing_required,
-        rows_last_7d=rows_7d,
+        rows_last_7d=health.rows_synced_last_7d,
         required_tables=required_tables,
         source_id=source_id_str,
     )
@@ -243,11 +253,11 @@ async def _build_entry(
         is_native=True,
         display_name=display_name,
         connected=True,
-        last_sync_at=last_completed_at,
-        last_sync_status=last_sync_status,
-        last_error=last_error_text,
-        rows_last_24h=rows_24h,
-        rows_last_7d=rows_7d,
+        last_sync_at=health.last_completed_sync_at,
+        last_sync_status=health.sync_status,
+        last_error=health.last_unresolved_error,
+        rows_last_24h=health.rows_synced_last_24h,
+        rows_last_7d=health.rows_synced_last_7d,
         sources_map_present=bool(field_mapping),
         schema_columns_mapped=mapped_keys,
         schema_columns_required_missing=missing_required,
@@ -257,114 +267,6 @@ async def _build_entry(
         diagnosis=diagnosis,
         fix_suggestion=fix_suggestion,
     )
-
-
-@database_sync_to_async
-def _get_required_tables_status(source: ExternalDataSource, native: NativeMarketingSource) -> list[RequiredTableStatus]:
-    required_names = NEEDED_FIELDS_FOR_NATIVE_MARKETING_ANALYTICS.get(native, [])
-    if not required_names:
-        return []
-
-    schemas_by_name: dict[str, ExternalDataSchema] = {
-        s.name: s for s in ExternalDataSchema.objects.filter(source=source, deleted=False)
-    }
-    out: list[RequiredTableStatus] = []
-    for name in required_names:
-        schema = schemas_by_name.get(name)
-        if schema is None:
-            out.append(
-                RequiredTableStatus(table_name=name, present=False, should_sync=False, status=None, last_synced_at=None)
-            )
-        else:
-            out.append(
-                RequiredTableStatus(
-                    table_name=name,
-                    present=True,
-                    should_sync=schema.should_sync,
-                    status=schema.status,
-                    last_synced_at=getattr(schema, "last_synced_at", None),
-                )
-            )
-    return out
-
-
-@database_sync_to_async
-def _get_last_job_state(source: ExternalDataSource) -> tuple[datetime | None, str | None]:
-    """Return (last_completed_finished_at, last_unresolved_error_text) for a source.
-
-    `last_unresolved_error_text` is the latest FAILED job's error message *only
-    if* its created_at is newer than the most recent COMPLETED job — otherwise
-    the failure has been resolved by a subsequent successful sync.
-    """
-    last_completed = (
-        ExternalDataJob.objects.filter(pipeline=source, status=ExternalDataJob.Status.COMPLETED)
-        .order_by("-finished_at")
-        .values_list("finished_at", flat=True)
-        .first()
-    )
-    last_failed = (
-        ExternalDataJob.objects.filter(pipeline=source, status=ExternalDataJob.Status.FAILED)
-        .exclude(latest_error__isnull=True)
-        .order_by("-created_at")
-        .values("created_at", "latest_error")
-        .first()
-    )
-
-    error_text: str | None = None
-    if last_failed is not None:
-        if last_completed is None or last_failed["created_at"] > last_completed:
-            error_text = last_failed["latest_error"]
-
-    return last_completed, error_text
-
-
-@database_sync_to_async
-def _get_rows_synced(source: ExternalDataSource) -> tuple[int, int]:
-    now = timezone.now()
-    in_24h = (
-        ExternalDataJob.objects.filter(
-            pipeline=source,
-            status=ExternalDataJob.Status.COMPLETED,
-            finished_at__gte=now - timedelta(hours=24),
-        ).aggregate(total=Sum("rows_synced"))["total"]
-        or 0
-    )
-    in_7d = (
-        ExternalDataJob.objects.filter(
-            pipeline=source,
-            status=ExternalDataJob.Status.COMPLETED,
-            finished_at__gte=now - timedelta(days=7),
-        ).aggregate(total=Sum("rows_synced"))["total"]
-        or 0
-    )
-    return int(in_24h), int(in_7d)
-
-
-def _resolve_sync_status(
-    *,
-    last_completed_at: datetime | None,
-    last_error_text: str | None,
-    required_tables: list[RequiredTableStatus],
-) -> SyncStatus:
-    """Resolve the source-level sync status. Per-required-table state takes
-    priority over the source-level job state, because the Marketing analytics
-    dashboard surfaces those schema-level issues directly to users (banner)."""
-    missing = [t for t in required_tables if not t.present]
-    if missing:
-        return "tables_missing"
-    failed = [t for t in required_tables if t.status == "Failed"]
-    if failed:
-        return "tables_failed"
-    disabled = [t for t in required_tables if t.present and not t.should_sync]
-    if disabled:
-        return "tables_disabled"
-    if last_error_text is not None:
-        return "error"
-    if last_completed_at is None:
-        return "never"
-    if timezone.now() - last_completed_at > STALE_THRESHOLD:
-        return "stale"
-    return "ok"
 
 
 def _diagnose(

--- a/products/marketing_analytics/backend/services/test_data_source_health.py
+++ b/products/marketing_analytics/backend/services/test_data_source_health.py
@@ -1,5 +1,6 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
+from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
@@ -15,29 +16,13 @@ from products.marketing_analytics.backend.services.data_source_health import (
     DataSourceHealthEntry,
     _build_issues_summary,
     _compute_overall_status,
-    _resolve_sync_status,
     get_data_source_health,
 )
+from products.warehouse_sources.backend.facade import contracts as warehouse_contracts
 
-
-@freeze_time("2025-06-15")
-class TestResolveSyncStatus:
-    @parameterized.expand(
-        [
-            ("never_synced_returns_never", None, None, "never"),
-            ("recent_completed_returns_ok", timedelta(minutes=10), None, "ok"),
-            ("old_completed_returns_stale", STALE_THRESHOLD + timedelta(minutes=1), None, "stale"),
-            ("error_text_takes_priority_over_completed", timedelta(minutes=10), "boom", "error"),
-        ]
-    )
-    def test_resolve_sync_status(self, _name, age, last_error_text, expected):
-        last_completed_at = None if age is None else timezone.now() - age
-        assert (
-            _resolve_sync_status(
-                last_completed_at=last_completed_at, last_error_text=last_error_text, required_tables=[]
-            )
-            == expected
-        )
+# Sync-status resolution (never/ok/stale/error/tables_*) now lives in the warehouse
+# facade — decision-table coverage is in the facade's own tests. These tests cover
+# the marketing product layer: entry building, filtering, and overall status.
 
 
 def _entry(**kwargs: Any) -> DataSourceHealthEntry:
@@ -139,10 +124,31 @@ class TestBuildIssuesSummary:
         assert expected_substring in summary[0]
 
 
-class _FakeSource:
-    def __init__(self, source_id: str = "src-uuid-1", source_type: str = "GoogleAds"):
-        self.id = source_id
-        self.source_type = source_type
+_SRC_ID = UUID("12345678-1234-5678-1234-567812345678")
+
+
+def _health(
+    source_type: str = "GoogleAds",
+    sync_status: str = "ok",
+    *,
+    last_completed_sync_at: datetime | None = None,
+    last_unresolved_error: str | None = None,
+    rows_24h: int = 0,
+    rows_7d: int = 0,
+) -> warehouse_contracts.SourceHealth:
+    return warehouse_contracts.SourceHealth(
+        source_id=_SRC_ID,
+        team_id=1,
+        source_type=source_type,
+        prefix=None,
+        created_at=timezone.now(),
+        sync_status=sync_status,  # type: ignore[arg-type]
+        last_completed_sync_at=last_completed_sync_at,
+        last_unresolved_error=last_unresolved_error,
+        rows_synced_last_24h=rows_24h,
+        rows_synced_last_7d=rows_7d,
+        schemas=[],
+    )
 
 
 @freeze_time("2025-06-15")
@@ -151,22 +157,16 @@ class TestGetDataSourceHealthOrchestration(APIBaseTest):
         super().setUp()
         _TARGETS = {
             "sources_map": "products.marketing_analytics.backend.services.data_source_health._get_sources_map",
-            "sources_by_type": "products.marketing_analytics.backend.services.data_source_health._get_sources_by_type",
-            "last_job_state": "products.marketing_analytics.backend.services.data_source_health._get_last_job_state",
-            "rows_synced": "products.marketing_analytics.backend.services.data_source_health._get_rows_synced",
-            "required_tables": "products.marketing_analytics.backend.services.data_source_health._get_required_tables_status",
+            "health_by_type": "products.marketing_analytics.backend.services.data_source_health._get_health_by_type",
         }
         patchers = {key: patch(target, new_callable=AsyncMock) for key, target in _TARGETS.items()}
         self.mocks = {key: p.start() for key, p in patchers.items()}
         for p in patchers.values():
             self.addCleanup(p.stop)
 
-        # Defaults: empty config, no sources, never synced, no rows, no required tables.
+        # Defaults: empty config, no connected sources.
         self.mocks["sources_map"].return_value = {}
-        self.mocks["sources_by_type"].return_value = {}
-        self.mocks["last_job_state"].return_value = (None, None)
-        self.mocks["rows_synced"].return_value = (0, 0)
-        self.mocks["required_tables"].return_value = []
+        self.mocks["health_by_type"].return_value = {}
 
     @pytest.mark.asyncio
     async def test_no_sources_returns_no_sources_status(self):
@@ -178,11 +178,16 @@ class TestGetDataSourceHealthOrchestration(APIBaseTest):
 
     @pytest.mark.asyncio
     async def test_native_source_with_recent_sync_is_ok(self):
-        self.mocks["sources_by_type"].return_value = {"GoogleAds": _FakeSource()}
-        self.mocks["last_job_state"].return_value = (timezone.now() - timedelta(minutes=15), None)
-        self.mocks["rows_synced"].return_value = (500, 500)
+        self.mocks["health_by_type"].return_value = {
+            "GoogleAds": _health(
+                sync_status="ok",
+                last_completed_sync_at=timezone.now() - timedelta(minutes=15),
+                rows_24h=500,
+                rows_7d=500,
+            )
+        }
         self.mocks["sources_map"].return_value = {
-            "src-uuid-1": {"campaign": "name", "source": "src", "cost": "spend", "date": "day"}
+            str(_SRC_ID): {"campaign": "name", "source": "src", "cost": "spend", "date": "day"}
         }
 
         response = await get_data_source_health(self.team)
@@ -196,8 +201,9 @@ class TestGetDataSourceHealthOrchestration(APIBaseTest):
 
     @pytest.mark.asyncio
     async def test_failed_job_text_surfaces_as_error_status(self):
-        self.mocks["sources_by_type"].return_value = {"BingAds": _FakeSource(source_type="BingAds")}
-        self.mocks["last_job_state"].return_value = (None, "auth failed")
+        self.mocks["health_by_type"].return_value = {
+            "BingAds": _health(source_type="BingAds", sync_status="error", last_unresolved_error="auth failed")
+        }
 
         response = await get_data_source_health(self.team, source_type="BingAds")
 
@@ -206,9 +212,14 @@ class TestGetDataSourceHealthOrchestration(APIBaseTest):
         assert response.integrations[0].last_error == "auth failed"
 
     @pytest.mark.asyncio
-    async def test_stale_completed_is_marked_stale(self):
-        self.mocks["sources_by_type"].return_value = {"MetaAds": _FakeSource(source_type="MetaAds")}
-        self.mocks["last_job_state"].return_value = (timezone.now() - STALE_THRESHOLD - timedelta(hours=1), None)
+    async def test_stale_status_passes_through_to_entry(self):
+        self.mocks["health_by_type"].return_value = {
+            "MetaAds": _health(
+                source_type="MetaAds",
+                sync_status="stale",
+                last_completed_sync_at=timezone.now() - STALE_THRESHOLD - timedelta(hours=1),
+            )
+        }
 
         response = await get_data_source_health(self.team, source_type="MetaAds")
 
@@ -216,7 +227,7 @@ class TestGetDataSourceHealthOrchestration(APIBaseTest):
 
     @pytest.mark.asyncio
     async def test_filter_by_source_type_returns_only_that_one(self):
-        self.mocks["sources_by_type"].return_value = {"GoogleAds": _FakeSource()}
+        self.mocks["health_by_type"].return_value = {"GoogleAds": _health()}
 
         response = await get_data_source_health(self.team, source_type="GoogleAds")
 
@@ -235,9 +246,10 @@ class TestGetDataSourceHealthOrchestration(APIBaseTest):
         # sources (BigQuery, S3) need explicit column mapping. So for a native source,
         # `schema_columns_required_missing` must always be empty regardless of
         # `sources_map` content.
-        self.mocks["sources_by_type"].return_value = {"GoogleAds": _FakeSource()}
-        self.mocks["last_job_state"].return_value = (timezone.now() - timedelta(minutes=5), None)
-        self.mocks["sources_map"].return_value = {"src-uuid-1": {"campaign": "name"}}
+        self.mocks["health_by_type"].return_value = {
+            "GoogleAds": _health(last_completed_sync_at=timezone.now() - timedelta(minutes=5))
+        }
+        self.mocks["sources_map"].return_value = {str(_SRC_ID): {"campaign": "name"}}
 
         response = await get_data_source_health(self.team, source_type="GoogleAds")
 

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -3,8 +3,6 @@ import logging
 from collections.abc import Mapping
 from typing import cast
 
-from django.db.models import Q
-
 from asgiref.sync import async_to_sync
 from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema_field
 from opentelemetry import trace
@@ -99,27 +97,21 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
         return None
 
     def _get_data_import_status(self, team_id: int, ext_source_type: str, schema_name: str) -> str | None:
-        from products.warehouse_sources.backend.facade.models import ExternalDataSchema
+        from products.warehouse_sources.backend.facade import api as warehouse_api
+        from products.warehouse_sources.backend.facade.types import ExternalDataSchemaStatus
 
-        statuses = set(
-            ExternalDataSchema.objects.filter(
-                Q(name=schema_name) | Q(name__endswith=f".{schema_name}"),
-                team_id=team_id,
-                source__source_type=ext_source_type,
-            )
-            .exclude(source__deleted=True)
-            .values_list("status", flat=True)
-        )
-        if ExternalDataSchema.Status.RUNNING in statuses:
+        schemas = warehouse_api.list_schemas(team_id, source_type=ext_source_type)
+        statuses = {s.status for s in schemas if s.name == schema_name or s.name.endswith(f".{schema_name}")}
+        if ExternalDataSchemaStatus.RUNNING in statuses:
             return "running"
         # One failing repo outranks its siblings' success, so a broken repo is never hidden.
         if statuses & {
-            ExternalDataSchema.Status.FAILED,
-            ExternalDataSchema.Status.BILLING_LIMIT_REACHED,
-            ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW,
+            ExternalDataSchemaStatus.FAILED,
+            ExternalDataSchemaStatus.BILLING_LIMIT_REACHED,
+            ExternalDataSchemaStatus.BILLING_LIMIT_TOO_LOW,
         }:
             return "failed"
-        if ExternalDataSchema.Status.COMPLETED in statuses:
+        if ExternalDataSchemaStatus.COMPLETED in statuses:
             return "completed"
         return None
 

--- a/products/warehouse_sources/backend/facade/api.py
+++ b/products/warehouse_sources/backend/facade/api.py
@@ -16,7 +16,13 @@ Write paths (create/update of sources, schemas, tables, jobs) remain inside
 first facade serves the read consumers and the framework-free helpers.
 """
 
+from collections import defaultdict
+from collections.abc import Collection
+from datetime import datetime, timedelta
 from uuid import UUID
+
+from django.db.models import Max, Q, Sum
+from django.utils import timezone
 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob as _ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema as _ExternalDataSchema
@@ -44,7 +50,12 @@ __all__ = [
     "list_schemas_for_source",
     "get_table",
     "list_tables_for_source",
+    "list_tables_by_names",
+    "list_schemas_for_tables",
     "list_jobs_for_source",
+    "get_latest_job",
+    "get_source_health",
+    "list_source_health",
     # framework-free helper transforms
     "mysql_column_to_dwh_column",
     "mysql_columns_to_dwh_columns",
@@ -172,10 +183,219 @@ def list_tables_for_source(source_id: UUID, team_id: int) -> list[contracts.Data
     return [_to_table(t) for t in qs]
 
 
-def list_jobs_for_source(source_id: UUID, team_id: int) -> list[contracts.ExternalDataJob]:
+def list_jobs_for_source(source_id: UUID, team_id: int, *, limit: int | None = 100) -> list[contracts.ExternalDataJob]:
+    # Bounded by default: long-lived sources accumulate thousands of job rows, and an
+    # unbounded list materializes a contract per row. Pass limit=None deliberately.
     qs = (
         _ExternalDataJob.objects.select_related("schema", "pipeline")
         .filter(team_id=team_id, pipeline_id=source_id)
         .order_by("-created_at")
     )
+    if limit is not None:
+        qs = qs[:limit]
     return [_to_job(j) for j in qs]
+
+
+def get_latest_job(
+    team_id: int,
+    *,
+    source_id: UUID | None = None,
+    schema_id: UUID | None = None,
+    status: str | None = None,
+) -> contracts.ExternalDataJob | None:
+    qs = _ExternalDataJob.objects.select_related("schema", "pipeline").filter(team_id=team_id)
+    if source_id is not None:
+        qs = qs.filter(pipeline_id=source_id)
+    if schema_id is not None:
+        qs = qs.filter(schema_id=schema_id)
+    if status is not None:
+        qs = qs.filter(status=status)
+    job = qs.order_by("-created_at").first()
+    return _to_job(job) if job is not None else None
+
+
+def list_tables_by_names(team_id: int, names: Collection[str]) -> list[contracts.DataWarehouseTable]:
+    qs = _DataWarehouseTable.objects.filter(team_id=team_id, name__in=names).exclude(deleted=True)
+    return [_to_table(t) for t in qs]
+
+
+def list_schemas_for_tables(team_id: int, table_ids: Collection[UUID]) -> list[contracts.ExternalDataSchema]:
+    qs = _ExternalDataSchema.objects.select_related("source").filter(team_id=team_id, table_id__in=table_ids)
+    return [_to_schema(s) for s in qs]
+
+
+# --- Source health ---
+
+DEFAULT_STALE_THRESHOLD = timedelta(hours=24)
+
+
+def get_source_health(
+    source_id: UUID,
+    team_id: int,
+    *,
+    stale_threshold: timedelta = DEFAULT_STALE_THRESHOLD,
+    required_schema_names: list[str] | None = None,
+) -> contracts.SourceHealth:
+    source = _ExternalDataSource.objects.get(id=source_id, team_id=team_id)
+    required_by_type = {source.source_type: required_schema_names} if required_schema_names is not None else None
+    return _build_health([source], stale_threshold=stale_threshold, required_by_type=required_by_type)[0]
+
+
+def list_source_health(
+    team_id: int,
+    *,
+    source_types: list[str] | None = None,
+    stale_threshold: timedelta = DEFAULT_STALE_THRESHOLD,
+    required_schema_names_by_type: dict[str, list[str]] | None = None,
+) -> list[contracts.SourceHealth]:
+    qs = _ExternalDataSource.objects.filter(team_id=team_id).exclude(deleted=True)
+    if source_types is not None:
+        qs = qs.filter(source_type__in=source_types)
+    return _build_health(
+        list(qs.order_by("source_type", "-created_at")),
+        stale_threshold=stale_threshold,
+        required_by_type=required_schema_names_by_type,
+    )
+
+
+def _build_health(
+    sources: list[_ExternalDataSource],
+    *,
+    stale_threshold: timedelta,
+    required_by_type: dict[str, list[str] | None] | None,
+) -> list[contracts.SourceHealth]:
+    # Set-based on purpose: a fixed 3 queries for any number of sources (schemas,
+    # completed-job aggregate, newest-failed-job per source) — never per-source loops.
+    if not sources:
+        return []
+    source_ids = [s.id for s in sources]
+    now = timezone.now()
+
+    schemas_by_source: dict[UUID, list[_ExternalDataSchema]] = defaultdict(list)
+    for schema in _ExternalDataSchema.objects.filter(source_id__in=source_ids).exclude(deleted=True):
+        schemas_by_source[schema.source_id].append(schema)
+
+    completed_by_source = {
+        row["pipeline_id"]: row
+        for row in _ExternalDataJob.objects.filter(pipeline_id__in=source_ids, status=_ExternalDataJob.Status.COMPLETED)
+        .values("pipeline_id")
+        .annotate(
+            last_completed=Max("finished_at"),
+            rows_24h=Sum("rows_synced", filter=Q(finished_at__gte=now - timedelta(hours=24))),
+            rows_7d=Sum("rows_synced", filter=Q(finished_at__gte=now - timedelta(days=7))),
+        )
+    }
+    # Newest failed job with an error, per source (Postgres DISTINCT ON).
+    failed_by_source = {
+        row["pipeline_id"]: row
+        for row in _ExternalDataJob.objects.filter(
+            pipeline_id__in=source_ids,
+            status=_ExternalDataJob.Status.FAILED,
+            latest_error__isnull=False,
+        )
+        .order_by("pipeline_id", "-created_at")
+        .distinct("pipeline_id")
+        .values("pipeline_id", "created_at", "latest_error")
+    }
+
+    out: list[contracts.SourceHealth] = []
+    for source in sources:
+        completed = completed_by_source.get(source.id)
+        last_completed_at = completed["last_completed"] if completed else None
+
+        failed = failed_by_source.get(source.id)
+        # An error is only "unresolved" while no later sync has completed.
+        error_text: str | None = None
+        if failed is not None and (last_completed_at is None or failed["created_at"] > last_completed_at):
+            error_text = failed["latest_error"]
+
+        required_names = (required_by_type or {}).get(source.source_type)
+        schema_healths = _schema_healths(schemas_by_source.get(source.id, []), required_names)
+
+        out.append(
+            contracts.SourceHealth(
+                source_id=source.id,
+                team_id=source.team_id,
+                source_type=source.source_type,
+                prefix=source.prefix,
+                created_at=source.created_at,
+                sync_status=_resolve_sync_status(
+                    last_completed_at=last_completed_at,
+                    error_text=error_text,
+                    schema_healths=schema_healths,
+                    has_required_names=required_names is not None,
+                    now=now,
+                    stale_threshold=stale_threshold,
+                ),
+                last_completed_sync_at=last_completed_at,
+                last_unresolved_error=error_text,
+                rows_synced_last_24h=int((completed or {}).get("rows_24h") or 0),
+                rows_synced_last_7d=int((completed or {}).get("rows_7d") or 0),
+                schemas=schema_healths,
+            )
+        )
+    return out
+
+
+def _schema_healths(
+    schemas: list[_ExternalDataSchema], required_names: list[str] | None
+) -> list[contracts.SchemaHealth]:
+    if required_names is None:
+        return [
+            contracts.SchemaHealth(
+                schema_name=s.name,
+                present=True,
+                should_sync=s.should_sync,
+                status=s.status,
+                last_synced_at=s.last_synced_at,
+            )
+            for s in schemas
+        ]
+    by_name = {s.name: s for s in schemas}
+    out: list[contracts.SchemaHealth] = []
+    for name in required_names:
+        schema = by_name.get(name)
+        if schema is None:
+            out.append(
+                contracts.SchemaHealth(
+                    schema_name=name, present=False, should_sync=False, status=None, last_synced_at=None
+                )
+            )
+        else:
+            out.append(
+                contracts.SchemaHealth(
+                    schema_name=name,
+                    present=True,
+                    should_sync=schema.should_sync,
+                    status=schema.status,
+                    last_synced_at=schema.last_synced_at,
+                )
+            )
+    return out
+
+
+def _resolve_sync_status(
+    *,
+    last_completed_at: datetime | None,
+    error_text: str | None,
+    schema_healths: list[contracts.SchemaHealth],
+    has_required_names: bool,
+    now: datetime,
+    stale_threshold: timedelta,
+) -> contracts.SyncStatus:
+    # Schema-level states outrank job-level ones, but only against the caller's
+    # required names — without them a Failed optional schema must not mask "ok".
+    if has_required_names:
+        if any(not s.present for s in schema_healths):
+            return "tables_missing"
+        if any(s.status == _ExternalDataSchema.Status.FAILED for s in schema_healths):
+            return "tables_failed"
+        if any(s.present and not s.should_sync for s in schema_healths):
+            return "tables_disabled"
+    if error_text is not None:
+        return "error"
+    if last_completed_at is None:
+        return "never"
+    if now - last_completed_at > stale_threshold:
+        return "stale"
+    return "ok"

--- a/products/warehouse_sources/backend/facade/api.py
+++ b/products/warehouse_sources/backend/facade/api.py
@@ -48,6 +48,7 @@ __all__ = [
     "list_sources",
     "get_schema",
     "list_schemas_for_source",
+    "list_schemas",
     "get_table",
     "list_tables_for_source",
     "list_tables_by_names",
@@ -171,6 +172,25 @@ def get_schema(schema_id: UUID, team_id: int) -> contracts.ExternalDataSchema:
 
 def list_schemas_for_source(source_id: UUID, team_id: int) -> list[contracts.ExternalDataSchema]:
     qs = _ExternalDataSchema.objects.select_related("source").filter(team_id=team_id, source_id=source_id)
+    return [_to_schema(s) for s in qs]
+
+
+def list_schemas(
+    team_id: int,
+    *,
+    source_type: str | None = None,
+    should_sync: bool | None = None,
+) -> list[contracts.ExternalDataSchema]:
+    qs = (
+        _ExternalDataSchema.objects.select_related("source")
+        .filter(team_id=team_id)
+        .exclude(deleted=True)
+        .exclude(source__deleted=True)
+    )
+    if source_type is not None:
+        qs = qs.filter(source__source_type=source_type)
+    if should_sync is not None:
+        qs = qs.filter(should_sync=should_sync)
     return [_to_schema(s) for s in qs]
 
 

--- a/products/warehouse_sources/backend/facade/contracts.py
+++ b/products/warehouse_sources/backend/facade/contracts.py
@@ -17,6 +17,7 @@ demand map). The HogQL system-table model classes cross the boundary as objects 
 """
 
 from datetime import datetime, time, timedelta
+from typing import Literal
 from uuid import UUID
 
 from pydantic.dataclasses import dataclass
@@ -150,3 +151,51 @@ class DataWarehouseCredential:
     id: UUID
     team_id: int
     created_at: datetime
+
+
+# --- Source health (sync-status rollup) ---
+
+# Resolution order (strictest first): tables_missing > tables_failed > tables_disabled
+# > error > never > stale > ok. The tables_* states only arise when the caller supplied
+# required schema names; a source that doesn't exist is the caller's "not connected",
+# never a value here — health is only computed for real sources.
+SyncStatus = Literal[
+    "ok",
+    "stale",
+    "error",
+    "never",
+    "tables_failed",
+    "tables_disabled",
+    "tables_missing",
+]
+
+
+@dataclass(frozen=True)
+class SchemaHealth:
+    """Per-schema sync state inside a source health rollup. When the health call was
+    given required schema names, absent names appear with ``present=False``."""
+
+    schema_name: str
+    present: bool
+    should_sync: bool
+    status: str | None
+    last_synced_at: datetime | None
+
+
+@dataclass(frozen=True)
+class SourceHealth:
+    """The read behind "is my imported data fresh, and if not, why?"."""
+
+    source_id: UUID
+    team_id: int
+    source_type: str
+    prefix: str | None
+    created_at: datetime
+    sync_status: SyncStatus
+    last_completed_sync_at: datetime | None
+    # Latest FAILED job's error, only when it is newer than the last completed sync —
+    # an error that a later successful sync resolved is not surfaced.
+    last_unresolved_error: str | None
+    rows_synced_last_24h: int
+    rows_synced_last_7d: int
+    schemas: list[SchemaHealth]

--- a/products/warehouse_sources/backend/facade/types.py
+++ b/products/warehouse_sources/backend/facade/types.py
@@ -19,8 +19,21 @@ from products.warehouse_sources.backend.types import (
 __all__ = [
     "DIRECT_ENGINE_BY_SOURCE_TYPE",
     "DataWarehouseManagedViewSetKind",
+    "ExternalDataSchemaStatus",  # noqa: F822 — resolved lazily via __getattr__ below
     "ExternalDataSourceType",
     "IncrementalField",
     "IncrementalFieldType",
     "PartitionSettings",
 ]
+
+
+def __getattr__(name: str):
+    # Status choices live on the Django model; resolve lazily so this module stays
+    # importable before django.setup() (it is on the startup path for config consumers).
+    if name == "ExternalDataSchemaStatus":
+        from products.warehouse_sources.backend.models.external_data_schema import (  # noqa: PLC0415 — keeps the model off the pre-setup import path
+            ExternalDataSchema,
+        )
+
+        return ExternalDataSchema.Status
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/products/warehouse_sources/backend/tests/test_facade.py
+++ b/products/warehouse_sources/backend/tests/test_facade.py
@@ -1,6 +1,12 @@
 import uuid
+from datetime import timedelta
 
+from freezegun import freeze_time
 from posthog.test.base import BaseTest
+
+from django.utils import timezone
+
+from parameterized import parameterized
 
 from posthog.models import Team
 
@@ -104,6 +110,143 @@ class TestWarehouseSourcesFacade(BaseTest):
         other_team = Team.objects.create(organization=self.organization, name="other")
         with self.assertRaises(ExternalDataSource.DoesNotExist):
             api.get_source(self.source.id, other_team.pk)
+
+    def _job(
+        self,
+        status: str,
+        *,
+        finished_ago: timedelta | None = None,
+        created_ago: timedelta = timedelta(hours=1),
+        error: str | None = None,
+        rows: int = 0,
+        source: ExternalDataSource | None = None,
+    ) -> ExternalDataJob:
+        job = ExternalDataJob.objects.create(
+            team_id=self.team.pk,
+            pipeline=source or self.source,
+            schema=self.schema,
+            status=status,
+            schema_snapshot={},
+            rows_synced=rows,
+            latest_error=error,
+            finished_at=None if finished_ago is None else timezone.now() - finished_ago,
+        )
+        # created_at is auto_now_add; the error-resolution rule orders on it.
+        ExternalDataJob.objects.filter(id=job.id).update(created_at=timezone.now() - created_ago)
+        return job
+
+    @parameterized.expand(
+        [
+            ("no_jobs_is_never", [], "never", None),
+            ("recent_completed_is_ok", [("Completed", timedelta(minutes=10), None)], "ok", None),
+            ("old_completed_is_stale", [("Completed", timedelta(hours=25), None)], "stale", None),
+            (
+                "failed_after_completed_is_error",
+                [("Completed", timedelta(hours=2), None), ("Failed", timedelta(hours=1), "boom")],
+                "error",
+                "boom",
+            ),
+            (
+                "completed_after_failed_resolves_error",
+                [("Failed", timedelta(hours=2), "boom"), ("Completed", timedelta(hours=1), None)],
+                "ok",
+                None,
+            ),
+        ]
+    )
+    @freeze_time("2026-06-15")
+    def test_source_health_job_states(self, _name, jobs, expected_status, expected_error) -> None:
+        for status, ago, error in jobs:
+            self._job(status, finished_ago=ago if status == "Completed" else None, created_ago=ago, error=error)
+
+        health = api.get_source_health(self.source.id, self.team.pk)
+
+        assert health.sync_status == expected_status
+        assert health.last_unresolved_error == expected_error
+
+    @parameterized.expand(
+        [
+            ("required_name_absent_is_tables_missing", ["users", "orders"], None, True, "tables_missing"),
+            (
+                "required_schema_failed_is_tables_failed",
+                ["users"],
+                ExternalDataSchema.Status.FAILED,
+                True,
+                "tables_failed",
+            ),
+            ("required_schema_disabled_is_tables_disabled", ["users"], None, False, "tables_disabled"),
+        ]
+    )
+    @freeze_time("2026-06-15")
+    def test_source_health_required_schema_states(
+        self, _name, required_names, schema_status, should_sync, expected_status
+    ) -> None:
+        if schema_status is not None:
+            self.schema.status = schema_status
+        self.schema.should_sync = should_sync
+        self.schema.save()
+        # A recent successful sync must NOT mask required-table problems.
+        self._job("Completed", finished_ago=timedelta(minutes=10))
+
+        health = api.get_source_health(self.source.id, self.team.pk, required_schema_names=required_names)
+
+        assert health.sync_status == expected_status
+        assert {s.schema_name for s in health.schemas} == set(required_names)
+
+    @freeze_time("2026-06-15")
+    def test_source_health_without_required_names_ignores_failed_optional_schema(self) -> None:
+        self.schema.status = ExternalDataSchema.Status.FAILED
+        self.schema.save()
+        self._job("Completed", finished_ago=timedelta(minutes=10))
+
+        health = api.get_source_health(self.source.id, self.team.pk)
+
+        assert health.sync_status == "ok"
+        assert [s.schema_name for s in health.schemas] == ["users"]
+
+    @freeze_time("2026-06-15")
+    def test_source_health_row_windows(self) -> None:
+        self._job("Completed", finished_ago=timedelta(hours=1), rows=100)
+        self._job("Completed", finished_ago=timedelta(days=3), rows=40)
+        self._job("Completed", finished_ago=timedelta(days=10), rows=7)
+
+        health = api.get_source_health(self.source.id, self.team.pk)
+
+        assert health.rows_synced_last_24h == 100
+        assert health.rows_synced_last_7d == 140
+
+    @freeze_time("2026-06-15")
+    def test_list_source_health_attributes_jobs_to_the_right_source(self) -> None:
+        other = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Stripe",
+        )
+        self._job("Completed", finished_ago=timedelta(minutes=10), rows=100)
+        self._job("Failed", created_ago=timedelta(minutes=5), error="stripe down", source=other)
+
+        healths = {h.source_id: h for h in api.list_source_health(self.team.pk)}
+
+        assert healths[self.source.id].sync_status == "ok"
+        assert healths[self.source.id].rows_synced_last_24h == 100
+        assert healths[other.id].sync_status == "error"
+        assert healths[other.id].last_unresolved_error == "stripe down"
+
+    def test_list_jobs_for_source_is_bounded_and_get_latest_job_orders_by_created(self) -> None:
+        oldest = self._job("Completed", finished_ago=timedelta(hours=3), created_ago=timedelta(hours=3))
+        middle = self._job("Failed", created_ago=timedelta(hours=2), error="x")
+        newest = self._job("Completed", finished_ago=timedelta(hours=1), created_ago=timedelta(hours=1))
+
+        limited = api.list_jobs_for_source(self.source.id, self.team.pk, limit=2)
+        assert [j.id for j in limited] == [newest.id, middle.id]
+
+        latest = api.get_latest_job(self.team.pk, source_id=self.source.id)
+        assert latest is not None and latest.id == newest.id
+        latest_completed = api.get_latest_job(self.team.pk, source_id=self.source.id, status="Completed")
+        assert latest_completed is not None and latest_completed.id == newest.id
+        assert oldest.id not in {j.id for j in limited}
 
 
 def test_hogql_reexports_are_the_model_classes() -> None:

--- a/products/warehouse_sources/backend/tests/test_facade.py
+++ b/products/warehouse_sources/backend/tests/test_facade.py
@@ -234,6 +234,31 @@ class TestWarehouseSourcesFacade(BaseTest):
         assert healths[other.id].sync_status == "error"
         assert healths[other.id].last_unresolved_error == "stripe down"
 
+    def test_list_schemas_filters_by_source_type_and_excludes_deleted_sources(self) -> None:
+        deleted_source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Postgres",
+            deleted=True,
+        )
+        ExternalDataSchema.objects.create(team_id=self.team.pk, source=deleted_source, name="ghost", should_sync=True)
+        stripe_source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Stripe",
+        )
+        ExternalDataSchema.objects.create(team_id=self.team.pk, source=stripe_source, name="charges", should_sync=True)
+
+        postgres_schemas = api.list_schemas(self.team.pk, source_type="Postgres")
+        assert [s.name for s in postgres_schemas] == ["users"]
+
+        all_schemas = api.list_schemas(self.team.pk)
+        assert {s.name for s in all_schemas} == {"users", "charges"}
+
     def test_list_jobs_for_source_is_bounded_and_get_latest_job_orders_by_created(self) -> None:
         oldest = self._job("Completed", finished_ago=timedelta(hours=3), created_ago=timedelta(hours=3))
         middle = self._job("Failed", created_ago=timedelta(hours=2), error="x")


### PR DESCRIPTION
## Problem

Other products that need warehouse source data keep reaching past the facade into ORM internals, and "get source/schema sync status" is the read they most often hand-roll. Marketing analytics computed source health with its own per-source job queries, signals and the Max SQL tool queried schemas/sources through ORM re-exports, and the facade offered no health/freshness capability at all.

## Changes

- New contracts in the warehouse_sources facade: `SyncStatus`, `SchemaHealth`, `SourceHealth` (frozen, framework-free, no secrets).
- New facade reads: `get_source_health` / `list_source_health` (sync-status rollup, last unresolved error, 24h/7d row counts, optional required-schema checks), `get_latest_job`, `list_schemas(team_id, source_type=...)`, `list_tables_by_names`, `list_schemas_for_tables`, plus a lazy `ExternalDataSchemaStatus` re-export in `facade/types.py` (PEP 562, stays off the pre-setup import path).
- `list_jobs_for_source` is now bounded (`limit=100` default, `limit=None` opt-out).
- Three consumers migrated off ORM access onto contracts:
  - Marketing analytics `data_source_health` drops its four ORM helpers and consumes `list_source_health`; product layer (display names, diagnosis copy, URLs) unchanged.
  - Signals `_get_data_import_status` consumes `list_schemas` + the status enum re-export. Minor deliberate fix: soft-deleted schemas no longer count toward the status rollup.
  - Max AI `execute_sql` tool's `_existing_source_types` consumes `list_sources`.

### Migration coverage map

Every known out-of-facade consumer, with status:

| Consumer | Status |
|---|---|
| Marketing analytics source health | migrated (this PR) |
| Signals data-import status | migrated (this PR) |
| Max AI `execute_sql` source types | migrated (this PR) |
| Signals sync trigger | blocked: feeds an ORM schema into `trigger_external_data_workflow`; needs an id-taking operational facade fn |
| Max AI `read_data` semantics | blocked: per-user RBAC on the queryset (`filter_queryset_by_access_level`) + `schema.foreign_keys` not in contracts; needs the ACL-aware facade design, not a drive-by |
| Engineering analytics job-logs coordinator | blocked: needs encrypted `job_inputs` + team relation, excluded from contracts by design; needs a purpose-built capability |
| Weekly digest new-sources query | deferred: cross-team QuerySet threaded through shared digest machinery |
| `usage_report` billing aggregate | deferred: billing path, deserves its own careful PR |
| HogQL database builder + ducklake binding | intentionally exempt: query-time hot paths; stay on the sanctioned `facade/models.py` object-passing surface |

### Performance analysis of the migration

The health computation is set-based on purpose, a fixed 3 queries regardless of source count (schemas, one completed-job aggregate with filtered sums, one newest-failed-job per source via Postgres `DISTINCT ON`):

| Path | Before | After |
|---|---|---|
| Marketing analytics health, N native sources | 1 + 4N queries | 4 queries total |
| N = 8 native ad platforms | ~33 queries | 4 queries |
| Signals data-import status | 1 query (values_list) | 1 query + contract mapping (schema counts are tens) |
| Max AI source types | 1 query (values_list) | 1 query + contract mapping (source counts are tens) |

Contract construction adds one frozen pydantic object per row (microseconds at these row counts). The unbounded-list trap is closed before anything relies on it: `get_latest_job` plus the default limit on `list_jobs_for_source` prevent "latest job" callers from materializing thousands of contracts.

> [!NOTE]
> The blocked/deferred/exempt rows above are deliberate: hot paths keep ORM object-passing, RBAC and encrypted-config consumers need designed capabilities (that design is tracked in the warehouse platform plan), and billing gets its own PR.

## How did you test this code?

- `pytest products/warehouse_sources/backend/tests/test_facade.py` (22 passed): parameterized decision-table cases for the sync-status rollup (never/ok/stale/error, error-resolved-by-later-success), required-schema states (missing/failed/disabled must not be masked by a recent successful sync), row-count windows, multi-source attribution in `list_source_health` (guards DISTINCT ON/aggregate misattribution), job limit/latest ordering, and `list_schemas` source-type filtering + deleted-source exclusion (guards deleted sources' schemas resurfacing in signals' status).
- `pytest products/marketing_analytics/backend/services/test_data_source_health.py` (14 passed): existing orchestration suite as the migration's parity guard; mocks moved from five private ORM helpers to the two remaining seams.
- `pytest products/signals/backend/test/test_source_config_status.py` (8 passed) and `pytest ee/hogai/tools/execute_sql/test/test_import_suggestions.py` (17 passed): existing suites guarding the two other migrated consumers, unchanged.
- Not done: no manual UI verification of the marketing analytics settings page or signals config page; behavior is covered by the suites above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal facade surface, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code session driven by Daniel) as the first slice of the warehouse facade read API. Skills invoked: `/writing-tests`. Decisions: absorbed marketing analytics' status-resolution semantics verbatim into the facade (resolution order documented on the contract); rewrote the health computation set-based instead of wrapping the absorbed per-source helpers; audited every out-of-facade consumer and migrated the three clean ones, documenting why each remaining one is blocked, deferred, or exempt rather than forcing a generic contract through RBAC, encrypted-config, or hot-path constraints. A first attempt re-exported the schema status enum eagerly and broke pre-django.setup imports; switched to a lazy PEP 562 re-export.
