### PR TITLE
fix(inbox): wrap scout run boxes onto their own line on mobile

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -53,7 +53,10 @@ export function ScoutRowCard({
                 !config.enabled && 'opacity-65'
             )}
         >
-            <div className="flex items-center gap-4">
+            {/* On narrow (mobile) widths the row wraps: the run boxes drop to their own
+                full-width line so they can't collide with the name and controls. From `sm`
+                up the row is forced back onto a single line — the original layout. */}
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:flex-nowrap">
                 {/* Name + badges on top, cadence/emitted as a muted subtitle below — keeps the
                     metadata off the main row so the sparkline and controls have room to breathe. */}
                 <div className="flex flex-col gap-0.5 min-w-0 flex-1">
@@ -114,10 +117,15 @@ export function ScoutRowCard({
                     </div>
                 </div>
                 {/* The sparkline is the flexible region: it shrinks and clips the oldest runs
-                    off the left so it can never push the controls column off the row. */}
-                <div className="flex min-w-0 overflow-hidden">
-                    <ScoutRunBoxes runs={rollup?.runs ?? []} />
-                </div>
+                    off the left so it can never push the controls column off the row. When the
+                    row wraps (mobile) it goes order-last + full-width so it lands on its own
+                    line; the wrapper is skipped entirely when there are no runs so an empty
+                    scout doesn't reserve a blank wrapped line. */}
+                {(rollup?.runs?.length ?? 0) > 0 ? (
+                    <div className="order-last flex w-full min-w-0 overflow-hidden sm:order-none sm:w-auto">
+                        <ScoutRunBoxes runs={rollup?.runs ?? []} />
+                    </div>
+                ) : null}
                 <div className="flex items-center gap-2 shrink-0">
                     <ScoutEnabledSwitch config={config} onUpdate={onUpdate} />
                     <Tooltip title="Scout settings">


### PR DESCRIPTION
## Problem

On mobile, the scout cards in the Scout troop modal look broken. Each card lays out name, run-history boxes, and controls on a single flex row. Below phone widths there isn't room for all three, so the name column collapses to zero width and its text and badges paint straight over the run boxes.

## Changes

All in `ScoutRowCard.tsx`, purely responsive, so desktop is unchanged:

- The card row is now `flex-wrap` below Tailwind's `sm` breakpoint and forced back to `flex-nowrap` at `sm` and up, which is exactly the original single-line layout.
- When the row wraps, the run boxes move to their own full-width line under the name and controls (`order-last w-full` on mobile, reset at `sm`). The existing behavior of clipping the oldest runs off the left edge still applies if that line is too narrow.
- The run-box wrapper is skipped when a scout has no runs yet, so an empty scout doesn't reserve a blank wrapped line on mobile.

This covers both the fleet list in the setup modal and the scout detail header, since they share the same card component.

No after-screenshot, sorry. This was done in a remote agent session that can't run the app, and the before-state screenshot came from a phone against a real project so I'm not uploading it to the public assets repo.

## How did you test this code?

- `oxlint`/`oxfmt` via the repo's lint-staged hooks, plus `hogli ci:preflight --strict` on push (passed, no CI failure classes triggered).
- Full `pnpm --filter=@posthog/frontend typescript:check` currently fails on the base commit itself with an unrelated pre-existing error in `products/workflows/frontend/scenes/settings/WorkflowsEngagementEventsSettings.tsx`. Verified by stashing this change and re-running, the failure is identical without it.
- No manual browser testing (see above). The change is Tailwind classnames plus one render guard, no logic changes, so I'm leaning on CI here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, this is a layout fix for an alpha UI with no user-facing docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (well, Claude Code in a remote session) made this change, driven by Andrew from a mobile screenshot of the broken modal. Diagnosis: the overlap comes from the name column's `min-w` floor fighting a row that can't shrink enough, not from the run-box clipping logic, which already works. I chose a responsive `flex-wrap` over alternatives like lowering `MAX_BOXES` on mobile or a container query, because it keeps desktop pixel-identical and preserves the clip-oldest behavior on the wrapped line. No repo skills were invoked, the diff is Tailwind classnames and a render guard in one component.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8mPx6Qe8DwCH7zo9njkCs)_