### PR TITLE
feat(autoresearch): rerun failed jobs once on flaky gating workflows

### DIFF
--- a/.github/workflows/ci-rerun-flaky-jobs.yml
+++ b/.github/workflows/ci-rerun-flaky-jobs.yml
@@ -1,0 +1,48 @@
+name: CI Rerun Flaky Jobs
+
+# When a gating workflow fails a PR on its first attempt, rerun just the failed
+# jobs once. Measured on this repo (2026-07): 75-90% of human "re-run failed
+# jobs" clicks go green with no code change, but only ~11% of red runs ever get
+# that click — the rest of the flake tax lands on authors as pointless re-pushes.
+# Real failures simply fail twice and the check stays red, so nothing is masked.
+#
+# The watched list is only workflows with measured retry recovery (23-41% of
+# their reds). Python CI is deliberately absent: its reds are almost entirely
+# deterministic lint/type/format failures where a retry is a pure waste.
+#
+# Cost shape: the job-level `if` means successful completions skip without a
+# runner, and rerun-failed-jobs re-runs only the failed jobs (plus dependents),
+# never the whole matrix. run_attempt == 1 guarantees at most one machine retry.
+
+on:
+    workflow_run:
+        workflows: ['Backend CI', 'Frontend CI', 'Storybook', 'E2E CI Playwright']
+        types: [completed]
+
+permissions:
+    actions: write
+
+concurrency:
+    group: rerun-flaky-${{ github.event.workflow_run.id }}
+    cancel-in-progress: false
+
+jobs:
+    rerun:
+        name: Rerun failed jobs once
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: >
+            github.event.workflow_run.conclusion == 'failure' &&
+            github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.run_attempt == 1
+        steps:
+            - name: Rerun failed jobs of the triggering run
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+                  RUN_NAME: ${{ github.event.workflow_run.name }}
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+              run: |
+                  echo "Rerunning failed jobs of ${RUN_NAME} run ${RUN_ID}: ${RUN_URL}"
+                  gh api -X POST "repos/${{ github.repository }}/actions/runs/${RUN_ID}/rerun-failed-jobs" \
+                    || echo "::notice::Rerun request rejected (run superseded, already rerunning, or too old) — nothing to do"


### PR DESCRIPTION
## Problem

42% of PR pushes hit at least one red required check. Measured over recent weeks on this repo, a large share of those reds are flake, and the human response pattern is expensive in a specific way: people click "re-run failed jobs" on only ~11% of red runs, but when they do, 75–90% of those reruns go green with no code change. The other ~89% of flake reds cost a context switch and usually a pointless re-push. That's ~170 manual rerun cycles a day across gating workflows.

Created with Autoresearch.

## Changes

One new `workflow_run` workflow that does the click automatically. When Backend CI, Frontend CI, Storybook (both workflows share the name), or E2E CI Playwright completes a PR run with `conclusion: failure` on attempt 1, it calls `rerun-failed-jobs` on that run. Once, ever, per run.

Design constraints it respects:

- **Nothing is masked.** Real failures fail twice and the check stays red. The measured retry-recovery rates (23–41% of reds on these four workflows) are recoveries humans already achieve today by hand.
- **Python CI is deliberately excluded.** Its reds are ~96% deterministic lint/type/format, where a retry is pure waste. (A companion PR handles the format share of those with an autofix instead.)
- **Cost-shaped.** Job-level `if` means the ~90% of completions that are successes skip without spinning a runner. `rerun-failed-jobs` re-runs only failed jobs plus dependents, never the full matrix. `run_attempt == 1` caps machine retries at one; superseded runs get their reruns cancelled by the workflows' own per-branch concurrency groups.
- Runs from the default branch's copy of the workflow (`workflow_run`), so it needs no changes on open PR branches and can't be affected by unrebased branches.

> [!NOTE]
> Expected effect on the measured "hands-off green rate" (P(push goes all-green with no human touch), baseline 58%): +4.7 points conservative, using lower-bound recovery rates where every never-retried failure is assumed real. The live tracking insight is on the [CI self-driving health dashboard](https://us.posthog.com/project/2/dashboard/1884671).

## How did you test this code?

`bin/hogli lint:workflows` passes (timeout, concurrency, and the other 6 checks). I could not exercise the trigger pre-merge: `workflow_run` workflows execute only from the default branch, so the first real validation is after merge — watch the run list for `CI Rerun Flaky Jobs` and confirm reruns appear as attempt 2 on failed gating runs. The rerun API call is the same one the "Re-run failed jobs" UI button uses; a rejected call (run superseded or already rerunning) downgrades to a notice instead of failing the job.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, CI-infrastructure-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code) in an autoresearch session on CI reliability directed by Daniel Visca; the `/authoring-ci-workflows` skill was invoked and its checklist applied (job-level `if` over dispatch-then-run, `timeout-minutes`, canonical concurrency shape, no checkout at all in this workflow).
- The watched-workflow list and the impact estimate come from measured data: run-attempt splits over recent PR runs (recovery lower bounds: Backend 36%, Frontend 23%, E2E 41%, Storybook pooled 8% plus one shard responsible for 35% of its reds) via the engineering-analytics tools and the GitHub API.
- Considered and rejected: rerunning whole workflows (cost), watching Python CI (deterministic reds, measured 3.8% recovery), gating rerun on a flake classifier for v1 (the overseer classifier exists but adds complexity before the simple version proves out).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
