### PR TITLE
chore(toolbar): drop lowlight all-grammar re-export and posthog-typed typings from bundle graph

### DIFF
--- a/frontend/src/toolbar/shims/posthogTyped.ts
+++ b/frontend/src/toolbar/shims/posthogTyped.ts
@@ -1,0 +1,36 @@
+import type { CaptureOptions, CaptureResult, Properties } from 'posthog-js'
+import originalPostHog from 'posthog-js'
+
+// Toolbar shim — lib/posthog-typed is ~200 KB of generated event typings wrapped around a
+// small runtime. This mirrors that runtime exactly (capture/captureRaw delegating to the
+// posthog-js singleton, everything else proxied through) without the typings.
+const enhanced: Record<string, unknown> = {
+    capture: (
+        event_name: string,
+        properties?: Properties | null,
+        options?: CaptureOptions
+    ): CaptureResult | undefined => originalPostHog.capture(event_name, properties, options),
+    captureRaw: (
+        event_name: string,
+        properties?: Properties | null,
+        options?: CaptureOptions
+    ): CaptureResult | undefined => originalPostHog.capture(event_name, properties, options),
+}
+
+const posthog = new Proxy(enhanced, {
+    get(target, prop) {
+        if (prop in target) {
+            return target[prop as string]
+        }
+        return (originalPostHog as unknown as Record<string | symbol, unknown>)[prop]
+    },
+    set(_target, prop, value) {
+        ;(originalPostHog as unknown as Record<string | symbol, unknown>)[prop] = value
+        return true
+    },
+}) as unknown as typeof originalPostHog & { captureRaw: typeof originalPostHog.capture }
+
+export default posthog
+
+// Re-export everything else from posthog-js, matching lib/posthog-typed's surface
+export * from 'posthog-js'

--- a/frontend/src/toolbar/shims/shims.test.ts
+++ b/frontend/src/toolbar/shims/shims.test.ts
@@ -1,9 +1,13 @@
 import { expectLogic } from 'kea-test-utils'
+import posthogJs from 'posthog-js'
+
+import typedPosthog from 'lib/posthog-typed'
 
 import { initKeaTests } from '~/test/init'
 
 import { featureFlagLogic, getFeatureFlagPayload } from './featureFlagLogic'
 import { membersLogic } from './membersLogic'
+import shimmedPosthog from './posthogTyped'
 import { sceneLogic } from './sceneLogic'
 import { surveyQuestionLabelsLogic } from './surveyQuestionLabelsLogic'
 import { isAuthenticatedTeam, teamLogic } from './teamLogic'
@@ -74,6 +78,24 @@ describe('toolbar shims', () => {
     describe('getFeatureFlagPayload', () => {
         it.each([['SOME_FLAG'], ['ANOTHER_FLAG'], ['']])('returns undefined for %s', (flag) => {
             expect(getFeatureFlagPayload(flag)).toBeUndefined()
+        })
+    })
+
+    describe('posthogTyped shim', () => {
+        it('exposes every runtime member lib/posthog-typed adds beyond posthog-js', () => {
+            // The toolbar build swaps lib/posthog-typed for the shim, invisible to the
+            // typechecker — if the generator grows a new runtime method, the shim must too,
+            // or toolbar code calling it crashes on customer pages.
+            for (const key of Object.keys(typedPosthog)) {
+                expect(typeof (shimmedPosthog as any)[key]).toBe(typeof (typedPosthog as any)[key])
+            }
+        })
+
+        it.each([['capture'], ['captureRaw']] as const)('%s delegates to posthog-js capture', (method) => {
+            const captureSpy = jest.spyOn(posthogJs, 'capture').mockReturnValue(undefined)
+            shimmedPosthog[method]('some event', { foo: 'bar' })
+            expect(captureSpy).toHaveBeenCalledWith('some event', { foo: 'bar' }, undefined)
+            captureSpy.mockRestore()
         })
     })
 })

--- a/frontend/toolbar-config.mjs
+++ b/frontend/toolbar-config.mjs
@@ -1,7 +1,10 @@
 import * as fs from 'fs'
+import { createRequire } from 'module'
 import * as path from 'path'
 
 import { commonConfig, copyRRWebWorkerFiles, createHashlessEntrypoints, esbuildBuild, isDev } from '@posthog/esbuilder'
+
+const require = createRequire(import.meta.url)
 
 // `TOOLBAR_PUBLIC_PATH`, when set, overrides the default `publicPath` so the
 // toolbar bundle and its assets can be hosted under a versioned, content-pinned
