### PR TITLE
fix(custom): reject unsupported paginator config keys before sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import hashlib
+import inspect
 import graphlib
 from collections.abc import Callable
 from datetime import date
@@ -57,6 +58,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.config_setup import (
     build_resource_dependency_graph,
     create_auth,
+    get_paginator_class,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import (
     EndpointResource,
@@ -405,6 +407,52 @@ def _validate_incremental_configs(manifest: dict[str, Any]) -> None:
                 f"Resource {resource.get('name')!r}: endpoint.incremental.start_param is required and must be a "
                 "non-empty string naming the query parameter used to send the cursor value to the API"
             )
+
+
+def _validate_paginator_configs(manifest: dict[str, Any]) -> None:
+    """Reject paginator config keys that would deterministically crash at sync time.
+
+    A dict paginator config reaches the REST engine as ``PaginatorClass(**config)`` (minus
+    ``type``), so an unsupported key — e.g. one copied from newer dlt docs — arrives as an
+    unexpected kwarg and crashes sync setup with a ``TypeError`` the pipeline doesn't convert
+    to non-retryable, so Temporal retries a deterministic failure. An unknown ``type`` is
+    caught here too, rather than surfacing as a bare engine ``ValueError`` mid-sync.
+    """
+    client = manifest.get("client")
+    if isinstance(client, dict):
+        _check_paginator_config(client.get("paginator"), "client.paginator")
+
+    for resource in manifest.get("resources") or []:
+        if not isinstance(resource, dict):
+            continue
+        endpoint = resource.get("endpoint")
+        paginator = endpoint.get("paginator") if isinstance(endpoint, dict) else None
+        _check_paginator_config(paginator, f"Resource {resource.get('name')!r}: endpoint.paginator")
+
+
+def _check_paginator_config(paginator: Any, location: str) -> None:
+    # Only a dict is spread into the paginator constructor as kwargs; a string names a built-in
+    # and an instance is used as-is, so neither reaches the unexpected-kwarg path.
+    if not isinstance(paginator, dict):
+        return
+    try:
+        paginator_class = get_paginator_class(cast(Any, paginator.get("type", "auto")))
+    except ValueError as exc:
+        raise ManifestValidationError(f"{location}: {exc}") from exc
+    # "auto" (and any type mapped to None) applies no paginator, so extra keys are ignored.
+    if paginator_class is None:
+        return
+    supported = {
+        name
+        for name, param in inspect.signature(paginator_class).parameters.items()
+        if param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+    }
+    unsupported = sorted(set(paginator) - {"type"} - supported)
+    if unsupported:
+        raise ManifestValidationError(
+            f"{location} has unsupported {'keys' if len(unsupported) > 1 else 'key'} "
+            f"{', '.join(unsupported)}. Allowed keys: {', '.join(sorted(supported))}"
+        )
 
 
 # Plain-English replacements for the pydantic constraint messages users hit most
@@ -890,6 +938,7 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             # map feeds the probe's child filter below.
             resolved = _validate_resource_graph(manifest)
             _validate_incremental_configs(manifest)
+            _validate_paginator_configs(manifest)
         except ManifestValidationError as exc:
             return False, str(exc)
 
@@ -1140,6 +1189,7 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             # endpoint.incremental block missing start_param crashes the engine with a bare,
             # retryable KeyError. Reject it as a ValueError so it fails fast and non-retryably.
             _validate_incremental_configs({"resources": engine_resources})
+            _validate_paginator_configs({"client": manifest.get("client"), "resources": engine_resources})
 
             # The engine serializes a datetime watermark via str() (space-separated),
             # which strict APIs reject — format it to the declared wire format first.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -2525,6 +2525,41 @@ class TestCustomSourceIncrementalUnsupportedKeys(SimpleTestCase):
         assert err is not None and "upstream_row_order" in err and "'users'" in err
 
 
+class TestCustomSourcePaginatorUnsupportedKeys(SimpleTestCase):
+    def _manifest(self) -> dict:
+        manifest = _minimal_manifest()
+        manifest["resources"][0]["endpoint"]["paginator"] = {
+            "type": "offset",
+            "limit": 100,
+            "limit_body_path": "meta.limit",
+        }
+        return manifest
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.custom.source.rest_api_resources")
+    def test_unsupported_key_raises_non_retryable_before_engine(self, mock_resources):
+        mock_resources.return_value = [_fake_resource("users")]
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(self._manifest()))
+        inputs = MagicMock(
+            team_id=1,
+            schema_name="users",
+            job_id="job-1",
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+        )
+        with self.assertRaises(NonRetryableException) as ctx:
+            source.source_for_pipeline(config, inputs)
+        assert "limit_body_path" in str(ctx.exception)
+        mock_resources.assert_not_called()
+
+    def test_unsupported_key_rejected_at_validation(self):
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(self._manifest()), auth_token="abc")
+        ok, err = source.validate_credentials(config, team_id=999)
+        assert ok is False
+        assert err is not None and "limit_body_path" in err and "'users'" in err
+
+
 def _apikey_manifest() -> dict:
     """A minimal manifest whose auth is an api_key in a query param, so the
     injected secret is registered for value-based redaction."""


