### PR TITLE
fix(plain): document company:read as a required Plain API scope

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plain/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plain/source.py
@@ -57,6 +57,7 @@ You can create an API key in your [Plain workspace settings](https://app.plain.c
 
 Make sure to grant the following read permissions:
 - customer:read
+- company:read
 - thread:read
 - timeline:read
 - user:read
@@ -89,9 +90,10 @@ Make sure to grant the following read permissions:
         return {
             "401 Client Error": "Invalid Plain credentials. Please check your API key.",
             # Plain fails the whole GraphQL request when the key lacks a scope any requested field needs.
-            # Our customers/threads queries read assignee (user:read) and label (label:read) data on top
-            # of the basics, so name every required scope — retrying a key missing one never succeeds.
-            "403 Client Error": "Access forbidden. Grant your Plain API key these read permissions, then reconnect: customer:read, thread:read, timeline:read, user:read, label:read.",
+            # Our customers/threads queries read company (company:read), assignee (user:read), and label
+            # (label:read) data on top of the basics, so name every required scope — retrying a key
+            # missing one never succeeds.
+            "403 Client Error": "Access forbidden. Grant your Plain API key these read permissions, then reconnect: customer:read, company:read, thread:read, timeline:read, user:read, label:read.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plain/tests/test_plain_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plain/tests/test_plain_source.py
@@ -39,10 +39,11 @@ class TestPlainSource:
         assert "403 Client Error" in errors
 
     def test_source_config_documents_scopes_the_queries_require(self):
-        # The customers/threads queries read assignee (user:read) and label (label:read) data, and Plain
-        # 403s the whole request when the key lacks a scope any requested field needs. Keep the setup
-        # caption and the forbidden-error guidance in sync with what the queries actually fetch.
-        required_scopes = ["customer:read", "thread:read", "timeline:read", "user:read", "label:read"]
+        # The customers/threads queries read company (company:read), assignee (user:read), and label
+        # (label:read) data, and Plain 403s the whole request when the key lacks a scope any requested
+        # field needs. Keep the setup caption and the forbidden-error guidance in sync with what the
+        # queries actually fetch.
+        required_scopes = ["customer:read", "company:read", "thread:read", "timeline:read", "user:read", "label:read"]
         caption = self.source.get_source_config.caption
         forbidden_message = self.source.get_non_retryable_errors()["403 Client Error"]
         assert caption is not None


### PR DESCRIPTION
## Problem

PostHog's error tracking flagged a recurring non-retryable 403 from the `plain` data warehouse source: `Insufficient permissions, missing "company:read"`.

The `customers` GraphQL query reads a `company { id name }` field, which requires Plain's `company:read` scope. But the source's setup caption (the instructions shown when connecting Plain) and the 403 error guidance never mentioned that scope — only `customer:read`, `thread:read`, `timeline:read`, `user:read`, and `label:read`. A user who granted exactly the scopes we told them to would still be missing `company:read`, and Plain fails the whole GraphQL request when any requested field's scope is missing, so the sync fails permanently with no way to self-serve a fix from our own docs.

## Changes

- Added `company:read` to the required-permissions list in the Plain source setup caption.
- Added `company:read` to the 403 non-retryable error message that tells users which scopes to grant.

## How did you test this code?

Ran the existing Plain source test suite, including `test_source_config_documents_scopes_the_queries_require`, which now asserts `company:read` appears in both the caption and the forbidden-error message:

```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/plain/tests/ -q
# 41 passed
```

Also ran `ruff check` and `ruff format --check` on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no separate docs page for this source beyond the in-app setup caption, which this PR updates directly.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was generated in response to a PostHog error tracking alert for the `plain` warehouse source (403 Forbidden, missing `company:read`). I (Claude Code) traced the error to `execute()` in `plain.py`, confirmed the 403 was already marked non-retryable in `source.py`, then dug into why users kept hitting it despite that — the `customers` query requests a `company` field that needs a scope our own setup instructions never listed. Fixed by adding `company:read` everywhere the other required scopes are documented, and updated the existing scope-sync test to cover it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*