@@ -34,6 +37,9 @@ const shimmedModules = {
     // app (TZLabel, Link, HeatmapEventsPanel), whose scenes/urls import would otherwise pull
     // every product manifest into the bundle.
     'scenes/urls': 'src/toolbar/urls.ts',
+    // Not a kea shim: the generated event typings are ~200 KB of source the toolbar must
+    // not bundle. The shim mirrors the module's small runtime (capture/captureRaw proxy).
+    'lib/posthog-typed': 'src/toolbar/shims/posthogTyped.ts',
 }
 
 // Modules replaced with an inert proxy that logs access in debug mode
@@ -80,9 +86,28 @@ function createToolbarModulePlugin(dirname) {
             path.resolve(dirname, shimFile),
         ])
     )
+    // lowlight's package index re-exports `all` — every highlight.js grammar, ~1.2 MB of
+    // source — alongside the `common` set our code actually uses. The re-export alone pulls
+    // all 192 grammars into the bundle graph, so resolve 'lowlight' to a pared-down module
+    // instead. Its relative imports bypass the package's exports map (which hides lib/).
+    const lowlightDir = path.dirname(require.resolve('lowlight'))
+
     return {
         name: 'toolbar-module-replacements',
         setup(build) {
+            build.onResolve({ filter: /^lowlight$/ }, () => ({
+                path: 'lowlight',
+                namespace: 'lowlight-common-only',
+            }))
+            build.onLoad({ filter: /.*/, namespace: 'lowlight-common-only' }, () => ({
+                contents: `
+                    export { createLowlight } from './lib/index.js'
+                    export { grammars as common } from './lib/common.js'
+                `,
+                resolveDir: lowlightDir,
+                loader: 'js',
+            }))
+
             build.onResolve({ filter: /.*/ }, (args) => {
                 const shimFile = shimmedModules[args.path] ?? shimmedModules[args.path.replace(/^~\//, '')]
                 if (shimFile) {


### PR DESCRIPTION
## Problem

The toolbar module-boundary graph check (`frontend/bin/check-toolbar-graph.mjs`) budget has been raised five times in the last week by unrelated PRs (#71460, #71808, #72041, #69730, #72073, and [#72459](https://github.com/PostHog/posthog/pull/72459)), because the toolbar's input graph sat within ~50 KB of the 14.5 MB budget. Analysis of the esbuild metafile showed two large avoidable contributors:

- `lowlight`'s package index re-exports `all` – every highlight.js grammar, 192 files and ~1.2 MB of source – even though our code only uses the `common` set (37 grammars).
- `lib/posthog-typed` is ~200 KB of generated event-name typings wrapped around a tiny runtime, reachable from the toolbar via keyboard-shortcut hooks.

Neither ships extra bytes to customers (tree-shaking and lazy chunks handle output size), but both count fully against the input-graph budget, eating headroom that unrelated PRs then have to bump.

## Changes

- Toolbar build (`frontend/toolbar-config.mjs`): resolve `lowlight` to a pared-down module exposing only `createLowlight` and `common`, bypassing the package index's `all` re-export. Grammar files in the graph drop from 192 to 37.
- Add `src/toolbar/shims/posthogTyped.ts`, a runtime-equivalent shim for `lib/posthog-typed` (capture/captureRaw delegating to the posthog-js singleton, everything else proxied), and register it in the toolbar's shim map.

Result: toolbar input graph goes from **13.78 MiB (978 files) to 12.45 MiB (822 files)**, restoring ~2 MB of headroom under the 14.5 MB budget. Crossing edges (5), eager output size, and CSP checks are unchanged.

## How did you test this code?

- `node frontend/bin/build-toolbar.mjs` then all three toolbar checks pass: graph (12.45 MiB, 5 baseline edges, no forbidden packages), size (eager 1.55 MB under 1.66 MB budget, unchanged), CSP eval.
- `pnpm --filter=@posthog/frontend typescript:check` passes.
- Added a parity test in `shims.test.ts` that fails if the generated `lib/posthog-typed` module grows runtime surface the shim lacks – the regression this catches is toolbar code calling a new generated method that silently resolves to `undefined` on customer pages. Also two `test.each` cases asserting capture/captureRaw delegate to `posthog-js` capture.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed – build-internal change, no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated why [#72459](https://github.com/PostHog/posthog/pull/72459) needed a toolbar budget bump: the metric counts pre-tree-shake source bytes, so SDK bumps and shared-file churn trip it without shipping bytes. Ranked contributors from the esbuild metafile; lowlight's `all` re-export and the generated posthog-typed module were the two biggest avoidable ones. Considered also decoupling `~/types` from the graph (17 value importers) but deferred it as a larger structural change. Invoked /writing-tests before adding the shim parity test. Note: #72583 rewrites the graph check to boundary-only; this PR doesn't touch the budget constant so they compose cleanly.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
