### PR TITLE
fix(plain): document company:read and machineUser:read scopes

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plain/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plain/source.py
@@ -61,6 +61,8 @@ Make sure to grant the following read permissions:
 - timeline:read
 - user:read
 - label:read
+- company:read
+- machineUser:read
 """,
             iconPath="/static/services/plain.png",
             fields=cast(
@@ -89,9 +91,10 @@ Make sure to grant the following read permissions:
         return {
             "401 Client Error": "Invalid Plain credentials. Please check your API key.",
             # Plain fails the whole GraphQL request when the key lacks a scope any requested field needs.
-            # Our customers/threads queries read assignee (user:read) and label (label:read) data on top
-            # of the basics, so name every required scope — retrying a key missing one never succeeds.
-            "403 Client Error": "Access forbidden. Grant your Plain API key these read permissions, then reconnect: customer:read, thread:read, timeline:read, user:read, label:read.",
+            # Our customers/threads/timeline_entries queries read assignee (user:read), label (label:read),
+            # company (company:read), and machine-user actor (machineUser:read) data on top of the basics,
+            # so name every required scope — retrying a key missing one never succeeds.
+            "403 Client Error": "Access forbidden. Grant your Plain API key these read permissions, then reconnect: customer:read, thread:read, timeline:read, user:read, label:read, company:read, machineUser:read.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plain/tests/test_plain_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plain/tests/test_plain_source.py
@@ -39,10 +39,19 @@ class TestPlainSource:
         assert "403 Client Error" in errors
 
     def test_source_config_documents_scopes_the_queries_require(self):
-        # The customers/threads queries read assignee (user:read) and label (label:read) data, and Plain
-        # 403s the whole request when the key lacks a scope any requested field needs. Keep the setup
-        # caption and the forbidden-error guidance in sync with what the queries actually fetch.
-        required_scopes = ["customer:read", "thread:read", "timeline:read", "user:read", "label:read"]
+        # The customers/threads/timeline_entries queries read assignee (user:read), label (label:read),
+        # company (company:read), and machine-user actor (machineUser:read) data, and Plain 403s the whole
+        # request when the key lacks a scope any requested field needs. Keep the setup caption and the
+        # forbidden-error guidance in sync with what the queries actually fetch.
+        required_scopes = [
+            "customer:read",
+            "thread:read",
+            "timeline:read",
+            "user:read",
+            "label:read",
+            "company:read",
+            "machineUser:read",
+        ]
         caption = self.source.get_source_config.caption
         forbidden_message = self.source.get_non_retryable_errors()["403 Client Error"]
         assert caption is not None


### PR DESCRIPTION
## Problem

The Plain data-warehouse source's setup caption and forbidden-error message only listed 5 of the read scopes its GraphQL queries actually require: `customer:read`, `thread:read`, `timeline:read`, `user:read`, `label:read`. Error tracking has repeatedly caught customers reconnecting with exactly those scopes and hitting a fresh `403 Client Error: Forbidden` from Plain a moment later, each time for a different missing scope (`thread:read`, `user:read`, `company:read`, `machineUser:read` have all shown up).

The 403 is already correctly classified as non-retryable (`PlainSource.get_non_retryable_errors`), so the sync stops instead of retrying forever - that part works. The bug is that the guidance telling the customer what to grant was incomplete, so "fixing" the key and reconnecting kept failing on a scope we never told them about.

Reading `queries.py` against the errors: `CUSTOMERS_QUERY` fetches `company { id name }` (needs `company:read`), and all three queries (`customers`, `threads`, `timeline_entries`) resolve actor fields to `MachineUserActor`/`MachineUser` (needs `machineUser:read`) alongside the already-documented `user:read`.

## Changes

- Added `company:read` and `machineUser:read` to the setup caption's required-permissions list in `source.py`.
- Added the same two scopes to the `403 Client Error` non-retryable-error message shown on reconnect.

## How did you test this code?

Extended the existing `test_source_config_documents_scopes_the_queries_require` test (which already pins the caption/error-message scope list) to assert the two additional scopes are present. This is the same regression the test already caught, just with an incomplete scope list. Ran the full `test_plain_source.py` suite locally - all 11 tests pass.

## Docs update

N/A - no user-facing docs outside the in-app caption, which is part of this change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) investigated a `NonRetryableException` surfaced by PostHog error tracking for the Plain source, traced the stack trace into `plain.py`'s `_fetch_paginated_endpoint`/`execute`, and confirmed the 403 was already correctly non-retryable. Cross-referencing the error message text (which named different missing scopes across separate occurrences: `thread:read`, `user:read`, `company:read`, `machineUser:read`) against `queries.py`'s GraphQL query bodies showed the documented scope list was simply incomplete. No skill was invoked beyond `/writing-tests` (to validate extending the existing test was the right move rather than adding a new one).