### PR TITLE
feat(signals): tag eval-fixture generation as signals_eval

### DIFF
--- a/products/signals/backend/test/test_llm.py
+++ b/products/signals/backend/test/test_llm.py
@@ -3,7 +3,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import override_settings
 
+from products.signals.backend.temporal.emit_eval_signal import (
+    EmitEvalSignalInputs,
+    EvalSignalSummary,
+    summarize_eval_for_signal,
+)
 from products.signals.backend.temporal.llm import call_llm
+from products.signals.eval.llm_gen.client import CanonicalSignal, CanonicalSignalBatch, generate_canonical_signals
 
 MODULE_PATH = "products.signals.backend.temporal.llm"
 
@@ -75,3 +81,44 @@ async def test_without_ai_product_stays_on_python_gateway_even_with_env_set():
     legacy.assert_called_once()
     gateway.assert_not_called()
     assert client.messages.create.call_args.kwargs["extra_headers"] == {"x-posthog-property-ai_stage": "match"}
+
+
+# `ai_product` is the opt-in switch, not just a label: dropping it from a call site silently
+# reverts that site to the Python gateway and unattributes its spend, with no failing call to
+# notice. Each site that opts in pins its own tag and stage.
+
+
+@pytest.mark.asyncio
+async def test_eval_fixture_generation_opts_in_as_signals_eval():
+    batch = CanonicalSignalBatch(signals=[CanonicalSignal(title="a" * 10, body="b" * 20)])
+    with patch("products.signals.eval.llm_gen.client.call_llm", new=AsyncMock(return_value=batch)) as generation_call:
+        await generate_canonical_signals(team_id=1, system_prompt="s", user_prompt="u")
+
+    kwargs = generation_call.call_args.kwargs
+    assert kwargs["ai_product"] == "signals_eval"
+    assert kwargs["stage"] == "eval_signal_generation"
+
+
+@pytest.mark.asyncio
+async def test_eval_signal_summary_opts_in_as_signals_eval():
+    inputs = EmitEvalSignalInputs(
+        team_id=1,
+        evaluation_id="eval-1",
+        evaluation_name="name",
+        evaluation_prompt="prompt",
+        event_uuid="event-1",
+        event_type="generation",
+        trace_id="trace-1",
+        reasoning="reasoning",
+        model="claude-sonnet-4-5",
+        provider="anthropic",
+    )
+    summary = EvalSignalSummary(title="t", description="d", significance=0.5)
+    with patch(
+        "products.signals.backend.temporal.emit_eval_signal.call_llm", new=AsyncMock(return_value=summary)
+    ) as summary_call:
+        await summarize_eval_for_signal(inputs)
+
+    kwargs = summary_call.call_args.kwargs
+    assert kwargs["ai_product"] == "signals_eval"
+    assert kwargs["stage"] == "eval_signal_summary"

--- a/products/signals/eval/llm_gen/client.py
+++ b/products/signals/eval/llm_gen/client.py
@@ -43,7 +43,8 @@ async def generate_canonical_signals(
     Reuses `call_llm` from products.signals.backend.temporal.llm so we get the
     same retry-on-validation-failure behavior the rest of the pipeline uses.
     Model is controlled by the SIGNAL_MATCHING_LLM_MODEL env var (default
-    claude-sonnet-4-5). LLM cost is attributed to team_id via the gateway.
+    claude-sonnet-4-5). LLM cost is attributed to team_id via the gateway and
+    tagged `signals_eval`, alongside the eval summary stage.
     """
     batch = await call_llm(
         team_id=team_id,
@@ -52,5 +53,6 @@ async def generate_canonical_signals(
         validate=_validator(CanonicalSignalBatch),
         temperature=temperature,
         stage="eval_signal_generation",
+        ai_product="signals_eval",
     )
     return batch.signals


### PR DESCRIPTION
## Problem

Signals routes its LLM calls through the ai-gateway per stage, tagged by `ai_product`. The eval-fixture generator (`products/signals/eval/llm_gen`) calls the same `call_llm` helper but passed no `ai_product`, so its spend fell into the untagged catch-all instead of the signals books. It was the last signals `call_llm` site without a tag.

## Changes

- `generate_canonical_signals` passes `ai_product="signals_eval"`, the same tag the eval summary stage already uses, so both eval stages bill together.

## Verification

`test_llm.py` pins the tag and stage for both `signals_eval` call sites; dropping either kwarg fails its test. `ruff check` and `ruff format` clean.

`ai_product` is also the opt-in switch for the Go gateway, so wherever `AI_GATEWAY_URL` is configured this moves eval-fixture generation off the Python gateway alongside the other tagged signals stages. Reverting the kwarg reverts both.

## Note

This is eval-harness traffic (fixture generation), not the production pipeline. Tagging it keeps eval spend visible under signals; if eval cost should sit outside the signals product entirely, this is the line to revisit.

Refs PostHog/ai-gateway#357.
