### PR TITLE
chore(ci): cut storybook shard timeout from 60 to 30 minutes

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -349,7 +349,8 @@ jobs:
             && needs.changes.outputs.frontend == 'true'
             && needs.build-storybook.result == 'success'
             && needs.select-stories.outputs.should_run != 'false'
-        timeout-minutes: 60
+        # Healthy shards finish well under 15 minutes; the cap exists so a wedged shard fails fast.
+        timeout-minutes: 30
         container:
             image: ghcr.io/posthog/playwright:v1.60.0
         strategy:


### PR DESCRIPTION
## Problem

The `visual-regression` matrix job in `ci-storybook.yml` had `timeout-minutes: 60`. On any public run of the "Storybook" workflow you can see healthy chromium shards finish in roughly 11 min median / 13 min p90, and webkit shards (master only) in ~8 min. So 60 minutes is far more headroom than a healthy shard ever needs.

The cost shows up when a shard wedges: it runs all the way to the 60-minute kill. That burns about 5x a normal shard's runner time, and worse, it holds back the failure signal to the developer by ~45 minutes past the point the run was already doomed.

**Why:** wedged shards currently burn an hour of runner time and delay the failure signal, while healthy shards finish in a fraction of 30 minutes.

## Changes

Drop the `visual-regression` job's timeout from 60 to 30 minutes and add a one-line comment explaining the constraint. 30 minutes is still more than 2x the observed p90, so healthy shards keep their headroom, but a wedged shard now fails in half the time.

```diff
-        timeout-minutes: 60
+        # Healthy shards finish well under 15 minutes; the cap exists so a wedged shard fails fast.
+        timeout-minutes: 30
```

Nothing else changes. `flake-verification` (45), `build-storybook` (30, which has its own comment about degraded-runner slowness), and every other job are untouched. The `build-storybook` timeout is deliberately left alone since the degraded-runner slowness that motivated its headroom is specific to that job's Vite bundling, not to the shard runs.

## How did you test this code?

This is a single-value CI config change (one scalar plus one comment line). I did not run the Storybook suite. I verified the edited file still parses as YAML with `python3` + `pyyaml` from the repo venv (parses cleanly). `actionlint` was not available in my environment, so I could not run it; the change is a scalar value edit that does not alter the workflow's structure. I also grepped the file and `common/storybook/` to confirm nothing else keys off the 60-minute value: the only remaining `60` hits are SHA pins, the `v1.60.0` image tag, port 6006, and second-to-minute arithmetic, and the `timeout` references in `common/storybook/` are per-story Playwright/Jest millisecond selector timeouts, unrelated to the job cap.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference this timeout value.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) made this change end to end. I invoked the `/authoring-ci-workflows` skill before editing the workflow, per the repo's mandatory-skill rule.

The scope was deliberately kept to one line plus one comment. I considered whether `build-storybook` should also be trimmed and rejected that: its 30-minute timeout is intentional headroom for a memory-heavy Vite build on degraded runners and carries its own explanatory comment, so it stays as is. I picked 30 minutes because it sits above 2x the p90 shard duration observable on public runs while roughly halving the worst-case wedged-shard wait and waste.

All CI facts cited here are observable from public GitHub Actions runs of the Storybook workflow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
