### PR TITLE
fix(cdp): don't record poisoned rerun wrappers as replayable invocations

### DIFF
--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1763,7 +1763,10 @@ describe('Cyclotron V2', () => {
             const defaults = {
                 team_id: 1,
                 function_id: null,
-                queue_name: QUEUE,
+                // Default to a real invocation queue so a poisoned genuine invocation is recorded.
+                // The janitor only records give-ups on invocation queues; anything else is a
+                // wrapper/meta job that's dropped without a record (see WRAPPER drop tests below).
+                queue_name: 'hogflow',
                 status: 'available',
                 priority: 0,
                 scheduled: new Date(),
@@ -1982,7 +1985,11 @@ describe('Cyclotron V2', () => {
         // Both meta/wrapper queues share cyclotron_jobs with real invocations and
         // stamp function_id to a target function, so both must be dropped without a
         // record — else the autodrain replays a real flow with fabricated globals.
-        it.each(['rerun', 'hogflow_batch_resolve'])(
+        // 'some_future_meta_queue' is an unknown, non-invocation queue: it guards the allow-list's
+        // fail-safe. Under the old deny-list a queue nobody listed would be RECORDED as a replayable
+        // hog_flow (the autodrain would then replay a phantom flow) — with the allow-list any queue
+        // not in CYCLOTRON_INVOCATION_JOB_QUEUES is dropped without a record by default.
+        it.each(['rerun', 'hogflow_batch_resolve', 'some_future_meta_queue'])(
             'drops a poisoned %s wrapper without recording it, still records real invocations',
             async (wrapperQueue) => {
                 const staleHeartbeat = new Date(Date.now() - 60_000)

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1979,47 +1979,52 @@ describe('Cyclotron V2', () => {
             expect(await totalJobCount()).toBe(0)
         })
 
-        it('drops a poisoned rerun wrapper without recording it, still records real invocations', async () => {
-            const staleHeartbeat = new Date(Date.now() - 60_000)
-            const wrapperId = uuidv7()
-            const invocationId = uuidv7()
-            // A poisoned rerun WRAPPER job (queue_name='rerun') and a genuine
-            // poisoned invocation, in the same sweep.
-            await insertRawJob({
-                id: wrapperId,
-                function_id: uuidv7(),
-                queue_name: 'rerun',
-                status: 'running',
-                lock_id: uuidv7(),
-                last_heartbeat: staleHeartbeat,
-                janitor_touch_count: 3,
-            })
-            await insertRawJob({
-                id: invocationId,
-                function_id: uuidv7(),
-                status: 'running',
-                lock_id: uuidv7(),
-                last_heartbeat: staleHeartbeat,
-                janitor_touch_count: 3,
-            })
+        // Both meta/wrapper queues share cyclotron_jobs with real invocations and
+        // stamp function_id to a target function, so both must be dropped without a
+        // record — else the autodrain replays a real flow with fabricated globals.
+        it.each(['rerun', 'hogflow_batch_resolve'])(
+            'drops a poisoned %s wrapper without recording it, still records real invocations',
+            async (wrapperQueue) => {
+                const staleHeartbeat = new Date(Date.now() - 60_000)
+                const wrapperId = uuidv7()
+                const invocationId = uuidv7()
+                // A poisoned WRAPPER job and a genuine poisoned invocation, same sweep.
+                await insertRawJob({
+                    id: wrapperId,
+                    function_id: uuidv7(),
+                    queue_name: wrapperQueue,
+                    status: 'running',
+                    lock_id: uuidv7(),
+                    last_heartbeat: staleHeartbeat,
+                    janitor_touch_count: 3,
+                })
+                await insertRawJob({
+                    id: invocationId,
+                    function_id: uuidv7(),
+                    status: 'running',
+                    lock_id: uuidv7(),
+                    last_heartbeat: staleHeartbeat,
+                    janitor_touch_count: 3,
+                })
 
-            const { service, recordTerminalFailureDurably } = createMockResults(true)
-            const janitor = createJanitor({ stallTimeoutMs: 1_000, maxTouchCount: 2 }, service)
-            const result = await janitor.runOnce()
-            await janitor.stop()
+                const { service, recordTerminalFailureDurably } = createMockResults(true)
+                const janitor = createJanitor({ stallTimeoutMs: 1_000, maxTouchCount: 2 }, service)
+                const result = await janitor.runOnce()
+                await janitor.stop()
 
-            // The wrapper is dropped with NO replay record — recording it would let
-            // the autodrain rediscover it as a hog_flow and replay a real flow with
-            // fabricated globals. Only the genuine invocation is recorded.
-            expect(recordTerminalFailureDurably).toHaveBeenCalledTimes(1)
-            expect(recordTerminalFailureDurably).toHaveBeenCalledWith(
-                expect.objectContaining({ id: invocationId }),
-                expect.anything()
-            )
-            expect(result.poisonedIds).toEqual([invocationId])
-            // Both cyclotron rows are gone — the wrapper is given up on, just untraced.
-            expect(await totalJobCount()).toBe(0)
-        })
+                // The wrapper is dropped with NO replay record — recording it would let
+                // the autodrain rediscover it as a hog_flow and replay a real flow with
+                // fabricated globals. Only the genuine invocation is recorded.
+                expect(recordTerminalFailureDurably).toHaveBeenCalledTimes(1)
+                expect(recordTerminalFailureDurably).toHaveBeenCalledWith(
+                    expect.objectContaining({ id: invocationId }),
+                    expect.anything()
+                )
+                expect(result.poisonedIds).toEqual([invocationId])
+                // Both cyclotron rows are gone — the wrapper is given up on, just untraced.
+                expect(await totalJobCount()).toBe(0)
+            }
+        )
 
         it('keeps a poison pill (does not delete) when the recovery record cannot be produced', async () => {
             const staleHeartbeat = new Date(Date.now() - 60_000)

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1979,6 +1979,48 @@ describe('Cyclotron V2', () => {
             expect(await totalJobCount()).toBe(0)
         })
 
+        it('drops a poisoned rerun wrapper without recording it, still records real invocations', async () => {
+            const staleHeartbeat = new Date(Date.now() - 60_000)
+            const wrapperId = uuidv7()
+            const invocationId = uuidv7()
+            // A poisoned rerun WRAPPER job (queue_name='rerun') and a genuine
+            // poisoned invocation, in the same sweep.
+            await insertRawJob({
+                id: wrapperId,
+                function_id: uuidv7(),
+                queue_name: 'rerun',
+                status: 'running',
+                lock_id: uuidv7(),
+                last_heartbeat: staleHeartbeat,
+                janitor_touch_count: 3,
+            })
+            await insertRawJob({
+                id: invocationId,
+                function_id: uuidv7(),
+                status: 'running',
+                lock_id: uuidv7(),
+                last_heartbeat: staleHeartbeat,
+                janitor_touch_count: 3,
+            })
+
+            const { service, recordTerminalFailureDurably } = createMockResults(true)
+            const janitor = createJanitor({ stallTimeoutMs: 1_000, maxTouchCount: 2 }, service)
+            const result = await janitor.runOnce()
+            await janitor.stop()
+
+            // The wrapper is dropped with NO replay record — recording it would let
+            // the autodrain rediscover it as a hog_flow and replay a real flow with
+            // fabricated globals. Only the genuine invocation is recorded.
+            expect(recordTerminalFailureDurably).toHaveBeenCalledTimes(1)
+            expect(recordTerminalFailureDurably).toHaveBeenCalledWith(
+                expect.objectContaining({ id: invocationId }),
+                expect.anything()
+            )
+            expect(result.poisonedIds).toEqual([invocationId])
+            // Both cyclotron rows are gone — the wrapper is given up on, just untraced.
+            expect(await totalJobCount()).toBe(0)
+        })
+
         it('keeps a poison pill (does not delete) when the recovery record cannot be produced', async () => {
             const staleHeartbeat = new Date(Date.now() - 60_000)
             const jobId = uuidv7()

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -6,6 +6,7 @@ import { logger } from '~/common/utils/logger'
 
 import { RERUN_QUEUE_NAME } from '../../rerun/rerun-job.types'
 import { CyclotronJobInvocationHogFlow } from '../../types'
+import { HOGFLOW_BATCH_RESOLVE_QUEUE } from '../hogflows/batch-resolver.types'
 import { v2JobToInvocation } from '../job-queue/job-queue-postgres-v2'
 import { HogInvocationResultsService } from '../monitoring/hog-invocation-results.service'
 import { CyclotronV2CleanupResult, CyclotronV2DequeuedJob, CyclotronV2JanitorConfig } from './types'
@@ -14,6 +15,14 @@ import { CyclotronV2CleanupResult, CyclotronV2DequeuedJob, CyclotronV2JanitorCon
 // the janitor writes when it gives up on a poison pill. Lets operators target
 // exactly these give-ups from the rerun tooling (rerun filter `error_kind`).
 export const JANITOR_POISON_PILL_ERROR_KIND = 'janitor_poison_pill'
+
+// Queues that carry non-invocation "wrapper" / meta jobs — they share the
+// cyclotron_jobs table with real invocations, but their `function_id` points at a
+// target function and their `state` is not an invocation. The janitor must NOT
+// record their give-ups as replayable invocation results (that would let the
+// autodrain replay a real flow with fabricated globals — see recordAndDeletePoisonPills);
+// it gives up on them without a record instead. Add any new wrapper queue here.
+const WRAPPER_QUEUE_NAMES: string[] = [RERUN_QUEUE_NAME, HOGFLOW_BATCH_RESOLVE_QUEUE]
 
 // The first stall gets only this small jittered delay (not the full exponential
 // base), so a transient stall — a worker restart/deploy, where a healthy worker
@@ -43,9 +52,9 @@ const janitorGiveUpSkippedCounter = new Counter({
     help: 'Poison pills the janitor could not record a recovery row for, so kept (not deleted)',
 })
 
-const janitorRerunWrapperDroppedCounter = new Counter({
-    name: 'cdp_cyclotron_v2_janitor_rerun_wrapper_dropped',
-    help: 'Poisoned rerun wrapper jobs dropped without a replay record (a wrapper is a meta-job, not a replayable invocation)',
+const janitorWrapperDroppedCounter = new Counter({
+    name: 'cdp_cyclotron_v2_janitor_wrapper_dropped',
+    help: 'Poisoned wrapper/meta jobs dropped without a replay record (a wrapper is not a replayable invocation)',
 })
 
 const janitorRunCounter = new Counter({
@@ -247,15 +256,15 @@ export class CyclotronV2Janitor {
     private async recordAndDeletePoisonPills(): Promise<string[]> {
         const heartbeatCutoff = new Date(Date.now() - this.stallTimeoutMs)
 
-        // Rerun *wrapper* jobs share this table. A wrapper is a meta-job, not a
-        // replayable invocation — recording one as a `failed` result would give it
-        // `function_kind='hog_flow'` with the target's `function_id` (poisonRowToInvocation
-        // always tags hogFlow), making it indistinguishable from a genuine poisoned
-        // flow. The autodrain would then rediscover and replay a real flow with
-        // fabricated globals. So give up on poisoned wrappers separately: delete
-        // them with NO record. This is self-healing — the invocations the wrapper
-        // was draining keep their own poison rows and get picked up by a fresh rerun.
-        await this.dropRerunWrapperPoisonPills(heartbeatCutoff)
+        // Wrapper/meta jobs (rerun, batch-resolve) share this table. A wrapper is
+        // not a replayable invocation — recording one as a `failed` result would give
+        // it `function_kind='hog_flow'` with the target's `function_id`
+        // (poisonRowToInvocation always tags hogFlow), making it indistinguishable
+        // from a genuine poisoned flow. The autodrain would then rediscover and replay
+        // a real flow with fabricated globals. So give up on poisoned wrappers
+        // separately: delete them with NO record. This is self-healing — the work a
+        // wrapper was driving is re-derived on its next run.
+        await this.dropWrapperPoisonPills(heartbeatCutoff)
 
         const result = await this.pool.query<PoisonRow>(
             `SELECT id, team_id, function_id, queue_name, priority, scheduled, created,
@@ -265,11 +274,11 @@ export class CyclotronV2Janitor {
              WHERE status = 'running'
                AND COALESCE(last_heartbeat, $1) <= $1
                AND janitor_touch_count >= $2
-               AND queue_name <> $4
+               AND queue_name <> ALL($4::text[])
              ORDER BY last_transition ASC
              LIMIT $3
              FOR UPDATE SKIP LOCKED`,
-            [heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize, RERUN_QUEUE_NAME]
+            [heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize, WRAPPER_QUEUE_NAMES]
         )
 
         if (result.rows.length === 0) {
@@ -340,26 +349,26 @@ export class CyclotronV2Janitor {
     }
 
     /**
-     * Give up on poisoned rerun *wrapper* jobs by deleting them with no replay
-     * record — see the rationale in recordAndDeletePoisonPills. A wrapper is a
-     * meta-job, so there is nothing meaningful to replay; the invocations it was
-     * draining keep their own poison-pill rows and are re-picked-up by a fresh
-     * rerun, so dropping the wrapper is safe and self-healing.
+     * Give up on poisoned wrapper/meta jobs (rerun, batch-resolve) by deleting them
+     * with no replay record — see the rationale in recordAndDeletePoisonPills. A
+     * wrapper is not a replayable invocation, so there is nothing meaningful to
+     * record; dropping it is safe and self-healing (its work is re-derived on the
+     * next run).
      */
-    private async dropRerunWrapperPoisonPills(heartbeatCutoff: Date): Promise<number> {
+    private async dropWrapperPoisonPills(heartbeatCutoff: Date): Promise<number> {
         const deleted = await this.pool.query<{ id: string }>(
             `DELETE FROM cyclotron_jobs
              WHERE status = 'running'
-               AND queue_name = $1
+               AND queue_name = ANY($1::text[])
                AND COALESCE(last_heartbeat, $2) <= $2
                AND janitor_touch_count >= $3
              RETURNING id`,
-            [RERUN_QUEUE_NAME, heartbeatCutoff, this.maxTouchCount]
+            [WRAPPER_QUEUE_NAMES, heartbeatCutoff, this.maxTouchCount]
         )
         const count = deleted.rows.length
         if (count > 0) {
-            janitorRerunWrapperDroppedCounter.inc(count)
-            logger.warn('CyclotronV2Janitor dropped poisoned rerun wrapper jobs (no replay record — meta-job)', {
+            janitorWrapperDroppedCounter.inc(count)
+            logger.warn('CyclotronV2Janitor dropped poisoned wrapper jobs (no replay record — meta-job)', {
                 count,
                 ids: deleted.rows.map((r) => r.id),
             })

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -356,14 +356,26 @@ export class CyclotronV2Janitor {
      * next run).
      */
     private async dropWrapperPoisonPills(heartbeatCutoff: Date): Promise<number> {
+        // Bound the delete to cleanupBatchSize and pick rows via FOR UPDATE SKIP
+        // LOCKED, mirroring the genuine-poison-pill path below. This runs first in
+        // the tick: an unbounded delete could both lock a large row set and block on
+        // a row a worker/other janitor holds, stalling the whole tick before genuine
+        // pills get recorded. Skipping locked rows and capping the batch keeps the
+        // wrapper drain from starving the rest of the sweep — leftovers drain next tick.
         const deleted = await this.pool.query<{ id: string }>(
             `DELETE FROM cyclotron_jobs
-             WHERE status = 'running'
-               AND queue_name = ANY($1::text[])
-               AND COALESCE(last_heartbeat, $2) <= $2
-               AND janitor_touch_count >= $3
+             WHERE id IN (
+                 SELECT id FROM cyclotron_jobs
+                 WHERE status = 'running'
+                   AND queue_name = ANY($1::text[])
+                   AND COALESCE(last_heartbeat, $2) <= $2
+                   AND janitor_touch_count >= $3
+                 ORDER BY last_transition ASC
+                 LIMIT $4
+                 FOR UPDATE SKIP LOCKED
+             )
              RETURNING id`,
-            [WRAPPER_QUEUE_NAMES, heartbeatCutoff, this.maxTouchCount]
+            [WRAPPER_QUEUE_NAMES, heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize]
         )
         const count = deleted.rows.length
         if (count > 0) {

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -4,9 +4,7 @@ import { Counter, Gauge } from 'prom-client'
 
 import { logger } from '~/common/utils/logger'
 
-import { RERUN_QUEUE_NAME } from '../../rerun/rerun-job.types'
-import { CyclotronJobInvocationHogFlow } from '../../types'
-import { HOGFLOW_BATCH_RESOLVE_QUEUE } from '../hogflows/batch-resolver.types'
+import { CYCLOTRON_INVOCATION_JOB_QUEUES, CyclotronJobInvocationHogFlow } from '../../types'
 import { v2JobToInvocation } from '../job-queue/job-queue-postgres-v2'
 import { HogInvocationResultsService } from '../monitoring/hog-invocation-results.service'
 import { CyclotronV2CleanupResult, CyclotronV2DequeuedJob, CyclotronV2JanitorConfig } from './types'
@@ -16,13 +14,16 @@ import { CyclotronV2CleanupResult, CyclotronV2DequeuedJob, CyclotronV2JanitorCon
 // exactly these give-ups from the rerun tooling (rerun filter `error_kind`).
 export const JANITOR_POISON_PILL_ERROR_KIND = 'janitor_poison_pill'
 
-// Queues that carry non-invocation "wrapper" / meta jobs — they share the
-// cyclotron_jobs table with real invocations, but their `function_id` points at a
-// target function and their `state` is not an invocation. The janitor must NOT
-// record their give-ups as replayable invocation results (that would let the
-// autodrain replay a real flow with fabricated globals — see recordAndDeletePoisonPills);
-// it gives up on them without a record instead. Add any new wrapper queue here.
-const WRAPPER_QUEUE_NAMES: string[] = [RERUN_QUEUE_NAME, HOGFLOW_BATCH_RESOLVE_QUEUE]
+// Only jobs on a real invocation queue carry a replayable invocation. Everything else on this
+// shared cyclotron_jobs table (the rerun + batch-resolve wrappers, and any future meta queue) has a
+// `function_id` pointing at a target function and a `state` that is not an invocation — recording
+// one as a give-up would tag it `function_kind='hog_flow'` and let the autodrain replay a real flow
+// with fabricated globals (see recordAndDeletePoisonPills). So the janitor records give-ups only for
+// this allow-list and drops everything else without a record. Keying off the canonical allow-list
+// (it *is* the `CyclotronJobQueueKind` type) is deliberately fail-safe: a new meta queue is dropped
+// by default, and a new invocation queue has to be added to this list to compile — no hand-kept
+// deny-list to fall out of sync (which is how the batch-resolve queue was missed originally).
+const INVOCATION_QUEUE_NAMES: string[] = [...CYCLOTRON_INVOCATION_JOB_QUEUES]
 
 // The first stall gets only this small jittered delay (not the full exponential
 // base), so a transient stall — a worker restart/deploy, where a healthy worker
@@ -256,13 +257,12 @@ export class CyclotronV2Janitor {
     private async recordAndDeletePoisonPills(): Promise<string[]> {
         const heartbeatCutoff = new Date(Date.now() - this.stallTimeoutMs)
 
-        // Wrapper/meta jobs (rerun, batch-resolve) share this table. A wrapper is
-        // not a replayable invocation — recording one as a `failed` result would give
-        // it `function_kind='hog_flow'` with the target's `function_id`
-        // (poisonRowToInvocation always tags hogFlow), making it indistinguishable
-        // from a genuine poisoned flow. The autodrain would then rediscover and replay
-        // a real flow with fabricated globals. So give up on poisoned wrappers
-        // separately: delete them with NO record. This is self-healing — the work a
+        // Wrapper/meta jobs (rerun, batch-resolve, any future non-invocation queue) share this table.
+        // A wrapper is not a replayable invocation — recording one as a `failed` result would give it
+        // `function_kind='hog_flow'` with the target's `function_id` (poisonRowToInvocation always tags
+        // hogFlow), making it indistinguishable from a genuine poisoned flow, and the autodrain would
+        // then rediscover and replay a real flow with fabricated globals. So give up on anything not on
+        // an invocation queue separately: delete it with NO record. This is self-healing — the work a
         // wrapper was driving is re-derived on its next run.
         await this.dropWrapperPoisonPills(heartbeatCutoff)
 
@@ -274,11 +274,11 @@ export class CyclotronV2Janitor {
              WHERE status = 'running'
                AND COALESCE(last_heartbeat, $1) <= $1
                AND janitor_touch_count >= $2
-               AND queue_name <> ALL($4::text[])
+               AND queue_name = ANY($4::text[])
              ORDER BY last_transition ASC
              LIMIT $3
              FOR UPDATE SKIP LOCKED`,
-            [heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize, WRAPPER_QUEUE_NAMES]
+            [heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize, INVOCATION_QUEUE_NAMES]
         )
 
         if (result.rows.length === 0) {
@@ -349,11 +349,11 @@ export class CyclotronV2Janitor {
     }
 
     /**
-     * Give up on poisoned wrapper/meta jobs (rerun, batch-resolve) by deleting them
-     * with no replay record — see the rationale in recordAndDeletePoisonPills. A
-     * wrapper is not a replayable invocation, so there is nothing meaningful to
-     * record; dropping it is safe and self-healing (its work is re-derived on the
-     * next run).
+     * Give up on poisoned wrapper/meta jobs — anything not on an invocation queue (rerun,
+     * batch-resolve, any future meta queue) — by deleting them with no replay record. See the
+     * rationale in recordAndDeletePoisonPills. A wrapper is not a replayable invocation, so there is
+     * nothing meaningful to record; dropping it is safe and self-healing (its work is re-derived on
+     * the next run).
      */
     private async dropWrapperPoisonPills(heartbeatCutoff: Date): Promise<number> {
         // Bound the delete to cleanupBatchSize and pick rows via FOR UPDATE SKIP
@@ -367,7 +367,7 @@ export class CyclotronV2Janitor {
              WHERE id IN (
                  SELECT id FROM cyclotron_jobs
                  WHERE status = 'running'
-                   AND queue_name = ANY($1::text[])
+                   AND queue_name <> ALL($1::text[])
                    AND COALESCE(last_heartbeat, $2) <= $2
                    AND janitor_touch_count >= $3
                  ORDER BY last_transition ASC
@@ -375,7 +375,7 @@ export class CyclotronV2Janitor {
                  FOR UPDATE SKIP LOCKED
              )
              RETURNING id`,
-            [WRAPPER_QUEUE_NAMES, heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize]
+            [INVOCATION_QUEUE_NAMES, heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize]
         )
         const count = deleted.rows.length
         if (count > 0) {

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -4,6 +4,7 @@ import { Counter, Gauge } from 'prom-client'
 
 import { logger } from '~/common/utils/logger'
 
+import { RERUN_QUEUE_NAME } from '../../rerun/rerun-job.types'
 import { CyclotronJobInvocationHogFlow } from '../../types'
 import { v2JobToInvocation } from '../job-queue/job-queue-postgres-v2'
 import { HogInvocationResultsService } from '../monitoring/hog-invocation-results.service'
@@ -40,6 +41,11 @@ const janitorPoisonedCounter = new Counter({
 const janitorGiveUpSkippedCounter = new Counter({
     name: 'cdp_cyclotron_v2_janitor_give_up_skipped',
     help: 'Poison pills the janitor could not record a recovery row for, so kept (not deleted)',
+})
+
+const janitorRerunWrapperDroppedCounter = new Counter({
+    name: 'cdp_cyclotron_v2_janitor_rerun_wrapper_dropped',
+    help: 'Poisoned rerun wrapper jobs dropped without a replay record (a wrapper is a meta-job, not a replayable invocation)',
 })
 
 const janitorRunCounter = new Counter({
@@ -241,6 +247,16 @@ export class CyclotronV2Janitor {
     private async recordAndDeletePoisonPills(): Promise<string[]> {
         const heartbeatCutoff = new Date(Date.now() - this.stallTimeoutMs)
 
+        // Rerun *wrapper* jobs share this table. A wrapper is a meta-job, not a
+        // replayable invocation — recording one as a `failed` result would give it
+        // `function_kind='hog_flow'` with the target's `function_id` (poisonRowToInvocation
+        // always tags hogFlow), making it indistinguishable from a genuine poisoned
+        // flow. The autodrain would then rediscover and replay a real flow with
+        // fabricated globals. So give up on poisoned wrappers separately: delete
+        // them with NO record. This is self-healing — the invocations the wrapper
+        // was draining keep their own poison rows and get picked up by a fresh rerun.
+        await this.dropRerunWrapperPoisonPills(heartbeatCutoff)
+
         const result = await this.pool.query<PoisonRow>(
             `SELECT id, team_id, function_id, queue_name, priority, scheduled, created,
                     parent_run_id, state, distinct_id, person_id, action_id,
@@ -249,10 +265,11 @@ export class CyclotronV2Janitor {
              WHERE status = 'running'
                AND COALESCE(last_heartbeat, $1) <= $1
                AND janitor_touch_count >= $2
+               AND queue_name <> $4
              ORDER BY last_transition ASC
              LIMIT $3
              FOR UPDATE SKIP LOCKED`,
-            [heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize]
+            [heartbeatCutoff, this.maxTouchCount, this.cleanupBatchSize, RERUN_QUEUE_NAME]
         )
 
         if (result.rows.length === 0) {
@@ -320,6 +337,34 @@ export class CyclotronV2Janitor {
         }
 
         return deletedIds
+    }
+
+    /**
+     * Give up on poisoned rerun *wrapper* jobs by deleting them with no replay
+     * record — see the rationale in recordAndDeletePoisonPills. A wrapper is a
+     * meta-job, so there is nothing meaningful to replay; the invocations it was
+     * draining keep their own poison-pill rows and are re-picked-up by a fresh
+     * rerun, so dropping the wrapper is safe and self-healing.
+     */
+    private async dropRerunWrapperPoisonPills(heartbeatCutoff: Date): Promise<number> {
+        const deleted = await this.pool.query<{ id: string }>(
+            `DELETE FROM cyclotron_jobs
+             WHERE status = 'running'
+               AND queue_name = $1
+               AND COALESCE(last_heartbeat, $2) <= $2
+               AND janitor_touch_count >= $3
+             RETURNING id`,
+            [RERUN_QUEUE_NAME, heartbeatCutoff, this.maxTouchCount]
+        )
+        const count = deleted.rows.length
+        if (count > 0) {
+            janitorRerunWrapperDroppedCounter.inc(count)
+            logger.warn('CyclotronV2Janitor dropped poisoned rerun wrapper jobs (no replay record — meta-job)', {
+                count,
+                ids: deleted.rows.map((r) => r.id),
+            })
+        }
+        return count
     }
 
     // Turn a raw poisoned row into a hog flow invocation the results service can


### PR DESCRIPTION
## Problem

The cyclotron-v2 janitor's poison-pill sweep (`recordAndDeletePoisonPills`) scans `cyclotron_jobs` across **all** queues — including the `rerun` queue that carries wrapper (meta) jobs created by the rerun tooling. When it gives up on any stalled row, `poisonRowToInvocation` unconditionally tags it as a hog flow (`{ ...invocation, hogFlow: { id: functionId } }`), and the rerun manager deliberately stamps a wrapper's `function_id` to the *target* function's id. So a poisoned rerun **wrapper** was recorded to `hog_invocation_results` as `function_kind='hog_flow'` with the target's `function_id` — **indistinguishable from a genuine poisoned flow invocation** by every column a consumer filters on.

That was harmless while recovery was a manual, human-reviewed rerun (a person would notice the anomalous row). But the **poison-pill autodrain (#71538)** is an autonomous consumer: it would rediscover such a wrapper row, treat it as a real flow, and replay that flow **from its trigger with fabricated empty globals** (`event:{}`, `variables:{}`, `person:undefined`) — risking spurious side effects (webhooks/emails) with no genuine event behind them.

Reachable via the classic poison-pill mode: a worker repeatedly dying mid-page on a rerun wrapper until `janitor_touch_count` trips — exactly the failure class this system exists to handle.

## Changes

Fix it upstream in the janitor, so wrappers can never be conflated regardless of which consumer reads the table:

- **Exclude `queue_name = 'rerun'` from the record path.** `recordAndDeletePoisonPills` now only records genuine invocations.
- **Give up on poisoned wrappers separately, with no replay record** (`dropRerunWrapperPoisonPills`): they're deleted directly. A wrapper is a meta-job — there is nothing meaningful to replay — and dropping it is **self-healing**: the invocations it was draining keep their own poison-pill rows and are re-picked-up by a fresh rerun.
- New metric `cdp_cyclotron_v2_janitor_rerun_wrapper_dropped` for the wrapper give-ups (kept distinct from `cdp_cyclotron_v2_janitor_poisoned`, which stays "recorded, replayable invocations").

The legacy kill-switch path (`failPoisonPills`, recovery disabled) already marks poison pills failed with **no** record, so it never caused this conflation and is unchanged.

## How did you test this code?

Added a Postgres-backed janitor test (`cyclotron-v2.test.ts`): a poisoned `rerun`-queue wrapper and a genuine poisoned invocation in the same sweep — asserts the wrapper is **dropped without** `recordTerminalFailureDurably` being called for it, the real invocation **is** recorded, `result.poisonedIds` contains only the real invocation, and both cyclotron rows are gone. Guards the regression that a future change re-includes the rerun queue in the record path.

Agent scope note: I (the agent) couldn't run the ClickHouse/Postgres-backed suite in this environment (no infra); CI runs it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by Daniel. Companion to #71538 (poison-pill autodrain) — surfaced by reviewhog's automated review of that PR. Invoked `/writing-tests` to gate the new test. The autodrain is the first automatic actor on this latent conflation, so the decisive fix belongs here in the janitor rather than as a fragile downstream guard; shipped separately so it can merge on its own timeline. #71538 depends on this landing to fully close the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WCtr8RrgwKkPbvx3RyuvnX)_