### PR TITLE
chore(cli): reconcile changelog with actually published versions

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -26,15 +26,17 @@
 
 ## 0.8.1 — 2026-07-06
 
+### Minor changes
+
+- [066d914497](https://github.com/PostHog/posthog/commit/066d9144970955eaf366ff2a8be818460c6ad759) `symbol-sets upload` now also accepts Apple `.dSYM` bundles, packaging them through the same path as `dsym upload` (uppercase UUID chunk_ids, `AppleDsym` container). A single `posthog-cli symbol-sets upload --directory <dir>` run uploads both Linux ELF debug symbols and macOS dSYMs, so native symbol uploads no longer need a different command per platform. The dSYM branch shells out to `dwarfdump` (Xcode, macOS-only); when it is unavailable the bundle is reported and skipped while ELF symbols in the same directory still upload. The standalone `dsym upload` command is unchanged. — Thanks @cat-ph!
+
 ### Patch changes
 
 - [d57bdcce6d](https://github.com/PostHog/posthog/commit/d57bdcce6dc77adde629de5ffbbad10a6a99b850) Capture CLI errors with PostHog telemetry — Thanks @hpouillot!
 
 ## 0.8.0 — 2026-07-03
 
-### Minor changes
-
-- [066d914497](https://github.com/PostHog/posthog/commit/066d9144970955eaf366ff2a8be818460c6ad759) `symbol-sets upload` now also accepts Apple `.dSYM` bundles, packaging them through the same path as `dsym upload` (uppercase UUID chunk_ids, `AppleDsym` container). A single `posthog-cli symbol-sets upload --directory <dir>` run uploads both Linux ELF debug symbols and macOS dSYMs, so native symbol uploads no longer need a different command per platform. The dSYM branch shells out to `dwarfdump` (Xcode, macOS-only); when it is unavailable the bundle is reported and skipped while ELF symbols in the same directory still upload. The standalone `dsym upload` command is unchanged. — Thanks @cat-ph!
+_Never published: the release pipeline's Windows build failed after the version bump landed, so no tag, GitHub release, or npm package exists for this version. Its changes first shipped in 0.8.1._
 
 ## 0.7.34 — 2026-06-30
 
@@ -54,12 +56,11 @@
 ### Patch changes
 
 - [6fb4456e8f](https://github.com/PostHog/posthog/commit/6fb4456e8f9a5048b3db6ceb6d873241e14fe6b8) Fix the CLI release workflow so the Windows (`x86_64-pc-windows-msvc`) build succeeds and ships with each release. — Thanks @cat-ph!
+- [dfd1f66a9f](https://github.com/PostHog/posthog/commit/dfd1f66a9f0a5ae4e492887c79921b0692c97d51) Add `symbol-sets upload` for native (ELF) debug symbols: it scans a directory for executables, shared libraries, and `objcopy --only-keep-debug` companions that carry a GNU build id and uploads them to PostHog. — Thanks @cat-ph!
 
 ## 0.7.31 — 2026-06-24
 
-### Patch changes
-
-- [dfd1f66a9f](https://github.com/PostHog/posthog/commit/dfd1f66a9f0a5ae4e492887c79921b0692c97d51) Add `symbol-sets upload` for native (ELF) debug symbols: it scans a directory for executables, shared libraries, and `objcopy --only-keep-debug` companions that carry a GNU build id and uploads them to PostHog. — Thanks @cat-ph!
+_Never published: the release pipeline's Windows build failed after the version bump landed, so no tag, GitHub release, or npm package exists for this version. Its changes first shipped in 0.7.32._
 
 ## 0.7.30 — 2026-06-22
 


### PR DESCRIPTION
## Problem

`cli/CHANGELOG.md` lists two versions that were never published. The `Release CLI` workflow commits the version bump and changelog before cargo-dist builds, so when the Windows build job failed, the changelog kept the version while no tag, GitHub release, or npm package was ever created:

- **0.7.31** (2026-06-24): the Windows `build-local-artifacts` job failed because the node-gyp step didn't run under bash ([run](https://github.com/PostHog/posthog/actions/runs/28106409428), fixed by #65870, shipped as 0.7.32 the same day).
- **0.8.0** (2026-07-03): the Windows job failed at checkout on `clickhouse/hcl/roles/aux/` because `aux` is a reserved filename on Windows ([run](https://github.com/PostHog/posthog/actions/runs/28660623554), fixed by the rename in 1593d53b627, shipped as 0.8.1).

Both root causes are fixed and recent Windows builds succeed. But anyone using the changelog to answer "which version first has feature X" gets versions they can't install: this bit the Rust symbol-upload docs (PostHog/posthog.com#18705), which initially pointed users at v0.7.31/v0.8.0 release links that 404.

## Changes

- Moved the 0.7.31 entry (ELF `symbol-sets upload`) under 0.7.32 and the 0.8.0 entry (dSYM bundles in `symbol-sets upload`) under 0.8.1, the versions that actually first shipped them.
- Left the phantom version headers in place with a one-line note explaining they were never published and where their changes shipped, so references to those version numbers still resolve to an answer.

No changesets: this is a manual correction to already-released sections. Sampo prepends new sections, so editing history is safe, and the release workflow's changed-files guard doesn't parse changelog content.

## How did you test this code?

Docs-only change. Verified against reality: `git tag -l 'posthog-cli/v*'`, `gh release view`, and the npm registry all confirm 0.7.31 and 0.8.0 don't exist while 0.7.32 and 0.8.1 do. `hogli ci:preflight --fix` passes (markdown-format clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact beyond the changelog itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Catalin asked why the CLI changelog disagreed with published versions; I (Claude) traced both phantom versions through the `Release CLI` run history to their failed Windows jobs, then made this correction on request. The alternative considered was annotating the phantom headers without moving entries, but that keeps the feature-to-version mapping wrong for anyone scanning section headers, so entries were folded into the first shipped version with tombstone notes preserving greppability.