### PR DESCRIPTION
## Problem

Error tracking surfaced a `TypeError` from the custom REST warehouse source: `OffsetPaginator.__init__() got an unexpected keyword argument 'limit_body_path'` ([issue](https://us.posthog.com/project/2/error_tracking/019f86f1-84f6-7551-a7a6-4f342c1881a2)).

A custom source's manifest is a user-authored `RESTAPIConfig` that we pass through untouched to the REST engine. The engine builds a paginator as `PaginatorClass(**config)` (minus `type`), so any key in the manifest's paginator config that isn't a real constructor argument arrives as an unexpected kwarg and crashes `create_paginator`. This is deterministic: the same manifest produces the same crash on every attempt. Because a bare `TypeError` isn't converted to a non-retryable failure, Temporal kept retrying a config error that can only be fixed by editing the manifest.

This is the same failure class we already guard against for `endpoint.incremental`, where an unsupported key hits the engine's `Incremental(**config)` constructor. The paginator path had no equivalent check.

## Changes

Validate paginator configs the same way we validate incremental configs, at both create/update time (`validate_credentials`) and sync time (`source_for_pipeline`):

- For the client-level and each resource's endpoint paginator, resolve the paginator class from `type` and reject any config key that isn't a constructor parameter, with a pointed message listing the allowed keys.
- An unknown paginator `type` is caught here too, instead of surfacing as a bare engine `ValueError` mid-sync.
- Supported keys are read from each paginator class's constructor signature, so they can't drift as paginators gain options.

At sync time the check raises `ManifestValidationError` (a `ValueError`), which the existing handler converts to `NonRetryableException` — so the job fails fast and stops burning the retry budget. Valid paginator configs (`offset`, `page_number`, `cursor`, `json_response`, `header_link`, `single_page`, `auto`) are unaffected.

> [!NOTE]
> This is a config-validation fix, not a retry-policy change. Transient errors stay retryable; only deterministic manifest mistakes are rejected.

## How did you test this code?

Added `TestCustomSourcePaginatorUnsupportedKeys` with two cases that reproduce the reported crash via an unsupported paginator key: one asserts the sync path raises `NonRetryableException` before the engine is invoked, the other asserts `validate_credentials` rejects it up front. No existing test covered paginator-key validation — the existing paginator test only checks that valid configs thread through to the engine.

Ran locally (the OAuth2 wiring tests in the same file need a live Postgres and error at DB connect in this sandbox, unrelated to this change):

- `TestCustomSourcePaginatorUnsupportedKeys` and `TestCustomSourceIncrementalUnsupportedKeys` — pass
- Paginator / pipeline / validation slice of `test_custom_source.py` — 52 passed
- `ruff` and `mypy` on the changed module — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the `custom` warehouse source. Confirmed the stack originates in the source's own code path (`create_paginator` reached via `rest_api_resources` from `source.py`), read the implementation, and classified it as a fixable bug rather than a user/upstream error: the request shape is deterministic, so retrying can't help, and the existing incremental-config validation is the established pattern for exactly this "unsupported key crashes the engine constructor" problem.

Tool: Claude Code (Opus 4.8). Skill invoked: `/writing-tests` (to gate the new tests). Chose signature introspection over a hardcoded key list so the allow-list tracks the paginator constructors automatically.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
