### PR TITLE
fix(insights): clip metric tile viz to remove permanent scrollbar

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -63,6 +63,14 @@
     &--resizing {
         overflow: hidden;
     }
+
+    // The Metric display bleeds its sparkline to the card edges (negative margins plus a
+    // few-pixel downward shift so the line rests on the edge), so its content sits a hair
+    // taller than the box. Clip it — otherwise `overflow: auto` shows a permanent vertical
+    // scrollbar that overlaps the chart's rightmost points and blocks hover there.
+    &--Metric {
+        overflow: hidden;
+    }
 }
 
 .InsightCard__vizInner {


### PR DESCRIPTION
## Problem

On a dashboard, a trends insight using the Metric display (a headline number with a sparkline underneath, like "439 K / Total") always showed a vertical scrollbar pinned to the right edge of the tile. On macOS that overlay scrollbar floats over the chart's rightmost points and blocks hover there, so you can't inspect the most recent periods. Raising the tile height did not help. Reported via support.

## Changes

The Metric display bleeds its sparkline to the card edges on purpose (negative margins plus a few-pixel downward shift so the line rests on the edge), which makes its content a hair taller than the box. `.InsightCard__viz` uses `overflow: auto`, so that constant overshoot permanently tripped a vertical scrollbar.

The `.InsightCard__viz--Metric` class was already emitted by `Trends.tsx` for embedded (dashboard) tiles but had no rule. Setting it to `overflow: hidden` clips the intentional edge bleed instead of scrolling it, matching how the standalone quill `Metric` lives inside an `overflow: hidden` `<Card flush>`. Scoped to the Metric display only, so other tile types keep `overflow: auto`.

```diff
 &--resizing {
     overflow: hidden;
 }
+
+&--Metric {
+    overflow: hidden;
+}
```

## How did you test this code?

Manual: I verified on my local that a dashboard Metric tile no longer shows the scrollbar and that hover works across the most recent periods.

No automated test: this is a one-line CSS overflow rule with no meaningful unit-test surface, and there is no existing Storybook fixture for the Metric display in an InsightCard. Claude ran our repo code-reviewer agent over the change and it was approved (selector and specificity correct, tooltips portal out of the box so nothing gets clipped, and clipping the inner viz keeps the outer container from scrolling too). Claude could not capture an automated before/after screenshot without seeding a Metric dashboard tile, so it relied on my manual check.

No screenshots attached: the reporter's screenshot contains customer data, so it is not being uploaded to the public PR-assets repo.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drove this from a support ticket; Claude (PostHog Code, Opus 4.8) did the investigation and the edit. Skills and agents used: the `verify` skill and the repo `code-reviewer` agent. No backend or domain skills applied since this is a pure frontend CSS change.

Notable decisions: Claude traced the always-on scrollbar to a constant few-pixel content overshoot in the Metric / MetricSparkline composition rather than a height-dependent one, which is why raising the tile height never helped. It considered splitting `overflow` into `overflow-x: hidden; overflow-y: auto` on the shared `.InsightCard__viz`, but rejected that as broader than needed (and it would still leave an empty gutter). Scoping `overflow: hidden` to `.InsightCard__viz--Metric` fixes the reported case without changing other display types.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
