### PR TITLE
feat(autoresearch): heal dead connections before migration test classes

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -1554,6 +1554,18 @@ class BaseTestMigrations(QueryMatchingTest):
     apps: Optional[Any] = None
     assert_snapshots = False
 
+    @classmethod
+    def setUpClass(cls):
+        # An earlier test in the same process can leave a connection's underlying psycopg
+        # connection closed (e.g. dropped server-side) without Django noticing. Every
+        # migration test in the class then fails with "the connection is closed", and
+        # in-process reruns reuse the same dead wrapper, so they can never recover.
+        # Reset unusable connections before the class transaction machinery starts.
+        for conn in connections.all():
+            if conn.connection is not None and not conn.is_usable():
+                conn.close()
+        super().setUpClass()
+
     def setUp(self):
         assert hasattr(self, "migrate_from") and hasattr(self, "migrate_to"), (
             "TestCase '{}' must define migrate_from and migrate_to properties".format(type(self).__name__)


### PR DESCRIPTION
## Problem

`TestMigrations` subclasses fail intermittently in CI with `django.db.utils.OperationalError: the connection is closed`.
The failure is not caused by the PR being tested. It recurs across many unrelated PR branches, currently via the warehouse-sources product-test shard (`test_migration_0028.py`, `test_migration_0052.py`), and is one of the largest single contributors to Backend CI reds.

The mechanism. When a database connection drops server-side between test classes, Django's connection wrapper still holds the dead psycopg connection and doesn't know it's unusable. The next `TestMigrations` class enters its class transaction machinery on that dead wrapper and every test in the class fails. In-process retries (pytest-rerunfailures) reuse the same dead wrapper, so the `RERUN`, `RERUN`, `FAILED` pattern in the logs can never recover. A normal Django `TestCase` heals this on its atomics' exception path, which is why the poison only surfaces on migration test classes.

Created with Autoresearch.

## Changes

Add a `setUpClass` hook on `BaseTestMigrations` that health-checks all connections and resets any that are unusable, before the class transaction machinery starts. `is_usable()` is Django's own liveness probe (a `SELECT 1`), and `close()` on a dead wrapper makes the next use reconnect. When connections are healthy this costs one trivial query per class.

## How did you test this code?

I (Claude, in an autoresearch session) reproduced the failure mode red-green locally with a throwaway `TestMigrations` subclass whose `setUpClass` closes the raw psycopg connection underneath Django before calling `super()`, simulating the server-side drop:

- without this fix: `ERROR ... django.db.utils.OperationalError: the connection is closed` (the exact CI signature)
- with this fix: the test passes and the migration machinery runs normally

I didn't commit the repro as a permanent test: it costs ~100s of runtime (it runs real migrations) for an 8-line infra guard, which fails the test-efficiency bar. The two affected migration test files also pass locally with the fix in place.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, test-infrastructure-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code) during an autoresearch session on CI reliability, directed by Daniel Visca.
- The flake was identified and sized from the engineering-analytics MCP tools (`broken-tests`, `run-failure-logs`, `workflow-health`): the connection-closed signature family was the top cross-PR flaky group over the last 2 days.
- Decisions: hooked `setUpClass` rather than `setUp` because the class atomics enter before `setUp` runs, so a `setUp`-level reset would be too late. Guarded with `is_usable()` so healthy runs pay one `SELECT 1` per class instead of a reconnect. A first repro attempt with a plain poisoned `TestCase` self-healed via Django's atomics error path, which narrowed the real-world trigger to drops that happen between classes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
